### PR TITLE
Bump the tool-output-content fetch batch size and add visibility into conversation length

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.test.ts
+++ b/front/lib/api/assistant/conversation/fetch.test.ts
@@ -51,31 +51,43 @@ describe("computeMessagesWithToolOutputContent", () => {
   });
 
   it("excludes the oldest batch once the floor's start crosses a batch boundary, and stays put across many turns", () => {
-    // At n=14, floorStart=10, which is the first batch boundary: interactions 1-10 (ids) get
-    // excluded, 11-14 stay included.
-    const atFirstCrossing = computeMessagesWithToolOutputContent(
-      buildInteractions(14),
-      4
-    );
-    expect(atFirstCrossing).toEqual(new Set([11, 12, 13, 14]));
+    const floorCount = 4;
+    const batch = TOOL_OUTPUT_FETCH_BATCH_SIZE;
 
-    // Ten turns later (n=23, floorStart=19), the boundary hasn't moved yet: still exactly
-    // interactions 1-10 excluded, everything from 11 onward included.
-    const tenTurnsLater = computeMessagesWithToolOutputContent(
-      buildInteractions(23),
-      4
-    );
-    expect(tenTurnsLater).toEqual(
-      new Set(Array.from({ length: 13 }, (_, i) => i + 11))
-    );
+    // ids strictly after `excludedUpTo` (i.e. from excludedUpTo+1 to n).
+    const idsIncludedFrom = (excludedUpTo: number, n: number) =>
+      new Set(
+        Array.from({ length: n - excludedUpTo }, (_, i) => excludedUpTo + i + 1)
+      );
 
-    // One more turn (n=24, floorStart=20) crosses the next batch boundary: interactions 11-20 now
-    // also get excluded, in one jump.
-    const nextCrossing = computeMessagesWithToolOutputContent(
-      buildInteractions(24),
-      4
-    );
-    expect(nextCrossing).toEqual(new Set([21, 22, 23, 24]));
+    // First n where floorStart (n - floorCount) reaches the first batch boundary: ids 1..batch
+    // get excluded.
+    const nAtFirstCrossing = batch + floorCount;
+    expect(
+      computeMessagesWithToolOutputContent(
+        buildInteractions(nAtFirstCrossing),
+        floorCount
+      )
+    ).toEqual(idsIncludedFrom(batch, nAtFirstCrossing));
+
+    // Just before the second boundary: unchanged from above, the checkpoint hasn't moved yet.
+    const nJustBeforeNextCrossing = 2 * batch + floorCount - 1;
+    expect(
+      computeMessagesWithToolOutputContent(
+        buildInteractions(nJustBeforeNextCrossing),
+        floorCount
+      )
+    ).toEqual(idsIncludedFrom(batch, nJustBeforeNextCrossing));
+
+    // One more turn crosses the next boundary: ids batch+1..2*batch also get excluded, in one
+    // jump.
+    const nAtNextCrossing = 2 * batch + floorCount;
+    expect(
+      computeMessagesWithToolOutputContent(
+        buildInteractions(nAtNextCrossing),
+        floorCount
+      )
+    ).toEqual(idsIncludedFrom(2 * batch, nAtNextCrossing));
   });
 
   it("never re-includes an interaction once it stops being fetched, as the conversation grows", () => {
@@ -83,8 +95,10 @@ describe("computeMessagesWithToolOutputContent", () => {
     // batch boundary, that's the whole point. What must never happen is the opposite: something
     // that's already excluded coming back once more interactions arrive.
     let previouslyExcluded = new Set<number>();
+    // Comfortably past two batch boundary crossings, whatever the batch size is.
+    const upperBound = 2 * TOOL_OUTPUT_FETCH_BATCH_SIZE + 20;
 
-    for (let n = 1; n <= 50; n++) {
+    for (let n = 1; n <= upperBound; n++) {
       const included = computeMessagesWithToolOutputContent(
         buildInteractions(n),
         4

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -14,6 +14,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import type {
   AgentMessageType,
   CompactionMessageType,
@@ -94,7 +95,14 @@ export const getLightConversation = async (
 // guaranteed floor. The boundary is anchored on a fixed, absolute interaction index rather than
 // distance from the most recent interaction, so it only advances once a full batch of new
 // interactions has accumulated instead of sliding by one every single turn.
-export const TOOL_OUTPUT_FETCH_BATCH_SIZE = 10;
+//
+// When the boundary does advance, every interaction between the old and new checkpoint loses its
+// tool-output content in a single turn (see computeMessagesWithToolOutputContent), which busts the
+// prompt cache for that turn. A larger batch means fewer crossings overall. It also means most
+// conversations whose interaction count never reaches the threshold never cross it at all. 30 is a
+// placeholder pending real data on the interaction-count distribution (see the
+// "conversation.interactions_count" metric below). Revisit once that data is in.
+export const TOOL_OUTPUT_FETCH_BATCH_SIZE = 30;
 
 /**
  * Decides which agent messages should have their tool-output content fetched.
@@ -270,6 +278,12 @@ async function _getConversation<V extends "light" | "full">(
           // We don't care about the other messages.
         })
       )
+    );
+
+    // Purely observational, see TOOL_OUTPUT_FETCH_BATCH_SIZE above.
+    getStatsDClient().distribution(
+      "conversation.interactions_count",
+      interactions.length
     );
 
     messagesWithToolOutputContent = computeMessagesWithToolOutputContent(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We recently confirmed a real cache-busting bug in production: as a conversation grows, old tool results periodically get dropped from what we fetch for the model, and the way that drop is currently batched means it happens in big, sudden jumps rather than gradually. When one of those jumps hits, the model sees content disappear that it saw in full just one turn earlier, which invalidates the whole prompt cache from that point forward and makes the next request far more expensive than it needs to be.

We looked at a more involved fix that tracks, per conversation, exactly how much history is still needed and adjusts the fetch window accordingly, but decided to hold off on landing that until we understand the problem better. Instead of guessing at the right batch size, this change raises the current threshold to a safer default and adds a metric that reports how many interactions a typical conversation actually has. Once we have a few days of real numbers, we can either tune this constant with confidence or revisit the more thorough fix if it turns out long conversations are common enough to matter.

This is a low-risk, mostly observational change. Nothing changes for the vast majority of conversations that stay under the new threshold, and we'll be watching the new metric before deciding what to do next.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
