### PR TITLE
feat(model-picker): remove Dust/auto section from input bar model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -128,8 +128,6 @@ export function InputBarModelPicker({
   const allModelsWithEfforts = useMemo<ModelWithReasoningEffort[]>(
     () =>
       models
-        // The auto model is surfaced through the dedicated "Auto" toggle, not as
-        // a browsable model line (its own "Dust" provider group / a search hit).
         .filter((model) => model.modelId !== AUTO_MODEL_ID)
         .flatMap((model) =>
           getSelectableReasoningEfforts(model).map((effort) => ({

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -22,6 +22,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -126,12 +127,16 @@ export function InputBarModelPicker({
 
   const allModelsWithEfforts = useMemo<ModelWithReasoningEffort[]>(
     () =>
-      models.flatMap((model) =>
-        getSelectableReasoningEfforts(model).map((effort) => ({
-          model,
-          effort,
-        }))
-      ),
+      models
+        // The auto model is surfaced through the dedicated "Auto" toggle, not as
+        // a browsable model line (its own "Dust" provider group / a search hit).
+        .filter((model) => model.modelId !== AUTO_MODEL_ID)
+        .flatMap((model) =>
+          getSelectableReasoningEfforts(model).map((effort) => ({
+            model,
+            effort,
+          }))
+        ),
     [models]
   );
 


### PR DESCRIPTION
## Description

Removes the "Dust" / auto provider group from the input bar model picker. The auto model was being bucketed into `moreByProvider` (rendered as a "Dust" section under "More models") and also surfaced as a hit when searching. Since auto selection is already exposed through the dedicated "Auto" toggle at the top of the dropdown, this section was redundant.

The auto model is now filtered out of `allModelsWithEfforts`, so it no longer appears as a browsable model line — neither as its own "Dust" provider group nor as a search result. The "Auto" toggle is unaffected and remains the way to enable auto model selection.

## Tests

Manually verify in the input bar model picker:
- The "Dust" section no longer appears under "More models".
- Searching for "auto" or "dust" no longer returns the auto model as a line item.
- The "Auto" toggle still enables/disables auto model selection as before.
