### PR TITLE
feat: add endpoint to create regular manual groups

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -1,3 +1,4 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -13,6 +14,14 @@ function getGroups(
   return honoApp.request(
     `/api/w/${workspace.sId}/groups${search ? `?${search}` : ""}`
   );
+}
+
+function postGroup(workspace: { sId: string }, body: Record<string, unknown>) {
+  return honoApp.request(`/api/w/${workspace.sId}/groups`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 describe("GET /api/w/:wId/groups", () => {
@@ -120,5 +129,126 @@ describe("GET /api/w/:wId/groups", () => {
     );
     expect(backendGroup).toBeDefined();
     expect(backendGroup.memberCount).toBe(1);
+  });
+});
+
+describe("POST /api/w/:wId/groups", () => {
+  it("lets an admin create a regular_manual group", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await postGroup(workspace, { name: "Finance" });
+
+    expect(response.status).toBe(200);
+    const { group } = await response.json();
+    expect(group.name).toBe("Finance");
+    expect(group.kind).toBe("regular_manual");
+
+    const created = await GroupResource.fetchById(auth, group.sId);
+    expect(created.isOk()).toBe(true);
+  });
+
+  it("creates a group seeded with the provided members", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const extraUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, extraUser, { role: "user" });
+
+    const response = await postGroup(workspace, {
+      name: "Seeded",
+      memberIds: [user.sId, extraUser.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const { group } = await response.json();
+
+    const created = await GroupResource.fetchById(auth, group.sId);
+    if (created.isErr()) {
+      throw created.error;
+    }
+    const members = await created.value.getActiveMembers(auth);
+    expect(new Set(members.map((m) => m.sId))).toEqual(
+      new Set([user.sId, extraUser.sId])
+    );
+  });
+
+  it("returns 404 when a member id does not belong to the workspace", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    // A user that exists but is not a member of this workspace.
+    const outsider = await UserFactory.basic();
+
+    const response = await postGroup(workspace, {
+      name: "Bad members",
+      memberIds: [outsider.sId],
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("user_not_found");
+  });
+
+  it("lets a business admin create a regular_manual group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "business_admin",
+    });
+
+    const response = await postGroup(workspace, { name: "Legal" });
+
+    expect(response.status).toBe(200);
+    const { group } = await response.json();
+    expect(group.kind).toBe("regular_manual");
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const response = await postGroup(workspace, { name: "Nope" });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 403 for a builder", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+
+    const response = await postGroup(workspace, { name: "Nope" });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 409 when a group with the same name already exists", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    await GroupFactory.regularManual(workspace, "Duplicate");
+
+    const response = await postGroup(workspace, { name: "Duplicate" });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when name is missing or empty", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    expect((await postGroup(workspace, {})).status).toBe(400);
+    expect((await postGroup(workspace, { name: "" })).status).toBe(400);
   });
 });

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -134,12 +134,15 @@ describe("GET /api/w/:wId/groups", () => {
 
 describe("POST /api/w/:wId/groups", () => {
   it("lets an admin create a regular_manual group", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    const response = await postGroup(workspace, { name: "Finance" });
+    const response = await postGroup(workspace, {
+      name: "Finance",
+      memberIds: [user.sId],
+    });
 
     expect(response.status).toBe(200);
     const { group } = await response.json();
@@ -194,12 +197,15 @@ describe("POST /api/w/:wId/groups", () => {
   });
 
   it("lets a business admin create a regular_manual group", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
       role: "business_admin",
     });
 
-    const response = await postGroup(workspace, { name: "Legal" });
+    const response = await postGroup(workspace, {
+      name: "Legal",
+      memberIds: [user.sId],
+    });
 
     expect(response.status).toBe(200);
     const { group } = await response.json();
@@ -230,25 +236,46 @@ describe("POST /api/w/:wId/groups", () => {
   });
 
   it("returns 409 when a group with the same name already exists", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
     await GroupFactory.regularManual(workspace, "Duplicate");
 
-    const response = await postGroup(workspace, { name: "Duplicate" });
+    const response = await postGroup(workspace, {
+      name: "Duplicate",
+      memberIds: [user.sId],
+    });
 
     expect(response.status).toBe(409);
     expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 
   it("returns 400 when name is missing or empty", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    expect((await postGroup(workspace, { memberIds: [user.sId] })).status).toBe(
+      400
+    );
+    expect(
+      (await postGroup(workspace, { name: "", memberIds: [user.sId] })).status
+    ).toBe(400);
+  });
+
+  it("returns 400 when members are missing or empty", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    expect((await postGroup(workspace, {})).status).toBe(400);
-    expect((await postGroup(workspace, { name: "" })).status).toBe(400);
+    expect((await postGroup(workspace, { name: "No members" })).status).toBe(
+      400
+    );
+    expect(
+      (await postGroup(workspace, { name: "No members", memberIds: [] })).status
+    ).toBe(400);
   });
 });

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -1,8 +1,14 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  CreateGroupBodySchema,
+  type PostGroupResponseBody,
+} from "@app/types/api/groups/manage";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import { GroupKindCodec } from "@app/types/groups";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
@@ -49,6 +55,64 @@ app.get(
     }));
 
     return ctx.json({ groups: groupsWithMemberCount });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("json", CreateGroupBodySchema),
+  async (ctx): HandlerResult<PostGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { name, memberIds } = ctx.req.valid("json");
+
+    const groupRes = await GroupResource.makeNewRegularManual(auth, {
+      name,
+      memberIds,
+    });
+    if (groupRes.isErr()) {
+      switch (groupRes.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: {
+              type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "user_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "user_not_found",
+              message: groupRes.error.message,
+            },
+          });
+        case "user_already_member":
+        case "group_requirements_not_met":
+        case "system_or_global_group":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        default:
+          assertNever(groupRes.error.code);
+      }
+    }
+
+    return ctx.json({ group: groupRes.value.toJSON() });
   }
 );
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -430,7 +430,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async makeNewRegularManual(
     auth: Authenticator,
-    { name, memberIds }: { name: string; memberIds?: string[] }
+    { name, memberIds }: { name: string; memberIds: string[] }
   ): Promise<
     Result<
       GroupResource,
@@ -471,20 +471,18 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: owner.id,
     });
 
-    const uniqueMemberIds = memberIds ? [...new Set(memberIds)] : [];
-    if (uniqueMemberIds.length > 0) {
-      const users = await UserResource.fetchByIds(uniqueMemberIds);
-      if (users.length !== uniqueMemberIds.length) {
-        return new Err(
-          new DustError("user_not_found", "Some users were not found.")
-        );
-      }
-      const addResult = await group.dangerouslyAddMembers(auth, {
-        users: users.map((u) => u.toJSON()),
-      });
-      if (addResult.isErr()) {
-        return new Err(addResult.error);
-      }
+    const uniqueMemberIds = [...new Set(memberIds)];
+    const users = await UserResource.fetchByIds(uniqueMemberIds);
+    if (users.length !== uniqueMemberIds.length) {
+      return new Err(
+        new DustError("user_not_found", "Some users were not found.")
+      );
+    }
+    const addResult = await group.dangerouslyAddMembers(auth, {
+      users: users.map((u) => u.toJSON()),
+    });
+    if (addResult.isErr()) {
+      return new Err(addResult.error);
     }
 
     return new Ok(group);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -41,6 +41,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { BUSINESS_ADMIN_ROLE_NAME } from "@app/types/user";
 import type { DirectoryGroup } from "@workos-inc/node";
 import assert from "assert";
 import type {
@@ -420,6 +421,73 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     return defaultGroup;
+  }
+
+  /**
+   * Creates a new regular_manual group. These groups are created and managed
+   * manually by workspace admins and business admins from the UI to grant
+   * permissions to their members.
+   */
+  static async makeNewRegularManual(
+    auth: Authenticator,
+    { name, memberIds }: { name: string; memberIds?: string[] }
+  ): Promise<
+    Result<
+      GroupResource,
+      DustError<
+        | "unauthorized"
+        | "name_conflict"
+        | "user_not_found"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (!auth.isBusinessAdmin()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          `Only workspace admins and ${BUSINESS_ADMIN_ROLE_NAME}s can create groups.`
+        )
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    const existing = await GroupResource.fetchByName(auth, name);
+    if (existing) {
+      return new Err(
+        new DustError(
+          "name_conflict",
+          `A group named "${name}" already exists in this workspace.`
+        )
+      );
+    }
+
+    const group = await GroupResource.makeNew({
+      name,
+      kind: "regular_manual",
+      workspaceId: owner.id,
+    });
+
+    const uniqueMemberIds = memberIds ? [...new Set(memberIds)] : [];
+    if (uniqueMemberIds.length > 0) {
+      const users = await UserResource.fetchByIds(uniqueMemberIds);
+      if (users.length !== uniqueMemberIds.length) {
+        return new Err(
+          new DustError("user_not_found", "Some users were not found.")
+        );
+      }
+      const addResult = await group.dangerouslyAddMembers(auth, {
+        users: users.map((u) => u.toJSON()),
+      });
+      if (addResult.isErr()) {
+        return new Err(addResult.error);
+      }
+    }
+
+    return new Ok(group);
   }
 
   static async findAgentIdsForGroups(

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -16,6 +16,14 @@ export class GroupFactory {
     });
   }
 
+  static async regularManual(workspace: WorkspaceType, name: string) {
+    return GroupResource.makeNew({
+      name,
+      kind: "regular_manual",
+      workspaceId: workspace.id,
+    });
+  }
+
   static async withMembers(
     auth: Authenticator,
     group: GroupResource,

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -1,0 +1,13 @@
+import type { GroupType } from "@app/types/groups";
+import { z } from "zod";
+
+export const CreateGroupBodySchema = z.object({
+  name: z.string().min(1),
+  memberIds: z.array(z.string()).optional(),
+});
+
+export type CreateGroupBodyType = z.infer<typeof CreateGroupBodySchema>;
+
+export type PostGroupResponseBody = {
+  group: GroupType;
+};

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const CreateGroupBodySchema = z.object({
   name: z.string().min(1),
-  memberIds: z.array(z.string()).optional(),
+  memberIds: z.array(z.string()).min(1),
 });
 
 export type CreateGroupBodyType = z.infer<typeof CreateGroupBodySchema>;

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -28,6 +28,8 @@ export const ACTIVE_ROLES = [
 ] as const;
 export const ANONYMOUS_USER_IMAGE_URL = "/static/humanavatar/anonymous.png";
 
+export const BUSINESS_ADMIN_ROLE_NAME = "business admin";
+
 function keyObject<T extends readonly string[]>(
   arr: T
 ): { [K in T[number]]: null } {


### PR DESCRIPTION
## Description

This PR adds a `POST /api/w/:wId/groups` endpoint to allow admins and business admins to create `regular_manual` groups.

## Tests
Added tests covering: successful creation by admin and business admin, seeding members, invalid member IDs, duplicate names, missing name, and role-based access rejections (user and builder).

## Risks

Low.

## Deploy Plan

Standard deployment.