### PR TITLE
feat(sandbox): inject pod env vars and secrets at pod sandbox boot

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -1,7 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -226,7 +228,15 @@ describe("runSandboxBashTool", () => {
     mockFetchActionById.mockResolvedValue(null);
   });
 
-  function makeExtra() {
+  function makeExtra(
+    overrides: {
+      // The fixture is an untyped fake (the runContext is cast as never), so
+      // this Picks only the fields the tools read — typed against the real
+      // conversation shape so renames surface at compile time.
+      conversation?: Pick<ConversationWithoutContentType, "sId"> &
+        Partial<Pick<ConversationWithoutContentType, "spaceId">>;
+    } = {}
+  ) {
     return {
       auth: {
         getNonNullableWorkspace: () => ({
@@ -241,7 +251,7 @@ describe("runSandboxBashTool", () => {
         },
         modelInfo: { endpoint: { modelConfig: { providerId: "openai" } } },
         agentMessage: { sId: "message-id", agentMessageId: 1 },
-        conversation: { sId: "conversation-id" },
+        conversation: overrides.conversation ?? { sId: "conversation-id" },
         action: {
           sId: "sandbox-action-id",
           toJSON: () => ({ sId: "sandbox-action-id" }),
@@ -329,6 +339,62 @@ describe("runSandboxBashTool", () => {
       },
       "sandbox bash output contained env var values; redacted"
     );
+  });
+
+  it("redacts pod env var values for conversations running in a pod", async () => {
+    const workspaceValue = "workspace-entropy-token-123";
+    const podValue = "pod-entropy-token-456";
+    mockLoadEnv.mockImplementation((_auth: unknown, scope: { kind: string }) =>
+      Promise.resolve(
+        new Ok(
+          scope.kind === "pod"
+            ? { DST_POD_TOKEN: podValue }
+            : { DST_API_TOKEN: workspaceValue }
+        )
+      )
+    );
+    const fetchSpaceSpy = vi
+      .spyOn(SpaceResource, "fetchById")
+      .mockResolvedValue({
+        sId: "space-id",
+        isProject: () => true,
+      } as unknown as SpaceResource);
+
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout: `ws=${workspaceValue} pod=${podValue}`,
+          stderr: "",
+        })
+      ),
+    };
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+
+    const result = await runSandboxBashTool(
+      { command: "echo token", description: "Run command" },
+      makeExtra({
+        conversation: { sId: "conversation-id", spaceId: "space-id" },
+      })
+    );
+    fetchSpaceSpy.mockRestore();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).toContain("«redacted: $DST_API_TOKEN»");
+    expect(first.text).toContain("«redacted: $DST_POD_TOKEN»");
+    expect(first.text).not.toContain(workspaceValue);
+    expect(first.text).not.toContain(podValue);
   });
 
   it("redacts eligible values from appended network proxy logs", async () => {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -44,12 +44,14 @@ import {
 } from "@app/lib/api/sandbox/image/profile";
 import { recordToolDuration } from "@app/lib/api/sandbox/instrumentation";
 import { ensureConversationSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { resolvePodForRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import logger from "@app/logger/logger";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
@@ -195,6 +197,7 @@ function isRedactionEligible(value: string): boolean {
 // remains the primary disclosure control.
 async function redactSandboxEnvVarsFromOutput(
   auth: Authenticator,
+  conversation: ConversationType,
   output: string
 ): Promise<Result<string, Error>> {
   // loadEnv is intentionally config-only. HTTPS secrets are injected as DSEC
@@ -207,6 +210,31 @@ async function redactSandboxEnvVarsFromOutput(
     return envResult;
   }
 
+  // A conversation inside a pod runs with the pod's env vars injected —
+  // redact those values too, resolving the pod through the same shared rule
+  // as the injection side.
+  const runtimeOwner = {
+    kind: "conversation" as const,
+    conversationId: conversation.sId,
+    spaceId: conversation.spaceId ?? null,
+  };
+  const redactionEnv = { ...envResult.value };
+  const podResult = await resolvePodForRuntimeOwner(auth, runtimeOwner);
+  if (podResult.isErr()) {
+    return podResult;
+  }
+  if (podResult.value) {
+    const podEnvResult = await SandboxEnvVarResource.loadEnv(
+      auth,
+      { kind: "pod", pod: podResult.value },
+      runtimeOwner
+    );
+    if (podEnvResult.isErr()) {
+      return podEnvResult;
+    }
+    Object.assign(redactionEnv, podEnvResult.value);
+  }
+
   const workspaceId = auth.getNonNullableWorkspace().sId;
   let redactedOutput = output;
   const redactedNames: string[] = [];
@@ -214,7 +242,7 @@ async function redactSandboxEnvVarsFromOutput(
   // O(env_count × output_size): split/join scans the full output once per
   // eligible env var. Acceptable at current bounds (env_count ≤ 50 per
   // MAX_VARS_PER_WORKSPACE, output capped upstream).
-  for (const [name, value] of Object.entries(envResult.value)) {
+  for (const [name, value] of Object.entries(redactionEnv)) {
     if (!isRedactionEligible(value)) {
       continue;
     }
@@ -502,6 +530,7 @@ export async function runSandboxBashTool(
   const output = formatExecOutput(execResult.value, { denyLogEntries });
   const redactedOutputResult = await redactSandboxEnvVarsFromOutput(
     auth,
+    conversation,
     output
   );
   if (redactedOutputResult.isErr()) {

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -133,6 +133,7 @@ describe("sandbox egress helpers", () => {
   const runtimeOwner = {
     kind: "conversation" as const,
     conversationId: "conversation-id",
+    spaceId: null,
   };
 
   beforeEach(() => {
@@ -229,7 +230,11 @@ describe("sandbox egress helpers", () => {
       "/usr/bin/install -o root -g root -m 600 /dev/stdin"
     );
     expect(tokenCall).toContain("/etc/dust/egress-token");
-    expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      runtimeOwner
+    );
     expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(
       auth,
       sandbox,
@@ -525,7 +530,11 @@ describe("sandbox egress helpers", () => {
     const result = await ensure(sandbox, { wokeFromSleep: true });
 
     expect(result).toEqual(new Ok(undefined));
-    expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      runtimeOwner
+    );
     expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(
       auth,
       sandbox,

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -624,7 +624,7 @@ export async function setupEgressForwarder(
 
   const secretsWriteResult = await traceSandboxStartupPhase(
     "egress.write_secrets",
-    () => writeEgressSecretsFile(auth, sandbox)
+    () => writeEgressSecretsFile(auth, sandbox, runtimeOwner)
   );
   if (secretsWriteResult.isErr()) {
     return secretsWriteResult;

--- a/front/lib/api/sandbox/egress_secrets.test.ts
+++ b/front/lib/api/sandbox/egress_secrets.test.ts
@@ -4,11 +4,14 @@ import {
 } from "@app/lib/api/sandbox/root_command";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   buildEgressSecretFileEntries,
+  buildEgressSecretFileEntriesForOwner,
+  buildPodEgressSecretEntries,
   writeEgressSecretsFile,
 } from "./egress_secrets";
 
@@ -100,7 +103,12 @@ describe("egress secrets file", () => {
 
     const result = await writeEgressSecretsFile(
       authenticator,
-      sandbox as never
+      sandbox as never,
+      {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: null,
+      }
     );
 
     expect(result).toEqual(new Ok(undefined));
@@ -122,6 +130,271 @@ describe("egress secrets file", () => {
         value: "api-secret",
         allowedDomains: ["api.example.com"],
       }),
+    ]);
+  });
+});
+
+describe("egress secrets per-owner build", () => {
+  it("returns workspace entries unchanged for conversation-owned sandboxes", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const secretResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace: authenticator.getNonNullableWorkspace() },
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "api-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(secretResult.isOk()).toBe(true);
+
+    const entriesResult = await buildEgressSecretFileEntriesForOwner(
+      authenticator,
+      {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: null,
+      }
+    );
+    expect(entriesResult.isOk()).toBe(true);
+    if (entriesResult.isErr()) {
+      throw entriesResult.error;
+    }
+    expect(entriesResult.value).toEqual([
+      expect.objectContaining({ name: "API_TOKEN", value: "api-secret" }),
+    ]);
+  });
+
+  it("merges pod entries for conversation-owned sandboxes running in a pod", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace" as const, workspace },
+      {
+        name: "SHARED_TOKEN",
+        kind: "https_secret",
+        value: "workspace-secret",
+        allowedDomains: ["workspace.example.com"],
+      }
+    );
+    expect(workspaceResult.isOk()).toBe(true);
+
+    const podResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod" as const, pod },
+      {
+        name: "SHARED_TOKEN",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["pod.example.com"],
+      }
+    );
+    expect(podResult.isOk()).toBe(true);
+
+    const entriesResult = await buildEgressSecretFileEntriesForOwner(
+      authenticator,
+      {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: pod.sId,
+      }
+    );
+    expect(entriesResult.isOk()).toBe(true);
+    if (entriesResult.isErr()) {
+      throw entriesResult.error;
+    }
+
+    // Pod wins on name collision for conversations in the pod, exactly as
+    // for pod-owned sandboxes.
+    expect(entriesResult.value).toEqual([
+      expect.objectContaining({
+        name: "SHARED_TOKEN",
+        value: "pod-secret",
+        allowedDomains: ["pod.example.com"],
+      }),
+    ]);
+  });
+
+  it("returns workspace entries only for conversations in a non-pod space", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace" as const, workspace },
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "workspace-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(workspaceResult.isOk()).toBe(true);
+
+    const podResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod" as const, pod },
+      {
+        name: "POD_TOKEN",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["pod.example.com"],
+      }
+    );
+    expect(podResult.isOk()).toBe(true);
+
+    // Unknown space sId: the pod layer is skipped, matching the env
+    // injection rule.
+    const entriesResult = await buildEgressSecretFileEntriesForOwner(
+      authenticator,
+      {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: "spc_nonexistent",
+      }
+    );
+    expect(entriesResult.isOk()).toBe(true);
+    if (entriesResult.isErr()) {
+      throw entriesResult.error;
+    }
+    expect(entriesResult.value).toEqual([
+      expect.objectContaining({ name: "API_TOKEN", value: "workspace-secret" }),
+    ]);
+  });
+
+  it("merges pod entries over workspace entries for pod-owned sandboxes", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const workspaceScope = { kind: "workspace" as const, workspace };
+    const podScope = { kind: "pod" as const, pod };
+
+    const workspaceSharedResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      workspaceScope,
+      {
+        name: "SHARED_TOKEN",
+        kind: "https_secret",
+        value: "workspace-secret",
+        allowedDomains: ["workspace.example.com"],
+      }
+    );
+    expect(workspaceSharedResult.isOk()).toBe(true);
+
+    const workspaceOnlyResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      workspaceScope,
+      {
+        name: "WORKSPACE_ONLY_TOKEN",
+        kind: "https_secret",
+        value: "workspace-only-secret",
+        allowedDomains: ["workspace.example.com"],
+      }
+    );
+    expect(workspaceOnlyResult.isOk()).toBe(true);
+
+    const podSharedResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      podScope,
+      {
+        name: "SHARED_TOKEN",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["pod.example.com"],
+      }
+    );
+    expect(podSharedResult.isOk()).toBe(true);
+    if (podSharedResult.isErr()) {
+      throw podSharedResult.error;
+    }
+
+    const podOnlyResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      podScope,
+      {
+        name: "POD_ONLY_TOKEN",
+        kind: "https_secret",
+        value: "pod-only-secret",
+        allowedDomains: ["pod.example.com"],
+      }
+    );
+    expect(podOnlyResult.isOk()).toBe(true);
+
+    const entriesResult = await buildEgressSecretFileEntriesForOwner(
+      authenticator,
+      { kind: "pod", spaceId: pod.sId }
+    );
+    expect(entriesResult.isOk()).toBe(true);
+    if (entriesResult.isErr()) {
+      throw entriesResult.error;
+    }
+
+    const entriesByName = new Map(
+      entriesResult.value.map((entry) => [entry.name, entry])
+    );
+    expect(entriesByName.size).toBe(3);
+
+    // Pod wins on name collision, including placeholder and domains.
+    expect(entriesByName.get("SHARED_TOKEN")).toEqual({
+      name: "SHARED_TOKEN",
+      placeholder: `__DSEC_${podSharedResult.value.toJSON().placeholderNonce}__`,
+      value: "pod-secret",
+      allowedDomains: ["pod.example.com"],
+    });
+    expect(entriesByName.get("WORKSPACE_ONLY_TOKEN")).toEqual(
+      expect.objectContaining({ value: "workspace-only-secret" })
+    );
+    expect(entriesByName.get("POD_ONLY_TOKEN")).toEqual(
+      expect.objectContaining({ value: "pod-only-secret" })
+    );
+  });
+
+  it("builds pod entries with values decrypted under the pod scope key", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const secretResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "pod-api-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(secretResult.isOk()).toBe(true);
+    if (secretResult.isErr()) {
+      throw secretResult.error;
+    }
+
+    const entriesResult = await buildPodEgressSecretEntries(
+      authenticator,
+      pod,
+      { kind: "pod", spaceId: pod.sId }
+    );
+    expect(entriesResult.isOk()).toBe(true);
+    if (entriesResult.isErr()) {
+      throw entriesResult.error;
+    }
+    expect(entriesResult.value).toEqual([
+      {
+        name: "API_TOKEN",
+        placeholder: `__DSEC_${secretResult.value.toJSON().placeholderNonce}__`,
+        value: "pod-api-secret",
+        allowedDomains: ["api.example.com"],
+      },
     ]);
   });
 });

--- a/front/lib/api/sandbox/egress_secrets.ts
+++ b/front/lib/api/sandbox/egress_secrets.ts
@@ -4,10 +4,15 @@ import {
   renderEgressSecretPlaceholder,
   scopeEncryptionKey,
 } from "@app/lib/api/sandbox/env_vars";
+import {
+  resolvePodForRuntimeOwner,
+  type SandboxRuntimeOwner,
+} from "@app/lib/api/sandbox/owner";
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { decrypt } from "@app/types/shared/utils/encryption";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -82,11 +87,128 @@ export async function buildEgressSecretFileEntries(
   return new Ok(entries);
 }
 
+export async function buildPodEgressSecretEntries(
+  auth: Authenticator,
+  pod: SpaceResource,
+  runtimeOwner: SandboxRuntimeOwner
+): Promise<Result<EgressSecretFileEntry[], Error>> {
+  const scope = { kind: "pod" as const, pod };
+  const resources = await SandboxEnvVarResource.listHttpsSecretsForEgress(
+    auth,
+    scope,
+    runtimeOwner
+  );
+
+  const entries: EgressSecretFileEntry[] = [];
+  for (const resource of resources) {
+    if (!resource.placeholderNonce) {
+      return new Err(
+        new Error(
+          `Pod HTTPS secret sandbox environment variable ${resource.envName} is missing its placeholder nonce.`
+        )
+      );
+    }
+    if (!resource.allowedDomains) {
+      return new Err(
+        new Error(
+          `Pod HTTPS secret sandbox environment variable ${resource.envName} is missing allowed domains.`
+        )
+      );
+    }
+
+    let value: string;
+    try {
+      value = decrypt({
+        encrypted: resource.encryptedValue,
+        key: scopeEncryptionKey(scope),
+        useCase: "developer_secret",
+      });
+    } catch (error) {
+      return new Err(
+        new Error(
+          `Failed to decrypt pod sandbox HTTPS secret ${resource.envName}: ${
+            normalizeError(error).message
+          }`
+        )
+      );
+    }
+
+    entries.push({
+      name: resource.name,
+      placeholder: renderEgressSecretPlaceholder(resource.placeholderNonce),
+      value,
+      allowedDomains: Array.from(resource.allowedDomains),
+    });
+  }
+
+  return new Ok(entries);
+}
+
+// Pod entries shadow workspace entries of the same name, mirroring the env
+// injection precedence (owner env layer beats the workspace layer).
+export function mergeEgressSecretFileEntries({
+  workspaceEntries,
+  podEntries,
+}: {
+  workspaceEntries: EgressSecretFileEntry[];
+  podEntries: EgressSecretFileEntry[];
+}): EgressSecretFileEntry[] {
+  const byName = new Map(workspaceEntries.map((entry) => [entry.name, entry]));
+  for (const entry of podEntries) {
+    byName.set(entry.name, entry);
+  }
+  return [...byName.values()];
+}
+
+// Builds the full entry set for a sandbox given its runtime owner: workspace
+// entries for every sandbox, plus pod entries (pod wins on name collision)
+// for every sandbox running in a pod — pod-owned or a conversation inside
+// the pod (resolvePodForRuntimeOwner is the shared rule). Any resolution
+// failure aborts the whole build — we never write a partial or empty-valued
+// entry.
+export async function buildEgressSecretFileEntriesForOwner(
+  auth: Authenticator,
+  runtimeOwner: SandboxRuntimeOwner
+): Promise<Result<EgressSecretFileEntry[], Error>> {
+  const workspaceEntriesResult = await buildEgressSecretFileEntries(auth);
+  if (workspaceEntriesResult.isErr()) {
+    return workspaceEntriesResult;
+  }
+
+  const podResult = await resolvePodForRuntimeOwner(auth, runtimeOwner);
+  if (podResult.isErr()) {
+    return podResult;
+  }
+  if (!podResult.value) {
+    return workspaceEntriesResult;
+  }
+
+  const podEntriesResult = await buildPodEgressSecretEntries(
+    auth,
+    podResult.value,
+    runtimeOwner
+  );
+  if (podEntriesResult.isErr()) {
+    return podEntriesResult;
+  }
+
+  return new Ok(
+    mergeEgressSecretFileEntries({
+      workspaceEntries: workspaceEntriesResult.value,
+      podEntries: podEntriesResult.value,
+    })
+  );
+}
+
 export async function writeEgressSecretsFile(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
+  runtimeOwner: SandboxRuntimeOwner
 ): Promise<Result<void, Error>> {
-  const entriesResult = await buildEgressSecretFileEntries(auth);
+  const entriesResult = await buildEgressSecretFileEntriesForOwner(
+    auth,
+    runtimeOwner
+  );
   if (entriesResult.isErr()) {
     return entriesResult;
   }

--- a/front/lib/api/sandbox/egress_secrets.ts
+++ b/front/lib/api/sandbox/egress_secrets.ts
@@ -37,28 +37,16 @@ export async function buildEgressSecretFileEntries(
     kind: "workspace" as const,
     workspace: auth.getNonNullableWorkspace(),
   };
-  const resources = await SandboxEnvVarResource.listHttpsSecretsForEgress(
+  const secretsResult = await SandboxEnvVarResource.listHttpsSecretsForEgress(
     auth,
     scope
   );
+  if (secretsResult.isErr()) {
+    return secretsResult;
+  }
 
   const entries: EgressSecretFileEntry[] = [];
-  for (const resource of resources) {
-    if (!resource.placeholderNonce) {
-      return new Err(
-        new Error(
-          `HTTPS secret sandbox environment variable ${resource.envName} is missing its placeholder nonce.`
-        )
-      );
-    }
-    if (!resource.allowedDomains) {
-      return new Err(
-        new Error(
-          `HTTPS secret sandbox environment variable ${resource.envName} is missing allowed domains.`
-        )
-      );
-    }
-
+  for (const resource of secretsResult.value) {
     let value: string;
     try {
       value = decrypt({
@@ -93,29 +81,17 @@ export async function buildPodEgressSecretEntries(
   runtimeOwner: SandboxRuntimeOwner
 ): Promise<Result<EgressSecretFileEntry[], Error>> {
   const scope = { kind: "pod" as const, pod };
-  const resources = await SandboxEnvVarResource.listHttpsSecretsForEgress(
+  const secretsResult = await SandboxEnvVarResource.listHttpsSecretsForEgress(
     auth,
     scope,
     runtimeOwner
   );
+  if (secretsResult.isErr()) {
+    return secretsResult;
+  }
 
   const entries: EgressSecretFileEntry[] = [];
-  for (const resource of resources) {
-    if (!resource.placeholderNonce) {
-      return new Err(
-        new Error(
-          `Pod HTTPS secret sandbox environment variable ${resource.envName} is missing its placeholder nonce.`
-        )
-      );
-    }
-    if (!resource.allowedDomains) {
-      return new Err(
-        new Error(
-          `Pod HTTPS secret sandbox environment variable ${resource.envName} is missing allowed domains.`
-        )
-      );
-    }
-
+  for (const resource of secretsResult.value) {
     let value: string;
     try {
       value = decrypt({

--- a/front/lib/api/sandbox/env_manifest.test.ts
+++ b/front/lib/api/sandbox/env_manifest.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/sandbox/root_command";
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,8 +18,8 @@ describe("sandbox environment manifest", () => {
   const conversationOwner = {
     kind: "conversation" as const,
     conversationId: "conversation-id",
+    spaceId: null,
   };
-  const podOwner = { kind: "pod" as const, spaceId: "space-id" };
 
   it("builds a deterministic manifest without any value field", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
@@ -123,12 +124,15 @@ describe("sandbox environment manifest", () => {
   });
 
   it("uses SPACE_ID instead of CONVERSATION_ID for pod sandbox manifests", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
 
-    const manifestResult = await buildSandboxEnvManifest(
-      authenticator,
-      podOwner
-    );
+    const manifestResult = await buildSandboxEnvManifest(authenticator, {
+      kind: "pod",
+      spaceId: pod.sId,
+    });
 
     expect(manifestResult.isOk()).toBe(true);
     if (manifestResult.isErr()) {
@@ -145,6 +149,86 @@ describe("sandbox environment manifest", () => {
         description: "current workspace sId",
       },
     ]);
+  });
+
+  it("lists pod vars (pod wins on collision) for sandboxes running in a pod", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceVar = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace },
+      { name: "WORKSPACE_ONLY", value: "workspace-value" }
+    );
+    expect(workspaceVar.isOk()).toBe(true);
+
+    const collidingSecret = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace },
+      {
+        name: "SHARED_SECRET",
+        kind: "https_secret",
+        value: "workspace-secret",
+        allowedDomains: ["workspace.example.com"],
+      }
+    );
+    expect(collidingSecret.isOk()).toBe(true);
+
+    const podSecret = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      {
+        name: "SHARED_SECRET",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["pod.example.com"],
+      }
+    );
+    expect(podSecret.isOk()).toBe(true);
+    if (podSecret.isErr()) {
+      throw podSecret.error;
+    }
+
+    const podVar = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      { name: "POD_ONLY", value: "pod-value" }
+    );
+    expect(podVar.isOk()).toBe(true);
+
+    // Same listing for the pod owner and a conversation running in the pod.
+    for (const owner of [
+      { kind: "pod" as const, spaceId: pod.sId },
+      {
+        kind: "conversation" as const,
+        conversationId: "conversation-test",
+        spaceId: pod.sId,
+      },
+    ]) {
+      const manifestResult = await buildSandboxEnvManifest(
+        authenticator,
+        owner
+      );
+      expect(manifestResult.isOk()).toBe(true);
+      if (manifestResult.isErr()) {
+        throw manifestResult.error;
+      }
+
+      expect(manifestResult.value.config).toEqual([
+        { name: "DST_POD_ONLY" },
+        { name: "DST_WORKSPACE_ONLY" },
+      ]);
+      // Pod wins on collision: the pod row's placeholder and domains.
+      expect(manifestResult.value.httpsSecrets).toEqual([
+        {
+          name: "DSEC_SHARED_SECRET",
+          placeholder: `__DSEC_${podSecret.value.toJSON().placeholderNonce}__`,
+          allowedDomains: ["pod.example.com"],
+        },
+      ]);
+    }
   });
 
   it("rejects an HTTPS secret missing a placeholder nonce", async () => {

--- a/front/lib/api/sandbox/env_manifest.ts
+++ b/front/lib/api/sandbox/env_manifest.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import { renderEgressSecretPlaceholder } from "@app/lib/api/sandbox/env_vars";
 import {
   getSandboxOwnerEnvManifestEntries,
+  resolvePodForRuntimeOwner,
   type SandboxRuntimeOwner,
 } from "@app/lib/api/sandbox/owner";
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
@@ -38,10 +39,32 @@ export async function buildSandboxEnvManifest(
   auth: Authenticator,
   owner: SandboxRuntimeOwner
 ): Promise<Result<SandboxEnvManifest, Error>> {
-  const allVars = await SandboxEnvVarResource.listForScope(auth, {
+  const workspaceVars = await SandboxEnvVarResource.listForScope(auth, {
     kind: "workspace",
     workspace: auth.getNonNullableWorkspace(),
   });
+
+  // Sandboxes running in a pod also receive the pod's vars — list them too,
+  // pod winning on name collision, mirroring the injection and
+  // egress-secrets merges.
+  const podResult = await resolvePodForRuntimeOwner(auth, owner);
+  if (podResult.isErr()) {
+    return podResult;
+  }
+  const podVars = podResult.value
+    ? await SandboxEnvVarResource.listForScope(auth, {
+        kind: "pod",
+        pod: podResult.value,
+      })
+    : [];
+
+  const byEnvName = new Map(
+    workspaceVars.map((resource) => [resource.envName, resource])
+  );
+  for (const resource of podVars) {
+    byEnvName.set(resource.envName, resource);
+  }
+  const allVars = [...byEnvName.values()];
 
   const httpsSecrets: SandboxEnvManifest["httpsSecrets"] = [];
   for (const resource of allVars) {

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -136,6 +136,7 @@ describe("ensureConversationSandboxReady", () => {
   let conversationOwner: {
     kind: "conversation";
     conversationId: string;
+    spaceId: string | null;
   };
   const pod = { sId: "space-id" };
   const podOwner = {
@@ -162,6 +163,7 @@ describe("ensureConversationSandboxReady", () => {
     conversationOwner = {
       kind: "conversation",
       conversationId: conversation.sId,
+      spaceId: null,
     };
     sandbox = await SandboxFactory.create(auth, conversation);
 
@@ -231,15 +233,19 @@ describe("ensureConversationSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    // runtimeOwner stays the conversation (env vars, logs, file system)...
+    // The runtime owner stays the conversation but carries its pod, and the
+    // egress policy is scoped to the Pod's shared file.
+    const podConversationOwner = {
+      ...conversationOwner,
+      spaceId: "space-id",
+    };
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,
       sandbox,
-      // ...but the egress policy is scoped to the Pod's shared file.
-      { runtimeOwner: conversationOwner, egressPolicyOwnerId: "space-id" }
+      { runtimeOwner: podConversationOwner, egressPolicyOwnerId: "space-id" }
     );
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
-      runtimeOwner: conversationOwner,
+      runtimeOwner: podConversationOwner,
       egressPolicyOwnerId: "space-id",
       wokeFromSleep: false,
     });

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -210,13 +210,14 @@ export async function ensureConversationSandboxReady(
     ensureActive: () =>
       ConversationSandboxAdapter.ensureSandboxActive(auth, conversation),
     getFileSystem: () => DustFileSystem.forConversation(auth, conversation),
+    // Pod-level sandbox config applies to everything running in the Pod: a
+    // conversation inside a Pod uses the Pod's shared egress policy file and
+    // receives the Pod's env vars and HTTPS secrets at creation.
     runtimeOwner: {
       kind: "conversation",
       conversationId: conversation.sId,
+      spaceId: conversation.spaceId ?? null,
     },
-    // Pod network settings apply to everything running in the Pod: a
-    // conversation inside a Pod uses the Pod's shared policy file, not a
-    // per-conversation one.
     egressPolicyOwnerId: conversation.spaceId ?? conversation.sId,
   });
 }

--- a/front/lib/api/sandbox/owner.ts
+++ b/front/lib/api/sandbox/owner.ts
@@ -1,8 +1,49 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type SandboxRuntimeOwner =
-  | { kind: "conversation"; conversationId: string }
+  // `spaceId` is the space the conversation lives in (a pod when it is a
+  // project space). Pod-level sandbox config — egress policy, env vars,
+  // HTTPS secrets — applies to every Computer running in the Pod, so
+  // conversation-owned sandboxes carry their pod alongside pod-owned ones.
+  | { kind: "conversation"; conversationId: string; spaceId: string | null }
   | { kind: "pod"; spaceId: string };
+
+// Resolves the pod a sandbox runs in, if any. Pod-level config (env vars,
+// HTTPS secrets, egress policy) applies to every Computer running in the
+// Pod, so every consumer of pod-scoped config resolves through this one
+// rule: a pod-owned sandbox without its pod space is nonsense and errors; a
+// conversation whose space is missing or not a project simply has no pod
+// (workspace config only).
+export async function resolvePodForRuntimeOwner(
+  auth: Authenticator,
+  owner: SandboxRuntimeOwner
+): Promise<Result<SpaceResource | null, Error>> {
+  switch (owner.kind) {
+    case "conversation": {
+      if (!owner.spaceId) {
+        return new Ok(null);
+      }
+      const pod = await SpaceResource.fetchById(auth, owner.spaceId);
+      return new Ok(pod?.isProject() ? pod : null);
+    }
+
+    case "pod": {
+      const pod = await SpaceResource.fetchById(auth, owner.spaceId);
+      if (!pod || !pod.isProject()) {
+        return new Err(
+          new Error(`Pod space ${owner.spaceId} not found for sandbox owner.`)
+        );
+      }
+      return new Ok(pod);
+    }
+
+    default:
+      assertNever(owner);
+  }
+}
 
 export function getSandboxOwnerEnvVars(
   owner: SandboxRuntimeOwner

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import {
   type EnsureSandboxResult,
   type SandboxCreateBlob,
@@ -7,18 +8,25 @@ import {
   type SandboxLifecycleOwner,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
-import type { Result } from "@app/types/shared/result";
+import { Ok, type Result } from "@app/types/shared/result";
 import { Op, type Transaction } from "sequelize";
 
 type ConversationSandboxOwner = Pick<
   ConversationWithoutContentType,
   "id" | "sId"
 >;
+
+// ensureSandboxActive additionally needs the conversation's space (a string
+// sId, so ConversationResource — whose spaceId is a ModelId — does not
+// qualify) to inject pod-scoped env vars for conversations inside a pod.
+type ConversationSandboxEnsureOwner = ConversationSandboxOwner &
+  Pick<ConversationWithoutContentType, "spaceId">;
 
 type ConversationSandboxLifecycleOwner = Pick<
   ConversationResource,
@@ -134,15 +142,58 @@ export class ConversationSandboxAdapter {
 
   static async ensureSandboxActive(
     auth: Authenticator,
-    conversation: ConversationSandboxOwner
+    conversation: ConversationSandboxEnsureOwner
   ): Promise<Result<EnsureSandboxResult, Error>> {
     return SandboxResource.ensureActive(auth, {
       lockKey: conversation.sId,
-      envVars: { CONVERSATION_ID: conversation.sId },
+      // Factory form: the pod-scope loads only run when a sandbox is
+      // actually created.
+      envVars: () => this.buildConversationEnvVars(auth, conversation),
       logLabel: "conversation",
       fetchSandbox: () => this.fetchSandbox(auth, conversation),
       createSandbox: (blob) =>
         this.createSandboxRecordForConversation(auth, conversation, blob),
+    });
+  }
+
+  // Pod-level sandbox config applies to every Computer running in the Pod:
+  // a conversation inside a pod receives the pod's config vars and DSEC
+  // placeholders alongside its own env, same layering as pod-owned
+  // sandboxes (owner layer beats the workspace layer, pod wins on name
+  // collision). A conversation whose space is missing or not a project gets
+  // workspace vars only — the egress-secrets file build applies the same
+  // rule, keeping the file and the env consistent.
+  private static async buildConversationEnvVars(
+    auth: Authenticator,
+    conversation: ConversationSandboxEnsureOwner
+  ): Promise<Result<Record<string, string>, Error>> {
+    const baseEnv = { CONVERSATION_ID: conversation.sId };
+
+    if (!conversation.spaceId) {
+      return new Ok(baseEnv);
+    }
+
+    const pod = await SpaceResource.fetchById(auth, conversation.spaceId);
+    if (!pod || !pod.isProject()) {
+      return new Ok(baseEnv);
+    }
+
+    const podScopedResult = await PodSandboxAdapter.buildPodScopedEnvVars(
+      auth,
+      pod,
+      {
+        kind: "conversation",
+        conversationId: conversation.sId,
+        spaceId: pod.sId,
+      }
+    );
+    if (podScopedResult.isErr()) {
+      return podScopedResult;
+    }
+
+    return new Ok({
+      ...podScopedResult.value,
+      ...baseEnv,
     });
   }
 

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -1,3 +1,4 @@
+import { resolvePodForRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import type { Authenticator } from "@app/lib/auth";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -8,7 +9,6 @@ import {
   type SandboxLifecycleOwner,
   SandboxResource,
 } from "@app/lib/resources/sandbox_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -169,23 +169,23 @@ export class ConversationSandboxAdapter {
   ): Promise<Result<Record<string, string>, Error>> {
     const baseEnv = { CONVERSATION_ID: conversation.sId };
 
-    if (!conversation.spaceId) {
-      return new Ok(baseEnv);
+    const runtimeOwner = {
+      kind: "conversation" as const,
+      conversationId: conversation.sId,
+      spaceId: conversation.spaceId ?? null,
+    };
+    const podResult = await resolvePodForRuntimeOwner(auth, runtimeOwner);
+    if (podResult.isErr()) {
+      return podResult;
     }
-
-    const pod = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (!pod || !pod.isProject()) {
+    if (!podResult.value) {
       return new Ok(baseEnv);
     }
 
     const podScopedResult = await PodSandboxAdapter.buildPodScopedEnvVars(
       auth,
-      pod,
-      {
-        kind: "conversation",
-        conversationId: conversation.sId,
-        spaceId: pod.sId,
-      }
+      podResult.value,
+      runtimeOwner
     );
     if (podScopedResult.isErr()) {
       return podScopedResult;

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -1,8 +1,10 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { ensurePodStateHealthOnSleep } from "@app/lib/api/sandbox/db";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
+import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import type { Authenticator } from "@app/lib/auth";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import {
   type EnsureSandboxResult,
   type SandboxCreateBlob,
@@ -16,7 +18,7 @@ import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ModelId } from "@app/types/shared/model_id";
-import type { Result } from "@app/types/shared/result";
+import { Ok, type Result } from "@app/types/shared/result";
 import assert from "assert";
 import { Op, type Transaction } from "sequelize";
 
@@ -158,13 +160,73 @@ export class PodSandboxAdapter {
       auth,
       {
         ...this.toSandboxLifecycleOwner(auth, pod),
-        envVars: { SPACE_ID: pod.sId },
+        // Factory form: the loads only run when a sandbox is actually
+        // created — ensureActive on an already-running sandbox discards
+        // owner env vars, so eager loads would waste two queries per call.
+        envVars: () => this.buildPodEnvVars(auth, pod),
         logLabel: "pod",
         createSandbox: (blob) =>
           this.createSandboxRecordForPod(auth, pod, blob),
       },
       { beforeSleep: this.podPreSleepCheck(auth, pod), requireRunning }
     );
+  }
+
+  // Pod env vars ride the owner env layer, which beats the workspace env
+  // layer in buildSandboxEnvVars — so a pod var shadows a workspace var of
+  // the same name, consistent with the egress-secrets file merge. Config
+  // vars are injected in cleartext; HTTPS secrets as their DSEC
+  // placeholders (dsbx swaps them on the wire). Fail closed: a var we
+  // cannot resolve aborts sandbox creation rather than booting without it.
+  private static async buildPodEnvVars(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<Result<Record<string, string>, Error>> {
+    const podScopedResult = await PodSandboxAdapter.buildPodScopedEnvVars(
+      auth,
+      pod,
+      { kind: "pod", spaceId: pod.sId }
+    );
+    if (podScopedResult.isErr()) {
+      return podScopedResult;
+    }
+
+    return new Ok({
+      ...podScopedResult.value,
+      SPACE_ID: pod.sId,
+    });
+  }
+
+  // Pod config vars (cleartext) + HTTPS secret DSEC placeholders for any
+  // sandbox running in the pod — pod-owned or a conversation inside the pod
+  // (the runtime owner must be tied to the pod either way).
+  static async buildPodScopedEnvVars(
+    auth: Authenticator,
+    pod: SpaceResource,
+    runtimeOwner: SandboxRuntimeOwner
+  ): Promise<Result<Record<string, string>, Error>> {
+    const podEnvResult = await SandboxEnvVarResource.loadEnv(
+      auth,
+      { kind: "pod", pod },
+      runtimeOwner
+    );
+    if (podEnvResult.isErr()) {
+      return podEnvResult;
+    }
+    const podPlaceholderEnvResult =
+      await SandboxEnvVarResource.loadHttpsSecretPlaceholderEnv(
+        auth,
+        { kind: "pod", pod },
+        runtimeOwner
+      );
+    if (podPlaceholderEnvResult.isErr()) {
+      return podPlaceholderEnvResult;
+    }
+
+    return new Ok({
+      ...podEnvResult.value,
+      ...podPlaceholderEnvResult.value,
+    });
   }
 
   static async pauseSandboxForApproval(

--- a/front/lib/resources/sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/sandbox_env_var_resource.test.ts
@@ -672,7 +672,7 @@ describe("SandboxEnvVarResource pod scope", () => {
     ).rejects.toThrow("Only pod spaces can have sandbox environment variables");
   });
 
-  it("rejects pod boot loads for sandboxes not owned by the pod", async () => {
+  it("rejects pod boot loads for sandboxes not running in the pod", async () => {
     const { authenticator, workspace, user, pod } = await setupPod();
     const otherPod = await SpaceFactory.project(workspace, user.id);
 
@@ -682,23 +682,61 @@ describe("SandboxEnvVarResource pod scope", () => {
         spaceId: otherPod.sId,
       })
     ).rejects.toThrow(
-      "Pod env vars can only be loaded for pod-owned sandboxes"
+      "Pod env vars can only be loaded for sandboxes running in that pod"
+    );
+
+    // A conversation outside any pod (or in another pod) does not qualify.
+    await expect(
+      SandboxEnvVarResource.loadEnv(authenticator, podScope(pod), {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: null,
+      })
+    ).rejects.toThrow(
+      "Pod env vars can only be loaded for sandboxes running in that pod"
     );
 
     await expect(
       SandboxEnvVarResource.loadEnv(authenticator, podScope(pod), {
         kind: "conversation",
         conversationId: "conversation-test",
+        spaceId: otherPod.sId,
       })
     ).rejects.toThrow(
-      "Pod env vars can only be loaded for pod-owned sandboxes"
+      "Pod env vars can only be loaded for sandboxes running in that pod"
     );
 
     await expect(
       SandboxEnvVarResource.loadEnv(authenticator, podScope(pod))
     ).rejects.toThrow(
-      "Pod env vars can only be loaded for pod-owned sandboxes"
+      "Pod env vars can only be loaded for sandboxes running in that pod"
     );
+  });
+
+  it("allows pod boot loads for conversation sandboxes running in the pod", async () => {
+    const { authenticator, pod } = await setupPod();
+
+    const createResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      podScope(pod),
+      { name: "CONFIG_TOKEN", value: "pod-config-value" }
+    );
+    expect(createResult.isOk()).toBe(true);
+
+    const envResult = await SandboxEnvVarResource.loadEnv(
+      authenticator,
+      podScope(pod),
+      {
+        kind: "conversation",
+        conversationId: "conversation-test",
+        spaceId: pod.sId,
+      }
+    );
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({ DST_CONFIG_TOKEN: "pod-config-value" });
   });
 
   it("rejects mutations through a scope the row does not belong to", async () => {

--- a/front/lib/resources/sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/sandbox_env_var_resource.test.ts
@@ -8,6 +8,7 @@ import { SandboxEnvVarFactory } from "@app/tests/utils/SandboxEnvVarFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { decrypt } from "@app/types/shared/utils/encryption";
+import { randomBytes } from "crypto";
 import { describe, expect, it } from "vitest";
 
 function wsScope(auth: Authenticator): SandboxEnvVarScope {
@@ -107,6 +108,27 @@ describe("SandboxEnvVarResource", () => {
     expect(envResult.isErr()).toBe(true);
     if (envResult.isErr()) {
       expect(envResult.error.message).toContain("DST_API_TOKEN");
+    }
+  });
+
+  it("fails closed on an https_secret row missing allowed domains", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    await SandboxEnvVarFactory.create(authenticator, {
+      name: "API_TOKEN",
+      kind: "https_secret",
+      placeholderNonce: randomBytes(16),
+    });
+
+    const result = await SandboxEnvVarResource.listHttpsSecretsForEgress(
+      authenticator,
+      wsScope(authenticator)
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "DSEC_API_TOKEN is missing allowed domains"
+      );
     }
   });
 

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -48,6 +48,15 @@ export type PatchSandboxEnvVarResponseBody = {
   envVar: SandboxEnvVarType;
 };
 
+// An https_secret row with its secret material present. The columns are
+// nullable at the table level (config rows have neither), so egress-path
+// readers narrow through `isHttpsSecretWithMaterial` instead of re-checking
+// each field.
+export type HttpsSecretSandboxEnvVar = SandboxEnvVarResource & {
+  placeholderNonce: Buffer;
+  allowedDomains: string[];
+};
+
 const USER_JOIN_INCLUDES: Includeable[] = [
   {
     association: "createdByUser",
@@ -155,6 +164,16 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
 
   private static maxVarsForScope(scope: SandboxEnvVarScope): number {
     return scope.kind === "pod" ? MAX_VARS_PER_POD : MAX_VARS_PER_WORKSPACE;
+  }
+
+  // Write paths guarantee https_secret rows carry a nonce and domains; this
+  // narrows the row-level nullable columns for readers of that kind.
+  isHttpsSecretWithMaterial(): this is HttpsSecretSandboxEnvVar {
+    return (
+      this.kind === "https_secret" &&
+      this.placeholderNonce !== null &&
+      this.allowedDomains !== null
+    );
   }
 
   // Whether this row belongs to the given scope. Fetches are scope-filtered
@@ -855,15 +874,35 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     auth: Authenticator,
     scope: SandboxEnvVarScope,
     owner?: SandboxRuntimeOwner
-  ): Promise<SandboxEnvVarResource[]> {
+  ): Promise<Result<HttpsSecretSandboxEnvVar[], Error>> {
     this.assertBootOwner(scope, owner);
 
-    return this.baseFetch(
+    const resources = await this.baseFetch(
       auth,
       scope,
       { kind: "https_secret" },
       { withUserJoins: false }
     );
+
+    // Fail closed on rows violating the write-time invariant, so callers
+    // get the narrowed type without re-checking per field.
+    const secrets: HttpsSecretSandboxEnvVar[] = [];
+    for (const resource of resources) {
+      if (!resource.isHttpsSecretWithMaterial()) {
+        const missing =
+          resource.placeholderNonce === null
+            ? "its placeholder nonce"
+            : "allowed domains";
+        return new Err(
+          new Error(
+            `HTTPS secret sandbox environment variable ${resource.envName} is missing ${missing}.`
+          )
+        );
+      }
+      secrets.push(resource);
+    }
+
+    return new Ok(secrets);
   }
 
   static async loadHttpsSecretPlaceholderEnv(
@@ -871,18 +910,17 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     scope: SandboxEnvVarScope,
     owner?: SandboxRuntimeOwner
   ): Promise<Result<Record<string, string>, Error>> {
-    const resources = await this.listHttpsSecretsForEgress(auth, scope, owner);
+    const secretsResult = await this.listHttpsSecretsForEgress(
+      auth,
+      scope,
+      owner
+    );
+    if (secretsResult.isErr()) {
+      return secretsResult;
+    }
 
     const env: Record<string, string> = {};
-    for (const resource of resources) {
-      if (!resource.placeholderNonce) {
-        return new Err(
-          new Error(
-            `HTTPS secret sandbox environment variable ${resource.envName} is missing its placeholder nonce.`
-          )
-        );
-      }
-
+    for (const resource of secretsResult.value) {
       env[resource.envName] = renderEgressSecretPlaceholder(
         resource.placeholderNonce
       );

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -181,18 +181,18 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
 
   // Boot-path loads for a pod scope must be tied to the sandbox activation
   // owner: it states caller intent, catching plumbing that would inject one
-  // pod's secrets into another pod's sandbox. Not an authorization point —
-  // row scoping decides access.
+  // pod's secrets into another pod's sandbox. Pod config applies to every
+  // Computer running in the Pod, so both pod-owned sandboxes and
+  // conversation-owned sandboxes whose conversation lives in the pod
+  // qualify. Not an authorization point — row scoping decides access.
   private static assertBootOwner(
     scope: SandboxEnvVarScope,
     owner: SandboxRuntimeOwner | undefined
   ) {
     if (scope.kind === "pod") {
       assert(
-        owner !== undefined &&
-          owner.kind === "pod" &&
-          owner.spaceId === scope.pod.sId,
-        "Pod env vars can only be loaded for pod-owned sandboxes."
+        owner !== undefined && owner.spaceId === scope.pod.sId,
+        "Pod env vars can only be loaded for sandboxes running in that pod."
       );
     }
   }

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -55,6 +55,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
   SandboxModel,
@@ -954,6 +955,139 @@ describe("SandboxResource.ensureActive", () => {
       "SPACE_ID"
     );
     expect(mockProviderExec).not.toHaveBeenCalled();
+  });
+
+  it("pod env vars win over workspace env vars in provider.create", async () => {
+    const workspace = authenticator.getNonNullableWorkspace();
+    const user = authenticator.getNonNullableUser();
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceVarResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace },
+      {
+        name: "COLLIDE_TOKEN",
+        value: "workspace-collide-value",
+      }
+    );
+    expect(workspaceVarResult.isOk()).toBe(true);
+
+    const workspaceSecretResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace },
+      {
+        name: "COLLIDE_SECRET",
+        kind: "https_secret",
+        value: "workspace-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(workspaceSecretResult.isOk()).toBe(true);
+
+    const podVarResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      {
+        name: "COLLIDE_TOKEN",
+        value: "pod-collide-value",
+      }
+    );
+    expect(podVarResult.isOk()).toBe(true);
+
+    const podSecretResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      {
+        name: "COLLIDE_SECRET",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(podSecretResult.isOk()).toBe(true);
+    if (podSecretResult.isErr()) {
+      throw podSecretResult.error;
+    }
+
+    const result = await PodSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      pod
+    );
+    expect(result.isOk()).toBe(true);
+
+    // The owner env layer beats the workspace layer in buildSandboxEnvVars,
+    // so a pod var shadows a workspace var of the same name — for cleartext
+    // config vars and DSEC placeholders alike, matching the egress-secrets
+    // file merge precedence.
+    expect(mockProviderCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DST_COLLIDE_TOKEN: "pod-collide-value",
+          DSEC_COLLIDE_SECRET: `__DSEC_${podSecretResult.value.toJSON().placeholderNonce}__`,
+          SPACE_ID: pod.sId,
+        }),
+      }),
+      { workspaceId: workspace.sId }
+    );
+  });
+
+  it("conversation sandboxes running in a pod receive the pod env vars", async () => {
+    const workspace = authenticator.getNonNullableWorkspace();
+    const user = authenticator.getNonNullableUser();
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceVarResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "workspace", workspace },
+      { name: "COLLIDE_TOKEN", value: "workspace-collide-value" }
+    );
+    expect(workspaceVarResult.isOk()).toBe(true);
+
+    const podVarResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      { name: "COLLIDE_TOKEN", value: "pod-collide-value" }
+    );
+    expect(podVarResult.isOk()).toBe(true);
+
+    const podSecretResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      { kind: "pod", pod },
+      {
+        name: "POD_SECRET",
+        kind: "https_secret",
+        value: "pod-secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    expect(podSecretResult.isOk()).toBe(true);
+    if (podSecretResult.isErr()) {
+      throw podSecretResult.error;
+    }
+
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      { id: conversation.id, sId: conversation.sId, spaceId: pod.sId }
+    );
+    expect(result.isOk()).toBe(true);
+
+    // Pod config applies to every Computer running in the Pod: the
+    // conversation sandbox gets the pod vars (pod wins on collision) and
+    // DSEC placeholders, but not the pod-owner SPACE_ID marker.
+    expect(mockProviderCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DST_COLLIDE_TOKEN: "pod-collide-value",
+          DSEC_POD_SECRET: `__DSEC_${podSecretResult.value.toJSON().placeholderNonce}__`,
+          CONVERSATION_ID: conversation.sId,
+        }),
+      }),
+      { workspaceId: workspace.sId }
+    );
+    const createEnvVars =
+      mockProviderCreate.mock.calls[mockProviderCreate.mock.calls.length - 1][0]
+        .envVars;
+    expect(createEnvVars.SPACE_ID).toBeUndefined();
   });
 
   it("records baseImage and version from the registered image on fresh create", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -72,7 +72,13 @@ export type SandboxPreSleepCheck = (
 
 type SandboxCreateOwner = SandboxLifecycleOwner & {
   createSandbox: (blob: SandboxCreateBlob) => Promise<SandboxResource>;
-  envVars: Record<string, string>;
+  // Owner env vars are only consumed when a sandbox is actually created.
+  // Owners whose env requires DB reads (e.g. pod env vars) should pass the
+  // factory form so ensureActive calls on an already-running sandbox don't
+  // pay for loads that would be discarded.
+  envVars:
+    | Record<string, string>
+    | (() => Promise<Result<Record<string, string>, Error>>);
   logLabel: string;
 };
 
@@ -439,6 +445,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
   }
 
+  // Owner env vars come either as a plain record or as a factory for owners
+  // whose env requires DB reads — the factory only runs on the create paths,
+  // so ensure calls on an already-running sandbox pay nothing.
+  private static async resolveOwnerEnvVars(
+    owner: SandboxCreateOwner
+  ): Promise<Result<Record<string, string>, Error>> {
+    return typeof owner.envVars === "function"
+      ? owner.envVars()
+      : new Ok(owner.envVars);
+  }
+
   // Compose the env vars passed to provider.create. Precedence (lowest →
   // highest): workspace env vars → image runEnv → owner vars → system vars.
   // Owner and system layers always win, so even if a row slips past suffix
@@ -547,9 +564,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         const createConfig = imageResult.value.toCreateConfig();
+        const ownerEnvVarsResult = await this.resolveOwnerEnvVars(owner);
+        if (ownerEnvVarsResult.isErr()) {
+          return ownerEnvVarsResult;
+        }
+
         const envVarsResult = await this.buildSandboxEnvVars(
           auth,
-          owner.envVars,
+          ownerEnvVarsResult.value,
           createConfig.envVars
         );
         if (envVarsResult.isErr()) {
@@ -686,9 +708,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
 
           const createConfig = imageResult.value.toCreateConfig();
+          const ownerEnvVarsResult = await this.resolveOwnerEnvVars(owner);
+          if (ownerEnvVarsResult.isErr()) {
+            return ownerEnvVarsResult;
+          }
+
           const envVarsResult = await this.buildSandboxEnvVars(
             auth,
-            owner.envVars,
+            ownerEnvVarsResult.value,
             createConfig.envVars
           );
           if (envVarsResult.isErr()) {

--- a/front/tests/utils/SandboxEnvVarFactory.ts
+++ b/front/tests/utils/SandboxEnvVarFactory.ts
@@ -14,6 +14,8 @@ export class SandboxEnvVarFactory {
       space?: SpaceResource;
       kind?: SandboxEnvVarKind;
       encryptedValue?: string;
+      placeholderNonce?: Buffer;
+      allowedDomains?: string[];
     }
   ): Promise<SandboxEnvVarModel> {
     const user = auth.getNonNullableUser();
@@ -24,6 +26,8 @@ export class SandboxEnvVarFactory {
       name: opts.name,
       kind: opts.kind ?? "config",
       encryptedValue: opts.encryptedValue ?? "test-encrypted-value",
+      placeholderNonce: opts.placeholderNonce ?? null,
+      allowedDomains: opts.allowedDomains ?? null,
       createdByUserId: user.id,
       lastUpdatedByUserId: user.id,
     });


### PR DESCRIPTION
## Description

Follow up of #28861 (unified scope-aware resource). Wires Pod-scoped sandbox secrets into the pod sandbox boot path — the only PR of the stack that changes what a running sandbox does.

**What this PR does:**

1. **Pod config applies to every Computer running in the Pod** — mirroring the egress-policy decision: both pod-owned sandboxes *and* conversation-owned sandboxes whose conversation lives in the pod receive the pod's env vars and secrets. The conversation runtime owner now carries its `spaceId` (same linkage the egress policy file already keys on).
2. **`egress-secrets.json` is built per runtime owner**: workspace entries for every sandbox; for sandboxes running in a pod, pod entries are merged in and **pod wins on name collision** (placeholder and allowed domains included, not just the value). Pod entries decrypt inline under the pod scope key against the unified table (`spaceId`-scoped rows) — any failure (missing nonce, missing domains, decrypt error) aborts the whole write, never a partial or empty-valued entry. A missing pod space fails the build for pod-owned sandboxes; for conversations it skips the pod layer (same rule as the env injection, keeping file and env consistent).
3. **`writeEgressSecretsFile` takes the `SandboxRuntimeOwner`** already in scope at `setupEgressForwarder` (the same owner that feeds the `ownerId` JWT claim).
4. **Both adapters inject pod env vars** through the owner env layer: config vars in cleartext (`DST_*`), HTTPS secrets as their DSEC placeholders (dsbx swaps them on the wire). The owner layer beats the workspace layer in `buildSandboxEnvVars`, so env precedence matches the egress-file merge — pod wins in both places. Fail closed: a var that cannot be resolved aborts activation rather than booting without it. The loads ride a lazy `envVars` factory so `ensureActive` on an already-running sandbox pays nothing.
5. **Bash-output redaction covers pod scope**: conversations in a pod now run with pod var values in their sandbox, so `redactSandboxEnvVarsFromOutput` scrubs the pod's config values from tool output alongside the workspace ones.
6. **The env manifest lists pod vars too** (`sandbox-env-manifest.json` — names/placeholders/domains only, never values): sandboxes running in a pod see the merged var set, pod winning on collision, so function/skill authors can discover pod vars. The owner→pod resolution is now one shared rule (`resolvePodForRuntimeOwner`) used by the egress-secrets build and the manifest alike — pod-owned sandboxes hard-fail without their pod space; conversations without a (project) space just get workspace config.

Pod-beats-workspace precedence for plain env vars (owner layer over workspace layer in `buildSandboxEnvVars`) is locked by a test: a colliding `DST_*` var and `DSEC_*` placeholder both surface the pod value in `provider.create`.

> [!NOTE]
> Behavioral no-op in production until the pod secrets API routes (next PR) let admins create pod env vars — until then no rows exist, both builders return workspace-only output, and the owner env layer adds nothing.

## Risk

Worst case, a sandbox running in a pod fails activation on an unresolvable pod var (fail-closed by design). Conversations outside a pod are untouched: their path returns workspace entries unchanged and their env gains nothing. Safe to rollback.

## Tests

Pod/workspace merge with pod-wins collision (placeholder + domains + value) for both pod-owned and conversation-in-pod owners, manifest listing merged for both owner kinds, non-pod-space conversations get workspace entries only, conversation-owner passthrough regression, decrypt-under-pod-scope-key via the real egress consumer, env-layer precedence pinned at `provider.create` for both adapters (including no `SPACE_ID` leak into conversation sandboxes), boot-owner assert matrix (wrong pod / no pod / matching pod conversation), stdin-not-argv write regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
