### PR TITLE
Add HubSpot custom object lookup and write support

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -985,6 +985,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
+    "create_custom_object": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "create_deal": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -1069,6 +1073,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
+    "list_custom_object_schemas": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "list_email_campaigns": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -1102,6 +1110,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "advanced",
     },
     "update_contact": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_custom_object": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -2836,6 +2848,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "create_communication": "high",
     "create_company": "high",
     "create_contact": "high",
+    "create_custom_object": "high",
     "create_deal": "high",
     "create_lead": "high",
     "create_meeting": "high",
@@ -2857,6 +2870,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_user_activity": "never_ask",
     "list_association_labels": "never_ask",
     "list_associations": "never_ask",
+    "list_custom_object_schemas": "never_ask",
     "list_email_campaigns": "never_ask",
     "list_email_events": "never_ask",
     "list_marketing_emails": "never_ask",
@@ -2866,6 +2880,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "search_owners": "never_ask",
     "update_company": "high",
     "update_contact": "high",
+    "update_custom_object": "high",
     "update_deal": "high",
     "update_task": "high",
   },

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -57,7 +57,6 @@ export const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 type SimpleObjectType = (typeof SIMPLE_OBJECTS)[number];
 
 const SPECIAL_OBJECTS = ["owners"] as const;
-type SpecialObjectType = (typeof SPECIAL_OBJECTS)[number];
 
 export const ALL_OBJECTS = [...SIMPLE_OBJECTS, ...SPECIAL_OBJECTS] as const;
 
@@ -293,7 +292,7 @@ export const getObjectProperties = async ({
   creatableOnly,
 }: {
   accessToken: string;
-  objectType: SimpleObjectType | SpecialObjectType;
+  objectType: string;
   creatableOnly: boolean;
 }) => {
   const hubspotClient = new Client({ accessToken });
@@ -1182,19 +1181,7 @@ export const searchCrmObjects = async ({
   after,
 }: {
   accessToken: string;
-  objectType:
-    | SimpleObjectType
-    | "tasks"
-    | "notes"
-    | "meetings"
-    | "calls"
-    | "emails"
-    | "line_items"
-    | "quotes"
-    | "feedback_submissions"
-    | "products"
-    | "tickets"
-    | "leads";
+  objectType: string;
   filters?: Array<HubspotFilter>;
   query?: string;
   propertiesToReturn?: string[];
@@ -1224,11 +1211,30 @@ export const searchCrmObjects = async ({
     }
   }
 
+  const STANDARD_SORTABLE_OBJECT_TYPES = new Set([
+    "contacts",
+    "companies",
+    "deals",
+    "tasks",
+    "notes",
+    "meetings",
+    "calls",
+    "emails",
+    "products",
+    "line_items",
+    "quotes",
+    "feedback_submissions",
+    "tickets",
+    "leads",
+  ]);
+
   const searchRequest: HubspotSearchRequest = {
     filterGroups: filters
       ? [{ filters: buildHubspotFilters(filters, propertyTypes) }]
       : [],
-    sorts: ["-createdate"],
+    sorts: STANDARD_SORTABLE_OBJECT_TYPES.has(objectType)
+      ? ["-createdate"]
+      : undefined,
     properties: finalPropertiesToReturn,
     limit: Math.min(limit, MAX_LIMIT),
     after: after,
@@ -1312,9 +1318,11 @@ export const searchCrmObjects = async ({
           );
         break;
       default:
-        throw new Error(
-          `Search for object type "${objectType}" is not explicitly implemented. Add to switch.`
+        searchResponse = await hubspotClient.crm.objects.searchApi.doSearch(
+          objectType,
+          searchRequest
         );
+        break;
     }
 
     return {
@@ -1629,6 +1637,106 @@ export const deleteTask = async ({
     localLogger.error(
       { error, taskId },
       `Error deleting task with ID ${taskId}:`
+    );
+    throw normalizeError(error);
+  }
+};
+
+export const listCustomObjectSchemas = async ({
+  accessToken,
+}: {
+  accessToken: string;
+}) => {
+  const hubspotClient = new Client({ accessToken });
+  const response = await hubspotClient.crm.schemas.coreApi.getAll();
+
+  return response.results.map((schema) => ({
+    name: schema.name,
+    objectTypeId: schema.objectTypeId,
+    fullyQualifiedName: schema.fullyQualifiedName,
+    labels: schema.labels,
+    properties: schema.properties.map((p) => ({
+      name: p.name,
+      label: p.label,
+      type: p.type,
+    })),
+  }));
+};
+
+export const createCustomObject = async ({
+  accessToken,
+  objectType,
+  properties,
+  associations,
+}: {
+  accessToken: string;
+  objectType: string;
+  properties: Record<string, string>;
+  associations?: Array<{
+    toObjectId: string;
+    toObjectType: string;
+  }>;
+}): Promise<SimplePublicObject> => {
+  const hubspotClient = new Client({ accessToken });
+
+  const builtAssociations: SimplePublicObjectInputForCreate["associations"] =
+    [];
+
+  if (associations && associations.length > 0) {
+    for (const assoc of associations) {
+      const associationTypeId = await getAssociationTypeId(
+        accessToken,
+        objectType,
+        assoc.toObjectType
+      );
+      builtAssociations.push({
+        to: { id: assoc.toObjectId },
+        types: [
+          {
+            associationCategory:
+              AssociationSpecAssociationCategoryEnum.HubspotDefined,
+            associationTypeId,
+          },
+        ],
+      });
+    }
+  }
+
+  const objectData: SimplePublicObjectInputForCreate = {
+    properties,
+    associations: builtAssociations,
+  };
+
+  return hubspotClient.crm.objects.basicApi.create(objectType, objectData);
+};
+
+export const updateCustomObject = async ({
+  accessToken,
+  objectType,
+  objectId,
+  properties,
+}: {
+  accessToken: string;
+  objectType: string;
+  objectId: string;
+  properties: Record<string, string>;
+}): Promise<SimplePublicObject> => {
+  const hubspotClient = new Client({ accessToken });
+
+  const updateInput: SimplePublicObjectInput = {
+    properties,
+  };
+
+  try {
+    return await hubspotClient.crm.objects.basicApi.update(
+      objectType,
+      objectId,
+      updateInput
+    );
+  } catch (error) {
+    localLogger.error(
+      { error, objectType, objectId },
+      `Error updating custom object ${objectType} with ID ${objectId}:`
     );
     throw normalizeError(error);
   }

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -6,25 +6,15 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const ALL_OBJECTS = ["contacts", "companies", "deals", "owners"] as const;
 const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 
-const searchableObjectTypes = [
-  "contacts",
-  "companies",
-  "deals",
-  "tasks",
-  "notes",
-  "meetings",
-  "calls",
-  "emails",
-  "products",
-  "line_items",
-  "quotes",
-  "feedback_submissions",
-  "tickets",
-  "leads",
-] as const;
+const objectTypeSchema = z
+  .string()
+  .describe(
+    `The HubSpot object type: a standard object type name, or — for custom ` +
+      `objects — the object type ID (e.g. "2-12345") or fully-qualified name, ` +
+      `discoverable via list_custom_object_schemas.`
+  );
 
 const filterSchema = z.object({
   propertyName: z.string().describe("The name of the property to search by."),
@@ -70,13 +60,28 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     description:
       "List all available properties for a Hubspot object. When creatableOnly is true, returns only properties that can be modified through forms (excludes hidden, calculated, read-only and file upload fields).",
     schema: {
-      objectType: z.enum(ALL_OBJECTS),
+      objectType: objectTypeSchema,
       creatableOnly: z.boolean().optional(),
     },
     stake: "never_ask",
     displayLabels: {
       running: "Retrieving HubSpot object properties",
       done: "Retrieve HubSpot object properties",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  list_custom_object_schemas: {
+    description:
+      "List all custom object types (schemas) defined in the HubSpot account, " +
+      "with their type IDs, fully-qualified names, and properties. Use this to " +
+      "discover the object type to pass to search_crm_objects, get_object_properties, " +
+      "create_custom_object, and update_custom_object.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing HubSpot custom object schemas",
+      done: "List HubSpot custom object schemas",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
@@ -179,7 +184,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   search_crm_objects: {
     description:
       "Search, filter, read, open, or retrieve HubSpot records: contacts, companies, deals, " +
-      "leads, tickets, and activity records (tasks, notes, meetings, calls, emails). " +
+      "leads, tickets, activity records (tasks, notes, meetings, calls, emails), and custom objects. " +
       "Filter by any property to: open or read a single contact, company, or deal record " +
       "by its id (hs_object_id EQ <id>); find a contact or company by email; " +
       "find contacts at a company; search deals by close date or amount; " +
@@ -190,7 +195,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       "get_object_properties first to discover the exact values. " +
       "For comprehensive user activity across all types, use get_user_activity.",
     schema: {
-      objectType: z.enum(searchableObjectTypes),
+      objectType: objectTypeSchema,
       filters: z
         .array(filterSchema)
         .optional()
@@ -215,7 +220,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     description:
       "Export CRM objects of a given type to CSV, with filters, property selection, and row limits. The resulting file is available for table queries.",
     schema: {
-      objectType: z.enum(searchableObjectTypes),
+      objectType: objectTypeSchema,
       propertiesToExport: z
         .array(z.string())
         .min(1)
@@ -714,6 +719,28 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
+  create_custom_object: {
+    description:
+      "Create a new custom object record in Hubspot, with optional associations. " +
+      "Use list_custom_object_schemas to find the object type and its properties.",
+    schema: {
+      objectType: objectTypeSchema,
+      properties: z
+        .record(z.string())
+        .describe("An object containing the properties for the custom object."),
+      associations: z
+        .array(associationSchema)
+        .optional()
+        .describe("Optional array of associations to create."),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Creating HubSpot custom object",
+      done: "Create HubSpot custom object",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
   create_association: {
     description:
       "Create an association between two existing HubSpot objects (e.g., associate a contact with a company). " +
@@ -801,6 +828,27 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Updating HubSpot deal",
       done: "Update HubSpot deal",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  update_custom_object: {
+    description:
+      "Update properties of a HubSpot custom object record by ID. Use " +
+      "list_custom_object_schemas to find the object type and its properties.",
+    schema: {
+      objectType: objectTypeSchema,
+      objectId: z.string().describe("The ID of the custom object to update."),
+      properties: z
+        .record(z.string())
+        .describe(
+          "An object containing the properties to update with their new values."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Updating HubSpot custom object",
+      done: "Update HubSpot custom object",
     },
     toolCostCategory: "advanced",
     freeUsage: false,

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -7,6 +7,7 @@ import {
   createCommunication,
   createCompany,
   createContact,
+  createCustomObject,
   createDeal,
   createLead,
   createMeeting,
@@ -26,6 +27,7 @@ import {
   getUserDetails,
   listAssociationLabels,
   listAssociations,
+  listCustomObjectSchemas,
   listEmailCampaigns,
   listEmailEvents,
   listMarketingEmails,
@@ -36,6 +38,7 @@ import {
   searchOwners,
   updateCompany,
   updateContact,
+  updateCustomObject,
   updateDeal,
   updateTask,
 } from "@app/lib/api/actions/servers/hubspot/client";
@@ -75,6 +78,27 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
       return new Ok([
         { type: "text" as const, text: "Properties retrieved successfully" },
         { type: "text" as const, text: formattedText },
+      ]);
+    });
+  },
+
+  list_custom_object_schemas: async (_params, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const schemas = await listCustomObjectSchemas({ accessToken });
+      if (!schemas.length) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "No custom object schemas found in this HubSpot account.",
+          },
+        ]);
+      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Found ${schemas.length} custom object schema(s).`,
+        },
+        { type: "text" as const, text: JSON.stringify(schemas, null, 2) },
       ]);
     });
   },
@@ -695,6 +719,27 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
     });
   },
 
+  create_custom_object: async (
+    { objectType, properties, associations },
+    extra
+  ) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await createCustomObject({
+        accessToken,
+        objectType,
+        properties,
+        associations,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Custom object (${objectType}) created successfully.`,
+        },
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
   create_association: async (
     {
       fromObjectType,
@@ -766,6 +811,24 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
         properties,
       });
       return new Ok([
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ]);
+    });
+  },
+
+  update_custom_object: async ({ objectType, objectId, properties }, extra) => {
+    return withAuth(extra, async (accessToken) => {
+      const result = await updateCustomObject({
+        accessToken,
+        objectType,
+        objectId,
+        properties,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Custom object (${objectType}) updated successfully.`,
+        },
         { type: "text" as const, text: JSON.stringify(result, null, 2) },
       ]);
     });

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -44,6 +44,7 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       "crm.objects.owners.read",
       "crm.schemas.custom.read",
       "crm.objects.custom.read",
+      "crm.objects.custom.write",
       "crm.objects.quotes.read",
       "crm.objects.line_items.read",
       "files",


### PR DESCRIPTION
## Description

Solves [HubSpot MCP] Enable custom object lookup and write  [#9061](https://github.com/dust-tt/tasks/issues/9061)
Adds HubSpot custom object support to the MCP server by extending the existing read tools (`search_crm_objects`, `get_object_properties`) to accept dynamic custom object type IDs, adding a `list_custom_object_schemas` discovery tool, and adding generic create_custom_object / update_custom_object write tools (gated by the new `crm.objects.custom.write` scope).

## Tests

Tested manually locally. 

## Risk

Low 
## Deploy Plan

Add scope crm.objects.custom.write to prod and then deploy