### PR TITLE
feat: endpoint to get regular manual group details

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -24,6 +24,10 @@ function postGroup(workspace: { sId: string }, body: Record<string, unknown>) {
   });
 }
 
+function getGroup(workspace: { sId: string }, groupId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/groups/${groupId}`);
+}
+
 describe("GET /api/w/:wId/groups", () => {
   it("returns groups with correct member counts", async () => {
     const { workspace, user, auth } = await createPrivateApiMockRequest({
@@ -277,5 +281,84 @@ describe("POST /api/w/:wId/groups", () => {
     expect(
       (await postGroup(workspace, { name: "No members", memberIds: [] })).status
     ).toBe(400);
+  });
+});
+
+describe("GET /api/w/:wId/groups/:groupId", () => {
+  it("returns the group with its members inline", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const extraUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, extraUser, { role: "user" });
+
+    const group = await GroupFactory.regularManual(workspace, "Finance");
+    const addResult = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON(), extraUser.toJSON()],
+    });
+    if (addResult.isErr()) {
+      throw addResult.error;
+    }
+
+    const response = await getGroup(workspace, group.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.group.sId).toBe(group.sId);
+    expect(body.group.kind).toBe("regular_manual");
+    expect(new Set(body.members.map((m: { sId: string }) => m.sId))).toEqual(
+      new Set([user.sId, extraUser.sId])
+    );
+  });
+
+  it("lets an admin read the group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Legal");
+
+    const response = await getGroup(workspace, group.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("lets a business admin read the group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Legal");
+
+    const response = await getGroup(workspace, group.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Secret");
+
+    const response = await getGroup(workspace, group.sId);
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 404 for a non-regular_manual group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularAuto(workspace, "Automatic");
+
+    const response = await getGroup(workspace, group.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
   });
 });

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -1,0 +1,80 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { GetGroupResponseBody } from "@app/types/api/groups/manage";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  groupId: z.string(),
+});
+
+// Mounted at /api/w/:wId/groups/:groupId.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { groupId } = ctx.req.valid("param");
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      switch (groupRes.error.code) {
+        case "invalid_id":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: groupRes.error.message,
+            },
+          });
+        default:
+          assertNever(groupRes.error.code);
+      }
+    }
+
+    const group = groupRes.value;
+
+    // This management API only surfaces manually-managed groups.
+    if (!group.isRegularManual()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: "Group not found.",
+        },
+      });
+    }
+
+    const members = await group.getActiveMembers(auth);
+
+    return ctx.json({
+      group: group.toJSON(),
+      members: members.map((member) => member.toJSON()),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -12,6 +12,7 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import groupDetail from "./[groupId]";
 import spendLimit from "./[groupId]/spend_limit";
 
 export type GetGroupsResponseBody = {
@@ -117,5 +118,6 @@ app.post(
 );
 
 app.route("/:groupId/spend_limit", spendLimit);
+app.route("/:groupId", groupDetail);
 
 export default app;

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -1,4 +1,5 @@
 import type { GroupType } from "@app/types/groups";
+import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
 export const CreateGroupBodySchema = z.object({
@@ -10,4 +11,9 @@ export type CreateGroupBodyType = z.infer<typeof CreateGroupBodySchema>;
 
 export type PostGroupResponseBody = {
   group: GroupType;
+};
+
+export type GetGroupResponseBody = {
+  group: GroupType;
+  members: UserType[];
 };


### PR DESCRIPTION
## Description

This PR adds a new API endpoint to retrieve details of a regular manual group, including its members.

## Tests

Added tests covering:
- Correct response shape (group `sId`, `kind`, and member `sId`s).
- Access control: admin and business admin get `200`, regular user gets `403`.
- `404` returned for non-`regular_manual` groups.

## Risks

Low.

## Deploy Plan

Standard deployment.