### PR TITLE
feat: add regular manual groups to cap eligible group kinds

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -907,6 +907,7 @@ export async function getMemberUsage({
     GroupResource.listGroupNamesByUserModelIdInWorkspace({
       workspace,
       userModelIds: [userResource.id],
+      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
     }),
     GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
       workspace,

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -46,8 +46,11 @@ export type GroupKind = (typeof GROUP_KINDS)[number];
 
 // Group kinds that can carry a per-group usage spend limit and be surfaced in
 // the Usage > Groups admin table. Only "provisioned" (SSO/SCIM directory)
-// groups.
-export const CAP_ELIGIBLE_GROUP_KINDS = ["provisioned"] as const;
+// and regular_manual groups.
+export const CAP_ELIGIBLE_GROUP_KINDS = [
+  "provisioned",
+  "regular_manual",
+] as const;
 
 export function isCapEligibleGroupKind(kind: GroupKind): boolean {
   return CAP_ELIGIBLE_GROUP_KINDS.some((k) => k === kind);


### PR DESCRIPTION
## Description

This PR adds `regular_manual` groups to the `CAP_ELIGIBLE_GROUP_KINDS` constant, enabling them to carry per-group usage spend limits and appear in the Usage > Groups admin table alongside `provisioned` groups.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.