### PR TITLE
Share tool approval handling across run contexts

### DIFF
--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -119,7 +119,8 @@ export interface SandboxFunctionMCPApproveExecutionEvent
   type: "tool_approve_execution";
 }
 
-export interface MCPApproveExecutionEventData extends ToolExecutionBase {
+// Scope-neutral approval event fields. Callers add agent-loop or sandbox-function identifiers.
+export interface MCPApproveExecutionEventBase extends ToolExecutionBase {
   type: "tool_approve_execution";
 }
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -18,7 +18,7 @@ export type SandboxFunctionEventScope = {
   invocationId: string;
 };
 
-interface ToolExecutionBase<
+export interface ToolExecutionBase<
   T extends MCPValidationMetadataType = MCPValidationMetadataType,
 > {
   actionId: string;
@@ -116,6 +116,10 @@ export interface AgentLoopMCPApproveExecutionEvent
 
 export interface SandboxFunctionMCPApproveExecutionEvent
   extends SandboxFunctionToolExecution {
+  type: "tool_approve_execution";
+}
+
+export interface MCPApproveExecutionEventData extends ToolExecutionBase {
   type: "tool_approve_execution";
 }
 

--- a/front/lib/actions/tool_approval_events.ts
+++ b/front/lib/actions/tool_approval_events.ts
@@ -1,0 +1,67 @@
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import {
+  getInternalMCPServerDisplayedAs,
+  getInternalMCPServerNameFromSId,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPApproveExecutionEventData } from "@app/lib/actions/mcp_internal_actions/events";
+import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import type { Authenticator } from "@app/lib/auth";
+
+type ApprovalToolConfiguration = Pick<
+  MCPToolConfigurationType,
+  | "argumentsRequiringApproval"
+  | "icon"
+  | "mcpServerName"
+  | "originalName"
+  | "permission"
+  | "toolServerId"
+>;
+
+export async function makeMCPApproveExecutionEventData(
+  auth: Authenticator,
+  {
+    actionId,
+    toolConfiguration,
+    inputs,
+    approvalLabelInputs = inputs,
+    approvalSubjectName,
+  }: {
+    actionId: string;
+    toolConfiguration: ApprovalToolConfiguration;
+    inputs: Record<string, unknown>;
+    approvalLabelInputs?: Record<string, unknown>;
+    approvalSubjectName: string;
+  }
+): Promise<MCPApproveExecutionEventData> {
+  const argumentsRequiringApproval =
+    toolConfiguration.argumentsRequiringApproval ?? [];
+
+  return {
+    type: "tool_approve_execution",
+    actionId,
+    created: Date.now(),
+    inputs,
+    stake: toolConfiguration.permission,
+    userId: auth.user()?.sId,
+    metadata: {
+      toolName: toolConfiguration.originalName,
+      mcpServerName: toolConfiguration.mcpServerName,
+      agentName: "agent",
+      icon: toolConfiguration.icon,
+      displayedAs: getInternalMCPServerDisplayedAs(
+        toolConfiguration.toolServerId
+      ),
+    },
+    argumentsRequiringApproval,
+    approvalArgsLabel: await getApprovalArgsLabel({
+      auth,
+      internalMCPServerName: getInternalMCPServerNameFromSId(
+        toolConfiguration.toolServerId
+      ),
+      toolName: toolConfiguration.originalName,
+      agentName: approvalSubjectName,
+      inputs: approvalLabelInputs,
+      argumentsRequiringApproval,
+    }),
+  };
+}

--- a/front/lib/actions/tool_approval_events.ts
+++ b/front/lib/actions/tool_approval_events.ts
@@ -3,7 +3,7 @@ import {
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { MCPApproveExecutionEventData } from "@app/lib/actions/mcp_internal_actions/events";
+import type { MCPApproveExecutionEventBase } from "@app/lib/actions/mcp_internal_actions/events";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -17,7 +17,7 @@ type ApprovalToolConfiguration = Pick<
   | "toolServerId"
 >;
 
-export async function makeMCPApproveExecutionEventData(
+export async function makeMCPApproveExecutionEventBase(
   auth: Authenticator,
   {
     actionId,
@@ -32,7 +32,7 @@ export async function makeMCPApproveExecutionEventData(
     approvalLabelInputs?: Record<string, unknown>;
     approvalSubjectName: string;
   }
-): Promise<MCPApproveExecutionEventData> {
+): Promise<MCPApproveExecutionEventBase> {
   const argumentsRequiringApproval =
     toolConfiguration.argumentsRequiringApproval ?? [];
 

--- a/front/lib/actions/tool_approval_events.ts
+++ b/front/lib/actions/tool_approval_events.ts
@@ -35,6 +35,16 @@ export async function makeMCPApproveExecutionEventBase(
 ): Promise<MCPApproveExecutionEventBase> {
   const argumentsRequiringApproval =
     toolConfiguration.argumentsRequiringApproval ?? [];
+  const approvalArgsLabel = await getApprovalArgsLabel({
+    auth,
+    internalMCPServerName: getInternalMCPServerNameFromSId(
+      toolConfiguration.toolServerId
+    ),
+    toolName: toolConfiguration.originalName,
+    agentName: approvalSubjectName,
+    inputs: approvalLabelInputs,
+    argumentsRequiringApproval,
+  });
 
   return {
     type: "tool_approve_execution",
@@ -53,15 +63,6 @@ export async function makeMCPApproveExecutionEventBase(
       ),
     },
     argumentsRequiringApproval,
-    approvalArgsLabel: await getApprovalArgsLabel({
-      auth,
-      internalMCPServerName: getInternalMCPServerNameFromSId(
-        toolConfiguration.toolServerId
-      ),
-      toolName: toolConfiguration.originalName,
-      agentName: approvalSubjectName,
-      inputs: approvalLabelInputs,
-      argumentsRequiringApproval,
-    }),
+    approvalArgsLabel,
   };
 }

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -1,7 +1,6 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isNumberOrBoolean, isString } from "@app/types/shared/utils/general";
 
@@ -19,11 +18,11 @@ export async function getExecutionStatusFromConfig(
   auth: Authenticator,
   {
     actionConfiguration,
-    agentMessage,
+    skipToolsValidation = false,
     context,
   }: {
     actionConfiguration: StakeCheckConfiguration;
-    agentMessage: AgentMessageType;
+    skipToolsValidation?: boolean;
     context?: ToolInputContext;
   }
 ): Promise<{
@@ -31,10 +30,8 @@ export async function getExecutionStatusFromConfig(
   status: "ready_allowed_implicitly" | "blocked_validation_required";
   serverId?: string;
 }> {
-  // If the agent message is marked as "skipToolsValidation" we skip all tools validation
-  // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
-  // created by an API call where the caller explicitly set `skipToolsValidation` to true.
-  if (agentMessage.skipToolsValidation) {
+  // Explicit validation bypasses take precedence over the tool permission.
+  if (skipToolsValidation) {
     return { status: "ready_allowed_implicitly" };
   }
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -35,6 +35,7 @@ import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_r
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
@@ -231,6 +232,20 @@ describe("createSandboxChildAction", () => {
     expect(child?.status).toBe("blocked_validation_required");
     expect(child?.toolConfiguration.permission).toBe("medium");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+    expect(vi.mocked(updateResourceAndPublishEvent)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: "tool_approve_execution",
+          actionId: child?.sId,
+          inputs: { objectName: "Contact" },
+          stake: "medium",
+          metadata: expect.objectContaining({
+            toolName: TOOL_NAME,
+          }),
+        }),
+      })
+    );
   });
 
   it("auto-approves medium-stake tools when an approval recorded on a direct call exists", async () => {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -3,13 +3,9 @@ import {
   deduplicateMCPServerConfigurations,
   disambiguateServerNamesBySpace,
 } from "@app/lib/actions/mcp_actions";
-import {
-  getInternalMCPServerDisplayedAs,
-  getInternalMCPServerNameFromSId,
-} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
-import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { makeMCPApproveExecutionEventData } from "@app/lib/actions/tool_approval_events";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
@@ -184,7 +180,7 @@ export async function createSandboxChildAction(
 
   const { status } = await getExecutionStatusFromConfig(auth, {
     actionConfiguration: fullToolConfiguration,
-    agentMessage,
+    skipToolsValidation: agentMessage.skipToolsValidation,
     context: {
       agentId: agentConfiguration.sId,
       toolInputs: rawInputs,
@@ -206,40 +202,17 @@ export async function createSandboxChildAction(
   });
 
   if (status === "blocked_validation_required") {
-    const argumentsRequiringApproval =
-      fullToolConfiguration.argumentsRequiringApproval ?? [];
-    const internalMCPServerName = getInternalMCPServerNameFromSId(
-      fullToolConfiguration.toolServerId
-    );
     const approvalRequirementEvent: AgentLoopMCPApproveExecutionEvent = {
-      type: "tool_approve_execution",
-      actionId: action.sId,
+      ...(await makeMCPApproveExecutionEventData(auth, {
+        actionId: action.sId,
+        toolConfiguration: fullToolConfiguration,
+        inputs: rawInputs,
+        approvalSubjectName: agentConfiguration.name,
+      })),
       configurationId: fullToolConfiguration.sId,
       conversationId: conversation.sId,
-      created: Date.now(),
-      inputs: rawInputs,
       messageId: agentMessage.sId,
-      stake: fullToolConfiguration.permission,
-      userId: auth.user()?.sId,
       isLastBlockingEventForStep: true,
-      metadata: {
-        toolName: fullToolConfiguration.originalName,
-        mcpServerName: fullToolConfiguration.mcpServerName,
-        agentName: "agent",
-        icon: fullToolConfiguration.icon,
-        displayedAs: getInternalMCPServerDisplayedAs(
-          fullToolConfiguration.toolServerId
-        ),
-      },
-      argumentsRequiringApproval,
-      approvalArgsLabel: await getApprovalArgsLabel({
-        auth,
-        internalMCPServerName,
-        toolName: fullToolConfiguration.originalName,
-        agentName: agentConfiguration.name,
-        inputs: rawInputs,
-        argumentsRequiringApproval,
-      }),
     };
 
     await updateResourceAndPublishEvent(auth, {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/actions/mcp_actions";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
-import { makeMCPApproveExecutionEventData } from "@app/lib/actions/tool_approval_events";
+import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
@@ -203,7 +203,7 @@ export async function createSandboxChildAction(
 
   if (status === "blocked_validation_required") {
     const approvalRequirementEvent: AgentLoopMCPApproveExecutionEvent = {
-      ...(await makeMCPApproveExecutionEventData(auth, {
+      ...(await makeMCPApproveExecutionEventBase(auth, {
         actionId: action.sId,
         toolConfiguration: fullToolConfiguration,
         inputs: rawInputs,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -3,7 +3,7 @@ import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { makeMCPApproveExecutionEventData } from "@app/lib/actions/tool_approval_events";
+import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -277,7 +277,7 @@ async function createActionForTool(
     approvalEventData:
       status === "blocked_validation_required"
         ? {
-            ...(await makeMCPApproveExecutionEventData(auth, {
+            ...(await makeMCPApproveExecutionEventBase(auth, {
               actionId: action.sId,
               toolConfiguration: actionConfiguration,
               inputs: action.augmentedInputs,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,13 +1,9 @@
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
-import {
-  getInternalMCPServerDisplayedAs,
-  getInternalMCPServerNameFromSId,
-} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { makeMCPApproveExecutionEventData } from "@app/lib/actions/tool_approval_events";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -158,12 +154,9 @@ async function createActionForTool(
   );
 
   const rawInputs = JSON.parse(stepContent.value.value.arguments);
-  const argumentsRequiringApproval =
-    actionConfiguration.argumentsRequiringApproval ?? [];
-
   const { status } = await getExecutionStatusFromConfig(auth, {
     actionConfiguration,
-    agentMessage,
+    skipToolsValidation: agentMessage.skipToolsValidation,
     context: {
       agentId: agentConfiguration.sId,
       toolInputs: rawInputs,
@@ -284,35 +277,16 @@ async function createActionForTool(
     approvalEventData:
       status === "blocked_validation_required"
         ? {
-            type: "tool_approve_execution",
-            actionId: action.sId,
+            ...(await makeMCPApproveExecutionEventData(auth, {
+              actionId: action.sId,
+              toolConfiguration: actionConfiguration,
+              inputs: action.augmentedInputs,
+              approvalLabelInputs: rawInputs,
+              approvalSubjectName: agentConfiguration.name,
+            })),
             configurationId: agentConfiguration.sId,
             conversationId: conversation.sId,
-            created: Date.now(),
-            inputs: action.augmentedInputs,
             messageId: agentMessage.sId,
-            stake: actionConfiguration.permission,
-            userId: auth.user()?.sId,
-            metadata: {
-              toolName: actionConfiguration.originalName,
-              mcpServerName: actionConfiguration.mcpServerName,
-              agentName: "agent",
-              icon: actionConfiguration.icon,
-              displayedAs: getInternalMCPServerDisplayedAs(
-                actionConfiguration.toolServerId
-              ),
-            },
-            argumentsRequiringApproval,
-            approvalArgsLabel: await getApprovalArgsLabel({
-              auth,
-              internalMCPServerName: getInternalMCPServerNameFromSId(
-                actionConfiguration.toolServerId
-              ),
-              toolName: actionConfiguration.originalName,
-              agentName: agentConfiguration.name,
-              inputs: rawInputs,
-              argumentsRequiringApproval,
-            }),
           }
         : undefined,
   };


### PR DESCRIPTION
## Description

Decouple tool stake resolution from agent messages and centralize approval-event payload construction across agent-loop and sandbox child calls. This prepares sandbox functions to reuse the same approval policy and event shape without changing their execution behavior yet.

## Tests

- `cd front && NODE_ENV=test npm test lib/api/sandbox/create_child_action.test.ts lib/actions/tool_status.test.ts`
- tested locally

## Risk

Low. This is a behavior-preserving refactor covered by the existing approval tests.

## Deploy Plan

- deploy `front`