### PR TITLE
feat: endpoint to update regular manual group

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -28,6 +28,18 @@ function getGroup(workspace: { sId: string }, groupId: string) {
   return honoApp.request(`/api/w/${workspace.sId}/groups/${groupId}`);
 }
 
+function patchGroup(
+  workspace: { sId: string },
+  groupId: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(`/api/w/${workspace.sId}/groups/${groupId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 describe("GET /api/w/:wId/groups", () => {
   it("returns groups with correct member counts", async () => {
     const { workspace, user, auth } = await createPrivateApiMockRequest({
@@ -360,5 +372,211 @@ describe("GET /api/w/:wId/groups/:groupId", () => {
 
     expect(response.status).toBe(404);
     expect((await response.json()).error.type).toBe("group_not_found");
+  });
+});
+
+describe("PATCH /api/w/:wId/groups/:groupId", () => {
+  it("renames the group", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Old name");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.group.name).toBe("New name");
+
+    const refetched = await GroupResource.fetchById(auth, group.sId);
+    if (refetched.isErr()) {
+      throw refetched.error;
+    }
+    expect(refetched.value.name).toBe("New name");
+  });
+
+  it("sets the full member list", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const extraUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, extraUser, { role: "user" });
+
+    const group = await GroupFactory.regularManual(workspace, "Team");
+    // Seed with a single member that should be replaced by the PATCH.
+    const seed = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (seed.isErr()) {
+      throw seed.error;
+    }
+
+    const response = await patchGroup(workspace, group.sId, {
+      memberIds: [extraUser.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(new Set(body.members.map((m: { sId: string }) => m.sId))).toEqual(
+      new Set([extraUser.sId])
+    );
+  });
+
+  it("clears all members with an empty array", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Team");
+    const seed = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (seed.isErr()) {
+      throw seed.error;
+    }
+
+    const response = await patchGroup(workspace, group.sId, {
+      memberIds: [],
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.members).toEqual([]);
+  });
+
+  it("renames and sets members in a single request", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Old name");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+      memberIds: [user.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.group.name).toBe("New name");
+    expect(new Set(body.members.map((m: { sId: string }) => m.sId))).toEqual(
+      new Set([user.sId])
+    );
+  });
+
+  it("leaves members unchanged when only renaming", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Old name");
+    const seed = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (seed.isErr()) {
+      throw seed.error;
+    }
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(new Set(body.members.map((m: { sId: string }) => m.sId))).toEqual(
+      new Set([user.sId])
+    );
+  });
+
+  it("lets a business admin update the group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "business_admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Old name");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Old name");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 404 for a non-regular_manual group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularAuto(workspace, "Automatic");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "New name",
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+  });
+
+  it("returns 409 when renaming to an existing group name", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    await GroupFactory.regularManual(workspace, "Taken");
+    const group = await GroupFactory.regularManual(workspace, "Original");
+
+    const response = await patchGroup(workspace, group.sId, {
+      name: "Taken",
+    });
+
+    expect(response.status).toBe(409);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when a member id does not belong to the workspace", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Team");
+    const outsider = await UserFactory.basic();
+
+    const response = await patchGroup(workspace, group.sId, {
+      memberIds: [outsider.sId],
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("user_not_found");
+  });
+
+  it("returns 400 for an empty name", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Team");
+
+    const response = await patchGroup(workspace, group.sId, { name: "" });
+
+    expect(response.status).toBe(400);
   });
 });

--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -579,4 +579,17 @@ describe("PATCH /api/w/:wId/groups/:groupId", () => {
 
     expect(response.status).toBe(400);
   });
+
+  it("returns 400 for an empty body", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Team");
+
+    const response = await patchGroup(workspace, group.sId, {});
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
 });

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -92,6 +92,16 @@ app.patch(
     const { groupId } = ctx.req.valid("param");
     const { name, memberIds } = ctx.req.valid("json");
 
+    if (name === undefined && memberIds === undefined) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "At least one of `name` or `memberIds` must be provided.",
+        },
+      });
+    }
+
     const groupRes = await GroupResource.fetchById(auth, groupId);
     if (groupRes.isErr()) {
       switch (groupRes.error.code) {

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -1,5 +1,9 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
-import type { GetGroupResponseBody } from "@app/types/api/groups/manage";
+import type {
+  GetGroupResponseBody,
+  PatchGroupResponseBody,
+} from "@app/types/api/groups/manage";
+import { PatchGroupBodySchema } from "@app/types/api/groups/manage";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
@@ -66,6 +70,116 @@ app.get(
           message: "Group not found.",
         },
       });
+    }
+
+    const members = await group.getActiveMembers(auth);
+
+    return ctx.json({
+      group: group.toJSON(),
+      members: members.map((member) => member.toJSON()),
+    });
+  }
+);
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("param", ParamsSchema),
+  validate("json", PatchGroupBodySchema),
+  async (ctx): HandlerResult<PatchGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { groupId } = ctx.req.valid("param");
+    const { name, memberIds } = ctx.req.valid("json");
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      switch (groupRes.error.code) {
+        case "invalid_id":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: groupRes.error.message,
+            },
+          });
+        default:
+          assertNever(groupRes.error.code);
+      }
+    }
+
+    const group = groupRes.value;
+
+    if (!group.isRegularManual()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: "Group not found.",
+        },
+      });
+    }
+
+    const updateRes = await group.updateRegularManualGroup(auth, {
+      name,
+      memberIds,
+    });
+    if (updateRes.isErr()) {
+      switch (updateRes.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: updateRes.error.message,
+            },
+          });
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateRes.error.message,
+            },
+          });
+        case "user_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "user_not_found",
+              message: updateRes.error.message,
+            },
+          });
+        case "user_not_member":
+        case "user_already_member":
+        case "group_requirements_not_met":
+        case "system_or_global_group":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateRes.error.message,
+            },
+          });
+        default:
+          assertNever(updateRes.error.code);
+      }
     }
 
     const members = await group.getActiveMembers(auth);

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -126,16 +126,6 @@ app.patch(
 
     const group = groupRes.value;
 
-    if (!group.isRegularManual()) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "group_not_found",
-          message: "Group not found.",
-        },
-      });
-    }
-
     const updateRes = await group.updateRegularManualGroup(auth, {
       name,
       memberIds,
@@ -163,6 +153,14 @@ app.patch(
             status_code: 404,
             api_error: {
               type: "user_not_found",
+              message: updateRes.error.message,
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
               message: updateRes.error.message,
             },
           });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2211,6 +2211,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         | "user_not_found"
         | "user_not_member"
         | "user_already_member"
+        | "group_not_found"
         | "group_requirements_not_met"
         | "system_or_global_group"
       >
@@ -2223,6 +2224,10 @@ export class GroupResource extends BaseResource<GroupModel> {
           `Only workspace admins and ${BUSINESS_ADMIN_ROLE_NAME}s can update groups.`
         )
       );
+    }
+
+    if (!this.isRegularManual()) {
+      return new Err(new DustError("group_not_found", "Group not found."));
     }
 
     if (name !== undefined) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2199,6 +2199,69 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  async updateRegularManualGroup(
+    auth: Authenticator,
+    { name, memberIds }: { name?: string; memberIds?: string[] }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "name_conflict"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (!auth.isBusinessAdmin()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          `Only workspace admins and ${BUSINESS_ADMIN_ROLE_NAME}s can update groups.`
+        )
+      );
+    }
+
+    if (name !== undefined) {
+      const existing = await GroupResource.fetchByName(auth, name);
+      if (existing && existing.id !== this.id) {
+        return new Err(
+          new DustError(
+            "name_conflict",
+            `A group named "${name}" already exists in this workspace.`
+          )
+        );
+      }
+
+      const updateRes = await this.updateName(auth, name);
+      if (updateRes.isErr()) {
+        return new Err(new DustError("unauthorized", updateRes.error.message));
+      }
+    }
+
+    if (memberIds !== undefined) {
+      const uniqueMemberIds = [...new Set(memberIds)];
+      const users = await UserResource.fetchByIds(uniqueMemberIds);
+      if (users.length !== uniqueMemberIds.length) {
+        return new Err(
+          new DustError("user_not_found", "Some users were not found.")
+        );
+      }
+
+      const setResult = await this.dangerouslySetMembers(auth, {
+        users: users.map((u) => u.toJSON()),
+      });
+      if (setResult.isErr()) {
+        return new Err(setResult.error);
+      }
+    }
+
+    return new Ok(undefined);
+  }
+
   // Per-group usage spend limit (excluding seat allowance), applied per member.
   // Pass null to clear the cap.
   async updatePoolCap(

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -17,3 +17,15 @@ export type GetGroupResponseBody = {
   group: GroupType;
   members: UserType[];
 };
+
+export const PatchGroupBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  memberIds: z.array(z.string()).optional(),
+});
+
+export type PatchGroupBodyType = z.infer<typeof PatchGroupBodySchema>;
+
+export type PatchGroupResponseBody = {
+  group: GroupType;
+  members: UserType[];
+};


### PR DESCRIPTION
## Description

This PR adds a `PATCH /api/w/:wId/groups/:groupId` endpoint to update a regular manual group's name and/or member list in a single request.

## Tests

Added tests covering: rename, set members, clear members, combined rename + set members, rename-only leaving members unchanged, business admin access, 403 for regular user, 404 for non-`regular_manual` group, 409 for duplicate name, 404 for out-of-workspace member, and 400 for empty name.

## Risks

Low.

## Deploy Plan

Standard deployment.