### PR TITLE
feat(model-picker): hide suggested section when agent has a default

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -202,15 +202,11 @@ export function InputBarModelPicker({
       ? { model: selection.model, effort: selection.effort }
       : null;
   }, [agentModel, models]);
-  // Drop the agent default from Suggested
+  // Hide the Suggested section entirely when the agent has a configured
+  // default: the default already surfaces the recommended pick, so the
+  // suggestions would be redundant.
   const suggested = useMemo(
-    () =>
-      suggestedModelsWithEfforts.filter(
-        (s) =>
-          agentDefault?.effort !== s.effort ||
-          agentDefault?.model.modelId !== s.model.modelId ||
-          agentDefault?.model.providerId !== s.model.providerId
-      ),
+    () => (agentDefault ? [] : suggestedModelsWithEfforts),
     [suggestedModelsWithEfforts, agentDefault]
   );
 


### PR DESCRIPTION
## Description

Hides the "Suggested" section in the model picker when the current agent has a configured default model. Previously both the "Default from agent" and "Suggested" sections rendered side by side (with the default merely filtered out of the suggestions list), which was redundant — the agent's default already surfaces the recommended pick. When a default is present, the Suggested section is now omitted entirely; when there is no default, suggestions render as before.

## Tests

Manually verified in the model picker dropdown:
- Agent with a configured default model → only the "Default from agent" section shows, no "Suggested" section.
- Agent without a default → "Suggested" section renders as before.
