### PR TITLE
[front] enh: polish skill info page

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -3,6 +3,7 @@ import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButton
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
 import { hasRelations } from "@app/lib/skill";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
@@ -94,11 +95,7 @@ function SkillInfoContent({
     if (!skill.updatedAt) {
       return null;
     }
-    return new Date(skill.updatedAt).toLocaleDateString("en-US", {
-      year: "2-digit",
-      month: "2-digit",
-      day: "2-digit",
-    });
+    return formatTimestampToFriendlyDate(skill.updatedAt, "compactWithDay");
   }, [skill.updatedAt]);
 
   const editedBy = useMemo(
@@ -106,7 +103,7 @@ function SkillInfoContent({
     [skill.relations.editedByUser?.fullName]
   );
 
-  const editorsForAvatars = useMemo(() => {
+  const editorAvatars = useMemo(() => {
     const seen = new Set<string>();
     const users: UserType[] = [];
     const maybePush = (u: UserType | null | undefined) => {
@@ -120,7 +117,11 @@ function SkillInfoContent({
     for (const editor of skill.relations.editors ?? []) {
       maybePush(editor);
     }
-    return users.slice(0, 3);
+    return users.map((editor) => ({
+      name: editor.fullName,
+      visual: editor.image ?? undefined,
+      isRounded: true,
+    }));
   }, [skill.relations.editedByUser, skill.relations.editors]);
 
   return (
@@ -128,21 +129,21 @@ function SkillInfoContent({
       {editedBy && editedAt && (
         <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
           <div>
-            Edited by {editedBy}, {editedAt}
+            Last edited {editedAt} by {editedBy}
           </div>
-          {editorsForAvatars.length > 0 && (
-            <div className="flex items-center -space-x-2">
-              {editorsForAvatars.map((u) => (
-                <Avatar key={u.sId} size="sm" visual={u.image} isRounded />
-              ))}
-            </div>
+          {editorAvatars.length > 0 && (
+            <Avatar.Stack
+              avatars={editorAvatars}
+              nbVisibleItems={3}
+              size="sm"
+            />
           )}
         </div>
       )}
       <SkillInfoTab
         owner={owner}
         skill={skill}
-        showDescription
+        showDescription={false}
         spaces={spaces}
       />
     </div>

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -52,7 +52,12 @@ export function SkillDetailsButtonBar({
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button icon={DotsHorizontal} size="sm" variant="ghost" />
+            <Button
+              icon={DotsHorizontal}
+              size="sm"
+              variant="ghost"
+              tooltip="Skill options"
+            />
           </DropdownMenuTrigger>
           <DropdownMenuContent>
             <DropdownMenuItem

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -235,7 +235,7 @@ export function SkillInfoTab({
 
       {shouldLoadSpaces ? (
         <div className="flex flex-col gap-4">
-          <div className="heading-lg text-foreground">Spaces</div>
+          <div className="heading-lg text-foreground">Spaces and Pods</div>
           {isSpacesLoading ? (
             <div className="flex flex-row items-center gap-2">
               <Spinner size="xs" />


### PR DESCRIPTION
## Description

Skill details currently refer only to Spaces even though skills can also require Pods, and the capabilities sheet repeats the user-facing description.

This PR renames the requirement section to “Spaces and Pods”, keeps the description in the sheet header only, and polishes the edit metadata and actions with a friendly date, named editor avatars, and an accessible skill-options label. The standalone skill details sheet continues to show its description.

## Tests

- Not tested (copy and presentation-only changes).

## Risk

- Low.

## Deploy Plan

- Deploy front.