### PR TITLE
Add HubSpot communications read scope and search support

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1194,7 +1194,8 @@ export const searchCrmObjects = async ({
     | "feedback_submissions"
     | "products"
     | "tickets"
-    | "leads";
+    | "leads"
+    | "communications";
   filters?: Array<HubspotFilter>;
   query?: string;
   propertiesToReturn?: string[];
@@ -1308,6 +1309,12 @@ export const searchCrmObjects = async ({
       case "leads":
         searchResponse =
           await hubspotClient.crm.objects.leads.searchApi.doSearch(
+            searchRequest
+          );
+        break;
+      case "communications":
+        searchResponse =
+          await hubspotClient.crm.objects.communications.searchApi.doSearch(
             searchRequest
           );
         break;

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -24,6 +24,7 @@ const searchableObjectTypes = [
   "feedback_submissions",
   "tickets",
   "leads",
+  "communications",
 ] as const;
 
 const filterSchema = z.object({

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -55,6 +55,7 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       "content",
       "tickets",
       "crm.objects.products.read",
+      "crm.objects.communications.read",
     ];
 
     const workspaceGrantedScopes = extraConfig?.workspace_granted_scopes;


### PR DESCRIPTION
## Description

Fixes "Agents cannot read Communications objects" #9531 
Adds the `crm.objects.communications.read` OAuth scope and wires communications into the HubSpot MCP search tools so agents can list and read logged emails, calls, and texts.

## Tests

Manually 

## Risk

Low

## Deploy Plan

Add scope to hubspot app and then deploy