### PR TITLE
[front] enh: add back concise Computer tool manifest

### DIFF
--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -94,6 +94,7 @@ export function getSandboxImage(
 export { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 export {
   createToolManifest,
+  toolManifestToCompactText,
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image/tool_manifest";

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -106,6 +106,7 @@ export type {
   SandboxCapability,
   SandboxImageId,
   SandboxResources,
+  ToolCategory,
   ToolEntry,
   ToolManifest,
   ToolProfile,

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -107,6 +107,7 @@ export type {
   SandboxImageId,
   SandboxResources,
   ToolEntry,
+  ToolGroup,
   ToolManifest,
   ToolProfile,
   ToolRuntime,

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -107,7 +107,6 @@ export type {
   SandboxImageId,
   SandboxResources,
   ToolEntry,
-  ToolGroup,
   ToolManifest,
   ToolProfile,
   ToolRuntime,

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -106,7 +106,6 @@ export type {
   SandboxCapability,
   SandboxImageId,
   SandboxResources,
-  ToolCategory,
   ToolEntry,
   ToolManifest,
   ToolProfile,

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.54",
+      tag: "0.8.55",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.55",
+      tag: "0.8.54",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.55";
+const DUST_BASE_IMAGE_VERSION = "0.8.54";
 const DSBX_CLI_VERSION = "0.1.33";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -793,6 +793,17 @@ SHELLEOF`,
     runtime: "system",
     category: "dust",
   })
+  // --- pptx_slides: safe slide-level structural edits ---
+  .registerTool({
+    name: "pptx_slides",
+    description:
+      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
+    usage:
+      "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
+    returns: "A one-line summary of the change and the deck's new slide count",
+    runtime: "system",
+    category: "dust",
+  })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
     name: "docx_inspect",

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -479,8 +479,7 @@ SHELLEOF`,
   .registerTool({
     name: DSBX_TOOL_NAME,
     description: "Dust CLI",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   .runCmd("mkdir -p /skills && chmod 755 /skills", { user: "root" })
   .runCmd(
@@ -498,8 +497,7 @@ SHELLEOF`,
     usage:
       "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
     returns: "Summary of applied changes (A/M/D per file)",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: "openai",
   })
   .runCmd(
@@ -680,8 +678,7 @@ SHELLEOF`,
     usage: "read_file <path> [offset] [limit]",
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: ["anthropic", "openai"],
   })
   .registerTool({
@@ -691,8 +688,7 @@ SHELLEOF`,
     usage: "read_file <path> [start] [end]",
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: "gemini",
   })
   .registerTool({
@@ -701,8 +697,7 @@ SHELLEOF`,
       "Write content to file (atomic write, creates parent directories)",
     usage: "write_file <path> <content>",
     returns: "'Wrote <path> (<bytes> bytes)' on success",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: ["anthropic", "gemini"],
   })
   .registerTool({
@@ -711,8 +706,7 @@ SHELLEOF`,
       "Replace exact text in a single file. Supports --replace-all and returns unified diff",
     usage: "edit_file [--replace-all] <old_text> <new_text> <path>",
     returns: "'Edited <path>' on success, unified diff on stderr",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: ["anthropic", "gemini"],
   })
   // --- grep_files: anthropic has extra flags ---
@@ -723,8 +717,7 @@ SHELLEOF`,
     usage:
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N] [--output-mode content|files|count] [--case-insensitive] [--max-line-length N]",
     returns: "file:line:content format with match count footer",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: "anthropic",
   })
   .registerTool({
@@ -734,8 +727,7 @@ SHELLEOF`,
     usage:
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N]",
     returns: "file:line:content format with match count footer",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
     profile: ["openai", "gemini"],
   })
   // --- glob: uniform with pagination ---
@@ -744,8 +736,7 @@ SHELLEOF`,
     description: "Find files by glob pattern. Sorted, paginated output",
     usage: "glob <pattern> [--path PATH] [--offset N] [--limit N]",
     returns: "Sorted file paths with pagination hint",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- list_dir: uniform with type suffixes and pagination ---
   .registerTool({
@@ -755,66 +746,60 @@ SHELLEOF`,
     usage: "list_dir [path] [--depth N] [--offset N] [--limit N]",
     returns: "Sorted paths with type suffixes and pagination hint",
     profile: ["openai", "gemini"],
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- xlsx_inspect: structural inspection of .xlsx workbooks ---
   .registerTool({
     name: "xlsx_inspect",
     description:
-      "Inspect .xlsx structure: sheets, formulas, cached values, number formats, font and fill color (theme/indexed colors resolved to ARGB). --grep --meta searches by metadata tokens (e.g. 'fill: FFFF...' for yellow highlights, 'numFmt: 0%' for percent-formatted cells)",
+      "Inspect workbook structure, formulas, values, and styles. Inspect .xlsx structure: sheets, formulas, cached values, number formats, font and fill color (theme/indexed colors resolved to ARGB). --grep --meta searches by metadata tokens (e.g. 'fill: FFFF...' for yellow highlights, 'numFmt: 0%' for percent-formatted cells)",
     usage:
       "xlsx_inspect <file> [--sheet NAME] [--range A1:Z50] [--grep PATTERN [--regex] [--meta]] [--names] [--limit N] [--offset N]",
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- pptx_inspect: structural inspection of .pptx decks ---
   .registerTool({
     name: "pptx_inspect",
     description:
-      "Inspect and QA .pptx structure (slides, layouts, shapes, text, charts, tables, embedded media) throughout the edit loop. Overview by default, plus modes --slide, --layouts, --text, --media, --render, --qa (post-edit boxed-render + text-readback visual gate) and --compare FILE (template-fidelity [QA: PASS/FAIL] gate). Run with --help for the full per-mode flag reference; the pptx skill covers when and how to use each.",
+      "Inspect and QA slide structure, content, rendering, and fidelity. Inspect .pptx structure (slides, layouts, shapes, text, charts, tables, embedded media) throughout the edit loop. Overview by default, plus modes --slide, --layouts, --text, --media, --render, --qa (post-edit boxed-render + text-readback visual gate) and --compare FILE (template-fidelity [QA: PASS/FAIL] gate). Run with --help for the full per-mode flag reference; the pptx skill covers when and how to use each.",
     usage:
       "pptx_inspect <file> [--qa N[,N,...]] [--slide N[,N,...]] [--layouts] [--text] [--media] [--render] [--render-dir DIR] [--compare FILE] [--max-shapes N] [--offset N] (see --help)",
     returns:
       "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
     name: "pptx_slides",
     description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
+      "Duplicate, move, or delete .pptx slides without corrupting the package. Shares image parts, deep-clones charts, and rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
     name: "pptx_slides",
     description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
+      "Duplicate, move, or delete .pptx slides without corrupting the package. Shares image parts, deep-clones charts, and rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
     name: "docx_inspect",
     description:
-      "Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline. --render rasterizes pages to JPEG, published into the conversation; the command prints each page's scoped path (a files__cat-readable image). --render-dir DIR is the base dir renders publish under, as DIR/.docx_render/<doc>/ (default /files/conversation)",
+      "Inspect document structure, styles, content, and rendering. Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline. --render rasterizes pages to JPEG, published into the conversation; the command prints each page's scoped path (a files__cat-readable image). --render-dir DIR is the base dir renders publish under, as DIR/.docx_render/<doc>/ (default /files/conversation)",
     usage:
       "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] [--sections] [--changes] [--fields] [--media] [--render] [--render-dir DIR] [--offset N] [--max N] [--page N]",
     returns:
       "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
-    runtime: "system",
-    category: "dust",
+    runtime: "dust",
   })
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.54";
+const DUST_BASE_IMAGE_VERSION = "0.8.55";
 const DSBX_CLI_VERSION = "0.1.33";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -480,7 +480,7 @@ SHELLEOF`,
     name: DSBX_TOOL_NAME,
     description: "Dust CLI",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   .runCmd("mkdir -p /skills && chmod 755 /skills", { user: "root" })
   .runCmd(
@@ -499,7 +499,7 @@ SHELLEOF`,
       "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
     returns: "Summary of applied changes (A/M/D per file)",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: "openai",
   })
   .runCmd(
@@ -681,7 +681,7 @@ SHELLEOF`,
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: ["anthropic", "openai"],
   })
   .registerTool({
@@ -692,7 +692,7 @@ SHELLEOF`,
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: "gemini",
   })
   .registerTool({
@@ -702,7 +702,7 @@ SHELLEOF`,
     usage: "write_file <path> <content>",
     returns: "'Wrote <path> (<bytes> bytes)' on success",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: ["anthropic", "gemini"],
   })
   .registerTool({
@@ -712,7 +712,7 @@ SHELLEOF`,
     usage: "edit_file [--replace-all] <old_text> <new_text> <path>",
     returns: "'Edited <path>' on success, unified diff on stderr",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: ["anthropic", "gemini"],
   })
   // --- grep_files: anthropic has extra flags ---
@@ -724,7 +724,7 @@ SHELLEOF`,
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N] [--output-mode content|files|count] [--case-insensitive] [--max-line-length N]",
     returns: "file:line:content format with match count footer",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: "anthropic",
   })
   .registerTool({
@@ -735,7 +735,7 @@ SHELLEOF`,
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N]",
     returns: "file:line:content format with match count footer",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
     profile: ["openai", "gemini"],
   })
   // --- glob: uniform with pagination ---
@@ -745,7 +745,7 @@ SHELLEOF`,
     usage: "glob <pattern> [--path PATH] [--offset N] [--limit N]",
     returns: "Sorted file paths with pagination hint",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- list_dir: uniform with type suffixes and pagination ---
   .registerTool({
@@ -756,7 +756,7 @@ SHELLEOF`,
     returns: "Sorted paths with type suffixes and pagination hint",
     profile: ["openai", "gemini"],
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- xlsx_inspect: structural inspection of .xlsx workbooks ---
   .registerTool({
@@ -768,7 +768,7 @@ SHELLEOF`,
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- pptx_inspect: structural inspection of .pptx decks ---
   .registerTool({
@@ -780,7 +780,7 @@ SHELLEOF`,
     returns:
       "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -791,7 +791,7 @@ SHELLEOF`,
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -802,7 +802,7 @@ SHELLEOF`,
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
@@ -814,7 +814,7 @@ SHELLEOF`,
     returns:
       "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
     runtime: "system",
-    group: "dust",
+    isDustTool: true,
   })
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -768,7 +768,7 @@ SHELLEOF`,
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
     runtime: "system",
-    category: "office",
+    category: "dust",
   })
   // --- pptx_inspect: structural inspection of .pptx decks ---
   .registerTool({
@@ -780,7 +780,7 @@ SHELLEOF`,
     returns:
       "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
     runtime: "system",
-    category: "office",
+    category: "dust",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -791,7 +791,7 @@ SHELLEOF`,
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
     runtime: "system",
-    category: "office",
+    category: "dust",
   })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
@@ -803,7 +803,7 @@ SHELLEOF`,
     returns:
       "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
     runtime: "system",
-    category: "office",
+    category: "dust",
   })
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -479,7 +479,8 @@ SHELLEOF`,
   .registerTool({
     name: DSBX_TOOL_NAME,
     description: "Dust CLI",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   .runCmd("mkdir -p /skills && chmod 755 /skills", { user: "root" })
   .runCmd(
@@ -497,7 +498,8 @@ SHELLEOF`,
     usage:
       "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
     returns: "Summary of applied changes (A/M/D per file)",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: "openai",
   })
   .runCmd(
@@ -678,7 +680,8 @@ SHELLEOF`,
     usage: "read_file <path> [offset] [limit]",
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: ["anthropic", "openai"],
   })
   .registerTool({
@@ -688,7 +691,8 @@ SHELLEOF`,
     usage: "read_file <path> [start] [end]",
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: "gemini",
   })
   .registerTool({
@@ -697,7 +701,8 @@ SHELLEOF`,
       "Write content to file (atomic write, creates parent directories)",
     usage: "write_file <path> <content>",
     returns: "'Wrote <path> (<bytes> bytes)' on success",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: ["anthropic", "gemini"],
   })
   .registerTool({
@@ -706,7 +711,8 @@ SHELLEOF`,
       "Replace exact text in a single file. Supports --replace-all and returns unified diff",
     usage: "edit_file [--replace-all] <old_text> <new_text> <path>",
     returns: "'Edited <path>' on success, unified diff on stderr",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: ["anthropic", "gemini"],
   })
   // --- grep_files: anthropic has extra flags ---
@@ -717,7 +723,8 @@ SHELLEOF`,
     usage:
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N] [--output-mode content|files|count] [--case-insensitive] [--max-line-length N]",
     returns: "file:line:content format with match count footer",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: "anthropic",
   })
   .registerTool({
@@ -727,7 +734,8 @@ SHELLEOF`,
     usage:
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N]",
     returns: "file:line:content format with match count footer",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
     profile: ["openai", "gemini"],
   })
   // --- glob: uniform with pagination ---
@@ -736,7 +744,8 @@ SHELLEOF`,
     description: "Find files by glob pattern. Sorted, paginated output",
     usage: "glob <pattern> [--path PATH] [--offset N] [--limit N]",
     returns: "Sorted file paths with pagination hint",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- list_dir: uniform with type suffixes and pagination ---
   .registerTool({
@@ -746,7 +755,8 @@ SHELLEOF`,
     usage: "list_dir [path] [--depth N] [--offset N] [--limit N]",
     returns: "Sorted paths with type suffixes and pagination hint",
     profile: ["openai", "gemini"],
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- xlsx_inspect: structural inspection of .xlsx workbooks ---
   .registerTool({
@@ -757,7 +767,8 @@ SHELLEOF`,
       "xlsx_inspect <file> [--sheet NAME] [--range A1:Z50] [--grep PATTERN [--regex] [--meta]] [--names] [--limit N] [--offset N]",
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- pptx_inspect: structural inspection of .pptx decks ---
   .registerTool({
@@ -768,7 +779,8 @@ SHELLEOF`,
       "pptx_inspect <file> [--qa N[,N,...]] [--slide N[,N,...]] [--layouts] [--text] [--media] [--render] [--render-dir DIR] [--compare FILE] [--max-shapes N] [--offset N] (see --help)",
     returns:
       "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -778,7 +790,8 @@ SHELLEOF`,
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -788,7 +801,8 @@ SHELLEOF`,
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
@@ -799,7 +813,8 @@ SHELLEOF`,
       "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] [--sections] [--changes] [--fields] [--media] [--render] [--render-dir DIR] [--offset N] [--max N] [--page N]",
     returns:
       "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
-    runtime: "dust",
+    runtime: "system",
+    group: "dust",
   })
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -758,6 +758,7 @@ SHELLEOF`,
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
     runtime: "system",
+    category: "office",
   })
   // --- pptx_inspect: structural inspection of .pptx decks ---
   .registerTool({
@@ -769,6 +770,7 @@ SHELLEOF`,
     returns:
       "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
     runtime: "system",
+    category: "office",
   })
   // --- pptx_slides: safe slide-level structural edits ---
   .registerTool({
@@ -779,16 +781,7 @@ SHELLEOF`,
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
     runtime: "system",
-  })
-  // --- pptx_slides: safe slide-level structural edits ---
-  .registerTool({
-    name: "pptx_slides",
-    description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
-    usage:
-      "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
-    returns: "A one-line summary of the change and the deck's new slide count",
-    runtime: "system",
+    category: "office",
   })
   // --- docx_inspect: structural inspection of .docx documents ---
   .registerTool({
@@ -800,6 +793,7 @@ SHELLEOF`,
     returns:
       "Document overview with theme + default typography and heading outline, or one paragraph/style/section/table/change/field per line. Render mode publishes each page and prints its scoped path (files__cat-readable)",
     runtime: "system",
+    category: "office",
   })
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -752,7 +752,7 @@ SHELLEOF`,
   .registerTool({
     name: "xlsx_inspect",
     description:
-      "Inspect workbook structure, formulas, values, and styles. Inspect .xlsx structure: sheets, formulas, cached values, number formats, font and fill color (theme/indexed colors resolved to ARGB). --grep --meta searches by metadata tokens (e.g. 'fill: FFFF...' for yellow highlights, 'numFmt: 0%' for percent-formatted cells)",
+      "Inspect .xlsx structure: sheets, formulas, cached values, number formats, font and fill color (theme/indexed colors resolved to ARGB). --grep --meta searches by metadata tokens (e.g. 'fill: FFFF...' for yellow highlights, 'numFmt: 0%' for percent-formatted cells)",
     usage:
       "xlsx_inspect <file> [--sheet NAME] [--range A1:Z50] [--grep PATTERN [--regex] [--meta]] [--names] [--limit N] [--offset N]",
     returns:
@@ -763,7 +763,7 @@ SHELLEOF`,
   .registerTool({
     name: "pptx_inspect",
     description:
-      "Inspect and QA slide structure, content, rendering, and fidelity. Inspect .pptx structure (slides, layouts, shapes, text, charts, tables, embedded media) throughout the edit loop. Overview by default, plus modes --slide, --layouts, --text, --media, --render, --qa (post-edit boxed-render + text-readback visual gate) and --compare FILE (template-fidelity [QA: PASS/FAIL] gate). Run with --help for the full per-mode flag reference; the pptx skill covers when and how to use each.",
+      "Inspect and QA .pptx structure (slides, layouts, shapes, text, charts, tables, embedded media) throughout the edit loop. Overview by default, plus modes --slide, --layouts, --text, --media, --render, --qa (post-edit boxed-render + text-readback visual gate) and --compare FILE (template-fidelity [QA: PASS/FAIL] gate). Run with --help for the full per-mode flag reference; the pptx skill covers when and how to use each.",
     usage:
       "pptx_inspect <file> [--qa N[,N,...]] [--slide N[,N,...]] [--layouts] [--text] [--media] [--render] [--render-dir DIR] [--compare FILE] [--max-shapes N] [--offset N] (see --help)",
     returns:
@@ -774,7 +774,7 @@ SHELLEOF`,
   .registerTool({
     name: "pptx_slides",
     description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package. Shares image parts, deep-clones charts, and rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
+      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
@@ -784,7 +784,7 @@ SHELLEOF`,
   .registerTool({
     name: "pptx_slides",
     description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package. Shares image parts, deep-clones charts, and rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
+      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
     usage:
       "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
     returns: "A one-line summary of the change and the deck's new slide count",
@@ -794,7 +794,7 @@ SHELLEOF`,
   .registerTool({
     name: "docx_inspect",
     description:
-      "Inspect document structure, styles, content, and rendering. Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline. --render rasterizes pages to JPEG, published into the conversation; the command prints each page's scoped path (a files__cat-readable image). --render-dir DIR is the base dir renders publish under, as DIR/.docx_render/<doc>/ (default /files/conversation)",
+      "Inspect .docx structure: sections, headings outline, paragraph and character styles with resolved typography, run formatting, tables, tracked changes, fields, embedded media. Use before editing a document to map style names so the model can apply Heading1 / Normal / Quote rather than restyling inline. --render rasterizes pages to JPEG, published into the conversation; the command prints each page's scoped path (a files__cat-readable image). --render-dir DIR is the base dir renders publish under, as DIR/.docx_render/<doc>/ (default /files/conversation)",
     usage:
       "docx_inspect <file> [--styles] [--paragraphs] [--text] [--tables] [--sections] [--changes] [--fields] [--media] [--render] [--render-dir DIR] [--offset N] [--max N] [--page N]",
     returns:

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -480,6 +480,7 @@ SHELLEOF`,
     name: DSBX_TOOL_NAME,
     description: "Dust CLI",
     runtime: "system",
+    category: "dust",
   })
   .runCmd("mkdir -p /skills && chmod 755 /skills", { user: "root" })
   .runCmd(
@@ -498,6 +499,7 @@ SHELLEOF`,
       "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
     returns: "Summary of applied changes (A/M/D per file)",
     runtime: "system",
+    category: "dust",
     profile: "openai",
   })
   .runCmd(
@@ -679,6 +681,7 @@ SHELLEOF`,
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
     runtime: "system",
+    category: "dust",
     profile: ["anthropic", "openai"],
   })
   .registerTool({
@@ -689,6 +692,7 @@ SHELLEOF`,
     returns:
       "Header with line range + numbered lines (format: '  N\\tcontent')",
     runtime: "system",
+    category: "dust",
     profile: "gemini",
   })
   .registerTool({
@@ -698,6 +702,7 @@ SHELLEOF`,
     usage: "write_file <path> <content>",
     returns: "'Wrote <path> (<bytes> bytes)' on success",
     runtime: "system",
+    category: "dust",
     profile: ["anthropic", "gemini"],
   })
   .registerTool({
@@ -707,6 +712,7 @@ SHELLEOF`,
     usage: "edit_file [--replace-all] <old_text> <new_text> <path>",
     returns: "'Edited <path>' on success, unified diff on stderr",
     runtime: "system",
+    category: "dust",
     profile: ["anthropic", "gemini"],
   })
   // --- grep_files: anthropic has extra flags ---
@@ -718,6 +724,7 @@ SHELLEOF`,
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N] [--output-mode content|files|count] [--case-insensitive] [--max-line-length N]",
     returns: "file:line:content format with match count footer",
     runtime: "system",
+    category: "dust",
     profile: "anthropic",
   })
   .registerTool({
@@ -728,6 +735,7 @@ SHELLEOF`,
       "grep_files <pattern> [--glob GLOB] [--path PATH] [--max-results N] [--max-per-file N] [--context N] [--offset N]",
     returns: "file:line:content format with match count footer",
     runtime: "system",
+    category: "dust",
     profile: ["openai", "gemini"],
   })
   // --- glob: uniform with pagination ---
@@ -737,6 +745,7 @@ SHELLEOF`,
     usage: "glob <pattern> [--path PATH] [--offset N] [--limit N]",
     returns: "Sorted file paths with pagination hint",
     runtime: "system",
+    category: "dust",
   })
   // --- list_dir: uniform with type suffixes and pagination ---
   .registerTool({
@@ -747,6 +756,7 @@ SHELLEOF`,
     returns: "Sorted paths with type suffixes and pagination hint",
     profile: ["openai", "gemini"],
     runtime: "system",
+    category: "dust",
   })
   // --- xlsx_inspect: structural inspection of .xlsx workbooks ---
   .registerTool({

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -1,5 +1,6 @@
 import {
   createToolManifest,
+  toolManifestToCompactText,
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image/tool_manifest";
@@ -115,6 +116,27 @@ describe("toolManifestToJSON()", () => {
 
     expect(parsed.version).toBe("1.0");
     expect(parsed.tools.system).toHaveLength(1);
+  });
+});
+
+describe("toolManifestToCompactText()", () => {
+  test("lists names and versions on one line per runtime", () => {
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+      {
+        name: "pandas",
+        version: "2.2.3",
+        description: "Data analysis",
+        runtime: "python",
+      },
+      { name: "tsx", description: "TypeScript executor", runtime: "node" },
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+    const manifest = createToolManifest(tools);
+
+    const text = toolManifestToCompactText(manifest);
+
+    expect(text).toBe("- System: curl\n- Python: pandas 2.2.3\n- Node: tsx");
   });
 });
 

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -15,21 +15,9 @@ describe("createToolManifest()", () => {
     expect(manifest.version).toBe("1.0");
   });
 
-  test("groups tools by category", () => {
+  test("groups tools by runtime", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
-      {
-        name: "read_file",
-        description: "File reader",
-        runtime: "system",
-        category: "dust",
-      },
-      {
-        name: "xlsx_inspect",
-        description: "Workbook inspector",
-        runtime: "system",
-        category: "dust",
-      },
       { name: "pandas", description: "Data analysis", runtime: "python" },
       { name: "tsx", description: "TypeScript executor", runtime: "node" },
     ];
@@ -39,10 +27,6 @@ describe("createToolManifest()", () => {
     expect(manifest.tools.system).toEqual([
       { name: "curl", description: "HTTP client" },
     ]);
-    expect(manifest.tools.dust).toEqual([
-      { name: "read_file", description: "File reader" },
-      { name: "xlsx_inspect", description: "Workbook inspector" },
-    ]);
     expect(manifest.tools.python).toEqual([
       { name: "pandas", description: "Data analysis" },
     ]);
@@ -51,7 +35,7 @@ describe("createToolManifest()", () => {
     ]);
   });
 
-  test("omits empty categories", () => {
+  test("omits empty runtime categories", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
     ];
@@ -59,7 +43,6 @@ describe("createToolManifest()", () => {
     const manifest = createToolManifest(tools);
 
     expect(manifest.tools.system).toBeDefined();
-    expect(manifest.tools.dust).toBeUndefined();
     expect(manifest.tools.python).toBeUndefined();
     expect(manifest.tools.node).toBeUndefined();
   });
@@ -147,12 +130,6 @@ describe("toolManifestToCompactText()", () => {
         category: "dust",
       },
       {
-        name: "xlsx_inspect",
-        description: "Workbook inspector",
-        runtime: "system",
-        category: "dust",
-      },
-      {
         name: "pandas",
         version: "2.2.3",
         description: "Data analysis",
@@ -166,7 +143,7 @@ describe("toolManifestToCompactText()", () => {
     const text = toolManifestToCompactText(manifest);
 
     expect(text).toBe(
-      "- System: curl\n- Dust: read_file, xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
+      "- System: curl\n- Dust: read_file\n- Python: pandas 2.2.3\n- Node: tsx"
     );
   });
 });

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -15,9 +15,15 @@ describe("createToolManifest()", () => {
     expect(manifest.version).toBe("1.0");
   });
 
-  test("groups tools by runtime", () => {
+  test("groups tools by category", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
+      {
+        name: "xlsx_inspect",
+        description: "Workbook inspector",
+        runtime: "system",
+        category: "office",
+      },
       { name: "pandas", description: "Data analysis", runtime: "python" },
       { name: "tsx", description: "TypeScript executor", runtime: "node" },
     ];
@@ -27,6 +33,9 @@ describe("createToolManifest()", () => {
     expect(manifest.tools.system).toEqual([
       { name: "curl", description: "HTTP client" },
     ]);
+    expect(manifest.tools.office).toEqual([
+      { name: "xlsx_inspect", description: "Workbook inspector" },
+    ]);
     expect(manifest.tools.python).toEqual([
       { name: "pandas", description: "Data analysis" },
     ]);
@@ -35,7 +44,7 @@ describe("createToolManifest()", () => {
     ]);
   });
 
-  test("omits empty runtime categories", () => {
+  test("omits empty categories", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
     ];
@@ -43,6 +52,7 @@ describe("createToolManifest()", () => {
     const manifest = createToolManifest(tools);
 
     expect(manifest.tools.system).toBeDefined();
+    expect(manifest.tools.office).toBeUndefined();
     expect(manifest.tools.python).toBeUndefined();
     expect(manifest.tools.node).toBeUndefined();
   });
@@ -120,9 +130,15 @@ describe("toolManifestToJSON()", () => {
 });
 
 describe("toolManifestToCompactText()", () => {
-  test("lists names and versions on one line per runtime", () => {
+  test("lists names and versions on one line per category", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
+      {
+        name: "xlsx_inspect",
+        description: "Workbook inspector",
+        runtime: "system",
+        category: "office",
+      },
       {
         name: "pandas",
         version: "2.2.3",
@@ -136,7 +152,9 @@ describe("toolManifestToCompactText()", () => {
 
     const text = toolManifestToCompactText(manifest);
 
-    expect(text).toBe("- System: curl\n- Python: pandas 2.2.3\n- Node: tsx");
+    expect(text).toBe(
+      "- System: curl\n- Office: xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
+    );
   });
 });
 

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -120,7 +120,7 @@ describe("toolManifestToJSON()", () => {
 });
 
 describe("toolManifestToCompactText()", () => {
-  test("lists names and versions on one line per section", () => {
+  test("lists names and versions on one line per runtime", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
@@ -143,7 +143,7 @@ describe("toolManifestToCompactText()", () => {
     const text = toolManifestToCompactText(manifest);
 
     expect(text).toBe(
-      "- System: curl\n- Dust: read_file\n- Python: pandas 2.2.3\n- Node: tsx"
+      "- System: curl, read_file\n- Python: pandas 2.2.3\n- Node: tsx"
     );
   });
 });

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -28,7 +28,7 @@ describe("createToolManifest()", () => {
         name: "xlsx_inspect",
         description: "Workbook inspector",
         runtime: "system",
-        category: "office",
+        category: "dust",
       },
       { name: "pandas", description: "Data analysis", runtime: "python" },
       { name: "tsx", description: "TypeScript executor", runtime: "node" },
@@ -41,8 +41,6 @@ describe("createToolManifest()", () => {
     ]);
     expect(manifest.tools.dust).toEqual([
       { name: "read_file", description: "File reader" },
-    ]);
-    expect(manifest.tools.office).toEqual([
       { name: "xlsx_inspect", description: "Workbook inspector" },
     ]);
     expect(manifest.tools.python).toEqual([
@@ -62,7 +60,6 @@ describe("createToolManifest()", () => {
 
     expect(manifest.tools.system).toBeDefined();
     expect(manifest.tools.dust).toBeUndefined();
-    expect(manifest.tools.office).toBeUndefined();
     expect(manifest.tools.python).toBeUndefined();
     expect(manifest.tools.node).toBeUndefined();
   });
@@ -153,7 +150,7 @@ describe("toolManifestToCompactText()", () => {
         name: "xlsx_inspect",
         description: "Workbook inspector",
         runtime: "system",
-        category: "office",
+        category: "dust",
       },
       {
         name: "pandas",
@@ -169,7 +166,7 @@ describe("toolManifestToCompactText()", () => {
     const text = toolManifestToCompactText(manifest);
 
     expect(text).toBe(
-      "- System: curl\n- Dust: read_file\n- Office: xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
+      "- System: curl\n- Dust: read_file, xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
     );
   });
 });

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -19,6 +19,12 @@ describe("createToolManifest()", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
+        name: "read_file",
+        description: "File reader",
+        runtime: "system",
+        category: "dust",
+      },
+      {
         name: "xlsx_inspect",
         description: "Workbook inspector",
         runtime: "system",
@@ -32,6 +38,9 @@ describe("createToolManifest()", () => {
 
     expect(manifest.tools.system).toEqual([
       { name: "curl", description: "HTTP client" },
+    ]);
+    expect(manifest.tools.dust).toEqual([
+      { name: "read_file", description: "File reader" },
     ]);
     expect(manifest.tools.office).toEqual([
       { name: "xlsx_inspect", description: "Workbook inspector" },
@@ -52,6 +61,7 @@ describe("createToolManifest()", () => {
     const manifest = createToolManifest(tools);
 
     expect(manifest.tools.system).toBeDefined();
+    expect(manifest.tools.dust).toBeUndefined();
     expect(manifest.tools.office).toBeUndefined();
     expect(manifest.tools.python).toBeUndefined();
     expect(manifest.tools.node).toBeUndefined();
@@ -134,6 +144,12 @@ describe("toolManifestToCompactText()", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
+        name: "read_file",
+        description: "File reader",
+        runtime: "system",
+        category: "dust",
+      },
+      {
         name: "xlsx_inspect",
         description: "Workbook inspector",
         runtime: "system",
@@ -153,7 +169,7 @@ describe("toolManifestToCompactText()", () => {
     const text = toolManifestToCompactText(manifest);
 
     expect(text).toBe(
-      "- System: curl\n- Office: xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
+      "- System: curl\n- Dust: read_file\n- Office: xlsx_inspect\n- Python: pandas 2.2.3\n- Node: tsx"
     );
   });
 });

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -120,14 +120,13 @@ describe("toolManifestToJSON()", () => {
 });
 
 describe("toolManifestToCompactText()", () => {
-  test("lists names and versions on one line per category", () => {
+  test("lists names and versions on one line per runtime", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
         name: "read_file",
         description: "File reader",
-        runtime: "system",
-        category: "dust",
+        runtime: "dust",
       },
       {
         name: "pandas",

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -122,21 +122,21 @@ describe("toolManifestToJSON()", () => {
 describe("toolManifestToCompactText()", () => {
   test("lists names and versions on one line per runtime", () => {
     const tools: ToolEntry[] = [
-      { name: "curl", description: "HTTP client", runtime: "system" },
       {
         name: "read_file",
         description: "File reader",
         runtime: "system",
         isDustTool: true,
       },
+      { name: "curl", description: "HTTP client", runtime: "system" },
       {
         name: "pandas",
         version: "2.2.3",
         description: "Data analysis",
         runtime: "python",
       },
-      { name: "tsx", description: "TypeScript executor", runtime: "node" },
       { name: "curl", description: "HTTP client", runtime: "system" },
+      { name: "tsx", description: "TypeScript executor", runtime: "node" },
     ];
     const manifest = createToolManifest(tools);
 

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -120,13 +120,14 @@ describe("toolManifestToJSON()", () => {
 });
 
 describe("toolManifestToCompactText()", () => {
-  test("lists names and versions on one line per runtime", () => {
+  test("lists names and versions on one line per group", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
         name: "read_file",
         description: "File reader",
-        runtime: "dust",
+        runtime: "system",
+        group: "dust",
       },
       {
         name: "pandas",

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -120,14 +120,14 @@ describe("toolManifestToJSON()", () => {
 });
 
 describe("toolManifestToCompactText()", () => {
-  test("lists names and versions on one line per group", () => {
+  test("lists names and versions on one line per section", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
       {
         name: "read_file",
         description: "File reader",
         runtime: "system",
-        group: "dust",
+        isDustTool: true,
       },
       {
         name: "pandas",

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -4,6 +4,7 @@ import type {
   ToolManifest,
   ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
+import { TOOL_RUNTIMES } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
@@ -12,7 +13,6 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
     python: [],
     node: [],
   };
-  const dustTools: ManifestToolEntry[] = [];
 
   for (const tool of tools) {
     const entry: ManifestToolEntry = {
@@ -22,25 +22,21 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
       ...(tool.usage && { usage: tool.usage }),
       ...(tool.returns && { returns: tool.returns }),
     };
-    if (tool.isDustTool) {
-      dustTools.push(entry);
-    } else {
-      toolsByRuntime[tool.runtime].push(entry);
+    toolsByRuntime[tool.runtime].push(entry);
+  }
+
+  const filteredTools: Partial<
+    Record<ToolRuntime, readonly ManifestToolEntry[]>
+  > = {};
+  for (const runtime of TOOL_RUNTIMES) {
+    if (toolsByRuntime[runtime].length > 0) {
+      filteredTools[runtime] = toolsByRuntime[runtime];
     }
   }
 
   return {
     version: "1.0",
-    tools: {
-      ...(toolsByRuntime.system.length > 0 && {
-        system: toolsByRuntime.system,
-      }),
-      ...(dustTools.length > 0 && { dust: dustTools }),
-      ...(toolsByRuntime.python.length > 0 && {
-        python: toolsByRuntime.python,
-      }),
-      ...(toolsByRuntime.node.length > 0 && { node: toolsByRuntime.node }),
-    },
+    tools: filteredTools,
   };
 }
 
@@ -49,29 +45,21 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
 }
 
 export function toolManifestToCompactText(manifest: ToolManifest): string {
-  const formatTools = (
-    label: string,
-    tools: readonly ManifestToolEntry[] | undefined
-  ): string | null => {
+  return TOOL_RUNTIMES.flatMap((runtime) => {
+    const tools = manifest.tools[runtime];
     if (!tools) {
-      return null;
+      return [];
     }
+
     const entries = new Set(
       tools.map((tool) =>
         tool.version ? `${tool.name} ${tool.version}` : tool.name
       )
     );
-    return `- ${label}: ${[...entries].join(", ")}`;
-  };
+    const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
 
-  return [
-    formatTools("System", manifest.tools.system),
-    formatTools("Dust", manifest.tools.dust),
-    formatTools("Python", manifest.tools.python),
-    formatTools("Node", manifest.tools.node),
-  ]
-    .filter((line): line is string => line !== null)
-    .join("\n");
+    return [`- ${label}: ${[...entries].join(", ")}`];
+  }).join("\n");
 }
 
 export function toolManifestToYAML(manifest: ToolManifest): string {

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -10,6 +10,7 @@ import * as yaml from "js-yaml";
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
   const toolsByCategory: Record<ToolCategory, ManifestToolEntry[]> = {
     system: [],
+    dust: [],
     office: [],
     python: [],
     node: [],

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -58,7 +58,7 @@ export function toolManifestToCompactText(manifest: ToolManifest): string {
     );
     const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
 
-    return [`- ${label}: ${[...entries].join(", ")}`];
+    return [`- ${label}: ${[...entries].sort().join(", ")}`];
   }).join("\n");
 }
 

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,14 +1,14 @@
 import type {
   ManifestToolEntry,
-  ToolCategory,
   ToolEntry,
   ToolManifest,
+  ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
-import { TOOL_CATEGORIES } from "@app/lib/api/sandbox/image/types";
+import { TOOL_RUNTIMES } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
-  const toolsByCategory: Record<ToolCategory, ManifestToolEntry[]> = {
+  const toolsByRuntime: Record<ToolRuntime, ManifestToolEntry[]> = {
     system: [],
     dust: [],
     python: [],
@@ -23,15 +23,15 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
       ...(tool.usage && { usage: tool.usage }),
       ...(tool.returns && { returns: tool.returns }),
     };
-    toolsByCategory[tool.category ?? tool.runtime].push(entry);
+    toolsByRuntime[tool.runtime].push(entry);
   }
 
   const filteredTools: Partial<
-    Record<ToolCategory, readonly ManifestToolEntry[]>
+    Record<ToolRuntime, readonly ManifestToolEntry[]>
   > = {};
-  for (const category of TOOL_CATEGORIES) {
-    if (toolsByCategory[category].length > 0) {
-      filteredTools[category] = toolsByCategory[category];
+  for (const runtime of TOOL_RUNTIMES) {
+    if (toolsByRuntime[runtime].length > 0) {
+      filteredTools[runtime] = toolsByRuntime[runtime];
     }
   }
 
@@ -46,8 +46,8 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
 }
 
 export function toolManifestToCompactText(manifest: ToolManifest): string {
-  return TOOL_CATEGORIES.flatMap((category) => {
-    const tools = manifest.tools[category];
+  return TOOL_RUNTIMES.flatMap((runtime) => {
+    const tools = manifest.tools[runtime];
     if (!tools) {
       return [];
     }
@@ -57,7 +57,7 @@ export function toolManifestToCompactText(manifest: ToolManifest): string {
         tool.version ? `${tool.name} ${tool.version}` : tool.name
       )
     );
-    const label = category.charAt(0).toUpperCase() + category.slice(1);
+    const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
 
     return [`- ${label}: ${[...entries].join(", ")}`];
   }).join("\n");

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -11,7 +11,6 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
   const toolsByCategory: Record<ToolCategory, ManifestToolEntry[]> = {
     system: [],
     dust: [],
-    office: [],
     python: [],
     node: [],
   };

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,15 +1,16 @@
 import type {
   ManifestToolEntry,
+  ToolCategory,
   ToolEntry,
   ToolManifest,
-  ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
-import { TOOL_RUNTIMES } from "@app/lib/api/sandbox/image/types";
+import { TOOL_CATEGORIES } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
-  const toolsByRuntime: Record<ToolRuntime, ManifestToolEntry[]> = {
+  const toolsByCategory: Record<ToolCategory, ManifestToolEntry[]> = {
     system: [],
+    office: [],
     python: [],
     node: [],
   };
@@ -22,15 +23,15 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
       ...(tool.usage && { usage: tool.usage }),
       ...(tool.returns && { returns: tool.returns }),
     };
-    toolsByRuntime[tool.runtime].push(entry);
+    toolsByCategory[tool.category ?? tool.runtime].push(entry);
   }
 
   const filteredTools: Partial<
-    Record<ToolRuntime, readonly ManifestToolEntry[]>
+    Record<ToolCategory, readonly ManifestToolEntry[]>
   > = {};
-  for (const runtime of TOOL_RUNTIMES) {
-    if (toolsByRuntime[runtime].length > 0) {
-      filteredTools[runtime] = toolsByRuntime[runtime];
+  for (const category of TOOL_CATEGORIES) {
+    if (toolsByCategory[category].length > 0) {
+      filteredTools[category] = toolsByCategory[category];
     }
   }
 
@@ -45,8 +46,8 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
 }
 
 export function toolManifestToCompactText(manifest: ToolManifest): string {
-  return TOOL_RUNTIMES.flatMap((runtime) => {
-    const tools = manifest.tools[runtime];
+  return TOOL_CATEGORIES.flatMap((category) => {
+    const tools = manifest.tools[category];
     if (!tools) {
       return [];
     }
@@ -56,7 +57,7 @@ export function toolManifestToCompactText(manifest: ToolManifest): string {
         tool.version ? `${tool.name} ${tool.version}` : tool.name
       )
     );
-    const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
+    const label = category.charAt(0).toUpperCase() + category.slice(1);
 
     return [`- ${label}: ${[...entries].join(", ")}`];
   }).join("\n");

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -44,6 +44,24 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
   return JSON.stringify(manifest, null, 2);
 }
 
+export function toolManifestToCompactText(manifest: ToolManifest): string {
+  return TOOL_RUNTIMES.flatMap((runtime) => {
+    const tools = manifest.tools[runtime];
+    if (!tools) {
+      return [];
+    }
+
+    const entries = new Set(
+      tools.map((tool) =>
+        tool.version ? `${tool.name} ${tool.version}` : tool.name
+      )
+    );
+    const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
+
+    return [`- ${label}: ${[...entries].join(", ")}`];
+  }).join("\n");
+}
+
 export function toolManifestToYAML(manifest: ToolManifest): string {
   return yaml.dump(manifest);
 }

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,14 +1,20 @@
 import type {
   ManifestToolEntry,
   ToolEntry,
+  ToolGroup,
   ToolManifest,
-  ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
-import { TOOL_RUNTIMES } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
+const TOOL_GROUPS = [
+  "system",
+  "dust",
+  "python",
+  "node",
+] as const satisfies readonly ToolGroup[];
+
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
-  const toolsByRuntime: Record<ToolRuntime, ManifestToolEntry[]> = {
+  const toolsByGroup: Record<ToolGroup, ManifestToolEntry[]> = {
     system: [],
     dust: [],
     python: [],
@@ -23,15 +29,15 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
       ...(tool.usage && { usage: tool.usage }),
       ...(tool.returns && { returns: tool.returns }),
     };
-    toolsByRuntime[tool.runtime].push(entry);
+    toolsByGroup[tool.group ?? tool.runtime].push(entry);
   }
 
   const filteredTools: Partial<
-    Record<ToolRuntime, readonly ManifestToolEntry[]>
+    Record<ToolGroup, readonly ManifestToolEntry[]>
   > = {};
-  for (const runtime of TOOL_RUNTIMES) {
-    if (toolsByRuntime[runtime].length > 0) {
-      filteredTools[runtime] = toolsByRuntime[runtime];
+  for (const group of TOOL_GROUPS) {
+    if (toolsByGroup[group].length > 0) {
+      filteredTools[group] = toolsByGroup[group];
     }
   }
 
@@ -46,8 +52,8 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
 }
 
 export function toolManifestToCompactText(manifest: ToolManifest): string {
-  return TOOL_RUNTIMES.flatMap((runtime) => {
-    const tools = manifest.tools[runtime];
+  return TOOL_GROUPS.flatMap((group) => {
+    const tools = manifest.tools[group];
     if (!tools) {
       return [];
     }
@@ -57,7 +63,7 @@ export function toolManifestToCompactText(manifest: ToolManifest): string {
         tool.version ? `${tool.name} ${tool.version}` : tool.name
       )
     );
-    const label = runtime.charAt(0).toUpperCase() + runtime.slice(1);
+    const label = group.charAt(0).toUpperCase() + group.slice(1);
 
     return [`- ${label}: ${[...entries].join(", ")}`];
   }).join("\n");

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,25 +1,18 @@
 import type {
   ManifestToolEntry,
   ToolEntry,
-  ToolGroup,
   ToolManifest,
+  ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
-const TOOL_GROUPS = [
-  "system",
-  "dust",
-  "python",
-  "node",
-] as const satisfies readonly ToolGroup[];
-
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
-  const toolsByGroup: Record<ToolGroup, ManifestToolEntry[]> = {
+  const toolsByRuntime: Record<ToolRuntime, ManifestToolEntry[]> = {
     system: [],
-    dust: [],
     python: [],
     node: [],
   };
+  const dustTools: ManifestToolEntry[] = [];
 
   for (const tool of tools) {
     const entry: ManifestToolEntry = {
@@ -29,21 +22,25 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
       ...(tool.usage && { usage: tool.usage }),
       ...(tool.returns && { returns: tool.returns }),
     };
-    toolsByGroup[tool.group ?? tool.runtime].push(entry);
-  }
-
-  const filteredTools: Partial<
-    Record<ToolGroup, readonly ManifestToolEntry[]>
-  > = {};
-  for (const group of TOOL_GROUPS) {
-    if (toolsByGroup[group].length > 0) {
-      filteredTools[group] = toolsByGroup[group];
+    if (tool.isDustTool) {
+      dustTools.push(entry);
+    } else {
+      toolsByRuntime[tool.runtime].push(entry);
     }
   }
 
   return {
     version: "1.0",
-    tools: filteredTools,
+    tools: {
+      ...(toolsByRuntime.system.length > 0 && {
+        system: toolsByRuntime.system,
+      }),
+      ...(dustTools.length > 0 && { dust: dustTools }),
+      ...(toolsByRuntime.python.length > 0 && {
+        python: toolsByRuntime.python,
+      }),
+      ...(toolsByRuntime.node.length > 0 && { node: toolsByRuntime.node }),
+    },
   };
 }
 
@@ -52,21 +49,29 @@ export function toolManifestToJSON(manifest: ToolManifest): string {
 }
 
 export function toolManifestToCompactText(manifest: ToolManifest): string {
-  return TOOL_GROUPS.flatMap((group) => {
-    const tools = manifest.tools[group];
+  const formatTools = (
+    label: string,
+    tools: readonly ManifestToolEntry[] | undefined
+  ): string | null => {
     if (!tools) {
-      return [];
+      return null;
     }
-
     const entries = new Set(
       tools.map((tool) =>
         tool.version ? `${tool.name} ${tool.version}` : tool.name
       )
     );
-    const label = group.charAt(0).toUpperCase() + group.slice(1);
+    return `- ${label}: ${[...entries].join(", ")}`;
+  };
 
-    return [`- ${label}: ${[...entries].join(", ")}`];
-  }).join("\n");
+  return [
+    formatTools("System", manifest.tools.system),
+    formatTools("Dust", manifest.tools.dust),
+    formatTools("Python", manifest.tools.python),
+    formatTools("Node", manifest.tools.node),
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
 }
 
 export function toolManifestToYAML(manifest: ToolManifest): string {

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -37,11 +37,8 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 // Tool Runtime & Profile
 // ---------------------------------------------------------------------------
 
-export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
+export const TOOL_RUNTIMES = ["system", "dust", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
-
-export const TOOL_CATEGORIES = ["system", "dust", "python", "node"] as const;
-export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
 
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;
 export type ToolProfile = (typeof TOOL_PROFILES)[number];
@@ -57,7 +54,6 @@ export interface ToolEntry {
   readonly usage?: string;
   readonly returns?: string;
   readonly runtime: ToolRuntime;
-  readonly category?: ToolCategory;
   readonly profile?: ToolProfile | readonly ToolProfile[];
 }
 
@@ -146,7 +142,7 @@ export interface ManifestToolEntry {
 export interface ToolManifest {
   readonly version: "1.0";
   readonly tools: Readonly<
-    Partial<Record<ToolCategory, readonly ManifestToolEntry[]>>
+    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
   >;
 }
 

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -39,7 +39,6 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 
 export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
-export type ToolGroup = ToolRuntime | "dust";
 
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;
 export type ToolProfile = (typeof TOOL_PROFILES)[number];
@@ -55,7 +54,7 @@ export interface ToolEntry {
   readonly usage?: string;
   readonly returns?: string;
   readonly runtime: ToolRuntime;
-  readonly group?: ToolGroup;
+  readonly isDustTool?: boolean;
   readonly profile?: ToolProfile | readonly ToolProfile[];
 }
 
@@ -144,7 +143,9 @@ export interface ManifestToolEntry {
 export interface ToolManifest {
   readonly version: "1.0";
   readonly tools: Readonly<
-    Partial<Record<ToolGroup, readonly ManifestToolEntry[]>>
+    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>> & {
+      readonly dust?: readonly ManifestToolEntry[];
+    }
   >;
 }
 

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -40,13 +40,7 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
 
-export const TOOL_CATEGORIES = [
-  "system",
-  "dust",
-  "office",
-  "python",
-  "node",
-] as const;
+export const TOOL_CATEGORIES = ["system", "dust", "python", "node"] as const;
 export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
 
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -40,6 +40,9 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
 
+export const TOOL_CATEGORIES = ["system", "office", "python", "node"] as const;
+export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;
 export type ToolProfile = (typeof TOOL_PROFILES)[number];
 
@@ -54,6 +57,7 @@ export interface ToolEntry {
   readonly usage?: string;
   readonly returns?: string;
   readonly runtime: ToolRuntime;
+  readonly category?: ToolCategory;
   readonly profile?: ToolProfile | readonly ToolProfile[];
 }
 
@@ -142,7 +146,7 @@ export interface ManifestToolEntry {
 export interface ToolManifest {
   readonly version: "1.0";
   readonly tools: Readonly<
-    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
+    Partial<Record<ToolCategory, readonly ManifestToolEntry[]>>
   >;
 }
 

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -40,7 +40,13 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
 
-export const TOOL_CATEGORIES = ["system", "office", "python", "node"] as const;
+export const TOOL_CATEGORIES = [
+  "system",
+  "dust",
+  "office",
+  "python",
+  "node",
+] as const;
 export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
 
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -143,9 +143,7 @@ export interface ManifestToolEntry {
 export interface ToolManifest {
   readonly version: "1.0";
   readonly tools: Readonly<
-    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>> & {
-      readonly dust?: readonly ManifestToolEntry[];
-    }
+    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
   >;
 }
 

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -37,8 +37,9 @@ export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
 // Tool Runtime & Profile
 // ---------------------------------------------------------------------------
 
-export const TOOL_RUNTIMES = ["system", "dust", "python", "node"] as const;
+export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
 export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
+export type ToolGroup = ToolRuntime | "dust";
 
 export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;
 export type ToolProfile = (typeof TOOL_PROFILES)[number];
@@ -54,6 +55,7 @@ export interface ToolEntry {
   readonly usage?: string;
   readonly returns?: string;
   readonly runtime: ToolRuntime;
+  readonly group?: ToolGroup;
   readonly profile?: ToolProfile | readonly ToolProfile[];
 }
 
@@ -142,7 +144,7 @@ export interface ManifestToolEntry {
 export interface ToolManifest {
   readonly version: "1.0";
   readonly tools: Readonly<
-    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
+    Partial<Record<ToolGroup, readonly ManifestToolEntry[]>>
   >;
 }
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -18,6 +18,12 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
+    expect(instructions).toMatch(
+      /Unlike the standard Linux utilities above, `xlsx_inspect`, `pptx_inspect`,\s+and `docx_inspect` are Dust-specific commands for structural inspection/
+    );
+    expect(instructions).toContain(
+      "`pptx_slides` safely duplicates, moves, or deletes slides"
+    );
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -14,10 +14,12 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).toContain("dsbx tools");
-    expect(instructions).toContain("- System: git, curl");
-    expect(instructions).toContain(
-      "- Dust: dsbx, apply_patch, read_file, write_file, edit_file, grep_files, glob, list_dir, xlsx_inspect, pptx_inspect, pptx_slides, docx_inspect"
-    );
+    const systemTools = instructions
+      .split("\n")
+      .find((line) => line.startsWith("- System:"));
+    expect(systemTools).toContain("git, curl");
+    expect(systemTools).toContain("xlsx_inspect");
+    expect(instructions).not.toContain("- Dust:");
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
@@ -41,11 +43,11 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).not.toContain("dsbx tools");
-    const dustTools = instructions
+    const systemTools = instructions
       .split("\n")
-      .find((line) => line.startsWith("- Dust:"));
-    expect(dustTools).toBeDefined();
-    expect(dustTools).not.toContain("dsbx");
+      .find((line) => line.startsWith("- System:"));
+    expect(systemTools).toBeDefined();
+    expect(systemTools).not.toContain("dsbx");
     expect(instructions).not.toContain("- `dsbx`: Dust CLI");
   });
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -18,6 +18,14 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
+    const systemTools = instructions
+      .split("\n")
+      .find((line) => line.startsWith("- System:"));
+    expect(systemTools).toBeDefined();
+    expect(systemTools).not.toContain("xlsx_inspect");
+    expect(systemTools).not.toContain("pptx_inspect");
+    expect(systemTools).not.toContain("docx_inspect");
+    expect(systemTools).not.toContain("pptx_slides");
     expect(instructions).toContain(
       "Dust-specific Office helpers (not standard Linux commands)"
     );

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -21,18 +21,10 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
-    const systemTools = instructions
-      .split("\n")
-      .find((line) => line.startsWith("- System:"));
-    expect(systemTools).toBeDefined();
-    expect(systemTools).not.toContain("dsbx");
-    expect(systemTools).not.toContain("read_file");
-    expect(systemTools).not.toContain("xlsx_inspect");
+    expect(instructions).toContain("Notable Dust helpers:");
     expect(instructions).toContain(
-      "System tools are standard preinstalled command-line utilities"
+      "- `pptx_slides`: Duplicate, move, or delete .pptx slides without corrupting"
     );
-    expect(instructions).toContain("Dust tools are");
-    expect(instructions).toContain("non-standard helpers provided by Dust");
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -21,7 +21,8 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
-    expect(instructions).toContain("Notable Dust helpers:");
+    expect(instructions).toContain("Dust tool details:");
+    expect(instructions).toContain("- `dsbx`: Dust CLI");
     expect(instructions).toContain(
       "- `pptx_slides`: Duplicate, move, or delete .pptx slides without corrupting"
     );
@@ -45,6 +46,7 @@ describe("sandboxSkill", () => {
       .find((line) => line.startsWith("- Dust:"));
     expect(dustTools).toBeDefined();
     expect(dustTools).not.toContain("dsbx");
+    expect(instructions).not.toContain("- `dsbx`: Dust CLI");
   });
 
   it("instructs the model to analyze mounted tabular files with code", async () => {

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -16,10 +16,7 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("dsbx tools");
     expect(instructions).toContain("- System: git, curl");
     expect(instructions).toContain(
-      "- Dust: dsbx, apply_patch, read_file, write_file, edit_file, grep_files, glob, list_dir"
-    );
-    expect(instructions).toContain(
-      "- Office: xlsx_inspect, pptx_inspect, pptx_slides, docx_inspect"
+      "- Dust: dsbx, apply_patch, read_file, write_file, edit_file, grep_files, glob, list_dir, xlsx_inspect, pptx_inspect, pptx_slides, docx_inspect"
     );
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
@@ -34,9 +31,8 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain(
       "System tools are standard preinstalled command-line utilities"
     );
-    expect(instructions).toMatch(
-      /Dust and Office\s+tools are Dust-provided helpers/
-    );
+    expect(instructions).toContain("Dust tools are");
+    expect(instructions).toContain("non-standard helpers provided by Dust");
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -6,7 +6,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 describe("sandboxSkill", () => {
-  it("points to the on-demand toolset description instead of inlining it", async () => {
+  it("inlines a compact toolset and points to detailed help", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
     const instructions = await sandboxSkill.fetchInstructions(auth, {
@@ -14,7 +14,11 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).toContain("dsbx tools");
+    expect(instructions).toContain("- System: git, curl");
+    expect(instructions).toContain("- Python: python, pandas 3.0.1");
+    expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
+    expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");
   });
@@ -29,6 +33,11 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).not.toContain("dsbx tools");
+    const systemTools = instructions
+      .split("\n")
+      .find((line) => line.startsWith("- System:"));
+    expect(systemTools).toBeDefined();
+    expect(systemTools).not.toContain("dsbx");
   });
 
   it("instructs the model to analyze mounted tabular files with code", async () => {

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -18,11 +18,20 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
-    expect(instructions).toMatch(
-      /Unlike the standard Linux utilities above, `xlsx_inspect`, `pptx_inspect`,\s+and `docx_inspect` are Dust-specific commands for structural inspection/
+    expect(instructions).toContain(
+      "Dust-specific Office helpers (not standard Linux commands)"
     );
     expect(instructions).toContain(
-      "`pptx_slides` safely duplicates, moves, or deletes slides"
+      "- `xlsx_inspect`: Inspect workbook sheets, ranges, formulas"
+    );
+    expect(instructions).toContain(
+      "- `pptx_inspect`: Inspect and QA deck structure"
+    );
+    expect(instructions).toContain(
+      "- `docx_inspect`: Inspect document structure, styles"
+    );
+    expect(instructions).toContain(
+      "- `pptx_slides`: Safely duplicate, move, or delete slides"
     );
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -16,6 +16,9 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("dsbx tools");
     expect(instructions).toContain("- System: git, curl");
     expect(instructions).toContain(
+      "- Dust: dsbx, apply_patch, read_file, write_file, edit_file, grep_files, glob, list_dir"
+    );
+    expect(instructions).toContain(
       "- Office: xlsx_inspect, pptx_inspect, pptx_slides, docx_inspect"
     );
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
@@ -25,11 +28,15 @@ describe("sandboxSkill", () => {
       .split("\n")
       .find((line) => line.startsWith("- System:"));
     expect(systemTools).toBeDefined();
+    expect(systemTools).not.toContain("dsbx");
+    expect(systemTools).not.toContain("read_file");
     expect(systemTools).not.toContain("xlsx_inspect");
-    expect(systemTools).not.toContain("pptx_inspect");
-    expect(systemTools).not.toContain("docx_inspect");
-    expect(systemTools).not.toContain("pptx_slides");
-    expect(instructions).toContain("Office tools are Dust-specific helpers");
+    expect(instructions).toContain(
+      "System tools are standard preinstalled command-line utilities"
+    );
+    expect(instructions).toMatch(
+      /Dust and Office\s+tools are Dust-provided helpers/
+    );
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");
@@ -45,11 +52,11 @@ describe("sandboxSkill", () => {
     });
 
     expect(instructions).not.toContain("dsbx tools");
-    const systemTools = instructions
+    const dustTools = instructions
       .split("\n")
-      .find((line) => line.startsWith("- System:"));
-    expect(systemTools).toBeDefined();
-    expect(systemTools).not.toContain("dsbx");
+      .find((line) => line.startsWith("- Dust:"));
+    expect(dustTools).toBeDefined();
+    expect(dustTools).not.toContain("dsbx");
   });
 
   it("instructs the model to analyze mounted tabular files with code", async () => {

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -15,6 +15,9 @@ describe("sandboxSkill", () => {
 
     expect(instructions).toContain("dsbx tools");
     expect(instructions).toContain("- System: git, curl");
+    expect(instructions).toContain(
+      "- Office: xlsx_inspect, pptx_inspect, pptx_slides, docx_inspect"
+    );
     expect(instructions).toContain("- Python: python, pandas 3.0.1");
     expect(instructions).toContain("- Node: typescript, tsx");
     expect(instructions).toContain("`describe_toolset`");
@@ -26,21 +29,7 @@ describe("sandboxSkill", () => {
     expect(systemTools).not.toContain("pptx_inspect");
     expect(systemTools).not.toContain("docx_inspect");
     expect(systemTools).not.toContain("pptx_slides");
-    expect(instructions).toContain(
-      "Dust-specific Office helpers (not standard Linux commands)"
-    );
-    expect(instructions).toContain(
-      "- `xlsx_inspect`: Inspect workbook sheets, ranges, formulas"
-    );
-    expect(instructions).toContain(
-      "- `pptx_inspect`: Inspect and QA deck structure"
-    );
-    expect(instructions).toContain(
-      "- `docx_inspect`: Inspect document structure, styles"
-    );
-    expect(instructions).toContain(
-      "- `pptx_slides`: Safely duplicate, move, or delete slides"
-    );
+    expect(instructions).toContain("Office tools are Dust-specific helpers");
     expect(instructions).toContain("`<command> --help`");
     expect(instructions).not.toContain("name: dsbx");
     expect(instructions).not.toContain("```yaml");

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -17,14 +17,27 @@ describe("sandboxSkill", () => {
     const systemTools = instructions
       .split("\n")
       .find((line) => line.startsWith("- System:"));
-    expect(systemTools).toContain("git, curl");
+    expect(systemTools).toContain("git");
+    expect(systemTools).toContain("curl");
     expect(systemTools).toContain("xlsx_inspect");
     expect(instructions).not.toContain("- Dust:");
-    expect(instructions).toContain("- Python: python, pandas 3.0.1");
-    expect(instructions).toContain("- Node: typescript, tsx");
+    const pythonTools = instructions
+      .split("\n")
+      .find((line) => line.startsWith("- Python:"));
+    expect(pythonTools).toContain("python");
+    expect(pythonTools).toContain("pandas 3.0.1");
+    const nodeTools = instructions
+      .split("\n")
+      .find((line) => line.startsWith("- Node:"));
+    expect(nodeTools).toContain("typescript");
+    expect(nodeTools).toContain("tsx");
     expect(instructions).toContain("`describe_toolset`");
     expect(instructions).toContain("Dust tool details:");
+    expect(instructions).toContain("- `apply_patch`:");
     expect(instructions).toContain("- `dsbx`: Dust CLI");
+    expect(instructions.indexOf("- `apply_patch`:")).toBeLessThan(
+      instructions.indexOf("- `dsbx`:")
+    );
     expect(instructions).toContain(
       "- `pptx_slides`: Duplicate, move, or delete .pptx slides without corrupting"
     );

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -350,7 +350,7 @@ async function buildSandboxInstructions(
   const compactManifest = toolManifestToCompactText(manifest);
   const dustToolDetailsSection = buildToolDetailsSection(
     "Dust",
-    manifest.tools.dust ?? []
+    toolsResult.value.filter((tool) => tool.isDustTool)
   );
 
   return `${sandboxInstructions}
@@ -367,7 +367,7 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-System tools are standard preinstalled command-line utilities. Dust tools are
+System tools include standard preinstalled command-line utilities and
 non-standard helpers provided by Dust.
 
 ${dustToolDetailsSection}Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -358,7 +358,7 @@ export const sandboxSkill = {
     "Run code, scripts, and shell commands in the conversation's Computer (a sandboxed Linux environment).",
   agentFacingDescription:
     "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
-    "process data, install packages, manipulate files, or perform any task requiring shell access. " +
+    "process data, manipulate files, or perform any task requiring shell access. " +
     "You must enable this skill proactively as soon as the user uploads files or you need to work with files, " +
     "including PDFs, spreadsheets, archives, or generated artifacts. Use it to extract text from files, " +
     "parse lengthy tool outputs, run code and shell commands, process data, manipulate files, or perform " +

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -6,6 +6,7 @@ import {
   filterDsbxToolEntries,
   getSandboxImage,
   getToolsForProvider,
+  type ToolManifest,
   toolManifestToCompactText,
 } from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
@@ -289,6 +290,27 @@ value you should not have — apologize, do not retry the command, and do not
 attempt to reconstruct, decode, or otherwise recover the value.`;
 }
 
+function buildNotableDustHelpersSection(manifest: ToolManifest): string {
+  const helpers = new Map(
+    (manifest.tools.dust ?? [])
+      .filter((tool) => /\.(?:docx|pptx|xlsx)\b/.test(tool.description))
+      .map((tool) => [tool.name, tool])
+  );
+
+  if (helpers.size === 0) {
+    return "";
+  }
+
+  const descriptions = [...helpers.values()]
+    .map((tool) => {
+      const summary = tool.description.match(/^.*?\.(?=\s|$)/)?.[0];
+      return `- \`${tool.name}\`: ${summary ?? tool.description}`;
+    })
+    .join("\n");
+
+  return `Notable Dust helpers:\n\n${descriptions}\n\n`;
+}
+
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId: ModelProviderIdType | undefined,
@@ -326,9 +348,9 @@ async function buildSandboxInstructions(
     return `${sandboxInstructions}\n\n${filesSections}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
   }
 
-  const compactManifest = toolManifestToCompactText(
-    createToolManifest(toolsResult.value)
-  );
+  const manifest = createToolManifest(toolsResult.value);
+  const compactManifest = toolManifestToCompactText(manifest);
+  const notableDustHelpersSection = buildNotableDustHelpersSection(manifest);
 
   return `${sandboxInstructions}
 
@@ -347,16 +369,7 @@ possible. Call \`describe_toolset\` for full descriptions and usage metadata.
 System tools are standard preinstalled command-line utilities. Dust tools are
 non-standard helpers provided by Dust.
 
-Notable Dust helpers:
-
-- \`xlsx_inspect\`: Inspect workbook structure, formulas, values, and styles.
-- \`pptx_inspect\`: Inspect and QA slide structure, content, rendering, and
-  fidelity.
-- \`docx_inspect\`: Inspect document structure, styles, content, and rendering.
-- \`pptx_slides\`: Duplicate, move, or delete .pptx slides without corrupting
-  the package.
-
-Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed
+${notableDustHelpersSection}Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed
 above, NOTHING ELSE.
 
 `;

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -344,11 +344,21 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-Unlike the standard Linux utilities above, \`xlsx_inspect\`, \`pptx_inspect\`,
-and \`docx_inspect\` are Dust-specific commands for structural inspection and
-QA of Office files; \`pptx_slides\` safely duplicates, moves, or deletes slides.
-Prefer these helpers for their formats and run \`<command> --help\` for detailed
-usage. Use ONLY the tools listed above, NOTHING ELSE.
+
+Dust-specific Office helpers (not standard Linux commands):
+
+- \`xlsx_inspect\`: Inspect workbook sheets, ranges, formulas, cached values,
+  number formats, and cell styling; search values or formatting metadata.
+- \`pptx_inspect\`: Inspect and QA deck structure, layouts, shapes, text,
+  charts, tables, and media; render slides and compare edits with their source.
+- \`docx_inspect\`: Inspect document structure, styles, headings, paragraphs,
+  tables, sections, tracked changes, fields, and media; render pages for visual
+  review.
+- \`pptx_slides\`: Safely duplicate, move, or delete slides while preserving
+  package relationships.
+
+Prefer these helpers for the listed operations. Run \`<command> --help\` for
+detailed modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -18,6 +18,13 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { Ok } from "@app/types/shared/result";
 
+const DESCRIBED_OFFICE_TOOL_NAMES = new Set([
+  "xlsx_inspect",
+  "pptx_inspect",
+  "docx_inspect",
+  "pptx_slides",
+]);
+
 function buildSandboxInstructionProse({
   hasDsbxTools,
 }: {
@@ -327,7 +334,11 @@ async function buildSandboxInstructions(
   }
 
   const compactManifest = toolManifestToCompactText(
-    createToolManifest(toolsResult.value)
+    createToolManifest(
+      toolsResult.value.filter(
+        (tool) => !DESCRIBED_OFFICE_TOOL_NAMES.has(tool.name)
+      )
+    )
   );
 
   return `${sandboxInstructions}

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -18,13 +18,6 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { Ok } from "@app/types/shared/result";
 
-const DESCRIBED_OFFICE_TOOL_NAMES = new Set([
-  "xlsx_inspect",
-  "pptx_inspect",
-  "docx_inspect",
-  "pptx_slides",
-]);
-
 function buildSandboxInstructionProse({
   hasDsbxTools,
 }: {
@@ -334,11 +327,7 @@ async function buildSandboxInstructions(
   }
 
   const compactManifest = toolManifestToCompactText(
-    createToolManifest(
-      toolsResult.value.filter(
-        (tool) => !DESCRIBED_OFFICE_TOOL_NAMES.has(tool.name)
-      )
-    )
+    createToolManifest(toolsResult.value)
   );
 
   return `${sandboxInstructions}
@@ -355,21 +344,9 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-
-Dust-specific Office helpers (not standard Linux commands):
-
-- \`xlsx_inspect\`: Inspect workbook sheets, ranges, formulas, cached values,
-  number formats, and cell styling; search values or formatting metadata.
-- \`pptx_inspect\`: Inspect and QA deck structure, layouts, shapes, text,
-  charts, tables, and media; render slides and compare edits with their source.
-- \`docx_inspect\`: Inspect document structure, styles, headings, paragraphs,
-  tables, sections, tracked changes, fields, and media; render pages for visual
-  review.
-- \`pptx_slides\`: Safely duplicate, move, or delete slides while preserving
-  package relationships.
-
-Prefer these helpers for the listed operations. Run \`<command> --help\` for
-detailed modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
+Office tools are Dust-specific helpers for structural inspection, QA,
+rendering, and safe slide operations. Run \`<command> --help\` for detailed
+modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -344,8 +344,11 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-The Dust file helpers and Office inspectors support \`<command> --help\` for
-detailed usage. Use ONLY the tools listed above, NOTHING ELSE.
+Unlike the standard Linux utilities above, \`xlsx_inspect\`, \`pptx_inspect\`,
+and \`docx_inspect\` are Dust-specific commands for structural inspection and
+QA of Office files; \`pptx_slides\` safely duplicates, moves, or deletes slides.
+Prefer these helpers for their formats and run \`<command> --help\` for detailed
+usage. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -6,6 +6,7 @@ import {
   filterDsbxToolEntries,
   getSandboxImage,
   getToolsForProvider,
+  type ToolGroup,
   type ToolManifest,
   toolManifestToCompactText,
 } from "@app/lib/api/sandbox/image";
@@ -290,25 +291,27 @@ value you should not have — apologize, do not retry the command, and do not
 attempt to reconstruct, decode, or otherwise recover the value.`;
 }
 
-function buildNotableDustHelpersSection(manifest: ToolManifest): string {
-  const helpers = new Map(
-    (manifest.tools.dust ?? [])
-      .filter((tool) => /\.(?:docx|pptx|xlsx)\b/.test(tool.description))
-      .map((tool) => [tool.name, tool])
+function buildToolGroupDetailsSection(
+  manifest: ToolManifest,
+  group: ToolGroup
+): string {
+  const tools = new Map(
+    (manifest.tools[group] ?? []).map((tool) => [tool.name, tool])
   );
 
-  if (helpers.size === 0) {
+  if (tools.size === 0) {
     return "";
   }
 
-  const descriptions = [...helpers.values()]
+  const descriptions = [...tools.values()]
     .map((tool) => {
       const summary = tool.description.match(/^.*?\.(?=\s|$)/)?.[0];
       return `- \`${tool.name}\`: ${summary ?? tool.description}`;
     })
     .join("\n");
+  const label = group.charAt(0).toUpperCase() + group.slice(1);
 
-  return `Notable Dust helpers:\n\n${descriptions}\n\n`;
+  return `${label} tool details:\n\n${descriptions}\n\n`;
 }
 
 async function buildSandboxInstructions(
@@ -350,7 +353,7 @@ async function buildSandboxInstructions(
 
   const manifest = createToolManifest(toolsResult.value);
   const compactManifest = toolManifestToCompactText(manifest);
-  const notableDustHelpersSection = buildNotableDustHelpersSection(manifest);
+  const dustToolDetailsSection = buildToolGroupDetailsSection(manifest, "dust");
 
   return `${sandboxInstructions}
 
@@ -369,7 +372,7 @@ possible. Call \`describe_toolset\` for full descriptions and usage metadata.
 System tools are standard preinstalled command-line utilities. Dust tools are
 non-standard helpers provided by Dust.
 
-${notableDustHelpersSection}Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed
+${dustToolDetailsSection}Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed
 above, NOTHING ELSE.
 
 `;

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -344,9 +344,9 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-Office tools are Dust-specific helpers for structural inspection, QA,
-rendering, and safe slide operations. Run \`<command> --help\` for detailed
-modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
+System tools are standard preinstalled command-line utilities. Dust and Office
+tools are Dust-provided helpers. Run \`<command> --help\` for detailed modes
+and flags. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -345,8 +345,19 @@ ${compactManifest}
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
 System tools are standard preinstalled command-line utilities. Dust tools are
-non-standard helpers provided by Dust. Run \`<command> --help\` for detailed
-modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
+non-standard helpers provided by Dust.
+
+Notable Dust helpers:
+
+- \`xlsx_inspect\`: Inspect workbook structure, formulas, values, and styles.
+- \`pptx_inspect\`: Inspect and QA slide structure, content, rendering, and
+  fidelity.
+- \`docx_inspect\`: Inspect document structure, styles, content, and rendering.
+- \`pptx_slides\`: Duplicate, move, or delete .pptx slides without corrupting
+  the package.
+
+Run \`<command> --help\` for detailed modes and flags. Use ONLY the tools listed
+above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -6,10 +6,9 @@ import {
   filterDsbxToolEntries,
   getSandboxImage,
   getToolsForProvider,
-  type ToolGroup,
-  type ToolManifest,
   toolManifestToCompactText,
 } from "@app/lib/api/sandbox/image";
+import type { ManifestToolEntry } from "@app/lib/api/sandbox/image/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
@@ -291,13 +290,11 @@ value you should not have — apologize, do not retry the command, and do not
 attempt to reconstruct, decode, or otherwise recover the value.`;
 }
 
-function buildToolGroupDetailsSection(
-  manifest: ToolManifest,
-  group: ToolGroup
+function buildToolDetailsSection(
+  label: string,
+  entries: readonly ManifestToolEntry[]
 ): string {
-  const tools = new Map(
-    (manifest.tools[group] ?? []).map((tool) => [tool.name, tool])
-  );
+  const tools = new Map(entries.map((tool) => [tool.name, tool]));
 
   if (tools.size === 0) {
     return "";
@@ -309,8 +306,6 @@ function buildToolGroupDetailsSection(
       return `- \`${tool.name}\`: ${summary ?? tool.description}`;
     })
     .join("\n");
-  const label = group.charAt(0).toUpperCase() + group.slice(1);
-
   return `${label} tool details:\n\n${descriptions}\n\n`;
 }
 
@@ -353,7 +348,10 @@ async function buildSandboxInstructions(
 
   const manifest = createToolManifest(toolsResult.value);
   const compactManifest = toolManifestToCompactText(manifest);
-  const dustToolDetailsSection = buildToolGroupDetailsSection(manifest, "dust");
+  const dustToolDetailsSection = buildToolDetailsSection(
+    "Dust",
+    manifest.tools.dust ?? []
+  );
 
   return `${sandboxInstructions}
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -344,9 +344,9 @@ ${compactManifest}
 
 Versions are shown when pinned. Installing packages in the sandbox is NOT
 possible. Call \`describe_toolset\` for full descriptions and usage metadata.
-System tools are standard preinstalled command-line utilities. Dust and Office
-tools are Dust-provided helpers. Run \`<command> --help\` for detailed modes
-and flags. Use ONLY the tools listed above, NOTHING ELSE.
+System tools are standard preinstalled command-line utilities. Dust tools are
+non-standard helpers provided by Dust. Run \`<command> --help\` for detailed
+modes and flags. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -301,6 +301,7 @@ function buildToolDetailsSection(
   }
 
   const descriptions = [...tools.values()]
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map((tool) => {
       const summary = tool.description.match(/^.*?\.(?=\s|$)/)?.[0];
       return `- \`${tool.name}\`: ${summary ?? tool.description}`;

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -1,13 +1,22 @@
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { readWorkspacePolicy } from "@app/lib/api/sandbox/egress_policy";
+import {
+  createToolManifest,
+  filterDsbxToolEntries,
+  getSandboxImage,
+  getToolsForProvider,
+  toolManifestToCompactText,
+} from "@app/lib/api/sandbox/image";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+import { Ok } from "@app/types/shared/result";
 
 function buildSandboxInstructionProse({
   hasDsbxTools,
@@ -282,6 +291,7 @@ attempt to reconstruct, decode, or otherwise recover the value.`;
 
 async function buildSandboxInstructions(
   auth: Authenticator,
+  providerId: ModelProviderIdType | undefined,
   { hasDsbxTools, isProject }: { hasDsbxTools: boolean; isProject: boolean }
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
@@ -290,9 +300,35 @@ async function buildSandboxInstructions(
   const projectFilesSection = isProject ? buildProjectFilesSection() : null;
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
 
+  let toolsResult;
+
   const filesSections = [conversationFilesSection, projectFilesSection]
     .filter((s): s is string => s !== null)
     .join("\n\n");
+
+  if (providerId) {
+    toolsResult = getToolsForProvider(auth, providerId, {
+      includeDsbxTools: hasDsbxTools,
+    });
+  } else {
+    const imageResult = getSandboxImage(auth);
+    if (imageResult.isErr()) {
+      return `${sandboxInstructions}\n\n${filesSections}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
+    }
+    toolsResult = new Ok(
+      filterDsbxToolEntries(imageResult.value.tools, {
+        includeDsbxTools: hasDsbxTools,
+      })
+    );
+  }
+
+  if (toolsResult.isErr()) {
+    return `${sandboxInstructions}\n\n${filesSections}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
+  }
+
+  const compactManifest = toolManifestToCompactText(
+    createToolManifest(toolsResult.value)
+  );
 
   return `${sandboxInstructions}
 
@@ -304,10 +340,12 @@ ${environmentVariablesSection}
 
 #### Sandbox Available Tools and Libraries
 
-Tools and libraries are pre-installed in the sandbox environment. Installing
-packages in the sandbox is NOT possible. Call \`describe_toolset\` to inspect
-the available CLI binaries and language libraries, including their exact
-versions. Use ONLY the tools listed there, NOTHING ELSE.
+${compactManifest}
+
+Versions are shown when pinned. Installing packages in the sandbox is NOT
+possible. Call \`describe_toolset\` for full descriptions and usage metadata.
+The Dust file helpers and Office inspectors support \`<command> --help\` for
+detailed usage. Use ONLY the tools listed above, NOTHING ELSE.
 
 `;
 }
@@ -332,13 +370,14 @@ export const sandboxSkill = {
       agentLoopData,
     }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
+    const providerId = agentLoopData?.model.providerId;
     const flags = await getFeatureFlags(auth);
     const hasDsbxTools = isComputerFeatureEnabled(flags);
     const isProject = agentLoopData?.conversation
       ? isPodConversation(agentLoopData.conversation)
       : false;
 
-    return buildSandboxInstructions(auth, {
+    return buildSandboxInstructions(auth, providerId, {
       hasDsbxTools,
       isProject,
     });


### PR DESCRIPTION
## Description

Follow-up on #28856 that removed entirely the YAML manifest where we mention which libs/binaries are available on the sandbox in the skill's instructions. Removing it saves 2,548 tokens, but means the agent has no idea which tools and libraries are available until it calls `describe_toolset`. This is not an issue for the very common ones (`git`, `curl`, `wget`, `jq` for instance), but is more problematic for the non-standard ones we provide like `xlsx_inspect`, `docx_inspect`, etc..

Now amounts to 549 tokens.

This PR adds a compact list with one line per runtime and pinned versions where available, totaling roughly 800 characters. Full descriptions and usage metadata are exposed for the tools we provide that are not industry standards.

## Tests

- Tested locally on a local excel file with formulas.
- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.