### PR TITLE
Enforce sandbox function tool stakes

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -6,7 +6,18 @@ import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/t
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...actual,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+  };
+});
 
 vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
   const actual =
@@ -16,6 +27,9 @@ vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
     launchSandboxFunctionToolWorkflow: vi.fn(async () => new Ok(undefined)),
   };
 });
+
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
 
 function callSandboxTool(
   workspace: { sId: string },
@@ -48,6 +62,10 @@ async function setupWithView() {
 }
 
 describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("creates a running action and launches its workflow", async () => {
     const { auth, token, workspace, invocation, view } = await setupWithView();
 
@@ -72,6 +90,13 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     expect(action?.inputs).toEqual({ max: 10 });
     expect(action?.sandboxFunctionInvocationId).toBe(invocation.id);
     expect(action?.toolConfiguration.permission).toBe("never_ask");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledWith(
+      expect.anything(),
+      { action: expect.objectContaining({ sId: action?.sId }) }
+    );
+    expect(
+      vi.mocked(publishSandboxFunctionInvocationEvent)
+    ).not.toHaveBeenCalled();
   });
 
   it("returns 404 for an unknown server view", async () => {
@@ -87,7 +112,7 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     expect(response.status).toBe(404);
   });
 
-  it("creates actions for remote tools", async () => {
+  it("blocks high-stake tools and publishes an approval event", async () => {
     const context =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
     const remoteServer = await RemoteMCPServerFactory.create(context.workspace);
@@ -107,12 +132,29 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     const body = await response.json();
     expect(body.status).toBe("pending");
 
-    // The stake is snapshotted but not enforced: remote tools default to high and still run.
     const action = await SandboxFunctionMCPActionResource.fetchById(
       context.auth,
       body.actionId
     );
     expect(action?.toolConfiguration.permission).toBe("high");
+    expect(action?.status).toBe("blocked_validation_required");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
+    expect(
+      vi.mocked(publishSandboxFunctionInvocationEvent)
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "tool_approve_execution",
+        actionId: action?.sId,
+        sandboxFunctionId: context.sandboxFunction.sId,
+        invocationId: context.invocation.sId,
+        stake: "high",
+        inputs: {},
+        metadata: expect.objectContaining({
+          toolName: "tool",
+        }),
+      }),
+      { invocationId: context.invocation.sId }
+    );
   });
 
   it("creates actions for conversation-coupled servers too", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -37,9 +37,9 @@ app.post(
       arguments: toolArgs,
     } = ctx.req.valid("json");
 
-    // Sandbox function invocations have no conversation: the action is persisted on the
-    // invocation and executed by a dedicated workflow. The sandbox is never paused (function
-    // invocations are blocking execs) so the response can be returned directly.
+    // Sandbox function invocations have no conversation: the action and any approval event are
+    // scoped to the invocation. The sandbox is never paused (function invocations are blocking
+    // execs), so the response can be returned directly.
     if (isSandboxFunctionInvocationTokenPayload(claims)) {
       const result = await createSandboxFunctionMCPAction(auth, {
         sandboxFunctionId: claims.sandboxFunctionId,

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -1,7 +1,11 @@
 import type { ServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT } from "@app/lib/actions/mcp";
 import { buildToolConfigurationsFromRawTools } from "@app/lib/actions/mcp_actions";
+import type { SandboxFunctionMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
+import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -11,6 +15,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import omit from "lodash/omit";
 
 export class SandboxFunctionMCPActionError extends Error {
@@ -26,11 +31,8 @@ export class SandboxFunctionMCPActionError extends Error {
   }
 }
 
-// Resolves a tool for execution from a sandbox function invocation: the tool must exist and be
-// enabled. The tool's stake is snapshotted but not enforced yet: tools execute regardless of it.
-// TODO(2026-07-09 SANDBOX_FUNCTIONS): bubble approval events up from the frame instead, honoring
-// stakes (gated on invocation durability). Tools that need an agent-loop context error at
-// execution based on the run context.
+// Resolves a tool for execution from a sandbox function invocation. The tool must exist and be
+// enabled. Tools that need an agent-loop context error at execution based on the run context.
 async function resolveSandboxFunctionTool(
   auth: Authenticator,
   view: MCPServerViewResource,
@@ -100,7 +102,8 @@ async function resolveSandboxFunctionTool(
 
 /**
  * Creates a sandbox function MCP action (code running inside a sandbox function invocation
- * calling an MCP tool through the public sandbox API) and launches its execution workflow.
+ * calling an MCP tool through the public sandbox API). The workflow is launched immediately when
+ * the tool does not require approval; otherwise an approval event is published to the invocation.
  */
 export async function createSandboxFunctionMCPAction(
   auth: Authenticator,
@@ -181,18 +184,60 @@ export async function createSandboxFunctionMCPAction(
     );
   }
 
+  const toolConfiguration = toolConfigurationRes.value;
+  const { status: executionStatus } = await getExecutionStatusFromConfig(auth, {
+    actionConfiguration: toolConfiguration,
+  });
+
+  let actionStatus: "running" | "blocked_validation_required";
+  switch (executionStatus) {
+    case "ready_allowed_implicitly":
+      actionStatus = "running";
+      break;
+    case "blocked_validation_required":
+      actionStatus = "blocked_validation_required";
+      break;
+    default:
+      assertNever(executionStatus);
+  }
+
   const action = await SandboxFunctionMCPActionResource.makeNew(auth, {
     invocation,
     mcpServerView: view,
     toolName,
     inputs: rawInputs,
     toolConfiguration: omit(
-      toolConfigurationRes.value,
+      toolConfiguration,
       MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
     ),
+    status: actionStatus,
   });
 
-  await launchSandboxFunctionToolWorkflow(auth, { action });
+  switch (actionStatus) {
+    case "running":
+      await launchSandboxFunctionToolWorkflow(auth, { action });
+      break;
+    case "blocked_validation_required": {
+      const approvalEventBase = await makeMCPApproveExecutionEventBase(auth, {
+        actionId: action.sId,
+        toolConfiguration,
+        inputs: rawInputs,
+        approvalSubjectName: sandboxFunction.slug,
+      });
+      const approvalEvent: SandboxFunctionMCPApproveExecutionEvent = {
+        ...approvalEventBase,
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+      };
+
+      await publishSandboxFunctionInvocationEvent(approvalEvent, {
+        invocationId: invocation.sId,
+      });
+      break;
+    }
+    default:
+      assertNever(actionStatus);
+  }
 
   return new Ok({ actionId: action.sId });
 }

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -85,12 +85,14 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       toolName,
       inputs,
       toolConfiguration,
+      status,
     }: {
       invocation: SandboxFunctionInvocationResource;
       mcpServerView: MCPServerViewResource;
       toolName: string;
       inputs: Record<string, unknown>;
       toolConfiguration: LightMCPToolConfigurationType;
+      status: "running" | "blocked_validation_required";
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionMCPActionResource> {
@@ -111,7 +113,7 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
         toolName,
         inputs,
         toolConfiguration,
-        status: "running",
+        status,
       },
       { transaction }
     );

--- a/front/tests/utils/SandboxFunctionMCPActionFactory.ts
+++ b/front/tests/utils/SandboxFunctionMCPActionFactory.ts
@@ -13,11 +13,13 @@ export class SandboxFunctionMCPActionFactory {
       mcpServerView,
       toolName = "math_operation",
       inputs = { expression: "2+2" },
+      status = "running",
     }: {
       invocation: SandboxFunctionInvocationResource;
       mcpServerView: MCPServerViewResource;
       toolName?: string;
       inputs?: Record<string, unknown>;
+      status?: "running" | "blocked_validation_required";
     }
   ): Promise<SandboxFunctionMCPActionResource> {
     const serverName = mcpServerView.toJSON().server.name;
@@ -53,6 +55,7 @@ export class SandboxFunctionMCPActionFactory {
       toolName,
       inputs,
       toolConfiguration,
+      status,
     });
   }
 }


### PR DESCRIPTION
## Description

Apply the shared tool stake policy when sandbox functions call MCP tools. Approval-required actions are persisted as blocked and publish a scoped approval event to the invocation stream; implicitly allowed actions continue to launch immediately.

Workflow launch after approval remains in the follow-up validation endpoints.

## Tests

- `cd front-api && NODE_ENV=test npm test 'routes/v1/w/[wId]/sandbox/actions/call.test.ts'`

## Risk

Approval-required sandbox function calls remain blocked until resolved by the follow-up endpoints.
None since SandboxFunction is not live yet.

## Deploy Plan

- deploy `front`