### PR TITLE
Clarified type for fetchActiveByWorkspaceModelId

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -518,17 +518,6 @@ export async function handleSubscriptionActivationSuccess({
   // Switch workspace DB subscription to CP_BUSINESS_PLAN.
   const activeSubscription =
     await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-  if (!activeSubscription) {
-    logger.error(
-      {
-        panic: true,
-        workspaceId: workspace.sId,
-        contractId,
-      },
-      "[Business Activation] No active subscription found during webhook success — cannot activate"
-    );
-    return;
-  }
 
   // Snapshot validation: ensure the Metronome contract on the active subscription
   // still matches what was captured at checkout time. If another checkout already

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1613,13 +1613,6 @@ export async function processMetronomeWebhook({
 
       const activeSubscription =
         await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-      if (!activeSubscription) {
-        logger.warn(
-          { contractId, customerId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: no active subscription"
-        );
-        break;
-      }
 
       // Idempotency: re-deliveries land here with the active subscription
       // already pointing at the new contract.

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -265,7 +265,7 @@ async function resolveMetronomeSubscriptionInvoiceCtx(
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );
-  if (!subscription) {
+  if (subscription.isLegacyFreeNoPlan()) {
     return null;
   }
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -295,7 +295,7 @@ async function resolveCreditPurchaseInvoiceCtx(
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );
-  if (!subscription) {
+  if (subscription.isLegacyFreeNoPlan()) {
     return null;
   }
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -261,14 +261,11 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
   private static async _fetchActiveByWorkspaceModelIdUncached(
     workspaceModelId: ModelId
-  ): Promise<CachedSubscription | null> {
+  ): Promise<CachedSubscription> {
     const res = await SubscriptionResource.fetchActiveByWorkspacesModelId([
       workspaceModelId,
     ]);
     const subscription = res[workspaceModelId];
-    if (!subscription) {
-      return null;
-    }
     return {
       id: subscription.id,
       planId: subscription.planId,
@@ -379,7 +376,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   static async fetchActiveByWorkspaceModelId(
     workspaceModelId: ModelId,
     transaction?: Transaction
-  ): Promise<SubscriptionResource | null> {
+  ): Promise<SubscriptionResource> {
     // Bypass cache when transaction is provided for transactional consistency
     if (transaction) {
       logger.info(
@@ -393,14 +390,11 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         [workspaceModelId],
         transaction
       );
-      return res[workspaceModelId] ?? null;
+      return res[workspaceModelId];
     }
 
     const cached =
       await this.fetchActiveByWorkspaceModelIdCached(workspaceModelId);
-    if (!cached) {
-      return null;
-    }
 
     return this.fromCachedData(workspaceModelId, cached);
   }


### PR DESCRIPTION
## Description

fetchActiveByWorkspaceModelId cannot return null/undefined as it was described in the type - this lead to invalid/dead code while testing if subscription is null. "No subscription" is actually always "FREE_NO_PLAN"

## Tests

locally

## Risk

low

## Deploy Plan

deploy front
