### PR TITLE
Make previous-interactions pruning proactive instead of only kicking in near the hard context ceiling

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -178,6 +178,9 @@ describe("renderConversationForModel", () => {
     providerId: "openai",
     modelId: "gpt-4.1",
     tokenizer: "cl100k_base",
+    // Large enough that PRUNING_TARGET_CONTEXT_UTILIZATION never becomes the binding constraint
+    // in these tests, which are all sized in the low hundreds of tokens.
+    contextSize: 200_000,
   } as any;
 
   beforeEach(() => {
@@ -310,6 +313,96 @@ describe("renderConversationForModel", () => {
       "This tool result is no longer available"
     );
     expect(newTool.content).toBe("new_function");
+    expect(res.value.prunedContext).toBe(false);
+  });
+
+  it("proactively prunes previous interactions once they cross PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit them", async () => {
+    // contextSize: 2000 -> proactive target of 159 tokens (60% minus baseTokens), well below the
+    // 220-token previous interaction below.
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      userMessage("old_user"),
+      assistantMessage("old_assistant"),
+      functionMessage("old_tool", "old_function"),
+      userMessage("new_user"),
+      assistantMessage("new_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: {
+        old_user: 10,
+        old_assistant: 10,
+        old_function: 200,
+        new_user: 10,
+        new_assistant: 10,
+      },
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model: { ...model, contextSize: 2000 },
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      // Comfortably fits both interactions in full under the real ceiling: proves redaction is
+      // driven by the proactive target, not by running out of the real budget.
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 2000,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const oldTool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "old_tool"
+    );
+    expect(oldTool.content).toContain("no longer available");
+  });
+
+  it("still lets a legitimately large current interaction through, unaffected by the smaller proactive-pruning target", async () => {
+    // Same 159-token proactive target as above (contextSize: 2000), but the current interaction
+    // (320 tokens) comfortably fits the real allowedTokenCount, which is the ceiling that matters
+    // here (see previousInteractionsPruningBudget's own comment for why).
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      userMessage("cur_user"),
+      assistantMessage("cur_assistant"),
+      functionMessage("cur_tool", "cur_function"),
+    ]);
+    mockTokenCounter({
+      byContains: {
+        cur_user: 10,
+        cur_assistant: 10,
+        cur_function: 300,
+      },
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model: { ...model, contextSize: 2000 },
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 2000,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const currentTool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "cur_tool"
+    );
+    expect(currentTool.content).toBe("cur_function");
     expect(res.value.prunedContext).toBe(false);
   });
 

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -318,7 +318,10 @@ describe("renderConversationForModel", () => {
 
   it("proactively prunes previous interactions once they cross PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit them", async () => {
     // contextSize: 2000 -> proactive target of 159 tokens (60% minus baseTokens), well below the
-    // 220-token previous interaction below.
+    // 220-token previous interaction below. With only one previous interaction (inside
+    // PREVIOUS_INTERACTIONS_TO_PRESERVE's floor), this exercises prunePreviousInteractions' own
+    // last-resort floor redaction, not its checkpoint-based frontier. See the test below that
+    // exercises the checkpoint-based frontier instead.
     vi.mocked(renderAllMessages).mockResolvedValue([
       userMessage("old_user"),
       assistantMessage("old_assistant"),
@@ -404,6 +407,124 @@ describe("renderConversationForModel", () => {
     );
     expect(currentTool.content).toBe("cur_function");
     expect(res.value.prunedContext).toBe(false);
+  });
+
+  it("genuinely proactively prunes eligible interactions through the checkpoint-based frontier, not just the last-resort floor path", async () => {
+    // 5 previous interactions (250 tokens each: 10 user + 10 assistant + 230 tool),
+    // PREVIOUS_INTERACTIONS_TO_PRESERVE=3 leaves i0,i1 eligible and i2,i3,i4 as the protected
+    // floor. contextSize 3400 gives a proactive target of 999 tokens (60% minus baseTokens):
+    // the floor alone (750) comfortably fits under it, so last-resort never fires, but the full
+    // 1250-token total doesn't, so i0 and i1 (but not the floor) get redacted through the normal
+    // frontier search, leaving 838 tokens, back under the target without needing to drop anything.
+    const previousInteractionMessages = [0, 1, 2, 3, 4].flatMap((i) => [
+      userMessage(`i${i}_user`),
+      assistantMessage(`i${i}_assistant`),
+      functionMessage(`i${i}_tool`, `i${i}_tool_content`),
+    ]);
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      ...previousInteractionMessages,
+      userMessage("cur_user"),
+      assistantMessage("cur_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: Object.fromEntries([
+        ...[0, 1, 2, 3, 4].flatMap((i) => [
+          [`i${i}_user`, 10],
+          [`i${i}_assistant`, 10],
+          [`i${i}_tool_content`, 230],
+        ]),
+        ["cur_user", 10],
+        ["cur_assistant", 10],
+      ]),
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model: { ...model, contextSize: 3400 },
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      // Far above the real usage here: proves redaction comes from the proactive target, not from
+      // running out of the real budget.
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 20_000,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const i0Tool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "i0_tool"
+    );
+    const i4Tool = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "i4_tool"
+    );
+    expect(i0Tool.content).toContain("no longer available");
+    expect(i4Tool.content).toBe("i4_tool_content");
+  });
+
+  it("falls back to the real budget instead of forcing a negative proactive target, so a large system prompt/tool footprint on a small-context model never breaks the protected floor", async () => {
+    // contextSize 16_384 (GPT-3.5-turbo-sized) with a 6000-token prompt and 6000-token tool
+    // definitions footprint: baseTokens (~11224) alone already exceeds the 60% proactive target
+    // (~9830), which would go negative if applied naively. previousInteractionsPruningBudget must
+    // fall back to the real budgetForInteractions (300 here), which comfortably covers all 3
+    // previous interactions (all inside the protected floor), so none of them should be touched.
+    const previousInteractionMessages = [0, 1, 2].flatMap((i) => [
+      userMessage(`i${i}_user`),
+      assistantMessage(`i${i}_assistant`),
+      functionMessage(`i${i}_tool`, `i${i}_tool_content`),
+    ]);
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      ...previousInteractionMessages,
+      userMessage("cur_user"),
+      assistantMessage("cur_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: Object.fromEntries([
+        ...[0, 1, 2].flatMap((i) => [
+          [`i${i}_user`, 10],
+          [`i${i}_assistant`, 10],
+          [`i${i}_tool_content`, 20],
+        ]),
+        ["cur_user", 10],
+        ["cur_assistant", 10],
+      ]),
+      promptTokens: 6000,
+      toolsTokens: 6000,
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model: { ...model, contextSize: 16_384 },
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 6000,
+        toolsTokens: 6000,
+        interactionTokens: 300,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    for (const i of [0, 1, 2]) {
+      const tool = getFunctionMessage(
+        res.value.modelConversation.messages,
+        `i${i}_tool`
+      );
+      expect(tool.content).toBe(`i${i}_tool_content`);
+    }
   });
 
   it("merges content fragment into following user message", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -42,12 +42,10 @@ export const TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR = 0.7;
 export const TOKENS_MARGIN = 1024;
 
 // Target ceiling (as a fraction of contextSize) for triggering previous-interactions pruning,
-// picked to sit safely below the customer-facing compaction warning (~70% of contextSize).
-// Without this, allowedTokenCount alone (contextSize - generationTokensCount) sits anywhere from
-// 68% to 99% of contextSize depending on the model, so pruning would do nothing for most of the
-// fleet until conversations are already past the point where compaction forces the user to stop.
-// Kept independent of generationTokensCount, which also doubles as the actual max_tokens sent to
-// the provider.
+// picked to sit safely below the customer-facing compaction warning (~70% of contextSize) rather
+// than the real ceiling, which sits at 68-99% depending on the model and otherwise leaves pruning
+// doing nothing until compaction has already fired. Kept independent of generationTokensCount,
+// which also doubles as the actual max_tokens sent to the provider.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
 export async function renderConversationForModel(
@@ -162,16 +160,11 @@ export async function renderConversationForModel(
   const budgetForInteractions = allowedTokenCount - baseTokens;
 
   // See PRUNING_TARGET_CONTEXT_UTILIZATION for why this trigger exists. Kept separate from
-  // budgetForInteractions, which stays at the real ceiling below for the current interaction's own
-  // safety net: a legitimately large current turn must never be rejected just for this smaller,
-  // proactive target.
-  //
-  // Only applied when it's actually a positive constraint. For a small-context model with a large
-  // system prompt or many equipped tools, baseTokens alone can already exceed the proactive target,
-  // making it negative, and forcing that instead of budgetForInteractions would push
-  // prunePreviousInteractions into redacting its protected floor as routine behavior, not the rare
-  // last-resort case it's meant to be. Falling back to budgetForInteractions in that case keeps
-  // this proactive trigger strictly an early-warning mechanism, never a stricter one than before.
+  // budgetForInteractions (the real ceiling, used below for the current interaction's own safety
+  // net) and only applied when positive: a small-context model with a large prompt or many tools
+  // can push baseTokens past the target on its own, and forcing that negative number would make
+  // prunePreviousInteractions redact its protected floor as routine behavior, not a rare last
+  // resort.
   const pruningTargetCeiling =
     model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
   const previousInteractionsPruningBudget =

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -41,6 +41,15 @@ const IMAGE_CONTENT_TOKEN_COUNT = 3100;
 export const TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR = 0.7;
 export const TOKENS_MARGIN = 1024;
 
+// Target ceiling (as a fraction of contextSize) for triggering previous-interactions pruning,
+// picked to sit safely below the customer-facing compaction warning (~70% of contextSize).
+// Without this, allowedTokenCount alone (contextSize - generationTokensCount) sits anywhere from
+// 68% to 99% of contextSize depending on the model, so pruning would do nothing for most of the
+// fleet until conversations are already past the point where compaction forces the user to stop.
+// Kept independent of generationTokensCount, which also doubles as the actual max_tokens sent to
+// the provider.
+export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
+
 export async function renderConversationForModel(
   auth: Authenticator,
   {
@@ -152,9 +161,18 @@ export async function renderConversationForModel(
   // absorbs whatever budget remains, with its own progressive-pruning safety net below.
   const budgetForInteractions = allowedTokenCount - baseTokens;
 
+  // See PRUNING_TARGET_CONTEXT_UTILIZATION for why this trigger exists. Kept separate from
+  // budgetForInteractions, which stays at the real ceiling below for the current interaction's own
+  // safety net: a legitimately large current turn must never be rejected just for this smaller,
+  // proactive target.
+  const previousInteractionsPruningBudget = Math.min(
+    budgetForInteractions,
+    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens
+  );
+
   const previousInteractions = prunePreviousInteractions(
     interactions.slice(0, -1),
-    budgetForInteractions,
+    previousInteractionsPruningBudget,
     PREVIOUS_INTERACTIONS_TO_PRESERVE
   );
   const previousInteractionsTokens = previousInteractions.reduce(

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -165,10 +165,19 @@ export async function renderConversationForModel(
   // budgetForInteractions, which stays at the real ceiling below for the current interaction's own
   // safety net: a legitimately large current turn must never be rejected just for this smaller,
   // proactive target.
-  const previousInteractionsPruningBudget = Math.min(
-    budgetForInteractions,
-    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens
-  );
+  //
+  // Only applied when it's actually a positive constraint. For a small-context model with a large
+  // system prompt or many equipped tools, baseTokens alone can already exceed the proactive target,
+  // making it negative, and forcing that instead of budgetForInteractions would push
+  // prunePreviousInteractions into redacting its protected floor as routine behavior, not the rare
+  // last-resort case it's meant to be. Falling back to budgetForInteractions in that case keeps
+  // this proactive trigger strictly an early-warning mechanism, never a stricter one than before.
+  const pruningTargetCeiling =
+    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
+  const previousInteractionsPruningBudget =
+    pruningTargetCeiling > 0
+      ? Math.min(budgetForInteractions, pruningTargetCeiling)
+      : budgetForInteractions;
 
   const previousInteractions = prunePreviousInteractions(
     interactions.slice(0, -1),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Conversations are hitting the customer-facing compaction warning far more often than expected, and it traces back to how pruning and compaction ended up uncoordinated after pruning became budget-driven (see https://github.com/dust-tt/dust/pull/28751). Compaction watches real, provider-reported token usage as a percentage of the model's context window and warns around seventy percent, forcing the user to compact around eighty. Pruning, meanwhile, only started redacting old tool results once the conversation got close to the model's actual hard ceiling, which for several models in our fleet sits well above eighty percent of the window. In practice that meant pruning almost never got a chance to do its job before the user was already being forced to compact, on a good chunk of the model fleet.

This change gives pruning its own, smaller, proactive target, well below where compaction starts warning, so redaction of old tool output kicks in early and quietly instead of only as a last-ditch effort once the window is nearly full. It's deliberately a separate number from the model's real, hard ceiling, which stays exactly as it was: the safety net that decides whether the current turn's own content fits is untouched, so a legitimately large response still goes through exactly as before. The proactive number is a starting point, not something empirically tuned yet, and worth revisiting once we can see its effect in the instrumentation shipped earlier this week.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
