### PR TITLE
fix: reset member search pagination when search term changes

### DIFF
--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -33,7 +33,7 @@ import {
   Users01,
 } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -96,6 +96,7 @@ function WorkspaceMembersList({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
+  const [prevSearchTerm, setPrevSearchTerm] = useState(searchTerm);
 
   const [selectedMember, setSelectedMember] =
     useState<UserTypeWithWorkspace | null>(null);
@@ -108,10 +109,10 @@ function WorkspaceMembersList({
     groupKind: isProvisioningEnabled ? "provisioned" : undefined,
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: searchTerm is the reset trigger, not used in the body
-  useEffect(() => {
+  if (searchTerm !== prevSearchTerm) {
+    setPrevSearchTerm(searchTerm);
     setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
-  }, [searchTerm]);
+  }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const resetSelectedMember = useCallback(() => {

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -108,10 +108,10 @@ function WorkspaceMembersList({
     groupKind: isProvisioningEnabled ? "provisioned" : undefined,
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchTerm is the reset trigger, not used in the body
   useEffect(() => {
     setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
-  }, [setPagination]);
+  }, [searchTerm]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const resetSelectedMember = useCallback(() => {


### PR DESCRIPTION
## Description

Typing a new search term on page 2+ of the admin members list didn't reset pagination back to page 1, so a search with fewer results than the current offset silently rendered an empty list even though the count was correct.

## Tests

Manual — searched from page 2 and confirmed results now show on page 1.

## Risk

Low, single-file effect dependency fix.

## Deploy Plan

Standard deploy.