### PR TITLE
[SANDBOX] fix failing CI tests

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
@@ -14,7 +14,12 @@ export function formatDatabasesList(databases: LiveDatabaseEntry[]): string {
   }
 
   const lines = databases.map((db) => `- ${db.name} (${db.sizeBytes} bytes)`);
-  return lines.join("\n");
+  return [
+    "Pod databases:",
+    ...lines,
+    "",
+    "Use db_schema to inspect a database and db_query to run SQL against it.",
+  ].join("\n");
 }
 
 export async function dbListHandler(

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.32/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.33/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"


### PR DESCRIPTION
## Description

Fix two failing sandbox tests in CI: add the `Pod databases:` header and db_schema/db_query pointers to `db_list` output, and bump the expected dsbx version to 0.1.33.

## Tests

Both tests pass locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`