### PR TITLE
fix(input-bar): align footer buttons and tighten mobile spacing

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -146,6 +146,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             aria-disabled={isInputDisabled}
             className={cn(
               "inline-flex box-border items-center rounded-lg h-7 heading-xs px-2 gap-1.5 bg-muted-background border-border text-primary-900 transition-colors duration-200",
+              isMobile && "pl-1",
               isInputDisabled
                 ? "opacity-50 pointer-events-none"
                 : "cursor-pointer hover:bg-hover"
@@ -184,7 +185,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             variant="ghost-secondary"
             size={buttonSize}
             icon={Robot}
-            label="Agent"
+            label={!isMobile ? "Agent" : undefined}
             disabled={isInputDisabled}
             className={cn(disableAgentSelector && "bg-primary-150")}
           />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1610,7 +1610,7 @@ const InputBarContainer = ({
             )}
           </BubbleMenu>
           <div
-            className={cn("flex w-full flex-col", "pt-1.5 pb-2")}
+            className={cn("mt-auto flex w-full flex-col", "pt-1.5 pb-2")}
             style={{
               transition: `padding ${COLLAPSE_TRANSITION}`,
             }}
@@ -1641,7 +1641,7 @@ const InputBarContainer = ({
                 </React.Fragment>
               ))}
             </div>
-            <div className="relative flex w-full items-center justify-between">
+            <div className="relative flex min-h-7 w-full items-center justify-between">
               <div className={cn("flex w-full items-center px-2")}>
                 {!isRecording && (
                   <div
@@ -1690,211 +1690,216 @@ const InputBarContainer = ({
                   </div>
                 )}
                 <div className="grow" />
-                <div className="flex items-center gap-2 md:gap-1" />
-              </div>
-            </div>
-          </div>
-          <div
-            className={cn(
-              "absolute bottom-2 right-2 flex items-center",
-              isMobile ? "gap-1" : "gap-1.5"
-            )}
-          >
-            {clientType === "extension" && (
-              <>
-                <div ref={plusButtonRef}>
-                  <DropdownMenu
-                    open={isCaptureDropdownOpen}
-                    onOpenChange={setIsCaptureDropdownOpen}
-                  >
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost-secondary"
-                        icon={Plus}
-                        size={buttonSize}
-                        disabled={disableInput}
-                      />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+                <div
+                  className={cn(
+                    "flex items-center",
+                    isMobile ? "gap-1" : "gap-1.5"
+                  )}
+                >
+                  {clientType === "extension" && (
+                    <>
+                      <div ref={plusButtonRef}>
+                        <DropdownMenu
+                          open={isCaptureDropdownOpen}
+                          onOpenChange={setIsCaptureDropdownOpen}
+                        >
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost-secondary"
+                              icon={Plus}
+                              size={buttonSize}
+                              disabled={disableInput}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {actions.includes("attachment") && (
+                              <DropdownMenuItem
+                                icon={Attachment01}
+                                label="Attach knowledge"
+                                onClick={() => {
+                                  setIsCaptureDropdownOpen(false);
+                                  setShowKnowledgePicker(true);
+                                }}
+                              />
+                            )}
+                            {captureActions && (
+                              <>
+                                <DropdownMenuItem
+                                  icon={Globe01}
+                                  label="Attach page content"
+                                  disabled={
+                                    disableInput ||
+                                    captureActions.isCapturing ||
+                                    fileUploaderService.isProcessingFiles
+                                  }
+                                  onClick={() =>
+                                    captureActions.onCapture("text")
+                                  }
+                                  endComponent={
+                                    <DropdownMenuShortcut
+                                      shortcut={pageShortcut}
+                                      className="text-xs text-faint"
+                                    />
+                                  }
+                                />
+                                <DropdownMenuItem
+                                  icon={Camera01}
+                                  label="Take screenshot"
+                                  disabled={
+                                    disableInput ||
+                                    captureActions.isCapturing ||
+                                    fileUploaderService.isProcessingFiles
+                                  }
+                                  onClick={() =>
+                                    captureActions.onCapture("screenshot")
+                                  }
+                                  endComponent={
+                                    <DropdownMenuShortcut
+                                      shortcut={screenshotShortcut}
+                                      className="text-xs text-faint"
+                                    />
+                                  }
+                                />
+                                {captureActions.onSavePageToPod && (
+                                  <DropdownMenuItem
+                                    icon={FilePlus03}
+                                    label="Save page to Pod"
+                                    disabled={
+                                      disableInput ||
+                                      captureActions.isCapturing ||
+                                      captureActions.isSavingPageToPod ||
+                                      fileUploaderService.isProcessingFiles
+                                    }
+                                    onClick={() => {
+                                      void captureActions.onSavePageToPod?.();
+                                    }}
+                                  />
+                                )}
+                              </>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
                       {actions.includes("attachment") && (
-                        <DropdownMenuItem
-                          icon={Attachment01}
-                          label="Attach knowledge"
-                          onClick={() => {
-                            setIsCaptureDropdownOpen(false);
-                            setShowKnowledgePicker(true);
+                        <InputBarAttachmentsPicker
+                          fileUploaderService={fileUploaderService}
+                          owner={owner}
+                          isLoading={false}
+                          onNodeSelect={onNodeSelect}
+                          onNodeUnselect={onNodeUnselect}
+                          attachedNodes={attachedNodes}
+                          buttonSize={buttonSize}
+                          toolFileUpload={{
+                            useCase: "conversation",
+                            useCaseMetadata: {
+                              conversationId: conversation?.sId,
+                            },
                           }}
+                          spaceId={space?.sId}
+                          type="dropdown"
+                          onFileChange={() => setShowKnowledgePicker(false)}
+                          externalOpen={showKnowledgePicker}
+                          onExternalOpenChange={setShowKnowledgePicker}
+                          anchorRef={plusButtonRef}
+                          disabled={disableInput}
                         />
                       )}
-                      {captureActions && (
-                        <>
-                          <DropdownMenuItem
-                            icon={Globe01}
-                            label="Attach page content"
-                            disabled={
-                              disableInput ||
-                              captureActions.isCapturing ||
-                              fileUploaderService.isProcessingFiles
-                            }
-                            onClick={() => captureActions.onCapture("text")}
-                            endComponent={
-                              <DropdownMenuShortcut
-                                shortcut={pageShortcut}
-                                className="text-xs text-faint"
-                              />
-                            }
-                          />
-                          <DropdownMenuItem
-                            icon={Camera01}
-                            label="Take screenshot"
-                            disabled={
-                              disableInput ||
-                              captureActions.isCapturing ||
-                              fileUploaderService.isProcessingFiles
-                            }
-                            onClick={() =>
-                              captureActions.onCapture("screenshot")
-                            }
-                            endComponent={
-                              <DropdownMenuShortcut
-                                shortcut={screenshotShortcut}
-                                className="text-xs text-faint"
-                              />
-                            }
-                          />
-                          {captureActions.onSavePageToPod && (
-                            <DropdownMenuItem
-                              icon={FilePlus03}
-                              label="Save page to Pod"
-                              disabled={
-                                disableInput ||
-                                captureActions.isCapturing ||
-                                captureActions.isSavingPageToPod ||
-                                fileUploaderService.isProcessingFiles
-                              }
-                              onClick={() => {
-                                void captureActions.onSavePageToPod?.();
-                              }}
-                            />
-                          )}
-                        </>
+                    </>
+                  )}
+                  <div
+                    className={cn(
+                      "flex items-center",
+                      isMobile ? "gap-0.5" : "gap-1"
+                    )}
+                  >
+                    {conversation && (
+                      <ContextUsageIndicator
+                        buttonSize={buttonSize}
+                        owner={owner}
+                        conversationId={conversation?.sId}
+                      />
+                    )}
+                    {!subscription.plan.isByok &&
+                      owner.metadata?.allowVoiceTranscription !== false &&
+                      actions.includes("voice") &&
+                      !isCompact && (
+                        <VoicePicker
+                          status={activeVoiceService.status}
+                          level={activeVoiceService.level}
+                          elapsedSeconds={activeVoiceService.elapsedSeconds}
+                          onRecordStart={activeVoiceService.startRecording}
+                          onRecordStop={activeVoiceService.stopRecording}
+                          size={buttonSize}
+                          showStopLabel={!isMobile}
+                          disabled={disableInput}
+                        />
                       )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  </div>
+                  <TooltipProvider>
+                    <TooltipRoot
+                      open={isBlockTooltipOpen && submitBlockMessage !== null}
+                    >
+                      <TooltipTrigger
+                        asChild
+                        onPointerEnter={() => {
+                          if (submitBlockMessage) {
+                            setIsBlockTooltipOpen(true);
+                          }
+                        }}
+                        onPointerLeave={() => {
+                          if (blockTooltipTimerRef.current) {
+                            clearTimeout(blockTooltipTimerRef.current);
+                            blockTooltipTimerRef.current = null;
+                          }
+                          setIsBlockTooltipOpen(false);
+                        }}
+                      >
+                        <Button
+                          size={buttonSize}
+                          isLoading={
+                            isSubmitting &&
+                            activeVoiceService.status !== "transcribing"
+                          }
+                          icon={ArrowUp}
+                          variant={
+                            isSubmitBlocked ? "ghost-secondary" : "highlight"
+                          }
+                          disabled={isSubmitDisabled}
+                          onClick={async (
+                            e: React.MouseEvent<HTMLButtonElement>
+                          ) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (disableAutoFocus) {
+                              editorService.blur();
+                              // wait a bit for the keyboard to be closed on mobile
+                              if (isMobile) {
+                                editorService.setLoading(true);
+                                await new Promise((resolve) =>
+                                  setTimeout(resolve, 500)
+                                );
+                                editorService.setLoading(false);
+                              }
+                            }
+                            onEnterKeyDownWithShake(
+                              editorService.isEmpty() && !canSubmitEmpty,
+                              editorService.getMarkdownAndMentions(),
+                              () => {
+                                editorService.clearEditor();
+                              },
+                              editorService.setLoading
+                            );
+                          }}
+                        />
+                      </TooltipTrigger>
+                      {submitBlockMessage && (
+                        <TooltipContent>{submitBlockMessage}</TooltipContent>
+                      )}
+                    </TooltipRoot>
+                  </TooltipProvider>
                 </div>
-                {actions.includes("attachment") && (
-                  <InputBarAttachmentsPicker
-                    fileUploaderService={fileUploaderService}
-                    owner={owner}
-                    isLoading={false}
-                    onNodeSelect={onNodeSelect}
-                    onNodeUnselect={onNodeUnselect}
-                    attachedNodes={attachedNodes}
-                    buttonSize={buttonSize}
-                    toolFileUpload={{
-                      useCase: "conversation",
-                      useCaseMetadata: {
-                        conversationId: conversation?.sId,
-                      },
-                    }}
-                    spaceId={space?.sId}
-                    type="dropdown"
-                    onFileChange={() => setShowKnowledgePicker(false)}
-                    externalOpen={showKnowledgePicker}
-                    onExternalOpenChange={setShowKnowledgePicker}
-                    anchorRef={plusButtonRef}
-                    disabled={disableInput}
-                  />
-                )}
-              </>
-            )}
-            <div
-              className={cn(
-                "flex items-center",
-                isMobile ? "gap-0.5" : "gap-1"
-              )}
-            >
-              {conversation && (
-                <ContextUsageIndicator
-                  buttonSize={buttonSize}
-                  owner={owner}
-                  conversationId={conversation?.sId}
-                />
-              )}
-              {!subscription.plan.isByok &&
-                owner.metadata?.allowVoiceTranscription !== false &&
-                actions.includes("voice") &&
-                !isCompact && (
-                  <VoicePicker
-                    status={activeVoiceService.status}
-                    level={activeVoiceService.level}
-                    elapsedSeconds={activeVoiceService.elapsedSeconds}
-                    onRecordStart={activeVoiceService.startRecording}
-                    onRecordStop={activeVoiceService.stopRecording}
-                    size={buttonSize}
-                    showStopLabel={!isMobile}
-                    disabled={disableInput}
-                  />
-                )}
+              </div>
             </div>
-            <TooltipProvider>
-              <TooltipRoot
-                open={isBlockTooltipOpen && submitBlockMessage !== null}
-              >
-                <TooltipTrigger
-                  asChild
-                  onPointerEnter={() => {
-                    if (submitBlockMessage) {
-                      setIsBlockTooltipOpen(true);
-                    }
-                  }}
-                  onPointerLeave={() => {
-                    if (blockTooltipTimerRef.current) {
-                      clearTimeout(blockTooltipTimerRef.current);
-                      blockTooltipTimerRef.current = null;
-                    }
-                    setIsBlockTooltipOpen(false);
-                  }}
-                >
-                  <Button
-                    size={buttonSize}
-                    isLoading={
-                      isSubmitting &&
-                      activeVoiceService.status !== "transcribing"
-                    }
-                    icon={ArrowUp}
-                    variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}
-                    disabled={isSubmitDisabled}
-                    onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      if (disableAutoFocus) {
-                        editorService.blur();
-                        // wait a bit for the keyboard to be closed on mobile
-                        if (isMobile) {
-                          editorService.setLoading(true);
-                          await new Promise((resolve) =>
-                            setTimeout(resolve, 500)
-                          );
-                          editorService.setLoading(false);
-                        }
-                      }
-                      onEnterKeyDownWithShake(
-                        editorService.isEmpty() && !canSubmitEmpty,
-                        editorService.getMarkdownAndMentions(),
-                        () => {
-                          editorService.clearEditor();
-                        },
-                        editorService.setLoading
-                      );
-                    }}
-                  />
-                </TooltipTrigger>
-                {submitBlockMessage && (
-                  <TooltipContent>{submitBlockMessage}</TooltipContent>
-                )}
-              </TooltipRoot>
-            </TooltipProvider>
           </div>
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1610,7 +1610,7 @@ const InputBarContainer = ({
             )}
           </BubbleMenu>
           <div
-            className={cn("flex w-full flex-col", "py-1.5 md:pb-2")}
+            className={cn("flex w-full flex-col", "pt-1.5 pb-2")}
             style={{
               transition: `padding ${COLLAPSE_TRANSITION}`,
             }}
@@ -1641,10 +1641,15 @@ const InputBarContainer = ({
                 </React.Fragment>
               ))}
             </div>
-            <div className="relative flex min-h-8 w-full items-center justify-between">
+            <div className="relative flex w-full items-center justify-between">
               <div className={cn("flex w-full items-center px-2")}>
                 {!isRecording && (
-                  <div className="flex items-center gap-1">
+                  <div
+                    className={cn(
+                      "flex items-center",
+                      isMobile ? "gap-0.5" : "gap-1"
+                    )}
+                  >
                     <InputBarButtons
                       actions={actions}
                       allAgents={allAgents}
@@ -1689,7 +1694,12 @@ const InputBarContainer = ({
               </div>
             </div>
           </div>
-          <div className="absolute bottom-2 right-2 flex items-center gap-1.5">
+          <div
+            className={cn(
+              "absolute bottom-2 right-2 flex items-center",
+              isMobile ? "gap-1" : "gap-1.5"
+            )}
+          >
             {clientType === "extension" && (
               <>
                 <div ref={plusButtonRef}>
@@ -1798,7 +1808,12 @@ const InputBarContainer = ({
                 )}
               </>
             )}
-            <div className="flex items-center gap-1">
+            <div
+              className={cn(
+                "flex items-center",
+                isMobile ? "gap-0.5" : "gap-1"
+              )}
+            >
               {conversation && (
                 <ContextUsageIndicator
                   buttonSize={buttonSize}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1641,7 +1641,7 @@ const InputBarContainer = ({
                 </React.Fragment>
               ))}
             </div>
-            <div className="relative flex min-h-7 w-full items-center justify-between">
+            <div className="flex min-h-7 w-full items-center">
               <div className={cn("flex w-full items-center px-2")}>
                 {!isRecording && (
                   <div

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -312,6 +312,7 @@ export function InputBarModelPicker({
     >
       <DropdownMenuTrigger asChild>
         <Button
+          className="px-2"
           variant="ghost-secondary"
           size={buttonSize}
           label={label}


### PR DESCRIPTION
## Description

Fixes the layout of the input bar footer buttons:

1. On narrow mobile widths the left buttons and right buttons crowded/overlapped.
2. The left buttons and the right buttons weren't aligned on the same vertical line.

while fixing this more problem appeared:
4. The send button wasn't balanced in its corner (more padding below than to the right).
5. The model picker had too much horizontal padding on mobile.
6. The agent button's icon wasn't flush with the editor text, and showed a redundant "Agent" label on mobile.
7. Deselecting an agent resized the whole input box slightly.


<img width="386" height="779" alt="Screenshot 2026-07-13 at 14 19 54" src="https://github.com/user-attachments/assets/c47d19ee-9881-4919-9a30-51f895c21f22" />
<img width="499" height="426" alt="Screenshot 2026-07-13 at 14 21 04" src="https://github.com/user-attachments/assets/39165c5a-be3c-40bf-8086-4e16edfa60fe" />
<img width="449" height="233" alt="Screenshot 2026-07-13 at 14 20 28" src="https://github.com/user-attachments/assets/fc5efd0f-e14f-4550-a81e-14dbfa6983ed" />
<img width="447" height="231" alt="Screenshot 2026-07-13 at 14 20 39" src="https://github.com/user-attachments/assets/6872de48-d622-433f-bdb8-cd8e86fe714e" />


<h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">InputBarContainer.tsx</code></h3>


|Change | Solves|
|-- | --|
|Moved the right-side buttons (context usage, mic/voice, send) out of their absolute-positioned cluster and into the same flex row as the left buttons | #2 alignment — the two groups now share one items-center row, so they're aligned by construction instead of by two independent vertical references. This was the root-cause fix.|
|mt-auto on the footer | #3 — pins the button row to the bottom of the input box (which stretches taller than its content), so the send button sits flush in the corner instead of floating high.|
|Footer padding py-1.5 md:pb-2 → pt-1.5 pb-2 | #3 — makes the bottom gap a consistent 8px on all breakpoints, matching the send button's right inset so its corner is balanced.|
|min-h-7 on the button row | #6 — pins the row to 28px (the agent pill's height), the tallest it ever gets, so swapping between the pill and the plain agent button no longer changes the box height. Chosen over the old min-h-8 because 32px would reintroduce the send-button floating gap.|
|Reduced inter-button gaps on mobile (left group gap-1→gap-0.5, right cluster gap-1.5→gap-1, inner right group gap-1→gap-0.5) | #1 — tightens spacing so left/right buttons don't crowd on narrow widths.|





<h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">InputBarModelPicker.tsx</code></h3>


|Change | Solves|
|-- | --|
|className="px-2" on the model picker button | #4 — overrides the sm size's px-3 (12px) down to px-2 (8px) on mobile; desktop xs is already px-2, so unchanged there.|


