### PR TITLE
fix: use regular_auto group kind in fetchDistinctActiveManualGroupMembers

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1703,7 +1703,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const allGroups: GroupResource[] = [];
     for (const space of spaces) {
       const groups = space.groups.filter(
-        (g) => g.kind === "regular" || g.kind === "space_editors"
+        (g) => g.kind === "regular_auto" || g.kind === "space_editors"
       );
       manualGroupsBySpaceModelId.set(space.id, groups);
       allGroups.push(...groups);


### PR DESCRIPTION
## Summary

#28726 (`introduce regular_auto group kind`) renamed the `"regular"` group kind to `"regular_auto"` but left a stale comparison at `space_resource.ts:1706` in `fetchDistinctActiveManualGroupMembers`:

```ts
(g) => g.kind === "regular" || g.kind === "space_editors"
```

`"regular"` is no longer a member of the `GroupKind` union, so this is a `TS2367` no-overlap error. It's masked in `front`'s own noisy tsgo but hard-fails the **front-spa** tsgo check, turning every open PR's CI red through the merge check.

One-line fix: `"regular"` → `"regular_auto"`, matching the `["regular_auto", "space_editors"]` manual-group pattern used in `group_resource.ts`.

## Testing
Typecheck pass

## Deploy
1. Deploy front