### PR TITLE
Fixed ES usage count

### DIFF
--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -19,7 +19,7 @@ import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
-  intelligenceAwuFromRunUsages,
+  intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromAction,
 } from "@app/lib/metronome/events";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
@@ -206,7 +206,10 @@ export async function storeAgentAnalytics(
     contextOrigin
   );
 
-  const llmAwu = intelligenceAwuFromRunUsages(runUsages, contextOrigin);
+  const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
+    runUsages,
+    contextOrigin
+  );
   const toolAwu = toolsUsed.reduce((sum, tool) => sum + tool.cost_awu, 0);
   const cost = {
     full_awu: llmAwu + toolAwu,
@@ -284,12 +287,15 @@ export async function storeAgentAnalytics(
 }
 
 /**
- * Fetch the run usages for all runs associated with this agent message.
+ * Fetch the run usages for all runs associated with this agent message,
+ * tagged with the runKey of the agent-loop execution they belong to (so
+ * intelligence cost can be ceiled per execution, matching the billed
+ * Metronome events).
  */
 async function fetchRunUsagesForMessage(
   auth: Authenticator,
   agentMessage: AgentMessageModel
-): Promise<RunUsageType[]> {
+): Promise<(RunUsageType & { runKey: string | null })[]> {
   if (!agentMessage.runIds || agentMessage.runIds.length === 0) {
     return [];
   }


### PR DESCRIPTION
## Description

Fixes an undercount of AI/intelligence credits in the Elasticsearch analytics index (`cost.full_awu`) for any agent message that was interrupted and resumed (i.e. spans more than one agent-loop execution / `runKey`).

`storeAgentAnalytics` computed `llmAwu` with `intelligenceAwuFromRunUsages`, which sums run usages across **all** of a message's accumulated `runIds` and ceils once per `(providerId, modelId)` group over the whole message. Metronome instead emits one billing event **per execution**, each ceiled independently — so `ceil(a) + ceil(b) >= ceil(a + b)` means the analytics index systematically undercounts vs. what's actually billed whenever a message has more than one execution.

The correct, already-existing helper is `intelligenceAwuFromRunUsagesGroupedByRunKey` (used by `computeAgentMessageCredits` / `agentMessage.costCredits`, the value shown to users on the message itself), which ceils per `runKey` before summing — matching the Metronome events exactly. `storeAgentAnalytics` now uses that helper, and `fetchRunUsagesForMessage` threads the `runKey` field through (already returned by `RunResource.listRunUsagesForRuns`, just wasn't used here before).

This was found while investigating a discrepancy between poke's per-user "Consumed" column (backed by the ES analytics index) and the billed Metronome usage (`scripts/debug_user_awu_spend.ts`) for a specific user/workspace.

Note: this only fixes newly indexed documents going forward. Existing ES docs for messages that were already interrupted/resumed still carry the undercounted `cost.full_awu` — a backfill would be needed to correct historical numbers if that's wanted.

### Why `storeAgentAnalytics` recomputes instead of reading `agentMessage.costCredits`

`agentMessage.costCredits` (written by `computeAndStoreAgentMessageCredits`, already using the correct grouped-by-`runKey` helper) holds the same figure we now want in `cost.full_awu`. It's tempting to just read that column instead of recomputing — but the two are launched side by side in the same `Promise.all` in `temporal/agent_loop/activities/finalize.ts`:

```ts
launchAgentMessageAnalytics(auth, agentLoopArgs),   // fires a separate Temporal workflow, returns immediately
...
computeAndStoreAgentMessageCredits(auth, agentLoopArgs),   // runs inline, writes costCredits to Postgres
```

`launchAgentMessageAnalytics` only *starts* the `storeAgentAnalyticsWorkflow` (no `startDelay`, unlike the feedback workflow which explicitly waits 2 minutes for Langfuse) — the actual `storeAgentAnalyticsActivity` execution happens later, whenever a Temporal worker picks it up. `storeAgentAnalyticsActivity` does re-fetch the `AgentMessageModel` row fresh from Postgres at that point, so `costCredits` *would* be populated if `computeAndStoreAgentMessageCredits` already committed — but there's no ordering guarantee between the two: the analytics activity can just as easily run (or retry) before the inline credits write lands. Relying on `costCredits` would still need a recompute fallback for that case, so it wouldn't remove the need for correct recompute logic — it would only save a redundant computation in the common case.

Given that, this PR keeps `storeAgentAnalytics` independently recomputing (now with the correct grouped-by-`runKey` helper on both sides), which makes the race harmless: whichever of the two runs first, the number is right either way. Computing it twice is an accepted, intentional tradeoff here, not an oversight — an opportunistic "read `costCredits` if present, else recompute" optimization is a possible follow-up but out of scope for this fix.

## Tests

Typechecked (`npx tsgo --noEmit`). No existing functional test covers `storeAgentAnalytics`; not added here.

## Risk

Low — only changes how `cost.full_awu` / `cost.llm_awu` are computed at analytics-index time (increases the value for affected messages to match the real billed cost). No change to Metronome billing itself, seat/pool balances, or any user-facing enforcement path.

## Deploy Plan

Standard deploy. No migration or backfill included.
