### PR TITLE
feat: endpoint to delete regular manual group

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -40,6 +40,12 @@ function patchGroup(
   });
 }
 
+function deleteGroup(workspace: { sId: string }, groupId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/groups/${groupId}`, {
+    method: "DELETE",
+  });
+}
+
 describe("GET /api/w/:wId/groups", () => {
   it("returns groups with correct member counts", async () => {
     const { workspace, user, auth } = await createPrivateApiMockRequest({
@@ -591,5 +597,65 @@ describe("PATCH /api/w/:wId/groups/:groupId", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+});
+
+describe("DELETE /api/w/:wId/groups/:groupId", () => {
+  it("lets an admin delete the group", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Doomed");
+
+    const response = await deleteGroup(workspace, group.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).success).toBe(true);
+
+    const refetched = await GroupResource.fetchById(auth, group.sId);
+    expect(refetched.isErr()).toBe(true);
+  });
+
+  it("lets a business admin delete the group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "business_admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Doomed");
+
+    const response = await deleteGroup(workspace, group.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Doomed");
+
+    const response = await deleteGroup(workspace, group.sId);
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 404 for a non-regular_manual group", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularAuto(workspace, "Automatic");
+
+    const response = await deleteGroup(workspace, group.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+
+    // The group must not have been deleted.
+    const refetched = await GroupResource.fetchById(auth, group.sId);
+    expect(refetched.isOk()).toBe(true);
   });
 });

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -1,5 +1,6 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type {
+  DeleteGroupResponseBody,
   GetGroupResponseBody,
   PatchGroupResponseBody,
 } from "@app/types/api/groups/manage";
@@ -196,6 +197,85 @@ app.patch(
       group: group.toJSON(),
       members: members.map((member) => member.toJSON()),
     });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DeleteGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { groupId } = ctx.req.valid("param");
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      switch (groupRes.error.code) {
+        case "invalid_id":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: groupRes.error.message,
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: groupRes.error.message,
+            },
+          });
+        default:
+          assertNever(groupRes.error.code);
+      }
+    }
+
+    const group = groupRes.value;
+
+    const deleteRes = await group.deleteRegularManualGroup(auth);
+    if (deleteRes.isErr()) {
+      switch (deleteRes.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: deleteRes.error.message,
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: deleteRes.error.message,
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: deleteRes.error.message,
+            },
+          });
+        default:
+          assertNever(deleteRes.error.code);
+      }
+    }
+
+    return ctx.json({ success: true });
   }
 );
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2267,6 +2267,35 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  async deleteRegularManualGroup(
+    auth: Authenticator
+  ): Promise<
+    Result<
+      undefined,
+      DustError<"unauthorized" | "group_not_found" | "internal_error">
+    >
+  > {
+    if (!auth.isBusinessAdmin()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          `Only workspace admins and ${BUSINESS_ADMIN_ROLE_NAME}s can delete groups.`
+        )
+      );
+    }
+
+    if (!this.isRegularManual()) {
+      return new Err(new DustError("group_not_found", "Group not found."));
+    }
+
+    const deleteRes = await this.delete(auth);
+    if (deleteRes.isErr()) {
+      return new Err(new DustError("internal_error", deleteRes.error.message));
+    }
+
+    return new Ok(undefined);
+  }
+
   // Per-group usage spend limit (excluding seat allowance), applied per member.
   // Pass null to clear the cap.
   async updatePoolCap(

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -29,3 +29,7 @@ export type PatchGroupResponseBody = {
   group: GroupType;
   members: UserType[];
 };
+
+export type DeleteGroupResponseBody = {
+  success: true;
+};


### PR DESCRIPTION
## Description

This PR adds a `DELETE /api/w/:wId/groups/:groupId` endpoint to allow admins and business admins to delete regular manual groups.

## Tests

Added tests covering: admin deletion, business admin deletion, 403 for regular users, and 404 when trying to delete a non-`regular_manual` group (e.g. `regular_auto`).

## Risks

Low.

## Deploy Plan

Standard deployment.