### PR TITLE
[front] enh: remove inline manifest in Computer skill instructions

### DIFF
--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -6,7 +6,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 describe("sandboxSkill", () => {
-  it("includes dsbx tools instructions and manifest entry when sandbox is enabled", async () => {
+  it("points to the on-demand toolset description instead of inlining it", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const instructions = await sandboxSkill.fetchInstructions(auth, {
@@ -14,10 +14,12 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).toContain("dsbx tools");
-    expect(instructions).toContain("name: dsbx");
+    expect(instructions).toContain("`describe_toolset`");
+    expect(instructions).not.toContain("name: dsbx");
+    expect(instructions).not.toContain("```yaml");
   });
 
-  it("hides dsbx tools instructions and manifest entry when computer is disabled", async () => {
+  it("hides dsbx tools instructions when computer is disabled", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
@@ -27,7 +29,6 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).not.toContain("dsbx tools");
-    expect(instructions).not.toContain("name: dsbx");
   });
 
   it("instructs the model to analyze mounted tabular files with code", async () => {

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -1,22 +1,13 @@
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { readWorkspacePolicy } from "@app/lib/api/sandbox/egress_policy";
-import {
-  createToolManifest,
-  filterDsbxToolEntries,
-  getSandboxImage,
-  getToolsForProvider,
-  toolManifestToYAML,
-} from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
-import { Ok } from "@app/types/shared/result";
 
 function buildSandboxInstructionProse({
   hasDsbxTools,
@@ -78,7 +69,7 @@ immediately visible through the other.
 Default to the sandbox, not the \`files\` MCP server. Whenever the sandbox
 is available, navigate and process conversation files and tool outputs
 with bash on \`/files/conversation\` using the standard POSIX toolchain
-plus \`jq\` / \`rg\` (see the available tools manifest below). This is
+plus \`jq\` / \`rg\` (call \`describe_toolset\` for the full list). This is
 cheaper than MCP round-trips, keeps intermediate output out of the
 conversation context, and lets you compose pipelines. Reach for the
 \`files\` MCP server only for a trivial one-shot read where spinning up a
@@ -291,7 +282,6 @@ attempt to reconstruct, decode, or otherwise recover the value.`;
 
 async function buildSandboxInstructions(
   auth: Authenticator,
-  providerId: ModelProviderIdType | undefined,
   { hasDsbxTools, isProject }: { hasDsbxTools: boolean; isProject: boolean }
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
@@ -300,34 +290,9 @@ async function buildSandboxInstructions(
   const projectFilesSection = isProject ? buildProjectFilesSection() : null;
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
 
-  let toolsResult;
-
   const filesSections = [conversationFilesSection, projectFilesSection]
     .filter((s): s is string => s !== null)
     .join("\n\n");
-
-  if (providerId) {
-    toolsResult = getToolsForProvider(auth, providerId, {
-      includeDsbxTools: hasDsbxTools,
-    });
-  } else {
-    const imageResult = getSandboxImage(auth);
-    if (imageResult.isErr()) {
-      return `${sandboxInstructions}\n\n${filesSections}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
-    }
-    toolsResult = new Ok(
-      filterDsbxToolEntries(imageResult.value.tools, {
-        includeDsbxTools: hasDsbxTools,
-      })
-    );
-  }
-
-  if (toolsResult.isErr()) {
-    return `${sandboxInstructions}\n\n${filesSections}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
-  }
-
-  const manifest = createToolManifest(toolsResult.value);
-  const manifestYaml = toolManifestToYAML(manifest);
 
   return `${sandboxInstructions}
 
@@ -339,13 +304,10 @@ ${environmentVariablesSection}
 
 #### Sandbox Available Tools and Libraries
 
-The following tools and libraries are pre-installed in the sandbox environment.
-Installing packages in the sandbox is NOT possible.
-CRITICAL: Use ONLY the sandbox tools listed below, NOTHING ELSE.
-
-\`\`\`yaml
-${manifestYaml}
-\`\`\`
+Tools and libraries are pre-installed in the sandbox environment. Installing
+packages in the sandbox is NOT possible. Call \`describe_toolset\` to inspect
+the available CLI binaries and language libraries, including their exact
+versions. Use ONLY the tools listed there, NOTHING ELSE.
 
 `;
 }
@@ -370,14 +332,13 @@ export const sandboxSkill = {
       agentLoopData,
     }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
-    const providerId = agentLoopData?.model.providerId;
     const flags = await getFeatureFlags(auth);
     const hasDsbxTools = isComputerFeatureEnabled(flags);
     const isProject = agentLoopData?.conversation
       ? isPodConversation(agentLoopData.conversation)
       : false;
 
-    return buildSandboxInstructions(auth, providerId, {
+    return buildSandboxInstructions(auth, {
       hasDsbxTools,
       isProject,
     });


### PR DESCRIPTION
## Description

The Computer skill currently injects in its instructions a yaml manifest of all the libraries that are available at runtime. This list started small but grew big over time, now accounting for 2,548 tokens (see trace [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3BH3rmurWjSK&peek=72ca03e416f06d9c0e3ceed4a6882d7c&timestamp=2026-07-13T07%3A44%3A55.589Z&observation=8475ff7dce2c7589)).

This PR replaces the inline manifest with an on-demand call to `describe_toolset`..

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
