### PR TITLE
[front] fix: keep system skill tools eager

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -132,9 +132,10 @@ app.post(
         conversation,
       });
 
-    const skillServers = await getSkillServers(auth, {
+    const { skillServers, systemSkillServers } = await getSkillServers(auth, {
       agentConfiguration,
-      skills: [...systemSkills, ...enabledSkills],
+      systemSkills,
+      enabledSkills,
     });
 
     const clientSideMCPActionConfigurations =
@@ -181,7 +182,7 @@ app.post(
         agentMessage: placeholderAgentMessage,
         clientSideActionConfigurations: clientSideMCPActionConfigurations,
       },
-      { jitServers, skillServers }
+      { jitServers, skillServers, systemSkillServers }
     );
 
     const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -139,14 +139,17 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
     conversation,
     attachments,
   });
-  const skillServers = await resolveSkillMCPServers(auth, {
-    agentConfiguration: agentConfig,
-    conversation,
-  });
+  const { systemSkillServers, skillServers } = await resolveSkillMCPServers(
+    auth,
+    {
+      agentConfiguration: agentConfig,
+      conversation,
+    }
+  );
   for (const srv of jitServers) {
     viewIds.add(srv.mcpServerViewId);
   }
-  for (const srv of skillServers) {
+  for (const srv of [...systemSkillServers, ...skillServers]) {
     if (isServerSideMCPServerConfiguration(srv)) {
       viewIds.add(srv.mcpServerViewId);
     }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1035,6 +1035,8 @@ export async function tryListMCPTools(
   const skillServerKeys = new Set(
     skillServers.map(getMCPServerConfigurationKey)
   );
+  // System servers are included in skillServers, but should keep their eager
+  // metadata even when the same server is also exposed by an enabled skill.
   for (const systemSkillServer of systemSkillServers) {
     skillServerKeys.delete(getMCPServerConfigurationKey(systemSkillServer));
   }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1025,26 +1025,20 @@ export async function tryListMCPTools(
     skillServers,
     jitServers,
   });
-  const nonSkillServerKeys = new Set(
+  const nonDeferredServerKeys = new Set(
     [
       ...agentLoopListToolsContext.agentConfiguration.actions,
       ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
       ...jitServers,
+      ...systemSkillServers,
     ].map(getMCPServerConfigurationKey)
   );
   const skillServerKeys = new Set(
     skillServers.map(getMCPServerConfigurationKey)
   );
-  const systemSkillServerKeys = new Set(
-    systemSkillServers.map(getMCPServerConfigurationKey)
-  );
-  const shouldDeferSkillServerConfig = deduplicatedConfigs.map((config) => {
+  const isSkillServerConfig = deduplicatedConfigs.map((config) => {
     const key = getMCPServerConfigurationKey(config);
-    return (
-      skillServerKeys.has(key) &&
-      !systemSkillServerKeys.has(key) &&
-      !nonSkillServerKeys.has(key)
-    );
+    return skillServerKeys.has(key) && !nonDeferredServerKeys.has(key);
   });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(
@@ -1053,7 +1047,7 @@ export async function tryListMCPTools(
   );
   const mcpServerActionsWithOrigin = mcpServerActions.map((action, index) => ({
     action,
-    shouldDeferSkillServer: shouldDeferSkillServerConfig[index],
+    isFromSkillServer: isSkillServerConfig[index],
   }));
 
   // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries.
@@ -1071,7 +1065,7 @@ export async function tryListMCPTools(
   // Discover all tools exposed by all available MCP servers.
   const results = await concurrentExecutor(
     mcpServerActionsWithOrigin,
-    async ({ action, shouldDeferSkillServer }) => {
+    async ({ action, isFromSkillServer }) => {
       let connectionParams: MCPConnectionParams;
       if (isServerSideMCPServerConfiguration(action)) {
         const mcpServerView = preFetchedMcpServerViews.get(
@@ -1218,7 +1212,7 @@ export async function tryListMCPTools(
 
         processedTools.push({
           ...toolConfig,
-          ...(shouldDeferSkillServer ? { eager: undefined } : {}),
+          ...(isFromSkillServer ? { eager: undefined } : {}),
           originalName: toolConfig.name,
           mcpServerName: action.name,
           name: toolName,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1009,9 +1009,11 @@ export async function tryListMCPTools(
   {
     jitServers,
     skillServers,
+    systemSkillServers,
   }: {
     jitServers: MCPServerConfigurationType[];
     skillServers: MCPServerConfigurationType[];
+    systemSkillServers: MCPServerConfigurationType[];
   }
 ): Promise<ServerToolsAndInstructions[]> {
   const owner = auth.getNonNullableWorkspace();
@@ -1033,9 +1035,16 @@ export async function tryListMCPTools(
   const skillServerKeys = new Set(
     skillServers.map(getMCPServerConfigurationKey)
   );
-  const isSkillServerConfig = deduplicatedConfigs.map((config) => {
+  const systemSkillServerKeys = new Set(
+    systemSkillServers.map(getMCPServerConfigurationKey)
+  );
+  const shouldDeferSkillServerConfig = deduplicatedConfigs.map((config) => {
     const key = getMCPServerConfigurationKey(config);
-    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
+    return (
+      skillServerKeys.has(key) &&
+      !systemSkillServerKeys.has(key) &&
+      !nonSkillServerKeys.has(key)
+    );
   });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(
@@ -1044,7 +1053,7 @@ export async function tryListMCPTools(
   );
   const mcpServerActionsWithOrigin = mcpServerActions.map((action, index) => ({
     action,
-    isFromSkillServer: isSkillServerConfig[index],
+    shouldDeferSkillServer: shouldDeferSkillServerConfig[index],
   }));
 
   // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries.
@@ -1062,7 +1071,7 @@ export async function tryListMCPTools(
   // Discover all tools exposed by all available MCP servers.
   const results = await concurrentExecutor(
     mcpServerActionsWithOrigin,
-    async ({ action, isFromSkillServer }) => {
+    async ({ action, shouldDeferSkillServer }) => {
       let connectionParams: MCPConnectionParams;
       if (isServerSideMCPServerConfiguration(action)) {
         const mcpServerView = preFetchedMcpServerViews.get(
@@ -1209,7 +1218,7 @@ export async function tryListMCPTools(
 
         processedTools.push({
           ...toolConfig,
-          ...(isFromSkillServer ? { eager: undefined } : {}),
+          ...(shouldDeferSkillServer ? { eager: undefined } : {}),
           originalName: toolConfig.name,
           mcpServerName: action.name,
           name: toolName,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1025,20 +1025,22 @@ export async function tryListMCPTools(
     skillServers,
     jitServers,
   });
-  const nonDeferredServerKeys = new Set(
+  const nonSkillServerKeys = new Set(
     [
       ...agentLoopListToolsContext.agentConfiguration.actions,
       ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
       ...jitServers,
-      ...systemSkillServers,
     ].map(getMCPServerConfigurationKey)
   );
   const skillServerKeys = new Set(
     skillServers.map(getMCPServerConfigurationKey)
   );
+  for (const systemSkillServer of systemSkillServers) {
+    skillServerKeys.delete(getMCPServerConfigurationKey(systemSkillServer));
+  }
   const isSkillServerConfig = deduplicatedConfigs.map((config) => {
     const key = getMCPServerConfigurationKey(config);
-    return skillServerKeys.has(key) && !nonDeferredServerKeys.has(key);
+    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
   });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1022,7 +1022,7 @@ export async function tryListMCPTools(
     agentActions: agentLoopListToolsContext.agentConfiguration.actions,
     clientSideActions:
       agentLoopListToolsContext.clientSideActionConfigurations ?? [],
-    skillServers,
+    skillServers: [...systemSkillServers, ...skillServers],
     jitServers,
   });
   const nonSkillServerKeys = new Set(
@@ -1035,14 +1035,17 @@ export async function tryListMCPTools(
   const skillServerKeys = new Set(
     skillServers.map(getMCPServerConfigurationKey)
   );
-  // System servers are included in skillServers, but should keep their eager
-  // metadata even when the same server is also exposed by an enabled skill.
-  for (const systemSkillServer of systemSkillServers) {
-    skillServerKeys.delete(getMCPServerConfigurationKey(systemSkillServer));
-  }
+  const systemSkillServerKeys = new Set(
+    systemSkillServers.map(getMCPServerConfigurationKey)
+  );
+  // A server exposed by both buckets keeps its system-skill behavior.
   const isSkillServerConfig = deduplicatedConfigs.map((config) => {
     const key = getMCPServerConfigurationKey(config);
-    return skillServerKeys.has(key) && !nonSkillServerKeys.has(key);
+    return (
+      skillServerKeys.has(key) &&
+      !systemSkillServerKeys.has(key) &&
+      !nonSkillServerKeys.has(key)
+    );
   });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -56,10 +56,13 @@ describe("resolveSkillMCPServers", () => {
       conversation,
     });
 
-    const skillServers = await resolveSkillMCPServers(authenticator, {
-      agentConfiguration,
-      conversation,
-    });
+    const { skillServers, systemSkillServers } = await resolveSkillMCPServers(
+      authenticator,
+      {
+        agentConfiguration,
+        conversation,
+      }
+    );
 
     const serverToolsAndInstructions = await tryListMCPTools(
       authenticator,
@@ -72,6 +75,7 @@ describe("resolveSkillMCPServers", () => {
       {
         jitServers: [],
         skillServers,
+        systemSkillServers,
       }
     );
 
@@ -95,6 +99,12 @@ describe("resolveSkillMCPServers", () => {
         (tool) => tool.name === `${SKILL_COMPANY_DATA_SERVER_NAME}__cat`
       )
     ).toHaveLength(1);
+    expect(
+      companyDataTools.find(
+        (tool) =>
+          tool.name === `${SKILL_COMPANY_DATA_SERVER_NAME}__semantic_search`
+      )?.eager
+    ).toBe(true);
     expect(
       serverToolsAndInstructions
         .flatMap(({ tools }) => tools)
@@ -152,6 +162,7 @@ describe("resolveSkillMCPServers", () => {
             serverNameOverride: SKILL_MANAGEMENT_SERVER_NAME,
           }),
         ],
+        systemSkillServers: [],
       }
     );
 

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -299,12 +299,6 @@ export async function resolveSkillMCPServers(
     }
   );
 
-  const activeSkills = [...systemSkills, ...enabledSkills];
-
-  if (activeSkills.length === 0) {
-    return { skillServers: [], systemSkillServers: [] };
-  }
-
   return getSkillServers(auth, {
     agentConfiguration,
     enabledSkills,

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -17,16 +17,24 @@ const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
 const SKILL_KNOWLEDGE_DATA_WAREHOUSE_SERVER_NAME =
   "skill_knowledge_data_warehouse";
 
+type ResolvedSkillMCPServers = {
+  skillServers: MCPServerConfigurationType[];
+  systemSkillServers: MCPServerConfigurationType[];
+};
+
 export async function getSkillServers(
   auth: Authenticator,
   {
     agentConfiguration,
-    skills,
+    enabledSkills,
+    systemSkills,
   }: {
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    skills: SkillResource[];
+    enabledSkills: SkillResource[];
+    systemSkills: SkillResource[];
   }
-): Promise<MCPServerConfigurationType[]> {
+): Promise<ResolvedSkillMCPServers> {
+  const skills = [...systemSkills, ...enabledSkills];
   let inheritedDataSourceViews: DataSourceViewResource[] = [];
   if (skills.some((skill) => skill.inheritsAgentConfigurationDataSources)) {
     inheritedDataSourceViews = await DataSourceViewResource.listBySpaceIds(
@@ -43,7 +51,8 @@ export async function getSkillServers(
     (v) => !isRemoteDatabase(v.dataSource)
   );
 
-  const mcpServers = skills.flatMap((skill) =>
+  const systemSkillIds = new Set(systemSkills.map((skill) => skill.sId));
+  const mcpServersWithOrigin = skills.flatMap((skill) =>
     skill.mcpServerConfigurations.map((config) => {
       const { view, childAgentId, serverNameOverride } = config;
 
@@ -67,14 +76,22 @@ export async function getSkillServers(
         filter: dsView.toViewFilter(),
       }));
 
-      return buildServerSideMCPServerConfiguration({
-        mcpServerView: view,
-        dataSources,
-        childAgentId,
-        serverNameOverride,
-      });
+      return {
+        server: buildServerSideMCPServerConfiguration({
+          mcpServerView: view,
+          dataSources,
+          childAgentId,
+          serverNameOverride,
+        }),
+        isSystemSkill: systemSkillIds.has(skill.sId),
+      };
     })
   );
+
+  const mcpServers = mcpServersWithOrigin.map(({ server }) => server);
+  const systemSkillServers = mcpServersWithOrigin
+    .filter(({ isSystemSkill }) => isSystemSkill)
+    .map(({ server }) => server);
 
   const {
     documentDataSourceConfigurations,
@@ -106,10 +123,13 @@ export async function getSkillServers(
     mcpServerView: autoInternalViews.get("data_warehouses") ?? null,
   });
 
-  return [
-    ...mcpServers,
-    ...removeNulls([fileSystemServer, dataWarehouseServer]),
-  ];
+  return {
+    skillServers: [
+      ...mcpServers,
+      ...removeNulls([fileSystemServer, dataWarehouseServer]),
+    ],
+    systemSkillServers,
+  };
 }
 
 /**
@@ -270,7 +290,7 @@ export async function resolveSkillMCPServers(
     agentConfiguration: AgentConfigurationType;
     conversation: ConversationType;
   }
-): Promise<MCPServerConfigurationType[]> {
+): Promise<ResolvedSkillMCPServers> {
   const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
     auth,
     {
@@ -282,11 +302,12 @@ export async function resolveSkillMCPServers(
   const activeSkills = [...systemSkills, ...enabledSkills];
 
   if (activeSkills.length === 0) {
-    return [];
+    return { skillServers: [], systemSkillServers: [] };
   }
 
   return getSkillServers(auth, {
     agentConfiguration,
-    skills: activeSkills,
+    enabledSkills,
+    systemSkills,
   });
 }

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -88,7 +88,9 @@ export async function getSkillServers(
     })
   );
 
-  const mcpServers = mcpServersWithOrigin.map(({ server }) => server);
+  const skillServers = mcpServersWithOrigin
+    .filter(({ isSystemSkill }) => !isSystemSkill)
+    .map(({ server }) => server);
   const systemSkillServers = mcpServersWithOrigin
     .filter(({ isSystemSkill }) => isSystemSkill)
     .map(({ server }) => server);
@@ -125,7 +127,7 @@ export async function getSkillServers(
 
   return {
     skillServers: [
-      ...mcpServers,
+      ...skillServers,
       ...removeNulls([fileSystemServer, dataWarehouseServer]),
     ],
     systemSkillServers,

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -22,6 +22,39 @@ type ResolvedSkillMCPServers = {
   systemSkillServers: MCPServerConfigurationType[];
 };
 
+function skillMCPServerConfigToServerSideConfig(auth: Authenticator, config: SkillMCPServerConfiguration, {
+remoteDbDataSourceViews, nonRemoteDbDataSourceViews
+}: {remoteDbDataSourceViews: DataSourceViewResource[]; nonRemoteDbDataSourceViews: DataSourceViewResource[]}): ServerSideMCPServerConfigurationType {
+  const { view, childAgentId, serverNameOverride } = config;
+
+  const {
+    requiresDataWarehouseConfiguration,
+    requiresDataSourceConfiguration,
+  } = getMCPServerRequirements(view.toJSON());
+
+  let applicableViews: DataSourceViewResource[];
+  if (requiresDataWarehouseConfiguration) {
+    applicableViews = remoteDbDataSourceViews;
+  } else if (requiresDataSourceConfiguration) {
+    applicableViews = nonRemoteDbDataSourceViews;
+  } else {
+    applicableViews = [];
+  }
+
+  const dataSources = applicableViews.map((dsView) => ({
+    dataSourceViewId: dsView.sId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    filter: dsView.toViewFilter(),
+  }));
+
+  return buildServerSideMCPServerConfiguration({
+      mcpServerView: view,
+      dataSources,
+      childAgentId,
+      serverNameOverride,
+    });
+}
+
 export async function getSkillServers(
   auth: Authenticator,
   {
@@ -44,56 +77,19 @@ export async function getSkillServers(
     );
   }
 
-  const remoteDbViews = inheritedDataSourceViews.filter((v) =>
+  const remoteDbDataSourceViews = inheritedDataSourceViews.filter((v) =>
     isRemoteDatabase(v.dataSource)
   );
-  const nonRemoteDbViews = inheritedDataSourceViews.filter(
+  const nonRemoteDbDataSourceViews = inheritedDataSourceViews.filter(
     (v) => !isRemoteDatabase(v.dataSource)
   );
 
-  const systemSkillIds = new Set(systemSkills.map((skill) => skill.sId));
-  const mcpServersWithOrigin = skills.flatMap((skill) =>
-    skill.mcpServerConfigurations.map((config) => {
-      const { view, childAgentId, serverNameOverride } = config;
-
-      const {
-        requiresDataWarehouseConfiguration,
-        requiresDataSourceConfiguration,
-      } = getMCPServerRequirements(view.toJSON());
-
-      let applicableViews: DataSourceViewResource[];
-      if (requiresDataWarehouseConfiguration) {
-        applicableViews = remoteDbViews;
-      } else if (requiresDataSourceConfiguration) {
-        applicableViews = nonRemoteDbViews;
-      } else {
-        applicableViews = [];
-      }
-
-      const dataSources = applicableViews.map((dsView) => ({
-        dataSourceViewId: dsView.sId,
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        filter: dsView.toViewFilter(),
-      }));
-
-      return {
-        server: buildServerSideMCPServerConfiguration({
-          mcpServerView: view,
-          dataSources,
-          childAgentId,
-          serverNameOverride,
-        }),
-        isSystemSkill: systemSkillIds.has(skill.sId),
-      };
-    })
+  const skillServers = enabledSkills.flatMap((skill) =>
+    skill.mcpServerConfigurations.map((config) => skillMCPServerConfigToServerSideConfig(auth, config, {remoteDbDataSourceViews, nonRemoteDbDataSourceViews}))
   );
-
-  const skillServers = mcpServersWithOrigin
-    .filter(({ isSystemSkill }) => !isSystemSkill)
-    .map(({ server }) => server);
-  const systemSkillServers = mcpServersWithOrigin
-    .filter(({ isSystemSkill }) => isSystemSkill)
-    .map(({ server }) => server);
+  const systemSkillServers = systemSkills.flatMap((skill) =>
+    skill.mcpServerConfigurations.map((config) => skillMCPServerConfigToServerSideConfig(auth, config, {remoteDbDataSourceViews, nonRemoteDbDataSourceViews}))
+  );
 
   const {
     documentDataSourceConfigurations,

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -1,5 +1,8 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
-import type {MCPServerConfigurationType, ServerSideMCPServerConfigurationType} from "@app/lib/actions/mcp";
+import type {
+  MCPServerConfigurationType,
+  ServerSideMCPServerConfigurationType,
+} from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
@@ -7,7 +10,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import {type SkillMCPServerConfiguration, SkillResource} from "@app/lib/resources/skill/skill_resource";
+import {
+  type SkillMCPServerConfiguration,
+  SkillResource,
+} from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -22,9 +28,17 @@ type ResolvedSkillMCPServers = {
   systemSkillServers: MCPServerConfigurationType[];
 };
 
-function skillMCPServerConfigToServerSideConfig(auth: Authenticator, config: SkillMCPServerConfiguration, {
-remoteDbDataSourceViews, nonRemoteDbDataSourceViews
-}: {remoteDbDataSourceViews: DataSourceViewResource[]; nonRemoteDbDataSourceViews: DataSourceViewResource[]}): ServerSideMCPServerConfigurationType {
+function skillMCPServerConfigToServerSideConfig(
+  auth: Authenticator,
+  config: SkillMCPServerConfiguration,
+  {
+    remoteDbDataSourceViews,
+    nonRemoteDbDataSourceViews,
+  }: {
+    remoteDbDataSourceViews: DataSourceViewResource[];
+    nonRemoteDbDataSourceViews: DataSourceViewResource[];
+  }
+): ServerSideMCPServerConfigurationType {
   const { view, childAgentId, serverNameOverride } = config;
 
   const {
@@ -48,11 +62,11 @@ remoteDbDataSourceViews, nonRemoteDbDataSourceViews
   }));
 
   return buildServerSideMCPServerConfiguration({
-      mcpServerView: view,
-      dataSources,
-      childAgentId,
-      serverNameOverride,
-    });
+    mcpServerView: view,
+    dataSources,
+    childAgentId,
+    serverNameOverride,
+  });
 }
 
 export async function getSkillServers(
@@ -85,10 +99,20 @@ export async function getSkillServers(
   );
 
   const skillServers = enabledSkills.flatMap((skill) =>
-    skill.mcpServerConfigurations.map((config) => skillMCPServerConfigToServerSideConfig(auth, config, {remoteDbDataSourceViews, nonRemoteDbDataSourceViews}))
+    skill.mcpServerConfigurations.map((config) =>
+      skillMCPServerConfigToServerSideConfig(auth, config, {
+        remoteDbDataSourceViews,
+        nonRemoteDbDataSourceViews,
+      })
+    )
   );
   const systemSkillServers = systemSkills.flatMap((skill) =>
-    skill.mcpServerConfigurations.map((config) => skillMCPServerConfigToServerSideConfig(auth, config, {remoteDbDataSourceViews, nonRemoteDbDataSourceViews}))
+    skill.mcpServerConfigurations.map((config) =>
+      skillMCPServerConfigToServerSideConfig(auth, config, {
+        remoteDbDataSourceViews,
+        nonRemoteDbDataSourceViews,
+      })
+    )
   );
 
   const {

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -1,5 +1,5 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
-import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type {MCPServerConfigurationType, ServerSideMCPServerConfigurationType} from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
@@ -7,7 +7,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import {type SkillMCPServerConfiguration, SkillResource} from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -110,17 +110,20 @@ export async function createSandboxChildAction(
     conversation,
     attachments: [],
   });
-  const { skillServers } = await resolveSkillMCPServers(auth, {
-    agentConfiguration,
-    conversation,
-  });
+  const { skillServers, systemSkillServers } = await resolveSkillMCPServers(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+    }
+  );
 
   const serverConfigs = await disambiguateServerNamesBySpace(
     auth,
     deduplicateMCPServerConfigurations({
       agentActions: agentConfiguration.actions,
       clientSideActions: [],
-      skillServers,
+      skillServers: [...systemSkillServers, ...skillServers],
       jitServers,
     })
   );

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -110,7 +110,7 @@ export async function createSandboxChildAction(
     conversation,
     attachments: [],
   });
-  const skillServers = await resolveSkillMCPServers(auth, {
+  const { skillServers } = await resolveSkillMCPServers(auth, {
     agentConfiguration,
     conversation,
   });

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -107,9 +107,10 @@ makeScript(
         conversation,
       });
 
-    const skillServers = await getSkillServers(auth, {
+    const { skillServers, systemSkillServers } = await getSkillServers(auth, {
       agentConfiguration,
-      skills: [...systemSkills, ...enabledSkills],
+      enabledSkills,
+      systemSkills,
     });
 
     const clientSideMCPActionConfigurations =
@@ -156,7 +157,7 @@ makeScript(
         agentMessage: placeholderAgentMessage,
         clientSideActionConfigurations: clientSideMCPActionConfigurations,
       },
-      { jitServers, skillServers }
+      { jitServers, skillServers, systemSkillServers }
     );
 
     const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -173,9 +173,10 @@ async function listAvailableTools(
     runAgentData
   );
 
-  const skillServers = await getSkillServers(auth, {
+  const { skillServers, systemSkillServers } = await getSkillServers(auth, {
     agentConfiguration,
-    skills: [...systemSkills, ...enabledSkills],
+    enabledSkills,
+    systemSkills,
   });
 
   const mcpActions = await tryListMCPTools(
@@ -189,6 +190,7 @@ async function listAvailableTools(
     {
       jitServers,
       skillServers,
+      systemSkillServers,
     }
   );
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -450,9 +450,10 @@ export async function runModel(
     const { enabledSkills, systemSkills, equippedSkills } =
       await SkillResource.listForAgentLoop(auth, runAgentData);
 
-    const skillServers = await getSkillServers(auth, {
+    const { skillServers, systemSkillServers } = await getSkillServers(auth, {
       agentConfiguration,
-      skills: [...systemSkills, ...enabledSkills],
+      enabledSkills,
+      systemSkills,
     });
 
     const serverToolsAndInstructions = await startActiveObservation(
@@ -466,7 +467,7 @@ export async function runModel(
             agentMessage,
             clientSideActionConfigurations: clientSideMCPActionConfigurations,
           },
-          { jitServers, skillServers }
+          { jitServers, skillServers, systemSkillServers }
         )
     );
 


### PR DESCRIPTION
## Description

Tools exposed through skills are deferred by clearing `eager`, even when their tool metadata marks them eager. System skills should be exempt from that behavior.

This PR keeps system-skill server keys out of the `isFromSkillServer` classification used to clear `eager`. Regular skill-only tools remain deferred, and system origin wins when the same server is exposed by both a system skill and an enabled skill.

## Tests

- Updated existing testts.

## Risk

- Low.

## Deploy Plan

- Deploy front.
