### PR TITLE
Skip workspace scrub when there's a pending subscription

### DIFF
--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -1531,7 +1531,31 @@ export async function processStripeWebhookEvent({
           );
           await matchingSubscription.markAsEnded("ended");
           break;
-        case "active":
+        case "active": {
+          // Race-safety: a poke switch_contract cutover may already have
+          // provisioned a pending Metronome subscription for this workspace.
+          // Stripe's subscription.deleted can be delivered/processed before
+          // Metronome's contract.start webhook that activates it. If a
+          // pending subscription exists, this deletion is an expected part
+          // of the cutover, not organic churn — leave this subscription
+          // alone (contract.start's activatePending() will end it) and do
+          // not scrub.
+          const pendingSubscription =
+            await SubscriptionResource.fetchPendingByWorkspaceModelId(
+              matchingSubscription.workspaceId
+            );
+          if (pendingSubscription) {
+            logger.info(
+              {
+                event,
+                workspaceId: stripeSubscription.metadata?.workspaceId,
+                pendingSubscriptionId: pendingSubscription.sId,
+              },
+              "[Stripe Webhook] customer.subscription.deleted raced ahead of a pending Metronome cutover. Leaving subscription active; contract.start will finalize the swap."
+            );
+            break;
+          }
+
           logger.info(
             { event },
             "[Stripe Webhook] Received customer.subscription.deleted event with the subscription status = active. Ending the subscription and deleting some workspace data"
@@ -1586,6 +1610,7 @@ export async function processStripeWebhookEvent({
             });
           }
           break;
+        }
         default:
           assertNever(matchingSubscription.status);
       }


### PR DESCRIPTION
## Description

Fixes a race condition in the legacy Pro (Stripe) → Business (Metronome) contract
switch (`poke switch_contract` / `migrate_legacy_pro_monthly_to_business.ts`).

At cutover time, two independent webhooks fire: Metronome's `contract.start`
(which activates the pre-provisioned pending subscription) and Stripe's
`customer.subscription.deleted` (from the scheduled `cancel_at`). These are
delivered by separate systems with no ordering guarantee.

If Stripe's `customer.subscription.deleted` is processed **before** Metronome's
`contract.start`, the DB subscription row is still `status: "active"` at that
point. The existing `active` branch in the webhook handler had no awareness of
an in-flight Metronome cutover and treated this as organic churn:

- ended the subscription immediately,
- scheduled the (new, replacement) Metronome contract to end early,
- launched the workspace data-scrub Temporal workflow,
- and sent the customer a "your data will be deleted" warning email.

This left the workspace fully paywalled (no active subscription) until the
scrub's grace period, purely due to webhook delivery order — not any actual
cancellation.

This mirrors a check that already exists on the other side: Metronome's
`contract.end` handler does a successor-contract lookup before scrubbing
(`lib/api/metronome/process_webhook.ts`, `contract.end` / `case "active"`), to
avoid the equivalent race in the opposite direction. This PR adds the missing
counterpart on the Stripe side.

### Fix

In `customer.subscription.deleted`'s `active` branch, before ending the
subscription or scrubbing, check `SubscriptionResource.fetchPendingByWorkspaceModelId`.
If a pending (`created_backend_only`) subscription exists for the workspace, this
deletion is expected — leave the subscription `active` and do nothing else.
`contract.start`'s `activatePending()` already correctly ends the still-`active`
Stripe-backed row (as `ended_backend_only`) and flips the pending row to active
when it eventually fires. When Stripe's webhook is later reprocessed against the
now-`ended_backend_only` row, it hits the pre-existing safe no-op branch that
finalizes without scrubbing.

If Metronome's `contract.start` fires first (the non-racy order), nothing
changes — that path already handles the swap atomically and was not affected by
this bug.

## Tests

- `npx tsgo --noEmit` and `biome check --write` clean.
- Manually reproduced the race on a staging workspace: scheduled a
  `switchContract` cutover ~1h out, paused the Metronome webhook endpoint so
  only Stripe's `customer.subscription.deleted` could be delivered at cutover
  time. Confirmed all four symptoms above (paywall, scrub workflow launch,
  premature contract end schedule, deletion email) before the fix.
- No automated functional test added yet — flagging for follow-up given
  [TEST1], since this path requires stubbing both Stripe and Metronome webhook
  delivery order.

## Risk

Low / narrowly scoped: the new branch only changes behavior when a pending
subscription already exists for the workspace, which only happens mid-cutover
(poke `switch_contract` / the legacy Pro→Business migration script). Organic
cancellations (no pending subscription) are unaffected and continue through
the existing `active` branch unchanged.

## Deploy Plan

Standard deploy, no migration required. Should land before running further
batches of `migrate_legacy_pro_monthly_to_business.ts` (staggered Jul 23 – Aug
23 2026 migration), since every scheduled cutover in that batch hits this race
window.