### PR TITLE
Prune tool results by recency across the whole conversation, not per turn

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.test.ts
+++ b/front/lib/api/assistant/conversation/fetch.test.ts
@@ -2,7 +2,7 @@ import {
   computeMessagesWithToolOutputContent,
   TOOL_OUTPUT_FETCH_BATCH_SIZE,
 } from "@app/lib/api/assistant/conversation/fetch";
-import type { Interaction } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
 import { describe, expect, it } from "vitest";
 
 // Builds n interactions, each a user message followed by an agent message. Agent message ids are

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,5 +1,5 @@
 import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
-import type { Interaction } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,5 +1,5 @@
-import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
 import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
+import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -1,7 +1,13 @@
-import type {
-  Interaction,
-  MinimalMessageType,
-} from "@app/lib/api/assistant/conversation_rendering/pruning";
+// The minimal shape groupMessagesIntoInteractions needs to slice a conversation into
+// interactions. Consumers that need more (e.g. token counts for pruning) instantiate
+// Interaction<T> with a richer message type.
+export type MinimalMessageType = {
+  role: string;
+};
+
+export type Interaction<T extends MinimalMessageType> = {
+  messages: T[];
+};
 
 /**
  * Group messages into interactions (user turn + agent responses), using turn type

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -208,9 +208,9 @@ describe("renderConversationForModel", () => {
     expect(res.value.prunedContext).toBe(false);
   });
 
-  it("redacts old tool outputs beyond TOOL_RESULTS_TO_PRESERVE but keeps the most recent ones, across separate interactions", async () => {
+  it("prunes old tool outputs beyond TOOL_RESULTS_TO_PRESERVE but keeps the most recent ones, across separate interactions", async () => {
     // 12 interactions (TOOL_RESULTS_TO_PRESERVE is 10), each with one tool call: the first 2 are
-    // outside the preserved window and must be redacted. The last 10 are the protected floor and
+    // outside the preserved window and must be pruned. The last 10 are the protected floor and
     // must survive untouched, regardless of budget-driven checkpoint search.
     const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
       userMessage(`u_${i}`),
@@ -234,7 +234,7 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Total unredacted: 12 * 5020 = 60_240. Redacting the 2 eligible tool results (outside the
+      // Total unpruned: 12 * 5020 = 60_240. Pruning the 2 eligible tool results (outside the
       // floor of 10) saves 2 * (5000 - 24) = 9_952, bringing it to 50_288, comfortably under
       // this budget. Nothing else needs to be touched.
       allowedTokenCount: computeAllowedTokenCount({
@@ -272,10 +272,10 @@ describe("renderConversationForModel", () => {
     expect(res.value.prunedContext).toBe(true);
   });
 
-  it("redacts a single turn's OWN earlier tool-call steps once it makes many tool calls, since the current turn gets no special exemption", async () => {
+  it("prunes a single turn's OWN earlier tool-call steps once it makes many tool calls, since the current turn gets no special exemption", async () => {
     // ONE continuous interaction: a single user question answered via 12 tool-call steps before
     // the final reply. Nothing here is a "previous interaction", it's all the current turn, yet
-    // its own earliest steps (beyond TOOL_RESULTS_TO_PRESERVE=10) still get redacted.
+    // its own earliest steps (beyond TOOL_RESULTS_TO_PRESERVE=10) still get pruned.
     const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     const steps = indices.flatMap((i) => [
       assistantMessage(`thinking_${i}`),
@@ -303,7 +303,7 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Total unredacted: 10 (question) + 12*(10+5000) + 10 (answer) = 60_140. Redacting the 2
+      // Total unpruned: 10 (question) + 12*(10+5000) + 10 (answer) = 60_140. Pruning the 2
       // steps outside the floor of 10 saves 2 * (5000-24) = 9_952 -> 50_188, under this budget.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
@@ -340,12 +340,12 @@ describe("renderConversationForModel", () => {
     expect(res.value.prunedContext).toBe(true);
   });
 
-  it("proactively redacts once the conversation crosses PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit it", async () => {
+  it("proactively prunes once the conversation crosses PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit it", async () => {
     // 12 small interactions (TOOL_RESULTS_TO_PRESERVE=10, so 2 fall outside the floor). contextSize
     // 4_000 gives a proactive target of 1_359 tokens (baseTokens=1041, so 4_000*0.6 - 1041):
-    // comfortably above the 1_288 tokens left after redacting the 2 eligible tool results, but
-    // well below the 1_440 unredacted total, so the proactive target is what forces the
-    // redaction, not the real ceiling, which is set far higher below.
+    // comfortably above the 1_288 tokens left after pruning the 2 eligible tool results, but
+    // well below the 1_440 unpruned total, so the proactive target is what forces the
+    // pruning, not the real ceiling, which is set far higher below.
     const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
       userMessage(`u_${i}`),
       assistantMessage(`a_${i}`),
@@ -368,7 +368,7 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Real ceiling comfortably fits everything (1_440) in full: proves redaction is driven by
+      // Real ceiling comfortably fits everything (1_440) in full: proves pruning is driven by
       // the proactive target, not by running out of the real budget.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
@@ -394,9 +394,9 @@ describe("renderConversationForModel", () => {
     expect(tool12.content).toBe("result_12");
   });
 
-  it("drops a whole previous interaction entirely, not just its tool result, when redaction alone still doesn't fit", async () => {
-    // Ten previous interactions, each dominated by large USER/ASSISTANT text (never redacted by
-    // pruneToolResults) rather than tool output. Redaction alone cannot shrink these enough, so
+  it("drops a whole previous interaction entirely, not just its tool result, when pruning alone still doesn't fit", async () => {
+    // Ten previous interactions, each dominated by large USER/ASSISTANT text (never pruned by
+    // pruneToolResults) rather than tool output. Pruning alone cannot shrink these enough, so
     // dropInteractionsToFit must remove some of them wholesale.
     const previousInteractions = [1, 2, 3, 4, 5].flatMap((i) => [
       userMessage(`old_user_${i}_big`),
@@ -438,8 +438,7 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const roles = res.value.modelConversation.messages;
-    const survivingUserTexts = roles
+    const survivingUserTexts = res.value.modelConversation.messages
       .filter(isUserMessage)
       .map((m) => textOf(m.content[0]));
     // Oldest interactions are dropped first. The newest ones (closest to "new_user") survive.
@@ -580,6 +579,29 @@ describe("renderConversationForModel", () => {
     }
   });
 
+  it("returns a distinct error, not a context-window one, when the conversation has no messages at all", async () => {
+    vi.mocked(renderAllMessages).mockResolvedValue([]);
+    mockTokenCounter({ byContains: {} });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 100,
+      }),
+    });
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("Conversation contains no messages");
+    }
+  });
+
   it("bubbles prompt/tools tokenization errors", async () => {
     vi.mocked(renderAllMessages).mockResolvedValue([userMessage("u1")]);
     vi.mocked(tokenCountForTexts).mockImplementation(async (texts) => {
@@ -695,16 +717,16 @@ describe("renderConversationForModel", () => {
     });
 
     // Each interaction is 90 tokens (30 + 30 + 30), well within TOOL_RESULTS_TO_PRESERVE (10 tool
-    // results total here), so Layer 1 (redaction) can't touch any of them at all, this is meant
-    // to exercise Layer 2 (drop-entirely) in isolation, not cascade into Layer 3's force-redaction.
+    // results total here), so Layer 1 (pruning) can't touch any of them at all, this is meant
+    // to exercise Layer 2 (drop-entirely) in isolation, not cascade into Layer 3's force-pruning.
     //
-    // Hand-verified: total unredacted = 8 * 90 = 720. Layer 2's target for the 7 previous
+    // Hand-verified: total unpruned = 8 * 90 = 720. Layer 2's target for the 7 previous
     // interactions is budgetForInteractions(400) - current's cost(90) = 310. With
     // PREVIOUS_INTERACTIONS_TO_PRESERVE=3, i1-i4 (4 * 90 = 360) can be dropped, leaving the
     // protected floor i5-i7 (3 * 90 = 270) plus current i8 (90) = 360 <= 400: Layer 2 alone gets
-    // under budget, so Layer 3/4 never fire and i5-i8 survive WITH THEIR REAL, UNREDACTED CONTENT
-    //, an earlier version of this test only checked message names, which stay the same whether
-    // a tool result is redacted or not, and so couldn't actually tell the difference.
+    // under budget, so Layer 3/4 never fire and i5-i8 survive WITH THEIR REAL, UNPRUNED CONTENT.
+    // An earlier version of this test only checked message names, which stay the same whether
+    // a tool result is pruned or not, and so couldn't actually tell the difference.
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
       model,
@@ -732,8 +754,8 @@ describe("renderConversationForModel", () => {
     expect(names).not.toContain("tool_03");
     expect(names).not.toContain("tool_04");
 
-    // The surviving tool results carry their REAL content, not a redaction placeholder,
-    // confirming Layer 2 (drop) alone was enough, and Layer 3 (force-redact) never fired.
+    // The surviving tool results carry their REAL content, not a pruning placeholder,
+    // confirming Layer 2 (drop) alone was enough, and Layer 3 (force-prune) never fired.
     for (const [i, name] of ["f_05", "f_06", "f_07", "f_08"].entries()) {
       expect(functionMessages[i].content).toBe(name);
     }

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -112,21 +112,6 @@ function getFunctionMessage(
   return message;
 }
 
-// The previous-interaction messages built by the tests below are always named "i1_user",
-// "i1_tool", etc. This pulls out just those (never the current interaction's messages) as plain
-// comparable objects, regardless of whether they're user or function messages.
-function previousInteractionSummaries(
-  messages: ModelMessageTypeMultiActions[]
-): Array<{ role: string; name: string; content: string | Content[] }> {
-  return messages
-    .filter(
-      (m): m is UserMessageTypeModel | FunctionMessageTypeModel =>
-        isUserMessage(m) || isFunctionMessage(m)
-    )
-    .filter((m) => m.name.startsWith("i"))
-    .map((m) => ({ role: m.role, name: m.name, content: m.content }));
-}
-
 function mockTokenCounter({
   byContains,
   promptTokens = 10,
@@ -179,7 +164,8 @@ describe("renderConversationForModel", () => {
     modelId: "gpt-4.1",
     tokenizer: "cl100k_base",
     // Large enough that PRUNING_TARGET_CONTEXT_UTILIZATION never becomes the binding constraint
-    // in these tests, which are all sized in the low hundreds of tokens.
+    // in these tests, which are all sized in the low hundreds of tokens, unless explicitly
+    // overridden.
     contextSize: 200_000,
   } as any;
 
@@ -222,18 +208,24 @@ describe("renderConversationForModel", () => {
     expect(res.value.prunedContext).toBe(false);
   });
 
-  it("prunes current interaction progressively when it exceeds budget", async () => {
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      userMessage("curr_user"),
-      assistantMessage("curr_assistant"),
-      functionMessage("curr_tool", "curr_function_big"),
+  it("redacts old tool outputs beyond TOOL_RESULTS_TO_PRESERVE but keeps the most recent ones, across separate interactions", async () => {
+    // 12 interactions (TOOL_RESULTS_TO_PRESERVE is 10), each with one tool call: the first 2 are
+    // outside the preserved window and must be redacted. The last 10 are the protected floor and
+    // must survive untouched, regardless of budget-driven checkpoint search.
+    const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
+      userMessage(`u_${i}`),
+      assistantMessage(`a_${i}`),
+      functionMessage(`tool_${i}`, `result_${i}`),
     ]);
+    vi.mocked(renderAllMessages).mockResolvedValue(messages);
     mockTokenCounter({
-      byContains: {
-        curr_user: 10,
-        curr_assistant: 10,
-        curr_function_big: 80,
-      },
+      byContains: Object.fromEntries(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
+          [`u_${i}`, 10],
+          [`a_${i}`, 10],
+          [`result_${i}`, 5000],
+        ])
+      ),
     });
 
     const res = await renderConversationForModel(auth, {
@@ -242,10 +234,13 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
+      // Total unredacted: 12 * 5020 = 60_240. Redacting the 2 eligible tool results (outside the
+      // floor of 10) saves 2 * (5000 - 24) = 9_952, bringing it to 50_288, comfortably under
+      // this budget. Nothing else needs to be touched.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
-        interactionTokens: 79,
+        interactionTokens: 51_000,
       }),
     });
 
@@ -254,198 +249,127 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const functionOutput = getFunctionMessage(
-      res.value.modelConversation.messages
+    const tool1 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "tool_1"
     );
-    expect(functionOutput.content).toContain(
-      "This tool result is no longer available"
+    const tool2 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "tool_2"
     );
+    const tool3 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "tool_3"
+    );
+    const tool12 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "tool_12"
+    );
+    expect(tool1.content).toContain("This tool result is no longer available");
+    expect(tool2.content).toContain("This tool result is no longer available");
+    expect(tool3.content).toBe("result_3");
+    expect(tool12.content).toBe("result_12");
     expect(res.value.prunedContext).toBe(true);
   });
 
-  it("prunes previous interactions tool outputs and keeps last interaction", async () => {
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      userMessage("old_user"),
-      assistantMessage("old_assistant"),
-      functionMessage("old_tool", "old_function_big"),
-      userMessage("new_user"),
-      assistantMessage("new_assistant"),
-      functionMessage("new_tool", "new_function"),
-    ]);
-    mockTokenCounter({
-      byContains: {
-        old_user: 20,
-        old_assistant: 20,
-        old_function_big: 200,
-        new_user: 20,
-        new_assistant: 20,
-        new_function: 20,
-      },
-    });
-
-    const res = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model,
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 10,
-        toolsTokens: 10,
-        interactionTokens: 212,
-      }),
-    });
-
-    expect(res.isOk()).toBe(true);
-    if (res.isErr()) {
-      return;
-    }
-
-    const oldTool = getFunctionMessage(
-      res.value.modelConversation.messages,
-      "old_tool"
-    );
-    const newTool = getFunctionMessage(
-      res.value.modelConversation.messages,
-      "new_tool"
-    );
-    expect(oldTool.content).toContain(
-      "This tool result is no longer available"
-    );
-    expect(newTool.content).toBe("new_function");
-    expect(res.value.prunedContext).toBe(false);
-  });
-
-  it("proactively prunes previous interactions once they cross PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit them", async () => {
-    // contextSize: 2000 -> proactive target of 159 tokens (60% minus baseTokens), well below the
-    // 220-token previous interaction below. With only one previous interaction (inside
-    // PREVIOUS_INTERACTIONS_TO_PRESERVE's floor), this exercises prunePreviousInteractions' own
-    // last-resort floor redaction, not its checkpoint-based frontier. See the test below that
-    // exercises the checkpoint-based frontier instead.
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      userMessage("old_user"),
-      assistantMessage("old_assistant"),
-      functionMessage("old_tool", "old_function"),
-      userMessage("new_user"),
-      assistantMessage("new_assistant"),
-    ]);
-    mockTokenCounter({
-      byContains: {
-        old_user: 10,
-        old_assistant: 10,
-        old_function: 200,
-        new_user: 10,
-        new_assistant: 10,
-      },
-    });
-
-    const res = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model: { ...model, contextSize: 2000 },
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      // Comfortably fits both interactions in full under the real ceiling: proves redaction is
-      // driven by the proactive target, not by running out of the real budget.
-      allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 10,
-        toolsTokens: 10,
-        interactionTokens: 2000,
-      }),
-    });
-
-    expect(res.isOk()).toBe(true);
-    if (res.isErr()) {
-      return;
-    }
-
-    const oldTool = getFunctionMessage(
-      res.value.modelConversation.messages,
-      "old_tool"
-    );
-    expect(oldTool.content).toContain("no longer available");
-  });
-
-  it("still lets a legitimately large current interaction through, unaffected by the smaller proactive-pruning target", async () => {
-    // Same 159-token proactive target as above (contextSize: 2000), but the current interaction
-    // (320 tokens) comfortably fits the real allowedTokenCount, which is the ceiling that matters
-    // here (see previousInteractionsPruningBudget's own comment for why).
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      userMessage("cur_user"),
-      assistantMessage("cur_assistant"),
-      functionMessage("cur_tool", "cur_function"),
-    ]);
-    mockTokenCounter({
-      byContains: {
-        cur_user: 10,
-        cur_assistant: 10,
-        cur_function: 300,
-      },
-    });
-
-    const res = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model: { ...model, contextSize: 2000 },
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 10,
-        toolsTokens: 10,
-        interactionTokens: 2000,
-      }),
-    });
-
-    expect(res.isOk()).toBe(true);
-    if (res.isErr()) {
-      return;
-    }
-
-    const currentTool = getFunctionMessage(
-      res.value.modelConversation.messages,
-      "cur_tool"
-    );
-    expect(currentTool.content).toBe("cur_function");
-    expect(res.value.prunedContext).toBe(false);
-  });
-
-  it("genuinely proactively prunes eligible interactions through the checkpoint-based frontier, not just the last-resort floor path", async () => {
-    // 5 previous interactions (250 tokens each: 10 user + 10 assistant + 230 tool),
-    // PREVIOUS_INTERACTIONS_TO_PRESERVE=3 leaves i0,i1 eligible and i2,i3,i4 as the protected
-    // floor. contextSize 3400 gives a proactive target of 999 tokens (60% minus baseTokens):
-    // the floor alone (750) comfortably fits under it, so last-resort never fires, but the full
-    // 1250-token total doesn't, so i0 and i1 (but not the floor) get redacted through the normal
-    // frontier search, leaving 838 tokens, back under the target without needing to drop anything.
-    const previousInteractionMessages = [0, 1, 2, 3, 4].flatMap((i) => [
-      userMessage(`i${i}_user`),
-      assistantMessage(`i${i}_assistant`),
-      functionMessage(`i${i}_tool`, `i${i}_tool_content`),
+  it("redacts a single turn's OWN earlier tool-call steps once it makes many tool calls, since the current turn gets no special exemption", async () => {
+    // ONE continuous interaction: a single user question answered via 12 tool-call steps before
+    // the final reply. Nothing here is a "previous interaction", it's all the current turn, yet
+    // its own earliest steps (beyond TOOL_RESULTS_TO_PRESERVE=10) still get redacted.
+    const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    const steps = indices.flatMap((i) => [
+      assistantMessage(`thinking_${i}`),
+      functionMessage(`step_${i}`, `step_${i}_result_big`),
     ]);
     vi.mocked(renderAllMessages).mockResolvedValue([
-      ...previousInteractionMessages,
-      userMessage("cur_user"),
-      assistantMessage("cur_assistant"),
+      userMessage("the_question"),
+      ...steps,
+      assistantMessage("final_answer"),
     ]);
     mockTokenCounter({
       byContains: Object.fromEntries([
-        ...[0, 1, 2, 3, 4].flatMap((i) => [
-          [`i${i}_user`, 10],
-          [`i${i}_assistant`, 10],
-          [`i${i}_tool_content`, 230],
+        ["the_question", 10],
+        ["final_answer", 10],
+        ...indices.flatMap((i) => [
+          [`thinking_${i}`, 10],
+          [`step_${i}_result_big`, 5000],
         ]),
-        ["cur_user", 10],
-        ["cur_assistant", 10],
       ]),
     });
 
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
-      model: { ...model, contextSize: 3400 },
+      model,
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Far above the real usage here: proves redaction comes from the proactive target, not from
-      // running out of the real budget.
+      // Total unredacted: 10 (question) + 12*(10+5000) + 10 (answer) = 60_140. Redacting the 2
+      // steps outside the floor of 10 saves 2 * (5000-24) = 9_952 -> 50_188, under this budget.
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 51_000,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const step1 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "step_1"
+    );
+    const step2 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "step_2"
+    );
+    const step3 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "step_3"
+    );
+    const step12 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "step_12"
+    );
+    expect(step1.content).toContain("This tool result is no longer available");
+    expect(step2.content).toContain("This tool result is no longer available");
+    expect(step3.content).toBe("step_3_result_big");
+    expect(step12.content).toBe("step_12_result_big");
+    expect(res.value.prunedContext).toBe(true);
+  });
+
+  it("proactively redacts once the conversation crosses PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit it", async () => {
+    // 12 small interactions (TOOL_RESULTS_TO_PRESERVE=10, so 2 fall outside the floor). contextSize
+    // 4_000 gives a proactive target of 1_359 tokens (baseTokens=1041, so 4_000*0.6 - 1041):
+    // comfortably above the 1_288 tokens left after redacting the 2 eligible tool results, but
+    // well below the 1_440 unredacted total, so the proactive target is what forces the
+    // redaction, not the real ceiling, which is set far higher below.
+    const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
+      userMessage(`u_${i}`),
+      assistantMessage(`a_${i}`),
+      functionMessage(`tool_${i}`, `result_${i}`),
+    ]);
+    vi.mocked(renderAllMessages).mockResolvedValue(messages);
+    mockTokenCounter({
+      byContains: Object.fromEntries(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
+          [`u_${i}`, 10],
+          [`a_${i}`, 10],
+          [`result_${i}`, 100],
+        ])
+      ),
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model: { ...model, contextSize: 4_000 },
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      // Real ceiling comfortably fits everything (1_440) in full: proves redaction is driven by
+      // the proactive target, not by running out of the real budget.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
@@ -458,58 +382,54 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const i0Tool = getFunctionMessage(
+    const tool1 = getFunctionMessage(
       res.value.modelConversation.messages,
-      "i0_tool"
+      "tool_1"
     );
-    const i4Tool = getFunctionMessage(
+    const tool12 = getFunctionMessage(
       res.value.modelConversation.messages,
-      "i4_tool"
+      "tool_12"
     );
-    expect(i0Tool.content).toContain("no longer available");
-    expect(i4Tool.content).toBe("i4_tool_content");
+    expect(tool1.content).toContain("no longer available");
+    expect(tool12.content).toBe("result_12");
   });
 
-  it("falls back to the real budget instead of forcing a negative proactive target, so a large system prompt/tool footprint on a small-context model never breaks the protected floor", async () => {
-    // contextSize 16_384 (GPT-3.5-turbo-sized) with a 6000-token prompt and 6000-token tool
-    // definitions footprint: baseTokens (~11224) alone already exceeds the 60% proactive target
-    // (~9830), which would go negative if applied naively. previousInteractionsPruningBudget must
-    // fall back to the real budgetForInteractions (300 here), which comfortably covers all 3
-    // previous interactions (all inside the protected floor), so none of them should be touched.
-    const previousInteractionMessages = [0, 1, 2].flatMap((i) => [
-      userMessage(`i${i}_user`),
-      assistantMessage(`i${i}_assistant`),
-      functionMessage(`i${i}_tool`, `i${i}_tool_content`),
+  it("drops a whole previous interaction entirely, not just its tool result, when redaction alone still doesn't fit", async () => {
+    // Ten previous interactions, each dominated by large USER/ASSISTANT text (never redacted by
+    // pruneToolResults) rather than tool output. Redaction alone cannot shrink these enough, so
+    // dropInteractionsToFit must remove some of them wholesale.
+    const previousInteractions = [1, 2, 3, 4, 5].flatMap((i) => [
+      userMessage(`old_user_${i}_big`),
+      assistantMessage(`old_assistant_${i}_big`),
     ]);
     vi.mocked(renderAllMessages).mockResolvedValue([
-      ...previousInteractionMessages,
-      userMessage("cur_user"),
-      assistantMessage("cur_assistant"),
+      ...previousInteractions,
+      userMessage("new_user"),
+      assistantMessage("new_assistant"),
     ]);
     mockTokenCounter({
       byContains: Object.fromEntries([
-        ...[0, 1, 2].flatMap((i) => [
-          [`i${i}_user`, 10],
-          [`i${i}_assistant`, 10],
-          [`i${i}_tool_content`, 20],
+        ...[1, 2, 3, 4, 5].flatMap((i) => [
+          [`old_user_${i}_big`, 200],
+          [`old_assistant_${i}_big`, 200],
         ]),
-        ["cur_user", 10],
-        ["cur_assistant", 10],
+        ["new_user", 10],
+        ["new_assistant", 10],
       ]),
-      promptTokens: 6000,
-      toolsTokens: 6000,
     });
 
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
-      model: { ...model, contextSize: 16_384 },
+      model,
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
+      // Each old interaction costs 400 tokens. Budget only leaves room for the current (20) plus
+      // roughly one old interaction (400), nowhere near all 5 (2000).
       allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 6000,
-        toolsTokens: 6000,
-        interactionTokens: 300,
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 450,
       }),
     });
 
@@ -518,16 +438,70 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    for (const i of [0, 1, 2]) {
-      const tool = getFunctionMessage(
-        res.value.modelConversation.messages,
-        `i${i}_tool`
-      );
-      expect(tool.content).toBe(`i${i}_tool_content`);
-    }
+    const roles = res.value.modelConversation.messages;
+    const survivingUserTexts = roles
+      .filter(isUserMessage)
+      .map((m) => textOf(m.content[0]));
+    // Oldest interactions are dropped first. The newest ones (closest to "new_user") survive.
+    expect(survivingUserTexts).not.toContain("old_user_1_big");
+    expect(survivingUserTexts).toContain("new_user");
   });
 
-  it("merges content fragment into following user message", async () => {
+  it("drops a content fragment TOGETHER WITH its user message when the whole interaction is dropped, never separates them", async () => {
+    // The oldest interaction carries a content fragment (e.g. a file upload) immediately before
+    // its user message. When that whole interaction is dropped for space, the content fragment
+    // must go with it, never survive alone with no user message to merge into.
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      contentFragmentMessage("uploaded_file_big"),
+      userMessage("old_user_big"),
+      assistantMessage("old_assistant_big"),
+      userMessage("new_user"),
+      assistantMessage("new_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: {
+        uploaded_file_big: 300,
+        old_user_big: 200,
+        old_assistant_big: 200,
+        new_user: 10,
+        new_assistant: 10,
+      },
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      // Budget only fits the current interaction (20 tokens). The 700-token old interaction
+      // (content fragment + user + assistant) must be dropped as a whole.
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 50,
+      }),
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    const roles = res.value.modelConversation.messages.map((m) => m.role);
+    // No dangling content_fragment role should ever reach the final output (they're merged into
+    // user messages, or dropped together with them), this asserts the merge-or-drop invariant
+    // held even though the interaction carrying the fragment was entirely dropped.
+    expect(roles).not.toContain("content_fragment");
+
+    const survivingUserTexts = res.value.modelConversation.messages
+      .filter(isUserMessage)
+      .map((m) => textOf(m.content[0]));
+    expect(survivingUserTexts).not.toContain("old_user_big");
+    expect(survivingUserTexts).toContain("new_user");
+  });
+
+  it("merges content fragment into following user message when both survive", async () => {
     vi.mocked(renderAllMessages).mockResolvedValue([
       contentFragmentMessage("fragment_text"),
       userMessage("user_text"),
@@ -573,7 +547,7 @@ describe("renderConversationForModel", () => {
     expect(textOf(firstUser.content[1])).toBe("user_text");
   });
 
-  it("returns an error when context window is still exceeded after pruning", async () => {
+  it("returns an error when context window is still exceeded after every pruning layer", async () => {
     vi.mocked(renderAllMessages).mockResolvedValue([
       userMessage("BIG_USER"),
       assistantMessage("BIG_ASSISTANT"),
@@ -603,87 +577,6 @@ describe("renderConversationForModel", () => {
       expect(res.error.message).toContain(
         "Context window exceeded: at least one message is required"
       );
-    }
-  });
-
-  it("does not error when previousInteractions' floor alone overflows its budget, as long as the current interaction fits on its own", async () => {
-    // There are 3 previous interactions here, and PREVIOUS_INTERACTIONS_TO_PRESERVE is 3, so all
-    // 3 are kept in full and are never redacted. Each one is 340 tokens (20 + 20 + 300), so all 3
-    // together are 1020 tokens. The token budget for previous interactions is only 100 (set below
-    // via allowedTokenCount). There is no way to fit 1020 tokens of previous interactions into a
-    // budget of 100.
-    //
-    // The current interaction, on the other hand, is tiny: just 20 tokens (10 + 10), no tool call.
-    // It fits into the 100 token budget on its own, easily.
-    //
-    // What this test checks: the render must still succeed. It would be wrong to compute
-    // "100 minus the 1020 tokens previous interactions actually take" and use that negative
-    // number to decide if the current interaction fits, because that would make even a tiny
-    // current interaction look too big and fail the whole request. The current interaction only
-    // needs to fit the 100 token budget by itself. Previous interactions get trimmed down
-    // separately to make room.
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      userMessage("floor1_user"),
-      assistantMessage("floor1_assistant"),
-      functionMessage("floor1_tool", "floor1_tool_content"),
-      userMessage("floor2_user"),
-      assistantMessage("floor2_assistant"),
-      functionMessage("floor2_tool", "floor2_tool_content"),
-      userMessage("floor3_user"),
-      assistantMessage("floor3_assistant"),
-      functionMessage("floor3_tool", "floor3_tool_content"),
-      userMessage("cur_user"),
-      assistantMessage("cur_assistant"),
-    ]);
-    mockTokenCounter({
-      byContains: {
-        floor1_user: 20,
-        floor1_assistant: 20,
-        floor1_tool_content: 300,
-        floor2_user: 20,
-        floor2_assistant: 20,
-        floor2_tool_content: 300,
-        floor3_user: 20,
-        floor3_assistant: 20,
-        floor3_tool_content: 300,
-        cur_user: 10,
-        cur_assistant: 10,
-      },
-    });
-
-    const res = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model,
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      // budgetForInteractions = 100: far less than the floor's real size (3 * 340 = 1020) or even
-      // its fully-redacted minimum (3 * 64 = 192), but comfortably more than the current
-      // interaction's own 20 tokens.
-      allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 10,
-        toolsTokens: 10,
-        interactionTokens: 100,
-      }),
-    });
-
-    expect(res.isOk()).toBe(true);
-    if (res.isErr()) {
-      return;
-    }
-
-    const currentUser = res.value.modelConversation.messages.find(
-      (m) => isUserMessage(m) && textOf(m.content[0]) === "cur_user"
-    );
-    expect(currentUser).toBeDefined();
-
-    // previousInteractions couldn't all survive, but the render degraded gracefully instead of
-    // failing outright: at least one floor interaction made it through, redacted.
-    const survivingFloorTools =
-      res.value.modelConversation.messages.filter(isFunctionMessage);
-    expect(survivingFloorTools.length).toBeGreaterThan(0);
-    for (const tool of survivingFloorTools) {
-      expect(tool.content).toContain("no longer available");
     }
   });
 
@@ -801,9 +694,17 @@ describe("renderConversationForModel", () => {
       },
     });
 
-    // Each interaction is 90 tokens (30 + 30 + 30).
-    // Budget below allows exactly 2 interactions to fit after base tokens:
-    // interaction budget = 189 => 2 * 90 = 180 fits, 3 * 90 = 270 does not.
+    // Each interaction is 90 tokens (30 + 30 + 30), well within TOOL_RESULTS_TO_PRESERVE (10 tool
+    // results total here), so Layer 1 (redaction) can't touch any of them at all, this is meant
+    // to exercise Layer 2 (drop-entirely) in isolation, not cascade into Layer 3's force-redaction.
+    //
+    // Hand-verified: total unredacted = 8 * 90 = 720. Layer 2's target for the 7 previous
+    // interactions is budgetForInteractions(400) - current's cost(90) = 310. With
+    // PREVIOUS_INTERACTIONS_TO_PRESERVE=3, i1-i4 (4 * 90 = 360) can be dropped, leaving the
+    // protected floor i5-i7 (3 * 90 = 270) plus current i8 (90) = 360 <= 400: Layer 2 alone gets
+    // under budget, so Layer 3/4 never fire and i5-i8 survive WITH THEIR REAL, UNREDACTED CONTENT
+    //, an earlier version of this test only checked message names, which stay the same whether
+    // a tool result is redacted or not, and so couldn't actually tell the difference.
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
       model,
@@ -813,7 +714,7 @@ describe("renderConversationForModel", () => {
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
-        interactionTokens: 189,
+        interactionTokens: 400,
       }),
     });
 
@@ -822,148 +723,20 @@ describe("renderConversationForModel", () => {
       return;
     }
 
-    const names = res.value.modelConversation.messages
-      .filter(isFunctionMessage)
-      .map((m) => m.name);
-    expect(names).toEqual(["tool_07", "tool_08"]);
+    const functionMessages =
+      res.value.modelConversation.messages.filter(isFunctionMessage);
+    const names = functionMessages.map((m) => m.name);
+    expect(names).toEqual(["tool_05", "tool_06", "tool_07", "tool_08"]);
     expect(names).not.toContain("tool_01");
     expect(names).not.toContain("tool_02");
     expect(names).not.toContain("tool_03");
     expect(names).not.toContain("tool_04");
-    expect(names).not.toContain("tool_05");
-    expect(names).not.toContain("tool_06");
-  });
 
-  it("renders previous interactions identically across turns, regardless of how big the current interaction happens to be", async () => {
-    // Four previous interactions (i1..i4), each 70 tokens (10 user + 10 assistant + 50 tool),
-    // comfortably within budgetForInteractions on their own. Prior to the fix, this scenario used
-    // to drop i2/i3/i4 entirely on the turn where the current interaction grew large, purely
-    // because current and previousInteractions shared one live pool in the final selection loop.
-    // Now previousInteractions gets a fixed, current-independent claim on the budget, so its
-    // rendering must be byte-identical across both calls below.
-    const previousInteractionMessages = [
-      userMessage("i1_user"),
-      assistantMessage("i1_assistant"),
-      functionMessage("i1_tool", "i1_tool_content"),
-      userMessage("i2_user"),
-      assistantMessage("i2_assistant"),
-      functionMessage("i2_tool", "i2_tool_content"),
-      userMessage("i3_user"),
-      assistantMessage("i3_assistant"),
-      functionMessage("i3_tool", "i3_tool_content"),
-      userMessage("i4_user"),
-      assistantMessage("i4_assistant"),
-      functionMessage("i4_tool", "i4_tool_content"),
-    ];
-    const byContains = {
-      i1_user: 10,
-      i1_assistant: 10,
-      i1_tool_content: 50,
-      i2_user: 10,
-      i2_assistant: 10,
-      i2_tool_content: 50,
-      i3_user: 10,
-      i3_assistant: 10,
-      i3_tool_content: 50,
-      i4_user: 10,
-      i4_assistant: 10,
-      i4_tool_content: 50,
-      cur_user_small: 10,
-      cur_assistant_small: 10,
-      cur_user_big: 10,
-      cur_assistant_big: 10,
-      cur_tool_big_content: 200,
-    };
-
-    // Same allowedTokenCount on both calls, same model, same context window. The only thing that
-    // differs between "turn T" and "turn T+1" is how big the new current-turn content is.
-    // budgetForInteractions = 400 comfortably covers i1..i4 (4 * 70 = 280) on its own.
-    const allowedTokenCount = computeAllowedTokenCount({
-      promptTokens: 10,
-      toolsTokens: 10,
-      interactionTokens: 400,
-    });
-
-    // Turn T: current interaction is small (20 tokens: just user + assistant, no tool call).
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      ...previousInteractionMessages,
-      userMessage("cur_user_small"),
-      assistantMessage("cur_assistant_small"),
-    ]);
-    mockTokenCounter({ byContains });
-
-    const turnT = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model,
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      allowedTokenCount,
-    });
-    expect(turnT.isOk()).toBe(true);
-    if (turnT.isErr()) {
-      return;
+    // The surviving tool results carry their REAL content, not a redaction placeholder,
+    // confirming Layer 2 (drop) alone was enough, and Layer 3 (force-redact) never fired.
+    for (const [i, name] of ["f_05", "f_06", "f_07", "f_08"].entries()) {
+      expect(functionMessages[i].content).toBe(name);
     }
-
-    const previousMessagesAtTurnT = previousInteractionSummaries(
-      turnT.value.modelConversation.messages
-    );
-
-    // All four previous interactions are rendered in full at turn T.
-    const toolNamesAtTurnT = previousMessagesAtTurnT
-      .filter((m) => m.role === "function")
-      .map((m) => m.name);
-    expect(toolNamesAtTurnT).toEqual([
-      "i1_tool",
-      "i2_tool",
-      "i3_tool",
-      "i4_tool",
-    ]);
-    for (const i of [1, 2, 3, 4]) {
-      const tool = previousMessagesAtTurnT.find((m) => m.name === `i${i}_tool`);
-      expect(tool?.content).toBe(`i${i}_tool_content`);
-    }
-
-    // Turn T+1: i1..i4 are byte-for-byte identical to turn T. The ONLY change is that this
-    // turn's new current interaction now includes a big tool call (220 tokens instead of 20),
-    // exactly like a user turn that happens to trigger a large tool result.
-    vi.mocked(renderAllMessages).mockResolvedValue([
-      ...previousInteractionMessages,
-      userMessage("cur_user_big"),
-      assistantMessage("cur_assistant_big"),
-      functionMessage("cur_tool_big", "cur_tool_big_content"),
-    ]);
-    mockTokenCounter({ byContains });
-
-    const turnTPlus1 = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model,
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      allowedTokenCount, // same context window budget as turn T
-    });
-    expect(turnTPlus1.isOk()).toBe(true);
-    if (turnTPlus1.isErr()) {
-      return;
-    }
-
-    const previousMessagesAtTurnTPlus1 = previousInteractionSummaries(
-      turnTPlus1.value.modelConversation.messages
-    );
-
-    // Byte-identical to turn T: none of i1..i4 moved, despite the current interaction growing
-    // from 20 to 220 tokens.
-    expect(previousMessagesAtTurnTPlus1).toEqual(previousMessagesAtTurnT);
-
-    // The current interaction itself is free to vary. It's new content, never previously cached,
-    // and its own tool result gets progressively pruned since it doesn't fit its ideal share of
-    // the budget on its own.
-    const currentToolAtTurnTPlus1 = getFunctionMessage(
-      turnTPlus1.value.modelConversation.messages,
-      "cur_tool_big"
-    );
-    expect(currentToolAtTurnTPlus1.content).toContain("no longer available");
   });
 
   it("prepends leading messages", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -103,7 +103,9 @@ function pruneConversationToBudget(
     totalTokens = sumInteractionTokens(pruned);
   }
 
-  // Layer 3: pruning alone wasn't enough, force it past TOOL_RESULTS_TO_PRESERVE.
+  // Layer 3: reaching here means layer 2 dropped every previous interaction it was allowed to,
+  // and what remains (the last PREVIOUS_INTERACTIONS_TO_PRESERVE plus the current interaction)
+  // still doesn't fit. Force pruning past TOOL_RESULTS_TO_PRESERVE into the protected floor.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
@@ -114,7 +116,9 @@ function pruneConversationToBudget(
     totalTokens = sumInteractionTokens(pruned);
   }
 
-  // Layer 4: still over budget, drop previous interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE.
+  // Layer 4: still over budget with every tool result already at placeholder size. Drop previous
+  // interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE, down to the current interaction alone
+  // if needed.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -25,15 +25,16 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { MessageWithTokens } from "./pruning";
 import {
+  dropInteractionsToFit,
   getInteractionTokenCount,
-  progressivelyPruneInteraction,
-  prunePreviousInteractions,
+  pruneToolResults,
+  TOOL_RESULTS_TO_PRESERVE,
 } from "./pruning";
 
-// When previous interactions pruning is enabled, we'll attempt to fully preserve this number of
-// interactions. This value was originally at 1 and bumped at 3 with the introduction of
-// gracefully_stopped agent message and user message steering to don't prune tool outputs too
-// aggressively.
+// How many of the most recent interactions dropInteractionsToFit never drops entirely, even if
+// their own tool results were already redacted. A different floor from TOOL_RESULTS_TO_PRESERVE
+// (pruning.ts). That one protects tool result content regardless of turn. This one protects whole
+// recent turns from being erased regardless of how many tool calls they made.
 export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
 
 // Fixed number of tokens assumed for image contents
@@ -41,11 +42,10 @@ const IMAGE_CONTENT_TOKEN_COUNT = 3100;
 export const TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR = 0.7;
 export const TOKENS_MARGIN = 1024;
 
-// Target ceiling (as a fraction of contextSize) for triggering previous-interactions pruning,
-// picked to sit safely below the customer-facing compaction warning (~70% of contextSize) rather
-// than the real ceiling, which sits at 68-99% depending on the model and otherwise leaves pruning
-// doing nothing until compaction has already fired. Kept independent of generationTokensCount,
-// which also doubles as the actual max_tokens sent to the provider.
+// Proactive redaction target as a fraction of contextSize, picked to sit below the customer-facing
+// compaction warning (~70%) rather than the real ceiling (68-99% depending on model), which would
+// otherwise leave pruning inactive until compaction has already fired. Applies to the whole
+// conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
 export async function renderConversationForModel(
@@ -152,45 +152,19 @@ export async function renderConversationForModel(
 
   const interactions = groupMessagesIntoInteractions(messagesWithTokens);
 
-  // Previous interactions get first, fixed claim on the token budget, independent of how big this
-  // turn's own new content happens to be. This is what keeps their rendering stable across turns.
-  // The budget prunePreviousInteractions works against never depends on a live, per-turn
-  // quantity. The current interaction (this turn's own new content, never previously cached)
-  // absorbs whatever budget remains, with its own progressive-pruning safety net below.
+  // Hard ceiling shared by every interaction combined: previous history plus the current,
+  // still-in-progress turn.
   const budgetForInteractions = allowedTokenCount - baseTokens;
 
-  // See PRUNING_TARGET_CONTEXT_UTILIZATION for why this trigger exists. Kept separate from
-  // budgetForInteractions (the real ceiling, used below for the current interaction's own safety
-  // net) and only applied when positive: a small-context model with a large prompt or many tools
-  // can push baseTokens past the target on its own, and forcing that negative number would make
-  // prunePreviousInteractions redact its protected floor as routine behavior, not a rare last
-  // resort.
+  // Only applied when positive: a small-context model with a large prompt/tools footprint can
+  // push baseTokens past the target alone, and a negative value would make the floor redact by
+  // default instead of as a last resort.
   const pruningTargetCeiling =
     model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
-  const previousInteractionsPruningBudget =
+  const pruningBudget =
     pruningTargetCeiling > 0
       ? Math.min(budgetForInteractions, pruningTargetCeiling)
       : budgetForInteractions;
-
-  const previousInteractions = prunePreviousInteractions(
-    interactions.slice(0, -1),
-    previousInteractionsPruningBudget,
-    PREVIOUS_INTERACTIONS_TO_PRESERVE
-  );
-  const previousInteractionsTokens = previousInteractions.reduce(
-    (sum, interaction) => sum + getInteractionTokenCount(interaction),
-    0
-  );
-
-  let currentInteraction = interactions[interactions.length - 1];
-  let currentInteractionTokens = getInteractionTokenCount(currentInteraction);
-
-  // Ideally, the current interaction gets whatever's left after previousInteractions. But
-  // previousInteractions is capped by construction (see prunePreviousInteractions), so this can
-  // only go negative in the rare case where even the (redacted) floor alone didn't fit. In that
-  // case we still only require the current interaction to fit the full fixed pool on its own,
-  // matching the pre-existing hard safety net below.
-  const currentBudget = budgetForInteractions - previousInteractionsTokens;
 
   const logDetails = {
     workspaceId: conversation.owner.sId,
@@ -214,60 +188,103 @@ export async function renderConversationForModel(
     pokeUrl: `https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
   };
 
-  if (currentInteractionTokens > currentBudget) {
-    // The last interaction does not fit within its ideal share of the token budget.
-    // We apply progressive pruning to that interaction until it fits.
-    currentInteraction = progressivelyPruneInteraction(
-      currentInteraction,
-      currentBudget
+  // Layer 1: proactive tool-result redaction across the whole conversation (see pruneToolResults).
+  let redactedInteractions = pruneToolResults(
+    interactions,
+    pruningBudget,
+    TOOL_RESULTS_TO_PRESERVE
+  );
+  let prunedContext = redactedInteractions !== interactions;
+  let totalTokens = redactedInteractions.reduce(
+    (sum, interaction) => sum + getInteractionTokenCount(interaction),
+    0
+  );
+
+  // Layer 2: redaction alone wasn't enough. Drop old interactions entirely (never the current
+  // one, sliced out below and always re-appended).
+  if (totalTokens > budgetForInteractions) {
+    const currentInteraction =
+      redactedInteractions[redactedInteractions.length - 1];
+    const previousInteractionsBefore = redactedInteractions.slice(0, -1);
+    const previousInteractionsAfter = dropInteractionsToFit(
+      previousInteractionsBefore,
+      budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      PREVIOUS_INTERACTIONS_TO_PRESERVE
     );
-    if (currentInteraction.prunedContext) {
-      logger.warn(
-        {
-          ...logDetails,
-          currentInteractionTokens,
-          currentBudget,
-        },
-        "Last tool result was pruned to fit in context window."
-      );
+    if (previousInteractionsAfter !== previousInteractionsBefore) {
+      prunedContext = true;
     }
-    currentInteractionTokens = getInteractionTokenCount(currentInteraction);
-    // The hard requirement is only that the current interaction fits the full fixed pool on its
-    // own: previousInteractions can still be trimmed further below (oldest first) to make room.
-    if (currentInteractionTokens > budgetForInteractions) {
-      logger.error(
-        {
-          ...logDetails,
-          failureStage: "interaction_exceeds_after_pruning",
-          currentInteractionTokens,
-          budgetForInteractions,
-        },
-        "Render Conversation V2: No interactions fit in context window."
-      );
-      return new Err(
-        new Error("Context window exceeded: at least one message is required")
-      );
-    }
+    redactedInteractions = [...previousInteractionsAfter, currentInteraction];
+    totalTokens = redactedInteractions.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
   }
 
-  const prunedInteractions = [...previousInteractions, currentInteraction];
-
-  // Select interactions that fit within token budget.
-  const selected: MessageWithTokens[] = [];
-  let tokensUsed = baseTokens;
-
-  // Go backward through interactions.
-  for (let i = prunedInteractions.length - 1; i >= 0; i--) {
-    const interaction = prunedInteractions[i];
-
-    const interactionTokens = getInteractionTokenCount(interaction);
-    if (tokensUsed + interactionTokens <= allowedTokenCount) {
-      tokensUsed += interactionTokens;
-      selected.unshift(...interaction.messages);
-    } else {
-      break;
-    }
+  // Layer 3: still over budget. Force redaction into the protected floor too.
+  if (totalTokens > budgetForInteractions) {
+    logger.warn(
+      { ...logDetails, totalTokens, budgetForInteractions },
+      "Dropped every eligible previous interaction; still over budget, forcing floor redaction."
+    );
+    redactedInteractions = pruneToolResults(
+      redactedInteractions,
+      budgetForInteractions,
+      0
+    );
+    prunedContext = true;
+    totalTokens = redactedInteractions.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
   }
+
+  // Layer 4 (last resort): a turn whose bulk is plain text can't be shrunk by redaction alone.
+  // Drop old interactions again, past the normal floor (current interaction still never dropped).
+  if (totalTokens > budgetForInteractions) {
+    logger.warn(
+      { ...logDetails, totalTokens, budgetForInteractions },
+      "Floor redaction still not enough; dropping previous interactions past the normal floor."
+    );
+    const currentInteraction =
+      redactedInteractions[redactedInteractions.length - 1];
+    const previousInteractionsBefore = redactedInteractions.slice(0, -1);
+    const previousInteractionsAfter = dropInteractionsToFit(
+      previousInteractionsBefore,
+      budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      0
+    );
+    if (previousInteractionsAfter !== previousInteractionsBefore) {
+      prunedContext = true;
+    }
+    redactedInteractions = [...previousInteractionsAfter, currentInteraction];
+    totalTokens = redactedInteractions.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
+  }
+
+  if (totalTokens > budgetForInteractions) {
+    logger.error(
+      {
+        ...logDetails,
+        failureStage: "interaction_exceeds_after_pruning",
+        totalTokens,
+        budgetForInteractions,
+      },
+      "Render Conversation V2: No interactions fit in context window."
+    );
+    return new Err(
+      new Error("Context window exceeded: at least one message is required")
+    );
+  }
+
+  // totalTokens <= budgetForInteractions is now guaranteed, so every remaining message is kept.
+  // No further backward "does it fit" pass is needed.
+  const selected: MessageWithTokens[] = redactedInteractions.flatMap(
+    (interaction) => interaction.messages
+  );
+  const tokensUsed = baseTokens + totalTokens;
 
   // Merge content fragments into user messages.
   for (let i = selected.length - 1; i >= 0; i--) {
@@ -324,8 +341,6 @@ export async function renderConversationForModel(
       ): message is ModelMessageTypeMultiActionsWithoutContentFragment =>
         message.role !== "content_fragment"
     );
-
-  const prunedContext = currentInteraction.prunedContext ?? false;
 
   const pruneSelectAndFinalizeMs = Date.now() - stepStart;
 

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -79,11 +79,10 @@ function pruneConversationToBudget(
   Error
 > {
   // Layer 1: proactive pruning, within the protected floor, up to pruningBudget.
-  let pruned = pruneToolResults(
-    interactions,
-    pruningBudget,
-    TOOL_RESULTS_TO_PRESERVE
-  );
+  let pruned = pruneToolResults(interactions, {
+    maxTokens: pruningBudget,
+    toolResultsToPreserve: TOOL_RESULTS_TO_PRESERVE,
+  });
   let prunedContext = pruned !== interactions;
   let totalTokens = sumInteractionTokens(pruned);
 
@@ -112,7 +111,10 @@ function pruneConversationToBudget(
       { ...logDetails, totalTokens, budgetForInteractions },
       "Dropped every eligible previous interaction; still over budget, forcing floor pruning."
     );
-    pruned = pruneToolResults(pruned, budgetForInteractions, 0);
+    pruned = pruneToolResults(pruned, {
+      maxTokens: budgetForInteractions,
+      toolResultsToPreserve: 0,
+    });
     prunedContext = true;
     totalTokens = sumInteractionTokens(pruned);
   }

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -77,6 +77,7 @@ function pruneConversationToBudget(
   { interactions: InteractionWithTokens[]; prunedContext: boolean },
   Error
 > {
+  // Layer 1: proactive redaction, within the protected floor, up to pruningBudget.
   let redacted = pruneToolResults(
     interactions,
     pruningBudget,
@@ -88,6 +89,7 @@ function pruneConversationToBudget(
     0
   );
 
+  // Layer 2: drop whole previous interactions, oldest first, never the current one.
   if (totalTokens > budgetForInteractions) {
     const currentInteraction = redacted[redacted.length - 1];
     const previousBefore = redacted.slice(0, -1);
@@ -106,6 +108,7 @@ function pruneConversationToBudget(
     );
   }
 
+  // Layer 3: redaction alone wasn't enough, force it past TOOL_RESULTS_TO_PRESERVE.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
@@ -119,6 +122,7 @@ function pruneConversationToBudget(
     );
   }
 
+  // Layer 4: still over budget, drop previous interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
@@ -141,6 +145,7 @@ function pruneConversationToBudget(
     );
   }
 
+  // Last resort exhausted: even the current interaction alone doesn't fit.
   if (totalTokens > budgetForInteractions) {
     logger.error(
       {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -87,7 +87,8 @@ function pruneConversationToBudget(
   let prunedContext = pruned !== interactions;
   let totalTokens = sumInteractionTokens(pruned);
 
-  // Layer 2: drop whole previous interactions, oldest first, never the current one.
+  // Layer 2: drop whole previous interactions, oldest first. The last
+  // PREVIOUS_INTERACTIONS_TO_PRESERVE of them are protected, and the current one always survives.
   if (totalTokens > budgetForInteractions) {
     const currentInteraction = pruned[pruned.length - 1];
     const previousBefore = pruned.slice(0, -1);

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -23,7 +23,7 @@ import type { CredentialsType } from "@app/types/provider";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { MessageWithTokens } from "./pruning";
+import type { InteractionWithTokens, MessageWithTokens } from "./pruning";
 import {
   dropInteractionsToFit,
   getInteractionTokenCount,
@@ -47,6 +47,117 @@ export const TOKENS_MARGIN = 1024;
 // otherwise leave pruning inactive until compaction has already fired. Applies to the whole
 // conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
+
+/**
+ * Escalates through redaction and dropping until the conversation fits budgetForInteractions, or
+ * returns an error if even the last resort isn't enough. Four layers, each tried only if the
+ * previous one left the conversation over budget: redact proactively (up to pruningBudget),
+ * drop old interactions entirely (never the current one), force redaction into the protected
+ * floor, then force dropping past the protected floor.
+ *
+ * pruneToolResults and dropInteractionsToFit are each called twice, once with their normal floor
+ * and once with a floor of 0. This is safe because both floors work off the CURRENT state: a
+ * message pruneToolResults already redacted is already at the placeholder size, so redacting it
+ * again would save nothing and its own eligibility check excludes it, and an interaction
+ * dropInteractionsToFit already dropped is simply gone from the array, so there's nothing left
+ * for the second call to reconsider. Each call only ever reaches further than the one before it.
+ */
+function pruneConversationToBudget(
+  interactions: InteractionWithTokens[],
+  {
+    pruningBudget,
+    budgetForInteractions,
+    logDetails,
+  }: {
+    pruningBudget: number;
+    budgetForInteractions: number;
+    logDetails: Record<string, unknown>;
+  }
+): Result<
+  { interactions: InteractionWithTokens[]; prunedContext: boolean },
+  Error
+> {
+  let redacted = pruneToolResults(
+    interactions,
+    pruningBudget,
+    TOOL_RESULTS_TO_PRESERVE
+  );
+  let prunedContext = redacted !== interactions;
+  let totalTokens = redacted.reduce(
+    (sum, interaction) => sum + getInteractionTokenCount(interaction),
+    0
+  );
+
+  if (totalTokens > budgetForInteractions) {
+    const currentInteraction = redacted[redacted.length - 1];
+    const previousBefore = redacted.slice(0, -1);
+    const previousAfter = dropInteractionsToFit(
+      previousBefore,
+      budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      PREVIOUS_INTERACTIONS_TO_PRESERVE
+    );
+    if (previousAfter !== previousBefore) {
+      prunedContext = true;
+    }
+    redacted = [...previousAfter, currentInteraction];
+    totalTokens = redacted.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
+  }
+
+  if (totalTokens > budgetForInteractions) {
+    logger.warn(
+      { ...logDetails, totalTokens, budgetForInteractions },
+      "Dropped every eligible previous interaction; still over budget, forcing floor redaction."
+    );
+    redacted = pruneToolResults(redacted, budgetForInteractions, 0);
+    prunedContext = true;
+    totalTokens = redacted.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
+  }
+
+  if (totalTokens > budgetForInteractions) {
+    logger.warn(
+      { ...logDetails, totalTokens, budgetForInteractions },
+      "Floor redaction still not enough; dropping previous interactions past the normal floor."
+    );
+    const currentInteraction = redacted[redacted.length - 1];
+    const previousBefore = redacted.slice(0, -1);
+    const previousAfter = dropInteractionsToFit(
+      previousBefore,
+      budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      0
+    );
+    if (previousAfter !== previousBefore) {
+      prunedContext = true;
+    }
+    redacted = [...previousAfter, currentInteraction];
+    totalTokens = redacted.reduce(
+      (sum, interaction) => sum + getInteractionTokenCount(interaction),
+      0
+    );
+  }
+
+  if (totalTokens > budgetForInteractions) {
+    logger.error(
+      {
+        ...logDetails,
+        failureStage: "interaction_exceeds_after_pruning",
+        totalTokens,
+        budgetForInteractions,
+      },
+      "Render Conversation V2: No interactions fit in context window."
+    );
+    return new Err(
+      new Error("Context window exceeded: at least one message is required")
+    );
+  }
+
+  return new Ok({ interactions: redacted, prunedContext });
+}
 
 export async function renderConversationForModel(
   auth: Authenticator,
@@ -188,99 +299,20 @@ export async function renderConversationForModel(
     pokeUrl: `https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
   };
 
-  // Layer 1: proactive tool-result redaction across the whole conversation (see pruneToolResults).
-  let redactedInteractions = pruneToolResults(
-    interactions,
+  const pruneRes = pruneConversationToBudget(interactions, {
     pruningBudget,
-    TOOL_RESULTS_TO_PRESERVE
-  );
-  let prunedContext = redactedInteractions !== interactions;
-  let totalTokens = redactedInteractions.reduce(
+    budgetForInteractions,
+    logDetails,
+  });
+  if (pruneRes.isErr()) {
+    return pruneRes;
+  }
+  const { interactions: redactedInteractions, prunedContext } = pruneRes.value;
+  const totalTokens = redactedInteractions.reduce(
     (sum, interaction) => sum + getInteractionTokenCount(interaction),
     0
   );
 
-  // Layer 2: redaction alone wasn't enough. Drop old interactions entirely (never the current
-  // one, sliced out below and always re-appended).
-  if (totalTokens > budgetForInteractions) {
-    const currentInteraction =
-      redactedInteractions[redactedInteractions.length - 1];
-    const previousInteractionsBefore = redactedInteractions.slice(0, -1);
-    const previousInteractionsAfter = dropInteractionsToFit(
-      previousInteractionsBefore,
-      budgetForInteractions - getInteractionTokenCount(currentInteraction),
-      PREVIOUS_INTERACTIONS_TO_PRESERVE
-    );
-    if (previousInteractionsAfter !== previousInteractionsBefore) {
-      prunedContext = true;
-    }
-    redactedInteractions = [...previousInteractionsAfter, currentInteraction];
-    totalTokens = redactedInteractions.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
-  }
-
-  // Layer 3: still over budget. Force redaction into the protected floor too.
-  if (totalTokens > budgetForInteractions) {
-    logger.warn(
-      { ...logDetails, totalTokens, budgetForInteractions },
-      "Dropped every eligible previous interaction; still over budget, forcing floor redaction."
-    );
-    redactedInteractions = pruneToolResults(
-      redactedInteractions,
-      budgetForInteractions,
-      0
-    );
-    prunedContext = true;
-    totalTokens = redactedInteractions.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
-  }
-
-  // Layer 4 (last resort): a turn whose bulk is plain text can't be shrunk by redaction alone.
-  // Drop old interactions again, past the normal floor (current interaction still never dropped).
-  if (totalTokens > budgetForInteractions) {
-    logger.warn(
-      { ...logDetails, totalTokens, budgetForInteractions },
-      "Floor redaction still not enough; dropping previous interactions past the normal floor."
-    );
-    const currentInteraction =
-      redactedInteractions[redactedInteractions.length - 1];
-    const previousInteractionsBefore = redactedInteractions.slice(0, -1);
-    const previousInteractionsAfter = dropInteractionsToFit(
-      previousInteractionsBefore,
-      budgetForInteractions - getInteractionTokenCount(currentInteraction),
-      0
-    );
-    if (previousInteractionsAfter !== previousInteractionsBefore) {
-      prunedContext = true;
-    }
-    redactedInteractions = [...previousInteractionsAfter, currentInteraction];
-    totalTokens = redactedInteractions.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
-  }
-
-  if (totalTokens > budgetForInteractions) {
-    logger.error(
-      {
-        ...logDetails,
-        failureStage: "interaction_exceeds_after_pruning",
-        totalTokens,
-        budgetForInteractions,
-      },
-      "Render Conversation V2: No interactions fit in context window."
-    );
-    return new Err(
-      new Error("Context window exceeded: at least one message is required")
-    );
-  }
-
-  // totalTokens <= budgetForInteractions is now guaranteed, so every remaining message is kept.
-  // No further backward "does it fit" pass is needed.
   const selected: MessageWithTokens[] = redactedInteractions.flatMap(
     (interaction) => interaction.messages
   );

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -28,11 +28,12 @@ import {
   dropInteractionsToFit,
   getInteractionTokenCount,
   pruneToolResults,
+  sumInteractionTokens,
   TOOL_RESULTS_TO_PRESERVE,
 } from "./pruning";
 
 // How many of the most recent interactions dropInteractionsToFit never drops entirely, even if
-// their own tool results were already redacted. A different floor from TOOL_RESULTS_TO_PRESERVE
+// their own tool results were already pruned. A different floor from TOOL_RESULTS_TO_PRESERVE
 // (pruning.ts). That one protects tool result content regardless of turn. This one protects whole
 // recent turns from being erased regardless of how many tool calls they made.
 export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
@@ -42,22 +43,22 @@ const IMAGE_CONTENT_TOKEN_COUNT = 3100;
 export const TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR = 0.7;
 export const TOKENS_MARGIN = 1024;
 
-// Proactive redaction target as a fraction of contextSize, picked to sit below the customer-facing
+// Proactive pruning target as a fraction of contextSize, picked to sit below the customer-facing
 // compaction warning (~70%) rather than the real ceiling (68-99% depending on model), which would
 // otherwise leave pruning inactive until compaction has already fired. Applies to the whole
 // conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
 /**
- * Escalates through redaction and dropping until the conversation fits budgetForInteractions, or
+ * Escalates through pruning and dropping until the conversation fits budgetForInteractions, or
  * returns an error if even the last resort isn't enough. Four layers, each tried only if the
- * previous one left the conversation over budget: redact proactively (up to pruningBudget),
- * drop old interactions entirely (never the current one), force redaction into the protected
- * floor, then force dropping past the protected floor.
+ * previous one left the conversation over budget: prune tool results proactively (up to
+ * pruningBudget), drop old interactions entirely (never the current one), force pruning into the
+ * protected floor, then force dropping past the protected floor.
  *
  * pruneToolResults and dropInteractionsToFit are each called twice, once with their normal floor
  * and once with a floor of 0. This is safe because both floors work off the CURRENT state: a
- * message pruneToolResults already redacted is already at the placeholder size, so redacting it
+ * message pruneToolResults already pruned is already at the placeholder size, so pruning it
  * again would save nothing and its own eligibility check excludes it, and an interaction
  * dropInteractionsToFit already dropped is simply gone from the array, so there's nothing left
  * for the second call to reconsider. Each call only ever reaches further than the one before it.
@@ -77,22 +78,19 @@ function pruneConversationToBudget(
   { interactions: InteractionWithTokens[]; prunedContext: boolean },
   Error
 > {
-  // Layer 1: proactive redaction, within the protected floor, up to pruningBudget.
-  let redacted = pruneToolResults(
+  // Layer 1: proactive pruning, within the protected floor, up to pruningBudget.
+  let pruned = pruneToolResults(
     interactions,
     pruningBudget,
     TOOL_RESULTS_TO_PRESERVE
   );
-  let prunedContext = redacted !== interactions;
-  let totalTokens = redacted.reduce(
-    (sum, interaction) => sum + getInteractionTokenCount(interaction),
-    0
-  );
+  let prunedContext = pruned !== interactions;
+  let totalTokens = sumInteractionTokens(pruned);
 
   // Layer 2: drop whole previous interactions, oldest first, never the current one.
   if (totalTokens > budgetForInteractions) {
-    const currentInteraction = redacted[redacted.length - 1];
-    const previousBefore = redacted.slice(0, -1);
+    const currentInteraction = pruned[pruned.length - 1];
+    const previousBefore = pruned.slice(0, -1);
     const previousAfter = dropInteractionsToFit(
       previousBefore,
       budgetForInteractions - getInteractionTokenCount(currentInteraction),
@@ -101,35 +99,29 @@ function pruneConversationToBudget(
     if (previousAfter !== previousBefore) {
       prunedContext = true;
     }
-    redacted = [...previousAfter, currentInteraction];
-    totalTokens = redacted.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
+    pruned = [...previousAfter, currentInteraction];
+    totalTokens = sumInteractionTokens(pruned);
   }
 
-  // Layer 3: redaction alone wasn't enough, force it past TOOL_RESULTS_TO_PRESERVE.
+  // Layer 3: pruning alone wasn't enough, force it past TOOL_RESULTS_TO_PRESERVE.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
-      "Dropped every eligible previous interaction; still over budget, forcing floor redaction."
+      "Dropped every eligible previous interaction; still over budget, forcing floor pruning."
     );
-    redacted = pruneToolResults(redacted, budgetForInteractions, 0);
+    pruned = pruneToolResults(pruned, budgetForInteractions, 0);
     prunedContext = true;
-    totalTokens = redacted.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
+    totalTokens = sumInteractionTokens(pruned);
   }
 
   // Layer 4: still over budget, drop previous interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
-      "Floor redaction still not enough; dropping previous interactions past the normal floor."
+      "Floor pruning still not enough; dropping previous interactions past the normal floor."
     );
-    const currentInteraction = redacted[redacted.length - 1];
-    const previousBefore = redacted.slice(0, -1);
+    const currentInteraction = pruned[pruned.length - 1];
+    const previousBefore = pruned.slice(0, -1);
     const previousAfter = dropInteractionsToFit(
       previousBefore,
       budgetForInteractions - getInteractionTokenCount(currentInteraction),
@@ -138,11 +130,8 @@ function pruneConversationToBudget(
     if (previousAfter !== previousBefore) {
       prunedContext = true;
     }
-    redacted = [...previousAfter, currentInteraction];
-    totalTokens = redacted.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
-    );
+    pruned = [...previousAfter, currentInteraction];
+    totalTokens = sumInteractionTokens(pruned);
   }
 
   // Last resort exhausted: even the current interaction alone doesn't fit.
@@ -161,7 +150,7 @@ function pruneConversationToBudget(
     );
   }
 
-  return new Ok({ interactions: redacted, prunedContext });
+  return new Ok({ interactions: pruned, prunedContext });
 }
 
 export async function renderConversationForModel(
@@ -273,7 +262,7 @@ export async function renderConversationForModel(
   const budgetForInteractions = allowedTokenCount - baseTokens;
 
   // Only applied when positive: a small-context model with a large prompt/tools footprint can
-  // push baseTokens past the target alone, and a negative value would make the floor redact by
+  // push baseTokens past the target alone, and a negative value would make the floor prune by
   // default instead of as a last resort.
   const pruningTargetCeiling =
     model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
@@ -312,13 +301,10 @@ export async function renderConversationForModel(
   if (pruneRes.isErr()) {
     return pruneRes;
   }
-  const { interactions: redactedInteractions, prunedContext } = pruneRes.value;
-  const totalTokens = redactedInteractions.reduce(
-    (sum, interaction) => sum + getInteractionTokenCount(interaction),
-    0
-  );
+  const { interactions: prunedInteractions, prunedContext } = pruneRes.value;
+  const totalTokens = sumInteractionTokens(prunedInteractions);
 
-  const selected: MessageWithTokens[] = redactedInteractions.flatMap(
+  const selected: MessageWithTokens[] = prunedInteractions.flatMap(
     (interaction) => interaction.messages
   );
   const tokensUsed = baseTokens + totalTokens;
@@ -351,19 +337,21 @@ export async function renderConversationForModel(
     }
   }
 
+  // Only reachable when the conversation had no messages to begin with: pruning never drops the
+  // current interaction, and the merge above throws before it could empty one out. Not a context
+  // window problem, despite living downstream of the budget machinery.
   if (selected.length === 0) {
     logger.error(
       {
         ...logDetails,
-        failureStage: "no_interactions_selected",
+        failureStage: "no_messages_to_render",
         tokensUsed,
         budgetForInteractions,
-        selectedMessageCount: selected.length,
       },
-      "Render Conversation V2: No interactions fit in context window."
+      "Render Conversation V2: conversation has no messages to render."
     );
     return new Err(
-      new Error("Context window exceeded: at least one message is required")
+      new Error("Conversation contains no messages: at least one is required")
     );
   }
 

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -116,7 +116,10 @@ describe("pruneToolResults", () => {
   it("keeps everything untouched when the budget comfortably covers the full history", () => {
     const messages = [1, 2, 3, 4].flatMap((i) => turn(i));
     const wrapped = asInteractions(messages);
-    const pruned = pruneToolResults(wrapped, HUGE_BUDGET, 10);
+    const pruned = pruneToolResults(wrapped, {
+      maxTokens: HUGE_BUDGET,
+      toolResultsToPreserve: 10,
+    });
 
     expect(pruned).toBe(wrapped); // same reference: nothing needed pruning.
     for (const fn of functionMessagesOf(flatMessages(pruned))) {
@@ -128,7 +131,10 @@ describe("pruneToolResults", () => {
     // 6 turns, one tool result each (all big enough that pruning several is required).
     const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
     // Budget forces pruning of everything except the last 2 tool results.
-    const pruned = pruneToolResults(asInteractions(messages), 12_000, 2);
+    const pruned = pruneToolResults(asInteractions(messages), {
+      maxTokens: 12_000,
+      toolResultsToPreserve: 2,
+    });
 
     const fns = functionMessagesOf(flatMessages(pruned));
     expect(fns.map((f) => isPruned(f.content))).toEqual([
@@ -145,7 +151,10 @@ describe("pruneToolResults", () => {
     // ONE interaction (one continuous turn) making 6 tool calls in a row, e.g. a single agent
     // response that does 6 tool-call steps before its final answer. Preserve only the last 2.
     const oneLongTurn = [1, 2, 3, 4, 5, 6].flatMap((i) => toolStep(i, 5000));
-    const pruned = pruneToolResults(asInteractions(oneLongTurn), 12_000, 2);
+    const pruned = pruneToolResults(asInteractions(oneLongTurn), {
+      maxTokens: 12_000,
+      toolResultsToPreserve: 2,
+    });
 
     const fns = functionMessagesOf(flatMessages(pruned));
     // Steps 1-4 (this SAME turn's own earlier steps) get pruned. Only the last 2 survive.
@@ -170,11 +179,10 @@ describe("pruneToolResults", () => {
 
     // First call: same as the test above. Prunes turns 1-4, protects the floor of the last 2
     // (turns 5 and 6, each still at their full 5000 tokens).
-    const afterFirstCall = pruneToolResults(
-      asInteractions(messages),
-      12_000,
-      2
-    );
+    const afterFirstCall = pruneToolResults(asInteractions(messages), {
+      maxTokens: 12_000,
+      toolResultsToPreserve: 2,
+    });
     const prunedAfterFirstCall = functionMessagesOf(
       flatMessages(afterFirstCall)
     ).map((f) => isPruned(f.content));
@@ -191,7 +199,10 @@ describe("pruneToolResults", () => {
     // at 44 tokens each, turns 5-6 still at 5020 each) is 10_216, so both floor turns need
     // pruning too: pruning turn 5 alone only brings it to 5_240, still over 300, so turn 6
     // gets pruned as well, landing at 264.
-    const afterSecondCall = pruneToolResults(afterFirstCall, 300, 0);
+    const afterSecondCall = pruneToolResults(afterFirstCall, {
+      maxTokens: 300,
+      toolResultsToPreserve: 0,
+    });
     const flatAfterSecondCall = flatMessages(afterSecondCall);
 
     // Turns 1-4 are untouched by the second call: same pruned placeholders as after the first.
@@ -219,7 +230,10 @@ describe("pruneToolResults", () => {
   it("never touches non-function messages, regardless of budget", () => {
     const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
     const pruned = flatMessages(
-      pruneToolResults(asInteractions(messages), 100, 0)
+      pruneToolResults(asInteractions(messages), {
+        maxTokens: 100,
+        toolResultsToPreserve: 0,
+      })
     );
 
     for (const [i, m] of pruned.entries()) {
@@ -236,7 +250,10 @@ describe("pruneToolResults", () => {
     // Budget impossibly small: even pruning everything eligible won't fit. The floor (last 2
     // tool results) must still survive untouched, since that's this function's contract. Fitting
     // the impossible case is the caller's job (dropInteractionsToFit or a smaller floor).
-    const pruned = pruneToolResults(asInteractions(messages), 1, 2);
+    const pruned = pruneToolResults(asInteractions(messages), {
+      maxTokens: 1,
+      toolResultsToPreserve: 2,
+    });
 
     const fns = functionMessagesOf(flatMessages(pruned));
     expect(fns.map((f) => isPruned(f.content))).toEqual([true, false, false]);
@@ -294,7 +311,10 @@ describe("pruneToolResults", () => {
     // sweep the three tiny results in too, each GROWING by 23 tokens (1 -> 24), pushing the real
     // total to 1_596, over the 1_530 budget.
     const pruned = flatMessages(
-      pruneToolResults(asInteractions(messages), 1530, 1)
+      pruneToolResults(asInteractions(messages), {
+        maxTokens: 1530,
+        toolResultsToPreserve: 1,
+      })
     );
     const totalTokens = pruned.reduce((sum, m) => sum + m.tokenCount, 0);
 
@@ -329,11 +349,10 @@ describe("pruneToolResults", () => {
 
     const historyA = [0, 1, 2, 3, 4, 5].map((i) => toolResult(i, 4000));
     const prunedA = flatMessages(
-      pruneToolResults(
-        asInteractions(historyA),
+      pruneToolResults(asInteractions(historyA), {
         maxTokens,
-        toolResultsToPreserve
-      )
+        toolResultsToPreserve,
+      })
     );
     // Hand-verified: pruning indices 0-4 (saving 3976 tokens each) brings the 24_000-token
     // total down to 4_120, under the 6_000 budget. The checkpoint (20_000) happens to land
@@ -348,11 +367,10 @@ describe("pruneToolResults", () => {
     // unchanged: this is the batching guarantee in action.
     const historyB = [...historyA, toolResult(6, 500)];
     const prunedB = flatMessages(
-      pruneToolResults(
-        asInteractions(historyB),
+      pruneToolResults(asInteractions(historyB), {
         maxTokens,
-        toolResultsToPreserve
-      )
+        toolResultsToPreserve,
+      })
     );
     expect(
       functionMessagesOf(prunedB)
@@ -371,11 +389,10 @@ describe("pruneToolResults", () => {
     // added in this very call, gets pruned too, not just index 5.
     const historyC = [...historyA, toolResult(6, 4000)];
     const prunedC = flatMessages(
-      pruneToolResults(
-        asInteractions(historyC),
+      pruneToolResults(asInteractions(historyC), {
         maxTokens,
-        toolResultsToPreserve
-      )
+        toolResultsToPreserve,
+      })
     );
     const prunedFlagsC = functionMessagesOf(prunedC).map((f) =>
       isPruned(f.content)
@@ -385,8 +402,14 @@ describe("pruneToolResults", () => {
 
   it("is a pure function of history: the same input always yields the same pruning decision", () => {
     const messages = [1, 2, 3, 4, 5].flatMap((i) => turn(i, 3000));
-    const first = pruneToolResults(asInteractions(messages), 10_000, 2);
-    const second = pruneToolResults(asInteractions(messages), 10_000, 2);
+    const first = pruneToolResults(asInteractions(messages), {
+      maxTokens: 10_000,
+      toolResultsToPreserve: 2,
+    });
+    const second = pruneToolResults(asInteractions(messages), {
+      maxTokens: 10_000,
+      toolResultsToPreserve: 2,
+    });
     expect(first).toEqual(second);
   });
 
@@ -397,7 +420,10 @@ describe("pruneToolResults", () => {
     const interactions = groupMessagesIntoInteractions(
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => turn(i, 5000))
     );
-    const pruned = pruneToolResults(interactions, 51_000, 10);
+    const pruned = pruneToolResults(interactions, {
+      maxTokens: 51_000,
+      toolResultsToPreserve: 10,
+    });
 
     // Interaction boundaries survive exactly: still 12 interactions, each still 3 messages.
     expect(pruned).toHaveLength(12);

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -161,6 +161,61 @@ describe("pruneToolResults", () => {
     ]);
   });
 
+  it("calling it twice with a wider floor only ever reaches further, never reconsiders what the first call already redacted", () => {
+    // This is the pattern index.ts's escalation uses: call once with the normal floor, then again
+    // with a smaller floor (0) and a tighter budget if that wasn't enough. Verifies the two calls
+    // don't conflict: the first call's redactions are untouched, and the second call reaches
+    // exactly the previously-protected tool results, nothing more, nothing less.
+    const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
+
+    // First call: same as the test above. Redacts turns 1-4, protects the floor of the last 2
+    // (turns 5 and 6, each still at their full 5000 tokens).
+    const afterFirstCall = pruneToolResults(
+      asInteractions(messages),
+      12_000,
+      2
+    );
+    const redactedAfterFirstCall = functionMessagesOf(
+      flatMessages(afterFirstCall)
+    ).map((f) => isRedacted(f.content));
+    expect(redactedAfterFirstCall).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
+
+    // Second call: floor widened to 0, budget tightened to 300. Current total (turns 1-4 redacted
+    // at 44 tokens each, turns 5-6 still at 5020 each) is 10_216, so both floor turns need
+    // redacting too: redacting turn 5 alone only brings it to 5_240, still over 300, so turn 6
+    // gets redacted as well, landing at 264.
+    const afterSecondCall = pruneToolResults(afterFirstCall, 300, 0);
+    const flatAfterSecondCall = flatMessages(afterSecondCall);
+
+    // Turns 1-4 are untouched by the second call: same redacted placeholders as after the first.
+    // The eligibility filter already excludes them (redacting an already-redacted message saves
+    // nothing), so the second call never reprocesses them.
+    for (let i = 0; i < 4; i++) {
+      expect(functionMessagesOf(flatAfterSecondCall)[i].content).toBe(
+        functionMessagesOf(flatMessages(afterFirstCall))[i].content
+      );
+    }
+    // Turns 5-6, previously protected by the floor, are now reachable and redacted.
+    expect(
+      functionMessagesOf(flatAfterSecondCall)
+        .slice(4)
+        .map((f) => isRedacted(f.content))
+    ).toEqual([true, true]);
+
+    const totalTokens = flatAfterSecondCall.reduce(
+      (sum, m) => sum + m.tokenCount,
+      0
+    );
+    expect(totalTokens).toBeLessThanOrEqual(300);
+  });
+
   it("never touches non-function messages, regardless of budget", () => {
     const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
     const pruned = flatMessages(

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -4,34 +4,16 @@ import type {
   MessageWithTokens,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import {
+  dropInteractionsToFit,
   getInteractionTokenCount,
-  PRUNING_CHECKPOINT_TOKENS,
-  pruneAllToolResults,
-  prunePreviousInteractions,
+  pruneToolResults,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
 import { describe, expect, it } from "vitest";
 
-// Never enough to force budget-driven pruning in these tests: they isolate the
-// sliding-window rule from the token-budget rule.
+// Never enough to force budget-driven pruning in these tests: they isolate the redaction
+// mechanism itself from the "is the budget the binding constraint" question.
 const HUGE_BUDGET = 1_000_000;
-
-/**
- * A deterministic pseudo-random number generator, used instead of Math.random() so a failing
- * test prints a seed that reproduces the exact same failure when rerun.
- *
- * This is a linear congruential generator: state = (state * multiplier + increment) mod m,
- * the same simple formula behind C's rand(). 1103515245 and 12345 are its standard multiplier
- * and increment constants. Masking with 0x7fffffff keeps state a positive 31-bit integer, and
- * dividing by that same value scales the result into [0, 1), like Math.random().
- */
-function makeDeterministicRng(seed: number): () => number {
-  let state = seed;
-  return () => {
-    state = (state * 1103515245 + 12345) & 0x7fffffff;
-    return state / 0x7fffffff;
-  };
-}
 
 function withTokens<T extends ModelMessageTypeMultiActions>(
   message: T,
@@ -40,10 +22,7 @@ function withTokens<T extends ModelMessageTypeMultiActions>(
   return { ...message, tokenCount };
 }
 
-function buildTurnWithSize(
-  index: number,
-  toolTokens: number
-): MessageWithTokens[] {
+function turn(index: number, toolTokens = 10): MessageWithTokens[] {
   return [
     withTokens(
       {
@@ -74,263 +53,363 @@ function buildTurnWithSize(
   ];
 }
 
-function buildTurn(index: number): MessageWithTokens[] {
-  return buildTurnWithSize(index, 10);
+function toolStep(index: number, toolTokens = 10): MessageWithTokens[] {
+  return [
+    withTokens(
+      {
+        role: "assistant" as const,
+        name: "assistant",
+        content: `step_a${index}`,
+        contents: [
+          {
+            type: "function_call" as const,
+            value: {
+              id: `step_${index}_call`,
+              name: `step_tool_${index}`,
+              arguments: "{}",
+            },
+          },
+        ],
+      },
+      10
+    ),
+    withTokens(
+      {
+        role: "function" as const,
+        name: `step_tool_${index}`,
+        function_call_id: `step_${index}_call`,
+        content: `step_result_${index}`,
+      },
+      toolTokens
+    ),
+  ];
 }
 
-function toolResultOf(
-  interactions: ReturnType<typeof prunePreviousInteractions>,
-  index: number
-) {
-  const message = interactions[index].messages.find(
-    (m) => m.role === "function"
+function functionMessagesOf(messages: MessageWithTokens[]) {
+  return messages.filter(
+    (m): m is Extract<MessageWithTokens, { role: "function" }> =>
+      m.role === "function"
   );
-  if (!message || message.role !== "function") {
-    throw new Error(`Expected interaction ${index} to have a tool result`);
-  }
-  return message.content;
 }
 
 function isRedacted(content: unknown): boolean {
   return typeof content === "string" && content.includes("no longer available");
 }
 
-describe("prunePreviousInteractions", () => {
+// pruneToolResults takes/returns InteractionWithTokens[] (it flattens/re-slices internally). Most
+// of these tests don't care about interaction boundaries at all, they exercise the underlying
+// flat redaction algorithm, so they wrap a flat message array as a single interaction and
+// unwrap the result back to a flat array to assert on.
+function asInteractions(
+  messages: MessageWithTokens[]
+): InteractionWithTokens[] {
+  return [{ messages }];
+}
+
+function flatMessages(
+  interactions: InteractionWithTokens[]
+): MessageWithTokens[] {
+  return interactions.flatMap((interaction) => interaction.messages);
+}
+
+describe("pruneToolResults", () => {
   it("keeps everything untouched when the budget comfortably covers the full history", () => {
-    // Unlike the old sliding-window rule, there is no more forced redaction beyond the floor when
-    // the budget was never actually a constraint.
-    const messages = [1, 2, 3, 4].flatMap(buildTurn);
-    const previousInteractions = groupMessagesIntoInteractions(messages);
-    const pruned = prunePreviousInteractions(
-      previousInteractions,
-      HUGE_BUDGET,
-      3
-    );
+    const messages = [1, 2, 3, 4].flatMap((i) => turn(i));
+    const wrapped = asInteractions(messages);
+    const pruned = pruneToolResults(wrapped, HUGE_BUDGET, 10);
 
-    expect(toolResultOf(pruned, 0)).toBe("result_1");
-    expect(toolResultOf(pruned, 1)).toBe("result_2");
-    expect(toolResultOf(pruned, 2)).toBe("result_3");
-    expect(toolResultOf(pruned, 3)).toBe("result_4");
-  });
-
-  it("keeps the floor fully intact and redacts only the oldest, over-budget interaction", () => {
-    const messages = [1, 2, 3, 4].flatMap((i) => buildTurnWithSize(i, 40)); // 60 tokens each
-    const previousInteractions = groupMessagesIntoInteractions(messages);
-    // Floor (last 3) alone = 180, comfortably within budget. Adding interaction 1 (60 more) tips
-    // it over 230, but redacting interaction 1 alone (60 -> 44) brings it back under.
-    const pruned = prunePreviousInteractions(previousInteractions, 230, 3);
-
-    expect(isRedacted(toolResultOf(pruned, 0))).toBe(true);
-    expect(toolResultOf(pruned, 1)).toBe("result_2");
-    expect(toolResultOf(pruned, 2)).toBe("result_3");
-    expect(toolResultOf(pruned, 3)).toBe("result_4");
-  });
-
-  it("renders an already-settled old interaction identically across turns when using the same fixed budget, instead of flipping every time a new turn is appended", () => {
-    // n is derived from the budget, comfortably past the point where redaction becomes necessary,
-    // so this test stays valid regardless of PRUNING_CHECKPOINT_TOKENS's value. n and n+1 sit
-    // inside the same stable stretch, so an interaction deep in the already-redacted region must
-    // render identically whether or not the newest turn has arrived yet.
-    const toolTokens = 40;
-    const interactionSize = 60; // toolTokens + user/assistant overhead, per buildTurnWithSize
-    const floor = 3;
-    const budget = PRUNING_CHECKPOINT_TOKENS;
-    const n = Math.ceil((budget / interactionSize) * 1.2);
-    const DEEP_INDEX = 10; // well before the frontier in both cases
-
-    const buildHistory = (count: number) =>
-      groupMessagesIntoInteractions(
-        Array.from({ length: count }, (_, i) => i + 1).flatMap((i) =>
-          buildTurnWithSize(i, toolTokens)
-        )
-      );
-
-    const prunedAtN = prunePreviousInteractions(buildHistory(n), budget, floor);
-    const prunedAtNPlus1 = prunePreviousInteractions(
-      buildHistory(n + 1),
-      budget,
-      floor
-    );
-
-    expect(isRedacted(toolResultOf(prunedAtN, DEEP_INDEX))).toBe(true);
-    expect(toolResultOf(prunedAtNPlus1, DEEP_INDEX)).toBe(
-      toolResultOf(prunedAtN, DEEP_INDEX)
-    );
-  });
-
-  it("batches redaction across a checkpoint boundary instead of advancing on every single turn", () => {
-    // n0 (like n above) is derived from the budget: the first turn count where redaction becomes
-    // necessary at all. Sampling a window right past that point exercises real batching at a
-    // realistic scale, rather than tiny numbers where everything eligible redacts in one shot.
-    const toolTokens = 40; // interaction = 60 tokens
-    const interactionSize = 60;
-    const floor = 3;
-    const budget = PRUNING_CHECKPOINT_TOKENS;
-    const n0 = Math.ceil(budget / interactionSize) + 1;
-
-    const frontierAt = (n: number) => {
-      const messages = Array.from({ length: n }, (_, i) => i + 1).flatMap((i) =>
-        buildTurnWithSize(i, toolTokens)
-      );
-      const previous = groupMessagesIntoInteractions(messages);
-      const pruned = prunePreviousInteractions(previous, budget, floor);
-      return pruned.findIndex((interaction) => {
-        const content = toolResultOf([interaction], 0);
-        return !isRedacted(content);
-      });
-    };
-
-    // Once redaction is needed at all (n large enough), the boundary between redacted and full
-    // interactions should stay put for a long run of consecutive turns rather than advancing on
-    // every single one. Sample a 20-turn window known to sit inside such a stable stretch for
-    // these parameters.
-    const boundaries = new Set<number>();
-    for (let n = n0; n <= n0 + 19; n++) {
-      boundaries.add(frontierAt(n));
+    expect(pruned).toBe(wrapped); // same reference: nothing needed redaction.
+    for (const fn of functionMessagesOf(flatMessages(pruned))) {
+      expect(isRedacted(fn.content)).toBe(false);
     }
-
-    expect(boundaries.size).toBeLessThan(5);
   });
 
-  it("never returns interactions whose combined token count exceeds maxTokens, across a wide randomized sweep (short of the floor's own unavoidable minimum)", () => {
-    for (let seed = 1; seed <= 2000; seed++) {
-      const rng = makeDeterministicRng(seed);
-      const n = 1 + Math.floor(rng() * 15);
-      const toPreserve = 1 + Math.floor(rng() * 4);
-      const items: InteractionWithTokens[] = [];
-      for (let i = 0; i < n; i++) {
-        const roll = rng();
-        const toolTokens =
-          roll < 0.1
-            ? 20 + Math.floor(rng() * 3000)
-            : 5 + Math.floor(rng() * 150);
-        items.push({ messages: buildTurnWithSize(i, toolTokens) });
+  it("redacts the oldest eligible tool results first, preserving the last toolResultsToPreserve", () => {
+    // 6 turns, one tool result each (all big enough that redacting several is required).
+    const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
+    // Budget forces redaction of everything except the last 2 tool results.
+    const pruned = pruneToolResults(asInteractions(messages), 12_000, 2);
+
+    const fns = functionMessagesOf(flatMessages(pruned));
+    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  it("makes a single turn's OWN early tool calls eligible for redaction once they exceed the preserved window, since there is no exemption for the current turn", () => {
+    // ONE interaction (one continuous turn) making 6 tool calls in a row, e.g. a single agent
+    // response that does 6 tool-call steps before its final answer. Preserve only the last 2.
+    const oneLongTurn = [1, 2, 3, 4, 5, 6].flatMap((i) => toolStep(i, 5000));
+    const pruned = pruneToolResults(asInteractions(oneLongTurn), 12_000, 2);
+
+    const fns = functionMessagesOf(flatMessages(pruned));
+    // Steps 1-4 (this SAME turn's own earlier steps) get redacted. Only the last 2 survive.
+    // Nothing here belongs to a "previous" interaction, this proves redaction operates on tool
+    // results flatly, not "protect everything in the current turn."
+    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  it("never touches non-function messages, regardless of budget", () => {
+    const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
+    const pruned = flatMessages(
+      pruneToolResults(asInteractions(messages), 100, 0)
+    );
+
+    for (const [i, m] of pruned.entries()) {
+      if (m.role !== "function") {
+        // Redaction only ever replaces function-role messages. Every other message keeps its
+        // exact original reference.
+        expect(m).toBe(messages[i]);
       }
-      const maxTokens = 10 + Math.floor(rng() * 500);
-
-      const pruned = prunePreviousInteractions(items, maxTokens, toPreserve);
-      const total = pruned.reduce(
-        (sum, interaction) => sum + getInteractionTokenCount(interaction),
-        0
-      );
-
-      // The floor's own redacted-to-the-max size is the true floor of what's achievable. The
-      // function can't do better than that even in the rare out-of-room case.
-      const floorStart = Math.max(items.length - toPreserve, 0);
-      const floorMinimum = items
-        .slice(floorStart)
-        .reduce(
-          (sum, interaction) =>
-            sum + getInteractionTokenCount(pruneAllToolResults(interaction)),
-          0
-        );
-
-      expect(
-        total,
-        `seed=${seed} n=${n} toPreserve=${toPreserve} maxTokens=${maxTokens} total=${total} floorMinimum=${floorMinimum}`
-      ).toBeLessThanOrEqual(Math.max(maxTokens, floorMinimum));
     }
   });
 
-  it("drops already-redacted interactions entirely, oldest first, when even full redaction isn't enough", () => {
-    // 6 previous interactions, floor=3, tiny budget: even redacting everything eligible plus the
-    // floor won't fit, so the oldest, already-redacted interactions must be dropped entirely.
-    const messages = [1, 2, 3, 4, 5, 6].flatMap((i) =>
-      buildTurnWithSize(i, 90)
-    );
-    const previousInteractions = groupMessagesIntoInteractions(messages);
-    const pruned = prunePreviousInteractions(previousInteractions, 189, 3);
+  it("respects the floor even when the budget cannot be met: never redacts the last toolResultsToPreserve tool results", () => {
+    const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
+    // Budget impossibly small: even redacting everything eligible won't fit. The floor (last 2
+    // tool results) must still survive untouched, since that's this function's contract. Fitting
+    // the impossible case is the caller's job (dropInteractionsToFit or a smaller floor).
+    const pruned = pruneToolResults(asInteractions(messages), 1, 2);
 
-    expect(pruned.length).toBeLessThan(previousInteractions.length);
-    const total = pruned.reduce(
-      (sum, interaction) => sum + getInteractionTokenCount(interaction),
-      0
+    const fns = functionMessagesOf(flatMessages(pruned));
+    expect(fns.map((f) => isRedacted(f.content))).toEqual([true, false, false]);
+  });
+
+  it("never sweeps a tiny tool result (already smaller than the placeholder) into the checkpoint's forward-rounding, even though doing so would still be within the eligible range", () => {
+    // Regression test: the checkpoint-rounding search used to extend the redaction set purely by
+    // position, without checking whether redacting each swept-in message actually helps. A tool
+    // result smaller than PRUNED_TOOL_RESULT_TOKENS (24) GROWS when "redacted" (replaced by the
+    // placeholder), so sweeping one in can push the total over maxTokens, breaking this
+    // function's own contract that the result never exceeds maxTokens (short of the floor).
+    const messages: MessageWithTokens[] = [
+      withTokens(
+        {
+          role: "user" as const,
+          name: "user",
+          content: [{ type: "text" as const, text: "u" }],
+        },
+        500
+      ),
+      withTokens(
+        {
+          role: "function" as const,
+          name: "big",
+          function_call_id: "big_call",
+          content: "big_result",
+        },
+        19000
+      ),
+      ...["tiny1", "tiny2", "tiny3"].map((name) =>
+        withTokens(
+          {
+            role: "function" as const,
+            name,
+            function_call_id: `${name}_call`,
+            content: "ok",
+          },
+          1
+        )
+      ),
+      withTokens(
+        {
+          role: "function" as const,
+          name: "floor",
+          function_call_id: "floor_call",
+          content: "floor_result",
+        },
+        1000
+      ),
+    ];
+
+    // Redacting only "big" (19000 -> 24) already brings the 20_503-token total down to 1_527,
+    // under this budget, the minimal frontier stops there. Without the fix, the
+    // checkpoint-rounding search (finding no bucket boundary between "big" and the floor) used to
+    // sweep the three tiny results in too, each GROWING by 23 tokens (1 -> 24), pushing the real
+    // total to 1_596, over the 1_530 budget.
+    const pruned = flatMessages(
+      pruneToolResults(asInteractions(messages), 1530, 1)
     );
-    // Whatever remains is at least redacted. The function did everything it could.
-    for (const interaction of pruned) {
-      expect(isRedacted(toolResultOf([interaction], 0))).toBe(true);
+    const totalTokens = pruned.reduce((sum, m) => sum + m.tokenCount, 0);
+
+    expect(totalTokens).toBeLessThanOrEqual(1530);
+    const fns = functionMessagesOf(pruned);
+    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+      true, // big: redacted, it's the only one that actually needed to be
+      false, // tiny1: left alone, redacting it wouldn't help
+      false, // tiny2: left alone
+      false, // tiny3: left alone
+      false, // floor: protected (toolResultsToPreserve=1)
+    ]);
+  });
+
+  it("batches redaction via the checkpoint: a small addition doesn't retrigger new redaction, but a large enough one does", () => {
+    // Bare tool results, no surrounding user/assistant text, so the prefix sum is exactly
+    // (i+1) * 4000, easy to hand-verify against PRUNING_CHECKPOINT_TOKENS (20_000).
+    function toolResult(index: number, tokenCount: number): MessageWithTokens {
+      return withTokens(
+        {
+          role: "function" as const,
+          name: `tool_${index}`,
+          function_call_id: `tool_${index}_call`,
+          content: `result_${index}`,
+        },
+        tokenCount
+      );
     }
-    expect(total).toBeGreaterThan(0);
+
+    const toolResultsToPreserve = 0;
+    const maxTokens = 6_000;
+
+    const historyA = [0, 1, 2, 3, 4, 5].map((i) => toolResult(i, 4000));
+    const prunedA = flatMessages(
+      pruneToolResults(
+        asInteractions(historyA),
+        maxTokens,
+        toolResultsToPreserve
+      )
+    );
+    // Hand-verified: redacting indices 0-4 (saving 3976 tokens each) brings the 24_000-token
+    // total down to 4_120, under the 6_000 budget. The checkpoint (20_000) happens to land
+    // exactly at index 4's prefix sum (20_000), so no extra over-redaction is needed here.
+    const redactedA = functionMessagesOf(prunedA).map((f) =>
+      isRedacted(f.content)
+    );
+    expect(redactedA).toEqual([true, true, true, true, true, false]);
+
+    // Small addition: one more, much smaller tool result, well under a full checkpoint's
+    // worth of new content. The decision for indices 0-5 (present in both histories) must be
+    // unchanged: this is the batching guarantee in action.
+    const historyB = [...historyA, toolResult(6, 500)];
+    const prunedB = flatMessages(
+      pruneToolResults(
+        asInteractions(historyB),
+        maxTokens,
+        toolResultsToPreserve
+      )
+    );
+    expect(
+      functionMessagesOf(prunedB)
+        .slice(0, 6)
+        .map((f) => isRedacted(f.content))
+    ).toEqual(redactedA);
+
+    // Large addition: a whole new turn-sized tool result. This pushes the running total enough
+    // that the previously-kept index 5 must now also be redacted to fit the same budget.
+    // Batching means SOME stability, not that the frontier can never move again. Hand-verified:
+    // minimally, redacting indices 0-5 (6 items) would bring the 28_000-token total to 4_144,
+    // under budget, but the checkpoint search never finds a bucket boundary between index 4
+    // (prefix sum 20_000) and index 6 (prefix sum 28_000): all three land in the same
+    // floor(x/20_000)=1 bucket. With no checkpoint found in range, the search runs to the end of
+    // the eligible set rather than under-shooting the budget, so index 6, the tool result just
+    // added in this very call, gets redacted too, not just index 5.
+    const historyC = [...historyA, toolResult(6, 4000)];
+    const prunedC = flatMessages(
+      pruneToolResults(
+        asInteractions(historyC),
+        maxTokens,
+        toolResultsToPreserve
+      )
+    );
+    const redactedC = functionMessagesOf(prunedC).map((f) =>
+      isRedacted(f.content)
+    );
+    expect(redactedC).toEqual([true, true, true, true, true, true, true]);
+  });
+
+  it("is a pure function of history: the same input always yields the same redaction decision", () => {
+    const messages = [1, 2, 3, 4, 5].flatMap((i) => turn(i, 3000));
+    const first = pruneToolResults(asInteractions(messages), 10_000, 2);
+    const second = pruneToolResults(asInteractions(messages), 10_000, 2);
+    expect(first).toEqual(second);
+  });
+
+  it("redacts SOME messages while dropping OTHER whole interactions in a realistic multi-interaction conversation, preserving interaction boundaries throughout", () => {
+    // 12 separate interactions (TOOL_RESULTS_TO_PRESERVE-scale), each a real [user, assistant,
+    // function] turn, exercises pruneToolResults' interaction-boundary bookkeeping (flatten,
+    // redact, re-slice) against real turn structure, not a single synthetic interaction.
+    const interactions = groupMessagesIntoInteractions(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => turn(i, 5000))
+    );
+    const pruned = pruneToolResults(interactions, 51_000, 10);
+
+    // Interaction boundaries survive exactly: still 12 interactions, each still 3 messages.
+    expect(pruned).toHaveLength(12);
+    for (const interaction of pruned) {
+      expect(interaction.messages).toHaveLength(3);
+    }
+
+    const fns = functionMessagesOf(flatMessages(pruned));
+    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+      true, // tool_1: outside the floor of 10, redacted
+      true, // tool_2: outside the floor of 10, redacted
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false, // tool_3..tool_12: the protected floor
+    ]);
   });
 });
 
-describe("prunePreviousInteractions across a growing conversation (realistic, variable-size workload)", () => {
-  // Whether each previous interaction was redacted, keyed by the interaction's OWN identity (its
-  // tool name), not its array position. Array position is not a stable identity across turns.
-  // Interactions are appended at the end, and the drop-tier can remove interactions from the
-  // start, so results from two different turns can't be compared index-by-index. The only valid
-  // comparison is "what happened to interaction N specifically?".
-  function redactionStatusById(
-    interactions: ReturnType<typeof prunePreviousInteractions>
-  ): Map<number, "redacted" | "full"> {
-    const statusById = new Map<number, "redacted" | "full">();
-    for (const interaction of interactions) {
-      const fn = interaction.messages.find((m) => m.role === "function");
-      if (!fn || fn.role !== "function") {
-        throw new Error("Expected a function message in every interaction");
-      }
-      const id = Number(fn.name.replace("tool_", ""));
-      statusById.set(id, isRedacted(fn.content) ? "redacted" : "full");
-    }
-    return statusById;
+describe("dropInteractionsToFit", () => {
+  function interactionsFromMessages(messages: MessageWithTokens[]) {
+    return groupMessagesIntoInteractions(messages);
   }
 
-  it("keeps most turns byte-stable and never un-redacts an interaction, simulating a long conversation with realistic variable tool-result sizes", () => {
-    // Mostly small-to-medium tool results, with an occasional large one. Mirrors the real spread
-    // of interaction sizes observed in production (roughly 200 to 9000 characters per tool
-    // result).
-    const nextRandom = makeDeterministicRng(42);
-    const nextInteractionSizeTokens = () =>
-      nextRandom() < 0.15
-        ? 500 + Math.floor(nextRandom() * 2500) // occasional large tool result
-        : 50 + Math.floor(nextRandom() * 400); // typical tool result
+  it("returns the same reference when nothing needs to be dropped", () => {
+    const interactions = interactionsFromMessages(
+      [1, 2, 3].flatMap((i) => turn(i, 10))
+    );
+    const result = dropInteractionsToFit(interactions, HUGE_BUDGET, 3);
+    expect(result).toBe(interactions);
+  });
 
-    const TOTAL_TURNS = 80;
-    const FLOOR = 3;
-    // Order of magnitude of a real allowedTokenCount - baseTokens: large enough that many turns
-    // of small talk fit before any redaction is needed at all, matching the real production
-    // observation that redaction is a late, occasional event, not a per-turn certainty. Kept as a
-    // multiple of PRUNING_CHECKPOINT_TOKENS rather than an absolute number, so the checkpoint
-    // mechanism always has room to find a crossing regardless of that constant's current value.
-    const BUDGET = PRUNING_CHECKPOINT_TOKENS * 4;
+  it("drops whole interactions oldest-first until the budget fits", () => {
+    const interactions = interactionsFromMessages(
+      [1, 2, 3, 4, 5].flatMap((i) => turn(i, 100))
+    );
+    // Each interaction costs 120 tokens (10+10+100). Budget only fits 2.
+    const result = dropInteractionsToFit(interactions, 240, 0);
 
-    const interactionSizes: number[] = [];
-    let mutationTurnCount = 0;
-    let reversalCount = 0;
-    let statusAtPreviousTurn = new Map<number, "redacted" | "full">();
-
-    for (let turn = 1; turn <= TOTAL_TURNS; turn++) {
-      interactionSizes.push(nextInteractionSizeTokens());
-
-      const history = groupMessagesIntoInteractions(
-        interactionSizes.flatMap((toolTokens, i) =>
-          buildTurnWithSize(i + 1, toolTokens)
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => getInteractionTokenCount(i))).toEqual([120, 120]);
+    // The two that survive are the most recent (i4, i5), oldest dropped first.
+    const survivingUserTexts = result.flatMap((i) =>
+      i.messages
+        .filter(
+          (m): m is Extract<MessageWithTokens, { role: "user" }> =>
+            m.role === "user"
         )
-      );
-      const statusAtThisTurn = redactionStatusById(
-        prunePreviousInteractions(history, BUDGET, FLOOR)
-      );
+        .map((m) =>
+          m.content.map((c) => (c.type === "text" ? c.text : "")).join("")
+        )
+    );
+    expect(survivingUserTexts).toEqual(["u4", "u5"]);
+  });
 
-      for (const [id, previousStatus] of statusAtPreviousTurn) {
-        // Missing from this turn's map means the interaction was dropped entirely. That's also a
-        // mutation, just never a reversal (dropped is strictly "more pruned", not less).
-        const currentStatus = statusAtThisTurn.get(id);
-        if (currentStatus !== previousStatus) {
-          mutationTurnCount++;
-          if (previousStatus === "redacted" && currentStatus === "full") {
-            reversalCount++;
-          }
-          break; // one mutated interaction is enough to mark this turn as a mutation-turn
-        }
-      }
-
-      statusAtPreviousTurn = statusAtThisTurn;
-    }
-
-    // The fixed budget plus checkpoint-anchored frontier means most turns render previous
-    // interactions byte-identically to the turn before. Mutation is the occasional exception, not,
-    // as with the old sliding-window rule, something that happens on nearly every turn.
-    expect(mutationTurnCount).toBeLessThan(TOTAL_TURNS * 0.2);
-    expect(reversalCount).toBe(0);
+  it("never drops into the protected floor, even if that means staying over budget", () => {
+    const interactions = interactionsFromMessages(
+      [1, 2, 3].flatMap((i) => turn(i, 100))
+    );
+    // Budget is impossibly small, but interactionsToPreserve=3 protects all 3 interactions here.
+    const result = dropInteractionsToFit(interactions, 1, 3);
+    expect(result).toHaveLength(3);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -11,7 +11,7 @@ import {
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
 import { describe, expect, it } from "vitest";
 
-// Never enough to force budget-driven pruning in these tests: they isolate the redaction
+// Never enough to force budget-driven pruning in these tests: they isolate the pruning
 // mechanism itself from the "is the budget the binding constraint" question.
 const HUGE_BUDGET = 1_000_000;
 
@@ -92,13 +92,13 @@ function functionMessagesOf(messages: MessageWithTokens[]) {
   );
 }
 
-function isRedacted(content: unknown): boolean {
+function isPruned(content: unknown): boolean {
   return typeof content === "string" && content.includes("no longer available");
 }
 
 // pruneToolResults takes/returns InteractionWithTokens[] (it flattens/re-slices internally). Most
 // of these tests don't care about interaction boundaries at all, they exercise the underlying
-// flat redaction algorithm, so they wrap a flat message array as a single interaction and
+// flat pruning algorithm, so they wrap a flat message array as a single interaction and
 // unwrap the result back to a flat array to assert on.
 function asInteractions(
   messages: MessageWithTokens[]
@@ -118,20 +118,20 @@ describe("pruneToolResults", () => {
     const wrapped = asInteractions(messages);
     const pruned = pruneToolResults(wrapped, HUGE_BUDGET, 10);
 
-    expect(pruned).toBe(wrapped); // same reference: nothing needed redaction.
+    expect(pruned).toBe(wrapped); // same reference: nothing needed pruning.
     for (const fn of functionMessagesOf(flatMessages(pruned))) {
-      expect(isRedacted(fn.content)).toBe(false);
+      expect(isPruned(fn.content)).toBe(false);
     }
   });
 
-  it("redacts the oldest eligible tool results first, preserving the last toolResultsToPreserve", () => {
-    // 6 turns, one tool result each (all big enough that redacting several is required).
+  it("prunes the oldest eligible tool results first, preserving the last toolResultsToPreserve", () => {
+    // 6 turns, one tool result each (all big enough that pruning several is required).
     const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
-    // Budget forces redaction of everything except the last 2 tool results.
+    // Budget forces pruning of everything except the last 2 tool results.
     const pruned = pruneToolResults(asInteractions(messages), 12_000, 2);
 
     const fns = functionMessagesOf(flatMessages(pruned));
-    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+    expect(fns.map((f) => isPruned(f.content))).toEqual([
       true,
       true,
       true,
@@ -141,17 +141,17 @@ describe("pruneToolResults", () => {
     ]);
   });
 
-  it("makes a single turn's OWN early tool calls eligible for redaction once they exceed the preserved window, since there is no exemption for the current turn", () => {
+  it("makes a single turn's OWN early tool calls eligible for pruning once they exceed the preserved window, since there is no exemption for the current turn", () => {
     // ONE interaction (one continuous turn) making 6 tool calls in a row, e.g. a single agent
     // response that does 6 tool-call steps before its final answer. Preserve only the last 2.
     const oneLongTurn = [1, 2, 3, 4, 5, 6].flatMap((i) => toolStep(i, 5000));
     const pruned = pruneToolResults(asInteractions(oneLongTurn), 12_000, 2);
 
     const fns = functionMessagesOf(flatMessages(pruned));
-    // Steps 1-4 (this SAME turn's own earlier steps) get redacted. Only the last 2 survive.
-    // Nothing here belongs to a "previous" interaction, this proves redaction operates on tool
+    // Steps 1-4 (this SAME turn's own earlier steps) get pruned. Only the last 2 survive.
+    // Nothing here belongs to a "previous" interaction, this proves pruning operates on tool
     // results flatly, not "protect everything in the current turn."
-    expect(fns.map((f) => isRedacted(f.content))).toEqual([
+    expect(fns.map((f) => isPruned(f.content))).toEqual([
       true,
       true,
       true,
@@ -161,24 +161,24 @@ describe("pruneToolResults", () => {
     ]);
   });
 
-  it("calling it twice with a wider floor only ever reaches further, never reconsiders what the first call already redacted", () => {
+  it("calling it twice with a wider floor only ever reaches further, never reconsiders what the first call already pruned", () => {
     // This is the pattern index.ts's escalation uses: call once with the normal floor, then again
     // with a smaller floor (0) and a tighter budget if that wasn't enough. Verifies the two calls
-    // don't conflict: the first call's redactions are untouched, and the second call reaches
+    // don't conflict: the first call's prunings are untouched, and the second call reaches
     // exactly the previously-protected tool results, nothing more, nothing less.
     const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
 
-    // First call: same as the test above. Redacts turns 1-4, protects the floor of the last 2
+    // First call: same as the test above. Prunes turns 1-4, protects the floor of the last 2
     // (turns 5 and 6, each still at their full 5000 tokens).
     const afterFirstCall = pruneToolResults(
       asInteractions(messages),
       12_000,
       2
     );
-    const redactedAfterFirstCall = functionMessagesOf(
+    const prunedAfterFirstCall = functionMessagesOf(
       flatMessages(afterFirstCall)
-    ).map((f) => isRedacted(f.content));
-    expect(redactedAfterFirstCall).toEqual([
+    ).map((f) => isPruned(f.content));
+    expect(prunedAfterFirstCall).toEqual([
       true,
       true,
       true,
@@ -187,26 +187,26 @@ describe("pruneToolResults", () => {
       false,
     ]);
 
-    // Second call: floor widened to 0, budget tightened to 300. Current total (turns 1-4 redacted
+    // Second call: floor widened to 0, budget tightened to 300. Current total (turns 1-4 pruned
     // at 44 tokens each, turns 5-6 still at 5020 each) is 10_216, so both floor turns need
-    // redacting too: redacting turn 5 alone only brings it to 5_240, still over 300, so turn 6
-    // gets redacted as well, landing at 264.
+    // pruning too: pruning turn 5 alone only brings it to 5_240, still over 300, so turn 6
+    // gets pruned as well, landing at 264.
     const afterSecondCall = pruneToolResults(afterFirstCall, 300, 0);
     const flatAfterSecondCall = flatMessages(afterSecondCall);
 
-    // Turns 1-4 are untouched by the second call: same redacted placeholders as after the first.
-    // The eligibility filter already excludes them (redacting an already-redacted message saves
+    // Turns 1-4 are untouched by the second call: same pruned placeholders as after the first.
+    // The eligibility filter already excludes them (pruning an already-pruned message saves
     // nothing), so the second call never reprocesses them.
     for (let i = 0; i < 4; i++) {
       expect(functionMessagesOf(flatAfterSecondCall)[i].content).toBe(
         functionMessagesOf(flatMessages(afterFirstCall))[i].content
       );
     }
-    // Turns 5-6, previously protected by the floor, are now reachable and redacted.
+    // Turns 5-6, previously protected by the floor, are now reachable and pruned.
     expect(
       functionMessagesOf(flatAfterSecondCall)
         .slice(4)
-        .map((f) => isRedacted(f.content))
+        .map((f) => isPruned(f.content))
     ).toEqual([true, true]);
 
     const totalTokens = flatAfterSecondCall.reduce(
@@ -224,28 +224,28 @@ describe("pruneToolResults", () => {
 
     for (const [i, m] of pruned.entries()) {
       if (m.role !== "function") {
-        // Redaction only ever replaces function-role messages. Every other message keeps its
+        // Pruning only ever replaces function-role messages. Every other message keeps its
         // exact original reference.
         expect(m).toBe(messages[i]);
       }
     }
   });
 
-  it("respects the floor even when the budget cannot be met: never redacts the last toolResultsToPreserve tool results", () => {
+  it("respects the floor even when the budget cannot be met: never prunes the last toolResultsToPreserve tool results", () => {
     const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
-    // Budget impossibly small: even redacting everything eligible won't fit. The floor (last 2
+    // Budget impossibly small: even pruning everything eligible won't fit. The floor (last 2
     // tool results) must still survive untouched, since that's this function's contract. Fitting
     // the impossible case is the caller's job (dropInteractionsToFit or a smaller floor).
     const pruned = pruneToolResults(asInteractions(messages), 1, 2);
 
     const fns = functionMessagesOf(flatMessages(pruned));
-    expect(fns.map((f) => isRedacted(f.content))).toEqual([true, false, false]);
+    expect(fns.map((f) => isPruned(f.content))).toEqual([true, false, false]);
   });
 
   it("never sweeps a tiny tool result (already smaller than the placeholder) into the checkpoint's forward-rounding, even though doing so would still be within the eligible range", () => {
-    // Regression test: the checkpoint-rounding search used to extend the redaction set purely by
-    // position, without checking whether redacting each swept-in message actually helps. A tool
-    // result smaller than PRUNED_TOOL_RESULT_TOKENS (24) GROWS when "redacted" (replaced by the
+    // Regression test: the checkpoint-rounding search used to extend the pruning set purely by
+    // position, without checking whether pruning each swept-in message actually helps. A tool
+    // result smaller than PRUNED_TOOL_RESULT_TOKENS (24) GROWS when "pruned" (replaced by the
     // placeholder), so sweeping one in can push the total over maxTokens, breaking this
     // function's own contract that the result never exceeds maxTokens (short of the floor).
     const messages: MessageWithTokens[] = [
@@ -288,7 +288,7 @@ describe("pruneToolResults", () => {
       ),
     ];
 
-    // Redacting only "big" (19000 -> 24) already brings the 20_503-token total down to 1_527,
+    // Pruning only "big" (19000 -> 24) already brings the 20_503-token total down to 1_527,
     // under this budget, the minimal frontier stops there. Without the fix, the
     // checkpoint-rounding search (finding no bucket boundary between "big" and the floor) used to
     // sweep the three tiny results in too, each GROWING by 23 tokens (1 -> 24), pushing the real
@@ -300,16 +300,16 @@ describe("pruneToolResults", () => {
 
     expect(totalTokens).toBeLessThanOrEqual(1530);
     const fns = functionMessagesOf(pruned);
-    expect(fns.map((f) => isRedacted(f.content))).toEqual([
-      true, // big: redacted, it's the only one that actually needed to be
-      false, // tiny1: left alone, redacting it wouldn't help
+    expect(fns.map((f) => isPruned(f.content))).toEqual([
+      true, // big: pruned, it's the only one that actually needed to be
+      false, // tiny1: left alone, pruning it wouldn't help
       false, // tiny2: left alone
       false, // tiny3: left alone
       false, // floor: protected (toolResultsToPreserve=1)
     ]);
   });
 
-  it("batches redaction via the checkpoint: a small addition doesn't retrigger new redaction, but a large enough one does", () => {
+  it("batches pruning via the checkpoint: a small addition doesn't retrigger new pruning, but a large enough one does", () => {
     // Bare tool results, no surrounding user/assistant text, so the prefix sum is exactly
     // (i+1) * 4000, easy to hand-verify against PRUNING_CHECKPOINT_TOKENS (20_000).
     function toolResult(index: number, tokenCount: number): MessageWithTokens {
@@ -335,13 +335,13 @@ describe("pruneToolResults", () => {
         toolResultsToPreserve
       )
     );
-    // Hand-verified: redacting indices 0-4 (saving 3976 tokens each) brings the 24_000-token
+    // Hand-verified: pruning indices 0-4 (saving 3976 tokens each) brings the 24_000-token
     // total down to 4_120, under the 6_000 budget. The checkpoint (20_000) happens to land
-    // exactly at index 4's prefix sum (20_000), so no extra over-redaction is needed here.
-    const redactedA = functionMessagesOf(prunedA).map((f) =>
-      isRedacted(f.content)
+    // exactly at index 4's prefix sum (20_000), so no extra over-pruning is needed here.
+    const prunedFlagsA = functionMessagesOf(prunedA).map((f) =>
+      isPruned(f.content)
     );
-    expect(redactedA).toEqual([true, true, true, true, true, false]);
+    expect(prunedFlagsA).toEqual([true, true, true, true, true, false]);
 
     // Small addition: one more, much smaller tool result, well under a full checkpoint's
     // worth of new content. The decision for indices 0-5 (present in both histories) must be
@@ -357,18 +357,18 @@ describe("pruneToolResults", () => {
     expect(
       functionMessagesOf(prunedB)
         .slice(0, 6)
-        .map((f) => isRedacted(f.content))
-    ).toEqual(redactedA);
+        .map((f) => isPruned(f.content))
+    ).toEqual(prunedFlagsA);
 
     // Large addition: a whole new turn-sized tool result. This pushes the running total enough
-    // that the previously-kept index 5 must now also be redacted to fit the same budget.
+    // that the previously-kept index 5 must now also be pruned to fit the same budget.
     // Batching means SOME stability, not that the frontier can never move again. Hand-verified:
-    // minimally, redacting indices 0-5 (6 items) would bring the 28_000-token total to 4_144,
+    // minimally, pruning indices 0-5 (6 items) would bring the 28_000-token total to 4_144,
     // under budget, but the checkpoint search never finds a bucket boundary between index 4
     // (prefix sum 20_000) and index 6 (prefix sum 28_000): all three land in the same
     // floor(x/20_000)=1 bucket. With no checkpoint found in range, the search runs to the end of
     // the eligible set rather than under-shooting the budget, so index 6, the tool result just
-    // added in this very call, gets redacted too, not just index 5.
+    // added in this very call, gets pruned too, not just index 5.
     const historyC = [...historyA, toolResult(6, 4000)];
     const prunedC = flatMessages(
       pruneToolResults(
@@ -377,23 +377,23 @@ describe("pruneToolResults", () => {
         toolResultsToPreserve
       )
     );
-    const redactedC = functionMessagesOf(prunedC).map((f) =>
-      isRedacted(f.content)
+    const prunedFlagsC = functionMessagesOf(prunedC).map((f) =>
+      isPruned(f.content)
     );
-    expect(redactedC).toEqual([true, true, true, true, true, true, true]);
+    expect(prunedFlagsC).toEqual([true, true, true, true, true, true, true]);
   });
 
-  it("is a pure function of history: the same input always yields the same redaction decision", () => {
+  it("is a pure function of history: the same input always yields the same pruning decision", () => {
     const messages = [1, 2, 3, 4, 5].flatMap((i) => turn(i, 3000));
     const first = pruneToolResults(asInteractions(messages), 10_000, 2);
     const second = pruneToolResults(asInteractions(messages), 10_000, 2);
     expect(first).toEqual(second);
   });
 
-  it("redacts SOME messages while dropping OTHER whole interactions in a realistic multi-interaction conversation, preserving interaction boundaries throughout", () => {
+  it("prunes SOME messages while dropping OTHER whole interactions in a realistic multi-interaction conversation, preserving interaction boundaries throughout", () => {
     // 12 separate interactions (TOOL_RESULTS_TO_PRESERVE-scale), each a real [user, assistant,
     // function] turn, exercises pruneToolResults' interaction-boundary bookkeeping (flatten,
-    // redact, re-slice) against real turn structure, not a single synthetic interaction.
+    // prune, re-slice) against real turn structure, not a single synthetic interaction.
     const interactions = groupMessagesIntoInteractions(
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => turn(i, 5000))
     );
@@ -406,9 +406,9 @@ describe("pruneToolResults", () => {
     }
 
     const fns = functionMessagesOf(flatMessages(pruned));
-    expect(fns.map((f) => isRedacted(f.content))).toEqual([
-      true, // tool_1: outside the floor of 10, redacted
-      true, // tool_2: outside the floor of 10, redacted
+    expect(fns.map((f) => isPruned(f.content))).toEqual([
+      true, // tool_1: outside the floor of 10, pruned
+      true, // tool_2: outside the floor of 10, pruned
       false,
       false,
       false,

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -6,19 +6,18 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "</dust_system>";
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
-// Batch granularity for the redaction checkpoint in prunePreviousInteractions. Same idea as the
-// `clear_at_least` setting on provider-native context-editing features: don't invalidate a cached
-// prefix for a handful of tokens, only once enough new content has accumulated to make the
-// cache-write cost worthwhile. A turn running a couple of tool calls can easily produce several
-// thousand tokens on its own, so this needs enough headroom above that to actually batch.
-//
-// A flat value rather than a percentage of context size, since our model fleet has no context
-// window between 16k and 64k tokens: any model above that tier has ample room regardless of the
-// exact value chosen here. For a model whose budget never reaches this checkpoint, the search
-// simply never finds a crossing and falls back to redacting everything eligible once triggered,
-// still stable, just without the batching benefit. Starting point, tune against production
-// cache-miss metrics.
+// Batch size for the redaction checkpoint: like provider-native `clear_at_least`, don't move the
+// frontier for a handful of tokens, only once enough has accumulated to be worth invalidating the
+// cached prefix. Flat rather than a percentage of contextSize since no model in our fleet sits
+// between 16k-64k tokens. Starting point, tune against production cache-miss metrics.
 export const PRUNING_CHECKPOINT_TOKENS = 20_000;
+
+// How many of the most recent tool results pruneToolResults never redacts, regardless of budget.
+// Counted in tool results, not turns: a single turn's own long tool-call chain is eligible for
+// redaction past this window exactly like an older turn's would be. Mirrors Anthropic's own
+// `clear_tool_uses` (`keep: {type: "tool_uses", value: N}`), which has no turn concept either.
+// Starting point, tune against production metrics.
+export const TOOL_RESULTS_TO_PRESERVE = 10;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
@@ -35,10 +34,7 @@ export type Interaction<T extends MinimalMessageType> = {
 
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
 
-/**
- * Prunes all tool results in an interaction.
- * Returns a new interaction with all tool results replaced by placeholders.
- */
+/** Replaces every tool result in an interaction with a placeholder. */
 export function pruneAllToolResults(
   interaction: InteractionWithTokens
 ): InteractionWithTokens {
@@ -58,9 +54,7 @@ export function pruneAllToolResults(
   };
 }
 
-/**
- * Calculate total tokens for an interaction.
- */
+/** Total tokens across an interaction's messages. */
 export function getInteractionTokenCount(
   interaction: InteractionWithTokens
 ): number {
@@ -68,110 +62,52 @@ export function getInteractionTokenCount(
 }
 
 /**
- * Progressively prune tool results from an interaction to meet token budget. Prunes from oldest to
- * newest tool results until the interaction fits.
+ * Re-slices a flat message array back into template's interaction boundaries. Safe because
+ * redactFlat never adds, removes, or reorders messages. Throws if that's ever violated.
  */
-export function progressivelyPruneInteraction(
-  interaction: InteractionWithTokens,
-  maxTokens: number
-): InteractionWithTokens {
-  const currentTokens = getInteractionTokenCount(interaction);
-  if (currentTokens <= maxTokens) {
-    return interaction;
+function sliceIntoInteractions(
+  template: InteractionWithTokens[],
+  messages: MessageWithTokens[]
+): InteractionWithTokens[] {
+  const expectedLength = template.reduce(
+    (sum, interaction) => sum + interaction.messages.length,
+    0
+  );
+  if (messages.length !== expectedLength) {
+    throw new Error(
+      `sliceIntoInteractions: message count mismatch (expected ${expectedLength}, got ${messages.length}). Redaction must never add, remove, or reorder messages.`
+    );
   }
 
-  // Find all tool result messages.
-  const toolResultIndices: number[] = [];
-  for (let i = 0; i < interaction.messages.length; i++) {
-    if (interaction.messages[i].role === "function") {
-      toolResultIndices.push(i);
-    }
+  const result: InteractionWithTokens[] = [];
+  let offset = 0;
+  for (const interaction of template) {
+    const count = interaction.messages.length;
+    result.push({ messages: messages.slice(offset, offset + count) });
+    offset += count;
   }
-
-  let prunedContext = false;
-
-  // Prune from oldest to newest, recalculating tokens each time.
-  let prunedMessages = [...interaction.messages];
-  for (const index of toolResultIndices) {
-    // If very last tool result is pruned, we mark prunedContext as true.
-    if (index === toolResultIndices[toolResultIndices.length - 1]) {
-      prunedContext = true;
-    }
-    const message = prunedMessages[index];
-    if (message.role === "function") {
-      // Create a new array with the pruned message.
-      prunedMessages = [...prunedMessages];
-      prunedMessages[index] = {
-        ...message,
-        content: PRUNED_TOOL_RESULT_PLACEHOLDER,
-        tokenCount: PRUNED_TOOL_RESULT_TOKENS,
-      };
-
-      // Check if we've pruned enough.
-      const newTotalTokens = prunedMessages.reduce(
-        (sum, msg) => sum + msg.tokenCount,
-        0
-      );
-      if (newTotalTokens <= maxTokens) {
-        break;
-      }
-    }
-  }
-
-  return {
-    messages: prunedMessages,
-    prunedContext,
-  };
+  return result;
 }
 
-/**
- * Prunes tool results from previous interactions to fit within maxTokens, fully preserving the
- * last interactionsToPreserve interactions whenever the budget allows it. Guarantees the returned
- * interactions' combined token count never exceeds maxTokens, short of interactionsToPreserve's
- * own redacted floor alone exceeding it. That's a real out-of-room case left for the caller to
- * handle.
- *
- * The redaction boundary is computed from each interaction's ORIGINAL (pre-redaction) size. That
- * value never changes once an interaction is permanent history. It's then snapped back to the
- * nearest checkpoint in a prefix sum computed from the start of the conversation (see
- * PRUNING_CHECKPOINT_TOKENS). Because both of these are pure functions of immutable history plus
- * fixed constants, the same input history always yields the same redaction decisions across calls.
- * Those decisions only change once enough new content has accumulated to cross the next
- * checkpoint, not on every single turn. That's what keeps the rendered previous interactions
- * byte-stable across most turns and therefore reusable from the model provider's prompt cache.
- * Callers relying on this stability must always pass the SAME maxTokens across turns, not one
- * derived from a live, per-turn quantity like the current interaction's own size. See
- * renderConversationForModel for how that's arranged.
- *
- * If even fully redacting everything outside the floor isn't enough, for example many old
- * interactions whose placeholders alone add up, already-redacted interactions are dropped
- * entirely, oldest first, up to but never into the floor. This is a rare out-of-room
- * fallback, not routine operation.
- */
-export function prunePreviousInteractions(
-  inputInteractions: InteractionWithTokens[],
+/** The flat redaction algorithm behind pruneToolResults; see that function for the full contract. */
+function redactFlat(
+  messages: MessageWithTokens[],
   maxTokens: number,
-  interactionsToPreserve: number
-): InteractionWithTokens[] {
-  let interactions = [...inputInteractions];
-  const n = interactions.length;
+  toolResultsToPreserve: number
+): MessageWithTokens[] {
+  const n = messages.length;
   if (n === 0) {
-    return interactions;
+    return messages;
   }
 
-  // Original sizes are permanent. They never change once an interaction is history, regardless of
-  // how it eventually gets redacted. redactedTokens is what each interaction would cost if
-  // redacted, computed without mutating anything yet, purely to size the redaction savings.
-  const originalTokens = interactions.map((interaction) =>
-    getInteractionTokenCount(interaction)
-  );
-  const redactedTokens = interactions.map((interaction) =>
-    getInteractionTokenCount(pruneAllToolResults(interaction))
+  // redactedTokens is what each function-role message would cost once redacted.
+  const originalTokens = messages.map((m) => m.tokenCount);
+  const redactedTokens = messages.map((m, i) =>
+    m.role === "function" ? PRUNED_TOOL_RESULT_TOKENS : originalTokens[i]
   );
 
-  // Prefix sum from the START of the conversation. The value at a fixed index never changes
-  // across turns: it only depends on interactions that are already permanent by the time that
-  // index exists.
+  // Prefix sum from the start of the conversation. The value at a fixed index never changes once
+  // that message is history.
   const prefixSum: number[] = [];
   let running = 0;
   for (const tokens of originalTokens) {
@@ -179,87 +115,136 @@ export function prunePreviousInteractions(
     prefixSum.push(running);
   }
 
-  // The last interactionsToPreserve interactions are a hard floor: never redacted by this
-  // function, regardless of budget. (If the floor alone exceeds maxTokens, that's a real
-  // out-of-room situation handled by the caller's own downstream safety nets, not here.)
+  const functionIndices: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (messages[i].role === "function") {
+      functionIndices.push(i);
+    }
+  }
+
+  // Last toolResultsToPreserve tool results: never redacted, regardless of budget.
+  const floorStart = Math.max(
+    functionIndices.length - toolResultsToPreserve,
+    0
+  );
+  // Excludes results already smaller than the placeholder (e.g. "ok"). Redacting one would grow
+  // it, not shrink it, breaking the budget guarantee below.
+  const eligible = functionIndices
+    .slice(0, floorStart)
+    .filter((idx) => redactedTokens[idx] < originalTokens[idx]);
+
+  const totalIfNothingRedacted = prefixSum[n - 1];
+  if (totalIfNothingRedacted <= maxTokens) {
+    return messages;
+  }
+
+  // Minimal redaction needed: walk oldest-to-newest until the running total fits.
+  let total = totalIfNothingRedacted;
+  let neededFrontier = -1;
+  for (let k = 0; k < eligible.length && total > maxTokens; k++) {
+    const idx = eligible[k];
+    total -= originalTokens[idx] - redactedTokens[idx];
+    neededFrontier = k;
+  }
+
+  if (neededFrontier < 0) {
+    return messages;
+  }
+
+  // Round forward to the next checkpoint (a prefix-sum multiple of PRUNING_CHECKPOINT_TOKENS) so
+  // the same boundary keeps holding for several turns instead of creeping forward on every one.
+  let effectiveFrontier = neededFrontier;
+  for (let k = neededFrontier; k < eligible.length; k++) {
+    effectiveFrontier = k;
+    const idx = eligible[k];
+    if (idx === 0) {
+      break; // Start of conversation is trivially a checkpoint.
+    }
+    const bucketAtIdx = Math.floor(prefixSum[idx] / PRUNING_CHECKPOINT_TOKENS);
+    const bucketBefore = Math.floor(
+      prefixSum[idx - 1] / PRUNING_CHECKPOINT_TOKENS
+    );
+    if (bucketAtIdx !== bucketBefore) {
+      break;
+    }
+  }
+
+  const toRedact = new Set(eligible.slice(0, effectiveFrontier + 1));
+
+  return messages.map((m, i) => {
+    // Narrows m to the function-role variant. toRedact is already function-only by construction.
+    if (m.role === "function" && toRedact.has(i)) {
+      return {
+        ...m,
+        content: PRUNED_TOOL_RESULT_PLACEHOLDER,
+        tokenCount: PRUNED_TOOL_RESULT_TOKENS,
+      };
+    }
+    return m;
+  });
+}
+
+/**
+ * Redacts tool results across the whole conversation, previous interactions and the current,
+ * in-progress one combined, as one flat sequence, oldest eligible first. No exemption for the
+ * current turn: a long tool-call chain within it becomes eligible past toolResultsToPreserve
+ * exactly like an older turn's would (mirrors Anthropic's own `clear_tool_uses`, which has no turn
+ * concept either).
+ *
+ * Takes and returns `InteractionWithTokens[]`, flattening and re-slicing internally so callers
+ * never juggle a flat view and an interaction view themselves. Only ever replaces a function
+ * message's content. Never removes or reorders a message, so every tool_use stays paired with a
+ * tool_result and a content fragment is never separated from its user message. Dropping whole
+ * turns when redaction alone isn't enough is a separate operation (dropInteractionsToFit) for
+ * exactly that reason.
+ *
+ * The redaction boundary is a pure function of immutable history plus fixed constants, so the
+ * same input always redacts the same way, stable enough to survive the model provider's prompt
+ * cache. Callers must pass the SAME maxTokens across turns, not one derived from a live quantity.
+ */
+export function pruneToolResults(
+  interactions: InteractionWithTokens[],
+  maxTokens: number,
+  toolResultsToPreserve: number
+): InteractionWithTokens[] {
+  const messages = interactions.flatMap((interaction) => interaction.messages);
+  const redacted = redactFlat(messages, maxTokens, toolResultsToPreserve);
+  if (redacted === messages) {
+    return interactions; // No-op: same reference, same as dropInteractionsToFit below.
+  }
+  return sliceIntoInteractions(interactions, redacted);
+}
+
+/**
+ * Drops whole interactions entirely, oldest first, when redaction alone (pruneToolResults) isn't
+ * enough. Whole interactions only, since partial drops risk orphaning a tool_use or separating a
+ * content fragment from its user message.
+ *
+ * Never drops into the last interactionsToPreserve. A caller still over budget after that can
+ * retry with a smaller floor, or force pruneToolResults deeper.
+ */
+export function dropInteractionsToFit(
+  interactions: InteractionWithTokens[],
+  maxTokens: number,
+  interactionsToPreserve: number
+): InteractionWithTokens[] {
+  let result = interactions;
+  const n = result.length;
   const floorStart = Math.max(n - interactionsToPreserve, 0);
 
-  let totalIfNothingRedacted = 0;
-  for (let i = 0; i < n; i++) {
-    totalIfNothingRedacted += originalTokens[i];
-  }
-
-  if (totalIfNothingRedacted > maxTokens) {
-    // Redact starting from the OLDEST eligible interaction forward, tracking the actual running
-    // total (not just whether original sizes would exceed budget), until it fits. This is the
-    // minimal redaction needed. Nothing above this frontier is touched.
-    let total = totalIfNothingRedacted;
-    let neededFrontier = -1;
-    for (let i = 0; i < floorStart && total > maxTokens; i++) {
-      total -= originalTokens[i] - redactedTokens[i];
-      neededFrontier = i;
-    }
-
-    if (neededFrontier >= 0) {
-      // Round the frontier FORWARD to the next checkpoint at or after neededFrontier. A checkpoint
-      // is a position where the immutable prefix sum crosses a multiple of
-      // PRUNING_CHECKPOINT_TOKENS. This deliberately redacts a bit more than strictly necessary
-      // right now, so the same boundary keeps satisfying the budget for several subsequent turns
-      // instead of creeping forward by one interaction on almost every single turn. Never extends
-      // past floorStart - 1, so the budget is still always respected even if no checkpoint is
-      // found in range.
-      let effectiveFrontier = neededFrontier;
-      for (let i = neededFrontier; i < floorStart; i++) {
-        effectiveFrontier = i;
-        if (i === 0) {
-          // Index 0 is trivially always a checkpoint: it's the start of the conversation.
-          break;
-        }
-        const bucketAtI = Math.floor(prefixSum[i] / PRUNING_CHECKPOINT_TOKENS);
-        const bucketBefore = Math.floor(
-          prefixSum[i - 1] / PRUNING_CHECKPOINT_TOKENS
-        );
-        if (bucketAtI !== bucketBefore) {
-          // We fell into a different bucket than the previous interaction, so this is a
-          // checkpoint too.
-          break;
-        }
-      }
-
-      for (let i = 0; i <= effectiveFrontier; i++) {
-        interactions[i] = pruneAllToolResults(interactions[i]);
-      }
-    }
-  }
-
-  let totalTokens = interactions.reduce(
+  let totalTokens = result.reduce(
     (sum, interaction) => sum + getInteractionTokenCount(interaction),
     0
   );
 
-  // Still over budget after the redaction pass above. Either many old, already-redacted
-  // placeholders add up, or some eligible interactions above the frontier are themselves large.
-  // Drop already-redacted-or-eligible interactions entirely, oldest first, up to but never into
-  // the floor. This is strictly less disruptive than touching the floor, so it's always tried
-  // first.
   let dropUpToIndex = -1;
-  for (let i = 0; i < Math.min(floorStart, n) && totalTokens > maxTokens; i++) {
-    totalTokens -= getInteractionTokenCount(interactions[i]);
+  for (let i = 0; i < floorStart && totalTokens > maxTokens; i++) {
+    totalTokens -= getInteractionTokenCount(result[i]);
     dropUpToIndex = i;
   }
   if (dropUpToIndex >= 0) {
-    interactions = interactions.slice(dropUpToIndex + 1);
+    result = result.slice(dropUpToIndex + 1);
   }
 
-  // Absolute last resort: even with every eligible interaction dropped entirely, the floor's own
-  // real size alone still doesn't fit. Redact floor interactions too, oldest first. This only
-  // kicks in as a last resort, not routine operation, so it's fine for it to be driven by the
-  // floor's live size rather than a checkpoint.
-  for (let i = 0; i < interactions.length && totalTokens > maxTokens; i++) {
-    const before = getInteractionTokenCount(interactions[i]);
-    interactions[i] = pruneAllToolResults(interactions[i]);
-    totalTokens -= before - getInteractionTokenCount(interactions[i]);
-  }
-
-  return interactions;
+  return result;
 }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -1,3 +1,14 @@
+/**
+ * Mechanisms for fitting a conversation into a token budget. Two distinct operations, named
+ * consistently throughout this module and index.ts:
+ *
+ * - "prune" (pruneToolResults): replace a tool result's content with a small placeholder. The
+ *   message stays in place, so tool_use/tool_result pairing is never broken.
+ * - "drop" (dropInteractionsToFit): remove whole interactions entirely, oldest first.
+ *
+ * index.ts owns the policy of when to apply which. This module owns the mechanisms.
+ */
+import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
 import assert from "assert";
 
@@ -7,15 +18,15 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "</dust_system>";
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
-// Batch size for the redaction checkpoint: like provider-native `clear_at_least`, don't move the
+// Batch size for the pruning checkpoint: like provider-native `clear_at_least`, don't move the
 // frontier for a handful of tokens, only once enough has accumulated to be worth invalidating the
 // cached prefix. Flat rather than a percentage of contextSize since no model in our fleet sits
 // between 16k-64k tokens. Starting point, tune against production cache-miss metrics.
 export const PRUNING_CHECKPOINT_TOKENS = 20_000;
 
-// How many of the most recent tool results pruneToolResults never redacts, regardless of budget.
+// How many of the most recent tool results pruneToolResults never prunes, regardless of budget.
 // Counted in tool results, not turns: a single turn's own long tool-call chain is eligible for
-// redaction past this window exactly like an older turn's would be. Starting point, tune against
+// pruning past this window exactly like an older turn's would be. Starting point, tune against
 // production metrics.
 export const TOOL_RESULTS_TO_PRESERVE = 10;
 
@@ -23,38 +34,16 @@ export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
 };
 
-export type MinimalMessageType = {
-  role: string;
-};
-
-export type Interaction<T extends MinimalMessageType> = {
-  messages: T[];
-  prunedContext?: boolean;
-};
-
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
 
 /** Turns a function-role message into the pruned placeholder. */
-function redactToolResultMessage(
+function pruneToolResultMessage(
   message: Extract<MessageWithTokens, { role: "function" }>
 ): Extract<MessageWithTokens, { role: "function" }> {
   return {
     ...message,
     content: PRUNED_TOOL_RESULT_PLACEHOLDER,
     tokenCount: PRUNED_TOOL_RESULT_TOKENS,
-  };
-}
-
-/** Replaces every tool result in an interaction with a placeholder. */
-export function pruneAllToolResults(
-  interaction: InteractionWithTokens
-): InteractionWithTokens {
-  const prunedMessages = interaction.messages.map((msg) =>
-    msg.role === "function" ? redactToolResultMessage(msg) : msg
-  );
-
-  return {
-    messages: prunedMessages,
   };
 }
 
@@ -65,9 +54,19 @@ export function getInteractionTokenCount(
   return interaction.messages.reduce((sum, msg) => sum + msg.tokenCount, 0);
 }
 
+/** Total tokens across every interaction in the array. */
+export function sumInteractionTokens(
+  interactions: InteractionWithTokens[]
+): number {
+  return interactions.reduce(
+    (sum, interaction) => sum + getInteractionTokenCount(interaction),
+    0
+  );
+}
+
 /**
  * Re-slices a flat message array back into template's interaction boundaries. Safe because
- * redactFlat never adds, removes, or reorders messages. Throws if that's ever violated.
+ * pruneToolResultsFlat never adds, removes, or reorders messages. Throws if that's ever violated.
  */
 function sliceIntoInteractions(
   template: InteractionWithTokens[],
@@ -80,7 +79,7 @@ function sliceIntoInteractions(
 
   assert(
     messages.length === expectedLength,
-    `sliceIntoInteractions: message count mismatch (expected ${expectedLength}, got ${messages.length}). Redaction must never add, remove, or reorder messages.`
+    `sliceIntoInteractions: message count mismatch (expected ${expectedLength}, got ${messages.length}). Pruning must never add, remove, or reorder messages.`
   );
 
   const result: InteractionWithTokens[] = [];
@@ -93,8 +92,8 @@ function sliceIntoInteractions(
   return result;
 }
 
-/** The flat redaction algorithm behind pruneToolResults. See that function for the full contract. */
-function redactFlat(
+/** The flat algorithm behind pruneToolResults. See that function for the full contract. */
+function pruneToolResultsFlat(
   messages: MessageWithTokens[],
   maxTokens: number,
   toolResultsToPreserve: number
@@ -104,23 +103,29 @@ function redactFlat(
     return messages;
   }
 
-  // redactedTokens is what each message would cost once redacted, capped at its original size so
-  // a tool result already smaller than the placeholder is never reported as shrinking.
-  const originalTokens = messages.map((m) => m.tokenCount);
-  const redactedTokens = messages.map((m, i) =>
-    m.role === "function"
-      ? Math.min(originalTokens[i], PRUNED_TOOL_RESULT_TOKENS)
-      : originalTokens[i]
-  );
-
   // Prefix sum from the start of the conversation. The value at a fixed index never changes once
   // that message is history.
+  const originalTokens = messages.map((m) => m.tokenCount);
   const prefixSum: number[] = [];
   let running = 0;
   for (const tokens of originalTokens) {
     running += tokens;
     prefixSum.push(running);
   }
+
+  // Common case: everything already fits, nothing to decide.
+  const totalIfNothingPruned = prefixSum[n - 1];
+  if (totalIfNothingPruned <= maxTokens) {
+    return messages;
+  }
+
+  // prunedTokens is what each message would cost once pruned, capped at its original size so a
+  // tool result already smaller than the placeholder is never reported as shrinking.
+  const prunedTokens = messages.map((m, i) =>
+    m.role === "function"
+      ? Math.min(originalTokens[i], PRUNED_TOOL_RESULT_TOKENS)
+      : originalTokens[i]
+  );
 
   const functionIndices: number[] = [];
   for (let i = 0; i < n; i++) {
@@ -129,28 +134,26 @@ function redactFlat(
     }
   }
 
-  // Last toolResultsToPreserve tool results: never redacted, regardless of budget.
+  // Last toolResultsToPreserve tool results: never pruned, regardless of budget.
   const floorStart = Math.max(
     functionIndices.length - toolResultsToPreserve,
     0
   );
-  // Excludes results already smaller than the placeholder (e.g. "ok"). Redacting one would grow
+  // Excludes results already smaller than the placeholder (e.g. "ok"). Pruning one would grow
   // it, not shrink it, breaking the budget guarantee below.
+  //
+  // eligible holds indices into messages. The frontier variables below are indices into eligible
+  // itself (its k-th entry), not into messages.
   const eligible = functionIndices
     .slice(0, floorStart)
-    .filter((idx) => redactedTokens[idx] < originalTokens[idx]);
+    .filter((idx) => prunedTokens[idx] < originalTokens[idx]);
 
-  const totalIfNothingRedacted = prefixSum[n - 1];
-  if (totalIfNothingRedacted <= maxTokens) {
-    return messages;
-  }
-
-  // Minimal redaction needed: walk oldest-to-newest until the running total fits.
-  let total = totalIfNothingRedacted;
+  // Minimal pruning needed: walk oldest-to-newest until the running total fits.
+  let total = totalIfNothingPruned;
   let neededFrontier = -1;
   for (let k = 0; k < eligible.length && total > maxTokens; k++) {
     const idx = eligible[k];
-    total -= originalTokens[idx] - redactedTokens[idx];
+    total -= originalTokens[idx] - prunedTokens[idx];
     neededFrontier = k;
   }
 
@@ -160,6 +163,8 @@ function redactFlat(
 
   // Round forward to the next checkpoint (a prefix-sum multiple of PRUNING_CHECKPOINT_TOKENS) so
   // the same boundary keeps holding for several turns instead of creeping forward on every one.
+  // If no checkpoint exists in the remaining eligible range, the frontier runs to the end of it:
+  // over-pruning is acceptable, undershooting the budget is not.
   let effectiveFrontier = neededFrontier;
   for (let k = neededFrontier; k < eligible.length; k++) {
     effectiveFrontier = k;
@@ -176,15 +181,15 @@ function redactFlat(
     }
   }
 
-  const toRedact = new Set(eligible.slice(0, effectiveFrontier + 1));
+  const toPrune = new Set(eligible.slice(0, effectiveFrontier + 1));
 
   return messages.map((m, i) =>
-    m.role === "function" && toRedact.has(i) ? redactToolResultMessage(m) : m
+    m.role === "function" && toPrune.has(i) ? pruneToolResultMessage(m) : m
   );
 }
 
 /**
- * Redacts tool results across the whole conversation, previous interactions and the current,
+ * Prunes tool results across the whole conversation, previous interactions and the current,
  * in-progress one combined, as one flat sequence, oldest eligible first. No exemption for the
  * current turn: a long tool-call chain within it becomes eligible past toolResultsToPreserve
  * exactly like an older turn's would.
@@ -193,12 +198,15 @@ function redactFlat(
  * never juggle a flat view and an interaction view themselves. Only ever replaces a function
  * message's content. Never removes or reorders a message, so every tool_use stays paired with a
  * tool_result and a content fragment is never separated from its user message. Dropping whole
- * turns when redaction alone isn't enough is a separate operation (dropInteractionsToFit) for
+ * turns when pruning alone isn't enough is a separate operation (dropInteractionsToFit) for
  * exactly that reason.
  *
- * The redaction boundary is a pure function of immutable history plus fixed constants, so the
- * same input always redacts the same way, stable enough to survive the model provider's prompt
- * cache. Callers must pass the SAME maxTokens across turns, not one derived from a live quantity.
+ * The pruning boundary is a pure function of the (immutable) history and this call's inputs, so
+ * the same input always prunes the same way, stable enough to survive the model provider's
+ * prompt cache. maxTokens should be stable across turns for that to hold. It doesn't have to be
+ * byte-identical: the caller derives it from prompt and tool-definition sizes that drift a little
+ * between turns, and the checkpoint rounding absorbs drift well below PRUNING_CHECKPOINT_TOKENS.
+ * What it must not be is a fast-moving live quantity (remaining budget, time, message count).
  */
 export function pruneToolResults(
   interactions: InteractionWithTokens[],
@@ -206,15 +214,19 @@ export function pruneToolResults(
   toolResultsToPreserve: number
 ): InteractionWithTokens[] {
   const messages = interactions.flatMap((interaction) => interaction.messages);
-  const redacted = redactFlat(messages, maxTokens, toolResultsToPreserve);
-  if (redacted === messages) {
+  const pruned = pruneToolResultsFlat(
+    messages,
+    maxTokens,
+    toolResultsToPreserve
+  );
+  if (pruned === messages) {
     return interactions; // No-op: same reference, same as dropInteractionsToFit below.
   }
-  return sliceIntoInteractions(interactions, redacted);
+  return sliceIntoInteractions(interactions, pruned);
 }
 
 /**
- * Drops whole interactions entirely, oldest first, when redaction alone (pruneToolResults) isn't
+ * Drops whole interactions entirely, oldest first, when pruning alone (pruneToolResults) isn't
  * enough. Whole interactions only, since partial drops risk orphaning a tool_use or separating a
  * content fragment from its user message.
  *
@@ -230,10 +242,7 @@ export function dropInteractionsToFit(
   const n = result.length;
   const floorStart = Math.max(n - interactionsToPreserve, 0);
 
-  let totalTokens = result.reduce(
-    (sum, interaction) => sum + getInteractionTokenCount(interaction),
-    0
-  );
+  let totalTokens = sumInteractionTokens(result);
 
   let dropUpToIndex = -1;
   for (let i = 0; i < floorStart && totalTokens > maxTokens; i++) {

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -95,8 +95,13 @@ function sliceIntoInteractions(
 /** The flat algorithm behind pruneToolResults. See that function for the full contract. */
 function pruneToolResultsFlat(
   messages: MessageWithTokens[],
-  maxTokens: number,
-  toolResultsToPreserve: number
+  {
+    maxTokens,
+    toolResultsToPreserve,
+  }: {
+    maxTokens: number;
+    toolResultsToPreserve: number;
+  }
 ): MessageWithTokens[] {
   const n = messages.length;
   if (n === 0) {
@@ -210,15 +215,13 @@ function pruneToolResultsFlat(
  */
 export function pruneToolResults(
   interactions: InteractionWithTokens[],
-  maxTokens: number,
-  toolResultsToPreserve: number
+  opts: {
+    maxTokens: number;
+    toolResultsToPreserve: number;
+  }
 ): InteractionWithTokens[] {
   const messages = interactions.flatMap((interaction) => interaction.messages);
-  const pruned = pruneToolResultsFlat(
-    messages,
-    maxTokens,
-    toolResultsToPreserve
-  );
+  const pruned = pruneToolResultsFlat(messages, opts);
   if (pruned === messages) {
     return interactions; // No-op: same reference, same as dropInteractionsToFit below.
   }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -1,4 +1,5 @@
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import assert from "assert";
 
 const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "<dust_system>" +
@@ -33,20 +34,24 @@ export type Interaction<T extends MinimalMessageType> = {
 
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
 
+/** Turns a function-role message into the pruned placeholder. */
+function redactToolResultMessage(
+  message: Extract<MessageWithTokens, { role: "function" }>
+): Extract<MessageWithTokens, { role: "function" }> {
+  return {
+    ...message,
+    content: PRUNED_TOOL_RESULT_PLACEHOLDER,
+    tokenCount: PRUNED_TOOL_RESULT_TOKENS,
+  };
+}
+
 /** Replaces every tool result in an interaction with a placeholder. */
 export function pruneAllToolResults(
   interaction: InteractionWithTokens
 ): InteractionWithTokens {
-  const prunedMessages = interaction.messages.map((msg) => {
-    if (msg.role === "function") {
-      return {
-        ...msg,
-        content: PRUNED_TOOL_RESULT_PLACEHOLDER,
-        tokenCount: PRUNED_TOOL_RESULT_TOKENS,
-      };
-    }
-    return msg;
-  });
+  const prunedMessages = interaction.messages.map((msg) =>
+    msg.role === "function" ? redactToolResultMessage(msg) : msg
+  );
 
   return {
     messages: prunedMessages,
@@ -72,11 +77,11 @@ function sliceIntoInteractions(
     (sum, interaction) => sum + interaction.messages.length,
     0
   );
-  if (messages.length !== expectedLength) {
-    throw new Error(
-      `sliceIntoInteractions: message count mismatch (expected ${expectedLength}, got ${messages.length}). Redaction must never add, remove, or reorder messages.`
-    );
-  }
+
+  assert(
+    messages.length === expectedLength,
+    `sliceIntoInteractions: message count mismatch (expected ${expectedLength}, got ${messages.length}). Redaction must never add, remove, or reorder messages.`
+  );
 
   const result: InteractionWithTokens[] = [];
   let offset = 0;
@@ -88,7 +93,7 @@ function sliceIntoInteractions(
   return result;
 }
 
-/** The flat redaction algorithm behind pruneToolResults; see that function for the full contract. */
+/** The flat redaction algorithm behind pruneToolResults. See that function for the full contract. */
 function redactFlat(
   messages: MessageWithTokens[],
   maxTokens: number,
@@ -99,10 +104,13 @@ function redactFlat(
     return messages;
   }
 
-  // redactedTokens is what each function-role message would cost once redacted.
+  // redactedTokens is what each message would cost once redacted, capped at its original size so
+  // a tool result already smaller than the placeholder is never reported as shrinking.
   const originalTokens = messages.map((m) => m.tokenCount);
   const redactedTokens = messages.map((m, i) =>
-    m.role === "function" ? PRUNED_TOOL_RESULT_TOKENS : originalTokens[i]
+    m.role === "function"
+      ? Math.min(originalTokens[i], PRUNED_TOOL_RESULT_TOKENS)
+      : originalTokens[i]
   );
 
   // Prefix sum from the start of the conversation. The value at a fixed index never changes once
@@ -170,17 +178,9 @@ function redactFlat(
 
   const toRedact = new Set(eligible.slice(0, effectiveFrontier + 1));
 
-  return messages.map((m, i) => {
-    // Narrows m to the function-role variant. toRedact is already function-only by construction.
-    if (m.role === "function" && toRedact.has(i)) {
-      return {
-        ...m,
-        content: PRUNED_TOOL_RESULT_PLACEHOLDER,
-        tokenCount: PRUNED_TOOL_RESULT_TOKENS,
-      };
-    }
-    return m;
-  });
+  return messages.map((m, i) =>
+    m.role === "function" && toRedact.has(i) ? redactToolResultMessage(m) : m
+  );
 }
 
 /**

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -14,9 +14,8 @@ export const PRUNING_CHECKPOINT_TOKENS = 20_000;
 
 // How many of the most recent tool results pruneToolResults never redacts, regardless of budget.
 // Counted in tool results, not turns: a single turn's own long tool-call chain is eligible for
-// redaction past this window exactly like an older turn's would be. Mirrors Anthropic's own
-// `clear_tool_uses` (`keep: {type: "tool_uses", value: N}`), which has no turn concept either.
-// Starting point, tune against production metrics.
+// redaction past this window exactly like an older turn's would be. Starting point, tune against
+// production metrics.
 export const TOOL_RESULTS_TO_PRESERVE = 10;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
@@ -188,8 +187,7 @@ function redactFlat(
  * Redacts tool results across the whole conversation, previous interactions and the current,
  * in-progress one combined, as one flat sequence, oldest eligible first. No exemption for the
  * current turn: a long tool-call chain within it becomes eligible past toolResultsToPreserve
- * exactly like an older turn's would (mirrors Anthropic's own `clear_tool_uses`, which has no turn
- * concept either).
+ * exactly like an older turn's would.
  *
  * Takes and returns `InteractionWithTokens[]`, flattening and re-slicing internally so callers
  * never juggle a flat view and an interaction view themselves. Only ever replaces a function


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/28751.

A single agent turn used to be exempt from pruning as long as it was the one currently being answered, so a long tool-calling loop inside one response could grow the prompt without bound. This changes the redaction mechanism to look at tool results by plain recency across the entire conversation, current turn included, so an old tool call from three steps into the response being written right now gets treated exactly like an old tool call from three turns ago. Similar to how most context-editing feature work natively, having no notion of a current turn either.

Dropping a turn entirely, rather than just blanking out one of its tool results, still only ever happens to a whole turn at once, never partially, so a tool call can never end up separated from its result and an uploaded file can never end up separated from the message it belongs to. The turn actually being answered is never dropped under any circumstance, only ever redacted.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
