### PR TITLE
Resolve path-backed interactive file citations

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -1,6 +1,7 @@
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
 import type { FileEntry } from "@app/components/file_explorer/types";
 import {
+  fetchFileIdFromPath,
   getFileDownloadUrl,
   getFilePathDownloadUrl,
   getFilePathViewUrl,
@@ -25,10 +26,12 @@ interface PreviewableFile {
 
 type FilePreviewContextType = {
   openFilePreview: (file: PreviewableFile) => void;
+  resolveFileIdFromPath: (filePath: string) => Promise<string | null>;
 };
 
 const FilePreviewContext = createContext<FilePreviewContextType>({
   openFilePreview: () => {},
+  resolveFileIdFromPath: () => Promise.resolve(null),
 });
 
 interface FilePreviewProviderProps {
@@ -83,13 +86,21 @@ export function FilePreviewProvider({
     [owner]
   );
 
+  const resolveFileIdFromPath = useCallback(
+    (filePath: string) => fetchFileIdFromPath({ owner, filePath }),
+    [owner]
+  );
+
   const handleDownload = useCallback(async () => {
     if (previewState?.downloadUrl) {
       window.open(previewState.downloadUrl, "_blank");
     }
   }, [previewState?.downloadUrl]);
 
-  const contextValue = useMemo(() => ({ openFilePreview }), [openFilePreview]);
+  const contextValue = useMemo(
+    () => ({ openFilePreview, resolveFileIdFromPath }),
+    [openFilePreview, resolveFileIdFromPath]
+  );
 
   return (
     <FilePreviewContext.Provider value={contextValue}>

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -74,7 +74,7 @@ export function AttachmentCitation({
     "filePath" in attachmentCitation ? attachmentCitation.filePath : undefined;
 
   // Interactive content (spreadsheets etc.): open side panel instead of preview dialog.
-  // Only possible when we have a fileId (the side panel API requires it).
+  // Path-backed interactive citations are handled by PreviewableCitation below.
   if (
     fileId &&
     !isLoading &&

--- a/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
+++ b/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
@@ -3,9 +3,15 @@ import type {
   FileCitationCardSize,
 } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
+import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { isSupportedImageContentType } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  isSupportedImageContentType,
+} from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   Citation,
   CitationImage,
@@ -14,6 +20,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
+import { useContext } from "react";
 
 interface PreviewableCitationProps {
   containerClassName?: string;
@@ -52,10 +59,36 @@ export function PreviewableCitation({
   tooltipLabel,
   variant = "card",
 }: PreviewableCitationProps) {
-  const { openFilePreview } = useFilePreviewContext();
+  const { openFilePreview, resolveFileIdFromPath } = useFilePreviewContext();
+  const sendNotification = useSendNotification();
+  const sidePanel = useContext(ConversationSidePanelContext);
 
-  const handleClick = () =>
+  const handleClick = async () => {
+    if (isInteractiveContentType(contentType) && sidePanel) {
+      try {
+        const resolvedFileId =
+          fileId ?? (filePath ? await resolveFileIdFromPath(filePath) : null);
+
+        if (!resolvedFileId) {
+          throw new Error("No linked file was found for this Frame.");
+        }
+
+        sidePanel.openPanel({
+          type: "interactive_content",
+          fileId: resolvedFileId,
+        });
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to open Frame",
+          description: normalizeError(error).message,
+        });
+      }
+      return;
+    }
+
     openFilePreview({ fileId, filePath, title, contentType });
+  };
 
   if (variant === "inline") {
     const FileIcon = getFileTypeIcon(contentType, title);

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -1,16 +1,27 @@
+import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
 import {
   getFilePreviewDirectivePaths,
   getFilePreviewMarkdownDirective,
 } from "@app/lib/markdown/file_preview";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { DUST_FILE_ID_HEADER, frameContentType } from "@app/types/files";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { filePreviewDirective, getFilePreviewPlugin } from "./FilePreviewBlock";
 
 const mockOwner = LightWorkspaceFactory.build({
   sId: "w_test_ws",
+});
+
+const mockClientFetch = vi.fn();
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 type DirectiveNode = {
@@ -140,6 +151,56 @@ describe("getFilePreviewPlugin", () => {
     expect(
       screen.getByRole("button", { name: "Download" })
     ).toBeInTheDocument();
+  });
+
+  it("opens Frame files in the interactive content side panel", async () => {
+    const FilePreview = getFilePreviewPlugin();
+    const openPanel = vi.fn();
+    mockClientFetch.mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: { [DUST_FILE_ID_HEADER]: "fil_frame" },
+      })
+    );
+
+    render(
+      <ConversationSidePanelContext.Provider
+        value={{
+          currentPanel: undefined,
+          openPanel,
+          togglePanel: vi.fn(),
+          closePanel: vi.fn(),
+          onPanelClosed: vi.fn(),
+          setPanelRef: vi.fn(),
+          panelRef: { current: null },
+          setVirtuosoMsg: vi.fn(),
+          virtuosoMsg: null,
+          data: undefined,
+        }}
+      >
+        <FilePreviewProvider owner={mockOwner}>
+          <FilePreview
+            path="conversation-c1/frame.tsx"
+            title="frame.tsx"
+            contentType={frameContentType}
+          />
+        </FilePreviewProvider>
+      </ConversationSidePanelContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "frame.tsx" }));
+
+    await waitFor(() => {
+      expect(openPanel).toHaveBeenCalledWith({
+        type: "interactive_content",
+        fileId: "fil_frame",
+      });
+    });
+    expect(mockClientFetch).toHaveBeenCalledWith(
+      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
+      { method: "HEAD" }
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("infers the file name from the scoped path when metadata is absent", () => {

--- a/front/lib/swr/files.test.ts
+++ b/front/lib/swr/files.test.ts
@@ -1,0 +1,86 @@
+import {
+  fetchFileIdFromPath,
+  getFilePathContentApiPath,
+} from "@app/lib/swr/files";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClientFetch = vi.fn();
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}));
+
+const owner = LightWorkspaceFactory.build({ sId: "w_test_ws" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("file path API", () => {
+  it("encodes each scoped path segment", () => {
+    const canonicalPath = "conversation-c1/reports/frame draft@2.tsx";
+
+    expect(getFilePathContentApiPath(owner, canonicalPath)).toBe(
+      "/api/w/w_test_ws/files/path/conversation-c1/reports/frame%20draft%402.tsx"
+    );
+  });
+});
+
+describe("fetchFileIdFromPath", () => {
+  it("fetches the linked file id with HEAD", async () => {
+    mockClientFetch.mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: {
+          [DUST_FILE_ID_HEADER]: "fil_frame",
+        },
+      })
+    );
+
+    await expect(
+      fetchFileIdFromPath({
+        owner,
+        filePath: "conversation-c1/frame.tsx",
+      })
+    ).resolves.toBe("fil_frame");
+    expect(mockClientFetch).toHaveBeenCalledWith(
+      "/api/w/w_test_ws/files/path/conversation-c1/frame.tsx?metadata=1",
+      { method: "HEAD" }
+    );
+  });
+
+  it("returns null for a missing path", async () => {
+    mockClientFetch.mockResolvedValue(new Response(null, { status: 404 }));
+
+    await expect(
+      fetchFileIdFromPath({
+        owner,
+        filePath: "conversation-c1/missing.tsx",
+      })
+    ).resolves.toBeNull();
+    expect(mockClientFetch).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when the path has no linked file", async () => {
+    mockClientFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await expect(
+      fetchFileIdFromPath({
+        owner,
+        filePath: "conversation-c1/unlinked.tsx",
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("throws for unexpected responses", async () => {
+    mockClientFetch.mockResolvedValue(new Response(null, { status: 500 }));
+
+    await expect(
+      fetchFileIdFromPath({
+        owner,
+        filePath: "conversation-c1/frame.tsx",
+      })
+    ).rejects.toThrow("Failed to fetch file metadata (HTTP 500).");
+  });
+});

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -20,6 +20,7 @@ import type {
   FileTypeWithMetadata,
   SharingGrantType,
 } from "@app/types/files";
+import { DUST_FILE_ID_HEADER } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -61,6 +62,34 @@ export function getFilePathContentApiPath(
 ): string {
   const encoded = canonicalPath.split("/").map(encodeURIComponent).join("/");
   return `/api/w/${owner.sId}/files/path/${encoded}`;
+}
+
+function getFilePathMetadataApiPath(
+  owner: LightWorkspaceType,
+  canonicalPath: string
+): string {
+  return `${getFilePathContentApiPath(owner, canonicalPath)}?metadata=1`;
+}
+
+export async function fetchFileIdFromPath({
+  owner,
+  filePath,
+}: {
+  owner: LightWorkspaceType;
+  filePath: string;
+}): Promise<string | null> {
+  const response = await clientFetch(
+    getFilePathMetadataApiPath(owner, filePath),
+    { method: "HEAD" }
+  );
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file metadata (HTTP ${response.status}).`);
+  }
+
+  return response.headers.get(DUST_FILE_ID_HEADER);
 }
 
 type FileContentByUrlData =


### PR DESCRIPTION
## Description

Follow-up of #28304, which exposes the linked file id on path metadata responses.

Interactive-content panels use `fileId` as their canonical identity, while markdown file directives initially have only a scoped path. Resolve that path on click before opening the panel, keeping the panel API and URL state `fileId`-only. Non-interactive files keep the existing preview flow.

Stack: 1 of 2. Next: #28895.

## Tests

- Added HEAD resolution coverage for linked, unlinked, missing, and error responses.
- Added component coverage proving a path-backed Frame citation opens the panel with `fileId`.
- Ran the focused Vitest suites and full Front `tsgo --noEmit`.

## Risk

Low. Worst case, a path-backed interactive citation fails to resolve and shows an error notification. Existing file-id panel callers and non-interactive previews are unchanged. Safe to rollback.

## Deploy Plan

Deploy normally.