### PR TITLE
Sandbox functions: tool approval validation endpoint

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -1,7 +1,16 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
@@ -20,7 +29,27 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   };
 });
 
+vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@app/temporal/agent_loop/client")>();
+  return {
+    ...mod,
+    launchSandboxFunctionToolWorkflow: vi.fn(async () => new Ok(undefined)),
+  };
+});
+
+vi.mock("@app/lib/actions/tool_status", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@app/lib/actions/tool_status")>();
+  return {
+    ...mod,
+    setUserAlwaysApprovedTool: vi.fn(),
+  };
+});
+
+import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -90,7 +119,69 @@ async function setupSandboxFunction({
     expect(addMemberResult.isOk()).toBe(true);
   }
 
-  return { workspace, sandboxFunction };
+  return { workspace, sandboxFunction, adminAuth, space };
+}
+
+// Builds a blocked action awaiting validation, the state spolu's creation gate produces for
+// approval-requiring tools (created without a workflow launch).
+async function setupBlockedAction({
+  permission = "high",
+}: {
+  permission?: MCPToolStakeLevelType;
+} = {}) {
+  const { workspace, sandboxFunction, adminAuth, space } =
+    await setupSandboxFunction();
+
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  await SpaceResource.makeDefaultsForWorkspace(adminAuth, {
+    globalGroup,
+    systemGroup,
+  });
+  const server = await InternalMCPServerInMemoryResource.makeNew(adminAuth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const view = await MCPServerViewFactory.create(workspace, server.id, space);
+
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    adminAuth,
+    { sandboxFunction }
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(adminAuth, {
+    invocation,
+    mcpServerView: view,
+    permission,
+  });
+  const [blockedCount] = await action.updateStatusFromExpected(adminAuth, {
+    status: "blocked_validation_required",
+    expectedStatus: "running",
+  });
+  expect(blockedCount).toBe(1);
+
+  return { workspace, sandboxFunction, invocation, action, view, adminAuth };
+}
+
+function postValidate({
+  workspaceId,
+  functionIdOrSlug,
+  invocationId,
+  actionId,
+  body,
+}: {
+  workspaceId: string;
+  functionIdOrSlug: string;
+  invocationId: string;
+  actionId: string;
+  body: unknown;
+}) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/sandbox-functions/${encodeURIComponent(functionIdOrSlug)}/invocations/${invocationId}/actions/${actionId}/validate`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
 }
 
 function postInvocation({
@@ -266,6 +357,197 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         type: "feature_flag_not_found",
         message: "Sandbox Functions are not enabled for this workspace.",
       },
+    });
+  });
+});
+
+describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/validate", () => {
+  it("approves a blocked action and launches its workflow", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction();
+    const removeEventSpy = vi
+      .spyOn(getRedisHybridManager(), "removeEvent")
+      .mockResolvedValue(undefined);
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    expect(refetched?.status).toBe("running");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledWith(
+      expect.anything(),
+      { action: expect.objectContaining({ sId: action.sId }) }
+    );
+    expect(removeEventSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      `sandbox-function-invocation-${invocation.sId}`
+    );
+  });
+
+  it("rejects a blocked action without launching its workflow", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction();
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "rejected" },
+    });
+
+    expect(response.status).toBe(200);
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    // The poll endpoint surfaces `denied` as a 403 rejection to the in-sandbox caller.
+    expect(refetched?.status).toBe("denied");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
+  });
+
+  it("marks the action errored when the workflow launch throws", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction();
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+    vi.mocked(launchSandboxFunctionToolWorkflow).mockRejectedValueOnce(
+      new Error("temporal unavailable")
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+
+    expect(response.status).toBe(500);
+
+    // Compensated to a terminal status instead of hanging `running` with no workflow.
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    expect(refetched?.status).toBe("errored");
+  });
+
+  it("records an always-approve for low-stake tools", async () => {
+    const { workspace, sandboxFunction, invocation, action, view } =
+      await setupBlockedAction({ permission: "low" });
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "always_approved" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(setUserAlwaysApprovedTool)).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        mcpServerId: view.mcpServerId,
+        functionCallName: "math_operation",
+      }
+    );
+  });
+
+  it("returns action_not_blocked on a second validation", async () => {
+    const { workspace, sandboxFunction, invocation, action } =
+      await setupBlockedAction();
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const first = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+    expect(first.status).toBe(200);
+
+    // The client treats this error type as an already-successful validation.
+    const second = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+    expect(second.status).toBe(400);
+    expect(await second.json()).toMatchObject({
+      error: { type: "action_not_blocked" },
+    });
+  });
+
+  it("scopes actions to the invocation in the path", async () => {
+    const { workspace, sandboxFunction, action, adminAuth } =
+      await setupBlockedAction();
+    const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
+      adminAuth,
+      { sandboxFunction }
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: otherInvocation.sId,
+      actionId: action.sId,
+      body: { approved: "approved" },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: { type: "action_not_found" },
+    });
+  });
+
+  it("returns action_not_blocked for an action that is not awaiting validation", async () => {
+    const { workspace, sandboxFunction, invocation, view, adminAuth } =
+      await setupBlockedAction();
+    const runningAction = await SandboxFunctionMCPActionFactory.create(
+      adminAuth,
+      { invocation, mcpServerView: view }
+    );
+
+    const response = await postValidate({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: runningAction.sId,
+      body: { approved: "approved" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "action_not_blocked" },
     });
   });
 });

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -175,7 +175,7 @@ function postValidate({
   body: unknown;
 }) {
   return honoApp.request(
-    `/api/w/${workspaceId}/sandbox-functions/${encodeURIComponent(functionIdOrSlug)}/invocations/${invocationId}/actions/${actionId}/validate`,
+    `/api/w/${workspaceId}/sandbox-functions/${encodeURIComponent(functionIdOrSlug)}/invocations/${invocationId}/actions/${actionId}/validate-action`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -361,7 +361,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
   });
 });
 
-describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/validate", () => {
+describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/validate-action", () => {
   it("approves a blocked action and launches its workflow", async () => {
     const { workspace, sandboxFunction, invocation, action, adminAuth } =
       await setupBlockedAction();

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -148,7 +148,7 @@ app.post(
 
 /** @ignoreswagger */
 app.post(
-  "/:invocationId/actions/:actionId/validate",
+  "/:invocationId/actions/:actionId/validate-action",
   validate("param", ValidateActionParamsSchema),
   validate("json", ValidateActionBodySchema),
   async (ctx): HandlerResult<{ success: boolean }> => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,9 +1,12 @@
+import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
 } from "@app/types/api/sandbox_functions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { redirectToSse } from "@front-api/lib/api/sse/redirect";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -13,6 +16,18 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   functionIdOrSlug: z.string().min(1),
 });
+
+const ValidateActionParamsSchema = z.object({
+  functionIdOrSlug: z.string().min(1),
+  invocationId: z.string().min(1),
+  actionId: z.string().min(1),
+});
+
+const ValidateActionBodySchema = z
+  .object({
+    approved: z.enum(MCP_VALIDATION_OUTPUTS),
+  })
+  .strict();
 
 const PostSandboxFunctionInvocationBodySchema = z
   .object({
@@ -128,6 +143,65 @@ app.post(
       },
       201
     );
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/:invocationId/actions/:actionId/validate",
+  validate("param", ValidateActionParamsSchema),
+  validate("json", ValidateActionBodySchema),
+  async (ctx): HandlerResult<{ success: boolean }> => {
+    const auth = ctx.get("auth");
+    const { functionIdOrSlug, invocationId, actionId } = ctx.req.valid("param");
+    const { approved } = ctx.req.valid("json");
+
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+      auth,
+      functionIdOrSlug
+    );
+    if (!sandboxFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Sandbox function not found.",
+        },
+      });
+    }
+
+    const result = await validateSandboxFunctionAction(auth, {
+      sandboxFunction,
+      invocationId,
+      actionId,
+      approvalState: approved,
+    });
+    if (result.isErr()) {
+      switch (result.error.type) {
+        case "action_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: result.error.message,
+            },
+          });
+        case "action_not_blocked":
+          // The client treats this error type as an already-successful validation (multi-client
+          // races).
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "action_not_blocked",
+              message: result.error.message,
+            },
+          });
+        default:
+          return assertNever(result.error.type);
+      }
+    }
+
+    return ctx.json({ success: true });
   }
 );
 

--- a/front/lib/api/sandbox_functions/validate_action.ts
+++ b/front/lib/api/sandbox_functions/validate_action.ts
@@ -1,0 +1,162 @@
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
+import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { getSandboxFunctionInvocationChannelId } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import logger from "@app/logger/logger";
+import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export class SandboxFunctionActionValidationError extends Error {
+  constructor(
+    readonly type: "action_not_found" | "action_not_blocked",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Resolves a pending tool approval on a sandbox function invocation: flips the blocked action to
+ * `running` and launches its execution workflow (approved), or to `denied` (rejected), which the
+ * in-sandbox poll surfaces as a 403 rejection. The blocked action was created without a workflow,
+ * so approval performs the first launch.
+ */
+export async function validateSandboxFunctionAction(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    invocationId,
+    actionId,
+    approvalState,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    invocationId: string;
+    actionId: string;
+    approvalState: MCPValidationOutputType;
+  }
+): Promise<Result<undefined, SandboxFunctionActionValidationError>> {
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+  });
+  // Out-of-scope lookups report as not-found, same shape as truly missing ones.
+  if (!invocation) {
+    return new Err(
+      new SandboxFunctionActionValidationError(
+        "action_not_found",
+        "Action not found."
+      )
+    );
+  }
+
+  const action = await SandboxFunctionMCPActionResource.fetchById(
+    auth,
+    actionId
+  );
+  if (!action || action.invocationId !== invocation.sId) {
+    return new Err(
+      new SandboxFunctionActionValidationError(
+        "action_not_found",
+        "Action not found."
+      )
+    );
+  }
+
+  if (action.status !== "blocked_validation_required") {
+    return new Err(
+      new SandboxFunctionActionValidationError(
+        "action_not_blocked",
+        `Action is not blocked: ${action.status}.`
+      )
+    );
+  }
+
+  // Exhaustive so a future validation output cannot silently map to an approval.
+  let resolvedStatus: "running" | "denied";
+  switch (approvalState) {
+    case "approved":
+    case "always_approved":
+      resolvedStatus = "running";
+      break;
+    case "rejected":
+      resolvedStatus = "denied";
+      break;
+    default:
+      resolvedStatus = assertNever(approvalState);
+  }
+
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: resolvedStatus,
+    expectedStatus: "blocked_validation_required",
+  });
+
+  // Concurrent resolutions have exactly one winner through the compare-and-swap; losers succeed
+  // silently, the action already reached the state a resolution produces.
+  if (updatedCount === 0) {
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+        actionId,
+      },
+      "Sandbox function action already approved or rejected"
+    );
+    return new Ok(undefined);
+  }
+
+  const user = auth.user();
+  if (
+    approvalState === "always_approved" &&
+    user &&
+    // Low-stake approvals are recorded globally per (server, tool), same keying as the
+    // conversation flavor. Medium-stake records are keyed on an agent, which a sandbox function
+    // has none of: treated as a one-time approval.
+    action.toolConfiguration.permission === "low"
+  ) {
+    await setUserAlwaysApprovedTool(auth, {
+      mcpServerId: action.toolConfiguration.toolServerId,
+      functionCallName: action.toolConfiguration.name,
+    });
+  }
+
+  // TODO(2026-07-10 SANDBOX_FUNCTIONS): emit a tool.approval_resolved audit event once the schema
+  // supports function-scoped targets (the current one requires agent and conversation
+  // identifiers).
+
+  // Remove the pending approval event from the invocation channel so SSE history replay does not
+  // resurface the approval card.
+  await getRedisHybridManager().removeEvent(
+    (event) => {
+      const payload = JSON.parse(event.message["payload"]);
+      return isMCPApproveExecutionEvent(payload)
+        ? payload.actionId === actionId
+        : false;
+    },
+    getSandboxFunctionInvocationChannelId({ invocationId: invocation.sId })
+  );
+
+  if (approvalState !== "rejected") {
+    try {
+      await launchSandboxFunctionToolWorkflow(auth, { action });
+    } catch (err) {
+      // The action is already `running`; a failed launch would otherwise leave the poll hanging
+      // until token expiry with no workflow. Compensate to a terminal `errored` (CAS-guarded so a
+      // workflow that did start and already moved the status is not clobbered), then rethrow.
+      await action.updateStatusFromExpected(auth, {
+        status: "errored",
+        expectedStatus: "running",
+      });
+      throw err;
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -1,4 +1,5 @@
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 import type { ToolOutputItemType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -186,6 +187,30 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       status: "errored",
       executionDurationMs: Math.round(executionDurationMs),
     });
+  }
+
+  // Updates only if the action still has the expected status: a WHERE-guarded compare-and-swap,
+  // so concurrent resolutions of a blocked action have exactly one winner.
+  async updateStatusFromExpected(
+    auth: Authenticator,
+    {
+      status,
+      expectedStatus,
+    }: {
+      status: ToolExecutionBaseStatus;
+      expectedStatus: ToolExecutionBaseStatus;
+    }
+  ): Promise<[affectedCount: number]> {
+    return SandboxFunctionMCPActionModel.update(
+      { status },
+      {
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: expectedStatus,
+        },
+      }
+    );
   }
 
   private outputGcsPathFor(auth: Authenticator): string {

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -92,7 +92,7 @@ function getValidateActionRequest(
       };
     case "sandbox_function":
       return {
-        url: `/api/w/${workspaceId}/sandbox-functions/${request.sandboxFunctionId}/invocations/${request.invocationId}/actions/${request.actionId}/validate`,
+        url: `/api/w/${workspaceId}/sandbox-functions/${request.sandboxFunctionId}/invocations/${request.invocationId}/actions/${request.actionId}/validate-action`,
         body: { approved: request.approved },
       };
     default:

--- a/front/tests/utils/SandboxFunctionMCPActionFactory.ts
+++ b/front/tests/utils/SandboxFunctionMCPActionFactory.ts
@@ -1,3 +1,4 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -14,12 +15,14 @@ export class SandboxFunctionMCPActionFactory {
       toolName = "math_operation",
       inputs = { expression: "2+2" },
       status = "running",
+      permission = "never_ask",
     }: {
       invocation: SandboxFunctionInvocationResource;
       mcpServerView: MCPServerViewResource;
       toolName?: string;
       inputs?: Record<string, unknown>;
       status?: "running" | "blocked_validation_required";
+      permission?: MCPToolStakeLevelType;
     }
   ): Promise<SandboxFunctionMCPActionResource> {
     const serverName = mcpServerView.toJSON().server.name;
@@ -44,7 +47,7 @@ export class SandboxFunctionMCPActionFactory {
       secretName: null,
       dustProject: null,
       availability: "manual",
-      permission: "never_ask",
+      permission,
       toolServerId: mcpServerView.mcpServerId,
       retryPolicy: "no_retry",
     };


### PR DESCRIPTION
Follow up of #28824, which blocks approval-requiring sandbox function tool actions at creation (no workflow launched) and publishes the approval event to the invocation stream. This PR adds the resolution half: the validate endpoint the merged approval card (#28813) already calls.

`POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/validate` with `{ approved: "approved" | "rejected" | "always_approved" }`:

- Approved: compare-and-swap `blocked_validation_required` -> `running`, then the first `launchSandboxFunctionToolWorkflow` for the action. dsbx keeps polling (blocked reads as `202 pending`), so resumption needs no client cooperation.
- Rejected: CAS -> `denied`; the poll surfaces it as `403 rejected` and the in-sandbox tool call fails.
- `always_approved`: records a global always-approve for low-stake tools (same keying as the conversation flavor). Medium-stake records are keyed on an agent, which a sandbox function has none of: treated as a one-time approval.
- The pending approval event is removed from the invocation Redis channel so SSE history replay does not resurface the approval card.
- Concurrent resolutions have exactly one winner through the CAS (new `updateStatusFromExpected` on the action resource, mirroring the agent one); losers succeed silently, and a late duplicate gets `action_not_blocked`, which the client treats as success.

Authorization note: anyone who can read the pod space can resolve an approval, unlike the conversation flavor where only the parent message author may. Invocations record no initiating user, and this matches the invocation SSE route's access model. `always_approved` records the low-stake approval for the resolving user.

Audit is deferred with a dated TODO: the `tool.approval_resolved` schema requires agent and conversation targets that do not exist for functions.

Next PR: `resolve-authentication` for `tool_personal_auth_required`, pending the auth-blocked status addition to the base status union (to sync with the event delivery slice).

## Tests

Endpoint tests: approve (status, workflow launch, event removal), reject (denied, no launch), always-approve recording for low stake, double validation -> `action_not_blocked`, cross-invocation action -> 404, non-blocked action -> 400. Manual e2e locally: blocked action approved through the endpoint, workflow executed the tool and the poll reached `succeeded`; rejected action polled as `403 rejected`.

## Risk

None, SandboxFunction is not live yet. The endpoint is unreachable until #28824 creates blocked actions.

## Deploy Plan

- [ ] Deploy front