### PR TITLE
Fix tier resolution for generated custom models

### DIFF
--- a/front/lib/api/assistant/token_pricing/tiers.test.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.test.ts
@@ -13,11 +13,11 @@ import {
   STATIC_MODEL_IDS,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types/assistant/models/models";
-import type { ModelIdType } from "@app/types/assistant/models/types";
 import {
   GPT_5_5_MODEL_ID,
   GPT_5_NANO_MODEL_ID,
 } from "@app/types/assistant/models/openai";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import { GROK_4_FAST_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 import { describe, expect, it } from "vitest";

--- a/front/lib/api/assistant/token_pricing/tiers.test.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.test.ts
@@ -76,7 +76,7 @@ describe("token_pricing/tiers", () => {
   it("classifies generated custom models as premium", () => {
     // Custom models are generated from GCS at build time and are therefore not
     // present in the checked-in CUSTOM_MODEL_IDS fixture.
-    const customModelId: ModelIdType = "claude-fruitcake-eap";
+    const customModelId = "my-custom-model-from-eap" as ModelIdType;
 
     expect(ModelsTierResource.getTierForModel(customModelId, "high")).toBe(
       "premium"

--- a/front/lib/api/assistant/token_pricing/tiers.test.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.test.ts
@@ -76,7 +76,7 @@ describe("token_pricing/tiers", () => {
   it("classifies generated custom models as premium", () => {
     // Custom models are generated from GCS at build time and are therefore not
     // present in the checked-in CUSTOM_MODEL_IDS fixture.
-    const customModelId = "claude-fruitcake-eap" as ModelIdType;
+    const customModelId: ModelIdType = "claude-fruitcake-eap";
 
     expect(ModelsTierResource.getTierForModel(customModelId, "high")).toBe(
       "premium"

--- a/front/lib/api/assistant/token_pricing/tiers.test.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.test.ts
@@ -13,6 +13,7 @@ import {
   STATIC_MODEL_IDS,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types/assistant/models/models";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import {
   GPT_5_5_MODEL_ID,
   GPT_5_NANO_MODEL_ID,
@@ -70,6 +71,16 @@ describe("token_pricing/tiers", () => {
     expect(
       ModelsTierResource.getTierForModel(CLAUDE_FABLE_5_MODEL_ID, "high")
     ).toBe("premium");
+  });
+
+  it("classifies generated custom models as premium", () => {
+    // Custom models are generated from GCS at build time and are therefore not
+    // present in the checked-in CUSTOM_MODEL_IDS fixture.
+    const customModelId = "claude-fruitcake-eap" as ModelIdType;
+
+    expect(ModelsTierResource.getTierForModel(customModelId, "high")).toBe(
+      "premium"
+    );
   });
 
   it("classifies sonnet with light reasoning as cost efficient", () => {

--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -1,6 +1,7 @@
 import { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS } from "@app/lib/api/assistant/token_pricing/static_model_reasoning_efforts";
 import type { StaticModelIdType } from "@app/types/assistant/models/models";
 import type {
+  ModelIdType,
   ModelProviderIdType,
   ReasoningEffort,
   ReasoningEffortSupport,
@@ -19,7 +20,7 @@ export function isModelsTierName(value: unknown): value is ModelsTierName {
 }
 
 export type ModelTierSelection = {
-  modelId: StaticModelIdType;
+  modelId: ModelIdType;
   providerId: ModelProviderIdType;
   reasoningEffort: ReasoningEffort;
 };
@@ -76,7 +77,7 @@ export { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS };
 
 // Tier assignment per static model and supported reasoning effort. Must list every
 // StaticModelIdType and every effort from STATIC_MODEL_SUPPORTED_REASONING_EFFORTS.
-export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
+export const STATIC_MODEL_TIERS = {
   "gpt-3.5-turbo": {
     none: "cost_efficient",
   },

--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -77,7 +77,7 @@ export { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS };
 
 // Tier assignment per static model and supported reasoning effort. Must list every
 // StaticModelIdType and every effort from STATIC_MODEL_SUPPORTED_REASONING_EFFORTS.
-export const STATIC_MODEL_TIERS = {
+export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   "gpt-3.5-turbo": {
     none: "cost_efficient",
   },

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -25,6 +25,7 @@ import type {
   GroupAllowedModelTiersType,
   UserAllowedModelTiersType,
 } from "@app/types/api/model_tiers";
+import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -75,8 +76,9 @@ export class ModelsTierResource {
   static getTierForSelection(
     selection: ModelTierSelection
   ): ModelsTierName | null {
-    return (
-      STATIC_MODEL_TIERS[selection.modelId][selection.reasoningEffort] ?? null
+    return this.getTierForModel(
+      selection.modelId,
+      selection.reasoningEffort
     );
   }
 
@@ -84,7 +86,18 @@ export class ModelsTierResource {
     modelId: ModelTierSelection["modelId"],
     reasoningEffort: ModelTierSelection["reasoningEffort"]
   ): ModelsTierName | null {
-    return STATIC_MODEL_TIERS[modelId][reasoningEffort] ?? null;
+    // Custom models are generated at build time and cannot be exhaustively
+    // listed in STATIC_MODEL_TIERS. Default them to the most restrictive tier
+    // so newly introduced custom/EAP models are access-controlled immediately.
+    if (!isStaticModelId(modelId)) {
+      return "premium";
+    }
+
+    const tiersByReasoningEffort: Partial<
+      Record<ModelTierSelection["reasoningEffort"], ModelsTierName>
+    > = STATIC_MODEL_TIERS[modelId];
+
+    return tiersByReasoningEffort[reasoningEffort] ?? null;
   }
 
   private static assertIsAdmin(auth: Authenticator): void {

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -83,18 +83,11 @@ export class ModelsTierResource {
     modelId: ModelTierSelection["modelId"],
     reasoningEffort: ModelTierSelection["reasoningEffort"]
   ): ModelsTierName | null {
-    // Custom models are generated at build time and cannot be exhaustively
-    // listed in STATIC_MODEL_TIERS. Default them to the most restrictive tier
-    // so newly introduced custom/EAP models are access-controlled immediately.
+    // includes models added at runtime on GCP (EAPs)
     if (!isStaticModelId(modelId)) {
       return "premium";
     }
-
-    const tiersByReasoningEffort: Partial<
-      Record<ModelTierSelection["reasoningEffort"], ModelsTierName>
-    > = STATIC_MODEL_TIERS[modelId];
-
-    return tiersByReasoningEffort[reasoningEffort] ?? null;
+    return STATIC_MODEL_TIERS[modelId][reasoningEffort] ?? null;
   }
 
   private static assertIsAdmin(auth: Authenticator): void {

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -76,10 +76,7 @@ export class ModelsTierResource {
   static getTierForSelection(
     selection: ModelTierSelection
   ): ModelsTierName | null {
-    return this.getTierForModel(
-      selection.modelId,
-      selection.reasoningEffort
-    );
+    return this.getTierForModel(selection.modelId, selection.reasoningEffort);
   }
 
   static getTierForModel(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -461,6 +461,7 @@ export async function runModel(
       {
         agentName: agentConfiguration.name,
         model,
+        reasoningEffort: model.reasoningEffort,
         featureFlags,
       }
     );

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -247,6 +247,11 @@ export const STATIC_MODEL_IDS = [
 // Type for static model IDs only (excludes custom models from GCS).
 export type StaticModelIdType = (typeof STATIC_MODEL_IDS)[number];
 
+export const isStaticModelId = (
+  modelId: ModelIdType
+): modelId is StaticModelIdType =>
+  STATIC_MODEL_IDS.includes(modelId as StaticModelIdType);
+
 // Combined model IDs: static + custom (custom models generated at build time from GCS).
 export const MODEL_IDS = [...STATIC_MODEL_IDS, ...CUSTOM_MODEL_IDS] as const;
 


### PR DESCRIPTION
## Description

Fixes agent executions crashing before the provider call when a generated custom/EAP model is selected while model-tier enforcement is enabled.

- Widen `ModelTierSelection` to include generated custom model IDs.
- Keep `STATIC_MODEL_TIERS` compile-time exhaustive for static models by removing the widening annotation and retaining the `satisfies StaticModelTiersMap` check.
- Classify generated custom models, including `claude-fruitcake-eap`, as `premium` by default instead of indexing the static map with an absent key.
- Route full selections through the defensive lookup so future custom models cannot trigger the same `Cannot read properties of undefined` crash.
- Pass the resolved per-message reasoning effort to the runtime access check.
- Add a focused regression test for the EAP model.

This keeps custom models outside `STATIC_MODEL_TIERS`, since they are generated from GCS at build time and cannot be exhaustively represented in the checked-in static map. The conservative `premium` default ensures new custom models remain access-controlled immediately.

## Tests

- Added a unit regression test covering `claude-fruitcake-eap` as a generated custom model.
- Ran `git diff --check` successfully.
- Local unit tests were not run because the Computer clone does not include installed repository dependencies. Validation is delegated to PR CI.

## Risk

Low to moderate. The behavioral change is that all generated custom models default to the `premium` tier. This is intentionally conservative, but users without premium-tier access will no longer be able to select those models unless an explicit custom-model tier mechanism is added later.

The change is safe to roll back by reverting this PR.

## Deploy Plan

Deploy front normally. After deployment, verify that a `claude-fruitcake-eap` per-message selection reaches model execution or returns the expected model-tier access error, without an activity failure.
