### PR TITLE
[front] fix: align description size limit with Skill Builder in skill authoring

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,5 +1,5 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import {
   SKILL_REINFORCEMENT_MODES,
   SkillWithoutInstructionsAndToolsSchema,

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,6 +1,6 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
 import {
-  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
   SKILL_REINFORCEMENT_MODES,
   SkillWithoutInstructionsAndToolsSchema,
 } from "@app/types/assistant/skill_configuration";

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -1,5 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -67,6 +68,7 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
         .describe("Short description shown to users browsing skills."),
       agentFacingDescription: z
         .string()
+        .max(AGENT_FACING_DESCRIPTION_MAX_LENGTH)
         .describe(
           "Description used by agents to decide when to use the skill."
         ),
@@ -112,6 +114,7 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
         .describe("New short description shown to users browsing skills."),
       agentFacingDescription: z
         .string()
+        .max(AGENT_FACING_DESCRIPTION_MAX_LENGTH)
         .optional()
         .describe("New description used by agents to decide when to use it."),
       instructions: z

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -1,6 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -12,7 +12,7 @@ import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinf
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -12,14 +12,12 @@ import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinf
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import {
-  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
-  type SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { UserType } from "@app/types/user";

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -5,11 +5,9 @@ import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context"
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { SKILL_INSTRUCTION_HTML_EDIT_PROMPT } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
 import logger from "@app/logger/logger";
-import {
-  AGENT_FACING_DESCRIPTION_MAX_LENGTH,
-  type SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 const ASSEMBLY_ORDER = [
   "primary_goal",

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -5,7 +5,7 @@ import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context"
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { SKILL_INSTRUCTION_HTML_EDIT_PROMPT } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -31,7 +31,7 @@ import {
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -31,8 +31,8 @@ import {
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/constants";
 import logger from "@app/logger/logger";
-import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/lib/skills/constants.ts
+++ b/front/lib/skills/constants.ts
@@ -1,0 +1,2 @@
+// Maximum length (in characters) of a skill's agent-facing description.
+export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;

--- a/front/lib/skills/constants.ts
+++ b/front/lib/skills/constants.ts
@@ -1,2 +1,0 @@
-// Maximum length (in characters) of a skill's agent-facing description.
-export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;

--- a/front/lib/skills/labels.ts
+++ b/front/lib/skills/labels.ts
@@ -1,5 +1,5 @@
 // Maximum length (in characters) of a skill's agent-facing description.
-export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
+export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 1_000;
 
 export const SKILL_INVOCATION_LABEL = "When to use this skill";
 export const SKILL_INSTRUCTIONS_LABEL = "Instructions";

--- a/front/lib/skills/labels.ts
+++ b/front/lib/skills/labels.ts
@@ -1,2 +1,5 @@
+// Maximum length (in characters) of a skill's agent-facing description.
+export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
+
 export const SKILL_INVOCATION_LABEL = "When to use this skill";
 export const SKILL_INSTRUCTIONS_LABEL = "Instructions";

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -9,9 +9,6 @@ export type SkillStatus = (typeof SKILL_STATUSES)[number];
 export const SKILL_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
 export type SkillReinforcementMode = (typeof SKILL_REINFORCEMENT_MODES)[number];
 
-// Maximum length (in characters) of a skill's agent-facing description.
-export const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
-
 export const SKILL_VIEWS = ["full", "summary"] as const;
 export type SkillViewType = (typeof SKILL_VIEWS)[number];
 


### PR DESCRIPTION
## Description

Skill authoring could create or update skills with agent-facing descriptions longer than the 750-character limit enforced by Skill Builder. This PR fixes that.

Also bumps the limit to a round 1k.

Not too convinced we need this limit, but at the very least the xp should be the exact same between the tools and manual actions in Skill Builder.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
