### PR TITLE
[front] enh: polish skill builder UI

### DIFF
--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -25,7 +25,7 @@ function buildSkillDescriptionExtensions(): Extensions {
       placeholder:
         "When should this skill be used? What is this skill good for?",
       emptyNodeClass:
-        "first:before:text-primary-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+        "first:before:text-muted-foreground first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
     }),
   ];
 }

--- a/front/components/editor/editorStyles.ts
+++ b/front/components/editor/editorStyles.ts
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 export const editorVariants = cva(
   [
     "overflow-auto border rounded-xl px-3 pt-2 pb-8 resize-y",
-    "transition-all duration-200",
+    "transition-[background-color,border-color,box-shadow,outline-color,opacity] duration-200 motion-reduce:transition-none",
     "bg-muted-background",
   ],
   {

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -188,7 +188,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
 
   return (
     <section className="space-y-4">
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex flex-col items-start justify-between gap-2 sm:flex-row">
         <div className="space-y-1">
           <h3 className="heading-lg font-semibold text-foreground">
             {SKILL_INVOCATION_LABEL}


### PR DESCRIPTION
## Description

Skill Builder rendered the “When to use” placeholder with a different color from the Instructions placeholder. This aligns both on the shared `muted-foreground` token for consistent styling across themes.

This also limits the shared editor transition to visual focus-state properties, respects reduced-motion preferences, and lets the “When to use” header stack cleanly on narrow screens. Editor behavior remains unchanged.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
