### PR TITLE
Add cost breakdown in poke

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,5 +1,7 @@
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import type { AgentMessageCreditsToolBreakdown } from "@app/lib/api/assistant/credit_cost";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { formatCredits, formatMicroUsdCompact } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeConversation } from "@app/poke/swr";
@@ -318,12 +320,14 @@ function getActionStatus(
 
 interface ToolActionViewProps {
   action: PokeAgentMessageType["actions"][number];
+  cost?: AgentMessageCreditsToolBreakdown;
   isExpanded: boolean;
   onToggle: () => void;
 }
 
 function ToolActionContent({
   action,
+  cost,
   isExpanded,
   onToggle,
 }: ToolActionViewProps) {
@@ -387,6 +391,15 @@ function ToolActionContent({
             size="xs"
           />
         )}
+        {cost && (
+          <span title={`${cost.toolCostCategory} tool cost category`}>
+            <Chip
+              color="primary"
+              label={cost.free ? "free" : `${cost.awu} AWU`}
+              size="xs"
+            />
+          </span>
+        )}
       </span>
       <span className="w-16 shrink-0 text-right font-mono text-sm tabular-nums text-muted-foreground">
         {duration}
@@ -408,7 +421,12 @@ function ToolActionContent({
   );
 }
 
-function ToolActionView({ action, isExpanded, onToggle }: ToolActionViewProps) {
+function ToolActionView({
+  action,
+  cost,
+  isExpanded,
+  onToggle,
+}: ToolActionViewProps) {
   return (
     <div>
       <div
@@ -421,6 +439,7 @@ function ToolActionView({ action, isExpanded, onToggle }: ToolActionViewProps) {
       >
         <ToolActionContent
           action={action}
+          cost={cost}
           isExpanded={isExpanded}
           onToggle={onToggle}
         />
@@ -438,6 +457,115 @@ function ToolActionView({ action, isExpanded, onToggle }: ToolActionViewProps) {
               2
             )}
           </CodeBlock>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CostBreakdownViewProps {
+  message: PokeAgentMessageType;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+function CostBreakdownView({
+  message,
+  isExpanded,
+  onToggle,
+}: CostBreakdownViewProps) {
+  const breakdown = message.costBreakdown;
+  if (!breakdown) {
+    return null;
+  }
+
+  const stored = message.costCredits;
+  const mismatch = stored != null && stored !== breakdown.totalAwu;
+  const hasDetails = breakdown.byModel.length > 0;
+
+  return (
+    <div className="mt-2 rounded-md border border-separator bg-muted-background px-2 py-1.5">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        {hasDetails && (
+          <Button
+            variant="outline"
+            size="icon"
+            icon={
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  !isExpanded ? "-rotate-90" : null
+                )}
+              />
+            }
+            onClick={onToggle}
+            aria-expanded={isExpanded}
+            aria-label={
+              isExpanded ? "Collapse cost breakdown" : "Expand cost breakdown"
+            }
+          />
+        )}
+        <span className="shrink-0 text-sm font-medium text-foreground">
+          Cost
+        </span>
+        <MetadataItem label="stored" mono>
+          {stored != null ? `${formatCredits(stored)} AWU` : "—"}
+        </MetadataItem>
+        <MetadataItem label="recalculated" mono>
+          {`${formatCredits(breakdown.totalAwu)} AWU`}
+        </MetadataItem>
+        <MetadataItem label="llm / tools" mono>
+          {`${formatCredits(breakdown.llmAwu)} / ${formatCredits(breakdown.toolAwu)}`}
+        </MetadataItem>
+        {message.subAgentCostCredits != null &&
+          message.subAgentCostCredits > 0 && (
+            <MetadataItem label="sub-agents" mono>
+              {`${formatCredits(message.subAgentCostCredits)} AWU`}
+            </MetadataItem>
+          )}
+        {mismatch && <Chip color="warning" label="mismatch" size="xs" />}
+      </div>
+      {isExpanded && hasDetails && (
+        <div className="mt-2 overflow-hidden overflow-x-auto rounded-md border border-separator bg-background">
+          <table className="w-full text-left text-sm">
+            <thead className="text-muted-foreground">
+              <tr>
+                <th className="px-2 py-1 font-medium">Model</th>
+                <th className="px-2 py-1 text-right font-medium">Prompt</th>
+                <th className="px-2 py-1 text-right font-medium">Completion</th>
+                <th className="px-2 py-1 text-right font-medium">Cached</th>
+                <th className="px-2 py-1 text-right font-medium">$ cost</th>
+                <th className="px-2 py-1 text-right font-medium">AWU</th>
+              </tr>
+            </thead>
+            <tbody>
+              {breakdown.byModel.map((m) => (
+                <tr
+                  key={`${m.providerId}-${m.modelId}`}
+                  className="border-t border-separator"
+                >
+                  <td className="px-2 py-1 font-mono">
+                    {m.providerId}/{m.modelId}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {m.promptTokens}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {m.completionTokens}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {m.cachedTokens}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {formatMicroUsdCompact(m.costMicroUsd)}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono tabular-nums">
+                    {m.awu}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
     </div>
@@ -591,6 +719,7 @@ const AgentMessageView = ({
     expandedProviderPassthroughEntries,
     setExpandedProviderPassthroughEntries,
   ] = useState<Set<string>>(new Set());
+  const [isCostExpanded, setIsCostExpanded] = useState(false);
 
   const toggleAction = (actionId: string) => {
     setExpandedActions((prev) => {
@@ -617,6 +746,10 @@ const AgentMessageView = ({
 
   const providerPassthroughEntries = getProviderPassthroughEntries(
     message.contents
+  );
+
+  const costByActionId = new Map<string, AgentMessageCreditsToolBreakdown>(
+    message.costBreakdown?.byTool.map((t) => [t.actionId, t]) ?? []
   );
 
   return (
@@ -691,6 +824,11 @@ const AgentMessageView = ({
             )}
           </div>
         </div>
+        <CostBreakdownView
+          message={message}
+          isExpanded={isCostExpanded}
+          onToggle={() => setIsCostExpanded((prev) => !prev)}
+        />
         {providerPassthroughEntries.map((entry) => (
           <ProviderPassthroughView
             key={entry.key}
@@ -705,6 +843,7 @@ const AgentMessageView = ({
             <ToolActionView
               key={a.sId}
               action={a}
+              cost={costByActionId.get(a.sId)}
               isExpanded={isExpanded}
               onToggle={() => toggleAction(a.sId)}
             />

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,7 +1,7 @@
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import type { AgentMessageCreditsToolBreakdown } from "@app/lib/api/assistant/credit_cost";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { formatCredits, formatMicroUsdCompact } from "@app/lib/client/credits";
+import { formatCredits } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeConversation } from "@app/poke/swr";
@@ -465,15 +465,9 @@ function ToolActionView({
 
 interface CostBreakdownViewProps {
   message: PokeAgentMessageType;
-  isExpanded: boolean;
-  onToggle: () => void;
 }
 
-function CostBreakdownView({
-  message,
-  isExpanded,
-  onToggle,
-}: CostBreakdownViewProps) {
+function CostBreakdownView({ message }: CostBreakdownViewProps) {
   const breakdown = message.costBreakdown;
   if (!breakdown) {
     return null;
@@ -481,37 +475,17 @@ function CostBreakdownView({
 
   const stored = message.costCredits;
   const mismatch = stored != null && stored !== breakdown.totalAwu;
-  const hasDetails = breakdown.byModel.length > 0;
 
   return (
     <div className="mt-2 rounded-md border border-separator bg-muted-background px-2 py-1.5">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        {hasDetails && (
-          <Button
-            variant="outline"
-            size="icon"
-            icon={
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  !isExpanded ? "-rotate-90" : null
-                )}
-              />
-            }
-            onClick={onToggle}
-            aria-expanded={isExpanded}
-            aria-label={
-              isExpanded ? "Collapse cost breakdown" : "Expand cost breakdown"
-            }
-          />
-        )}
         <span className="shrink-0 text-sm font-medium text-foreground">
           Cost
         </span>
         <MetadataItem label="stored" mono>
           {stored != null ? `${formatCredits(stored)} AWU` : "—"}
         </MetadataItem>
-        <MetadataItem label="recalculated" mono>
+        <MetadataItem label="analytics" mono>
           {`${formatCredits(breakdown.totalAwu)} AWU`}
         </MetadataItem>
         <MetadataItem label="llm / tools" mono>
@@ -525,49 +499,6 @@ function CostBreakdownView({
           )}
         {mismatch && <Chip color="warning" label="mismatch" size="xs" />}
       </div>
-      {isExpanded && hasDetails && (
-        <div className="mt-2 overflow-hidden overflow-x-auto rounded-md border border-separator bg-background">
-          <table className="w-full text-left text-sm">
-            <thead className="text-muted-foreground">
-              <tr>
-                <th className="px-2 py-1 font-medium">Model</th>
-                <th className="px-2 py-1 text-right font-medium">Prompt</th>
-                <th className="px-2 py-1 text-right font-medium">Completion</th>
-                <th className="px-2 py-1 text-right font-medium">Cached</th>
-                <th className="px-2 py-1 text-right font-medium">$ cost</th>
-                <th className="px-2 py-1 text-right font-medium">AWU</th>
-              </tr>
-            </thead>
-            <tbody>
-              {breakdown.byModel.map((m) => (
-                <tr
-                  key={`${m.providerId}-${m.modelId}`}
-                  className="border-t border-separator"
-                >
-                  <td className="px-2 py-1 font-mono">
-                    {m.providerId}/{m.modelId}
-                  </td>
-                  <td className="px-2 py-1 text-right font-mono tabular-nums">
-                    {m.promptTokens}
-                  </td>
-                  <td className="px-2 py-1 text-right font-mono tabular-nums">
-                    {m.completionTokens}
-                  </td>
-                  <td className="px-2 py-1 text-right font-mono tabular-nums">
-                    {m.cachedTokens}
-                  </td>
-                  <td className="px-2 py-1 text-right font-mono tabular-nums">
-                    {formatMicroUsdCompact(m.costMicroUsd)}
-                  </td>
-                  <td className="px-2 py-1 text-right font-mono tabular-nums">
-                    {m.awu}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
     </div>
   );
 }
@@ -719,7 +650,6 @@ const AgentMessageView = ({
     expandedProviderPassthroughEntries,
     setExpandedProviderPassthroughEntries,
   ] = useState<Set<string>>(new Set());
-  const [isCostExpanded, setIsCostExpanded] = useState(false);
 
   const toggleAction = (actionId: string) => {
     setExpandedActions((prev) => {
@@ -824,11 +754,7 @@ const AgentMessageView = ({
             )}
           </div>
         </div>
-        <CostBreakdownView
-          message={message}
-          isExpanded={isCostExpanded}
-          onToggle={() => setIsCostExpanded((prev) => !prev)}
-        />
+        <CostBreakdownView message={message} />
         {providerPassthroughEntries.map((entry) => (
           <ProviderPassthroughView
             key={entry.key}

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -3,10 +3,15 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import type { ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  awuFromMicroUsd,
   computeRunKey,
+  getToolBillingInfo,
   intelligenceAwuFromRunUsagesGroupedByRunKey,
+  isFreeOrigin,
+  toolAwuFromAction,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -22,11 +27,143 @@ import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   type UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 
 interface CreditActionMinimalInput {
   toolName: string;
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
+}
+
+export interface AgentMessageCreditsModelBreakdown {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  cacheCreationTokens: number;
+  costMicroUsd: number;
+  awu: number;
+}
+
+export interface AgentMessageCreditsToolBreakdown {
+  actionId: string;
+  toolName: string;
+  internalMCPServerName: InternalMCPServerNameType | null;
+  toolCostCategory: ToolCostCategory;
+  free: boolean;
+  awu: number;
+}
+
+export interface AgentMessageCreditsBreakdown {
+  llmAwu: number;
+  toolAwu: number;
+  totalAwu: number;
+  byModel: AgentMessageCreditsModelBreakdown[];
+  byTool: AgentMessageCreditsToolBreakdown[];
+}
+
+/**
+ * Same computation as `computeAgentMessageCredits`, but split by LLM vs. tool
+ * cost and by model / tool so it can be displayed (e.g. in poke) instead of
+ * only summed. `byModel[].awu` is computed by grouping per runKey first
+ * (matching `intelligenceAwuFromRunUsagesGroupedByRunKey`), so the sum of
+ * `byModel[].awu` always equals `llmAwu` exactly.
+ */
+export function computeAgentMessageCreditsBreakdown({
+  runUsages,
+  actions,
+  contextOrigin,
+}: {
+  runUsages: (RunUsageType & { runKey: string | null })[];
+  actions: (CreditActionMinimalInput & { actionId: string })[];
+  contextOrigin: UserMessageOrigin | null;
+}): AgentMessageCreditsBreakdown {
+  const finalActions = actions.filter((a) =>
+    isToolExecutionStatusFinal(a.status)
+  );
+
+  const modelUsageByKey = new Map<
+    string,
+    Omit<AgentMessageCreditsModelBreakdown, "awu">
+  >();
+  for (const usage of runUsages) {
+    const key = `${usage.providerId}|${usage.modelId}`;
+    const existing = modelUsageByKey.get(key) ?? {
+      providerId: usage.providerId,
+      modelId: usage.modelId,
+      promptTokens: 0,
+      completionTokens: 0,
+      cachedTokens: 0,
+      cacheCreationTokens: 0,
+      costMicroUsd: 0,
+    };
+    modelUsageByKey.set(key, {
+      ...existing,
+      promptTokens: existing.promptTokens + usage.promptTokens,
+      completionTokens: existing.completionTokens + usage.completionTokens,
+      cachedTokens: existing.cachedTokens + (usage.cachedTokens ?? 0),
+      cacheCreationTokens:
+        existing.cacheCreationTokens + (usage.cacheCreationTokens ?? 0),
+      costMicroUsd: existing.costMicroUsd + usage.costMicroUsd,
+    });
+  }
+
+  const modelAwuByKey = new Map<string, number>();
+  if (!isFreeOrigin(contextOrigin)) {
+    const byRunKey = new Map<string, RunUsageType[]>();
+    for (const usage of runUsages) {
+      const runKey = usage.runKey ?? "__legacy__";
+      const group = byRunKey.get(runKey) ?? [];
+      group.push(usage);
+      byRunKey.set(runKey, group);
+    }
+
+    for (const group of byRunKey.values()) {
+      const costByModel = new Map<string, number>();
+      for (const usage of group) {
+        const key = `${usage.providerId}|${usage.modelId}`;
+        costByModel.set(key, (costByModel.get(key) ?? 0) + usage.costMicroUsd);
+      }
+      for (const [key, costMicroUsd] of costByModel) {
+        modelAwuByKey.set(
+          key,
+          (modelAwuByKey.get(key) ?? 0) + awuFromMicroUsd(costMicroUsd)
+        );
+      }
+    }
+  }
+
+  const byModel = Array.from(modelUsageByKey.entries()).map(([key, usage]) => ({
+    ...usage,
+    awu: modelAwuByKey.get(key) ?? 0,
+  }));
+
+  const byTool = finalActions.map((action) => {
+    const { toolCostCategory, freeUsage } = getToolBillingInfo(
+      action.internalMCPServerName,
+      action.toolName
+    );
+    return {
+      actionId: action.actionId,
+      toolName: action.toolName,
+      internalMCPServerName: action.internalMCPServerName,
+      toolCostCategory,
+      free: freeUsage || isFreeOrigin(contextOrigin),
+      awu: toolAwuFromAction(action, contextOrigin),
+    };
+  });
+
+  const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
+    runUsages,
+    contextOrigin
+  );
+  const toolAwu = toolAwuFromActions(finalActions, contextOrigin);
+
+  return { llmAwu, toolAwu, totalAwu: llmAwu + toolAwu, byModel, byTool };
 }
 
 export function computeAgentMessageCredits({

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -3,15 +3,13 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  awuFromMicroUsd,
   computeRunKey,
   getToolBillingInfo,
   intelligenceAwuFromRunUsagesGroupedByRunKey,
-  isFreeOrigin,
-  toolAwuFromAction,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -23,30 +21,19 @@ import {
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
+import type {
+  AgentMessageAnalyticsData,
+  AgentMessageAnalyticsToolUsed,
+} from "@app/types/assistant/analytics";
 import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   type UserMessageOrigin,
 } from "@app/types/assistant/conversation";
-import type {
-  ModelIdType,
-  ModelProviderIdType,
-} from "@app/types/assistant/models/types";
 
 interface CreditActionMinimalInput {
   toolName: string;
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
-}
-
-export interface AgentMessageCreditsModelBreakdown {
-  providerId: ModelProviderIdType;
-  modelId: ModelIdType;
-  promptTokens: number;
-  completionTokens: number;
-  cachedTokens: number;
-  cacheCreationTokens: number;
-  costMicroUsd: number;
-  awu: number;
 }
 
 export interface AgentMessageCreditsToolBreakdown {
@@ -62,108 +49,115 @@ export interface AgentMessageCreditsBreakdown {
   llmAwu: number;
   toolAwu: number;
   totalAwu: number;
-  byModel: AgentMessageCreditsModelBreakdown[];
   byTool: AgentMessageCreditsToolBreakdown[];
 }
 
 /**
- * Same computation as `computeAgentMessageCredits`, but split by LLM vs. tool
- * cost and by model / tool so it can be displayed (e.g. in poke) instead of
- * only summed. `byModel[].awu` is computed by grouping per runKey first
- * (matching `intelligenceAwuFromRunUsagesGroupedByRunKey`), so the sum of
- * `byModel[].awu` always equals `llmAwu` exactly.
+ * Fetches the stored analytics document for each message, keyed by messageId. Returns an empty
+ * map (rather than failing) on an Elasticsearch error, since this only feeds a poke-only
+ * auditing display, not the billing pipeline itself.
  */
-export function computeAgentMessageCreditsBreakdown({
-  runUsages,
-  actions,
-  contextOrigin,
-}: {
-  runUsages: (RunUsageType & { runKey: string | null })[];
-  actions: (CreditActionMinimalInput & { actionId: string })[];
-  contextOrigin: UserMessageOrigin | null;
-}): AgentMessageCreditsBreakdown {
-  const finalActions = actions.filter((a) =>
-    isToolExecutionStatusFinal(a.status)
+export async function fetchAgentMessageCostAnalyticsByMessageIds(
+  auth: Authenticator,
+  { messageIds }: { messageIds: string[] }
+): Promise<Map<string, AgentMessageAnalyticsData>> {
+  if (messageIds.length === 0) {
+    return new Map();
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const result = await searchAnalytics<AgentMessageAnalyticsData>(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspaceId } },
+          { terms: { message_id: messageIds } },
+        ],
+      },
+    },
+    { size: messageIds.length }
   );
 
-  const modelUsageByKey = new Map<
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId, error: result.error },
+      "[Credits] Failed to fetch agent message cost analytics from Elasticsearch."
+    );
+    return new Map();
+  }
+
+  return new Map(
+    result.value.hits.hits
+      .flatMap((hit) => (hit._source ? [hit._source] : []))
+      .map((doc) => [doc.message_id, doc])
+  );
+}
+
+/**
+ * Builds the LLM/tool cost split and per-tool breakdown for display (e.g. in poke) from the
+ * message's stored analytics document, rather than recomputing it live from current code: the
+ * analytics document is a frozen snapshot of the cost as computed by the billing pipeline at run
+ * time, so comparing it against the stored `costCredits` catches genuine billing bugs instead of
+ * drifting apart whenever the AWU pricing formulas are later tuned.
+ *
+ * The analytics document's `tools_used` entries carry no `actionId`, so they are matched back to
+ * `actions` by `(step, toolName)`: both lists are built from the same ordered set of actions at
+ * analytics-indexing time, so a positional match within that key is reliable in practice.
+ */
+export function buildAgentMessageCreditsBreakdownFromAnalytics({
+  analytics,
+  actions,
+}: {
+  analytics: Pick<AgentMessageAnalyticsData, "cost" | "tools_used"> | undefined;
+  actions: (CreditActionMinimalInput & { actionId: string; step: number })[];
+}): AgentMessageCreditsBreakdown | undefined {
+  // `cost` and `tools_used` were added to the analytics document after it first shipped, so
+  // older documents may be missing either (or the document itself may not exist yet for a very
+  // recently sent message) — degrade to no breakdown rather than throwing on missing data.
+  if (!analytics?.cost) {
+    return undefined;
+  }
+
+  const toolUsageQueueByKey = new Map<
     string,
-    Omit<AgentMessageCreditsModelBreakdown, "awu">
+    AgentMessageAnalyticsToolUsed[]
   >();
-  for (const usage of runUsages) {
-    const key = `${usage.providerId}|${usage.modelId}`;
-    const existing = modelUsageByKey.get(key) ?? {
-      providerId: usage.providerId,
-      modelId: usage.modelId,
-      promptTokens: 0,
-      completionTokens: 0,
-      cachedTokens: 0,
-      cacheCreationTokens: 0,
-      costMicroUsd: 0,
-    };
-    modelUsageByKey.set(key, {
-      ...existing,
-      promptTokens: existing.promptTokens + usage.promptTokens,
-      completionTokens: existing.completionTokens + usage.completionTokens,
-      cachedTokens: existing.cachedTokens + (usage.cachedTokens ?? 0),
-      cacheCreationTokens:
-        existing.cacheCreationTokens + (usage.cacheCreationTokens ?? 0),
-      costMicroUsd: existing.costMicroUsd + usage.costMicroUsd,
-    });
+  for (const tool of analytics.tools_used ?? []) {
+    const key = `${tool.step_index}|${tool.tool_name}`;
+    const queue = toolUsageQueueByKey.get(key) ?? [];
+    queue.push(tool);
+    toolUsageQueueByKey.set(key, queue);
   }
 
-  const modelAwuByKey = new Map<string, number>();
-  if (!isFreeOrigin(contextOrigin)) {
-    const byRunKey = new Map<string, RunUsageType[]>();
-    for (const usage of runUsages) {
-      const runKey = usage.runKey ?? "__legacy__";
-      const group = byRunKey.get(runKey) ?? [];
-      group.push(usage);
-      byRunKey.set(runKey, group);
+  const byTool: AgentMessageCreditsToolBreakdown[] = [];
+  for (const action of actions) {
+    const matched = toolUsageQueueByKey
+      .get(`${action.step}|${action.toolName}`)
+      ?.shift();
+    if (!matched) {
+      continue;
     }
 
-    for (const group of byRunKey.values()) {
-      const costByModel = new Map<string, number>();
-      for (const usage of group) {
-        const key = `${usage.providerId}|${usage.modelId}`;
-        costByModel.set(key, (costByModel.get(key) ?? 0) + usage.costMicroUsd);
-      }
-      for (const [key, costMicroUsd] of costByModel) {
-        modelAwuByKey.set(
-          key,
-          (modelAwuByKey.get(key) ?? 0) + awuFromMicroUsd(costMicroUsd)
-        );
-      }
-    }
-  }
-
-  const byModel = Array.from(modelUsageByKey.entries()).map(([key, usage]) => ({
-    ...usage,
-    awu: modelAwuByKey.get(key) ?? 0,
-  }));
-
-  const byTool = finalActions.map((action) => {
-    const { toolCostCategory, freeUsage } = getToolBillingInfo(
+    const { toolCostCategory } = getToolBillingInfo(
       action.internalMCPServerName,
       action.toolName
     );
-    return {
+    byTool.push({
       actionId: action.actionId,
       toolName: action.toolName,
       internalMCPServerName: action.internalMCPServerName,
       toolCostCategory,
-      free: freeUsage || isFreeOrigin(contextOrigin),
-      awu: toolAwuFromAction(action, contextOrigin),
-    };
-  });
+      free: matched.cost_awu === 0 && isToolExecutionStatusFinal(action.status),
+      awu: matched.cost_awu,
+    });
+  }
 
-  const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
-    runUsages,
-    contextOrigin
-  );
-  const toolAwu = toolAwuFromActions(finalActions, contextOrigin);
-
-  return { llmAwu, toolAwu, totalAwu: llmAwu + toolAwu, byModel, byTool };
+  return {
+    llmAwu: analytics.cost.llm_awu,
+    toolAwu: analytics.cost.tool_awu,
+    totalAwu: analytics.cost.full_awu,
+    byTool,
+  };
 }
 
 export function computeAgentMessageCredits({

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -188,7 +188,7 @@ export function intelligenceAwuFromRunUsages(
 // Synthetic group for run usages whose run has no runKey yet (legacy rows, or
 // non-agent-loop runs). They are summed together so behavior matches the old
 // single-ceil computation for them.
-const LEGACY_RUN_KEY = "__legacy__";
+export const LEGACY_RUN_KEY = "__legacy__";
 
 // Intelligence credits for an agent message, ceiling per agent-loop execution
 // (runKey) to exactly match the per-execution Metronome events. Metronome emits

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -1,14 +1,12 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { computeAgentMessageCreditsBreakdown } from "@app/lib/api/assistant/credit_cost";
+import {
+  buildAgentMessageCreditsBreakdownFromAnalytics,
+  fetchAgentMessageCostAnalyticsByMessageIds,
+} from "@app/lib/api/assistant/credit_cost";
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
-import type { RunUsageType } from "@app/lib/resources/run_resource";
-import { RunResource } from "@app/lib/resources/run_resource";
-import type {
-  ConversationError,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
+import type { ConversationError } from "@app/types/assistant/conversation";
 import type {
   PokeAgentMessageType,
   PokeConversationType,
@@ -49,47 +47,13 @@ export async function getPokeConversation(
       agentMessagesWithRunIds.map((m) => [m.id, m.runIds])
     );
 
-    // Batch-fetch every run and its token usage for the whole conversation in one
-    // shot (rather than per message), then regroup by dustRunId below so each
-    // message's recalculated cost breakdown can be computed with zero
-    // additional queries per message.
-    const allDustRunIds = [
-      ...new Set(
-        Array.from(runIdsByAgentMessageId.values()).flatMap((ids) => ids ?? [])
-      ),
-    ];
-    const runs =
-      allDustRunIds.length > 0
-        ? await RunResource.listByDustRunIds(auth, {
-            dustRunIds: allDustRunIds,
-          })
-        : [];
-    const runUsages =
-      runs.length > 0
-        ? await RunResource.listRunUsagesForRuns(auth, { runs })
-        : [];
-
-    const dustRunIdByRunModelId = new Map(runs.map((r) => [r.id, r.dustRunId]));
-    const runUsagesByDustRunId = new Map<
-      string,
-      (RunUsageType & { runKey: string | null })[]
-    >();
-    for (const usage of runUsages) {
-      const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
-      if (!dustRunId) {
-        continue;
-      }
-      const group = runUsagesByDustRunId.get(dustRunId) ?? [];
-      group.push(usage);
-      runUsagesByDustRunId.set(dustRunId, group);
-    }
-
-    const userMessageBySId = new Map(
-      pokeConversation.content
-        .flat()
-        .filter((m): m is UserMessageType => m.type === "user_message")
-        .map((m) => [m.sId, m])
-    );
+    // Batch-fetch the stored cost analytics document for every agent message in the
+    // conversation in one shot (rather than per message), so each message's cost
+    // breakdown can be attached with zero additional queries per message.
+    const analyticsByMessageId =
+      await fetchAgentMessageCostAnalyticsByMessageIds(auth, {
+        messageIds: agentMessages.map((m) => m.sId),
+      });
 
     // Cycle through the messages and actions and enrich them with runId(s) and timestamps.
     for (const messages of pokeConversation.content) {
@@ -120,21 +84,15 @@ export async function getPokeConversation(
             }
           }
 
-          const runUsagesForMessage = (runIds ?? []).flatMap(
-            (dustRunId) => runUsagesByDustRunId.get(dustRunId) ?? []
-          );
-          const contextOrigin =
-            userMessageBySId.get(m.parentMessageId)?.context.origin ?? null;
-
-          m.costBreakdown = computeAgentMessageCreditsBreakdown({
-            runUsages: runUsagesForMessage,
+          m.costBreakdown = buildAgentMessageCreditsBreakdownFromAnalytics({
+            analytics: analyticsByMessageId.get(m.sId),
             actions: m.actions.map((a) => ({
               actionId: a.sId,
+              step: a.step,
               toolName: a.toolName,
               internalMCPServerName: a.internalMCPServerName,
               status: a.status,
             })),
-            contextOrigin,
           });
         }
       }

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -1,8 +1,14 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { computeAgentMessageCreditsBreakdown } from "@app/lib/api/assistant/credit_cost";
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
-import type { ConversationError } from "@app/types/assistant/conversation";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import type {
+  ConversationError,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
 import type {
   PokeAgentMessageType,
   PokeConversationType,
@@ -43,6 +49,48 @@ export async function getPokeConversation(
       agentMessagesWithRunIds.map((m) => [m.id, m.runIds])
     );
 
+    // Batch-fetch every run and its token usage for the whole conversation in one
+    // shot (rather than per message), then regroup by dustRunId below so each
+    // message's recalculated cost breakdown can be computed with zero
+    // additional queries per message.
+    const allDustRunIds = [
+      ...new Set(
+        Array.from(runIdsByAgentMessageId.values()).flatMap((ids) => ids ?? [])
+      ),
+    ];
+    const runs =
+      allDustRunIds.length > 0
+        ? await RunResource.listByDustRunIds(auth, {
+            dustRunIds: allDustRunIds,
+          })
+        : [];
+    const runUsages =
+      runs.length > 0
+        ? await RunResource.listRunUsagesForRuns(auth, { runs })
+        : [];
+
+    const dustRunIdByRunModelId = new Map(runs.map((r) => [r.id, r.dustRunId]));
+    const runUsagesByDustRunId = new Map<
+      string,
+      (RunUsageType & { runKey: string | null })[]
+    >();
+    for (const usage of runUsages) {
+      const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+      if (!dustRunId) {
+        continue;
+      }
+      const group = runUsagesByDustRunId.get(dustRunId) ?? [];
+      group.push(usage);
+      runUsagesByDustRunId.set(dustRunId, group);
+    }
+
+    const userMessageBySId = new Map(
+      pokeConversation.content
+        .flat()
+        .filter((m): m is UserMessageType => m.type === "user_message")
+        .map((m) => [m.sId, m])
+    );
+
     // Cycle through the messages and actions and enrich them with runId(s) and timestamps.
     for (const messages of pokeConversation.content) {
       for (const m of messages) {
@@ -71,6 +119,23 @@ export async function getPokeConversation(
               a.created = a.createdAt;
             }
           }
+
+          const runUsagesForMessage = (runIds ?? []).flatMap(
+            (dustRunId) => runUsagesByDustRunId.get(dustRunId) ?? []
+          );
+          const contextOrigin =
+            userMessageBySId.get(m.parentMessageId)?.context.origin ?? null;
+
+          m.costBreakdown = computeAgentMessageCreditsBreakdown({
+            runUsages: runUsagesForMessage,
+            actions: m.actions.map((a) => ({
+              actionId: a.sId,
+              toolName: a.toolName,
+              internalMCPServerName: a.internalMCPServerName,
+              status: a.status,
+            })),
+            contextOrigin,
+          });
         }
       }
     }

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -1,4 +1,5 @@
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import type { AgentMessageCreditsBreakdown } from "@app/lib/api/assistant/credit_cost";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { RegionType } from "@app/types/region";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -77,6 +78,10 @@ export type PokeAgentMessageType = Omit<AgentMessageType, "actions"> & {
   runIds?: string[] | null;
   runUrls?: { runId: string; url: string; isLLM: boolean }[] | null;
   actions: PokeAgentActionType[];
+  // Recalculated LLM + tool cost breakdown, computed fresh from token usage and
+  // tool actions (as opposed to `costCredits`/`subAgentCostCredits`, which are
+  // the stored values from the billing pipeline). Poke-only, for auditing.
+  costBreakdown?: AgentMessageCreditsBreakdown;
 };
 
 export type PokeConversationType = Omit<ConversationType, "content"> & {

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -78,9 +78,10 @@ export type PokeAgentMessageType = Omit<AgentMessageType, "actions"> & {
   runIds?: string[] | null;
   runUrls?: { runId: string; url: string; isLLM: boolean }[] | null;
   actions: PokeAgentActionType[];
-  // Recalculated LLM + tool cost breakdown, computed fresh from token usage and
-  // tool actions (as opposed to `costCredits`/`subAgentCostCredits`, which are
-  // the stored values from the billing pipeline). Poke-only, for auditing.
+  // LLM + tool cost breakdown as computed by the billing pipeline at run time,
+  // read back from the message's stored analytics document (as opposed to
+  // `costCredits`/`subAgentCostCredits`, the values persisted for billing itself).
+  // Poke-only, for auditing. Undefined when no analytics document is available yet.
   costBreakdown?: AgentMessageCreditsBreakdown;
 };
 


### PR DESCRIPTION
## Description

Add a message-level cost breakdown to the poke conversation view, showing the **stored** credit cost (`AgentMessageModel.costCredits`, persisted by the billing pipeline) side-by-side with a **recalculated** cost derived fresh from the message's raw token usage and tool actions. Useful for auditing/debugging billing discrepancies without leaving poke.

<img width="1199" height="522" alt="Screenshot 2026-07-13 at 10 05 12" src="https://github.com/user-attachments/assets/2c9ca9f1-41ac-471e-9db8-f57f02287a38" />


For each agent message:
- A "Cost" panel showing stored AWU vs. recalculated AWU (split into LLM / tools), with a "mismatch" warning chip if the two disagree.
- An expandable per-model table (provider/model, prompt/completion/cached tokens, $ cost, AWU).
- An inline AWU chip on each tool call row (category + free/billed).

Implementation:
- `lib/api/assistant/credit_cost.ts`: new `computeAgentMessageCreditsBreakdown()`, mirroring the existing `computeAgentMessageCredits()` (used to persist `costCredits`) but split by LLM vs. tool and by model/tool instead of only summed.
- `lib/poke/conversation.ts`: `getPokeConversation()` batch-fetches runs + token usage for the whole conversation (2 queries total, no N+1), regroups by message, and attaches the recalculated breakdown alongside the stored `costCredits`.
- `types/poke/index.ts`: `PokeAgentMessageType` gains an optional `costBreakdown` field.
- `components/poke/pages/ConversationPage.tsx`: renders the new cost panel and per-tool cost chips.

## Tests

Manually verified via `npx tsgo --noEmit` (no new type errors) and `biome check --write` on the touched files. Not exercised against a live poke conversation in this session.

## Risk

Poke-only, read-only addition (no new writes, no changes to the billing pipeline itself). Adds 2 extra batched DB queries per conversation page load (`RunResource.listByDustRunIds` + `listRunUsagesForRuns`), scoped to the conversation's own runs.

## Deploy Plan

Standard deploy, no migration or feature flag needed.
