### PR TITLE
[front] fix: constrain Sidekick model suggestions to per-model reasoning efforts

### DIFF
--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -1780,6 +1780,39 @@ describe("agent_sidekick_context tools", () => {
       }
     });
 
+    it("returns error when suggesting an unsupported reasoning effort for the model", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const { getAgentConfigurationIdFromContext } = await import(
+        "@app/lib/api/actions/servers/agent_sidekick_helpers"
+      );
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agentConfiguration.sId
+      );
+
+      const tool = getToolByName("suggest_model");
+      // claude-sonnet-4-6 does not support reasoningEffort "none".
+      const result = await tool.handler(
+        {
+          suggestion: {
+            modelId: "claude-sonnet-4-6",
+            reasoningEffort: "none",
+          },
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Invalid reasoning effort");
+        expect(result.error.message).toContain("none");
+        expect(result.error.message).toContain("claude-sonnet-4-6");
+      }
+    });
+
     it("returns error when suggesting a model not available in the UI", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -67,6 +67,7 @@ import {
 } from "@app/types/assistant/conversation";
 import { isAgentMention } from "@app/types/assistant/mentions";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
+import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -1133,16 +1134,33 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
 
   suggest_model: async (params, { auth, runContext }) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
-    const availableModelIds = availableModels.map((m) => m.modelId);
 
-    const { modelId } = params.suggestion;
-    if (!availableModelIds.includes(modelId)) {
+    const { modelId, reasoningEffort } = params.suggestion;
+    const modelConfiguration = availableModels.find(
+      (m) => m.modelId === modelId
+    );
+    if (!modelConfiguration) {
       return new Err(
         new MCPError(
           `Invalid model ID: ${modelId}. Check <workspace_context> for valid model IDs.`,
           { tracked: false }
         )
       );
+    }
+
+    if (reasoningEffort) {
+      const supportedReasoningEfforts = getAvailableReasoningEfforts(
+        modelConfiguration.supportedReasoningEfforts
+      );
+      if (!supportedReasoningEfforts.includes(reasoningEffort)) {
+        return new Err(
+          new MCPError(
+            `Invalid reasoning effort "${reasoningEffort}" for model ${modelId}. ` +
+              `Supported reasoning efforts for this model: ${supportedReasoningEfforts.join(", ")}.`,
+            { tracked: false }
+          )
+        );
+      }
     }
 
     const agentConfigurationId = getAgentConfigurationIdFromContext({

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -13,6 +13,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
@@ -45,10 +46,16 @@ export function formatAvailableModels(
   const sections = Array.from(byProvider.entries()).map(
     ([provider, providerModels]) => {
       const modelLines = providerModels
-        .map(
-          (m) =>
-            `- **${m.displayName}** (modelId: ${m.modelId}): ${m.description}${m.supportsVision ? " (vision)" : " (no vision)"}`
-        )
+        .map((m) => {
+          const reasoningEfforts = getAvailableReasoningEfforts(
+            m.supportedReasoningEfforts
+          );
+          const reasoningInfo =
+            reasoningEfforts.length > 1
+              ? ` (supported reasoning efforts: ${reasoningEfforts.join(", ")})`
+              : "";
+          return `- **${m.displayName}** (modelId: ${m.modelId}): ${m.description}${m.supportsVision ? " (vision)" : " (no vision)"}${reasoningInfo}`;
+        })
         .join("\n");
       return `<provider id="${provider}">\n${modelLines}\n</provider>`;
     }


### PR DESCRIPTION
## Description

Sidekick could suggest `reasoningEffort: "none"` on a model even when the builder UI's reasoning-effort picker doesn't offer "none" for that model, so the suggestion couldn't be replicated manually.

Root cause: `suggest_model`'s schema validated `reasoningEffort` against the global `ORDERED_REASONING_EFFORTS` list rather than the target model's `supportedReasoningEfforts`, which is what the builder picker actually uses (`getAvailableReasoningEfforts`).

Changes:
- `suggest_model` handler now checks the suggested `reasoningEffort` against the model's `supportedReasoningEfforts` and returns an error listing the valid options if it's not supported.
- `formatAvailableModels` (Sidekick's model context) now includes each model's supported reasoning efforts, so it has a chance to pick a valid one up front instead of relying on the guardrail.

Fixes #9578

## Tests

Added a regression test using `claude-sonnet-4-6` (which doesn't support `none`) asserting `suggest_model` now errors out. Ran the full `agent_sidekick_context` test suite (63 tests, all passing).

## Risk

Low. Scoped to the Sidekick `suggest_model` tool; the new validation only rejects an already-invalid input, it doesn't change behavior for valid inputs.

## Deploy Plan

Standard deploy, no migration or feature flag involved.