### PR TITLE
Include the provider in the cache diagnostics key

### DIFF
--- a/front/lib/api/llm/cache_diagnostics.ts
+++ b/front/lib/api/llm/cache_diagnostics.ts
@@ -13,16 +13,23 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 // migration: flip the flag off and the keys expire on their own.
 const CACHE_DIAGNOSTICS_TTL_SECONDS = 600;
 
-function makeCacheDiagnosticsKey({
-  conversationId,
-  agentConfigurationId,
-}: {
+export interface CacheDiagnosticsKey {
   conversationId: string;
   agentConfigurationId: string;
-}): string {
+  providerId: string;
+}
+
+function makeCacheDiagnosticsKey({
+  agentConfigurationId,
+  conversationId,
+  providerId,
+}: CacheDiagnosticsKey): string {
   // Include the agent so concurrent agents answering in the same conversation
   // (multiple mentions) keep independent chains instead of clobbering each other.
-  return `cache_diagnostics:${conversationId}:${agentConfigurationId}`;
+  // Include the provider so a mid-conversation provider switch starts a fresh
+  // chain instead of sending another provider's response id. The model is not
+  // needed: Providers already detect model changes across consecutive requests.
+  return `cache_diagnostics:${conversationId}:${agentConfigurationId}:${providerId}`;
 }
 
 // Returns the previous LLM call's response id for this conversation and agent,
@@ -31,10 +38,9 @@ function makeCacheDiagnosticsKey({
 //
 // Diagnostics is pure observability, so a Redis failure must never break
 // generation: on error we log and behave as if there were no prior id.
-export async function getPreviousMessageId(key: {
-  conversationId: string;
-  agentConfigurationId: string;
-}): Promise<string | null> {
+export async function getPreviousMessageId(
+  key: CacheDiagnosticsKey
+): Promise<string | null> {
   try {
     return await runOnRedisCache({ origin: "cache_diagnostics" }, (client) =>
       client.get(makeCacheDiagnosticsKey(key))
@@ -52,10 +58,7 @@ export async function getPreviousMessageId(key: {
 // Best-effort: a Redis failure is logged and swallowed so it cannot break the
 // agent loop.
 export async function setPreviousMessageId(
-  key: {
-    conversationId: string;
-    agentConfigurationId: string;
-  },
+  key: CacheDiagnosticsKey,
   modelInteractionId: string
 ): Promise<void> {
   try {

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -1,5 +1,6 @@
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
 import {
+  type CacheDiagnosticsKey,
   getPreviousMessageId,
   setPreviousMessageId,
 } from "@app/lib/api/llm/cache_diagnostics";
@@ -279,10 +280,12 @@ export async function getOutputFromLLMStream(
   // can report why the cache prefix diverged. Keyed by conversation and agent in
   // Redis so the chain survives across steps and user turns. `null` (no prior, or
   // expired) is still a valid opt-in value. `undefined` keeps the feature off.
-  const cacheDiagnosticsKey = {
+  const cacheDiagnosticsKey: CacheDiagnosticsKey = {
     conversationId: conversation.sId,
     agentConfigurationId: agentConfiguration.sId,
+    providerId: model.providerId,
   };
+
   const previousMessageId = cacheDiagnosticsEnabled
     ? await getPreviousMessageId(cacheDiagnosticsKey)
     : undefined;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The prompt-cache diagnostics chain stores the previous response id in Redis keyed by conversation and agent. With the recent addition of tweaking model mid-flight in the conversation we need to account for this, as the next request could send a response id issued by a different provider, which is invalid and would failed the whole API call. This adds the provider to the key so a provider switch simply starts a fresh chain. The model itself is deliberately not part of the key: providers already detect model changes across consecutive requests and reports them in the diagnostics payload, so keeping the chain across model switches is exactly what lets us observe them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
