### PR TITLE
[cli] Honor DUST_REGION in headless auth so EU workspaces are reachable

### DIFF
--- a/cli/dust-cli/src/ui/commands/Auth.tsx
+++ b/cli/dust-cli/src/ui/commands/Auth.tsx
@@ -300,8 +300,9 @@ const Auth: FC<AuthProps> = ({ force = false, apiKey, wId }) => {
       // Store the workspace ID
       await TokenStorage.saveWorkspaceId(effectiveWId);
 
-      // Store a default region for API key auth
-      await TokenStorage.saveRegion("us-central1");
+      // Region for API key auth: honor DUST_REGION (e.g. "europe-west1"),
+      // defaulting to "us-central1" so existing setups are unaffected.
+      await TokenStorage.saveRegion(process.env.DUST_REGION ?? "us-central1");
 
       // Reset the dust client to use the new tokens
       resetDustClient();


### PR DESCRIPTION
## Description

Headless / API-key auth always stored `us-central1` as the region, so `dust-cli` routed requests for `europe-west1` workspaces to the US endpoint and failed with an authentication error. (OAuth login was unaffected — it saves the region from the access token's `region` claim.)

This makes `handleHeadlessAuth` honor a `DUST_REGION` environment variable, mirroring the existing `DUST_API_KEY` / `DUST_WORKSPACE_ID` reads, and defaulting to `us-central1` so existing setups are unchanged.

Fixes #27530.

## Tests

- `tsc --noEmit` passes.
- E2E against a `europe-west1` workspace: without the fix, headless auth hits `https://dust.tt` and fails with `not_authenticated`; with `DUST_REGION=europe-west1`, it reaches `https://eu.dust.tt` and the API key authenticates. With `DUST_REGION` unset, routing stays on `https://dust.tt` (non-breaking).

## Risk

Low — one line on the headless auth path, gated behind an opt-in env var; unset means behavior identical to today. Unknown values fall through to the existing `DEFAULT_DUST_API_DOMAIN` fallback.

## Deploy Plan

None — client-side CLI change, ships with the next CLI release.
