### PR TITLE
[BILLING] chunk Metronome seat ID edits to respect the 1000-seat cap

### DIFF
--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -6,6 +6,7 @@ import {
   createMetronomeContract,
   createMetronomeCredit,
   findSeatCreditSegmentForPeriod,
+  updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
 import type { Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -475,5 +476,90 @@ describe("addComplimentaryCommitToContract", () => {
     });
     expect(commit.access_schedule.schedule_items[0].amount).toBe(4_200);
     expect(commit).not.toHaveProperty("invoice_schedule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSubscriptionSeats
+// ---------------------------------------------------------------------------
+
+describe("updateSubscriptionSeats", () => {
+  const seatIds = (n: number, prefix: string) =>
+    Array.from({ length: n }, (_, i) => `${prefix}-${i}`);
+
+  it("sends a single edit when at or below the 1000-seat cap", async () => {
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+      addSeatIds: seatIds(1000, "add"),
+      startingAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    unwrapOk(result);
+    expect(mockContractsEdit).toHaveBeenCalledTimes(1);
+    const call = mockContractsEdit.mock.calls[0][0];
+    expect(
+      call.update_subscriptions[0].seat_updates.add_seat_ids[0].seat_ids
+    ).toHaveLength(1000);
+  });
+
+  it("chunks adds and removes into separate edits above the cap", async () => {
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+      addSeatIds: seatIds(2500, "add"),
+      removeSeatIds: seatIds(1200, "rm"),
+      addUnassignedSeats: 5,
+      startingAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    unwrapOk(result);
+    // 2500 adds → 3 chunks; 1200 removes → 2 chunks; editCount = max = 3.
+    expect(mockContractsEdit).toHaveBeenCalledTimes(3);
+
+    // No single edit exceeds the cap.
+    for (const [{ update_subscriptions }] of mockContractsEdit.mock.calls) {
+      for (const { seat_updates } of update_subscriptions) {
+        for (const entry of seat_updates.add_seat_ids ?? []) {
+          expect(entry.seat_ids.length).toBeLessThanOrEqual(1000);
+        }
+        for (const entry of seat_updates.remove_seat_ids ?? []) {
+          expect(entry.seat_ids.length).toBeLessThanOrEqual(1000);
+        }
+      }
+    }
+
+    // Every add/remove is sent exactly once across all edits.
+    const allAdds = mockContractsEdit.mock.calls.flatMap(
+      ([{ update_subscriptions }]) =>
+        update_subscriptions.flatMap(
+          ({
+            seat_updates,
+          }: {
+            seat_updates: { add_seat_ids?: { seat_ids: string[] }[] };
+          }) => (seat_updates.add_seat_ids ?? []).flatMap((e) => e.seat_ids)
+        )
+    );
+    expect(new Set(allAdds).size).toBe(2500);
+
+    // Unassigned delta is applied on the final edit only.
+    const lastCall = mockContractsEdit.mock.calls[2][0];
+    expect(
+      lastCall.update_subscriptions[0].seat_updates.add_unassigned_seats[0]
+        .quantity
+    ).toBe(5);
+  });
+
+  it("does not call edit when there is nothing to change", async () => {
+    const result = await updateSubscriptionSeats({
+      metronomeCustomerId: "cust-1",
+      contractId: "contract-1",
+      fromSubscriptionId: "sub-1",
+    });
+
+    unwrapOk(result);
+    expect(mockContractsEdit).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -27,6 +27,7 @@ import type {
 } from "@metronome/sdk/resources/v1/customers";
 import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import type { IncomingHttpHeaders } from "http";
+import chunk from "lodash/chunk";
 import { z } from "zod";
 import type {
   MetronomeBalance,
@@ -1537,6 +1538,9 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
  * - `removeUnassignedSeats`: seats to remove from `fromSubscriptionId` (pool
  *   reconciliation — consuming a pre-purchased slot)
  */
+// Metronome rejects any single contracts.edit carrying more than 1000 seat IDs.
+const MAX_SEAT_IDS_PER_EDIT = 1000;
+
 export async function updateSubscriptionSeats({
   metronomeCustomerId,
   contractId,
@@ -1571,76 +1575,96 @@ export async function updateSubscriptionSeats({
 
   const scheduleTime = startingAt ?? floorToHourISO(new Date());
 
-  const fromSeatUpdates = {
-    ...(removeSeatIds.length > 0
-      ? {
-          remove_seat_ids: [
-            { seat_ids: removeSeatIds, starting_at: scheduleTime },
-          ],
-        }
-      : {}),
-    ...(addUnassignedSeats > 0
-      ? {
-          add_unassigned_seats: [
-            { quantity: addUnassignedSeats, starting_at: scheduleTime },
-          ],
-        }
-      : {}),
-    ...(removeUnassignedSeats > 0
-      ? {
-          remove_unassigned_seats: [
-            { quantity: removeUnassignedSeats, starting_at: scheduleTime },
-          ],
-        }
-      : {}),
-    ...(hasFromSeatIds
-      ? { add_seat_ids: [{ seat_ids: addSeatIds, starting_at: scheduleTime }] }
-      : {}),
-  };
+  // Metronome caps each edit at 1000 seat IDs, so chunk adds/removes. Unassigned
+  // deltas go on the final edit, after every add has drained the pool.
+  const addChunks =
+    addSeatIds.length > 0 ? chunk(addSeatIds, MAX_SEAT_IDS_PER_EDIT) : [];
+  const removeChunks =
+    removeSeatIds.length > 0 ? chunk(removeSeatIds, MAX_SEAT_IDS_PER_EDIT) : [];
+  const editCount = Math.max(addChunks.length, removeChunks.length, 1);
 
-  const updateSubscriptions = [
-    ...(Object.keys(fromSeatUpdates).length > 0
-      ? [{ subscription_id: fromSubscriptionId, seat_updates: fromSeatUpdates }]
-      : []),
-    ...(toSubscriptionId && addSeatIds.length > 0
-      ? [
-          {
-            subscription_id: toSubscriptionId,
-            seat_updates: {
-              add_seat_ids: [
-                { seat_ids: addSeatIds, starting_at: scheduleTime },
-              ],
+  for (let i = 0; i < editCount; i++) {
+    const isLastEdit = i === editCount - 1;
+    const addChunk = addChunks[i] ?? [];
+    const removeChunk = removeChunks[i] ?? [];
+
+    const fromSeatUpdates = {
+      ...(removeChunk.length > 0
+        ? {
+            remove_seat_ids: [
+              { seat_ids: removeChunk, starting_at: scheduleTime },
+            ],
+          }
+        : {}),
+      ...(isLastEdit && addUnassignedSeats > 0
+        ? {
+            add_unassigned_seats: [
+              { quantity: addUnassignedSeats, starting_at: scheduleTime },
+            ],
+          }
+        : {}),
+      ...(isLastEdit && removeUnassignedSeats > 0
+        ? {
+            remove_unassigned_seats: [
+              { quantity: removeUnassignedSeats, starting_at: scheduleTime },
+            ],
+          }
+        : {}),
+      ...(!toSubscriptionId && addChunk.length > 0
+        ? { add_seat_ids: [{ seat_ids: addChunk, starting_at: scheduleTime }] }
+        : {}),
+    };
+
+    const updateSubscriptions = [
+      ...(Object.keys(fromSeatUpdates).length > 0
+        ? [
+            {
+              subscription_id: fromSubscriptionId,
+              seat_updates: fromSeatUpdates,
             },
-          },
-        ]
-      : []),
-  ];
+          ]
+        : []),
+      ...(toSubscriptionId && addChunk.length > 0
+        ? [
+            {
+              subscription_id: toSubscriptionId,
+              seat_updates: {
+                add_seat_ids: [
+                  { seat_ids: addChunk, starting_at: scheduleTime },
+                ],
+              },
+            },
+          ]
+        : []),
+    ];
 
-  if (updateSubscriptions.length === 0) {
-    return new Ok(undefined);
+    if (updateSubscriptions.length === 0) {
+      continue;
+    }
+
+    try {
+      await getMetronomeClient().v2.contracts.edit({
+        customer_id: metronomeCustomerId,
+        contract_id: contractId,
+        update_subscriptions: updateSubscriptions,
+      });
+    } catch (err) {
+      const error = normalizeError(err);
+      logger.error(
+        {
+          error,
+          metronomeCustomerId,
+          contractId,
+          fromSubscriptionId,
+          toSubscriptionId,
+        },
+        "[Metronome] Failed to update subscription seats"
+      );
+      return new Err(error);
+    }
   }
 
-  try {
-    await getMetronomeClient().v2.contracts.edit({
-      customer_id: metronomeCustomerId,
-      contract_id: contractId,
-      update_subscriptions: updateSubscriptions,
-    });
-    return new Ok(undefined);
-  } catch (err) {
-    const error = normalizeError(err);
-    logger.error(
-      {
-        error,
-        metronomeCustomerId,
-        contractId,
-        fromSubscriptionId,
-        toSubscriptionId,
-      },
-      "[Metronome] Failed to update subscription seats"
-    );
-    return new Err(error);
-  }
+  return new Ok(undefined);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Chunk `addSeatIds`/`removeSeatIds` into ≤1000-ID batches across sequential `contracts.edit` calls so large seat reconciles no longer hit Metronome's 1000-seat-per-edit limit (was throwing `400 Number of subscription seat IDs must be less than or equal to 1000` in `syncMetronomeSeatCountActivity`).

## Tests

Added unit tests in `client.test.ts` covering single edit at the cap, chunking above the cap (no batch >1000, each seat sent once, unassigned delta on the final edit), and the no-op case. All 22 pass; typecheck clean.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`