### PR TITLE
Open Frame directives in side panel

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -50,8 +50,9 @@ const SCOPED_PATH_HINT =
 
 const FILE_PREVIEW_DIRECTIVE_HINT =
   "To show a previewable file citation for a scoped file path in a final response, " +
-  `output the markdown directive \`${FILE_PREVIEW_DIRECTIVE_EXAMPLE}\`; include \`contentType\` when known. ` +
-  "The rendered citation opens the file preview, where the user can download the file. " +
+  `output the markdown directive \`${FILE_PREVIEW_DIRECTIVE_EXAMPLE}\`. ` +
+  "Always include `contentType` exactly as returned by this server; it is required to open Frame files in the side panel. " +
+  "The rendered citation opens Frame files in the side panel and other files in the file preview, where the user can download them. " +
   "Use the scoped path exactly as returned by this server and never invent an app URL for it.";
 
 const LIST_SCOPE_SCHEMA = z.discriminatedUnion("type", [

--- a/front/lib/markdown/file_preview.ts
+++ b/front/lib/markdown/file_preview.ts
@@ -222,7 +222,8 @@ export function getFilePreviewDirectiveInstruction({
     "Always place the previewable file directive inline within the sentence that mentions the file, " +
     "rather than as a standalone element at the end of the response. " +
     `For example: "Here is your file ${getFilePreviewMarkdownDirective({ contentType, path, title })}"\n` +
-    "The rendered link opens the file preview, where the user can download the file. " +
+    "The rendered link opens the appropriate file view: Frame files open in the side panel, " +
+    "and other files open the file preview where the user can download them. " +
     "Do not invent a URL for this file."
   );
 }


### PR DESCRIPTION
## Description

Follow-up to merged PR #28894.

Require agents to preserve the server-provided `contentType` in file preview directives. This lets the renderer recognize Frame files, resolve their scoped path to a `fileId`, and open the existing interactive side panel. Other file directives keep the existing preview flow.

## Tests

- Ran `lib/markdown/file_preview.test.ts`.
- Ran Biome on the changed files.
- Ran the full Front `tsgo --noEmit`.

## Risk

Low. This changes file-tool instructions only; runtime routing was merged in #28894. Safe to rollback.

## Deploy Plan

Deploy normally.