### PR TITLE
[front] enh: rewrite semantic search results for models

### DIFF
--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -10,6 +10,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isRunAgentQueryResourceType,
+  isSearchResultResourceType,
   isToolGeneratedFile,
   isToolMarkerResourceType,
   TOOL_GENERATED_FILE_MIME_TYPE,
@@ -106,7 +107,10 @@ export function hideFileFromActionOutput({
 }
 
 export function rewriteContentForModel(
-  content: CallToolResult["content"][number]
+  content: CallToolResult["content"][number],
+  {
+    renderSearchResultsAsMarkdown = false,
+  }: { renderSearchResultsAsMarkdown?: boolean } = {}
 ): CallToolResult["content"][number] | null {
   // Only render tool generated files that are supported.
   if (
@@ -147,6 +151,26 @@ export function rewriteContentForModel(
     isRunAgentQueryResourceType(content)
   ) {
     return null;
+  }
+
+  if (renderSearchResultsAsMarkdown && isSearchResultResourceType(content)) {
+    let text = `Search result: ${content.resource.text}\n`;
+    text += `id: ${content.resource.id}\n`;
+    text += `url: ${content.resource.uri}\n`;
+    text += `ref: ${content.resource.ref}\n`;
+    // We don't show the source provider, as it's redundant with the URL.
+
+    if (content.resource.tags.length > 0) {
+      text += `tags: ${content.resource.tags.join(", ")}\n`;
+    }
+    if (content.resource.chunks.length > 0) {
+      text += `retrieved chunks:\n-----------\n${content.resource.chunks.join("------------")}`;
+    }
+
+    return {
+      type: "text",
+      text,
+    };
   }
 
   return content;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -242,7 +242,7 @@ export async function getSteps(
   const actions = removeNulls(message.actions);
   const renderSearchResultsAsMarkdown = await hasFeatureFlag(
     auth,
-    "render_semantic_search_results_as_markdown"
+    "render_search_results_as_markdown"
   );
 
   // We store for each step (identified by its index) the "contents" array (raw model outputs, including

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -15,7 +15,7 @@ import {
 } from "@app/lib/api/assistant/skills_rendering";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { getConversationFileMountSignedUrl } from "@app/lib/api/files/gcs_mount/files";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   replaceMentionsWithAt,
@@ -110,7 +110,13 @@ async function renderActionForMultiActionsModel(
   auth: Authenticator,
   action: AgentMCPActionWithOutputType,
   model: ModelConfigurationType,
-  { conversationId }: { conversationId: string }
+  {
+    conversationId,
+    renderSearchResultsAsMarkdown,
+  }: {
+    conversationId: string;
+    renderSearchResultsAsMarkdown: boolean;
+  }
 ): Promise<FunctionMessageTypeModel> {
   if (action.status === "denied") {
     return {
@@ -146,7 +152,11 @@ async function renderActionForMultiActionsModel(
   }
 
   const outputItems = removeNulls(
-    action.output?.map(rewriteContentForModel) ?? []
+    action.output?.map((content) =>
+      rewriteContentForModel(content, {
+        renderSearchResultsAsMarkdown,
+      })
+    ) ?? []
   );
 
   let output: string | Content[];
@@ -230,6 +240,10 @@ export async function getSteps(
     return [];
   }
   const actions = removeNulls(message.actions);
+  const renderSearchResultsAsMarkdown = await hasFeatureFlag(
+    auth,
+    "render_semantic_search_results_as_markdown"
+  );
 
   // We store for each step (identified by its index) the "contents" array (raw model outputs, including
   // text content, reasoning and function calls) and "actions", i.e the function results.
@@ -247,6 +261,7 @@ export async function getSteps(
       action,
       result: await renderActionForMultiActionsModel(auth, action, model, {
         conversationId,
+        renderSearchResultsAsMarkdown,
       }),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -286,6 +286,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",
     stage: "dust_only",
   },
+  render_search_results_as_markdown: {
+    description:
+      "Render semantic search results as Markdown instead of serialized JSON",
+    stage: "dust_only",
+  },
   admin_governance: {
     description:
       "Access to admin governance features, including assigning the business_admin role from the UI",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -741,6 +741,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_usage_mcp"
   | "power_bi_mcp"
   | "reinforced_agents"
+  | "render_search_results_as_markdown"
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"


### PR DESCRIPTION
## Description

Semantic search outputs are currently rendered to models as noisy JSON, accounting for a lot of tokens. This PR rewrites search result resources into a compact text representation containing the document metadata, citation reference, tags, and retrieved chunks.

Tested on a few examples, was able to reduce token count by 35% on a few examples.

The new rendering is gated behind `render_search_results_as_markdown`; other resource outputs keep their existing behavior.

## Tests

- Tested locally.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
