### PR TITLE
[front] fix: restore skill description tooltips in slash menu

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownTooltipTrigger,
   LoadingBlock,
   ShapesPlus,
 } from "@dust-tt/sparkle";
@@ -146,14 +147,24 @@ function CapabilitiesPickerItemsList({
             label={item.label}
             description={item.description}
             truncateText
-            tooltip={item.kind === "skill" ? item.description : undefined}
             endComponent={endComponent}
             className="group"
             onClick={() => onItemSelect(item)}
           />
         );
 
-        return menuItem;
+        return item.kind === "skill" && item.description ? (
+          <DropdownTooltipTrigger
+            key={item.id}
+            description={item.description}
+            side="right"
+            sideOffset={8}
+          >
+            {menuItem}
+          </DropdownTooltipTrigger>
+        ) : (
+          menuItem
+        );
       })}
     </div>
   );

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownTooltipTrigger,
   LoadingBlock,
   ShapesPlus,
 } from "@dust-tt/sparkle";
@@ -138,7 +139,7 @@ function CapabilitiesPickerItemsList({
             />
           );
 
-        return (
+        const menuItem = (
           <DropdownMenuItem
             key={item.id}
             icon={item.icon}
@@ -150,6 +151,19 @@ function CapabilitiesPickerItemsList({
             className="group"
             onClick={() => onItemSelect(item)}
           />
+        );
+
+        return item.kind === "skill" && item.description ? (
+          <DropdownTooltipTrigger
+            key={item.id}
+            description={item.description}
+            side="right"
+            sideOffset={8}
+          >
+            {menuItem}
+          </DropdownTooltipTrigger>
+        ) : (
+          menuItem
         );
       })}
     </div>

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -41,7 +41,6 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  DropdownTooltipTrigger,
   LoadingBlock,
   ShapesPlus,
 } from "@dust-tt/sparkle";
@@ -147,24 +146,14 @@ function CapabilitiesPickerItemsList({
             label={item.label}
             description={item.description}
             truncateText
+            tooltip={item.kind === "skill" ? item.description : undefined}
             endComponent={endComponent}
             className="group"
             onClick={() => onItemSelect(item)}
           />
         );
 
-        return item.kind === "skill" && item.description ? (
-          <DropdownTooltipTrigger
-            key={item.id}
-            description={item.description}
-            side="right"
-            sideOffset={8}
-          >
-            {menuItem}
-          </DropdownTooltipTrigger>
-        ) : (
-          menuItem
-        );
+        return menuItem;
       })}
     </div>
   );

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -174,6 +174,9 @@ describe("getSkillSlashCommandItem", () => {
       hasDetails: true,
       id: "skill_create_memo",
       label: "Create memo",
+      tooltip: {
+        description: "Draft structured memos.",
+      },
     });
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -151,6 +151,9 @@ export function getSkillSlashCommandItem(
     icon: () => React.createElement(getSkillAvatarIcon(skill)),
     id: skill.sId,
     label: skill.name,
+    tooltip: skill.userFacingDescription
+      ? { description: skill.userFacingDescription }
+      : undefined,
   };
 }
 

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
@@ -30,10 +30,13 @@ describe("SlashCommandDropdown", () => {
       fireEvent.pointerMove(screen.getByRole("menuitem"), {
         pointerType: "mouse",
       });
-      await new Promise((resolve) => setTimeout(resolve, 350));
+      await new Promise((resolve) => setTimeout(resolve, 750));
     });
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Full skill description"
+    );
+    expect(document.querySelector('[data-side="right"]')).toHaveTextContent(
       "Full skill description"
     );
   });

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 describe("SlashCommandDropdown", () => {
-  it("shows an item tooltip when pointer highlighting prevents the default event", async () => {
+  it("shows an item tooltip on hover", async () => {
     render(
       <SlashCommandDropdown
         clientRect={() => new DOMRect(100, 200, 10, 20)}
@@ -30,7 +30,7 @@ describe("SlashCommandDropdown", () => {
       fireEvent.pointerMove(screen.getByRole("menuitem"), {
         pointerType: "mouse",
       });
-      await new Promise((resolve) => setTimeout(resolve, 750));
+      await new Promise((resolve) => setTimeout(resolve, 350));
     });
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.test.tsx
@@ -1,0 +1,40 @@
+import { SlashCommandDropdown } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("SlashCommandDropdown", () => {
+  it("shows an item tooltip when pointer highlighting prevents the default event", async () => {
+    render(
+      <SlashCommandDropdown
+        clientRect={() => new DOMRect(100, 200, 10, 20)}
+        command={vi.fn()}
+        sections={[
+          {
+            label: "Capabilities",
+            items: [
+              {
+                action: "select-skill",
+                description: "Short description",
+                icon: () => null,
+                id: "skill-1",
+                label: "Test skill",
+                tooltip: { description: "Full skill description" },
+              },
+            ],
+          },
+        ]}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.pointerMove(screen.getByRole("menuitem"), {
+        pointerType: "mouse",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Full skill description"
+    );
+  });
+});

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -324,11 +324,7 @@ export const SlashCommandDropdown = forwardRef<
                   truncateText
                   endComponent={<DropdownMenuShortcut shortcut="Esc" />}
                   onClick={() => selectEntry(0)}
-                  onPointerMove={(event) => {
-                    event.preventDefault();
-                    setSelectedIndex(0);
-                  }}
-                  onPointerLeave={(event) => event.preventDefault()}
+                  onFocus={() => setSelectedIndex(0)}
                   className={cn(
                     "text-muted-foreground [&_span]:text-xs",
                     selectedIndex === 0 &&
@@ -349,6 +345,11 @@ export const SlashCommandDropdown = forwardRef<
                         label={item.label}
                         description={item.description}
                         truncateText
+                        tooltip={
+                          item.tooltip?.media
+                            ? undefined
+                            : item.tooltip?.description
+                        }
                         endComponent={
                           canShowDetails ? (
                             <Button
@@ -368,11 +369,7 @@ export const SlashCommandDropdown = forwardRef<
                           ) : undefined
                         }
                         onClick={() => selectEntry(index)}
-                        onPointerMove={(e) => {
-                          e.preventDefault();
-                          setSelectedIndex(index);
-                        }}
-                        onPointerLeave={(e) => e.preventDefault()}
+                        onFocus={() => setSelectedIndex(index)}
                         className={cn(
                           "group",
                           index === selectedIndex &&
@@ -381,7 +378,7 @@ export const SlashCommandDropdown = forwardRef<
                       />
                     );
 
-                    const itemContent = item.tooltip ? (
+                    const itemContent = item.tooltip?.media ? (
                       <DropdownTooltipTrigger
                         description={item.tooltip.description}
                         media={item.tooltip.media}
@@ -441,6 +438,11 @@ export const SlashCommandDropdown = forwardRef<
                       label={item.label}
                       description={item.description}
                       truncateText
+                      tooltip={
+                        item.tooltip?.media
+                          ? undefined
+                          : item.tooltip?.description
+                      }
                       endComponent={
                         canShowDetails ? (
                           <Button
@@ -460,11 +462,7 @@ export const SlashCommandDropdown = forwardRef<
                         ) : undefined
                       }
                       onClick={() => selectEntry(entryIndex)}
-                      onPointerMove={(e) => {
-                        e.preventDefault();
-                        setSelectedIndex(entryIndex);
-                      }}
-                      onPointerLeave={(e) => e.preventDefault()}
+                      onFocus={() => setSelectedIndex(entryIndex)}
                       className={cn(
                         "group",
                         entryIndex === selectedIndex &&
@@ -473,7 +471,7 @@ export const SlashCommandDropdown = forwardRef<
                     />
                   );
 
-                  const itemContent = item.tooltip ? (
+                  const itemContent = item.tooltip?.media ? (
                     <DropdownTooltipTrigger
                       description={item.tooltip.description}
                       media={item.tooltip.media}

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -345,11 +345,6 @@ export const SlashCommandDropdown = forwardRef<
                         label={item.label}
                         description={item.description}
                         truncateText
-                        tooltip={
-                          item.tooltip?.media
-                            ? undefined
-                            : item.tooltip?.description
-                        }
                         endComponent={
                           canShowDetails ? (
                             <Button
@@ -378,7 +373,7 @@ export const SlashCommandDropdown = forwardRef<
                       />
                     );
 
-                    const itemContent = item.tooltip?.media ? (
+                    const itemContent = item.tooltip ? (
                       <DropdownTooltipTrigger
                         description={item.tooltip.description}
                         media={item.tooltip.media}
@@ -438,11 +433,6 @@ export const SlashCommandDropdown = forwardRef<
                       label={item.label}
                       description={item.description}
                       truncateText
-                      tooltip={
-                        item.tooltip?.media
-                          ? undefined
-                          : item.tooltip?.description
-                      }
                       endComponent={
                         canShowDetails ? (
                           <Button
@@ -471,7 +461,7 @@ export const SlashCommandDropdown = forwardRef<
                     />
                   );
 
-                  const itemContent = item.tooltip?.media ? (
+                  const itemContent = item.tooltip ? (
                     <DropdownTooltipTrigger
                       description={item.tooltip.description}
                       media={item.tooltip.media}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -999,6 +999,8 @@ const DropdownMenuFilters = React.forwardRef(DropdownMenuFiltersInner) as {
 DropdownMenuFilters.displayName = "DropdownMenuFilters";
 
 // DropdownTooltip: Simple tooltip with consistent layout: optional media at top, description below.
+const DROPDOWN_TOOLTIP_DELAY_MS = 700;
+
 export interface DropdownTooltipProps {
   description: string;
   media?: React.ReactNode;
@@ -1047,6 +1049,9 @@ const DropdownTooltipTrigger = React.forwardRef<
     ref
   ) => {
     const [isOpen, setIsOpen] = React.useState(false);
+    const openTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
 
     const handleOpenChange = React.useCallback(
       (open: boolean) => {
@@ -1054,6 +1059,15 @@ const DropdownTooltipTrigger = React.forwardRef<
         onVisibilityChange?.(open);
       },
       [onVisibilityChange]
+    );
+
+    React.useEffect(
+      () => () => {
+        if (openTimerRef.current) {
+          clearTimeout(openTimerRef.current);
+        }
+      },
+      []
     );
 
     React.useEffect(() => {
@@ -1091,9 +1105,43 @@ const DropdownTooltipTrigger = React.forwardRef<
     const container = useSheetContainer(mountPortalContainer);
 
     return (
-      <TooltipPrimitive.Provider delayDuration={700}>
+      <TooltipPrimitive.Provider delayDuration={DROPDOWN_TOOLTIP_DELAY_MS}>
         <TooltipPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
-          <TooltipPrimitive.Trigger asChild className={className} ref={ref}>
+          <TooltipPrimitive.Trigger
+            asChild
+            className={className}
+            ref={ref}
+            onPointerLeave={(event) => {
+              if (!event.defaultPrevented) {
+                return;
+              }
+
+              if (openTimerRef.current) {
+                clearTimeout(openTimerRef.current);
+                openTimerRef.current = null;
+              }
+              if (isOpen) {
+                handleOpenChange(false);
+              }
+            }}
+            onPointerMove={(event) => {
+              // Slash rows prevent pointer events to preserve editor focus. Radix skips its
+              // tooltip handler in that case, so preserve the same delayed open explicitly.
+              if (
+                event.pointerType === "touch" ||
+                !event.defaultPrevented ||
+                isOpen ||
+                openTimerRef.current
+              ) {
+                return;
+              }
+
+              openTimerRef.current = setTimeout(() => {
+                openTimerRef.current = null;
+                handleOpenChange(true);
+              }, DROPDOWN_TOOLTIP_DELAY_MS);
+            }}
+          >
             {/* Wrapper allows pointer events even when child is disabled, while maintaining proper positioning */}
             <span className="block w-full">{children}</span>
           </TooltipPrimitive.Trigger>

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -999,8 +999,6 @@ const DropdownMenuFilters = React.forwardRef(DropdownMenuFiltersInner) as {
 DropdownMenuFilters.displayName = "DropdownMenuFilters";
 
 // DropdownTooltip: Simple tooltip with consistent layout: optional media at top, description below.
-const DROPDOWN_TOOLTIP_DELAY_MS = 700;
-
 export interface DropdownTooltipProps {
   description: string;
   media?: React.ReactNode;
@@ -1049,9 +1047,6 @@ const DropdownTooltipTrigger = React.forwardRef<
     ref
   ) => {
     const [isOpen, setIsOpen] = React.useState(false);
-    const openTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-      null
-    );
 
     const handleOpenChange = React.useCallback(
       (open: boolean) => {
@@ -1059,15 +1054,6 @@ const DropdownTooltipTrigger = React.forwardRef<
         onVisibilityChange?.(open);
       },
       [onVisibilityChange]
-    );
-
-    React.useEffect(
-      () => () => {
-        if (openTimerRef.current) {
-          clearTimeout(openTimerRef.current);
-        }
-      },
-      []
     );
 
     React.useEffect(() => {
@@ -1105,43 +1091,9 @@ const DropdownTooltipTrigger = React.forwardRef<
     const container = useSheetContainer(mountPortalContainer);
 
     return (
-      <TooltipPrimitive.Provider delayDuration={DROPDOWN_TOOLTIP_DELAY_MS}>
+      <TooltipPrimitive.Provider delayDuration={700}>
         <TooltipPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
-          <TooltipPrimitive.Trigger
-            asChild
-            className={className}
-            ref={ref}
-            onPointerLeave={(event) => {
-              if (!event.defaultPrevented) {
-                return;
-              }
-
-              if (openTimerRef.current) {
-                clearTimeout(openTimerRef.current);
-                openTimerRef.current = null;
-              }
-              if (isOpen) {
-                handleOpenChange(false);
-              }
-            }}
-            onPointerMove={(event) => {
-              // Slash rows prevent pointer events to preserve editor focus. Radix skips its
-              // tooltip handler in that case, so preserve the same delayed open explicitly.
-              if (
-                event.pointerType === "touch" ||
-                !event.defaultPrevented ||
-                isOpen ||
-                openTimerRef.current
-              ) {
-                return;
-              }
-
-              openTimerRef.current = setTimeout(() => {
-                openTimerRef.current = null;
-                handleOpenChange(true);
-              }, DROPDOWN_TOOLTIP_DELAY_MS);
-            }}
-          >
+          <TooltipPrimitive.Trigger asChild className={className} ref={ref}>
             {/* Wrapper allows pointer events even when child is disabled, while maintaining proper positioning */}
             <span className="block w-full">{children}</span>
           </TooltipPrimitive.Trigger>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9422

Skill descriptions stopped appearing in hover tooltips in the slash menu, leaving the truncated row text and details sheet as the only ways to read them.

This PR restores the existing dropdown tooltip for skill items by passing the user-facing description through the shared slash-command item. Tool items and the existing “…” details action are unchanged.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
