### PR TITLE
fix(assistant): untoggling Auto returns to Default (or Auto) in model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -287,6 +287,10 @@ export function InputBarModelPicker({
 
   const toggleAuto = () => {
     if (isAutoOn) {
+      // Untoggling Auto returns to the agent's Default if it has one, and stays
+      // on Auto otherwise. Clearing any manual override surfaces the resolved
+      // default selection ("Default", or "Auto" when the agent has no default).
+      setUserOverride(null);
       setExpanded(true);
     } else {
       commitSelection({ kind: "auto", toSend: AUTO_MODEL_SELECTION });

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -287,9 +287,6 @@ export function InputBarModelPicker({
 
   const toggleAuto = () => {
     if (isAutoOn) {
-      // Untoggling Auto returns to the agent's Default if it has one, and stays
-      // on Auto otherwise. Clearing any manual override surfaces the resolved
-      // default selection ("Default", or "Auto" when the agent has no default).
       setUserOverride(null);
       setExpanded(true);
     } else {


### PR DESCRIPTION
## Description

In the conversation input bar model picker, turning the **Auto** toggle off now returns the selection to the agent's **Default** model when it has one, and stays on **Auto** when it doesn't.

Previously, untoggling Auto only expanded the model list without clearing the manual selection override. So if you had forced Auto on an agent that has a configured Default model, toggling Auto back off left you stuck on Auto instead of returning to the Default.

The fix clears the manual override in `toggleAuto`, which surfaces the resolved default selection from `resolveDefaultSelection` — the Default model if any, or Auto when the agent has no default.

## Tests

Manual, in the conversation input bar (behind the `models_picker` feature flag):

- On an agent with a configured Default model: turn Auto on, then off → selection returns to "Default".
- On an agent with no default (its model is Auto): turn Auto off → stays on "Auto" and expands the model list to browse.
