### PR TITLE
Add endDate / platform fee / logs

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -3,7 +3,6 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
-import type { SwitchContractBodySchema } from "@app/lib/api/poke/switch_contract";
 import { clientFetch } from "@app/lib/egress/client";
 import { amountCents } from "@app/lib/metronome/amounts";
 import { isPaygEligibleTier } from "@app/lib/metronome/types";
@@ -18,12 +17,10 @@ import {
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
 import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
-import {
-  BILLABLE_SEAT_TYPES,
-  isMembershipSeatType,
-} from "@app/types/memberships";
+import { BILLABLE_SEAT_TYPES } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { CreditUsageConfigurationSchema } from "@app/types/poke/credit_usage_configuration";
+import { SwitchContractBodySchema } from "@app/types/poke/switch_contract";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -45,137 +42,28 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const SwitchContractFormSchema = z
-  .object({
-    metronomePackageId: z.string().min(1, "Required"),
-    planCode: z.string().min(1, "Required"),
-    hubspotDealId: z.string().optional(),
-    purchaseOrderId: z.string().optional(),
-    startingAt: z.string().optional(),
-    // How the enterprise contract's start moment is resolved:
-    //  - "immediately": swap at the current hour (no startingAt sent).
-    //  - "retroactive_first_of_month": backdate to the 1st of the current month,
-    //    00:00 UTC.
-    //  - "select": use the operator-chosen `startingAt` (the only mode that
-    //    surfaces the date picker).
-    startMode: z
-      .enum(["immediately", "retroactive_first_of_month", "select"])
-      .default("select"),
-    stripeCustomerId: z.string(),
-    stripeCollectionMethod: z
-      .enum(["charge_automatically", "send_invoice"])
-      .default("charge_automatically"),
-    // Net payment terms in days (e.g. 30 for "Net 30"). Only relevant for
-    // `send_invoice`; empty leaves Metronome's account default in place.
-    netPaymentTermsDays: z
-      .number()
-      .int("Net payment terms must be a whole number of days")
-      .min(0, "Net payment terms must be ≥ 0")
-      .max(365, "Net payment terms must be ≤ 365")
-      .optional(),
-    // Credit usage configuration.
-    paygEnabled: z.boolean().default(false),
-    usageCapCredits: z
-      .number()
-      .int("Usage cap must be an integer number of credits")
-      .min(1, "Usage cap must be at least 1 credit")
-      .optional(),
-    defaultDiscountPercent: z.number().int().min(0).max(100).default(0),
-    balanceThresholdCredits: z.number().int().min(0).optional(),
-    defaultPoolCapCredits: z.number().int().min(0).optional(),
-    programmaticMonthlyCapCredits: z.number().int().min(0).optional(),
-    autoSeatUpgradeEnabled: z.boolean().default(false),
-    topUpEnabled: z.boolean().default(false),
-    autoInvoiceFinalizationEnabled: z.boolean().default(true),
-    // Optional seat-type override: when set, every seat-less (`none`) member is
-    // forced onto this seat on the new contract, preempting committed-seat
-    // placement. Empty string means no override (default assignment). Sent as
-    // `promoteNoneSeatsTo` on submit.
-    forceSeatType: z.string().optional(),
-    // One-off initial credits (contract-level prepaid commit). Toggled on via
-    // `showInitialCredits`; both fields are then required together and assembled
-    // into `initialCredits` on submit.
-    showInitialCredits: z.boolean().default(false),
-    initialCreditsAmount: z
-      .number()
-      .int("Initial credits must be an integer number of credits")
-      .min(1, "Initial credits must be at least 1 credit")
-      .optional(),
-    initialCreditsInvoiceAmount: z
-      .number()
-      .min(0, "Invoice amount must be zero or more")
-      .optional(),
-    initialCreditsFrequency: z
-      .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
-      .default("one_time"),
-    initialCreditsPeriods: z
-      .number()
-      .int("Number of periods must be a whole number")
-      .min(2, "Number of periods must be at least 2")
-      .max(60, "Number of periods must be at most 60")
-      .optional(),
-    // Optional recurring free AWU credit pool, granted directly on the
-    // contract (not tied to the package) — e.g. the Partner Demo shared
-    // monthly pool. Toggled via `showRecurringFreeCredit`; assembled into
-    // `recurringFreeCreditAwuPerMonth` on submit. No invoice involved, so no
-    // Stripe customer is required.
-    showRecurringFreeCredit: z.boolean().default(false),
-    recurringFreeCreditAwuPerMonth: z
-      .number()
-      .int("Recurring free credit must be an integer number of AWU credits")
-      .min(1, "Recurring free credit must be at least 1 credit")
-      .optional(),
-    // Per-seat-type settings, keyed by seat type. Every seat type the selected
-    // package knows about is shown; only `selected` ones are submitted. `selected`
-    // is pre-checked for the seats the package entitles by default, and can be
-    // toggled to opt into entitling additional seats. `minSeats` is the billing
-    // floor (0 = none); `rate` is the per-seat rate, prefilled from the package
-    // override default; `commitmentPrice` (optional) creates a prepaid commit of
-    // `minSeats * rate` invoiced at that price.
-    seats: z
-      .record(
-        z.string(),
-        z
-          .object({
-            selected: z.boolean().default(false),
-            minSeats: z.number().int().min(0),
-            rate: z.number().min(0),
-            commitmentPrice: z.number().min(0).optional(),
-            paymentFrequency: z
-              .enum([
-                "one_time",
-                "monthly",
-                "quarterly",
-                "semi_annually",
-                "annually",
-              ])
-              .default("one_time"),
-            paymentPeriods: z
-              .number()
-              .int("Number of periods must be a whole number")
-              .min(2, "Number of periods must be at least 2")
-              .max(60, "Number of periods must be at most 60")
-              .optional(),
-          })
-          .refine(
-            (s) =>
-              s.paymentFrequency === "one_time" ||
-              s.paymentPeriods !== undefined,
-            { message: "Periods required when frequency is not one-time" }
-          )
-      )
-      .default({}),
-  })
-  .refine(
-    (s) =>
-      !s.showInitialCredits ||
-      s.initialCreditsFrequency === "one_time" ||
-      s.initialCreditsPeriods !== undefined,
-    {
-      message: "Periods required when frequency is not one-time",
-      path: ["initialCreditsPeriods"],
-    }
-  );
+// Built on top of `SwitchContractBodySchema` so the many identical scalar
+// fields (planCode, startingAt, endingAt, netPaymentTermsDays, paygEnabled,
+// usageCapCredits, the credit-config fields, hubspotDealId, purchaseOrderId,
+// stripeCustomerId, promoteNoneSeatsTo, initialCredits, scheduledCharge,
+// recurringFreeCredit, seats, ...) are inherited verbatim instead of
+// duplicated. Each optional section's on/off toggle is just presence vs.
+// `undefined` on its inherited field — no separate toggle state needed.
+// `legacyMigrationFreeAwuCreditsPerUser` is omitted since it isn't used by
+// this dialog.
+const SwitchContractFormSchema = SwitchContractBodySchema.omit({
+  legacyMigrationFreeAwuCreditsPerUser: true,
+}).extend({
+  // How the enterprise contract's start moment is resolved:
+  //  - "immediately": swap at the current hour (no startingAt sent).
+  //  - "retroactive_first_of_month": backdate to the 1st of the current month,
+  //    00:00 UTC.
+  //  - "select": use the operator-chosen `startingAt` (the only mode that
+  //    surfaces the date picker).
+  startMode: z
+    .enum(["immediately", "retroactive_first_of_month", "select"])
+    .default("select"),
+});
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
 type SwitchContractBodyInput = z.input<typeof SwitchContractBodySchema>;
@@ -259,6 +147,7 @@ export default function SwitchContractDialog({
       purchaseOrderId: "",
       startingAt: "",
       startMode: "select",
+      endingAt: "",
       stripeCustomerId: stripeCustomerId ?? "",
       stripeCollectionMethod: "charge_automatically",
       netPaymentTermsDays: undefined,
@@ -271,14 +160,10 @@ export default function SwitchContractDialog({
       autoSeatUpgradeEnabled: false,
       topUpEnabled: false,
       autoInvoiceFinalizationEnabled: true,
-      forceSeatType: "",
-      showInitialCredits: false,
-      initialCreditsAmount: undefined,
-      initialCreditsInvoiceAmount: undefined,
-      initialCreditsFrequency: "one_time",
-      initialCreditsPeriods: undefined,
-      showRecurringFreeCredit: false,
-      recurringFreeCreditAwuPerMonth: undefined,
+      promoteNoneSeatsTo: undefined,
+      initialCredits: undefined,
+      scheduledCharge: undefined,
+      recurringFreeCredit: undefined,
       seats: {},
     },
   });
@@ -396,7 +281,7 @@ export default function SwitchContractDialog({
         selected: boolean;
         minSeats: number;
         rate: number;
-        paymentFrequency: "one_time";
+        paymentSchedule: { frequency: "one_time" };
       }
     > = {};
     for (const seat of selectedSeats) {
@@ -408,7 +293,7 @@ export default function SwitchContractDialog({
         selected: seat.entitled,
         minSeats: 0,
         rate,
-        paymentFrequency: "one_time",
+        paymentSchedule: { frequency: "one_time" },
       };
     }
     form.setValue("seats", next);
@@ -442,6 +327,7 @@ export default function SwitchContractDialog({
     if (selectedTier) {
       form.setValue("startingAt", defaultStartingAtUTC);
       form.setValue("startMode", "select");
+      form.setValue("endingAt", "");
     }
     if (selectedTier && !isPaygEligibleTier(selectedTier)) {
       form.setValue("paygEnabled", false);
@@ -464,6 +350,21 @@ export default function SwitchContractDialog({
       timeStyle: "short",
     });
   }, [startingAt]);
+
+  const endingAt = form.watch("endingAt");
+  const endingAtLocalLabel = useMemo(() => {
+    if (!endingAt) {
+      return null;
+    }
+    const d = new Date(endingAt + ":00Z");
+    if (isNaN(d.getTime())) {
+      return null;
+    }
+    return d.toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  }, [endingAt]);
 
   // 1st of the current month at 00:00 UTC — the "retroactive" anchor. Computed
   // as an ISO string sent verbatim to the server (no datetime-local conversion).
@@ -514,13 +415,13 @@ export default function SwitchContractDialog({
     "autoInvoiceFinalizationEnabled"
   );
 
-  const showInitialCredits = form.watch("showInitialCredits");
-  const initialCreditsFrequency = form.watch("initialCreditsFrequency");
-  const showRecurringFreeCredit = form.watch("showRecurringFreeCredit");
+  const initialCredits = form.watch("initialCredits");
+  const scheduledCharge = form.watch("scheduledCharge");
+  const recurringFreeCredit = form.watch("recurringFreeCredit");
 
   const stripeCollectionMethod = form.watch("stripeCollectionMethod");
   const watchedSeats = form.watch("seats");
-  const forceSeatType = form.watch("forceSeatType");
+  const promoteNoneSeatsTo = form.watch("promoteNoneSeatsTo");
 
   // "Force seat type" may only promote members onto a seat that is actually
   // entitled (checked) on the contract being created — offering an
@@ -537,31 +438,45 @@ export default function SwitchContractDialog({
   // unchecked it) so a stale override can't be submitted silently.
   useEffect(() => {
     if (
-      forceSeatType &&
-      !enterableSeatTypes.some((seatType) => seatType === forceSeatType)
+      promoteNoneSeatsTo &&
+      !enterableSeatTypes.some((seatType) => seatType === promoteNoneSeatsTo)
     ) {
-      form.setValue("forceSeatType", "");
+      form.setValue("promoteNoneSeatsTo", undefined);
     }
-  }, [forceSeatType, enterableSeatTypes, form]);
+  }, [promoteNoneSeatsTo, enterableSeatTypes, form]);
 
   // When any payment frequency field changes, pre-fill its sibling periods
   // field with the canonical default. Uses form.watch(callback) — the only
   // reliable way to know exactly which field changed (via the `name` argument).
   useEffect(() => {
     const { unsubscribe } = form.watch((value, { name }) => {
-      if (name === "initialCreditsFrequency") {
+      if (name === "initialCredits.paymentSchedule.frequency") {
+        const freq = value.initialCredits
+          ? (value.initialCredits.paymentSchedule?.frequency ?? "one_time")
+          : "one_time";
         form.setValue(
-          "initialCreditsPeriods",
-          DEFAULT_PERIODS_FOR_FREQUENCY[
-            value.initialCreditsFrequency ?? "one_time"
-          ]
+          "initialCredits.paymentSchedule.periods",
+          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
         );
       }
-      if (name?.startsWith("seats.") && name.endsWith(".paymentFrequency")) {
-        const seatType = name.split(".")[1];
-        const freq = value.seats?.[seatType]?.paymentFrequency ?? "one_time";
+      if (name === "scheduledCharge.paymentSchedule.frequency") {
+        const freq = value.scheduledCharge
+          ? (value.scheduledCharge.paymentSchedule?.frequency ?? "one_time")
+          : "one_time";
         form.setValue(
-          `seats.${seatType}.paymentPeriods`,
+          "scheduledCharge.paymentSchedule.periods",
+          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
+        );
+      }
+      if (
+        name?.startsWith("seats.") &&
+        name.endsWith(".paymentSchedule.frequency")
+      ) {
+        const seatType = name.split(".")[1];
+        const freq =
+          value.seats?.[seatType]?.paymentSchedule?.frequency ?? "one_time";
+        form.setValue(
+          `seats.${seatType}.paymentSchedule.periods`,
           DEFAULT_PERIODS_FOR_FREQUENCY[freq]
         );
       }
@@ -580,13 +495,14 @@ export default function SwitchContractDialog({
 
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
-      const trimmedStripe = values.stripeCustomerId.trim();
       const trimmedHubspotDealId = values.hubspotDealId?.trim();
       const trimmedPurchaseOrderId = values.purchaseOrderId?.trim();
       const cleaned: SwitchContractBodyInput = {
         metronomePackageId: values.metronomePackageId.trim(),
         planCode: values.planCode.trim(),
         paygEnabled: values.paygEnabled,
+        stripeCustomerId: values.stripeCustomerId.trim(),
+        stripeCollectionMethod: values.stripeCollectionMethod,
         ...(trimmedHubspotDealId
           ? { hubspotDealId: trimmedHubspotDealId }
           : {}),
@@ -594,13 +510,6 @@ export default function SwitchContractDialog({
           ? { purchaseOrderId: trimmedPurchaseOrderId }
           : {}),
       };
-      // The operator can omit the Stripe customer — the resulting Metronome
-      // contract has no Stripe billing link. The collection method only
-      // matters when a Stripe customer is wired in.
-      if (trimmedStripe) {
-        cleaned.stripeCustomerId = trimmedStripe;
-        cleaned.stripeCollectionMethod = values.stripeCollectionMethod;
-      }
       if (values.netPaymentTermsDays !== undefined) {
         cleaned.netPaymentTermsDays = values.netPaymentTermsDays;
       }
@@ -613,10 +522,9 @@ export default function SwitchContractDialog({
       cleaned.autoInvoiceFinalizationEnabled =
         values.autoInvoiceFinalizationEnabled;
       // Optional seat-type override: forces seat-less members onto this seat on
-      // the new contract. Only sent when a valid seat type is selected (empty
-      // string = no override).
-      if (values.forceSeatType && isMembershipSeatType(values.forceSeatType)) {
-        cleaned.promoteNoneSeatsTo = values.forceSeatType;
+      // the new contract. Only sent when the operator checked the override.
+      if (values.promoteNoneSeatsTo !== undefined) {
+        cleaned.promoteNoneSeatsTo = values.promoteNoneSeatsTo;
       }
       if (values.balanceThresholdCredits !== undefined) {
         cleaned.balanceThresholdCredits = values.balanceThresholdCredits;
@@ -628,54 +536,28 @@ export default function SwitchContractDialog({
         cleaned.programmaticMonthlyCapCredits =
           values.programmaticMonthlyCapCredits;
       }
-      // Initial credits: only sent when the operator toggled the section on.
-      // Both the credit amount and the invoice amount are then required, and a
-      // Stripe customer must be present to invoice against.
-      if (values.showInitialCredits) {
-        if (
-          values.initialCreditsAmount === undefined ||
-          values.initialCreditsInvoiceAmount === undefined
-        ) {
-          setError(
-            "Initial credits require both a credit amount and an invoice amount."
-          );
-          return;
-        }
-        if (!trimmedStripe) {
-          setError("Initial credits require a Stripe customer to invoice.");
-          return;
-        }
-        if (
-          values.initialCreditsFrequency !== "one_time" &&
-          (values.initialCreditsPeriods === undefined ||
-            values.initialCreditsPeriods < 2)
-        ) {
-          setError(
-            "Scheduled payments require a number of periods of at least 2."
-          );
-          return;
-        }
-        cleaned.initialCredits = {
-          amountCredits: values.initialCreditsAmount,
-          invoiceAmount: values.initialCreditsInvoiceAmount,
-          paymentSchedule: {
-            frequency: values.initialCreditsFrequency,
-            periods:
-              values.initialCreditsFrequency !== "one_time"
-                ? values.initialCreditsPeriods
-                : undefined,
-          },
+      // Initial credits: a contract-level prepaid commit. Only sent when the
+      // operator toggled the section on.
+      if (values.initialCredits !== undefined) {
+        cleaned.initialCredits = values.initialCredits;
+      }
+      // Scheduled charge: a pure invoice line item, no credit grant. Only
+      // sent when the operator toggled the section on.
+      if (values.scheduledCharge !== undefined) {
+        const { invoiceAmount, paymentSchedule, name } = values.scheduledCharge;
+        const trimmedScheduledChargeName = name?.trim();
+        cleaned.scheduledCharge = {
+          ...(trimmedScheduledChargeName
+            ? { name: trimmedScheduledChargeName }
+            : {}),
+          invoiceAmount,
+          paymentSchedule,
         };
       }
       // Recurring free credit pool: only sent when the operator toggled the
       // section on. No invoice involved, so no Stripe customer is required.
-      if (values.showRecurringFreeCredit) {
-        if (values.recurringFreeCreditAwuPerMonth === undefined) {
-          setError("Recurring free credit requires an amount.");
-          return;
-        }
-        cleaned.recurringFreeCreditAwuPerMonth =
-          values.recurringFreeCreditAwuPerMonth;
+      if (values.recurringFreeCredit !== undefined) {
+        cleaned.recurringFreeCredit = values.recurringFreeCredit;
       }
       // Resolve the start moment. "immediately" leaves `startingAt` unset so
       // the server swaps at the current hour.
@@ -685,12 +567,16 @@ export default function SwitchContractDialog({
         // datetime-local has no timezone — append Z to interpret as UTC.
         cleaned.startingAt = new Date(values.startingAt + ":00Z").toISOString();
       }
+      if (values.endingAt) {
+        // datetime-local has no timezone — append Z to interpret as UTC.
+        cleaned.endingAt = new Date(values.endingAt + ":00Z").toISOString();
+      }
       // Seats: every seat the package knows about, each carrying its `selected`
       // state, so the server can entitle checked seats and disable unchecked
       // ones the package would otherwise sell. Entitled-by-default seats are
       // pre-checked. A checked seat the package does not entitle requires a
       // positive rate (except the free seat, which may be entitled at rate 0).
-      const seats: SwitchContractBodyInput["seats"] = [];
+      const seats: NonNullable<SwitchContractBodyInput["seats"]> = {};
       for (const { seatType, entitled } of selectedSeats) {
         const entry = values.seats?.[seatType];
         const selected = entry?.selected ?? false;
@@ -709,8 +595,11 @@ export default function SwitchContractDialog({
         const commitmentPrice =
           explicitPrice ??
           (minSeats > 0 && rate > 0 ? minSeats * rate : undefined);
-        const paymentFrequency = entry?.paymentFrequency ?? "one_time";
-        const paymentPeriods = entry?.paymentPeriods;
+        // Periods-when-not-one-time is enforced by `paymentScheduleSchema`'s
+        // own refine, so it's guaranteed present here whenever needed.
+        const paymentSchedule = entry?.paymentSchedule ?? {
+          frequency: "one_time" as const,
+        };
         if (selected && !entitled && seatType !== "free" && !(rate > 0)) {
           setError(
             `Seat "${seatType}" is not entitled by the selected package and ` +
@@ -718,31 +607,15 @@ export default function SwitchContractDialog({
           );
           return;
         }
-        if (
-          commitmentPrice !== undefined &&
-          paymentFrequency !== "one_time" &&
-          (paymentPeriods === undefined || paymentPeriods < 2)
-        ) {
-          setError(
-            `Seat "${seatType}" has a scheduled payment frequency but no valid ` +
-              "number of periods (minimum 2)."
-          );
-          return;
-        }
-        seats.push({
-          seatType,
+        seats[seatType] = {
           selected,
           minSeats,
           rate,
           commitmentPrice,
-          paymentSchedule: {
-            frequency: paymentFrequency,
-            periods:
-              paymentFrequency !== "one_time" ? paymentPeriods : undefined,
-          },
-        });
+          paymentSchedule,
+        };
       }
-      if (seats.length > 0) {
+      if (Object.keys(seats).length > 0) {
         cleaned.seats = seats;
       }
 
@@ -808,41 +681,12 @@ export default function SwitchContractDialog({
                   {error && (
                     <div className="col-span-2 text-warning">{error}</div>
                   )}
-                  <Label className="text-sm">
-                    Stripe Customer ID
-                    <span className="ml-1 text-muted-foreground">
-                      (optional)
-                    </span>
-                  </Label>
+                  <Label className="text-sm">Stripe Customer ID</Label>
                   <InputField
                     control={form.control}
                     name="stripeCustomerId"
                     hideLabel
                     placeholder="cus_1234567890"
-                  />
-                  <Label className="text-sm">
-                    HubSpot Deal ID
-                    <span className="ml-1 text-muted-foreground">
-                      (optional)
-                    </span>
-                  </Label>
-                  <InputField
-                    control={form.control}
-                    name="hubspotDealId"
-                    hideLabel
-                    placeholder="e.g., 12345678901"
-                  />
-                  <Label className="text-sm">
-                    Purchase order
-                    <span className="ml-1 text-muted-foreground">
-                      (optional)
-                    </span>
-                  </Label>
-                  <InputField
-                    control={form.control}
-                    name="purchaseOrderId"
-                    hideLabel
-                    placeholder="PO number"
                   />
                   {isCurrencyLoading && (
                     <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground">
@@ -856,8 +700,37 @@ export default function SwitchContractDialog({
                       {currencyError.message}
                     </div>
                   )}
-                  {trimmedStripeCustomerId && (
-                    <>
+                </div>
+                {/* Nothing else renders until a Stripe customer resolves to a
+                    valid billing currency — there is no package, seat, or
+                    credit configuration to show for an unresolved customer. */}
+                {resolvedCurrency && (
+                  <>
+                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                      <Label className="text-sm">
+                        HubSpot Deal ID
+                        <span className="ml-1 text-muted-foreground">
+                          (optional)
+                        </span>
+                      </Label>
+                      <InputField
+                        control={form.control}
+                        name="hubspotDealId"
+                        hideLabel
+                        placeholder="e.g., 12345678901"
+                      />
+                      <Label className="text-sm">
+                        Purchase order
+                        <span className="ml-1 text-muted-foreground">
+                          (optional)
+                        </span>
+                      </Label>
+                      <InputField
+                        control={form.control}
+                        name="purchaseOrderId"
+                        hideLabel
+                        placeholder="PO number"
+                      />
                       <Label className="text-sm">Collection method</Label>
                       <SelectField
                         control={form.control}
@@ -875,330 +748,479 @@ export default function SwitchContractDialog({
                           },
                         ]}
                       />
-                    </>
-                  )}
-                  {trimmedStripeCustomerId &&
-                    stripeCollectionMethod === "send_invoice" && (
-                      <>
-                        <Label className="text-sm">
-                          Net payment terms (days)
-                        </Label>
-                        <InputField
-                          control={form.control}
-                          name="netPaymentTermsDays"
-                          hideLabel
-                          type="number"
-                          placeholder="Metronome account default"
-                        />
-                      </>
-                    )}
-                  {isPackagesLoading && (
-                    <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground">
-                      <Spinner size="sm" />
-                      <span>Loading Metronome packages...</span>
-                    </div>
-                  )}
-                  {!isPackagesLoading && packagesError && (
-                    <div className="col-span-2 text-sm text-warning">
-                      Failed to load Metronome packages: {packagesError.message}
-                    </div>
-                  )}
-                  {!isPackagesLoading &&
-                    !packagesError &&
-                    !isCurrencyLoading &&
-                    (resolvedCurrency || !trimmedStripeCustomerId) && (
-                      <>
-                        <Label className="text-sm">
-                          Package
-                          {resolvedCurrency &&
-                            ` (${resolvedCurrency.toUpperCase()})`}
-                        </Label>
-                        <SelectField
-                          control={form.control}
-                          name="metronomePackageId"
-                          hideLabel
-                          mountPortalContainer={portalContainer}
-                          groups={packageGroups}
-                        />
-                      </>
-                    )}
-                  {selectedTier === "enterprise" && (
-                    <>
-                      <Label className="text-sm">Enterprise plan</Label>
-                      <SelectField
-                        control={form.control}
-                        name="planCode"
-                        hideLabel
-                        mountPortalContainer={portalContainer}
-                        options={enterprisePlanOptions}
-                      />
-                    </>
-                  )}
-                  {(selectedTier === "enterprise" ||
-                    selectedTier === "business") && (
-                    <>
-                      <Label className="text-sm">Start</Label>
-                      <SelectField
-                        control={form.control}
-                        name="startMode"
-                        hideLabel
-                        mountPortalContainer={portalContainer}
-                        options={startModeOptions}
-                      />
-                      {startMode === "select" && (
+                      {stripeCollectionMethod === "send_invoice" && (
                         <>
-                          <Label className="text-sm">Starts at (UTC)</Label>
+                          <Label className="text-sm">
+                            Net payment terms (days)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="netPaymentTermsDays"
+                            hideLabel
+                            type="number"
+                            placeholder="Metronome account default"
+                          />
+                        </>
+                      )}
+                      {isPackagesLoading && (
+                        <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground">
+                          <Spinner size="sm" />
+                          <span>Loading Metronome packages...</span>
+                        </div>
+                      )}
+                      {!isPackagesLoading && packagesError && (
+                        <div className="col-span-2 text-sm text-warning">
+                          Failed to load Metronome packages:{" "}
+                          {packagesError.message}
+                        </div>
+                      )}
+                      {!isPackagesLoading && !packagesError && (
+                        <>
+                          <Label className="text-sm">
+                            Package ({resolvedCurrency.toUpperCase()})
+                          </Label>
+                          <SelectField
+                            control={form.control}
+                            name="metronomePackageId"
+                            hideLabel
+                            mountPortalContainer={portalContainer}
+                            groups={packageGroups}
+                          />
+                        </>
+                      )}
+                      {selectedTier === "enterprise" && (
+                        <>
+                          <Label className="text-sm">Enterprise plan</Label>
+                          <SelectField
+                            control={form.control}
+                            name="planCode"
+                            hideLabel
+                            mountPortalContainer={portalContainer}
+                            options={enterprisePlanOptions}
+                          />
+                        </>
+                      )}
+                      {(selectedTier === "enterprise" ||
+                        selectedTier === "business") && (
+                        <>
+                          <Label className="text-sm">Start</Label>
+                          <SelectField
+                            control={form.control}
+                            name="startMode"
+                            hideLabel
+                            mountPortalContainer={portalContainer}
+                            options={startModeOptions}
+                          />
+                          {startMode === "select" && (
+                            <>
+                              <Label className="text-sm">Starts at (UTC)</Label>
+                              <div className="relative">
+                                <InputField
+                                  control={form.control}
+                                  name="startingAt"
+                                  hideLabel
+                                  type="datetime-local"
+                                  step={3600}
+                                  transformValue={snapDatetimeLocalToHour}
+                                />
+                                {startingAtLocalLabel && (
+                                  <p className="mt-1 text-xs text-muted-foreground absolute top-2 right-2">
+                                    Local: {startingAtLocalLabel}
+                                  </p>
+                                )}
+                              </div>
+                            </>
+                          )}
+                          <Label className="text-sm">
+                            Ends at (UTC)
+                            <span className="ml-1 text-muted-foreground">
+                              (optional)
+                            </span>
+                          </Label>
                           <div className="relative">
                             <InputField
                               control={form.control}
-                              name="startingAt"
+                              name="endingAt"
                               hideLabel
                               type="datetime-local"
                               step={3600}
+                              placeholder="open-ended"
                               transformValue={snapDatetimeLocalToHour}
                             />
-                            {startingAtLocalLabel && (
+                            {endingAtLocalLabel && (
                               <p className="mt-1 text-xs text-muted-foreground absolute top-2 right-2">
-                                Local: {startingAtLocalLabel}
+                                Local: {endingAtLocalLabel}
                               </p>
                             )}
                           </div>
                         </>
                       )}
-                    </>
-                  )}
-                  {selectedTier === "business" && (
-                    <div className="col-span-2 text-sm text-muted-foreground">
-                      Target plan:{" "}
-                      <span className="font-mono">
-                        {form.watch("planCode")}
-                      </span>
+                      {selectedTier === "business" && (
+                        <div className="col-span-2 text-sm text-muted-foreground">
+                          Target plan:{" "}
+                          <span className="font-mono">
+                            {form.watch("planCode")}
+                          </span>
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-                {selectedTier && (
-                  <div className="border-t pt-4">
-                    <Label className="mb-3 block text-sm font-medium">
-                      Credit configuration
-                    </Label>
-                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
-                      {paygEligible && selectedTier === "enterprise" && (
-                        <>
-                          <Label className="text-sm">Pay-as-you-go</Label>
+                    {selectedTier && (
+                      <div className="border-t pt-4">
+                        <Label className="mb-3 block text-sm font-medium">
+                          Credit configuration
+                        </Label>
+                        <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                          {paygEligible && selectedTier === "enterprise" && (
+                            <>
+                              <Label className="text-sm">Pay-as-you-go</Label>
+                              <SliderToggle
+                                selected={paygEnabled}
+                                onClick={() =>
+                                  form.setValue("paygEnabled", !paygEnabled)
+                                }
+                              />
+                            </>
+                          )}
+                          <Label className="text-sm">
+                            Monthly usage cap (credits)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="usageCapCredits"
+                            hideLabel
+                            type="number"
+                            placeholder="no cap"
+                          />
+                          <Label className="text-sm">
+                            Default discount (%)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="defaultDiscountPercent"
+                            hideLabel
+                            type="number"
+                            placeholder="0"
+                          />
+                          <Label className="text-sm">
+                            Workspace credit pool threshold alert (credits)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="balanceThresholdCredits"
+                            hideLabel
+                            type="number"
+                            placeholder="no alert"
+                          />
+                          <Label className="text-sm">
+                            Default per-user workspace credit pool monthly limit
+                            (credits)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="defaultPoolCapCredits"
+                            hideLabel
+                            type="number"
+                            placeholder="no access"
+                          />
+                          <Label className="text-sm">
+                            Programmatic monthly limit (credits)
+                          </Label>
+                          <InputField
+                            control={form.control}
+                            name="programmaticMonthlyCapCredits"
+                            hideLabel
+                            type="number"
+                            placeholder="no cap"
+                          />
+                          <Label className="text-sm">Auto-upgrade seats</Label>
                           <SliderToggle
-                            selected={paygEnabled}
+                            selected={autoSeatUpgradeEnabled}
                             onClick={() =>
-                              form.setValue("paygEnabled", !paygEnabled)
+                              form.setValue(
+                                "autoSeatUpgradeEnabled",
+                                !autoSeatUpgradeEnabled
+                              )
                             }
                           />
-                        </>
-                      )}
-                      <Label className="text-sm">
-                        Monthly usage cap (credits)
-                      </Label>
-                      <InputField
-                        control={form.control}
-                        name="usageCapCredits"
-                        hideLabel
-                        type="number"
-                        placeholder="no cap"
-                      />
-                      <Label className="text-sm">Default discount (%)</Label>
-                      <InputField
-                        control={form.control}
-                        name="defaultDiscountPercent"
-                        hideLabel
-                        type="number"
-                        placeholder="0"
-                      />
-                      <Label className="text-sm">
-                        Workspace credit pool threshold alert (credits)
-                      </Label>
-                      <InputField
-                        control={form.control}
-                        name="balanceThresholdCredits"
-                        hideLabel
-                        type="number"
-                        placeholder="no alert"
-                      />
-                      <Label className="text-sm">
-                        Default per-user workspace credit pool monthly limit
-                        (credits)
-                      </Label>
-                      <InputField
-                        control={form.control}
-                        name="defaultPoolCapCredits"
-                        hideLabel
-                        type="number"
-                        placeholder="no access"
-                      />
-                      <Label className="text-sm">
-                        Programmatic monthly limit (credits)
-                      </Label>
-                      <InputField
-                        control={form.control}
-                        name="programmaticMonthlyCapCredits"
-                        hideLabel
-                        type="number"
-                        placeholder="no cap"
-                      />
-                      <Label className="text-sm">Auto-upgrade seats</Label>
-                      <SliderToggle
-                        selected={autoSeatUpgradeEnabled}
-                        onClick={() =>
-                          form.setValue(
-                            "autoSeatUpgradeEnabled",
-                            !autoSeatUpgradeEnabled
-                          )
-                        }
-                      />
-                      {selectedTier === "enterprise" && (
-                        <>
-                          <Label className="text-sm">Top-up (Enterprise)</Label>
+                          {selectedTier === "enterprise" && (
+                            <>
+                              <Label className="text-sm">
+                                Top-up (Enterprise)
+                              </Label>
+                              <SliderToggle
+                                selected={topUpEnabled}
+                                onClick={() =>
+                                  form.setValue("topUpEnabled", !topUpEnabled)
+                                }
+                              />
+                            </>
+                          )}
+                          <Label className="text-sm">
+                            Auto invoice finalization
+                          </Label>
                           <SliderToggle
-                            selected={topUpEnabled}
+                            selected={autoInvoiceFinalizationEnabled}
                             onClick={() =>
-                              form.setValue("topUpEnabled", !topUpEnabled)
+                              form.setValue(
+                                "autoInvoiceFinalizationEnabled",
+                                !autoInvoiceFinalizationEnabled
+                              )
                             }
                           />
-                        </>
-                      )}
-                      <Label className="text-sm">
-                        Auto invoice finalization
-                      </Label>
-                      <SliderToggle
-                        selected={autoInvoiceFinalizationEnabled}
-                        onClick={() =>
-                          form.setValue(
-                            "autoInvoiceFinalizationEnabled",
-                            !autoInvoiceFinalizationEnabled
-                          )
-                        }
-                      />
-                    </div>
-                  </div>
-                )}
-                {selectedSeats.length > 0 && (
-                  <div className="space-y-2 border-t pt-4">
-                    <Label className="text-sm">
-                      Seats configuration{" "}
-                      {resolvedCurrency
-                        ? `(rate & price in ${resolvedCurrency.toUpperCase()})`
-                        : ""}
-                    </Label>
-                    <div className="text-xs text-muted-foreground">
-                      Checked seats are entitled on the new contract. Seats the
-                      package does not entitle by default are unchecked — check
-                      one to entitle it (a non-zero rate is required, except for
-                      the free seat).
-                    </div>
-                    {/* Header row */}
-                    <div className="flex items-center gap-3 pb-1 text-xs font-medium text-muted-foreground">
-                      <div className="w-32 shrink-0" />
-                      <div className="flex-1">Min seats</div>
-                      <div className="flex-1">
-                        Seat rate
-                        {resolvedCurrency
-                          ? ` (${resolvedCurrency.toUpperCase()})`
-                          : ""}
+                        </div>
                       </div>
-                      <div className="flex-1">
-                        Commitment price
-                        {resolvedCurrency
-                          ? ` (${resolvedCurrency.toUpperCase()})`
-                          : ""}
-                      </div>
-                      <div className="flex-1">Payment schedule</div>
-                      <div className="flex-1">Periods</div>
-                    </div>
-                    {selectedSeats.map(({ seatType, entitled }) => {
-                      const isSelected =
-                        watchedSeats?.[seatType]?.selected ?? false;
-                      const seatPaymentFrequency =
-                        watchedSeats?.[seatType]?.paymentFrequency ??
-                        "one_time";
-                      const minSeats = watchedSeats?.[seatType]?.minSeats ?? 0;
-                      const rate = watchedSeats?.[seatType]?.rate ?? 0;
-                      const isAnnualSeat = seatType.endsWith("_yearly");
-                      const defaultCommitment =
-                        minSeats > 0 && rate > 0 ? minSeats * rate : null;
-                      const monthlyRate =
-                        isAnnualSeat && rate > 0 ? rate / 12 : null;
-                      return (
-                        <div key={seatType} className="flex items-center gap-3">
-                          <div className="flex w-32 shrink-0 items-center gap-2">
-                            <Checkbox
-                              checked={isSelected}
-                              onCheckedChange={(checked) =>
+                    )}
+                    {selectedSeats.length > 0 && (
+                      <div className="space-y-2 border-t pt-4">
+                        <Label className="text-sm">
+                          Seats configuration{" "}
+                          {resolvedCurrency
+                            ? `(rate & price in ${resolvedCurrency.toUpperCase()})`
+                            : ""}
+                        </Label>
+                        <div className="text-xs text-muted-foreground">
+                          Checked seats are entitled on the new contract. Seats
+                          the package does not entitle by default are unchecked
+                          — check one to entitle it (a non-zero rate is
+                          required, except for the free seat).
+                        </div>
+                        {/* Header row */}
+                        <div className="flex items-center gap-3 pb-1 text-xs font-medium text-muted-foreground">
+                          <div className="w-32 shrink-0" />
+                          <div className="flex-1">Min seats</div>
+                          <div className="flex-1">
+                            Seat rate
+                            {resolvedCurrency
+                              ? ` (${resolvedCurrency.toUpperCase()})`
+                              : ""}
+                          </div>
+                          <div className="flex-1">
+                            Commitment price
+                            {resolvedCurrency
+                              ? ` (${resolvedCurrency.toUpperCase()})`
+                              : ""}
+                          </div>
+                          <div className="flex-1">Payment schedule</div>
+                          <div className="flex-1">Periods</div>
+                        </div>
+                        {selectedSeats.map(({ seatType, entitled }) => {
+                          const isSelected =
+                            watchedSeats?.[seatType]?.selected ?? false;
+                          const seatPaymentFrequency =
+                            watchedSeats?.[seatType]?.paymentSchedule
+                              ?.frequency ?? "one_time";
+                          const minSeats =
+                            watchedSeats?.[seatType]?.minSeats ?? 0;
+                          const rate = watchedSeats?.[seatType]?.rate ?? 0;
+                          const isAnnualSeat = seatType.endsWith("_yearly");
+                          const defaultCommitment =
+                            minSeats > 0 && rate > 0 ? minSeats * rate : null;
+                          const monthlyRate =
+                            isAnnualSeat && rate > 0 ? rate / 12 : null;
+                          return (
+                            <div
+                              key={seatType}
+                              className="flex items-center gap-3"
+                            >
+                              <div className="flex w-32 shrink-0 items-center gap-2">
+                                <Checkbox
+                                  checked={isSelected}
+                                  onCheckedChange={(checked) =>
+                                    form.setValue(
+                                      `seats.${seatType}.selected`,
+                                      checked === true
+                                    )
+                                  }
+                                />
+                                <span className="font-mono text-sm">
+                                  {seatType}
+                                  {!entitled && (
+                                    <span className="ml-1 text-muted-foreground">
+                                      *
+                                    </span>
+                                  )}
+                                </span>
+                              </div>
+                              <div className="flex-1">
+                                <InputField
+                                  control={form.control}
+                                  name={`seats.${seatType}.minSeats`}
+                                  hideLabel
+                                  type="number"
+                                  placeholder="0"
+                                  disabled={!isSelected}
+                                />
+                              </div>
+                              <div className="flex-1 relative">
+                                <InputField
+                                  control={form.control}
+                                  name={`seats.${seatType}.rate`}
+                                  hideLabel
+                                  type="number"
+                                  placeholder="0"
+                                  disabled={!isSelected}
+                                />
+                                {isSelected && monthlyRate !== null && (
+                                  <p className="mt-0.5 text-xs text-muted-foreground absolute top-2 right-2">
+                                    {monthlyRate % 1 === 0
+                                      ? monthlyRate
+                                      : monthlyRate.toFixed(2)}
+                                    /mo
+                                  </p>
+                                )}
+                              </div>
+                              <div className="flex-1">
+                                <InputField
+                                  control={form.control}
+                                  name={`seats.${seatType}.commitmentPrice`}
+                                  hideLabel
+                                  type="number"
+                                  placeholder={
+                                    rate <= 0
+                                      ? "n/a (rate is 0)"
+                                      : defaultCommitment !== null
+                                        ? String(defaultCommitment)
+                                        : "optional"
+                                  }
+                                  disabled={!isSelected || rate <= 0}
+                                />
+                              </div>
+                              <div className="flex-1">
+                                <SelectField
+                                  control={form.control}
+                                  name={`seats.${seatType}.paymentSchedule.frequency`}
+                                  hideLabel
+                                  mountPortalContainer={portalContainer}
+                                  options={[
+                                    { value: "one_time", display: "One-time" },
+                                    { value: "monthly", display: "Monthly" },
+                                    {
+                                      value: "quarterly",
+                                      display: "Quarterly",
+                                    },
+                                    {
+                                      value: "semi_annually",
+                                      display: "Semi-annually",
+                                    },
+                                    { value: "annually", display: "Annually" },
+                                  ]}
+                                />
+                              </div>
+                              <div className="flex-1">
+                                {seatPaymentFrequency !== "one_time" && (
+                                  <InputField
+                                    control={form.control}
+                                    name={`seats.${seatType}.paymentSchedule.periods`}
+                                    hideLabel
+                                    type="number"
+                                    placeholder="e.g., 4"
+                                  />
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                        <div className="flex flex-col gap-1 border-t pt-3">
+                          <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                            <Label className="text-sm font-medium">
+                              Force seat type
+                            </Label>
+                            <SliderToggle
+                              selected={promoteNoneSeatsTo !== undefined}
+                              disabled={enterableSeatTypes.length === 0}
+                              onClick={() =>
                                 form.setValue(
-                                  `seats.${seatType}.selected`,
-                                  checked === true
+                                  "promoteNoneSeatsTo",
+                                  promoteNoneSeatsTo !== undefined
+                                    ? undefined
+                                    : enterableSeatTypes[0]
                                 )
                               }
                             />
-                            <span className="font-mono text-sm">
-                              {seatType}
-                              {!entitled && (
-                                <span className="ml-1 text-muted-foreground">
-                                  *
-                                </span>
-                              )}
-                            </span>
-                          </div>
-                          <div className="flex-1">
-                            <InputField
-                              control={form.control}
-                              name={`seats.${seatType}.minSeats`}
-                              hideLabel
-                              type="number"
-                              placeholder="0"
-                              disabled={!isSelected}
-                            />
-                          </div>
-                          <div className="flex-1 relative">
-                            <InputField
-                              control={form.control}
-                              name={`seats.${seatType}.rate`}
-                              hideLabel
-                              type="number"
-                              placeholder="0"
-                              disabled={!isSelected}
-                            />
-                            {isSelected && monthlyRate !== null && (
-                              <p className="mt-0.5 text-xs text-muted-foreground absolute top-2 right-2">
-                                {monthlyRate % 1 === 0
-                                  ? monthlyRate
-                                  : monthlyRate.toFixed(2)}
-                                /mo
-                              </p>
+                            {promoteNoneSeatsTo !== undefined && (
+                              <>
+                                <Label className="text-sm">Seat type</Label>
+                                <div className="w-64">
+                                  <SelectField
+                                    control={form.control}
+                                    name="promoteNoneSeatsTo"
+                                    hideLabel
+                                    mountPortalContainer={portalContainer}
+                                    options={enterableSeatTypes.map(
+                                      (seatType) => ({
+                                        value: seatType,
+                                        display: seatType,
+                                      })
+                                    )}
+                                  />
+                                </div>
+                              </>
                             )}
                           </div>
-                          <div className="flex-1">
+                          <div className="text-xs text-muted-foreground">
+                            Forces every seat-less ("none") member onto this
+                            seat on the new contract, preempting committed-seat
+                            placement.
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    <div className="border-t pt-4">
+                      <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                        <Label className="text-sm font-medium">
+                          Initial credits (prepaid commit)
+                        </Label>
+                        <SliderToggle
+                          selected={initialCredits !== undefined}
+                          onClick={() =>
+                            form.setValue(
+                              "initialCredits",
+                              initialCredits !== undefined
+                                ? undefined
+                                : {
+                                    amountCredits: 0,
+                                    invoiceAmount: 0,
+                                    paymentSchedule: { frequency: "one_time" },
+                                  }
+                            )
+                          }
+                        />
+                        {initialCredits !== undefined && (
+                          <>
+                            <Label className="text-sm">Credits (AWU)</Label>
                             <InputField
                               control={form.control}
-                              name={`seats.${seatType}.commitmentPrice`}
+                              name="initialCredits.amountCredits"
                               hideLabel
                               type="number"
-                              placeholder={
-                                rate <= 0
-                                  ? "n/a (rate is 0)"
-                                  : defaultCommitment !== null
-                                    ? String(defaultCommitment)
-                                    : "optional"
-                              }
-                              disabled={!isSelected || rate <= 0}
+                              placeholder="e.g., 100000"
                             />
-                          </div>
-                          <div className="flex-1">
+                            <Label className="text-sm">
+                              Invoice ({resolvedCurrency.toUpperCase()})
+                            </Label>
+                            <InputField
+                              control={form.control}
+                              name="initialCredits.invoiceAmount"
+                              hideLabel
+                              type="number"
+                              placeholder="e.g., 5000"
+                            />
+                            <Label className="text-sm">Payment schedule</Label>
                             <SelectField
                               control={form.control}
-                              name={`seats.${seatType}.paymentFrequency`}
+                              name="initialCredits.paymentSchedule.frequency"
                               hideLabel
                               mountPortalContainer={portalContainer}
                               options={[
-                                { value: "one_time", display: "One-time" },
+                                {
+                                  value: "one_time",
+                                  display: "One-time",
+                                },
                                 { value: "monthly", display: "Monthly" },
-                                { value: "quarterly", display: "Quarterly" },
+                                {
+                                  value: "quarterly",
+                                  display: "Quarterly",
+                                },
                                 {
                                   value: "semi_annually",
                                   display: "Semi-annually",
@@ -1206,151 +1228,139 @@ export default function SwitchContractDialog({
                                 { value: "annually", display: "Annually" },
                               ]}
                             />
-                          </div>
-                          <div className="flex-1">
-                            {seatPaymentFrequency !== "one_time" && (
-                              <InputField
-                                control={form.control}
-                                name={`seats.${seatType}.paymentPeriods`}
-                                hideLabel
-                                type="number"
-                                placeholder="e.g., 4"
-                              />
+                            {initialCredits.paymentSchedule.frequency !==
+                              "one_time" && (
+                              <>
+                                <Label className="text-sm">Periods</Label>
+                                <InputField
+                                  control={form.control}
+                                  name="initialCredits.paymentSchedule.periods"
+                                  hideLabel
+                                  type="number"
+                                  placeholder="e.g., 4"
+                                />
+                              </>
                             )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                    <div className="flex flex-col gap-1 border-t pt-3">
-                      <Label className="text-sm">
-                        Force seat type (optional)
-                      </Label>
-                      <div className="text-xs text-muted-foreground">
-                        Forces every seat-less ("none") member onto this seat on
-                        the new contract, preempting committed-seat placement.
-                        Leave unset for default seat assignment.
-                      </div>
-                      <div className="w-64">
-                        <SelectField
-                          control={form.control}
-                          name="forceSeatType"
-                          hideLabel
-                          mountPortalContainer={portalContainer}
-                          options={[
-                            { value: "", display: "— No override —" },
-                            ...enterableSeatTypes.map((seatType) => ({
-                              value: seatType,
-                              display: seatType,
-                            })),
-                          ]}
-                        />
+                          </>
+                        )}
                       </div>
                     </div>
-                  </div>
-                )}
-                {trimmedStripeCustomerId && resolvedCurrency && (
-                  <div className="border-t pt-4">
-                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
-                      <Label className="text-sm font-medium">
-                        Initial credits (prepaid commit)
-                      </Label>
-                      <SliderToggle
-                        selected={showInitialCredits}
-                        onClick={() =>
-                          form.setValue(
-                            "showInitialCredits",
-                            !showInitialCredits
-                          )
-                        }
-                      />
-                      {showInitialCredits && (
-                        <>
-                          <Label className="text-sm">Credits (AWU)</Label>
-                          <InputField
-                            control={form.control}
-                            name="initialCreditsAmount"
-                            hideLabel
-                            type="number"
-                            placeholder="e.g., 100000"
-                          />
-                          <Label className="text-sm">
-                            Invoice ({resolvedCurrency.toUpperCase()})
-                          </Label>
-                          <InputField
-                            control={form.control}
-                            name="initialCreditsInvoiceAmount"
-                            hideLabel
-                            type="number"
-                            placeholder="e.g., 5000"
-                          />
-                          <Label className="text-sm">Payment schedule</Label>
-                          <SelectField
-                            control={form.control}
-                            name="initialCreditsFrequency"
-                            hideLabel
-                            mountPortalContainer={portalContainer}
-                            options={[
-                              {
-                                value: "one_time",
-                                display: "One-time",
-                              },
-                              { value: "monthly", display: "Monthly" },
-                              {
-                                value: "quarterly",
-                                display: "Quarterly",
-                              },
-                              {
-                                value: "semi_annually",
-                                display: "Semi-annually",
-                              },
-                              { value: "annually", display: "Annually" },
-                            ]}
-                          />
-                          {initialCreditsFrequency !== "one_time" && (
-                            <>
-                              <Label className="text-sm">Periods</Label>
-                              <InputField
-                                control={form.control}
-                                name="initialCreditsPeriods"
-                                hideLabel
-                                type="number"
-                                placeholder="e.g., 4"
-                              />
-                            </>
-                          )}
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-                <div className="border-t pt-4">
-                  <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
-                    <Label className="text-sm font-medium">
-                      Recurring free credit pool (monthly)
-                    </Label>
-                    <SliderToggle
-                      selected={showRecurringFreeCredit}
-                      onClick={() =>
-                        form.setValue(
-                          "showRecurringFreeCredit",
-                          !showRecurringFreeCredit
-                        )
-                      }
-                    />
-                    {showRecurringFreeCredit && (
-                      <>
-                        <Label className="text-sm">Credits (AWU) / month</Label>
-                        <InputField
-                          control={form.control}
-                          name="recurringFreeCreditAwuPerMonth"
-                          hideLabel
-                          type="number"
-                          placeholder="e.g., 10000"
+                    <div className="border-t pt-4">
+                      <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                        <Label className="text-sm font-medium">
+                          Scheduled charge (platform fee)
+                        </Label>
+                        <SliderToggle
+                          selected={scheduledCharge !== undefined}
+                          onClick={() =>
+                            form.setValue(
+                              "scheduledCharge",
+                              scheduledCharge !== undefined
+                                ? undefined
+                                : {
+                                    name: undefined,
+                                    invoiceAmount: 0,
+                                    paymentSchedule: { frequency: "one_time" },
+                                  }
+                            )
+                          }
                         />
-                      </>
-                    )}
-                  </div>
-                </div>
+                        {scheduledCharge !== undefined && (
+                          <>
+                            <Label className="text-sm">
+                              Name
+                              <span className="ml-1 text-muted-foreground">
+                                (optional)
+                              </span>
+                            </Label>
+                            <InputField
+                              control={form.control}
+                              name="scheduledCharge.name"
+                              hideLabel
+                              placeholder="Platform fee"
+                            />
+                            <Label className="text-sm">
+                              Amount ({resolvedCurrency.toUpperCase()})
+                            </Label>
+                            <InputField
+                              control={form.control}
+                              name="scheduledCharge.invoiceAmount"
+                              hideLabel
+                              type="number"
+                              placeholder="e.g., 5000"
+                            />
+                            <Label className="text-sm">Payment schedule</Label>
+                            <SelectField
+                              control={form.control}
+                              name="scheduledCharge.paymentSchedule.frequency"
+                              hideLabel
+                              mountPortalContainer={portalContainer}
+                              options={[
+                                {
+                                  value: "one_time",
+                                  display: "One-time",
+                                },
+                                { value: "monthly", display: "Monthly" },
+                                {
+                                  value: "quarterly",
+                                  display: "Quarterly",
+                                },
+                                {
+                                  value: "semi_annually",
+                                  display: "Semi-annually",
+                                },
+                                { value: "annually", display: "Annually" },
+                              ]}
+                            />
+                            {scheduledCharge.paymentSchedule.frequency !==
+                              "one_time" && (
+                              <>
+                                <Label className="text-sm">Periods</Label>
+                                <InputField
+                                  control={form.control}
+                                  name="scheduledCharge.paymentSchedule.periods"
+                                  hideLabel
+                                  type="number"
+                                  placeholder="e.g., 4"
+                                />
+                              </>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <div className="border-t pt-4">
+                      <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                        <Label className="text-sm font-medium">
+                          Recurring free credit pool (monthly)
+                        </Label>
+                        <SliderToggle
+                          selected={recurringFreeCredit !== undefined}
+                          onClick={() =>
+                            form.setValue(
+                              "recurringFreeCredit",
+                              recurringFreeCredit !== undefined ? undefined : 0
+                            )
+                          }
+                        />
+                        {recurringFreeCredit !== undefined && (
+                          <>
+                            <Label className="text-sm">
+                              Credits (AWU) / month
+                            </Label>
+                            <InputField
+                              control={form.control}
+                              name="recurringFreeCredit"
+                              hideLabel
+                              type="number"
+                              placeholder="e.g., 10000"
+                            />
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
               </DialogContainer>
               <DialogFooter>
                 <Button

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -10,6 +10,7 @@ import {
   listMetronomePackages,
   type MetronomePackageSummary,
   type PackageSeatConfig,
+  scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
@@ -18,6 +19,7 @@ import {
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductFreeCreditId,
+  getProductPlatformFeeId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
   HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
@@ -55,149 +57,24 @@ import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_li
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
+import { isMembershipSeatType } from "@app/types/memberships";
+// The request schema is defined in `types/poke/switch_contract.ts` (no
+// server-only imports) so the SwitchContractDialog SPA form can import and
+// reuse the same pieces (payment schedule, scheduled charge shape) without
+// pulling this server-only module into the client bundle. Re-exported here
+// so existing importers of this file are unaffected.
 import {
-  isMembershipSeatType,
-  type MembershipSeatType,
-} from "@app/types/memberships";
+  type SwitchContractBody,
+  SwitchContractBodySchema,
+} from "@app/types/poke/switch_contract";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
-import { z } from "zod";
 
-const paymentScheduleSchema = z
-  .object({
-    frequency: z
-      .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
-      .default("one_time"),
-    periods: z.number().int().min(2).max(60).optional(),
-  })
-  .refine(
-    (s) => s.frequency === "one_time" || s.periods !== undefined,
-    "periods is required when frequency is not one_time"
-  )
-  .default({ frequency: "one_time" });
-
-export const SwitchContractBodySchema = z.object({
-  planCode: z.string().min(1),
-  metronomePackageId: z.string().min(1),
-  // ISO timestamp. Used only for enterprise-tier switches; any moment is
-  // accepted (including the past — backdating is allowed), and it is ceiled to
-  // the next hour boundary. Omitted for Pro/Business/Free, which swap at the
-  // current hour.
-  startingAt: z.string().optional(),
-  // Optional. Net payment terms in days (e.g. 30 for "Net 30"): how many days
-  // after invoice issuance the invoice is due. Applied to the Metronome
-  // contract and only meaningful with `send_invoice`; ignored when the card on
-  // file is auto-charged. Omitted leaves Metronome's account default in place.
-  netPaymentTermsDays: z.number().int().min(0).max(365).optional(),
-  // Optional: required for paid tiers (pro/business/enterprise), omitted
-  // for free-tier switches where Metronome contracts have no Stripe link.
-  stripeCustomerId: z.string().min(1).optional(),
-  // How Metronome collects Stripe invoices for this customer. Only takes
-  // effect when a Stripe customer is wired in. `charge_automatically` charges
-  // the card on file; `send_invoice` emails the invoice for manual payment.
-  stripeCollectionMethod: z
-    .enum(["charge_automatically", "send_invoice"])
-    .default("charge_automatically"),
-  paygEnabled: z.boolean().default(false),
-  // AWU credits — written directly to `credit_usage_configuration.usageCapCredits`.
-  usageCapCredits: z
-    .number()
-    .int("Usage cap must be an integer number of credits")
-    .min(1, "Usage cap must be at least 1 credit")
-    .optional(),
-  // Optional one-off initial AWU credits granted alongside the switch as a
-  // contract-level prepaid commit (priority 300, same as purchased commits).
-  // Requires a Stripe customer so the commit can be invoiced. `invoiceAmount`
-  // is in the customer's billing currency major units (e.g. dollars / euros).
-  initialCredits: z
-    .object({
-      amountCredits: z
-        .number()
-        .int("Initial credits must be an integer number of credits")
-        .min(1, "Initial credits must be at least 1 credit"),
-      invoiceAmount: z.number().min(0, "Invoice amount must be zero or more"),
-      paymentSchedule: paymentScheduleSchema,
-    })
-    .optional(),
-  // Optional recurring free AWU credit grant, applied as a contract-level
-  // (non-seat) `add_recurring_credits` edit rather than baked into a
-  // package — e.g. the Partner Demo shared monthly pool
-  // (dust-tt/decisions#937). Usable with any package/tier; recurs monthly,
-  // for the life of the contract (no end date). Unlike `initialCredits`,
-  // this is a pure credit grant with no invoice, so no Stripe customer is
-  // required.
-  recurringFreeCreditAwuPerMonth: z
-    .number()
-    .int("Recurring free credit must be an integer number of AWU credits")
-    .min(1, "Recurring free credit must be at least 1 credit")
-    .optional(),
-  // Optional per-seat-type settings for the new contract. `minSeats` is the
-  // billing floor persisted to `workspace_seat_limits`. `rate` is the per-seat
-  // rate in the currency's MAJOR units (dollars / euros), prefilled from the
-  // package override; the server converts it to Metronome's fiat unit (cents
-  // for USD, whole units for EUR) via `metronomeAmount`. When `commitmentPrice`
-  // is set (also in major units), a contract prepaid commit is created granting
-  // `minSeats * rate` of contract credit, invoiced at `commitmentPrice` —
-  // letting the customer prepay the seat commitment at a negotiated (lower)
-  // price. Unknown seat-type keys are ignored.
-  // Optional HubSpot deal ID. Stored on the subscription and forwarded to
-  // Metronome as a custom field so contracts can be joined back to HubSpot deals
-  // for ARR reporting.
-  hubspotDealId: z.string().optional(),
-  // Optional PO number, forwarded to Metronome as a contract-level custom
-  // field for finance reconciliation against the Stripe invoices Metronome
-  // generates for this contract.
-  purchaseOrderId: z.string().optional(),
-  // Optional: when set, memberships that would otherwise stay on `none` after
-  // the seat remap (e.g. legacy members with no explicit seat) are forced onto
-  // this seat type, provided the new contract bills it — preempting the
-  // committed-spare promotion (see `promoteNoneSeatTypesForContract`). Used by
-  // the legacy → Business migration to promote every member to a paid seat
-  // (`pro` for a monthly switch, `pro_yearly` for a yearly one).
-  promoteNoneSeatsTo: z
-    .custom<MembershipSeatType>(isMembershipSeatType)
-    .optional(),
-  // Optional: when set, marks the (future-dated) contract for the legacy →
-  // Business credit migration. At `contract.start`, the webhook converts the
-  // workspace's remaining convertible legacy credits to AWU ($1 = 100 AWU) and
-  // grants this many free AWU per workspace member — computed then, so the
-  // amounts reflect the workspace's state at migration time. Stamped as the
-  // `LEGACY_CREDIT_MIGRATION_CUSTOM_FIELD_KEY` custom field on the contract.
-  legacyMigrationFreeAwuCreditsPerUser: z.number().int().min(0).optional(),
-  seats: z
-    .array(
-      z.object({
-        seatType: z.string(),
-        // Whether the seat is entitled on the new contract. `true` (the default,
-        // for backward compatibility) entitles and configures the seat; `false`
-        // disables a seat the package would otherwise sell. The dialog submits
-        // every known seat so deselections can be turned into disable overrides.
-        selected: z.boolean().default(true),
-        minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
-        rate: z.number().min(0, "Rate must be ≥ 0"),
-        commitmentPrice: z
-          .number()
-          .min(0, "Commitment price must be ≥ 0")
-          .optional(),
-        paymentSchedule: paymentScheduleSchema,
-      })
-    )
-    .optional(),
-  // Credit usage configuration — written to credit_usage_configuration before
-  // provisioning so a failure aborts cleanly.
-  defaultDiscountPercent: z.number().int().min(0).max(100).default(0),
-  balanceThresholdCredits: z.number().int().min(0).optional(),
-  defaultPoolCapCredits: z.number().int().min(0).optional(),
-  programmaticMonthlyCapCredits: z.number().int().min(0).optional(),
-  autoSeatUpgradeEnabled: z.boolean().default(false),
-  topUpEnabled: z.boolean().default(false),
-  autoInvoiceFinalizationEnabled: z.boolean().default(true),
-});
-
-export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;
+export type { SwitchContractBody };
+export { SwitchContractBodySchema };
 
 export type SwitchContractErrorKind =
   // Bad input or precondition not met — handler should return 400.
@@ -408,13 +285,10 @@ async function checkEligibility(
 }
 
 async function resolveStripeCustomer(
-  stripeCustomerId: string | undefined
+  stripeCustomerId: string
 ): Promise<
-  Result<{ resolvedCurrency: SupportedCurrency | null }, SwitchContractError>
+  Result<{ resolvedCurrency: SupportedCurrency }, SwitchContractError>
 > {
-  if (!stripeCustomerId) {
-    return new Ok({ resolvedCurrency: null });
-  }
   const stripeCustomer = await getStripeCustomer(stripeCustomerId);
   if (!stripeCustomer) {
     return new Err(
@@ -435,7 +309,7 @@ async function resolveMetronomeCustomer({
   stripeCollectionMethod,
 }: {
   ownerLight: LightWorkspaceType;
-  stripeCustomerId: string | undefined;
+  stripeCustomerId: string;
   stripeCollectionMethod: "charge_automatically" | "send_invoice";
 }): Promise<Result<{ metronomeCustomerId: string }, SwitchContractError>> {
   const result = await ensureMetronomeCustomerForWorkspace({
@@ -456,7 +330,7 @@ async function resolveMetronomeCustomer({
 
 async function resolveAndValidatePackage(
   body: SwitchContractBody,
-  resolvedCurrency: SupportedCurrency | null
+  resolvedCurrency: SupportedCurrency
 ): Promise<
   Result<
     {
@@ -487,11 +361,7 @@ async function resolveAndValidatePackage(
       )
     );
   }
-  if (
-    pkg.tier !== "free" &&
-    resolvedCurrency &&
-    pkg.currency !== resolvedCurrency
-  ) {
+  if (pkg.tier !== "free" && pkg.currency !== resolvedCurrency) {
     return new Err(
       new SwitchContractError(
         "invalid_request",
@@ -513,42 +383,23 @@ async function resolveAndValidatePackage(
       )
     );
   }
-  if (body.initialCredits && !resolvedCurrency) {
-    return new Err(
-      new SwitchContractError(
-        "invalid_request",
-        "Initial credits require a Stripe customer to invoice — provide a stripeCustomerId."
-      )
-    );
-  }
-  const hasSeatCommitment = (body.seats ?? []).some(
-    (s) => s.commitmentPrice !== undefined && s.minSeats > 0 && s.rate > 0
-  );
-  if (hasSeatCommitment && !resolvedCurrency) {
-    return new Err(
-      new SwitchContractError(
-        "invalid_request",
-        "Seat commitments require a Stripe customer to invoice — provide a stripeCustomerId."
-      )
-    );
-  }
   const pkgSeatByType = new Map(pkg.seats.map((s) => [s.seatType, s]));
-  for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) {
+  for (const [seatType, seat] of Object.entries(body.seats)) {
+    if (!isMembershipSeatType(seatType)) {
       continue;
     }
-    const pkgSeat = pkgSeatByType.get(seat.seatType);
+    const pkgSeat = pkgSeatByType.get(seatType);
     if (
       seat.selected &&
       pkgSeat &&
       !pkgSeat.entitled &&
-      seat.seatType !== "free" &&
+      seatType !== "free" &&
       seat.rate <= 0
     ) {
       return new Err(
         new SwitchContractError(
           "invalid_request",
-          `Seat "${seat.seatType}" is not entitled by the selected package and ` +
+          `Seat "${seatType}" is not entitled by the selected package and ` +
             "requires a rate greater than 0 to entitle it."
         )
       );
@@ -590,6 +441,24 @@ function resolveSwapTiming(
   });
 }
 
+function resolveContractEndDate(
+  endingAt: string | undefined
+): Result<Date | undefined, SwitchContractError> {
+  if (!endingAt) {
+    return new Ok(undefined);
+  }
+  const requestedEndMs = Date.parse(endingAt);
+  if (Number.isNaN(requestedEndMs)) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        "endingAt is not a valid ISO timestamp."
+      )
+    );
+  }
+  return new Ok(new Date(requestedEndMs));
+}
+
 // Persist the per-seat-type billing floors BEFORE provisioning. The
 // provisioning sync clamps each seat's quantity up to its configured
 // `minSeats`, so the floor must already be in `workspace_seat_limits` when
@@ -598,28 +467,28 @@ async function persistSeatFloors(
   workspace: LightWorkspaceType,
   body: SwitchContractBody
 ): Promise<Result<void, SwitchContractError>> {
-  for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) {
+  for (const [seatType, seat] of Object.entries(body.seats)) {
+    if (!isMembershipSeatType(seatType)) {
       continue;
     }
     if (seat.selected && seat.minSeats > 0) {
       const result = await WorkspaceSeatLimitResource.upsert({
         workspace,
-        seatType: seat.seatType,
+        seatType,
         minSeats: seat.minSeats,
       });
       if (result.isErr()) {
         return new Err(
           new SwitchContractError(
             "metronome_api_error",
-            `Failed to persist seat floor for "${seat.seatType}": ${result.error.message}`
+            `Failed to persist seat floor for "${seatType}": ${result.error.message}`
           )
         );
       }
     } else {
       await WorkspaceSeatLimitResource.remove({
         workspace,
-        seatType: seat.seatType,
+        seatType,
       });
     }
   }
@@ -727,11 +596,12 @@ type PostProvisionCtx = {
   metronomeCustomerId: string;
   metronomeContractId: string;
   alignedStart: Date;
+  endingAtDate: Date | undefined;
   ownerLight: LightWorkspaceType;
   workspaceModelId: number;
   workspaceId: string;
   swapAt: "current-hour" | "next-hour";
-  resolvedCurrency: SupportedCurrency | null;
+  resolvedCurrency: SupportedCurrency;
   stripeSubscriptionId: string | null;
   pkg: MetronomePackageSummary;
   pkgSeatByType: Map<string, PackageSeatConfig>;
@@ -757,6 +627,9 @@ async function stepContractEdits({
   const addRecurringCredits: NonNullable<
     ContractEditParams["add_recurring_credits"]
   > = [];
+  const addScheduledCharges: NonNullable<
+    ContractEditParams["add_scheduled_charges"]
+  > = [];
 
   // Optional recurring free AWU credit pool, granted directly on this
   // contract (not baked into the package) — e.g. the Partner Demo shared
@@ -764,12 +637,12 @@ async function stepContractEdits({
   // misclassified as a legacy free credit by `isMetronomeFreeCredit` since
   // that additionally requires priority 1 and the programmatic-USD credit
   // type.
-  if (body.recurringFreeCreditAwuPerMonth) {
+  if (body.recurringFreeCredit) {
     addRecurringCredits.push({
       product_id: getProductFreeCreditId(),
       access_amount: {
         credit_type_id: getCreditTypeAwuId(),
-        unit_price: body.recurringFreeCreditAwuPerMonth,
+        unit_price: body.recurringFreeCredit,
         quantity: 1,
       },
       commit_duration: { value: 1, unit: "PERIODS" },
@@ -777,12 +650,12 @@ async function stepContractEdits({
       starting_at: floorToHourISO(alignedStart),
       applicable_product_tags: ["usage"],
       recurrence_frequency: "MONTHLY",
-      name: `Recurring free credit: ${body.recurringFreeCreditAwuPerMonth.toLocaleString()} AWU/month`,
+      name: `Recurring free credit: ${body.recurringFreeCredit.toLocaleString()} AWU/month`,
     });
   }
 
   // Initial credits prepaid commit.
-  if (body.initialCredits && resolvedCurrency) {
+  if (body.initialCredits) {
     const invoiceAmountCents = Math.round(
       body.initialCredits.invoiceAmount * 100
     );
@@ -825,25 +698,52 @@ async function stepContractEdits({
     });
   }
 
+  // Scheduled/one-off charge — a pure invoice line item, no credit grant.
+  if (body.scheduledCharge) {
+    const chargeAmountCents = Math.round(
+      body.scheduledCharge.invoiceAmount * 100
+    );
+    const scheduleItems = buildInvoiceScheduleItems({
+      invoiceAmountCents: chargeAmountCents,
+      resolvedCurrency,
+      alignedStart,
+      paymentSchedule: body.scheduledCharge.paymentSchedule,
+    });
+    addScheduledCharges.push({
+      product_id: getProductPlatformFeeId(),
+      name:
+        body.scheduledCharge.name ??
+        `Platform fee: ${body.scheduledCharge.invoiceAmount.toLocaleString()} ${resolvedCurrency.toUpperCase()}`,
+      schedule: {
+        credit_type_id: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+        schedule_items: scheduleItems.map((item) => ({
+          unit_price: item.unitPrice,
+          quantity: item.quantity,
+          timestamp: floorToHourISO(item.timestamp),
+        })),
+      },
+    });
+  }
+
   // Seat commitment commits and rate overrides.
-  for (const seat of body.seats ?? []) {
-    if (!isMembershipSeatType(seat.seatType)) {
+  for (const [seatType, seat] of Object.entries(body.seats)) {
+    if (!isMembershipSeatType(seatType)) {
       continue;
     }
-    const pkgSeat = pkgSeatByType.get(seat.seatType);
-    const billingFrequency = seat.seatType.endsWith("_yearly")
+    const pkgSeat = pkgSeatByType.get(seatType);
+    const billingFrequency = seatType.endsWith("_yearly")
       ? "ANNUAL"
       : "MONTHLY";
-    const rateNative = resolvedCurrency
-      ? metronomeAmount(Math.round(seat.rate * 100), resolvedCurrency)
-      : seat.rate;
+    const rateNative = metronomeAmount(
+      Math.round(seat.rate * 100),
+      resolvedCurrency
+    );
 
     if (
       seat.selected &&
       seat.commitmentPrice !== undefined &&
       seat.minSeats > 0 &&
       seat.rate > 0 &&
-      resolvedCurrency &&
       pkgSeat
     ) {
       const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency];
@@ -894,7 +794,7 @@ async function stepContractEdits({
       pkgSeat.entitled &&
       rateNative !== pkgSeat.defaultRate;
     const needsDisable = !seat.selected && pkgSeat != null && pkgSeat.entitled;
-    if (resolvedCurrency && pkgSeat && (needsEntitle || rateChanged)) {
+    if (pkgSeat && (needsEntitle || rateChanged)) {
       addOverrides.push({
         starting_at: alignedStart.toISOString(),
         type: "OVERWRITE",
@@ -911,7 +811,7 @@ async function stepContractEdits({
           credit_type_id: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
         },
       });
-    } else if (resolvedCurrency && pkgSeat && needsDisable) {
+    } else if (pkgSeat && needsDisable) {
       addOverrides.push({
         starting_at: alignedStart.toISOString(),
         type: "OVERWRITE",
@@ -936,7 +836,8 @@ async function stepContractEdits({
     netPaymentTermsDays === undefined &&
     addCommits.length === 0 &&
     addOverrides.length === 0 &&
-    addRecurringCredits.length === 0
+    addRecurringCredits.length === 0 &&
+    addScheduledCharges.length === 0
   ) {
     return null;
   }
@@ -951,6 +852,9 @@ async function stepContractEdits({
     ...(addOverrides.length > 0 ? { add_overrides: addOverrides } : {}),
     ...(addRecurringCredits.length > 0
       ? { add_recurring_credits: addRecurringCredits }
+      : {}),
+    ...(addScheduledCharges.length > 0
+      ? { add_scheduled_charges: addScheduledCharges }
       : {}),
   });
   if (result.isErr()) {
@@ -1076,6 +980,28 @@ async function stepSeatSync({
   return null;
 }
 
+// Optional fixed contract end date (exclusive) — e.g. a term-limited pilot or
+// negotiated agreement. Applied via a dedicated Metronome call
+// (`v1.contracts.updateEndDate`) since it isn't part of `v2.contracts.edit`.
+async function stepScheduleContractEnd({
+  metronomeCustomerId,
+  metronomeContractId,
+  endingAtDate,
+}: PostProvisionCtx): Promise<string | null> {
+  if (!endingAtDate) {
+    return null;
+  }
+  const result = await scheduleMetronomeContractEnd({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    endingBefore: endingAtDate,
+  });
+  if (result.isErr()) {
+    return `contract_end_date: ${result.error.message}`;
+  }
+  return null;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -1093,6 +1019,7 @@ async function stepSeatSync({
  * Post-provision (best-effort — failures collected as warnings):
  *   - Net payment terms, initial credits, pending subscription
  *   - Stripe cancellation schedule, seat configuration, seat remap/sync
+ *   - Contract end date
  *
  * Best-effort fire-and-forget (failure logged, never surfaces):
  *   - PAYG state dispatcher
@@ -1146,6 +1073,12 @@ export async function switchContract({
   }
   const { startingAtDate, swapAt } = timingResult.value;
 
+  const endDateResult = resolveContractEndDate(body.endingAt);
+  if (endDateResult.isErr()) {
+    return new Err(endDateResult.error);
+  }
+  const endingAtDate = endDateResult.value;
+
   const workosResult = await ensureWorkOSOrg(ownerLight, pkg.tier);
   if (workosResult.isErr()) {
     return new Err(workosResult.error);
@@ -1169,6 +1102,11 @@ export async function switchContract({
   if (cancelResult.isErr()) {
     return new Err(cancelResult.error);
   }
+
+  logger.info(
+    { workspaceId: owner.sId, body },
+    "[switch_contract] Provisioning contract with parameters"
+  );
 
   // ─── Provision ────────────────────────────────────────────────────────────
   // Disable the internal seat sync — switchContract always runs its own
@@ -1195,7 +1133,7 @@ export async function switchContract({
     packageAlias,
     startingAt: startingAtDate,
     swapAt,
-    enableStripeBilling: body.stripeCustomerId !== undefined,
+    enableStripeBilling: true,
     planCode: body.planCode,
     fromContractId: currentSubscription?.metronomeContractId ?? undefined,
     enableSeatSync: false,
@@ -1226,6 +1164,7 @@ export async function switchContract({
     metronomeCustomerId,
     metronomeContractId,
     alignedStart,
+    endingAtDate,
     ownerLight,
     workspaceModelId: owner.id,
     workspaceId: owner.sId,
@@ -1250,6 +1189,7 @@ export async function switchContract({
   warn(await stepSeatSync(ctx));
   warn(await stepPendingSubscription(ctx));
   warn(await stepStripeCancellation(ctx));
+  warn(await stepScheduleContractEnd(ctx));
 
   if (warnings.length > 0) {
     return new Err(

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -27,6 +27,7 @@ const DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
   "92f3466b-2423-4f2a-a8d1-0f6e9f7f0140";
 const DEV_PRODUCT_SEAT_SUBSCRIPTION_COMMIT =
   "475eb7dd-5043-49bc-96eb-1b08f94fda51";
+const DEV_PRODUCT_PLATFORM_FEE = "11e635e1-0fb9-44e1-9499-690d5ee27ace";
 
 // --- PROD (production) — TODO: update after running setup script in production ---
 
@@ -52,6 +53,7 @@ const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
   "03faa744-c1ab-4b94-aaf1-5fdaec89e11a";
 const PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT =
   "5cdb49e6-0a92-4a55-9c92-c8913b2df0d5";
+const PROD_PRODUCT_PLATFORM_FEE = "704ea5b4-6680-4618-a154-b2343d78a1e2";
 
 // --- Credit type IDs (stable across envs unless noted) ---
 
@@ -287,6 +289,8 @@ export const getProductExcessCreditsId = () =>
   devOrProd(DEV_PRODUCT_EXCESS_CREDITS, PROD_PRODUCT_EXCESS_CREDITS);
 export const getProductPrepaidCommitId = () =>
   devOrProd(DEV_PRODUCT_PREPAID_COMMIT, PROD_PRODUCT_PREPAID_COMMIT);
+export const getProductPlatformFeeId = () =>
+  devOrProd(DEV_PRODUCT_PLATFORM_FEE, PROD_PRODUCT_PLATFORM_FEE);
 export const getProductSeatSubscriptionCreditsId = () =>
   devOrProd(
     DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS,

--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -390,6 +390,14 @@ export const PRODUCTS: ProductDef[] = [
     name: "Seat Subscription Commit",
     type: "FIXED",
   },
+  // FIXED product for arbitrary scheduled/one-off invoice charges (e.g.
+  // professional services, setup fees) added via `add_scheduled_charges`.
+  // Unlike the credit products above, this grants no contract credit — it's
+  // a pure invoice line item.
+  {
+    name: "Platform Fee",
+    type: "FIXED",
+  },
 ];
 
 // Factory for a single seat subscription. All share the same ADVANCE collection

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -1,0 +1,166 @@
+import {
+  isMembershipSeatType,
+  type MembershipSeatType,
+} from "@app/types/memberships";
+import { z } from "zod";
+
+// Shared between the switch-contract poke plugin (server-side validation in
+// `lib/api/poke/switch_contract.ts`) and the SwitchContractDialog SPA form —
+// keeps validation rules for the pieces reused verbatim by both from
+// drifting apart across the client/server boundary.
+export const paymentScheduleSchema = z
+  .object({
+    frequency: z
+      .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
+      .default("one_time"),
+    periods: z.number().int().min(2).max(60).optional(),
+  })
+  .refine(
+    (s) => s.frequency === "one_time" || s.periods !== undefined,
+    "periods is required when frequency is not one_time"
+  )
+  .default({ frequency: "one_time" });
+
+// A pure invoice line item with no associated credit grant (e.g. a
+// professional-services or setup fee), applied via Metronome's
+// `add_scheduled_charges` contract edit rather than a commit.
+// `invoiceAmount` is in the customer's billing currency major units
+// (e.g. dollars / euros).
+export const scheduledChargeSchema = z.object({
+  name: z.string().min(1).optional(),
+  invoiceAmount: z.number().min(0, "Amount must be zero or more"),
+  paymentSchedule: paymentScheduleSchema,
+});
+
+// One-off initial AWU credits granted alongside a contract switch as a
+// contract-level prepaid commit. `invoiceAmount` is in the customer's
+// billing currency major units (e.g. dollars / euros).
+export const initialCreditsSchema = z.object({
+  amountCredits: z
+    .number()
+    .int("Initial credits must be an integer number of credits")
+    .min(1, "Initial credits must be at least 1 credit"),
+  invoiceAmount: z.number().min(0, "Invoice amount must be zero or more"),
+  paymentSchedule: paymentScheduleSchema,
+});
+
+// Bare leaf validator for the recurring free AWU credit grant (AWU credits
+// per month) — the body schema keeps this as a top-level number (no
+// wrapping object, since it has no other fields), while the dialog wraps it
+// in its own toggle-on/off union.
+export const recurringFreeCreditSchema = z
+  .number()
+  .int("Recurring free credit must be an integer number of AWU credits")
+  .min(1, "Recurring free credit must be at least 1 credit");
+
+// Per-seat-type settings for a contract switch, keyed by seat type (see
+// `SwitchContractBodySchema.seats`). `minSeats` is the billing floor
+// persisted to `workspace_seat_limits`. `rate` is the per-seat rate in the
+// currency's MAJOR units (dollars / euros); the server converts it to
+// Metronome's fiat unit via `metronomeAmount`. When `commitmentPrice` is set
+// (also in major units), a contract prepaid commit is created granting
+// `minSeats * rate` of contract credit, invoiced at `commitmentPrice`.
+export const seatEntrySchema = z.object({
+  // Whether the seat is entitled on the new contract. `true` (the default,
+  // for backward compatibility) entitles and configures the seat; `false`
+  // disables a seat the package would otherwise sell. The dialog submits
+  // every known seat so deselections can be turned into disable overrides.
+  selected: z.boolean().default(true),
+  minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
+  rate: z.number().min(0, "Rate must be ≥ 0"),
+  commitmentPrice: z.number().min(0, "Commitment price must be ≥ 0").optional(),
+  paymentSchedule: paymentScheduleSchema,
+});
+
+export const SwitchContractBodySchema = z.object({
+  planCode: z.string().min(1, "Required"),
+  metronomePackageId: z.string().min(1, "Required"),
+  // ISO timestamp. Used only for enterprise-tier switches; any moment is
+  // accepted (including the past — backdating is allowed), and it is ceiled to
+  // the next hour boundary. Omitted for Pro/Business/Free, which swap at the
+  // current hour.
+  startingAt: z.string().optional(),
+  // Optional ISO timestamp (exclusive) at which the new contract ends. Applied
+  // as a separate `v1.contracts.updateEndDate` call after provisioning.
+  // Omitted leaves the contract open-ended.
+  endingAt: z.string().optional(),
+  // Optional. Net payment terms in days (e.g. 30 for "Net 30"): how many days
+  // after invoice issuance the invoice is due. Applied to the Metronome
+  // contract and only meaningful with `send_invoice`; ignored when the card on
+  // file is auto-charged. Omitted leaves Metronome's account default in place.
+  netPaymentTermsDays: z
+    .number()
+    .int("Net payment terms must be a whole number of days")
+    .min(0, "Net payment terms must be ≥ 0")
+    .max(365, "Net payment terms must be ≤ 365")
+    .optional(),
+  // Every contract switch must be wired to a Stripe customer.
+  stripeCustomerId: z.string().min(1, "Required"),
+  // How Metronome collects Stripe invoices for this customer. Only takes
+  // effect when a Stripe customer is wired in. `charge_automatically` charges
+  // the card on file; `send_invoice` emails the invoice for manual payment.
+  stripeCollectionMethod: z
+    .enum(["charge_automatically", "send_invoice"])
+    .default("charge_automatically"),
+  paygEnabled: z.boolean().default(false),
+  // AWU credits — written directly to `credit_usage_configuration.usageCapCredits`.
+  usageCapCredits: z
+    .number()
+    .int("Usage cap must be an integer number of credits")
+    .min(1, "Usage cap must be at least 1 credit")
+    .optional(),
+  // Optional one-off initial AWU credits granted alongside the switch as a
+  // contract-level prepaid commit (priority 300, same as purchased commits),
+  // invoiced against `stripeCustomerId`. See `initialCreditsSchema`.
+  initialCredits: initialCreditsSchema.optional(),
+  // Optional scheduled/one-off charge, invoiced against `stripeCustomerId`.
+  // See `scheduledChargeSchema`.
+  scheduledCharge: scheduledChargeSchema.optional(),
+  // Optional recurring free AWU credit grant, applied as a contract-level
+  // (non-seat) `add_recurring_credits` edit rather than baked into a
+  // package — e.g. the Partner Demo shared monthly pool
+  // (dust-tt/decisions#937). Usable with any package/tier; recurs monthly,
+  // for the life of the contract (no end date). Unlike `initialCredits`,
+  // this is a pure credit grant with no invoice, so no Stripe customer is
+  // required.
+  recurringFreeCredit: recurringFreeCreditSchema.optional(),
+  // Optional HubSpot deal ID. Stored on the subscription and forwarded to
+  // Metronome as a custom field so contracts can be joined back to HubSpot deals
+  // for ARR reporting.
+  hubspotDealId: z.string().optional(),
+  // Optional PO number, forwarded to Metronome as a contract-level custom
+  // field for finance reconciliation against the Stripe invoices Metronome
+  // generates for this contract.
+  purchaseOrderId: z.string().optional(),
+  // Optional: when set, memberships that would otherwise stay on `none` after
+  // the seat remap (e.g. legacy members with no explicit seat) are forced onto
+  // this seat type, provided the new contract bills it — preempting the
+  // committed-spare promotion (see `promoteNoneSeatTypesForContract`). Used by
+  // the legacy → Business migration to promote every member to a paid seat
+  // (`pro` for a monthly switch, `pro_yearly` for a yearly one).
+  promoteNoneSeatsTo: z
+    .custom<MembershipSeatType>(isMembershipSeatType)
+    .optional(),
+  // Optional: when set, marks the (future-dated) contract for the legacy →
+  // Business credit migration. At `contract.start`, the webhook converts the
+  // workspace's remaining convertible legacy credits to AWU ($1 = 100 AWU) and
+  // grants this many free AWU per workspace member — computed then, so the
+  // amounts reflect the workspace's state at migration time. Stamped as the
+  // `LEGACY_CREDIT_MIGRATION_CUSTOM_FIELD_KEY` custom field on the contract.
+  legacyMigrationFreeAwuCreditsPerUser: z.number().int().min(0).optional(),
+  // Per-seat-type settings for the new contract, keyed by seat type. See
+  // `seatEntrySchema` for field semantics. Unknown seat-type keys are
+  // ignored.
+  seats: z.record(z.string(), seatEntrySchema).default({}),
+  // Credit usage configuration — written to credit_usage_configuration before
+  // provisioning so a failure aborts cleanly.
+  defaultDiscountPercent: z.number().int().min(0).max(100).default(0),
+  balanceThresholdCredits: z.number().int().min(0).optional(),
+  defaultPoolCapCredits: z.number().int().min(0).optional(),
+  programmaticMonthlyCapCredits: z.number().int().min(0).optional(),
+  autoSeatUpgradeEnabled: z.boolean().default(false),
+  topUpEnabled: z.boolean().default(false),
+  autoInvoiceFinalizationEnabled: z.boolean().default(true),
+});
+
+export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;


### PR DESCRIPTION
## Description

Extends the poke "Switch contract" dialog (`SwitchContractDialog`) with several operator-requested capabilities, and consolidates the request schema between the dialog and the server.

- **Optional contract end date.** Adds an "Ends at (UTC)" field alongside the existing start date, with the same hour-snapping and local-time label. Sent as `endingAt` and applied post-provision via a dedicated `v1.contracts.updateEndDate` call (`scheduleMetronomeContractEnd`) — left blank, the contract stays open-ended. 
<img width="501" height="198" alt="Screenshot 2026-07-13 at 12 12 42" src="https://github.com/user-attachments/assets/4cc8706e-5db4-4175-bbe5-61c1f8f6f9fc" />

- **Scheduled charge ("Platform Fee").** New toggle section lets an operator add a pure invoice-only charge (no credit grant) with the same payment-schedule shape as commits: one-time or monthly/quarterly/semi-annually/annually with a number of periods, plus an arbitrary amount and optional display name. Applied via Metronome's `add_scheduled_charges` contract edit against a new "Platform Fee" FIXED product.
<img width="635" height="416" alt="Screenshot 2026-07-13 at 12 12 36" src="https://github.com/user-attachments/assets/6f93923e-4346-4d60-b282-e0e43d902334" />
- **Stripe customer is now mandatory for every switch** (was optional, for a "free tier, no Stripe link" path that's no longer used — there is no free tier package anymore, and the dialog's own submit button already required a resolved currency in practice). `resolvedCurrency` is now non-nullable throughout `switch_contract.ts`, removing a number of now-unreachable "requires a Stripe customer" checks.
- **The dialog now shows nothing beyond the Stripe Customer ID field** (plus its resolution status) until that customer resolves to a valid billing currency — no package, seat, or credit configuration is rendered for an unresolved/invalid customer.
- **Schema consolidation.** Moved the request schema into an isomorphic module (`types/poke/switch_contract.ts`, no server-only imports) shared by both the server (`lib/api/poke/switch_contract.ts`) and the dialog. The dialog's form schema is now built directly on top of the server's `SwitchContractBodySchema` via `.omit()`/`.extend()` instead of hand-duplicating ~20 fields; only the few fields whose *editing* state genuinely differs from the wire payload are overridden. `seats` is now `Record<seatType, ...>` end-to-end (was an array server-side) since there's a single first-party caller. "Force seat type" now reuses `promoteNoneSeatsTo` directly (a `SliderToggle` + `undefined` represents "no override") instead of a separate sentinel-string field.
- **Logging.** Logs the full request body (with `workspaceId`) right before provisioning the contract, to make it easier to debug switch-contract issues from Datadog/logs alone.

## Tests

- `npx tsgo --noEmit` clean on `front` and `front-api`.
- Existing `front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts` (19 tests) pass unchanged.
- Manually exercised the dialog locally (package/tier selection, end date, scheduled charge toggle, seats).

## Risk

Medium — `stripeCustomerId` becoming mandatory and `seats` becoming a record are breaking changes to this private endpoint. Low practical impact: this poke endpoint has a single first-party caller (this dialog), which already required a Stripe customer via its own submit-button gating, and no script constructs a `seats` array literal. The "Platform Fee" Metronome product was provisioned in both sandbox and production via `scripts/metronome_setup.ts` before merge.

## Deploy Plan

Standard deploy. No migration or feature flag required.
