### PR TITLE
[MICROSOFT] Skip locked files (423) instead of wedging the delta sync

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -360,6 +360,22 @@ export async function syncOneFile({
       return false;
     }
 
+    // 423 Locked is transient: skip without persisting a skipReason so the next
+    // delta retries the file once it is unlocked.
+    if (axios.isAxiosError(error) && error.response?.status === 423) {
+      localLogger.info(
+        {
+          status: 423,
+          fileName: file.name,
+          internalId: documentId,
+          webUrl: file.webUrl,
+        },
+        "File is locked (423), skipping for this delta"
+      );
+
+      return false;
+    }
+
     // Re-throw other errors
     throw error;
   }


### PR DESCRIPTION
## Description

`syncOneFile` now returns `false` on a 423 Locked download (without persisting a `skipReason`) instead of throwing, so a single locked SharePoint/OneDrive file no longer wedges `processDeltaChangesFromGCS` at cursor 0 in an infinite retry loop.

## Tests

Not tested.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `connectors`