### PR TITLE
Surface sandbox function authentication events

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -78,6 +78,19 @@ describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () =
     });
   });
 
+  it("returns pending while the action awaits authentication", async () => {
+    const { token, workspace, action } = await setupWithAction();
+    await action.updateStatus("blocked_authentication_required");
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: "pending",
+      actionId: action.sId,
+    });
+  });
+
   it("returns the output once the action succeeded", async () => {
     const { auth, token, workspace, action } = await setupWithAction();
 

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -84,6 +84,7 @@ app.get(
 
       switch (action.status) {
         case "running":
+        case "blocked_authentication_required":
         case "blocked_validation_required":
           return ctx.json({ status: "pending", actionId: action.sId }, 202);
         case "succeeded":

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -344,6 +344,12 @@ export function isSandboxFunctionToolEvent<
   return "sandboxFunctionId" in event;
 }
 
+export function isAgentLoopToolEvent<
+  T extends AgentLoopEventScope | SandboxFunctionEventScope,
+>(event: T): event is Extract<T, AgentLoopEventScope> {
+  return "conversationId" in event;
+}
+
 export function isToolFileAuthRequiredEvent(
   event: unknown
 ): event is ToolFileAuthRequiredEvent {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -8,11 +8,12 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
+  AgentLoopEventScope,
   AgentLoopMCPApproveExecutionEvent,
   AgentLoopToolExecution,
   MCPApproveExecutionEvent,
+  SandboxFunctionEventScope,
   SandboxFunctionToolExecution,
-  SandboxFunctionToolPersonalAuthRequiredEvent,
   ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
@@ -284,12 +285,6 @@ export type ToolNotificationEvent =
   | AgentLoopToolNotificationEvent
   | SandboxFunctionToolNotificationEvent;
 
-export function isAgentLoopToolNotificationEvent(
-  event: ToolNotificationEvent
-): event is AgentLoopToolNotificationEvent {
-  return "messageId" in event;
-}
-
 // AgentActionRunningEvents are events related action execution within an agent loop.
 export type AgentActionRunningEvents =
   | AgentLoopToolParamsEvent
@@ -343,9 +338,9 @@ export function isToolPersonalAuthRequiredEvent(
   );
 }
 
-export function isSandboxFunctionToolPersonalAuthRequiredEvent(
-  event: ToolPersonalAuthRequiredEvent
-): event is SandboxFunctionToolPersonalAuthRequiredEvent {
+export function isSandboxFunctionToolEvent<
+  T extends AgentLoopEventScope | SandboxFunctionEventScope,
+>(event: T): event is Extract<T, SandboxFunctionEventScope> {
   return "sandboxFunctionId" in event;
 }
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -12,6 +12,7 @@ import type {
   AgentLoopToolExecution,
   MCPApproveExecutionEvent,
   SandboxFunctionToolExecution,
+  SandboxFunctionToolPersonalAuthRequiredEvent,
   ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
@@ -340,6 +341,12 @@ export function isToolPersonalAuthRequiredEvent(
     "type" in event &&
     event.type === "tool_personal_auth_required"
   );
+}
+
+export function isSandboxFunctionToolPersonalAuthRequiredEvent(
+  event: ToolPersonalAuthRequiredEvent
+): event is SandboxFunctionToolPersonalAuthRequiredEvent {
+  return "sandboxFunctionId" in event;
 }
 
 export function isToolFileAuthRequiredEvent(

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -150,16 +150,24 @@ export async function getExitOrPauseEvents(
         `The tool ${toolCallName} requires personal ` +
         `authentication, please authenticate to use it.`;
 
-      // The blocked statuses only exist on agent MCP actions; sandbox function invocations observe
-      // the returned event instead.
-      if (isAgentLoopRunContext(runContext)) {
-        // Update the action to mark it as blocked because of a personal authentication error.
-        await runContext.action.updateStatus("blocked_authentication_required");
-        await pauseSandboxBashForBlockedChild(
-          auth,
-          runContext.action,
-          runContext.conversation
-        );
+      switch (runContext.contextType) {
+        case "agent_loop":
+          await runContext.action.updateStatus(
+            "blocked_authentication_required"
+          );
+          await pauseSandboxBashForBlockedChild(
+            auth,
+            runContext.action,
+            runContext.conversation
+          );
+          break;
+        case "sandbox_function":
+          await runContext.action.updateStatus(
+            "blocked_authentication_required"
+          );
+          break;
+        default:
+          assertNever(runContext);
       }
 
       return [

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -7,11 +7,12 @@ const TOOL_EXECUTION_FINAL_STATUSES = [
 type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 
 // Base lifecycle shared by every MCP tool execution, regardless of context: the tool runs, may be
-// blocked awaiting user approval, and ends succeeded, errored, or denied. AgentMCPActionModel and
-// SandboxFunctionMCPActionModel both draw from this vocabulary; the agent loop extends it with its
-// scheduling and conversation-interaction states below.
+// blocked awaiting user approval or authentication, and ends succeeded, errored, or denied.
+// AgentMCPActionModel and SandboxFunctionMCPActionModel both draw from this vocabulary; the agent
+// loop extends it with its scheduling and conversation-interaction states below.
 export const TOOL_EXECUTION_BASE_STATUSES = [
   "running",
+  "blocked_authentication_required",
   "blocked_validation_required",
   ...TOOL_EXECUTION_FINAL_STATUSES,
 ] as const;
@@ -24,7 +25,6 @@ export type ToolExecutionBaseStatus =
 const TOOL_EXECUTION_AGENT_LOOP_EXTENSION_STATUSES = [
   "ready_allowed_explicitly",
   "ready_allowed_implicitly",
-  "blocked_authentication_required",
   "blocked_file_authorization_required",
   "blocked_child_action_input_required",
   "blocked_user_answer_required",

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -167,6 +167,12 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
     return action ?? null;
   }
 
+  async updateStatus(
+    status: ToolExecutionBaseStatus
+  ): Promise<[affectedCount: number]> {
+    return this.update({ status });
+  }
+
   async markAsSucceeded({
     executionDurationMs,
   }: {

--- a/front/lib/utils/async_utils.ts
+++ b/front/lib/utils/async_utils.ts
@@ -124,16 +124,3 @@ export async function withPeriodicHeartbeat<T>(
 export async function setTimeoutAync(delayMs: number = 0): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
-
-// Consume an async generator, discarding its yields, and return its return value. `for await`
-// discards generator return values and `yield*` only works inside another generator, so callers
-// that need the return value outside of a generator have to drain manually.
-export async function drainAsyncGenerator<Y, R>(
-  generator: AsyncGenerator<Y, R>
-): Promise<R> {
-  let result = await generator.next();
-  while (!result.done) {
-    result = await generator.next();
-  }
-  return result.value;
-}

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
@@ -20,6 +20,17 @@ vi.mock("@app/lib/actions/mcp_actions", async (importOriginal) => {
   };
 });
 
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...actual,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+  };
+});
+
 // The activity reads the temporal cancellation signal and heartbeats; neither exists outside a
 // real activity context.
 vi.mock("@temporalio/activity", () => ({
@@ -28,6 +39,8 @@ vi.mock("@temporalio/activity", () => ({
   },
   heartbeat: vi.fn(),
 }));
+
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 
 function mockToolCallResult(result: CallToolResult) {
   vi.mocked(tryCallMCPTool).mockImplementation(async function* () {
@@ -78,13 +91,9 @@ describe("runSandboxFunctionToolActivity", () => {
     expect(refetched?.status).toBe("succeeded");
   });
 
-  it("should fail closed to errored when the tool requires personal authentication", async () => {
+  it("should block and publish when the tool requires personal authentication", async () => {
     const { auth, action } = await setupActivityRun();
 
-    // Pause resources yield events without a terminal status; with no pause surface for function
-    // invocations the activity must fail closed, otherwise the action stays `running` and the
-    // poll hangs until token expiry. The resource lands in the output so the function sees what
-    // the tool needs.
     const authRequiredResource: AgentPauseOutputResourceType = {
       mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
       type: "tool_personal_auth_required",
@@ -106,7 +115,18 @@ describe("runSandboxFunctionToolActivity", () => {
         auth,
         action.id
       );
-    expect(refetched?.status).toBe("errored");
+    expect(refetched?.status).toBe("blocked_authentication_required");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "tool_personal_auth_required",
+        actionId: action.sId,
+        invocationId: action.invocationId,
+        authError: expect.objectContaining({
+          provider: "google_drive",
+        }),
+      }),
+      { invocationId: action.invocationId }
+    );
 
     const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
       call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,3 +1,4 @@
+import { isSandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
@@ -74,7 +75,7 @@ export async function runSandboxFunctionToolActivity(
       switch (event.type) {
         case "tool_personal_auth_required":
           assert(
-            "invocationId" in event,
+            isSandboxFunctionToolPersonalAuthRequiredEvent(event),
             "Expected a sandbox function authentication event."
           );
           await publishSandboxFunctionInvocationEvent(event, {

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,4 +1,4 @@
-import { isSandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp";
+import { isSandboxFunctionToolEvent } from "@app/lib/actions/mcp";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
@@ -75,7 +75,7 @@ export async function runSandboxFunctionToolActivity(
       switch (event.type) {
         case "tool_personal_auth_required":
           assert(
-            isSandboxFunctionToolPersonalAuthRequiredEvent(event),
+            isSandboxFunctionToolEvent(event),
             "Expected a sandbox function authentication event."
           );
           await publishSandboxFunctionInvocationEvent(event, {

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.ts
@@ -1,16 +1,18 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { getShutdownSignal } from "@app/lib/shutdown_signal";
-import { drainAsyncGenerator } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Context } from "@temporalio/activity";
+import assert from "assert";
 
 export async function runSandboxFunctionToolActivity(
   authType: AuthenticatorType,
@@ -58,31 +60,47 @@ export async function runSandboxFunctionToolActivity(
 
   const startTimeMs = performance.now();
 
-  // `runToolWithStreaming` executes the tool and persists the output. Its events are drained:
-  // there is no invocation event stream to forward them to yet.
-  // TODO(2026-07-08 SANDBOX_FUNCTIONS): forward these events to the invocation event stream once
-  // it exists (e.g. viz progress).
   const abortSignal = AbortSignal.any([
     Context.current().cancellationSignal,
     getShutdownSignal(),
   ]);
 
   try {
-    await drainAsyncGenerator(
-      runToolWithStreaming(
-        auth,
-        { toolContext: { runContext } },
-        { signal: abortSignal }
-      )
-    );
+    for await (const event of runToolWithStreaming(
+      auth,
+      { toolContext: { runContext } },
+      { signal: abortSignal }
+    )) {
+      switch (event.type) {
+        case "tool_personal_auth_required":
+          assert(
+            "invocationId" in event,
+            "Expected a sandbox function authentication event."
+          );
+          await publishSandboxFunctionInvocationEvent(event, {
+            invocationId: invocation.sId,
+          });
+          break;
+        case "tool_approve_execution":
+        case "tool_ask_user_question":
+        case "tool_early_exit":
+        case "tool_error":
+        case "tool_file_auth_required":
+        case "tool_notification":
+        case "tool_paused":
+        case "tool_success":
+          break;
+        default:
+          assertNever(event);
+      }
+    }
 
-    // Pause resources make the run yield events and return without a terminal status. There is
-    // no pause surface for function invocations yet, so fail closed to errored rather than leave
-    // the action `running` with the poll hanging until token expiry. The pause resource is
-    // persisted in the output, so the function sees what the tool needs (e.g. which provider to
-    // authenticate) and handles it on its side. Approval bubbling replaces this with
-    // `blocked_validation_required` plus an invocation stream event.
-    if (!isToolExecutionStatusFinal(action.status)) {
+    // Personal authentication is an expected non-terminal pause surfaced through the invocation
+    // stream. Other pause resources still fail closed until their resolution flows are wired.
+    if (
+      !isToolExecutionStatusFinal(action.status) &&
+      action.status !== "blocked_authentication_required"
+    ) {
       await action.markAsErrored({
         executionDurationMs: performance.now() - startTimeMs,
       });

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,4 @@
-import { isAgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
+import { isSandboxFunctionToolEvent } from "@app/lib/actions/mcp";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
@@ -494,7 +494,7 @@ async function executeToolStreaming(
         // Tools executed from the agent loop activity always run with an agent loop context, so
         // sandbox function notification events cannot surface here.
         assert(
-          isAgentLoopToolNotificationEvent(event),
+          !isSandboxFunctionToolEvent(event),
           "Unexpected sandbox function tool notification in the agent loop."
         );
         await handleNonDeferredEvents(auth, {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,4 @@
-import { isSandboxFunctionToolEvent } from "@app/lib/actions/mcp";
+import { isAgentLoopToolEvent } from "@app/lib/actions/mcp";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
@@ -494,7 +494,7 @@ async function executeToolStreaming(
         // Tools executed from the agent loop activity always run with an agent loop context, so
         // sandbox function notification events cannot surface here.
         assert(
-          !isSandboxFunctionToolEvent(event),
+          isAgentLoopToolEvent(event),
           "Unexpected sandbox function tool notification in the agent loop."
         );
         await handleNonDeferredEvents(auth, {

--- a/x/spolu/tool_context/SANBOX_PLAN.md
+++ b/x/spolu/tool_context/SANBOX_PLAN.md
@@ -1,0 +1,68 @@
+# Asynchronous sandbox function invocations
+
+Move the outer sandbox function execution out of the HTTP request and into its own Temporal
+workflow and activity.
+
+## Current flow
+
+```text
+POST invocation
+  -> create invocation
+  -> await sandbox.exec()
+      -> dsbx tool blocks for approval
+  -> return invocation ID
+```
+
+The visualization cannot subscribe to the invocation event stream until the POST returns. If the
+function calls a tool that requires approval, `dsbx` waits for the action while the UI waits for the
+invocation ID, creating a deadlock.
+
+## Target flow
+
+```text
+POST invocation
+  -> create invocation
+  -> launch sandbox function invocation workflow
+  -> immediately return invocation ID
+
+Invocation workflow/activity
+  -> ensure sandbox
+  -> run sandbox.exec()
+  -> publish terminal result or error events
+```
+
+This follows the agent loop ownership model: HTTP creates durable state and launches Temporal,
+while an activity owns the long-running execution.
+
+## Interaction with PR #28829
+
+PR #28829 remains responsible for resolving the inner tool approval:
+
+1. The invocation activity waits inside `sandbox.exec()`.
+2. `dsbx` creates a tool action and polls it.
+3. The action becomes `blocked_validation_required` and emits an approval event.
+4. The visualization already has the invocation ID, so its SSE subscription displays the approval
+   card.
+5. PR #28829 transitions the action to `running` and launches
+   `runSandboxFunctionToolWorkflow`.
+6. The tool completes, the `dsbx` poll returns, and the outer invocation activity continues.
+7. The runner publishes the terminal invocation result.
+
+## Implementation
+
+- Add `runSandboxFunctionInvocationWorkflow`.
+- Add `runSandboxFunctionInvocationActivity`.
+- Add a deterministic workflow ID based on the workspace and invocation model ID.
+- Add a launcher called after the POST endpoint creates the invocation.
+- Split creating an invocation from executing an existing invocation.
+- Configure the activity with `maximumAttempts: 1`, like other non-idempotent tool execution, to
+  avoid duplicating function side effects.
+- If workflow launch fails, publish an invocation error and transition the invocation to an error
+  state so callers do not wait indefinitely.
+
+## Follow-up
+
+Initially, the invocation activity can remain blocked while the function waits for tool approval or
+authentication. A follow-up can add invocation-level `execId` resume state, pause the sandbox, end
+the activity when blocked, and relaunch after resolution. That would match the existing agent-loop
+sandbox bash pause/resume behavior and avoid holding an activity during potentially long user waits.


### PR DESCRIPTION
## Description

Sandbox function tool actions now preserve personal-authentication blocks instead of being marked errored. Authentication-required events are published to the invocation stream, and the action polling endpoint keeps returning pending while authentication is required.

Includes an implementation note for moving outer sandbox function execution into Temporal so the visualization can subscribe before a blocking tool call. This follow-up is designed to compose with #28829, which resolves approvals and launches the inner tool workflow.

## Tests

- `NODE_ENV=test npm test temporal/agent_loop/activities/run_sandbox_function_tool.test.ts`
- `NODE_ENV=test npm test routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts`

## Risk

Low. Sandbox functions are not live yet; changes are limited to sandbox-function tool authentication state and event delivery.

## Deploy Plan

- deploy `front`