### PR TITLE
feat(analytics): export messages with agent tags

### DIFF
--- a/front/lib/api/analytics/enrichment.ts
+++ b/front/lib/api/analytics/enrichment.ts
@@ -1,4 +1,6 @@
+import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { LightWorkspaceType } from "@app/types/user";
 import { QueryTypes } from "sequelize";
@@ -43,6 +45,18 @@ export async function fetchAgentMetadata(
   return new Map(
     agents.map((a) => [a.sId, { name: a.name, settings: a.settings }])
   );
+}
+
+export async function fetchTagNames(
+  auth: Authenticator,
+  tagIds: string[]
+): Promise<Map<string, string>> {
+  if (tagIds.length === 0) {
+    return new Map();
+  }
+
+  const tags = await TagResource.fetchByIds(auth, tagIds);
+  return new Map(tags.map((t) => [t.sId, t.name]));
 }
 
 export async function fetchUserEmails(

--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -2,6 +2,7 @@ import { fetchMessageExportRows } from "@app/lib/api/analytics/messages_export";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TagFactory } from "@app/tests/utils/TagFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -78,6 +79,58 @@ describe("fetchMessageExportRows", () => {
     }
     expect(result.value).toHaveLength(1);
     expect(result.value[0].credits).toBe(7);
+  });
+
+  it("resolves agent_tag_ids to sorted, distinct tag names in the assistantTags column", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const [zeta, alpha] = await Promise.all([
+      TagFactory.create(workspace, { name: "Zeta" }),
+      TagFactory.create(workspace, { name: "Alpha" }),
+    ]);
+
+    mockMessageHits([
+      messageDoc({ agent_tag_ids: [zeta.sId, alpha.sId, "tag_unknown"] }),
+    ]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    // Sorted, distinct, and unknown ids dropped.
+    expect(result.value[0].assistantTags).toBe("Alpha,Zeta");
+  });
+
+  it("leaves assistantTags empty for docs indexed before agent_tag_ids shipped", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    mockMessageHits([messageDoc()]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].assistantTags).toBe("");
   });
 
   it("defaults credits to 0 for docs indexed before the cost fields shipped", async () => {

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -1,6 +1,7 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import {
   fetchAgentMetadata,
+  fetchTagNames,
   fetchUserEmails,
 } from "@app/lib/api/analytics/enrichment";
 import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
@@ -20,6 +21,8 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   message_id: string;
   timestamp: string;
   agent_id: string;
+  // Optional: docs indexed before agent_tag_ids shipped don't carry it.
+  agent_tag_ids?: string[];
   conversation_id: string;
   // Ids of the agent messages that triggered this message through `run_agent`,
   // direct parent first. Empty or absent for user-initiated messages.
@@ -39,6 +42,7 @@ export interface MessageExportRow {
   assistantId: string;
   assistantName: string;
   assistantSettings: string;
+  assistantTags: string;
   conversationId: string;
   parentMessageId: string;
   userId: string;
@@ -55,6 +59,7 @@ export const MESSAGE_EXPORT_HEADERS: (keyof MessageExportRow)[] = [
   "assistantId",
   "assistantName",
   "assistantSettings",
+  "assistantTags",
   "conversationId",
   "parentMessageId",
   "userId",
@@ -142,17 +147,22 @@ export async function fetchMessageExportRows({
   const uniqueUserIds = [
     ...new Set(docs.map((d) => d.user_id).filter(Boolean)),
   ];
+  const uniqueTagIds = [
+    ...new Set(docs.flatMap((d) => d.agent_tag_ids ?? []).filter(Boolean)),
+  ];
   const uniqueServerNames = [
     ...new Set(
       docs.flatMap((d) => (d.tools_used ?? []).map((t) => t.server_name))
     ),
   ];
 
-  const [agentMeta, userEmails, serverDisplayNames] = await Promise.all([
-    fetchAgentMetadata(uniqueAgentIds, owner),
-    fetchUserEmails(uniqueUserIds),
-    resolveServerDisplayNames(auth, uniqueServerNames),
-  ]);
+  const [agentMeta, userEmails, tagNames, serverDisplayNames] =
+    await Promise.all([
+      fetchAgentMetadata(uniqueAgentIds, owner),
+      fetchUserEmails(uniqueUserIds),
+      fetchTagNames(auth, uniqueTagIds),
+      resolveServerDisplayNames(auth, uniqueServerNames),
+    ]);
 
   const rows: MessageExportRow[] = docs.map((doc) => {
     const agent = agentMeta.get(doc.agent_id);
@@ -164,6 +174,9 @@ export async function fetchMessageExportRows({
       assistantId: doc.agent_id,
       assistantName: agent?.name ?? doc.agent_id,
       assistantSettings: agent?.settings ?? "unknown",
+      assistantTags: joinDistinctSorted(
+        (doc.agent_tag_ids ?? []).map((id) => tagNames.get(id))
+      ),
       conversationId: doc.conversation_id,
       parentMessageId: doc.ancestor_message_ids?.[0] ?? "",
       userId: doc.user_id,


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/8167

Expose agent tags name in the export (depends on #28823)

## Tests

- added tests
- downloaded an export from analytics dashboard:
```$ cat ~/Downloads/dust_messages_2026-06-10_2026-07-10.csv       
messageId,createdAt,assistantId,assistantName,assistantSettings,assistantTags,conversationId,parentMessageId,userId,userEmail,source,toolsUsed,skillsUsed,credits
Je81VrCfQ9,2026-07-10 08:07:35,QDUDNnvE5v,TestAgent,unpublished,,rySaZCrTAS,,ZWmML49W5v,sylvain@dust.tt,web,,,1
bHli8FB7hS,2026-07-10 08:46:29,QDUDNnvE5v,TestAgent,unpublished,tagB,rySaZCrTAS,,ZWmML49W5v,sylvain@dust.tt,web,,,4
okcFtAPuIu,2026-07-10 11:21:10,QDUDNnvE5v,TestAgent,unpublished,"tagA,tagB",rySaZCrTAS,,ZWmML49W5v,sylvain@dust.tt,web,,,4
nQQn3HhCQC,2026-07-10 12:52:07,QDUDNnvE5v,TestAgent,unpublished,"tagA,tagB",rySaZCrTAS,,ZWmML49W5v,sylvain@dust.tt,web,,,4
```

