### PR TITLE
Analytics: Add button to filter credit usage graph

### DIFF
--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -50,7 +50,7 @@ export function ChartContainer({
     <>
       <div className="observability-chart-container rounded-lg border border-border bg-background p-4">
         <div className="flex items-center justify-between">
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex shrink-0 items-center justify-between gap-2">
             <h3 className="text-base font-medium text-foreground">{title}</h3>
             {statusChip}
           </div>

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -12,6 +12,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { AnalyticsFilterDropdown } from "@app/components/workspace/analytics/AnalyticsFilterDropdown";
 import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import {
   isScopeDimension,
@@ -35,6 +36,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
@@ -193,6 +195,9 @@ export interface BaseAwuUsageFromAnalyticsChartProps {
   // selection when onFilterChange is provided.
   filter?: AnalyticsFilter;
   onFilterChange?: (next: AnalyticsFilter) => void;
+  // Rendered right of the filter chips. Injected by the workspace chart only:
+  // the dropdown needs the workspace auth context to list filterable entities.
+  filterDropdown?: ReactNode;
 }
 
 interface UsageChartControlsProps {
@@ -205,6 +210,7 @@ interface UsageChartControlsProps {
   groupByOptions: GroupByOption[];
   filter?: AnalyticsFilter;
   onFilterChange?: (next: AnalyticsFilter) => void;
+  filterDropdown?: ReactNode;
   hasDrilldown: boolean;
   onClearDrilldown: () => void;
   csvDownload: ReturnType<typeof useDownloadCsv>;
@@ -220,26 +226,32 @@ function UsageChartControls({
   groupByOptions,
   filter,
   onFilterChange,
+  filterDropdown,
   hasDrilldown,
   onClearDrilldown,
   csvDownload,
 }: UsageChartControlsProps) {
   return (
     <div className="flex items-center gap-2">
-      {filter &&
-        onFilterChange &&
-        SCOPE_DIMENSIONS.flatMap((dimension) =>
-          (filter[dimension] ?? []).map((entity) => (
-            <Chip
-              key={`${dimension}:${entity.id}`}
-              size="xs"
-              label={`${SCOPE_DIMENSION_LABEL[dimension]}: ${entity.name}`}
-              onRemove={() =>
-                onFilterChange(removeScopeEntity(filter, dimension, entity.id))
-              }
-            />
-          ))
-        )}
+      {filter && onFilterChange && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {SCOPE_DIMENSIONS.flatMap((dimension) =>
+            (filter[dimension] ?? []).map((entity) => (
+              <Chip
+                key={`${dimension}:${entity.id}`}
+                size="xs"
+                label={`${SCOPE_DIMENSION_LABEL[dimension]}: ${entity.name}`}
+                onRemove={() =>
+                  onFilterChange(
+                    removeScopeEntity(filter, dimension, entity.id)
+                  )
+                }
+              />
+            ))
+          )}
+        </div>
+      )}
+      {filterDropdown}
       {hasDrilldown && (
         <Button
           label="Clear filters"
@@ -537,6 +549,7 @@ export function BaseAwuUsageFromAnalyticsChart({
   groupByOptions = GROUP_BY_OPTIONS,
   filter,
   onFilterChange,
+  filterDropdown,
 }: BaseAwuUsageFromAnalyticsChartProps) {
   // Legend-driven drilldown: when non-null, only these series are shown.
   const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
@@ -634,6 +647,7 @@ export function BaseAwuUsageFromAnalyticsChart({
           groupByOptions={groupByOptions}
           filter={filter}
           onFilterChange={onFilterChange}
+          filterDropdown={filterDropdown}
           hasDrilldown={!!effectiveEnabledKeys}
           onClearDrilldown={() => setEnabledKeys(null)}
           csvDownload={csvDownload}
@@ -693,6 +707,12 @@ export function AwuUsageFromAnalyticsChart({
       exportUrlPrefix={`/api/w/${workspaceId}/analytics/awu-usage-analytics`}
       filter={filter}
       onFilterChange={onFilterChange}
+      filterDropdown={
+        <AnalyticsFilterDropdown
+          filter={filter}
+          onFilterChange={onFilterChange}
+        />
+      }
     />
   );
 }

--- a/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
+++ b/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
@@ -1,0 +1,177 @@
+import { USER_MESSAGE_ORIGIN_LABELS } from "@app/components/agent_builder/observability/constants";
+import type {
+  AnalyticsEntityFilter,
+  AnalyticsFilter,
+  AnalyticsScopeDimension,
+} from "@app/components/workspace/analytics/analyticsFilter";
+import {
+  SCOPE_DIMENSION_LABEL,
+  toggleScopeEntity,
+} from "@app/components/workspace/analytics/analyticsFilter";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useKeys } from "@app/lib/swr/apps";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useSearchMembers } from "@app/lib/swr/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuFilters,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  FilterFunnel01,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+const DIMENSION_FILTERS: DropdownMenuFilterOption<AnalyticsScopeDimension>[] = (
+  ["user", "agent", "origin", "api_key"] as const
+).map((dimension) => ({
+  value: dimension,
+  label: SCOPE_DIMENSION_LABEL[dimension],
+}));
+
+const MEMBERS_PAGE_SIZE = 25;
+
+interface AnalyticsFilterDropdownProps {
+  filter: AnalyticsFilter;
+  onFilterChange: (next: AnalyticsFilter) => void;
+}
+
+export function AnalyticsFilterDropdown({
+  filter,
+  onFilterChange,
+}: AnalyticsFilterDropdownProps) {
+  const owner = useWorkspace();
+  const [isOpen, setIsOpen] = useState(false);
+  const [dimension, setDimension] = useState<AnalyticsScopeDimension>("user");
+  const [searchText, setSearchText] = useState("");
+
+  const { members, isLoading: isMembersLoading } = useSearchMembers({
+    workspaceId: owner.sId,
+    searchTerm: searchText,
+    pageIndex: 0,
+    pageSize: MEMBERS_PAGE_SIZE,
+    disabled: !isOpen || dimension !== "user",
+  });
+
+  const { agentConfigurations, isAgentConfigurationsLoading } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: isOpen && dimension === "agent" ? "manage" : null,
+      sort: "alphabetical",
+    });
+
+  const { keys, isKeysLoading } = useKeys(owner, {
+    disabled: !isOpen || dimension !== "api_key",
+  });
+
+  const entities: AnalyticsEntityFilter[] = useMemo(() => {
+    const search = searchText.toLowerCase();
+    const matches = (name: string) => name.toLowerCase().includes(search);
+    switch (dimension) {
+      case "user":
+        // Search is applied server-side by useSearchMembers.
+        return members.map((member) => ({
+          id: member.sId,
+          name: member.fullName,
+        }));
+      case "agent":
+        return agentConfigurations
+          .filter((agent) => matches(agent.name))
+          .map((agent) => ({ id: agent.sId, name: agent.name }));
+      case "origin":
+        return Object.entries(USER_MESSAGE_ORIGIN_LABELS)
+          .map(([origin, { label }]) => ({ id: origin, name: label }))
+          .filter((entity) => matches(entity.name));
+      case "api_key":
+        // The analytics filter matches API keys by display name.
+        return keys
+          .filter((key) => matches(key.name))
+          .map((key) => ({ id: key.name, name: key.name }));
+      default:
+        assertNeverAndIgnore(dimension);
+        return [];
+    }
+  }, [dimension, searchText, members, agentConfigurations, keys]);
+
+  const selectedIds = useMemo(
+    () => new Set((filter[dimension] ?? []).map((entity) => entity.id)),
+    [filter, dimension]
+  );
+
+  const isLoading =
+    (dimension === "user" && isMembersLoading) ||
+    (dimension === "agent" && isAgentConfigurationsLoading) ||
+    (dimension === "api_key" && isKeysLoading);
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={FilterFunnel01}
+          size="xs"
+          variant="outline"
+          tooltip="Add filter"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-[320px]"
+        align="end"
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              value={searchText}
+              onChange={setSearchText}
+              name="search"
+              placeholder="Search"
+              autoFocus
+            />
+            <DropdownMenuFilters
+              filters={DIMENSION_FILTERS}
+              selectedValues={[dimension]}
+              onSelectFilter={setDimension}
+            />
+          </>
+        }
+      >
+        <DropdownMenuSeparator />
+        {isLoading ? (
+          <div className="flex h-24 items-center justify-center">
+            <Spinner size="sm" />
+          </div>
+        ) : entities.length > 0 ? (
+          entities.map((entity) => (
+            <DropdownMenuCheckboxItem
+              key={entity.id}
+              label={entity.name}
+              truncateText
+              checked={selectedIds.has(entity.id)}
+              onCheckedChange={() =>
+                onFilterChange(toggleScopeEntity(filter, dimension, entity))
+              }
+              // Keep the menu open so several values can be toggled in a row.
+              onSelect={(event) => event.preventDefault()}
+            />
+          ))
+        ) : (
+          <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+            No results
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -197,7 +197,11 @@ export function useProviders({
   };
 }
 
-export function useKeys(owner: LightWorkspaceType) {
+export function useKeys(
+  owner: LightWorkspaceType,
+  options?: { disabled?: boolean }
+) {
+  const disabled = options?.disabled ?? false;
   const { fetcher } = useFetcher();
   const keysFetcher: Fetcher<GetKeysResponseBody> = fetcher;
   const { data, error, isValidating } = useSWRWithDefaults(
@@ -205,12 +209,13 @@ export function useKeys(owner: LightWorkspaceType) {
     keysFetcher,
     {
       revalidateOnFocus: false,
+      disabled,
     }
   );
 
   return {
     isKeysError: error,
-    isKeysLoading: !error && !data,
+    isKeysLoading: !error && !data && !disabled,
     isValidating,
     keys: data?.keys ?? emptyArray(),
   };


### PR DESCRIPTION
## Description

Slightly related to https://github.com/dust-tt/tasks/issues/8167

Add a new button in the credits usage graph.
The button opens a menu to pick one or several values to filter on (users, api key, agents, source)
The actual mecanism for filtering already exist and already work well (it was by clicking a value). This just add a new way to do the filter and discover it.

## Tests

tested locally 

<img width="2278" height="844" alt="image" src="https://github.com/user-attachments/assets/12cc2aac-7e00-4752-8e88-41b256f7fdaf" />


<img width="1136" height="445" alt="Screenshot 2026-07-10 at 17 26 30" src="https://github.com/user-attachments/assets/b9976e3a-8a54-493b-81c0-e76d7a5e1997" />


https://github.com/user-attachments/assets/cf7430be-9075-4190-b668-21b9b2a37e8d



## Risk

low, easy to revert as it is entirely UI.

## Deploy Plan

deploy front
