### PR TITLE
feat(models): recommend GPT 5.6 Terra over GPT 5.5 in model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -2,7 +2,7 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
-import { GPT_5_6_SOL_MODEL_ID } from "@app/types/assistant/models/openai";
+import { GPT_5_6_TERRA_MODEL_ID } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -35,7 +35,7 @@ export const SUGGESTED_PINS: {
   },
   {
     providerId: "openai",
-    modelId: GPT_5_6_SOL_MODEL_ID,
+    modelId: GPT_5_6_TERRA_MODEL_ID,
     effort: "high",
     recommendation:
       "Hard problems. Recommended for high quality retrieval, complex analysis and Frames",

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -2,7 +2,7 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
-import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import { GPT_5_6_SOL_MODEL_ID } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -35,7 +35,7 @@ export const SUGGESTED_PINS: {
   },
   {
     providerId: "openai",
-    modelId: GPT_5_5_MODEL_ID,
+    modelId: GPT_5_6_SOL_MODEL_ID,
     effort: "high",
     recommendation:
       "Hard problems. Recommended for high quality retrieval, complex analysis and Frames",


### PR DESCRIPTION
## Description

Switches the recommended OpenAI model in the input bar model picker from GPT 5.5 to GPT 5.6 Sol (OpenAI's latest flagship model). The "Hard problems" suggested pin now points to `gpt-5.6-sol` at high reasoning effort instead of `gpt-5.5`.

## Tests

Type-checked with `npx tsgo --noEmit`. Manual verification: open the model picker and confirm the OpenAI suggestion under "Hard problems" resolves to GPT 5.6 Sol (falls back gracefully if the workspace doesn't have the model).

## Risk

Low. Cosmetic change to the suggested/recommended list; the pin resolves against the workspace's actual models and is skipped if unavailable. Safe to roll back.
