### PR TITLE
Scope authentication kind to agent loops

### DIFF
--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -56,7 +56,6 @@ export function GoogleDriveFileAuthorizationRequired({
   const { removeCompletedAction } = useBlockedActionsContext();
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
     owner,
-    kind: "file_authorization",
   });
   const isExtension = clientType === "extension";
 
@@ -162,6 +161,7 @@ export function GoogleDriveFileAuthorizationRequired({
   const handleSkip = useCallback(async () => {
     const denyRes = await resolveAuthentication({
       contextType: "agent_loop",
+      kind: "file_authorization",
       outcome: "denied",
       actionId: blockedAction.actionId,
       conversationId: blockedAction.conversationId,

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -34,6 +34,7 @@ export function MCPServerPersonalAuthenticationRequired({
   ): Promise<boolean> => {
     const result = await resolveAuthentication({
       contextType: "agent_loop",
+      kind: "authentication",
       outcome,
       actionId: blockedAction.actionId,
       conversationId: blockedAction.conversationId,

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -36,10 +36,22 @@ type ToolActionContext =
       invocationId: string;
     };
 
-type ResolveAuthenticationRequest = ToolActionContext & {
-  actionId: string;
-  outcome: ResolveAuthenticationOutcome;
-};
+type ResolveAuthenticationRequest =
+  | {
+      contextType: "agent_loop";
+      kind: ResolveAuthenticationKind;
+      conversationId: string;
+      messageId: string;
+      actionId: string;
+      outcome: ResolveAuthenticationOutcome;
+    }
+  | {
+      contextType: "sandbox_function";
+      sandboxFunctionId: string;
+      invocationId: string;
+      actionId: string;
+      outcome: ResolveAuthenticationOutcome;
+    };
 
 type ValidateActionRequest = ToolActionContext & {
   actionId: string;
@@ -53,13 +65,12 @@ interface ToolActionMutationRequest {
 
 function getResolveAuthenticationRequest(
   workspaceId: string,
-  kind: ResolveAuthenticationKind,
   request: ResolveAuthenticationRequest
 ): ToolActionMutationRequest {
   switch (request.contextType) {
     case "agent_loop":
       return {
-        url: `/api/w/${workspaceId}/assistant/conversations/${request.conversationId}/messages/${request.messageId}/${ROUTE_FOR_KIND[kind]}`,
+        url: `/api/w/${workspaceId}/assistant/conversations/${request.conversationId}/messages/${request.messageId}/${ROUTE_FOR_KIND[request.kind]}`,
         body: {
           actionId: request.actionId,
           outcome: request.outcome,
@@ -71,6 +82,19 @@ function getResolveAuthenticationRequest(
         url: `/api/w/${workspaceId}/sandbox-functions/${request.sandboxFunctionId}/invocations/${request.invocationId}/actions/${request.actionId}/resolve-authentication`,
         body: { outcome: request.outcome },
       };
+    default:
+      return assertNever(request);
+  }
+}
+
+function getAuthenticationKindLabel(
+  request: ResolveAuthenticationRequest
+): string {
+  switch (request.contextType) {
+    case "agent_loop":
+      return LABEL_FOR_KIND[request.kind];
+    case "sandbox_function":
+      return LABEL_FOR_KIND.authentication;
     default:
       return assertNever(request);
   }
@@ -102,12 +126,10 @@ function getValidateActionRequest(
 
 interface UseResolveAuthenticationParams {
   owner: LightWorkspaceType;
-  kind?: ResolveAuthenticationKind;
 }
 
 export function useResolveAuthentication({
   owner,
-  kind = "authentication",
 }: UseResolveAuthenticationParams) {
   const sendNotification = useSendNotification();
   const { fetcher } = useFetcher();
@@ -118,11 +140,7 @@ export function useResolveAuthentication({
       setIsResolving(true);
 
       try {
-        const request = getResolveAuthenticationRequest(
-          owner.sId,
-          kind,
-          resolution
-        );
+        const request = getResolveAuthenticationRequest(owner.sId, resolution);
         await fetcher(request.url, {
           method: "POST",
           headers: {
@@ -137,17 +155,18 @@ export function useResolveAuthentication({
           return { success: true };
         }
 
+        const label = getAuthenticationKindLabel(resolution);
         sendNotification({
           type: "error",
-          title: `Failed to resolve ${LABEL_FOR_KIND[kind]}`,
-          description: `Failed to resume the ${LABEL_FOR_KIND[kind]} tool. Please try again.`,
+          title: `Failed to complete ${label}`,
+          description: `The tool could not resume after ${label}. Please try again.`,
         });
         return { success: false };
       } finally {
         setIsResolving(false);
       }
     },
-    [owner.sId, sendNotification, fetcher, kind]
+    [owner.sId, sendNotification, fetcher]
   );
 
   return { resolveAuthentication, isResolving };

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { useFetcher } from "@app/lib/swr/swr";
 import { isAPIErrorResponse } from "@app/types/error";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
@@ -66,7 +66,7 @@ interface ToolActionMutationRequest {
 function getResolveAuthenticationRequest(
   workspaceId: string,
   request: ResolveAuthenticationRequest
-): ToolActionMutationRequest {
+): ToolActionMutationRequest | null {
   switch (request.contextType) {
     case "agent_loop":
       return {
@@ -83,7 +83,8 @@ function getResolveAuthenticationRequest(
         body: { outcome: request.outcome },
       };
     default:
-      return assertNever(request);
+      assertNeverAndIgnore(request);
+      return null;
   }
 }
 
@@ -96,14 +97,15 @@ function getAuthenticationKindLabel(
     case "sandbox_function":
       return LABEL_FOR_KIND.authentication;
     default:
-      return assertNever(request);
+      assertNeverAndIgnore(request);
+      return LABEL_FOR_KIND.authentication;
   }
 }
 
 function getValidateActionRequest(
   workspaceId: string,
   request: ValidateActionRequest
-): ToolActionMutationRequest {
+): ToolActionMutationRequest | null {
   switch (request.contextType) {
     case "agent_loop":
       return {
@@ -120,7 +122,8 @@ function getValidateActionRequest(
         body: { approved: request.approved },
       };
     default:
-      return assertNever(request);
+      assertNeverAndIgnore(request);
+      return null;
   }
 }
 
@@ -141,6 +144,9 @@ export function useResolveAuthentication({
 
       try {
         const request = getResolveAuthenticationRequest(owner.sId, resolution);
+        if (!request) {
+          return { success: false };
+        }
         await fetcher(request.url, {
           method: "POST",
           headers: {
@@ -187,6 +193,9 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
 
       try {
         const request = getValidateActionRequest(owner.sId, validation);
+        if (!request) {
+          return { success: false };
+        }
         await fetcher(request.url, {
           method: "POST",
           headers: {


### PR DESCRIPTION
## Description

Move authentication `kind` into the `agent_loop` request variant, where it determines the resolution route. Sandbox-function requests no longer accept an irrelevant kind.

Also clarify authentication failure notifications so they describe the blocking reason rather than calling it a tool type.

## Tests

- `cd front && NODE_ENV=test npm test components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx`

## Risk

Low. Request routing remains exhaustive and payloads are unchanged.

## Deploy Plan

- deploy `front`