### PR TITLE
Refactor sandbox function invocation lifecycle

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -5,7 +5,6 @@ import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_fu
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -297,7 +296,8 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
   });
 
   it("returns 500 when invocation execution fails", async () => {
-    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    const { workspace, sandboxFunction, adminAuth } =
+      await setupSandboxFunction();
     vi.mocked(
       SandboxFunctionInvocationResource.prototype.execute
     ).mockResolvedValueOnce(new Err(new Error("sandbox unavailable")));
@@ -314,13 +314,6 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         message: "Sandbox function invocation failed.",
       },
     });
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        sandboxFunctionId: sandboxFunction.id,
-        workspaceId: workspace.id,
-      },
-    });
-    expect(invocation?.status).toBe("errored");
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "sandbox_function_invocation_error",
@@ -330,6 +323,26 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       }),
       { invocationId: expect.stringMatching(/^sfi_/) }
     );
+    const errorEvent = vi
+      .mocked(publishSandboxFunctionInvocationEvent)
+      .mock.calls.find(
+        ([event]) => event.type === "sandbox_function_invocation_error"
+      )?.[0];
+    expect(errorEvent?.type).toBe("sandbox_function_invocation_error");
+    if (
+      !errorEvent ||
+      errorEvent.type !== "sandbox_function_invocation_error"
+    ) {
+      return;
+    }
+    const invocation = await SandboxFunctionInvocationResource.fetchById(
+      adminAuth,
+      {
+        sandboxFunction,
+        invocationId: errorEvent.invocationId,
+      }
+    );
+    expect(invocation?.status).toBe("errored");
   });
 
   it("requires sandbox functions to be enabled", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -5,6 +5,7 @@ import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_fu
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -67,6 +68,10 @@ const outputSchema: JSONSchema = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(
+    SandboxFunctionInvocationResource.prototype,
+    "execute"
+  ).mockResolvedValue(new Ok(undefined));
 });
 
 afterEach(() => {
@@ -206,19 +211,8 @@ function postInvocation({
 }
 
 describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () => {
-  it("creates an invocation through the sandbox function resource", async () => {
+  it("creates and executes an invocation", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
-    const createdAt = new Date().toISOString();
-    const invokeSpy = vi
-      .spyOn(SandboxFunctionResource.prototype, "invoke")
-      .mockResolvedValue(
-        new Ok({
-          sId: "test-invocation-id",
-          functionId: sandboxFunction.sId,
-          status: "created",
-          createdAt,
-        })
-      );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -231,46 +225,33 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
 
     expect(response.status).toBe(201);
     const body = await response.json();
-    expect(body).toEqual({
-      invocation: {
-        sId: "test-invocation-id",
+    expect(body).toMatchObject({
+      invocation: expect.objectContaining({
+        sId: expect.stringMatching(/^sfi_/),
         functionId: sandboxFunction.sId,
         status: "created",
-        createdAt,
-      },
+        createdAt: expect.any(String),
+      }),
     });
-    expect(invokeSpy).toHaveBeenCalledWith(expect.anything(), {
+    const invocation = body.invocation;
+    expect(
+      SandboxFunctionInvocationResource.prototype.execute
+    ).toHaveBeenCalledWith(expect.anything(), {
       input: { message: "hello" },
       context: { frameFileId: sandboxFunction.file.sId },
     });
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       {
         type: "sandbox_function_invocation_created",
-        created: Date.parse(createdAt),
-        invocation: {
-          sId: "test-invocation-id",
-          functionId: sandboxFunction.sId,
-          status: "created",
-          createdAt,
-        },
+        created: Date.parse(invocation.createdAt),
+        invocation,
       },
-      { invocationId: "test-invocation-id" }
+      { invocationId: invocation.sId }
     );
   });
 
   it("creates an invocation by pod id and function slug", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
-    const createdAt = new Date().toISOString();
-    const invokeSpy = vi
-      .spyOn(SandboxFunctionResource.prototype, "invoke")
-      .mockResolvedValue(
-        new Ok({
-          sId: "test-invocation-id",
-          functionId: sandboxFunction.sId,
-          status: "created",
-          createdAt,
-        })
-      );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -281,7 +262,9 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     });
 
     expect(response.status).toBe(201);
-    expect(invokeSpy).toHaveBeenCalledWith(expect.anything(), {
+    expect(
+      SandboxFunctionInvocationResource.prototype.execute
+    ).toHaveBeenCalledWith(expect.anything(), {
       input: { message: "hello" },
     });
   });
@@ -304,14 +287,6 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
 
   it("does not require Computer access", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
-    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValue(
-      new Ok({
-        sId: "test-invocation-id",
-        functionId: sandboxFunction.sId,
-        status: "created",
-        createdAt: new Date().toISOString(),
-      })
-    );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -321,11 +296,11 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(response.status).toBe(201);
   });
 
-  it("returns 500 when the resource invocation fails", async () => {
+  it("returns 500 when invocation execution fails", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
-    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValue(
-      new Err(new Error("sandbox failed"))
-    );
+    vi.mocked(
+      SandboxFunctionInvocationResource.prototype.execute
+    ).mockResolvedValueOnce(new Err(new Error("sandbox unavailable")));
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -339,6 +314,22 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         message: "Sandbox function invocation failed.",
       },
     });
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        sandboxFunctionId: sandboxFunction.id,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(invocation?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sandbox_function_invocation_error",
+        invocationId: expect.stringMatching(/^sfi_/),
+        functionId: sandboxFunction.sId,
+        message: "sandbox unavailable",
+      }),
+      { invocationId: expect.stringMatching(/^sfi_/) }
+    );
   });
 
   it("requires sandbox functions to be enabled", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -113,16 +113,12 @@ app.post(
       });
     }
 
-    const invocation = await SandboxFunctionInvocationResource.createAndPublish(
-      auth,
-      {
+    const invocationResult =
+      await SandboxFunctionInvocationResource.createAndStartExecution(auth, {
         sandboxFunction,
-      }
-    );
-
-    const executionResult = await invocation.execute(auth, body);
-    if (executionResult.isErr()) {
-      await invocation.fail(executionResult.error);
+        body,
+      });
+    if (invocationResult.isErr()) {
       return apiError(
         ctx,
         {
@@ -132,13 +128,13 @@ app.post(
             message: "Sandbox function invocation failed.",
           },
         },
-        executionResult.error
+        invocationResult.error
       );
     }
 
     return ctx.json(
       {
-        invocation: invocation.toJSON(),
+        invocation: invocationResult.value.toJSON(),
       },
       201
     );

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,6 +1,5 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -113,11 +112,7 @@ app.post(
       });
     }
 
-    const invocationResult =
-      await SandboxFunctionInvocationResource.createAndStartExecution(auth, {
-        sandboxFunction,
-        body,
-      });
+    const invocationResult = await sandboxFunction.invoke(auth, body);
     if (invocationResult.isErr()) {
       return apiError(
         ctx,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,5 +1,4 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
-import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -114,16 +113,11 @@ app.post(
       });
     }
 
-    const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
-      sandboxFunction,
-    });
-    await publishSandboxFunctionInvocationEvent(
+    const invocation = await SandboxFunctionInvocationResource.createAndPublish(
+      auth,
       {
-        type: "sandbox_function_invocation_created",
-        created: invocation.createdAt.getTime(),
-        invocation: invocation.toJSON(),
-      },
-      { invocationId: invocation.sId }
+        sandboxFunction,
+      }
     );
 
     const executionResult = await invocation.execute(auth, body);

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,5 +1,4 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
-import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
@@ -113,7 +112,7 @@ app.post(
       });
     }
 
-    const invocationResult = await sandboxFunction.invoke(auth, body);
+    const invocationResult = await sandboxFunction.createInvocation(auth);
     if (invocationResult.isErr()) {
       return apiError(
         ctx,
@@ -128,18 +127,25 @@ app.post(
       );
     }
 
-    await publishSandboxFunctionInvocationEvent(
-      {
-        type: "sandbox_function_invocation_created",
-        created: Date.parse(invocationResult.value.createdAt),
-        invocation: invocationResult.value,
-      },
-      { invocationId: invocationResult.value.sId }
-    );
+    const executionResult = await invocationResult.value.execute(auth, body);
+    if (executionResult.isErr()) {
+      await invocationResult.value.fail(executionResult.error);
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Sandbox function invocation failed.",
+          },
+        },
+        executionResult.error
+      );
+    }
 
     return ctx.json(
       {
-        invocation: invocationResult.value,
+        invocation: invocationResult.value.toJSON(),
       },
       201
     );

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,5 +1,7 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -112,24 +114,22 @@ app.post(
       });
     }
 
-    const invocationResult = await sandboxFunction.createInvocation(auth);
-    if (invocationResult.isErr()) {
-      return apiError(
-        ctx,
-        {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Sandbox function invocation failed.",
-          },
-        },
-        invocationResult.error
-      );
-    }
+    const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+      sandboxFunction,
+    });
+    const invocationType = invocation.toJSON();
+    await publishSandboxFunctionInvocationEvent(
+      {
+        type: "sandbox_function_invocation_created",
+        created: invocation.createdAt.getTime(),
+        invocation: invocationType,
+      },
+      { invocationId: invocation.sId }
+    );
 
-    const executionResult = await invocationResult.value.execute(auth, body);
+    const executionResult = await invocation.execute(auth, body);
     if (executionResult.isErr()) {
-      await invocationResult.value.fail(executionResult.error);
+      await invocation.fail(executionResult.error);
       return apiError(
         ctx,
         {
@@ -145,7 +145,7 @@ app.post(
 
     return ctx.json(
       {
-        invocation: invocationResult.value.toJSON(),
+        invocation: invocationType,
       },
       201
     );

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -117,12 +117,11 @@ app.post(
     const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
       sandboxFunction,
     });
-    const invocationType = invocation.toJSON();
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_created",
         created: invocation.createdAt.getTime(),
-        invocation: invocationType,
+        invocation: invocation.toJSON(),
       },
       { invocationId: invocation.sId }
     );
@@ -145,7 +144,7 @@ app.post(
 
     return ctx.json(
       {
-        invocation: invocationType,
+        invocation: invocation.toJSON(),
       },
       201
     );

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -1,6 +1,7 @@
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import type { SandboxFunctionInvocationStreamEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -88,15 +89,13 @@ async function setup(): Promise<{
   });
   const space = await SpaceFactory.project(workspace);
   const fn = await makeFunction(authenticator, space);
-  const invocationId = "sfi_test";
-  vi.spyOn(fn, "invoke").mockResolvedValue(
-    new Ok({
-      sId: invocationId,
-      functionId: fn.sId,
-      status: "created",
-      createdAt: new Date(0).toISOString(),
-    })
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    authenticator,
+    { sandboxFunction: fn }
   );
+  const invocationId = invocation.sId;
+  vi.spyOn(fn, "createInvocation").mockResolvedValue(new Ok(invocation));
+  vi.spyOn(invocation, "execute").mockResolvedValue(new Ok(undefined));
   return { auth: authenticator, fn, invocationId };
 }
 
@@ -274,9 +273,9 @@ describe("callSandboxFunction", () => {
     });
   });
 
-  it("propagates an Err from invoke()", async () => {
+  it("propagates an Err from createInvocation()", async () => {
     const { auth, fn } = await setup();
-    vi.spyOn(fn, "invoke").mockResolvedValue(
+    vi.spyOn(fn, "createInvocation").mockResolvedValue(
       new Err(new Error("sandbox unavailable"))
     );
 

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -11,7 +11,7 @@ import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_func
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   const actual =
@@ -89,18 +89,20 @@ async function setup(): Promise<{
   });
   const space = await SpaceFactory.project(workspace);
   const fn = await makeFunction(authenticator, space);
-  const invocation = await SandboxFunctionInvocationResource.makeNew(
-    authenticator,
-    { sandboxFunction: fn }
-  );
-  const invocationId = invocation.sId;
-  vi.spyOn(fn, "createInvocation").mockResolvedValue(new Ok(invocation));
-  vi.spyOn(invocation, "execute").mockResolvedValue(new Ok(undefined));
+  const invocationId = "sfi_test";
+  vi.spyOn(
+    SandboxFunctionInvocationResource.prototype,
+    "execute"
+  ).mockResolvedValue(new Ok(undefined));
   return { auth: authenticator, fn, invocationId };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("callSandboxFunction", () => {
@@ -273,11 +275,11 @@ describe("callSandboxFunction", () => {
     });
   });
 
-  it("propagates an Err from createInvocation()", async () => {
+  it("propagates an Err from execute()", async () => {
     const { auth, fn } = await setup();
-    vi.spyOn(fn, "createInvocation").mockResolvedValue(
-      new Err(new Error("sandbox unavailable"))
-    );
+    vi.mocked(
+      SandboxFunctionInvocationResource.prototype.execute
+    ).mockResolvedValueOnce(new Err(new Error("sandbox unavailable")));
 
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -25,7 +25,7 @@ const resultEnvelopeSchema = z.discriminatedUnion("ok", [
   }),
 ]);
 
-// Safety ceiling on waiting for the result event (delivered over the stream, not invoke()'s
+// Safety ceiling on waiting for the result event (delivered over the stream, not execute()'s
 // return). Under blocking exec it is already in history when we subscribe, so this rarely bites.
 const CALL_RESULT_WAIT_TIMEOUT_MS = 2 * 60 * 1_000;
 
@@ -57,11 +57,17 @@ export async function callSandboxFunction(
   sandboxFunction: SandboxFunctionResource,
   input: unknown
 ): Promise<Result<SandboxFunctionCallOutcome, Error>> {
-  const invocationResult = await sandboxFunction.invoke(auth, { input });
+  const invocationResult = await sandboxFunction.createInvocation(auth);
   if (invocationResult.isErr()) {
     return invocationResult;
   }
-  const { sId: invocationId } = invocationResult.value;
+  const invocation = invocationResult.value;
+  const executionResult = await invocation.execute(auth, { input });
+  if (executionResult.isErr()) {
+    await invocation.fail(executionResult.error);
+    return executionResult;
+  }
+  const { sId: invocationId } = invocation;
 
   for await (const { data } of getSandboxFunctionInvocationEvents({
     invocationId,

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,6 +1,5 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -58,11 +57,7 @@ export async function callSandboxFunction(
   sandboxFunction: SandboxFunctionResource,
   input: unknown
 ): Promise<Result<SandboxFunctionCallOutcome, Error>> {
-  const invocationResult =
-    await SandboxFunctionInvocationResource.createAndStartExecution(auth, {
-      sandboxFunction,
-      body: { input },
-    });
+  const invocationResult = await sandboxFunction.invoke(auth, { input });
   if (invocationResult.isErr()) {
     return invocationResult;
   }

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -58,15 +58,15 @@ export async function callSandboxFunction(
   sandboxFunction: SandboxFunctionResource,
   input: unknown
 ): Promise<Result<SandboxFunctionCallOutcome, Error>> {
-  const invocation = await SandboxFunctionInvocationResource.createAndPublish(
-    auth,
-    { sandboxFunction }
-  );
-  const executionResult = await invocation.execute(auth, { input });
-  if (executionResult.isErr()) {
-    await invocation.fail(executionResult.error);
-    return executionResult;
+  const invocationResult =
+    await SandboxFunctionInvocationResource.createAndStartExecution(auth, {
+      sandboxFunction,
+      body: { input },
+    });
+  if (invocationResult.isErr()) {
+    return invocationResult;
   }
+  const invocation = invocationResult.value;
   const { sId: invocationId } = invocation;
 
   for await (const { data } of getSandboxFunctionInvocationEvents({

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,7 +1,4 @@
-import {
-  getSandboxFunctionInvocationEvents,
-  publishSandboxFunctionInvocationEvent,
-} from "@app/lib/api/sandbox_functions/events";
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -61,16 +58,9 @@ export async function callSandboxFunction(
   sandboxFunction: SandboxFunctionResource,
   input: unknown
 ): Promise<Result<SandboxFunctionCallOutcome, Error>> {
-  const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
-    sandboxFunction,
-  });
-  await publishSandboxFunctionInvocationEvent(
-    {
-      type: "sandbox_function_invocation_created",
-      created: invocation.createdAt.getTime(),
-      invocation: invocation.toJSON(),
-    },
-    { invocationId: invocation.sId }
+  const invocation = await SandboxFunctionInvocationResource.createAndPublish(
+    auth,
+    { sandboxFunction }
   );
   const executionResult = await invocation.execute(auth, { input });
   if (executionResult.isErr()) {

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,5 +1,9 @@
-import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import {
+  getSandboxFunctionInvocationEvents,
+  publishSandboxFunctionInvocationEvent,
+} from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -57,11 +61,17 @@ export async function callSandboxFunction(
   sandboxFunction: SandboxFunctionResource,
   input: unknown
 ): Promise<Result<SandboxFunctionCallOutcome, Error>> {
-  const invocationResult = await sandboxFunction.createInvocation(auth);
-  if (invocationResult.isErr()) {
-    return invocationResult;
-  }
-  const invocation = invocationResult.value;
+  const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+    sandboxFunction,
+  });
+  await publishSandboxFunctionInvocationEvent(
+    {
+      type: "sandbox_function_invocation_created",
+      created: invocation.createdAt.getTime(),
+      invocation: invocation.toJSON(),
+    },
+    { invocationId: invocation.sId }
+  );
   const executionResult = await invocation.execute(auth, { input });
   if (executionResult.isErr()) {
     await invocation.fail(executionResult.error);

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1,0 +1,223 @@
+import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/sandbox/access_tokens", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/access_tokens")>();
+
+  return {
+    ...actual,
+    generateSandboxFunctionInvocationToken: vi.fn(),
+  };
+});
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    message: { type: "string" },
+  },
+  required: ["message"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    commentId: { type: "string" },
+  },
+  required: ["commentId"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function setupExecutionTest() {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
+  const file = await FileFactory.create(authenticator, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: "comments.ts",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+  const sandboxFunction = await SandboxFunctionResource.makeNew(authenticator, {
+    space,
+    file,
+    slug: "add-comment",
+    description: "Add a comment.",
+    inputSchema,
+    outputSchema,
+  });
+  const sandbox = await SandboxResource.makeNew(authenticator, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+  vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
+    "sbt-function-token"
+  );
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    authenticator,
+    { sandboxFunction }
+  );
+
+  return {
+    authenticator,
+    space,
+    file,
+    sandboxFunction,
+    sandbox,
+    invocation,
+  };
+}
+
+describe("SandboxFunctionInvocationResource", () => {
+  it("executes an invocation on the pod sandbox", async () => {
+    const { authenticator, space, file, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    const updateLastActivityAtSpy = vi.spyOn(sandbox, "updateLastActivityAt");
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    expect(invocation.toJSON()).toMatchObject({
+      functionId: sandboxFunction.sId,
+      status: "created",
+    });
+    expect(invocation.sId).toMatch(/^sfi_/);
+    expect(Date.parse(invocation.toJSON().createdAt)).not.toBeNaN();
+
+    const executionResult = await invocation.execute(authenticator, {
+      input: { message: "hello" },
+      context: { frameFileId: file.sId },
+    });
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("created");
+    expect(updateLastActivityAtSpy).toHaveBeenCalledOnce();
+    expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
+    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
+      authenticator,
+      {
+        sandbox,
+        sandboxFunction,
+        invocationId: invocation.sId,
+        execId: expect.any(String),
+      }
+    );
+    expect(execSpy).toHaveBeenCalledTimes(1);
+
+    const execCall = execSpy.mock.calls[0];
+    expect(execCall).toBeDefined();
+    if (!execCall) {
+      return;
+    }
+    const [, command, opts] = execCall;
+    // The bundle is read from the read-only mount, so the command is just the run, no staging write.
+    expect(command).toBe("/opt/bin/dsbx function run 'add-comment'");
+    expect(opts?.envVars).toMatchObject({
+      DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
+      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
+      DUST_SANDBOX_TOKEN: "sbt-function-token",
+    });
+    expect(opts?.user).toBe("agent-proxied");
+    expect(opts?.workingDirectory).toBe("/home/agent");
+    expect(typeof opts?.stdin).toBe("string");
+    if (typeof opts?.stdin !== "string") {
+      return;
+    }
+    const inputEnvelope = JSON.parse(opts.stdin);
+    expect(inputEnvelope).toMatchObject({
+      method: "POST",
+      url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${invocation.sId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-dust-frame-file-id": file.sId,
+        "x-dust-sandbox-function-id": sandboxFunction.sId,
+        "x-dust-sandbox-function-invocation-id": invocation.sId,
+      },
+      body: JSON.stringify({ message: "hello" }),
+      encoding: "utf8",
+    });
+  });
+
+  it("surfaces the runner stderr when the invocation exits non-zero", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: "some stdout",
+        stderr: "dsbx command failed: connection refused",
+      })
+    );
+
+    const result = await invocation.execute(authenticator, {
+      input: { message: "hello" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("exit code 1");
+    expect(result.error.message).toContain(
+      "dsbx command failed: connection refused"
+    );
+  });
+
+  it("falls back to the runner stdout when stderr is empty on failure", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 2,
+        stdout: "boom from stdout",
+        stderr: "",
+      })
+    );
+
+    const result = await invocation.execute(authenticator, {
+      input: { message: "hello" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("exit code 2");
+    expect(result.error.message).toContain("boom from stdout");
+  });
+});

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -1,3 +1,15 @@
+import config from "@app/lib/api/config";
+import {
+  getPodSandboxFunctionsMountPoint,
+  podDatabaseExecEnvVars,
+} from "@app/lib/api/files/mount_path";
+import {
+  generateExecId,
+  generateSandboxFunctionInvocationToken,
+} from "@app/lib/api/sandbox/access_tokens";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
@@ -11,10 +23,37 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import logger from "@app/logger/logger";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionInvocationType,
+} from "@app/types/api/sandbox_functions";
+import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
+
+const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
+const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
+const DSBX_BIN_PATH = "/opt/bin/dsbx";
+// Caps on runner output surfaced on failure: a small head for the error forwarded to the agent,
+// a larger one for the log fields.
+const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
+const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
+
+function dustAPIBaseUrlForSandbox(): string {
+  return isDevelopment() && config.getSandboxDevFrontHostName()
+    ? `https://${config.getSandboxDevFrontHostName()}`
+    : config.getApiBaseUrl();
+}
+
+function buildSandboxFunctionRunCommand(slug: string): string {
+  // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`, which is the
+  // read-only mount of the pod's published bundles.
+  return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionInvocationResource
@@ -41,6 +80,124 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  toJSON(): SandboxFunctionInvocationType {
+    return {
+      sId: this.sId,
+      functionId: this.sandboxFunction.sId,
+      status: this.status,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+
+  async fail(error: Error): Promise<void> {
+    await this.update({ status: "errored" });
+    await publishSandboxFunctionInvocationEvent(
+      {
+        type: "sandbox_function_invocation_error",
+        created: Date.now(),
+        invocationId: this.sId,
+        functionId: this.sandboxFunction.sId,
+        message: error.message,
+      },
+      { invocationId: this.sId }
+    );
+  }
+
+  async execute(
+    auth: Authenticator,
+    body: PostSandboxFunctionInvocationRequestBody
+  ): Promise<Result<undefined, Error>> {
+    try {
+      const { sandboxFunction } = this;
+      const ensureResult = await ensurePodSandboxReady(
+        auth,
+        sandboxFunction.space
+      );
+      if (ensureResult.isErr()) {
+        return ensureResult;
+      }
+
+      await ensureResult.value.sandbox.updateLastActivityAt();
+
+      const execId = generateExecId();
+      const token = await generateSandboxFunctionInvocationToken(auth, {
+        sandbox: ensureResult.value.sandbox,
+        sandboxFunction,
+        invocationId: this.sId,
+        execId,
+      });
+
+      const command = buildSandboxFunctionRunCommand(sandboxFunction.slug);
+      const inputEnvelope = {
+        method: "POST",
+        url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${this.sId}`,
+        headers: {
+          "content-type": "application/json",
+          "x-dust-sandbox-function-id": sandboxFunction.sId,
+          "x-dust-sandbox-function-invocation-id": this.sId,
+          ...(body.context?.frameFileId
+            ? { "x-dust-frame-file-id": body.context.frameFileId }
+            : {}),
+        },
+        ...(body.input === undefined
+          ? {}
+          : { body: JSON.stringify(body.input) }),
+        encoding: "utf8",
+      };
+
+      const execResult = await ensureResult.value.sandbox.exec(auth, command, {
+        workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
+        envVars: {
+          DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
+          DUST_FUNCTIONS_DIR: getPodSandboxFunctionsMountPoint(
+            sandboxFunction.space.sId
+          ),
+          ...podDatabaseExecEnvVars(),
+          DUST_SANDBOX_TOKEN: token,
+        },
+        stdin: JSON.stringify(inputEnvelope),
+        timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
+        user: "agent-proxied",
+      });
+      if (execResult.isErr()) {
+        return execResult;
+      }
+      if (execResult.value.exitCode !== 0) {
+        const { exitCode, stdout, stderr } = execResult.value;
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            spaceId: sandboxFunction.space.sId,
+            sandboxFunctionId: sandboxFunction.sId,
+            slug: sandboxFunction.slug,
+            invocationId: this.sId,
+            exitCode,
+            stdout: truncate(stdout, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+            stderr: truncate(stderr, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+          },
+          "Sandbox function invocation failed"
+        );
+        // Surface the runner's stderr (stdout when empty) so the agent sees the actual cause,
+        // not just the exit code.
+        const detail = truncate(
+          stderr || stdout,
+          SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS
+        ).trim();
+        return new Err(
+          new Error(
+            `Sandbox function invocation failed with exit code ${exitCode}${
+              detail ? `:\n${detail}` : "."
+            }`
+          )
+        );
+      }
+
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   }
 
   static modelIdToSId({

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -231,14 +231,16 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return new this(this.model, invocation.get(), { sandboxFunction });
   }
 
-  static async createAndPublish(
+  static async createAndStartExecution(
     auth: Authenticator,
     {
       sandboxFunction,
+      body,
     }: {
       sandboxFunction: SandboxFunctionResource;
+      body: PostSandboxFunctionInvocationRequestBody;
     }
-  ): Promise<SandboxFunctionInvocationResource> {
+  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
     const invocation = await this.makeNew(auth, { sandboxFunction });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -249,7 +251,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       { invocationId: invocation.sId }
     );
 
-    return invocation;
+    const executionResult = await invocation.execute(auth, body);
+    if (executionResult.isErr()) {
+      await invocation.fail(executionResult.error);
+      return new Err(executionResult.error);
+    }
+
+    return new Ok(invocation);
   }
 
   private static async baseFetch(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -231,6 +231,27 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return new this(this.model, invocation.get(), { sandboxFunction });
   }
 
+  static async createAndPublish(
+    auth: Authenticator,
+    {
+      sandboxFunction,
+    }: {
+      sandboxFunction: SandboxFunctionResource;
+    }
+  ): Promise<SandboxFunctionInvocationResource> {
+    const invocation = await this.makeNew(auth, { sandboxFunction });
+    await publishSandboxFunctionInvocationEvent(
+      {
+        type: "sandbox_function_invocation_created",
+        created: invocation.createdAt.getTime(),
+        invocation: invocation.toJSON(),
+      },
+      { invocationId: invocation.sId }
+    );
+
+    return invocation;
+  }
+
   private static async baseFetch(
     auth: Authenticator,
     {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,11 +1,6 @@
-import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
-import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import {
   SandboxFunctionInvocationModel,
   SandboxFunctionModel,
@@ -17,23 +12,8 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
-  ensurePodSandboxReady: vi.fn(),
-}));
-
-vi.mock("@app/lib/api/sandbox/access_tokens", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@app/lib/api/sandbox/access_tokens")>();
-
-  return {
-    ...actual,
-    generateSandboxFunctionInvocationToken: vi.fn(),
-  };
-});
+import { beforeEach, describe, expect, it } from "vitest";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -51,10 +31,7 @@ const outputSchema: JSONSchema = {
   required: ["commentId"],
 };
 
-const ONE_HOUR_MS = 60 * 60 * 1_000;
-
 beforeEach(() => {
-  vi.clearAllMocks();
   fileStorageMock.reset();
 });
 
@@ -368,225 +345,6 @@ describe("SandboxFunctionResource", () => {
         }),
       ])
     );
-  });
-
-  it("creates an invocation and executes it on the pod sandbox", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
-    });
-    const space = await SpaceFactory.project(workspace);
-    const file = await FileFactory.create(authenticator, null, {
-      contentType: sandboxFunctionContentType,
-      fileName: "comments.ts",
-      fileSize: 100,
-      status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
-    });
-    const sandboxFunction = await SandboxFunctionResource.makeNew(
-      authenticator,
-      {
-        space,
-        file,
-        slug: "add-comment",
-        description: "Add a comment.",
-        inputSchema,
-        outputSchema,
-      }
-    );
-    const sandbox = await SandboxResource.makeNew(authenticator, {
-      providerId: "test-provider-id",
-      status: "running",
-      baseImage: "dust-base",
-      version: "0.0.0-test",
-    });
-    const staleLastActivityAt = new Date(Date.now() - ONE_HOUR_MS);
-    await SandboxModel.update(
-      { lastActivityAt: staleLastActivityAt },
-      { where: { id: sandbox.id } }
-    );
-    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({
-        exitCode: 0,
-        stdout: "hello world\n",
-        stderr: "",
-      })
-    );
-    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
-      new Ok({ sandbox, freshlyCreated: false })
-    );
-    vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
-      "sbt-function-token"
-    );
-    const invocation = await SandboxFunctionInvocationResource.makeNew(
-      authenticator,
-      { sandboxFunction }
-    );
-
-    expect(invocation.toJSON()).toMatchObject({
-      functionId: sandboxFunction.sId,
-      status: "created",
-    });
-    expect(invocation.sId).toMatch(/^sfi_/);
-    expect(Date.parse(invocation.toJSON().createdAt)).not.toBeNaN();
-    expect(invocation.status).toBe("created");
-
-    const executionResult = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-      context: { frameFileId: file.sId },
-    });
-    if (executionResult.isErr()) {
-      throw executionResult.error;
-    }
-
-    const refetchedInvocation =
-      await SandboxFunctionInvocationResource.fetchById(authenticator, {
-        sandboxFunction,
-        invocationId: invocation.sId,
-      });
-    expect(refetchedInvocation?.status).toBe("created");
-    const refreshedSandbox = await SandboxModel.findOne({
-      where: { id: sandbox.id, workspaceId: workspace.id },
-    });
-    expect(refreshedSandbox?.lastActivityAt.getTime()).toBeGreaterThan(
-      staleLastActivityAt.getTime()
-    );
-    expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
-    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
-      authenticator,
-      {
-        sandbox,
-        sandboxFunction,
-        invocationId: invocation.sId,
-        execId: expect.any(String),
-      }
-    );
-    expect(execSpy).toHaveBeenCalledTimes(1);
-
-    const execCall = execSpy.mock.calls[0];
-    expect(execCall).toBeDefined();
-    if (!execCall) {
-      return;
-    }
-    const [, command, opts] = execCall;
-    // The bundle is read from the read-only mount, so the command is just the run, no staging write.
-    expect(command).toBe("/opt/bin/dsbx function run 'add-comment'");
-    expect(opts?.envVars).toMatchObject({
-      DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
-      DUST_POD_DATABASES_DIR: "/pod-state/databases",
-      DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
-      DUST_SANDBOX_TOKEN: "sbt-function-token",
-    });
-    expect(opts?.user).toBe("agent-proxied");
-    expect(opts?.workingDirectory).toBe("/home/agent");
-    expect(typeof opts?.stdin).toBe("string");
-    if (typeof opts?.stdin !== "string") {
-      return;
-    }
-    const inputEnvelope = JSON.parse(opts.stdin);
-    expect(inputEnvelope).toMatchObject({
-      method: "POST",
-      url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${invocation.sId}`,
-      headers: {
-        "content-type": "application/json",
-        "x-dust-frame-file-id": file.sId,
-        "x-dust-sandbox-function-id": sandboxFunction.sId,
-        "x-dust-sandbox-function-invocation-id": invocation.sId,
-      },
-      body: JSON.stringify({ message: "hello" }),
-      encoding: "utf8",
-    });
-  });
-
-  async function setupInvokeTest() {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "admin",
-    });
-    const space = await SpaceFactory.project(workspace);
-    const file = await FileFactory.create(authenticator, null, {
-      contentType: sandboxFunctionContentType,
-      fileName: "comments.ts",
-      fileSize: 100,
-      status: "created",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
-    });
-    const sandboxFunction = await SandboxFunctionResource.makeNew(
-      authenticator,
-      {
-        space,
-        file,
-        slug: "add-comment",
-        description: "Add a comment.",
-        inputSchema,
-        outputSchema,
-      }
-    );
-    const sandbox = await SandboxResource.makeNew(authenticator, {
-      providerId: "test-provider-id",
-      status: "running",
-      baseImage: "dust-base",
-      version: "0.0.0-test",
-    });
-    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
-      new Ok({ sandbox, freshlyCreated: false })
-    );
-    vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
-      "sbt-function-token"
-    );
-
-    const invocation = await SandboxFunctionInvocationResource.makeNew(
-      authenticator,
-      { sandboxFunction }
-    );
-
-    return { authenticator, sandboxFunction, sandbox, invocation };
-  }
-
-  it("surfaces the runner stderr when the invocation exits non-zero", async () => {
-    const { authenticator, sandbox, invocation } = await setupInvokeTest();
-    vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({
-        exitCode: 1,
-        stdout: "some stdout",
-        stderr: "dsbx command failed: connection refused",
-      })
-    );
-
-    const result = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isOk()) {
-      return;
-    }
-    expect(result.error.message).toContain("exit code 1");
-    expect(result.error.message).toContain(
-      "dsbx command failed: connection refused"
-    );
-  });
-
-  it("falls back to the runner stdout when stderr is empty on failure", async () => {
-    const { authenticator, sandbox, invocation } = await setupInvokeTest();
-    vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({
-        exitCode: 2,
-        stdout: "boom from stdout",
-        stderr: "",
-      })
-    );
-
-    const result = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isOk()) {
-      return;
-    }
-    expect(result.error.message).toContain("exit code 2");
-    expect(result.error.message).toContain("boom from stdout");
   });
 
   it("overwrites the bundle and contract in place on re-publish", async () => {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -418,18 +418,17 @@ describe("SandboxFunctionResource", () => {
     vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
       "sbt-function-token"
     );
-    const result = await sandboxFunction.createInvocation(authenticator);
+    const invocation = await SandboxFunctionInvocationResource.makeNew(
+      authenticator,
+      { sandboxFunction }
+    );
 
-    if (result.isErr()) {
-      throw result.error;
-    }
-    expect(result.value.toJSON()).toMatchObject({
+    expect(invocation.toJSON()).toMatchObject({
       functionId: sandboxFunction.sId,
       status: "created",
     });
-    expect(result.value.sId).toMatch(/^sfi_/);
-    expect(Date.parse(result.value.toJSON().createdAt)).not.toBeNaN();
-    const invocation = result.value;
+    expect(invocation.sId).toMatch(/^sfi_/);
+    expect(Date.parse(invocation.toJSON().createdAt)).not.toBeNaN();
     expect(invocation.status).toBe("created");
 
     const executionResult = await invocation.execute(authenticator, {
@@ -485,12 +484,12 @@ describe("SandboxFunctionResource", () => {
     const inputEnvelope = JSON.parse(opts.stdin);
     expect(inputEnvelope).toMatchObject({
       method: "POST",
-      url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${result.value.sId}`,
+      url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${invocation.sId}`,
       headers: {
         "content-type": "application/json",
         "x-dust-frame-file-id": file.sId,
         "x-dust-sandbox-function-id": sandboxFunction.sId,
-        "x-dust-sandbox-function-invocation-id": result.value.sId,
+        "x-dust-sandbox-function-invocation-id": invocation.sId,
       },
       body: JSON.stringify({ message: "hello" }),
       encoding: "utf8",

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -2,6 +2,7 @@ import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/acc
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
@@ -369,7 +370,7 @@ describe("SandboxFunctionResource", () => {
     );
   });
 
-  it("invokes the function on the pod sandbox", async () => {
+  it("creates an invocation and executes it on the pod sandbox", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -417,28 +418,32 @@ describe("SandboxFunctionResource", () => {
     vi.mocked(generateSandboxFunctionInvocationToken).mockResolvedValue(
       "sbt-function-token"
     );
-    const result = await sandboxFunction.invoke(authenticator, {
-      input: { message: "hello" },
-      context: { frameFileId: file.sId },
-    });
+    const result = await sandboxFunction.createInvocation(authenticator);
 
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value).toMatchObject({
+    expect(result.value.toJSON()).toMatchObject({
       functionId: sandboxFunction.sId,
       status: "created",
     });
     expect(result.value.sId).toMatch(/^sfi_/);
-    expect(Date.parse(result.value.createdAt)).not.toBeNaN();
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        sandboxFunctionId: sandboxFunction.id,
-      },
+    expect(Date.parse(result.value.toJSON().createdAt)).not.toBeNaN();
+    const invocation = result.value;
+    expect(invocation.status).toBe("created");
+
+    const executionResult = await invocation.execute(authenticator, {
+      input: { message: "hello" },
+      context: { frameFileId: file.sId },
     });
-    expect(invocation).not.toBeNull();
-    expect(invocation?.status).toBe("created");
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    const invocationModel = await SandboxFunctionInvocationModel.findOne({
+      where: { id: invocation.id, workspaceId: workspace.id },
+    });
+    expect(invocationModel?.status).toBe("created");
     const refreshedSandbox = await SandboxModel.findOne({
       where: { id: sandbox.id, workspaceId: workspace.id },
     });
@@ -451,7 +456,7 @@ describe("SandboxFunctionResource", () => {
       {
         sandbox,
         sandboxFunction,
-        invocationId: result.value.sId,
+        invocationId: invocation.sId,
         execId: expect.any(String),
       }
     );
@@ -529,11 +534,16 @@ describe("SandboxFunctionResource", () => {
       "sbt-function-token"
     );
 
-    return { authenticator, sandboxFunction, sandbox };
+    const invocation = await SandboxFunctionInvocationResource.makeNew(
+      authenticator,
+      { sandboxFunction }
+    );
+
+    return { authenticator, sandboxFunction, sandbox, invocation };
   }
 
   it("surfaces the runner stderr when the invocation exits non-zero", async () => {
-    const { authenticator, sandboxFunction, sandbox } = await setupInvokeTest();
+    const { authenticator, sandbox, invocation } = await setupInvokeTest();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 1,
@@ -542,7 +552,7 @@ describe("SandboxFunctionResource", () => {
       })
     );
 
-    const result = await sandboxFunction.invoke(authenticator, {
+    const result = await invocation.execute(authenticator, {
       input: { message: "hello" },
     });
 
@@ -557,7 +567,7 @@ describe("SandboxFunctionResource", () => {
   });
 
   it("falls back to the runner stdout when stderr is empty on failure", async () => {
-    const { authenticator, sandboxFunction, sandbox } = await setupInvokeTest();
+    const { authenticator, sandbox, invocation } = await setupInvokeTest();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 2,
@@ -566,7 +576,7 @@ describe("SandboxFunctionResource", () => {
       })
     );
 
-    const result = await sandboxFunction.invoke(authenticator, {
+    const result = await invocation.execute(authenticator, {
       input: { message: "hello" },
     });
 

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -439,10 +439,12 @@ describe("SandboxFunctionResource", () => {
       throw executionResult.error;
     }
 
-    const invocationModel = await SandboxFunctionInvocationModel.findOne({
-      where: { id: invocation.id, workspaceId: workspace.id },
-    });
-    expect(invocationModel?.status).toBe("created");
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("created");
     const refreshedSandbox = await SandboxModel.findOne({
       where: { id: sandbox.id, workspaceId: workspace.id },
     });

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,14 +1,3 @@
-import config from "@app/lib/api/config";
-import {
-  getPodSandboxFunctionsMountPoint,
-  podDatabaseExecEnvVars,
-} from "@app/lib/api/files/mount_path";
-import {
-  generateExecId,
-  generateSandboxFunctionInvocationToken,
-} from "@app/lib/api/sandbox/access_tokens";
-import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -28,41 +17,14 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import logger from "@app/logger/logger";
-import type {
-  PostSandboxFunctionInvocationRequestBody,
-  SandboxFunctionInvocationType,
-} from "@app/types/api/sandbox_functions";
 import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
-import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { truncate } from "@app/types/shared/utils/string_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
-
-const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
-const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
-const DSBX_BIN_PATH = "/opt/bin/dsbx";
-// Caps on runner output surfaced on failure: a small head for the error forwarded to the agent,
-// a larger one for the log fields.
-const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
-const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
-
-function dustAPIBaseUrlForSandbox(): string {
-  return isDevelopment() && config.getSandboxDevFrontHostName()
-    ? `https://${config.getSandboxDevFrontHostName()}`
-    : config.getApiBaseUrl();
-}
-
-function buildSandboxFunctionRunCommand(slug: string): string {
-  // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`, which is the
-  // read-only mount of the pod's published bundles.
-  return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionResource
@@ -376,143 +338,27 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return new Ok(sandboxFunctions.length);
   }
 
-  async invoke(
-    auth: Authenticator,
-    body: PostSandboxFunctionInvocationRequestBody
-  ): Promise<Result<SandboxFunctionInvocationType, Error>> {
-    let invocation: SandboxFunctionInvocationResource | null = null;
-
-    // Once the invocation exists, listeners may be waiting on its event channel for a terminal
-    // event: publish the error so they settle instead of waiting forever, then propagate it.
-    const failInvocation = async (
-      error: Error
-    ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
-      if (invocation) {
-        try {
-          await publishSandboxFunctionInvocationEvent(
-            {
-              type: "sandbox_function_invocation_error",
-              created: Date.now(),
-              invocationId: invocation.sId,
-              functionId: this.sId,
-              message: error.message,
-            },
-            { invocationId: invocation.sId }
-          );
-        } catch (publishError) {
-          // Best effort: the error is still propagated to the caller through the Err below.
-          logger.error(
-            {
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              sandboxFunctionId: this.sId,
-              invocationId: invocation.sId,
-              error: normalizeError(publishError),
-            },
-            "Failed to publish sandbox function invocation error event"
-          );
-        }
-      }
-      return new Err(error);
-    };
-
-    try {
-      if (!this.space.canReadOrAdministrate(auth)) {
-        return new Err(new Error("Sandbox function space is not accessible."));
-      }
-
-      const ensureResult = await ensurePodSandboxReady(auth, this.space);
-      if (ensureResult.isErr()) {
-        return ensureResult;
-      }
-
-      invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
-        sandboxFunction: this,
-      });
-      await ensureResult.value.sandbox.updateLastActivityAt();
-
-      const execId = generateExecId();
-      const token = await generateSandboxFunctionInvocationToken(auth, {
-        sandbox: ensureResult.value.sandbox,
-        sandboxFunction: this,
-        invocationId: invocation.sId,
-        execId,
-      });
-
-      const command = buildSandboxFunctionRunCommand(this.slug);
-      const inputEnvelope = {
-        method: "POST",
-        url: `https://dust.local/sandbox-functions/${this.sId}/invocations/${invocation.sId}`,
-        headers: {
-          "content-type": "application/json",
-          "x-dust-sandbox-function-id": this.sId,
-          "x-dust-sandbox-function-invocation-id": invocation.sId,
-          ...(body.context?.frameFileId
-            ? { "x-dust-frame-file-id": body.context.frameFileId }
-            : {}),
-        },
-        ...(body.input === undefined
-          ? {}
-          : { body: JSON.stringify(body.input) }),
-        encoding: "utf8",
-      };
-
-      const execResult = await ensureResult.value.sandbox.exec(auth, command, {
-        workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
-        envVars: {
-          DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
-          DUST_FUNCTIONS_DIR: getPodSandboxFunctionsMountPoint(this.space.sId),
-          ...podDatabaseExecEnvVars(),
-          DUST_SANDBOX_TOKEN: token,
-        },
-        stdin: JSON.stringify(inputEnvelope),
-        timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
-        user: "agent-proxied",
-      });
-      if (execResult.isErr()) {
-        return failInvocation(execResult.error);
-      }
-      if (execResult.value.exitCode !== 0) {
-        const { exitCode, stdout, stderr } = execResult.value;
-        logger.error(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            spaceId: this.space.sId,
-            sandboxFunctionId: this.sId,
-            slug: this.slug,
-            invocationId: invocation.sId,
-            exitCode,
-            stdout: truncate(stdout, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
-            stderr: truncate(stderr, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
-          },
-          "Sandbox function invocation failed"
-        );
-        // Surface the runner's stderr (stdout when empty) so the agent sees the actual cause,
-        // not just the exit code.
-        const detail = truncate(
-          stderr || stdout,
-          SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS
-        ).trim();
-        return failInvocation(
-          new Error(
-            `Sandbox function invocation failed with exit code ${exitCode}${
-              detail ? `:\n${detail}` : "."
-            }`
-          )
-        );
-      }
-
-      // Keep the invocation token valid for its short TTL. The durable version
-      // of this flow will let dsbx post invocation results back to Dust with
-      // the same token, then revoke it once results are accepted.
-      return new Ok({
-        sId: invocation.sId,
-        functionId: this.sId,
-        status: invocation.status,
-        createdAt: invocation.createdAt.toISOString(),
-      });
-    } catch (error) {
-      return failInvocation(normalizeError(error));
+  async createInvocation(
+    auth: Authenticator
+  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    if (!this.space.canReadOrAdministrate(auth)) {
+      return new Err(new Error("Sandbox function space is not accessible."));
     }
+
+    const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
+      sandboxFunction: this,
+    });
+
+    await publishSandboxFunctionInvocationEvent(
+      {
+        type: "sandbox_function_invocation_created",
+        created: invocation.createdAt.getTime(),
+        invocation: invocation.toJSON(),
+      },
+      { invocationId: invocation.sId }
+    );
+
+    return new Ok(invocation);
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,4 +1,3 @@
-import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -336,29 +335,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
 
     return new Ok(sandboxFunctions.length);
-  }
-
-  async createInvocation(
-    auth: Authenticator
-  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
-    if (!this.space.canReadOrAdministrate(auth)) {
-      return new Err(new Error("Sandbox function space is not accessible."));
-    }
-
-    const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
-      sandboxFunction: this,
-    });
-
-    await publishSandboxFunctionInvocationEvent(
-      {
-        type: "sandbox_function_invocation_created",
-        created: invocation.createdAt.getTime(),
-        invocation: invocation.toJSON(),
-      },
-      { invocationId: invocation.sId }
-    );
-
-    return new Ok(invocation);
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -16,6 +16,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
 import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -335,6 +336,16 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
 
     return new Ok(sandboxFunctions.length);
+  }
+
+  async invoke(
+    auth: Authenticator,
+    body: PostSandboxFunctionInvocationRequestBody
+  ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    return SandboxFunctionInvocationResource.createAndStartExecution(auth, {
+      sandboxFunction: this,
+      body,
+    });
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -4,7 +4,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 
-export const SANDBOX_FUNCTION_INVOCATION_STATUSES = ["created"] as const;
+export const SANDBOX_FUNCTION_INVOCATION_STATUSES = [
+  "created",
+  "errored",
+] as const;
 
 export type SandboxFunctionInvocationStatus =
   (typeof SANDBOX_FUNCTION_INVOCATION_STATUSES)[number];


### PR DESCRIPTION
## Description

- Separate sandbox function invocation creation from execution while keeping execution synchronous (will soon not be called directly from invioke/createAndStartExecution but instead from a workflow/activity)
- Move execution and failure handling onto `SandboxFunctionInvocationResource`, emit the created event when the invocation is created, and persist an `errored` status before emitting terminal errors. 
- Lifecycle is handled by `createAndStartExecution`
- Moves the tests to their right place

This prepares the full invocation lifecycle for durable workflow execution in a follow-up PR.
See: https://github.com/dust-tt/dust/blob/main/x/spolu/tool_context/SANBOX_PLAN.md

## Tests

- `NODE_ENV=test npm test lib/resources/sandbox_function_resource.test.ts lib/api/sandbox_functions/call_sandbox_function.test.ts`
- `NODE_ENV=test npm test 'routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts'`

## Risk

Low. The invocation remains synchronous and the API request/response schemas are unchanged.

## Deploy Plan

- deploy `front`