### PR TITLE
Clarify exact hostname matching in Computer settings

### DIFF
--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -172,7 +172,7 @@ export function NetworkSection() {
 
         <Page.SectionHeader
           title="Allowed domains"
-          description="These domains apply to every Computer in this workspace. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
+          description="These domains apply to every Computer in this workspace. Hostnames are matched exactly: allowing example.com does not allow www.example.com. Add both separately when needed, or use *.example.com to allow all subdomains. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
         />
 
         <form

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -172,7 +172,7 @@ export function NetworkSection() {
 
         <Page.SectionHeader
           title="Allowed domains"
-          description="These domains apply to every Computer in this workspace. Hostnames are matched exactly: allowing example.com does not allow www.example.com. Add both separately when needed, or use *.example.com to allow all subdomains. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
+          description="These domains apply to every Computer in this workspace. Hostnames are matched exactly. To allow both example.com and www.example.com, add each separately. A wildcard such as *.example.com allows subdomains, but not example.com itself. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
         />
 
         <form


### PR DESCRIPTION
## Description

Allowed-domain entries match exact hostnames, but the Computer settings did not make that clear ([context](https://github.com/dust-tt/tasks/issues/9579)). Clarify that apex and `www` hostnames must be added separately, and point admins to wildcards for subdomains.

## Tests

Not manually tested, copy-only change.

## Risk

Low. Copy-only change, safe to rollback.

## Deploy Plan

Standard deploy.