### PR TITLE
[Skills] Skill restrictions canRead --> isMember

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -20,9 +20,11 @@ import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SkillResource", () => {
@@ -61,6 +63,77 @@ describe("SkillResource", () => {
 
       expect(skill.canWrite(readOnlyAuth)).toBe(false);
       expect(skill.canAdministrate(readOnlyAuth)).toBe(false);
+    });
+  });
+
+  describe("space restriction visibility", () => {
+    async function nonMemberAuth() {
+      const outsider = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, outsider, {
+        role: "user",
+      });
+      return Authenticator.fromUserIdAndWorkspaceId(
+        outsider.sId,
+        testContext.workspace.sId
+      );
+    }
+
+    async function listSeesSkill(auth: Authenticator, skillSId: string) {
+      const list = await SkillResource.listByWorkspace(auth, {
+        onlyCustom: true,
+      });
+      return list.some((s) => s.sId === skillSId);
+    }
+
+    it("hides a skill restricted to an open Pod from non-members", async () => {
+      const pod = await SpaceFactory.project(
+        testContext.workspace,
+        testContext.user.id
+      );
+      await GroupSpaceFactory.associate(pod, testContext.globalGroup);
+      await testContext.authenticator.refresh();
+
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Open Pod Restricted Skill",
+        requestedSpaceIds: [pod.id],
+      });
+
+      expect(await listSeesSkill(testContext.authenticator, skill.sId)).toBe(
+        true
+      );
+
+      expect(await listSeesSkill(await nonMemberAuth(), skill.sId)).toBe(false);
+    });
+
+    it("hides a skill restricted to a restricted space from non-members", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await space.addMembers(testContext.authenticator, {
+        userIds: [testContext.user.sId],
+      });
+      await testContext.authenticator.refresh();
+
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Restricted Space Skill",
+        requestedSpaceIds: [space.id],
+      });
+
+      expect(await listSeesSkill(testContext.authenticator, skill.sId)).toBe(
+        true
+      );
+      expect(await listSeesSkill(await nonMemberAuth(), skill.sId)).toBe(false);
+    });
+
+    it("keeps a skill restricted to an open regular space visible to all members", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(space, testContext.globalGroup);
+      await testContext.authenticator.refresh();
+
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Open Regular Space Skill",
+        requestedSpaceIds: [space.id],
+      });
+
+      expect(await listSeesSkill(await nonMemberAuth(), skill.sId)).toBe(true);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -31,10 +31,6 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import {
-  createResourcePermissionsFromSpacesWithMap,
-  createSpaceIdToGroupsMap,
-} from "@app/lib/resources/permission_utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
@@ -581,7 +577,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    // Check if the user has access to skill requested spaces.
     const uniqueRequestedSpaceIds = uniq(
       customSkills.flatMap((c) => c.requestedSpaceIds)
     );
@@ -591,7 +586,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             transaction,
           })
         : [];
-    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+    const spaceById = new Map(spaces.map((s) => [s.id, s]));
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
 
     const validCustomSkills = customSkills.filter((skill) =>
@@ -599,11 +594,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
-      auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
-          spaceIdToGroupsMap,
-          skill.requestedSpaceIds
-        )
+      skill.requestedSpaceIds.every(
+        (spaceModelId) => spaceById.get(spaceModelId)?.isMember(auth) ?? false
       )
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);


### PR DESCRIPTION
## Description
This PR restricts skill space visibility to space members: skills that request a restricted space now use space.isMember(auth) instead of the broader canRead permission check, so they're only visible to members of that space.

## Tests
Tested locally.
Added resource-level tests covering member vs non-member visibility for open Pods, restricted spaces, and open regular spaces.

## Risk
Low risk.

## Deploy Plan
Normal deployment.
