### PR TITLE
feat(assistant): pass requested model to placeholder user message on model picker override

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -291,7 +291,7 @@ function buildFirstMessagePlaceholders(
   pending: PendingConversationMessage,
   user: UserType
 ): FirstMessagePlaceholders {
-  const { input, mentions, contentFragments } = pending;
+  const { input, mentions, contentFragments, modelSelection } = pending;
 
   // Empty conversation: ranks start at 0 (no existing messages).
   let rank =
@@ -304,6 +304,7 @@ function buildFirstMessagePlaceholders(
     branchId: null,
     rank,
     contentFragments,
+    requestedModel: modelSelection ?? null,
   });
 
   const agentMessages: VirtuosoMessage[] = [];
@@ -1178,6 +1179,7 @@ export const ConversationViewer = ({
             branchId: null, // We can't know the branch id yet, it will be set when the message is created.
             rank,
             contentFragments,
+            requestedModel: modelSelection ?? null,
           });
 
         // Skip placeholder agent messages if there's already a running agent in the conversation

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -8,6 +8,7 @@ import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import {
@@ -23,6 +24,7 @@ export type PendingConversationMessage = {
   input: string;
   mentions: RichMention[];
   contentFragments: ContentFragmentsType;
+  modelSelection?: ModelSelectionType;
 };
 
 export type PendingInputText = {

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -2,6 +2,7 @@ import type { AgentMessageWithStreaming } from "@app/components/assistant/conver
 import type { UserMessageType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentsType,
   ContentFragmentType,
@@ -17,6 +18,7 @@ export function createPlaceholderUserMessage({
   rank,
   branchId,
   contentFragments,
+  requestedModel,
 }: {
   input: string;
   mentions: RichMention[];
@@ -24,6 +26,7 @@ export function createPlaceholderUserMessage({
   rank: number;
   branchId: string | null;
   contentFragments?: ContentFragmentsType;
+  requestedModel?: ModelSelectionType | null;
 }): UserMessageType & { contentFragments: ContentFragmentType[] } {
   const createdAt = new Date().getTime();
   const { email, fullName, image, username } = user;
@@ -54,7 +57,7 @@ export function createPlaceholderUserMessage({
       origin: "web",
     },
     reactions: [],
-    requestedModel: null, // TODO(models_picker): add the requested model
+    requestedModel: requestedModel ?? null,
     contentFragments: [
       ...(contentFragments?.uploaded ?? []).map(
         (cf) =>

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -135,6 +135,7 @@ export function useCreateConversationWithMessage({
             input,
             mentions: richMentions ?? [],
             contentFragments,
+            modelSelection,
           });
 
           // Post the message in the background so navigation isn't blocked on it.

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -950,6 +950,40 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
 ];
 
+// "Model agents" are the global agents that merely wrap a single provider model
+// (e.g. "gpt-5", "claude-sonnet", "mistral-large") rather than one of Dust's
+// functional agents. When the models picker is enabled these are hidden from the
+// default agent list because the picker exposes the underlying models directly.
+const MODEL_GLOBAL_AGENTS_SID: readonly GLOBAL_AGENTS_SID[] = [
+  GLOBAL_AGENTS_SID.GPT35_TURBO,
+  GLOBAL_AGENTS_SID.GPT4,
+  GLOBAL_AGENTS_SID.GPT5,
+  GLOBAL_AGENTS_SID.GPT5_THINKING,
+  GLOBAL_AGENTS_SID.GPT5_NANO,
+  GLOBAL_AGENTS_SID.GPT5_MINI,
+  GLOBAL_AGENTS_SID.O1,
+  GLOBAL_AGENTS_SID.O1_MINI,
+  GLOBAL_AGENTS_SID.O1_HIGH_REASONING,
+  GLOBAL_AGENTS_SID.O3_MINI,
+  GLOBAL_AGENTS_SID.O3,
+  GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU,
+  GLOBAL_AGENTS_SID.CLAUDE_5_SONNET,
+  GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET,
+  GLOBAL_AGENTS_SID.CLAUDE_4_SONNET,
+  GLOBAL_AGENTS_SID.CLAUDE_3_OPUS,
+  GLOBAL_AGENTS_SID.CLAUDE_3_SONNET,
+  GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU,
+  GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET,
+  GLOBAL_AGENTS_SID.MISTRAL_LARGE,
+  GLOBAL_AGENTS_SID.MISTRAL_MEDIUM,
+  GLOBAL_AGENTS_SID.MISTRAL_SMALL,
+  GLOBAL_AGENTS_SID.GEMINI_PRO,
+];
+
+export function isModelGlobalAgent(sId: string): boolean {
+  return isGlobalAgentId(sId) && MODEL_GLOBAL_AGENTS_SID.includes(sId);
+}
+
 function getCustomModelIndexForGlobalAgent(sId: string): number | null {
   if (!isGlobalAgentId(sId)) {
     return null;
@@ -1116,6 +1150,14 @@ export async function getGlobalAgents(
   agentsIdsToFetch = agentsIdsToFetch.filter(
     (sId) => !isGlobalAgentId(sId) || canRoleSeeGlobalAgent(sId, auth)
   );
+
+  // Mirrors the `RETIRED_GLOBAL_AGENTS_SID` handling; explicit fetches
+  // still resolves them.
+  if (agentIds === undefined && flags.includes("models_picker")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => !isModelGlobalAgent(sId)
+    );
+  }
 
   const sidekickContext =
     variant === "full"


### PR DESCRIPTION
## Description

When the `models_picker` feature flag is enabled, the bare "model agents" — global
agents that merely wrap a single provider model (`gpt-5`, `claude-sonnet`,
`claude-4.5-haiku`, `mistral-large`, `gemini-pro`, the `o*` series, etc.) — are now
hidden from the default agent list. The model picker exposes these underlying models
directly in the input bar, so the wrapper agents are redundant when the flag is on.

The filtering is done in `getGlobalAgents` alongside the existing default-list
filters, and only applies when building the default list (`agentIds === undefined`) —
the same path every picker/list view uses. Explicit fetches by `agentId` still resolve
these agents, so existing conversations that reference them keep working. This mirrors
the existing `RETIRED_GLOBAL_AGENTS_SID` handling.

## Tests

Verify with the `models_picker` flag on: the model-wrapper global agents (e.g.
`claude-sonnet`, `gpt-5`) no longer appear in the agent picker / agent list, while a
pre-existing conversation using one of them still loads and runs. With the flag off,
they appear as before.
