### PR TITLE
fix: notification email footer link 404s on /w/{wId}/me

### DIFF
--- a/front/lib/notifications/email-templates/_layout.tsx
+++ b/front/lib/notifications/email-templates/_layout.tsx
@@ -52,13 +52,13 @@ export const EmailLayout = ({
         >
           <div>This is an automated email. Please do not reply.</div>
           <div>
-            Manage your notifications in{" "}
+            You can manage your notification preferences from{" "}
             <a
-              href={`${config.getAppUrl()}/w/${workspace.id}/me`}
+              href={`${config.getAppUrl()}/w/${workspace.id}`}
               target="_blank"
               style={{ color: "#1C91FF" }}
             >
-              your profile settings
+              your workspace
             </a>
             .
           </div>


### PR DESCRIPTION
## Description

The notification email footer linked to `/w/{wId}/me`, a route that no longer exists (profile settings moved to an in-app modal a few weeks back). Repointed it to the workspace root instead.

## Tests

Manual read-through, no route/behavior to exercise beyond the link target.

## Risk

Low, single link text/href change shared across all notification emails.

## Deploy Plan

Standard deploy.