### PR TITLE
Cache signed GCS URLs for conversation-rendered files

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -1,5 +1,8 @@
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
 import assert from "assert";
 import { Readable } from "stream";
@@ -661,7 +664,8 @@ describe("GCSFileSystemBackend.getDownloadUrl", () => {
       expect(result.value).toBe("https://signed.example.com/file.pdf");
     }
     expect(getSignedUrlMock).toHaveBeenCalledWith(
-      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
+      { expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS }
     );
   });
 
@@ -672,7 +676,8 @@ describe("GCSFileSystemBackend.getDownloadUrl", () => {
       expect(result.value).toBe("https://signed.example.com/file.pdf");
     }
     expect(getSignedUrlMock).toHaveBeenCalledWith(
-      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`,
+      { expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS }
     );
   });
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -13,6 +13,7 @@ import {
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import fileStorageConfig from "@app/lib/file_storage/config";
+import { getCachedPrivateUploadSignedUrl } from "@app/lib/file_storage/signed_url_cache";
 import logger from "@app/logger/logger";
 import type {
   FileSystemDirectoryEntry,
@@ -592,7 +593,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     try {
-      const url = await getPrivateUploadBucket().getSignedUrl(gcsPath);
+      const url = await getCachedPrivateUploadSignedUrl(gcsPath);
 
       return new Ok(url);
     } catch (err) {

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -9,7 +9,10 @@ import {
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -62,7 +65,9 @@ describe("getConversationFileMountSignedUrl", () => {
     if (result.isOk()) {
       expect(result.value).toBe("https://signed.example.com/photo.png");
     }
-    expect(getSignedUrlMock).toHaveBeenCalledWith(gcsPath);
+    expect(getSignedUrlMock).toHaveBeenCalledWith(gcsPath, {
+      expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+    });
   });
 
   it("returns Err without calling GCS when path belongs to a different conversation", async () => {

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getCachedPrivateUploadSignedUrl } from "@app/lib/file_storage/signed_url_cache";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -196,7 +197,7 @@ export async function getConversationFileMountSignedUrl(
     );
   }
   try {
-    const url = await getPrivateUploadBucket().getSignedUrl(gcsPath);
+    const url = await getCachedPrivateUploadSignedUrl(gcsPath);
     return new Ok(url);
   } catch (err) {
     return new Err(normalizeError(err));

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -29,7 +29,7 @@ const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
 // if the object does not already exist", which makes the create safe to retry.
 const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
 
-const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
+export const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
 // Threshold above which file uploads switch from a single multipart POST to a
 // resumable upload (see FileResource.getWriteStream). Below it, uploads are

--- a/front/lib/file_storage/signed_url_cache.test.ts
+++ b/front/lib/file_storage/signed_url_cache.test.ts
@@ -1,0 +1,67 @@
+import {
+  DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import {
+  computeSignedUrlCacheTtlMs,
+  getCachedPrivateUploadSignedUrl,
+} from "@app/lib/file_storage/signed_url_cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("computeSignedUrlCacheTtlMs", () => {
+  it("stays comfortably under the signed URL's own expiration", () => {
+    const ttlMs = computeSignedUrlCacheTtlMs(
+      DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS
+    );
+
+    expect(ttlMs).toBeLessThan(DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS);
+    expect(ttlMs).toBeGreaterThan(0);
+  });
+
+  it("scales with a custom expiration instead of staying fixed", () => {
+    const oneHourMs = 60 * 60 * 1000;
+
+    const defaultTtlMs = computeSignedUrlCacheTtlMs(
+      DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS
+    );
+    const oneHourTtlMs = computeSignedUrlCacheTtlMs(oneHourMs);
+
+    expect(oneHourTtlMs).toBeGreaterThan(defaultTtlMs);
+    expect(oneHourTtlMs).toBeLessThan(oneHourMs);
+  });
+});
+
+describe("getCachedPrivateUploadSignedUrl", () => {
+  let getSignedUrlMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getSignedUrlMock = vi
+      .fn()
+      .mockResolvedValue("https://signed.example.com/file.pdf");
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getSignedUrl: getSignedUrlMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("signs with the default expiration when none is provided", async () => {
+    const url = await getCachedPrivateUploadSignedUrl("w/ws/files/photo.png");
+
+    expect(url).toBe("https://signed.example.com/file.pdf");
+    expect(getSignedUrlMock).toHaveBeenCalledWith("w/ws/files/photo.png", {
+      expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+    });
+  });
+
+  it("passes a custom expiration through to the signer", async () => {
+    const oneHourMs = 60 * 60 * 1000;
+
+    const url = await getCachedPrivateUploadSignedUrl("w/ws/files/photo.png", {
+      expirationDelayMs: oneHourMs,
+    });
+
+    expect(url).toBe("https://signed.example.com/file.pdf");
+    expect(getSignedUrlMock).toHaveBeenCalledWith("w/ws/files/photo.png", {
+      expirationDelayMs: oneHourMs,
+    });
+  });
+});

--- a/front/lib/file_storage/signed_url_cache.ts
+++ b/front/lib/file_storage/signed_url_cache.ts
@@ -1,0 +1,43 @@
+import {
+  DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  getPrivateUploadBucket,
+} from "@app/lib/file_storage";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+
+// Cache TTL as a fraction of the signed URL's own expiration, so a served URL still has
+// real validity left instead of sitting right at its expiry.
+const SIGNED_URL_CACHE_TTL_RATIO = 0.8;
+
+export function computeSignedUrlCacheTtlMs(expirationDelayMs: number): number {
+  return Math.floor(expirationDelayMs * SIGNED_URL_CACHE_TTL_RATIO);
+}
+
+const getCachedSignedUrl = cacheWithRedis(
+  (gcsPath: string, expirationDelayMs: number): Promise<string> =>
+    getPrivateUploadBucket().getSignedUrl(gcsPath, { expirationDelayMs }),
+  (gcsPath, expirationDelayMs) => `${gcsPath}-${expirationDelayMs}`,
+  {
+    ttlMs: (_gcsPath, expirationDelayMs) =>
+      computeSignedUrlCacheTtlMs(expirationDelayMs),
+  }
+);
+
+/**
+ * Cached signed URL for a private-upload GCS path. Without this, conversation rendering
+ * generates a brand new URL (and expiry) on every render of every history-bearing image,
+ * breaking prompt-cache prefix stability for any interaction containing one.
+ */
+export async function getCachedPrivateUploadSignedUrl(
+  gcsPath: string,
+  {
+    expirationDelayMs = DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  }: { expirationDelayMs?: number } = {}
+): Promise<string> {
+  const url = await getCachedSignedUrl(gcsPath, expirationDelayMs);
+  if (url === null) {
+    throw new Error(
+      `Unexpected null signed URL from cache for path: ${gcsPath}`
+    );
+  }
+  return url;
+}

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -20,6 +20,7 @@ import {
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getCachedPrivateUploadSignedUrl } from "@app/lib/file_storage/signed_url_cache";
 import { isPastedFile } from "@app/lib/files";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -1039,7 +1040,7 @@ async function getSignedUrlForVersion(
     version,
   });
 
-  return getPrivateUploadBucket().getSignedUrl(fileCloudStoragePath);
+  return getCachedPrivateUploadSignedUrl(fileCloudStoragePath);
 }
 
 export async function getContentFragmentFromAttachmentFile(

--- a/front/lib/utils/cache.test.ts
+++ b/front/lib/utils/cache.test.ts
@@ -241,6 +241,41 @@ describe("cacheWithRedis", () => {
         })
       ).toThrow("ttlMs should be less than 24 hours");
     });
+
+    it("resolves ttlMs as a function of the call's own args", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(
+        mockFn,
+        (_key: string, ttl: number) => `${_key}-${ttl}`,
+        {
+          ttlMs: (_key: string, ttl: number) => ttl,
+        }
+      );
+      await cachedFn("key1", 12345);
+
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1-12345",
+        JSON.stringify("data"),
+        { PX: 12345 }
+      );
+    });
+
+    it("throws only once a call resolves a function ttlMs above 24 hours", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+
+      const cachedFn = cacheWithRedis(mockFn, (ttl: number) => `${ttl}`, {
+        ttlMs: (ttl: number) => ttl,
+      });
+
+      await expect(cachedFn(25 * 60 * 60 * 1000)).rejects.toThrow(
+        "ttlMs should be less than 24 hours"
+      );
+    });
   });
 
   describe("null value handling (cacheNullValues option)", () => {

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -52,7 +52,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
   options: {
-    ttlMs?: number;
+    ttlMs?: number | ((...args: Args) => number);
     redisUri?: string;
     useDistributedLock?: boolean;
     skipIfLocked?: false;
@@ -64,7 +64,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
   options: {
-    ttlMs?: number;
+    ttlMs?: number | ((...args: Args) => number);
     redisUri?: string;
     useDistributedLock: true;
     // When true and the distributed lock is taken, return null immediately.
@@ -84,7 +84,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     skipIfLocked = false,
     cacheNullValues = true,
   }: {
-    ttlMs?: number;
+    ttlMs?: number | ((...args: Args) => number);
     // Kept for backwards compatibility, no longer used.
     redisUri?: string;
     useDistributedLock?: boolean;
@@ -94,11 +94,18 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     cacheNullValues?: boolean;
   }
 ): (...args: Args) => Promise<JsonSerializable<T> | null> {
-  if (ttlMs !== undefined && ttlMs > 60 * 60 * 24 * 1000) {
+  // A static ttlMs is validated eagerly, same as before. A function ttlMs can only be
+  // validated once the args are known, so that case is checked per-call below instead.
+  if (typeof ttlMs === "number" && ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");
   }
 
   return async function (...args: Args): Promise<JsonSerializable<T> | null> {
+    const resolvedTtlMs = typeof ttlMs === "function" ? ttlMs(...args) : ttlMs;
+    if (resolvedTtlMs !== undefined && resolvedTtlMs > 60 * 60 * 24 * 1000) {
+      throw new Error("ttlMs should be less than 24 hours");
+    }
+
     const key = getCacheKey(fn, resolver, args);
 
     const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
@@ -143,9 +150,9 @@ export function cacheWithRedis<T, Args extends unknown[]>(
 
       const result = await fn(...args);
       if (cacheNullValues || result != null) {
-        if (ttlMs !== undefined) {
+        if (resolvedTtlMs !== undefined) {
           await redisCli.set(key, JSON.stringify(result), {
-            PX: ttlMs,
+            PX: resolvedTtlMs,
           });
         } else {
           await redisCli.set(key, JSON.stringify(result));


### PR DESCRIPTION
## Description

Every time a conversation is rendered for the model, any image or file it references gets a brand new signed GCS URL, even for history that hasn't changed at all, since generating one embeds a fresh timestamp-based signature and expiry on every call. That means any interaction containing an image can never be part of a stable cached prefix, since the exact bytes at that position diverge on every single turn. Added a cache-aside layer so repeated renders within the signed URL's own validity window reuse the same URL instead of hitting GCS again, applied at both the legacy and canonical file-path code paths that conversation rendering uses, since they converge on the same underlying signer. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
