### PR TITLE
feat: add regular manual groups

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -1,5 +1,11 @@
 import type { PokeListGroups } from "@app/lib/api/poke/groups";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GROUP_KINDS,
+  isAgentEditorGroupKind,
+  isSkillEditorGroupKind,
+  isSystemGroupKind,
+} from "@app/types/groups";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -13,13 +19,12 @@ app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
   const auth = ctx.get("auth");
 
   const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-    groupKinds: [
-      "global",
-      "regular_auto",
-      "regular_manual",
-      "space_editors",
-      "provisioned",
-    ],
+    groupKinds: GROUP_KINDS.filter(
+      (kind) =>
+        !isSystemGroupKind(kind) &&
+        !isAgentEditorGroupKind(kind) &&
+        !isSkillEditorGroupKind(kind)
+    ),
   });
 
   return ctx.json({ groups: groups.map((g) => g.toJSON()) });

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -13,7 +13,13 @@ app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
   const auth = ctx.get("auth");
 
   const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-    groupKinds: ["global", "regular_auto", "space_editors", "provisioned"],
+    groupKinds: [
+      "global",
+      "regular_auto",
+      "regular_manual",
+      "space_editors",
+      "provisioned",
+    ],
   });
 
   return ctx.json({ groups: groups.map((g) => g.toJSON()) });

--- a/front/lib/api/actions/servers/poke/tools/users.ts
+++ b/front/lib/api/actions/servers/poke/tools/users.ts
@@ -15,6 +15,12 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import {
+  GROUP_KINDS,
+  isAgentEditorGroupKind,
+  isSkillEditorGroupKind,
+  isSystemGroupKind,
+} from "@app/types/groups";
 import { Err } from "@app/types/shared/result";
 
 type UserHandlers = Pick<
@@ -42,13 +48,12 @@ export const userHandlers: UserHandlers = {
     const targetAuth = targetAuthResult.value;
 
     const groups = await GroupResource.listAllWorkspaceGroups(targetAuth, {
-      groupKinds: [
-        "global",
-        "regular_auto",
-        "regular_manual",
-        "space_editors",
-        "provisioned",
-      ],
+      groupKinds: GROUP_KINDS.filter(
+        (kind) =>
+          !isSystemGroupKind(kind) &&
+          !isAgentEditorGroupKind(kind) &&
+          !isSkillEditorGroupKind(kind)
+      ),
     });
 
     return jsonResponse({

--- a/front/lib/api/actions/servers/poke/tools/users.ts
+++ b/front/lib/api/actions/servers/poke/tools/users.ts
@@ -42,7 +42,13 @@ export const userHandlers: UserHandlers = {
     const targetAuth = targetAuthResult.value;
 
     const groups = await GroupResource.listAllWorkspaceGroups(targetAuth, {
-      groupKinds: ["global", "regular_auto", "space_editors", "provisioned"],
+      groupKinds: [
+        "global",
+        "regular_auto",
+        "regular_manual",
+        "space_editors",
+        "provisioned",
+      ],
     });
 
     return jsonResponse({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -31,6 +31,7 @@ import {
   CAP_ELIGIBLE_GROUP_KINDS,
   GROUP_KINDS,
   isAgentEditorGroupKind,
+  isRegularManualGroupKind,
   isSkillEditorGroupKind,
 } from "@app/types/groups";
 import type { ResourcePermission } from "@app/types/resource_permissions";
@@ -637,6 +638,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     groupKinds = [
       "global",
       "regular_auto",
+      "regular_manual",
       "space_editors",
       "system",
       "provisioned",
@@ -1511,6 +1513,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   > {
     assert(
       this.isRegularAuto() ||
+        this.isRegularManual() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1550,24 +1553,6 @@ export class GroupResource extends BaseResource<GroupModel> {
           userIds.length === 1
             ? "Cannot add: user is not a member of the workspace"
             : "Cannot add: users are not members of the workspace"
-        )
-      );
-    }
-
-    // Users can only be added to regular_auto, space_editors, agent_editors, skill_editors or provisioned groups.
-    if (
-      ![
-        "regular_auto",
-        "space_editors",
-        "agent_editors",
-        "skill_editors",
-        "provisioned",
-      ].includes(this.kind)
-    ) {
-      return new Err(
-        new DustError(
-          "system_or_global_group",
-          "Users can only be added to regular, space_editors, agent_editors, skill_editors or provisioned groups."
         )
       );
     }
@@ -1688,6 +1673,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   > {
     assert(
       this.isRegularAuto() ||
+        this.isRegularManual() ||
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
@@ -1721,24 +1707,6 @@ export class GroupResource extends BaseResource<GroupModel> {
           userIds.length === 1
             ? "Cannot remove: user is not a member of the workspace"
             : "Cannot remove: users are not members of the workspace"
-        )
-      );
-    }
-
-    // Users can only be removed from regular_auto, space_editors, agent_editors, skill_editors or provisioned groups.
-    if (
-      ![
-        "regular_auto",
-        "space_editors",
-        "agent_editors",
-        "skill_editors",
-        "provisioned",
-      ].includes(this.kind)
-    ) {
-      return new Err(
-        new DustError(
-          "system_or_global_group",
-          "Users can only be removed from regular, space_editors, agent_editors, skill_editors or provisioned groups."
         )
       );
     }
@@ -2337,6 +2305,24 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
+    if (this.isRegularManual()) {
+      return [
+        {
+          groups: [
+            {
+              id: this.id,
+              permissions: ["read"],
+            },
+          ],
+          roles: [
+            { role: "admin", permissions: ["read", "write", "admin"] },
+            { role: "business_admin", permissions: ["read", "write", "admin"] },
+          ],
+          workspaceId: this.workspaceId,
+        },
+      ];
+    }
+
     return [
       {
         groups: [
@@ -2373,6 +2359,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   isRegularAuto(): boolean {
     return this.kind === "regular_auto";
+  }
+
+  isRegularManual(): boolean {
+    return isRegularManualGroupKind(this.kind);
   }
 
   isSpaceEditor(): boolean {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -635,14 +635,9 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Use with care as this gives access to all groups in the workspace.
   static async internalFetchAllWorkspaceGroups({
     workspaceId,
-    groupKinds = [
-      "global",
-      "regular_auto",
-      "regular_manual",
-      "space_editors",
-      "system",
-      "provisioned",
-    ],
+    groupKinds = GROUP_KINDS.filter(
+      (k) => !isAgentEditorGroupKind(k) && !isSkillEditorGroupKind(k)
+    ),
     transaction,
   }: {
     workspaceId: ModelId;

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -11,11 +11,15 @@ import { isRoleType } from "./user";
  * global group: Contains all users from the workspace. Has access to the global
  * Space which holds all existing datasource created before spaces.
  *
- * regular_auto group: Contains specific users added by workspace admins. Has access
- * to the list of spaces configured by workspace admins.
+ * "regular" groups are groups for which users are selected one by one (as opposed
+ * to provisioned groups whose membership is synced from an external identity
+ * provider). They come in two flavors depending on how the group was created:
  *
- * regular_manual group: Groups created manually from the UI. They can be used to
- * grant specific permissions to users.
+ * regular_auto group: Created implicitly by Dust (e.g. agent editors, space
+ * members).
+ *
+ * regular_manual group: Created manually by the user via the UI. They can be used
+ * to grant specific permissions to users.
  *
  * agent_editors group: Group specific to represent agent editors, tied to an
  *  agent. Has special permissions: not restricted only to admins. Users can

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -11,8 +11,11 @@ import { isRoleType } from "./user";
  * global group: Contains all users from the workspace. Has access to the global
  * Space which holds all existing datasource created before spaces.
  *
- * regular group: Contains specific users added by workspace admins. Has access
+ * regular_auto group: Contains specific users added by workspace admins. Has access
  * to the list of spaces configured by workspace admins.
+ *
+ * regular_manual group: Groups created manually from the UI. They can be used to
+ * grant specific permissions to users.
  *
  * agent_editors group: Group specific to represent agent editors, tied to an
  *  agent. Has special permissions: not restricted only to admins. Users can
@@ -26,6 +29,7 @@ import { isRoleType } from "./user";
  */
 export const GROUP_KINDS = [
   "regular_auto",
+  "regular_manual",
   // space_editors is used to know if a member of a manual group can edit the group
   "space_editors",
   "global",
@@ -55,6 +59,10 @@ export function isGlobalGroupKind(value: GroupKind): boolean {
   return value === "global";
 }
 
+export function isRegularManualGroupKind(value: GroupKind): boolean {
+  return value === "regular_manual";
+}
+
 export function isAgentEditorGroupKind(value: GroupKind): boolean {
   return value === "agent_editors";
 }
@@ -78,6 +86,7 @@ export type GroupType = {
 export const GroupKindCodec = z.enum([
   "global",
   "regular_auto",
+  "regular_manual",
   "space_editors",
   "agent_editors",
   "skill_editors",


### PR DESCRIPTION
## Description

This PR introduces a new `regular_manual` group kind that can be created manually from the UI to grant specific permissions to users, distinct from `regular_auto` groups which are managed programmatically by workspace admins.

- Adds `regular_manual` to `GROUP_KINDS`, `GroupKindCodec`, and the `isRegularManualGroupKind()` helper in `front/types/groups.ts`.
- Adds an `isRegularManual()` method to `GroupResource` and defines its permission model (members get `read`, admins and business admins get `read/write/admin`).
- Extends `addMembers` and `removeMembers` to allow `regular_manual` groups
- Includes `regular_manual` in the default group kinds fetched by `listAllWorkspaceGroups` and exposes it in the poke API endpoints (groups listing and user groups).

## Tests

Manually.

## Risks
Regular manual groups might be fetched when not needed.

## Deploy Plan

Standard deployment.