### PR TITLE
[front] fix: skip replay specs for missing actions

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -425,11 +425,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        baseSpecifications,
-        conversation,
-        new Set()
-      );
+      buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+        modelConversation: conversation,
+      });
 
     expect(specifications).toEqual(baseSpecifications);
     expect(missingReplayedToolNames).toEqual([]);
@@ -445,8 +443,7 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
 
     const { specifications } = buildSpecificationsWithReplayPlaceholders(
       baseSpecifications,
-      conversation,
-      new Set()
+      { modelConversation: conversation }
     );
 
     expect(specifications[0].eager).toBe(true);
@@ -459,11 +456,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        baseSpecifications,
-        conversation,
-        new Set()
-      );
+      buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+        modelConversation: conversation,
+      });
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
     expect(specifications).toHaveLength(2);
@@ -478,11 +473,10 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        [],
-        conversation,
-        new Set(["call_0"])
-      );
+      buildSpecificationsWithReplayPlaceholders([], {
+        modelConversation: conversation,
+        missingActionCatcherFunctionCallIds: new Set(["call_0"]),
+      });
 
     expect(missingReplayedToolNames).toEqual([]);
     expect(specifications).toEqual([]);
@@ -498,11 +492,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        baseSpecifications,
-        conversation,
-        new Set()
-      );
+      buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+        modelConversation: conversation,
+      });
 
     expect(missingReplayedToolNames).toEqual(["middle_tool"]);
     expect(specifications.map((s) => s.name)).toEqual([
@@ -519,11 +511,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        baseSpecifications,
-        conversation,
-        new Set()
-      );
+      buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+        modelConversation: conversation,
+      });
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
     expect(specifications.map((s) => s.name)).toEqual([
@@ -542,11 +532,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders(
-        baseSpecifications,
-        conversation,
-        new Set()
-      );
+      buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+        modelConversation: conversation,
+      });
 
     expect(missingReplayedToolNames).toEqual([]);
     expect(specifications).toEqual(baseSpecifications);
@@ -559,7 +547,9 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders([], conversation, new Set());
+      buildSpecificationsWithReplayPlaceholders([], {
+        modelConversation: conversation,
+      });
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
     expect(specifications).toHaveLength(1);

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -427,7 +427,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const { specifications, missingReplayedToolNames } =
       buildSpecificationsWithReplayPlaceholders(
         baseSpecifications,
-        conversation
+        conversation,
+        new Set()
       );
 
     expect(specifications).toEqual(baseSpecifications);
@@ -444,7 +445,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
 
     const { specifications } = buildSpecificationsWithReplayPlaceholders(
       baseSpecifications,
-      conversation
+      conversation,
+      new Set()
     );
 
     expect(specifications[0].eager).toBe(true);
@@ -459,7 +461,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const { specifications, missingReplayedToolNames } =
       buildSpecificationsWithReplayPlaceholders(
         baseSpecifications,
-        conversation
+        conversation,
+        new Set()
       );
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
@@ -497,7 +500,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const { specifications, missingReplayedToolNames } =
       buildSpecificationsWithReplayPlaceholders(
         baseSpecifications,
-        conversation
+        conversation,
+        new Set()
       );
 
     expect(missingReplayedToolNames).toEqual(["middle_tool"]);
@@ -517,7 +521,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const { specifications, missingReplayedToolNames } =
       buildSpecificationsWithReplayPlaceholders(
         baseSpecifications,
-        conversation
+        conversation,
+        new Set()
       );
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
@@ -539,7 +544,8 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     const { specifications, missingReplayedToolNames } =
       buildSpecificationsWithReplayPlaceholders(
         baseSpecifications,
-        conversation
+        conversation,
+        new Set()
       );
 
     expect(missingReplayedToolNames).toEqual([]);
@@ -553,7 +559,7 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     ]);
 
     const { specifications, missingReplayedToolNames } =
-      buildSpecificationsWithReplayPlaceholders([], conversation);
+      buildSpecificationsWithReplayPlaceholders([], conversation, new Set());
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
     expect(specifications).toHaveLength(1);

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -469,6 +469,22 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
     expect(placeholder.eager).toBeUndefined();
   });
 
+  it("does not append placeholders for calls handled by the missing action catcher", () => {
+    const conversation = makeConversation([
+      assistantMessageWithFunctionCalls(["hallucinated_tool"]),
+    ]);
+
+    const { specifications, missingReplayedToolNames } =
+      buildSpecificationsWithReplayPlaceholders(
+        [],
+        conversation,
+        new Set(["call_0"])
+      );
+
+    expect(missingReplayedToolNames).toEqual([]);
+    expect(specifications).toEqual([]);
+  });
+
   it("sorts replay placeholders with the current tool specifications", () => {
     const baseSpecifications = [
       makeSpecification("zeta_tool"),

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -170,7 +170,7 @@ function concatWithNewlineBoundary(
 // provider-agnostic dispatch keyed on the passthrough provider id.
 function getReplayedToolNames(
   modelConversation: ModelConversationTypeMultiActions,
-  missingActionCatcherFunctionCallIds: ReadonlySet<string>
+  missingActionCatcherFunctionCallIds: Set<string>
 ): string[] {
   const toolNames = new Set<string>();
 
@@ -314,7 +314,7 @@ export function buildBaseSpecifications(
 export function buildSpecificationsWithReplayPlaceholders(
   baseSpecifications: AgentActionSpecification[],
   modelConversation: ModelConversationTypeMultiActions,
-  missingActionCatcherFunctionCallIds: ReadonlySet<string> = new Set()
+  missingActionCatcherFunctionCallIds: Set<string>
 ): {
   specifications: AgentActionSpecification[];
   missingReplayedToolNames: string[];

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,6 +2,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { StepContext } from "@app/lib/actions/types";
@@ -230,6 +231,10 @@ function getMissingActionCatcherFunctionCallIds(
   conversation: ConversationType
 ): Set<string> {
   const functionCallIds = new Set<string>();
+  const missingActionCatcherMCPServerId = autoInternalMCPServerNameToSId({
+    name: "missing_action_catcher",
+    workspaceId: conversation.owner.id,
+  });
 
   for (const messageVersions of conversation.content) {
     for (const message of messageVersions) {
@@ -238,7 +243,9 @@ function getMissingActionCatcherFunctionCallIds(
       }
 
       for (const action of message.actions) {
-        if (action.internalMCPServerName === "missing_action_catcher") {
+        // mcpServerId is serialized from the action's
+        // toolConfiguration.toolServerId.
+        if (action.mcpServerId === missingActionCatcherMCPServerId) {
           functionCallIds.add(action.functionCallId);
         }
       }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -320,8 +320,13 @@ export function buildBaseSpecifications(
 // definition.
 export function buildSpecificationsWithReplayPlaceholders(
   baseSpecifications: AgentActionSpecification[],
-  modelConversation: ModelConversationTypeMultiActions,
-  missingActionCatcherFunctionCallIds: Set<string>
+  {
+    modelConversation,
+    missingActionCatcherFunctionCallIds = new Set(),
+  }: {
+    modelConversation: ModelConversationTypeMultiActions;
+    missingActionCatcherFunctionCallIds?: Set<string>;
+  }
 ): {
   specifications: AgentActionSpecification[];
   missingReplayedToolNames: string[];
@@ -674,11 +679,11 @@ export async function runModel(
   }
 
   const { specifications, missingReplayedToolNames } =
-    buildSpecificationsWithReplayPlaceholders(
-      baseSpecifications,
-      modelConversationRes.value.modelConversation,
-      getMissingActionCatcherFunctionCallIds(conversation)
-    );
+    buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
+      modelConversation: modelConversationRes.value.modelConversation,
+      missingActionCatcherFunctionCallIds:
+        getMissingActionCatcherFunctionCallIds(conversation),
+    });
 
   if (missingReplayedToolNames.length > 0) {
     localLogger.info(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -85,8 +85,10 @@ import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type {
   AgentMessageType,
+  ConversationType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
 import {
   isTextContent,
   type ModelConversationTypeMultiActions,
@@ -167,7 +169,8 @@ function concatWithNewlineBoundary(
 // passthrough parsing below (block shapes, server tool names) belongs behind a
 // provider-agnostic dispatch keyed on the passthrough provider id.
 function getReplayedToolNames(
-  modelConversation: ModelConversationTypeMultiActions
+  modelConversation: ModelConversationTypeMultiActions,
+  missingActionCatcherFunctionCallIds: ReadonlySet<string>
 ): string[] {
   const toolNames = new Set<string>();
 
@@ -175,7 +178,12 @@ function getReplayedToolNames(
     switch (message.role) {
       case "assistant":
         for (const content of message.contents) {
-          if (content.type === "function_call") {
+          if (
+            content.type === "function_call" &&
+            !missingActionCatcherFunctionCallIds.has(content.value.id)
+          ) {
+            // Missing-action catcher calls remain in the replay so the model
+            // sees their error, but their attempted names were never tools.
             toolNames.add(content.value.name);
           }
           if (
@@ -216,6 +224,28 @@ function getReplayedToolNames(
   }
 
   return [...toolNames];
+}
+
+function getMissingActionCatcherFunctionCallIds(
+  conversation: ConversationType
+): Set<string> {
+  const functionCallIds = new Set<string>();
+
+  for (const messageVersions of conversation.content) {
+    for (const message of messageVersions) {
+      if (!isAgentMessageType(message)) {
+        continue;
+      }
+
+      for (const action of message.actions) {
+        if (action.internalMCPServerName === "missing_action_catcher") {
+          functionCallIds.add(action.functionCallId);
+        }
+      }
+    }
+  }
+
+  return functionCallIds;
 }
 
 function buildReplayOnlyToolSpecification(
@@ -283,13 +313,17 @@ export function buildBaseSpecifications(
 // definition.
 export function buildSpecificationsWithReplayPlaceholders(
   baseSpecifications: AgentActionSpecification[],
-  modelConversation: ModelConversationTypeMultiActions
+  modelConversation: ModelConversationTypeMultiActions,
+  missingActionCatcherFunctionCallIds: ReadonlySet<string> = new Set()
 ): {
   specifications: AgentActionSpecification[];
   missingReplayedToolNames: string[];
 } {
   const currentToolNames = new Set(baseSpecifications.map((spec) => spec.name));
-  const missingReplayedToolNames = getReplayedToolNames(modelConversation)
+  const missingReplayedToolNames = getReplayedToolNames(
+    modelConversation,
+    missingActionCatcherFunctionCallIds
+  )
     .filter((name) => !currentToolNames.has(name))
     .sort();
 
@@ -635,7 +669,8 @@ export async function runModel(
   const { specifications, missingReplayedToolNames } =
     buildSpecificationsWithReplayPlaceholders(
       baseSpecifications,
-      modelConversationRes.value.modelConversation
+      modelConversationRes.value.modelConversation,
+      getMissingActionCatcherFunctionCallIds(conversation)
     );
 
   if (missingReplayedToolNames.length > 0) {


### PR DESCRIPTION
## Description

Calls handled by `missing_action_catcher` are persisted in conversation history with the model-attempted name. `buildSpecificationsWithReplayPlaceholders` treated those names like previously available tools and added backfill specifications for those tools even though they never existed.

This PR fixes that.

Example of trace [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3BYYiuqdmnit&peek=bcfd1f7027c1f137b7cbce59aea0c87d&timestamp=2026-07-13T09%3A18%3A37.193Z&observation=d6726dc4aff9a7a1).

## Tests

- Added a regression test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
