### PR TITLE
feat(sandbox): space-scoped sandbox env vars on a unified table

### DIFF
--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -11,11 +11,13 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SandboxEnvVarFactory } from "@app/tests/utils/SandboxEnvVarFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -140,6 +142,44 @@ describe("SpaceResource", () => {
           },
         })
       ).resolves.toBe(0);
+    });
+
+    it("should delete pod-scoped sandbox env vars but keep workspace-scoped ones when hard deleting a space", async () => {
+      const pod = await SpaceFactory.project(workspace, user1.id);
+
+      await SandboxEnvVarFactory.create(adminAuth, {
+        name: "POD_TOKEN",
+        space: pod,
+      });
+      await SandboxEnvVarFactory.create(adminAuth, {
+        name: "WORKSPACE_TOKEN",
+      });
+
+      const softDeleteResult = await pod.delete(adminAuth, {
+        hardDelete: false,
+      });
+      expect(softDeleteResult.isOk()).toBe(true);
+
+      const deletedSpace = await SpaceResource.fetchById(adminAuth, pod.sId, {
+        includeDeleted: true,
+      });
+      if (!deletedSpace) {
+        throw new Error("Deleted space should exist");
+      }
+
+      const hardDeleteResult = await hardDeleteSpace(adminAuth, deletedSpace);
+      expect(hardDeleteResult.isOk()).toBe(true);
+
+      await expect(
+        WorkspaceSandboxEnvVarModel.count({
+          where: { workspaceId: workspace.id, spaceId: pod.id },
+        })
+      ).resolves.toBe(0);
+      await expect(
+        WorkspaceSandboxEnvVarModel.count({
+          where: { workspaceId: workspace.id, name: "WORKSPACE_TOKEN" },
+        })
+      ).resolves.toBe(1);
     });
 
     describe("authorization checks", () => {
@@ -1744,6 +1784,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "data_source_view",
   "group_vaults",
   "mcp_server_view",
+  "workspace_sandbox_env_var",
   "sandbox_function",
   "sandbox_owner",
   "project_metadata",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -13,6 +13,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -676,6 +677,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     if (hardDelete) {
       await SandboxOwnerModel.destroy({
+        where: {
+          spaceId: this.id,
+          workspaceId,
+        },
+        transaction,
+      });
+
+      // Pod-scoped env var rows only — workspace rows have spaceId NULL.
+      await WorkspaceSandboxEnvVarModel.destroy({
         where: {
           spaceId: this.id,
           workspaceId,

--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -3,16 +3,22 @@ import {
   DANGEROUSLY_UNBOUNDED_TEXT,
   DataTypes,
 } from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { Op } from "sequelize";
 
+// One table for both sandbox env var scopes, discriminated by `spaceId`:
+// NULL = workspace-scoped, set = pod-scoped (pods are project spaces).
+// Uniqueness is per scope via the partial indexes below.
 export class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel<WorkspaceSandboxEnvVarModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare spaceId: ForeignKey<SpaceModel["id"]> | null;
   declare name: string;
   declare kind: CreationOptional<WorkspaceSandboxEnvVarKind>;
   declare placeholderNonce: Buffer | null;
@@ -65,14 +71,49 @@ WorkspaceSandboxEnvVarModel.init(
     modelName: "workspace_sandbox_env_var",
     sequelize: frontSequelize,
     indexes: [
+      // TODO(2026-07-12 SANDBOX_SECRETS): legacy full unique, superseded by
+      // the partial uniques below. Kept so already-deployed
+      // (workspaceId, name) queries stay indexed; the resources PR drops it
+      // post-deploy.
       {
         name: "workspace_sandbox_env_vars_workspace_name_idx",
         unique: true,
         fields: ["workspaceId", "name"],
       },
+      // Per-scope uniqueness: one name per workspace scope...
+      {
+        name: "sandbox_env_vars_workspace_scope_name_idx",
+        unique: true,
+        fields: ["workspaceId", "name"],
+        where: { spaceId: null },
+        concurrently: true,
+      },
+      // ...and one name per pod. Also serves FK lookups on spaceId (the
+      // equality predicate implies the partial condition).
+      {
+        name: "sandbox_env_vars_pod_scope_name_idx",
+        unique: true,
+        fields: ["spaceId", "name"],
+        where: { spaceId: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      // User FKs are SET NULL on user deletion — without these indexes,
+      // scrubbing a user would scan the table (BACK13).
+      { fields: ["createdByUserId"], concurrently: true },
+      { fields: ["lastUpdatedByUserId"], concurrently: true },
     ],
   }
 );
+
+WorkspaceSandboxEnvVarModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "space",
+});
+
+SpaceModel.hasMany(WorkspaceSandboxEnvVarModel, {
+  foreignKey: { name: "spaceId", allowNull: true },
+});
 
 WorkspaceSandboxEnvVarModel.belongsTo(UserModel, {
   as: "createdByUser",

--- a/front/migrations/pre-deploy/20260712100000_add_space_scope_to_workspace_sandbox_env_vars.sql
+++ b/front/migrations/pre-deploy/20260712100000_add_space_scope_to_workspace_sandbox_env_vars.sql
@@ -1,0 +1,69 @@
+/*
+Statement 0
+
+Unifies sandbox env var scopes on one table: "spaceId" NULL = workspace
+scope (all existing rows), set = pod scope (pods are project spaces).
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_sandbox_env_vars" ADD COLUMN "spaceId" bigint;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_sandbox_env_vars" ADD CONSTRAINT "workspace_sandbox_env_vars_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES vaults(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 2
+
+Long timeout on purpose: validation scans existing rows.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_sandbox_env_vars" VALIDATE CONSTRAINT "workspace_sandbox_env_vars_spaceId_fkey";
+
+/*
+Statement 3
+
+Index names use the sandbox_env_vars_ prefix on purpose: the table now
+holds both scopes and workspace_ in its name is legacy.
+
+Per-scope uniqueness. The legacy full unique (workspaceId, name) index is
+intentionally KEPT for now: already-deployed queries filter without a
+"spaceId" predicate and would lose index support if it were dropped here.
+The resources PR swaps queries to be scope-aware and drops the legacy index
+post-deploy. Until that drop, a pod row cannot shadow a workspace name in
+prod — acceptable, pod writes are gated behind the resources PR.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY sandbox_env_vars_workspace_scope_name_idx ON public.workspace_sandbox_env_vars USING btree ("workspaceId", name) WHERE "spaceId" IS NULL;
+
+/*
+Statement 4
+
+Also serves FK lookups on "spaceId" — an equality predicate implies the
+partial condition.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY sandbox_env_vars_pod_scope_name_idx ON public.workspace_sandbox_env_vars USING btree ("spaceId", name) WHERE "spaceId" IS NOT NULL;
+
+/*
+Statement 5
+
+User FKs are SET NULL on user deletion — without these indexes, scrubbing a
+user would scan the table (BACK13). Pre-existing gap on this table.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY workspace_sandbox_env_vars_created_by_user_id ON public.workspace_sandbox_env_vars USING btree ("createdByUserId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY workspace_sandbox_env_vars_last_updated_by_user_id ON public.workspace_sandbox_env_vars USING btree ("lastUpdatedByUserId");

--- a/front/tests/utils/SandboxEnvVarFactory.ts
+++ b/front/tests/utils/SandboxEnvVarFactory.ts
@@ -1,0 +1,31 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
+
+export class SandboxEnvVarFactory {
+  // Writes the model directly on purpose: lets tests seed rows the
+  // resource layer would refuse or cannot express, e.g. a raw
+  // `encryptedValue` that is not valid ciphertext.
+  static async create(
+    auth: Authenticator,
+    opts: {
+      name: string;
+      space?: SpaceResource;
+      kind?: WorkspaceSandboxEnvVarKind;
+      encryptedValue?: string;
+    }
+  ): Promise<WorkspaceSandboxEnvVarModel> {
+    const user = auth.getNonNullableUser();
+
+    return WorkspaceSandboxEnvVarModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: opts.space?.id ?? null,
+      name: opts.name,
+      kind: opts.kind ?? "config",
+      encryptedValue: opts.encryptedValue ?? "test-encrypted-value",
+      createdByUserId: user.id,
+      lastUpdatedByUserId: user.id,
+    });
+  }
+}


### PR DESCRIPTION
## Description

Schema foundation for Pod-scoped sandbox secrets — **one unified table**, per the consolidation discussion below: pods and workspaces are two scopes of the same entity.

**What this PR does:**

1. `workspace_sandbox_env_vars` gains a nullable **`spaceId`** (FK `vaults(id)` RESTRICT): `NULL` = workspace scope (all existing rows, untouched — no backfill), set = pod scope (pods are project spaces). Uniqueness becomes per-scope via two partial unique indexes, so a pod var can shadow a workspace name — the pod-wins merge at sandbox boot depends on it.
2. User-FK indexes on `createdByUserId` / `lastUpdatedByUserId` (BACK13 — pre-existing gap on this table); pod-scoped rows die with their space (hard-delete path, reached transitively by workspace scrub); `KNOWN_SPACE_RELATED_MODELS` guard entry.

**Schema delta:**

| Change | Notes |
|---|---|
| `spaceId` bigint NULL, FK → `vaults(id)` RESTRICT | scope discriminator; rows die with their space |
| `sandbox_env_vars_workspace_scope_name_idx` | UNIQUE `("workspaceId", name) WHERE "spaceId" IS NULL` |
| `sandbox_env_vars_pod_scope_name_idx` | UNIQUE `("spaceId", name) WHERE "spaceId" IS NOT NULL`; also serves FK lookups |
| `createdByUserId` / `lastUpdatedByUserId` indexes | BACK13 |

Nothing reads or writes the new column yet — no behavior change.

> [!NOTE]
> The legacy full unique `workspace_sandbox_env_vars_workspace_name_idx` is **intentionally kept**: already-deployed queries filter `(workspaceId, name)` without a `spaceId` predicate and can't use the partial indexes. PR 2 ships scope-aware queries and drops the legacy index **post-deploy**. Until that drop, a pod row cannot shadow a workspace name in prod — fine, pod writes are gated behind PR 2.

> [!NOTE]
> An earlier revision of this stack also carried external-secret-provider columns (`secret_source_kind`, nullable `encrypted_value` + CHECK). That has been removed on purpose: we're meeting with 1Password to solidify the provider structure first, and the provider schema will land in a dedicated, purely additive PR once the shape is grounded in real requirements.

**Stack:**
- PR 1 (this PR): schema. **Merges and applies first.**
- PR 2 (`28861`): scope-aware `SandboxEnvVarResource` consolidating both scopes + legacy index drop post-deploy.
- PR 3 (`28862`): pod sandbox boot-path wiring (egress-secrets merge + owner env injection).
- PR 4 (`29327`): pod routes + shared env vars UI (workspace and pod on one component).

## Risk

Low, safe to rollback

## Deploy Plan

- [ ] Merge; ensure the pre-deploy migration is applied in US + EU before front deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
