### PR TITLE
feat(analytics): index agent tag ids

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -15,6 +15,9 @@
     "agent_version": {
       "type": "keyword"
     },
+    "agent_tag_ids": {
+      "type": "keyword"
+    },
     "ancestor_message_ids": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260709_add_agent_tag_ids_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260709_add_agent_tag_ids_to_agent_message_analytics_2.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "agent_tag_ids": {
+      "type": "keyword"
+    }
+  }
+}

--- a/front/lib/resources/tags_resource.test.ts
+++ b/front/lib/resources/tags_resource.test.ts
@@ -1,0 +1,100 @@
+import type { Authenticator } from "@app/lib/auth";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TagFactory } from "@app/tests/utils/TagFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("TagResource", () => {
+  let workspace: LightWorkspaceType;
+  let authenticator: Authenticator;
+
+  beforeEach(async () => {
+    const testSetup = await createResourceTest({ role: "admin" });
+    workspace = testSetup.workspace;
+    authenticator = testSetup.authenticator;
+  });
+
+  describe("listForAgentVersion", () => {
+    it("returns the tags attached to a given agent version", async () => {
+      const agent =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const tag1 = await TagFactory.create(workspace, { name: "tag-1" });
+      const tag2 = await TagFactory.create(workspace, { name: "tag-2" });
+      await tag1.addToAgent(authenticator, agent);
+      await tag2.addToAgent(authenticator, agent);
+
+      const tags = await TagResource.listForAgentVersion(
+        authenticator,
+        agent.sId,
+        agent.version
+      );
+
+      expect(tags.map((t) => t.sId).sort()).toEqual(
+        [tag1.sId, tag2.sId].sort()
+      );
+    });
+
+    it("returns an empty array when the agent version has no tags", async () => {
+      const agent =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const tags = await TagResource.listForAgentVersion(
+        authenticator,
+        agent.sId,
+        agent.version
+      );
+
+      expect(tags).toEqual([]);
+    });
+
+    it("only returns the tags attached to the requested version", async () => {
+      const agent =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+      const tagV0 = await TagFactory.create(workspace, { name: "tag-v0" });
+      await tagV0.addToAgent(authenticator, agent);
+
+      const updatedAgent = await AgentConfigurationFactory.updateTestAgent(
+        authenticator,
+        agent.sId
+      );
+      const tagV1 = await TagFactory.create(workspace, { name: "tag-v1" });
+      await tagV1.addToAgent(authenticator, updatedAgent);
+
+      expect(updatedAgent.version).not.toBe(agent.version);
+
+      const tagsV0 = await TagResource.listForAgentVersion(
+        authenticator,
+        agent.sId,
+        agent.version
+      );
+      const tagsV1 = await TagResource.listForAgentVersion(
+        authenticator,
+        updatedAgent.sId,
+        updatedAgent.version
+      );
+
+      expect(tagsV0.map((t) => t.sId)).toEqual([tagV0.sId]);
+      expect(tagsV1.map((t) => t.sId)).toEqual([tagV1.sId]);
+    });
+
+    it("does not return tags from another workspace", async () => {
+      const agent =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+      const tag = await TagFactory.create(workspace, { name: "tag" });
+      await tag.addToAgent(authenticator, agent);
+
+      const otherSetup = await createResourceTest({ role: "admin" });
+
+      const tags = await TagResource.listForAgentVersion(
+        otherSetup.authenticator,
+        agent.sId,
+        agent.version
+      );
+
+      expect(tags).toEqual([]);
+    });
+  });
+});

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TagModel } from "@app/lib/models/tags";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -218,6 +219,43 @@ export class TagResource extends BaseResource<TagModel> {
     return mapValues(groupBy(tagAgents, "agentConfigurationId"), (group) =>
       group.map((tagAgent) => tagsMap[tagAgent.tagId])
     );
+  }
+
+  /**
+   * List the tags attached to a specific agent configuration version, identified
+   * by its sId and version.
+   */
+  static async listForAgentVersion(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    agentConfigurationVersion: number
+  ): Promise<TagResource[]> {
+    const tagAgents = await TagAgentModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [
+        {
+          model: AgentConfigurationModel,
+          required: true,
+          attributes: [],
+          where: {
+            sId: agentConfigurationId,
+            version: agentConfigurationVersion,
+          },
+        },
+      ],
+    });
+
+    if (tagAgents.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      where: {
+        id: tagAgents.map((tagAgent) => tagAgent.tagId),
+      },
+    });
   }
 
   async addToAgent(

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -100,6 +100,7 @@ async function seedProgrammaticUsage(
     const document: AgentMessageAnalyticsData = {
       agent_id: `seed-agent-${i % AGENT_COUNT}`,
       agent_version: "1",
+      agent_tag_ids: [],
       ancestor_message_ids: [],
       conversation_id: `seed-conv-${i}`,
       cost: {

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -120,6 +120,7 @@ export async function seedAnalytics(
     const document: AgentMessageAnalyticsData = {
       agent_id: agentMessage.agentConfigurationId,
       agent_version: agentMessage.agentConfigurationVersion.toString(),
+      agent_tag_ids: [],
       ancestor_message_ids: [],
       conversation_id: conversationId,
       cost: {

--- a/front/temporal/analytics_queue/activities.test.ts
+++ b/front/temporal/analytics_queue/activities.test.ts
@@ -1,0 +1,235 @@
+import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+
+import type { Authenticator } from "@app/lib/auth";
+import { storeAgentAnalyticsActivity } from "@app/temporal/analytics_queue/activities";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TagFactory } from "@app/tests/utils/TagFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep the DB and resources real; only stub the Elasticsearch boundary so we can
+// capture the document that would be indexed without depending on a live cluster.
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, withEs: vi.fn() };
+});
+
+/**
+ * Wire `withEs` to run its callback against a stub client that records every
+ * `index` call, and return the array of captured params.
+ */
+function captureIndexedDocs(): Array<{ index: string; id: string; body: any }> {
+  const indexed: Array<{ index: string; id: string; body: any }> = [];
+  vi.mocked(withEs).mockImplementation(async (fn: any) => {
+    const client = {
+      index: async (params: any) => {
+        indexed.push(params);
+        return {};
+      },
+      bulk: async () => ({}),
+      update: async () => ({}),
+    };
+    return new Ok(await fn(client));
+  });
+  return indexed;
+}
+
+function analyticsDoc(
+  indexed: Array<{ index: string; body: any }>
+): Record<string, any> | undefined {
+  return indexed.find((p) => p.index === ANALYTICS_ALIAS_NAME)?.body;
+}
+
+/**
+ * Create a conversation with a user message and an agent message pinned to the
+ * given agent configuration id/version, and return the sIds needed to run the
+ * analytics activity.
+ */
+async function seedMessages(
+  auth: Authenticator,
+  {
+    agentConfigurationId,
+    agentConfigurationVersion,
+  }: {
+    agentConfigurationId: string;
+    agentConfigurationVersion: number;
+  }
+): Promise<{
+  conversationSId: string;
+  userMessageId: string;
+  agentMessageId: string;
+}> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId,
+    messagesCreatedAt: [],
+  });
+
+  const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+    auth,
+    workspace,
+    conversationId: conversation.id,
+    rank: 0,
+    content: "Hello",
+  });
+
+  const agentMessageRow = await ConversationFactory.createAgentMessageWithRank({
+    workspace,
+    conversationId: conversation.id,
+    rank: 1,
+    agentConfigurationId,
+    agentConfigurationVersion,
+  });
+
+  return {
+    conversationSId: conversation.sId,
+    userMessageId: userMessageRow.sId,
+    agentMessageId: agentMessageRow.sId,
+  };
+}
+
+async function runAnalytics(
+  auth: Authenticator,
+  {
+    conversationSId,
+    agentMessageId,
+    userMessageId,
+  }: { conversationSId: string; agentMessageId: string; userMessageId: string }
+): Promise<void> {
+  await storeAgentAnalyticsActivity(auth.toJSON(), {
+    agentLoopArgs: {
+      agentMessageId,
+      agentMessageVersion: 0,
+      conversationId: conversationSId,
+      conversationTitle: null,
+      conversationBranchId: null,
+      userMessageId,
+      userMessageVersion: 0,
+    },
+  });
+}
+
+describe("storeAgentAnalyticsActivity - agent_tag_ids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stamps the agent's tag sIds onto the analytics document", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const tag = await TagFactory.create(auth.getNonNullableWorkspace(), {
+      name: "post-sales",
+    });
+    await tag.addToAgent(auth, agent);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc).toBeDefined();
+    expect(doc?.agent_id).toBe(agent.sId);
+    expect(doc?.agent_tag_ids).toEqual([tag.sId]);
+  });
+
+  it("stamps all tag sIds when the agent has multiple tags", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const workspace = auth.getNonNullableWorkspace();
+    const tagA = await TagFactory.create(workspace, { name: "post-sales" });
+    const tagB = await TagFactory.create(workspace, { name: "help-center" });
+    await tagA.addToAgent(auth, agent);
+    await tagB.addToAgent(auth, agent);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc?.agent_tag_ids).toHaveLength(2);
+    expect([...doc!.agent_tag_ids].sort()).toEqual([tagA.sId, tagB.sId].sort());
+  });
+
+  it("stamps an empty array when the agent has no tags", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    expect(analyticsDoc(indexed)?.agent_tag_ids).toEqual([]);
+  });
+
+  it("stamps an empty array for global agents", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.HELPER,
+      agentConfigurationVersion: 0,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc?.agent_id).toBe(GLOBAL_AGENTS_SID.HELPER);
+    expect(doc?.agent_tag_ids).toEqual([]);
+  });
+
+  it("reflects the tags from the agent version that produced the message", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    // v0 has one tag.
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const tag = await TagFactory.create(auth.getNonNullableWorkspace(), {
+      name: "post-sales",
+    });
+    await tag.addToAgent(auth, agent);
+
+    // Bump to v1, which is created without tags.
+    const updated = await AgentConfigurationFactory.updateTestAgent(
+      auth,
+      agent.sId
+    );
+    expect(updated.version).toBeGreaterThan(agent.version);
+
+    // A message pinned to v0 still resolves v0's tags.
+    const seededV0 = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+    let indexed = captureIndexedDocs();
+    await runAnalytics(auth, seededV0);
+    expect(analyticsDoc(indexed)?.agent_tag_ids).toEqual([tag.sId]);
+
+    // A message pinned to v1 resolves v1's (empty) tags.
+    const seededV1 = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: updated.version,
+    });
+    indexed = captureIndexedDocs();
+    await runAnalytics(auth, seededV1);
+    expect(analyticsDoc(indexed)?.agent_tag_ids).toEqual([]);
+  });
+});

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -22,6 +22,7 @@ import {
   intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromAction,
 } from "@app/lib/metronome/events";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
   AgentMessageModel,
@@ -45,6 +46,7 @@ import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shar
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { makeSId } from "@app/lib/resources/string_ids";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import logger from "@app/logger/logger";
 import type {
   AgentLoopArgs,
@@ -206,6 +208,10 @@ export async function storeAgentAnalytics(
     contextOrigin
   );
 
+  // Collect the agent's tag ids at message time.
+  // NOTE: may not be stable over time, see `collectAgentTagIds` for details.
+  const agentTagIds = await collectAgentTagIds(auth, agentAgentMessageRow);
+
   const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
     runUsages,
     contextOrigin
@@ -248,6 +254,7 @@ export async function storeAgentAnalytics(
   const document: AgentMessageAnalyticsData = {
     agent_id: agentAgentMessageRow.agentConfigurationId,
     agent_version: agentAgentMessageRow.agentConfigurationVersion.toString(),
+    agent_tag_ids: agentTagIds,
     ancestor_message_ids: ancestorMessageIds,
     conversation_id: conversationRow.sId,
     cost,
@@ -401,6 +408,48 @@ async function collectToolUsageFromMessage(
       cost_awu,
     };
   });
+}
+
+/**
+ * Collect the tag ids attached to the agent configuration version that
+ * produced this message. Tags are stored per agent-configuration version, so we
+ * resolve the exact version to capture the agent's tags at message time. Global
+ * agents are code-defined and have no DB-backed tags.
+ *
+ * NOTE: there are several ways to edit agent tags, which creates a discrepancy:
+ *  - if a tag is added/removed through the route `w/{Id}/assistant/agent_configurations/{sId}/tags`,
+ *    the tag_agents model is updated and no new agent_configuration version is created.
+ *  - if a tag is added/removed through the route `w/{Id}/assistant/agent_configurations/{sId}`,
+ *    the agent_configuration version is bumped and the tag_agents model is updated.
+ * It results that we can loose the history of tags for a given agent_configuration version if the first
+ * route is used.
+ */
+async function collectAgentTagIds(
+  auth: Authenticator,
+  agentAgentMessageRow: AgentMessageModel
+): Promise<string[]> {
+  const { agentConfigurationId, agentConfigurationVersion } =
+    agentAgentMessageRow;
+
+  if (isGlobalAgentId(agentConfigurationId)) {
+    return [];
+  }
+
+  const agentConfiguration = await AgentConfigurationModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      sId: agentConfigurationId,
+      version: agentConfigurationVersion,
+    },
+    attributes: ["id"],
+  });
+
+  if (!agentConfiguration) {
+    return [];
+  }
+
+  const tags = await TagResource.listForAgent(auth, agentConfiguration.id);
+  return tags.map((tag) => tag.sId);
 }
 
 /**

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -22,7 +22,6 @@ import {
   intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromAction,
 } from "@app/lib/metronome/events";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
   AgentMessageModel,
@@ -435,20 +434,12 @@ async function collectAgentTagIds(
     return [];
   }
 
-  const agentConfiguration = await AgentConfigurationModel.findOne({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      sId: agentConfigurationId,
-      version: agentConfigurationVersion,
-    },
-    attributes: ["id"],
-  });
+  const tags = await TagResource.listForAgentVersion(
+    auth,
+    agentConfigurationId,
+    agentConfigurationVersion
+  );
 
-  if (!agentConfiguration) {
-    return [];
-  }
-
-  const tags = await TagResource.listForAgent(auth, agentConfiguration.id);
   return tags.map((tag) => tag.sId);
 }
 

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -52,6 +52,9 @@ export interface AgentMessageAnalyticsSkillUsed {
 export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_id: string;
   agent_version: string;
+  // Tag sIds attached to the agent configuration version that produced this
+  // message, captured at index time (reflects the agent's tags at message time).
+  agent_tag_ids: string[];
   ancestor_message_ids: string[];
   conversation_id: string;
   cost: AgentMessageAnalyticsCost;


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/8167

Adds an `agent_tag_ids` field to the `front.agent_message_analytics` Elasticsearch
index so analytics can be sliced/aggregated by agent tag (e.g. "message volume
across all agents tagged `post-sales).

## Tests
- added tests
- checked locally that ES index is populated with the tags ids, e.g
```
GET front.agent_message_analytics/_search
{
  "size": 5,
  "sort": [{ "timestamp": "desc" }],
  "query": { "exists": { "field": "agent_tag_ids" } },
  "_source": ["message_id","agent_id","agent_version","agent_tag_ids","timestamp"]
}
```

## Deploy Plan

1. apply ES migration
2. merge & deploy
