### PR TITLE
Use selected Spaces for runtime skill scope

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -126,14 +126,19 @@ app.post(
       attachments,
     });
 
-    const { enabledSkills, systemSkills, equippedSkills } =
-      await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration,
-        conversation,
-      });
+    const {
+      effectiveSpaceIds,
+      enabledSkills,
+      systemSkills,
+      equippedSkills,
+      hasSelectedSpacesOutsideAgentScope,
+    } = await SkillResource.listForAgentLoop(auth, {
+      agentConfiguration,
+      conversation,
+    });
 
     const { skillServers, systemSkillServers } = await getSkillServers(auth, {
-      agentConfiguration,
+      effectiveSpaceIds,
       systemSkills,
       enabledSkills,
     });
@@ -214,6 +219,7 @@ app.post(
       systemSkills,
       projectContext,
       isNewFileExplorer,
+      hasSelectedSpacesOutsideAgentScope,
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -48,12 +48,12 @@ async function findAvailableSkillForAgentLoop({
   agentLoopData: AgentLoopExecutionData;
   skillName: string;
 }): Promise<SkillResource | null> {
-  const { enabledSkills, equippedSkills, systemSkills } =
+  const { effectiveSpaceIds, enabledSkills, equippedSkills, systemSkills } =
     await SkillResource.listForAgentLoop(auth, agentLoopData);
   const userMessageSkills = await SkillResource.fetchByIds(
     auth,
     extractSkillIdsFromConversationMessages(agentLoopData),
-    { agentLoopData, onlyActive: true }
+    { agentLoopData, effectiveSpaceIds, onlyActive: true }
   );
   const directlyAllowedSkills = [
     ...enabledSkills,
@@ -76,6 +76,7 @@ async function findAvailableSkillForAgentLoop({
   );
   const candidate = await SkillResource.fetchByName(auth, skillName, {
     agentLoopData,
+    effectiveSpaceIds,
   });
   if (!candidate) {
     return null;

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -26,6 +26,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { Result } from "@app/types/shared/result";
@@ -331,6 +332,36 @@ describe("selected conversation Spaces", () => {
         conversation: conv,
       })
     ).resolves.toEqual([globalSpace.sId, validSelectedSpace.sId]);
+  });
+
+  it("keeps a selected Space that becomes open", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const conv = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: conv,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+    const globalGroupResult = await GroupResource.fetchWorkspaceGlobalGroup(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    if (globalGroupResult.isErr()) {
+      throw globalGroupResult.error;
+    }
+    await GroupSpaceFactory.associate(selectedSpace, globalGroupResult.value);
+
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: conv,
+      })
+    ).resolves.toEqual([globalSpace.sId, selectedSpace.sId]);
   });
 
   it("copies valid selected Spaces to a child conversation", async () => {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -295,6 +295,62 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(ephemeralContext).toHaveLength(0);
   });
 
+  it("should keep selected-space-scoped prompt sections out of cached tiers", () => {
+    const deepDiveConfig = {
+      ...agentConfig1,
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+      scope: "global" as const,
+    };
+
+    const baseParams = {
+      userMessage: userMessage1,
+      agentConfiguration: withoutModel(deepDiveConfig),
+      model: agentLoopModel(agentConfig1, modelConfig),
+      hasAvailableActions: true,
+      systemSkills: [],
+    };
+
+    const cachedSections = normalizePrompt(
+      constructPromptMultiActions(authenticator1, baseParams)
+    );
+    expect(cachedSections.instructions[0]?.content).toContain("## SKILLS");
+    expect(
+      cachedSections.sharedContext.some((section) =>
+        section.content.trim().startsWith("# TOOLS")
+      )
+    ).toBe(true);
+    expect(
+      cachedSections.ephemeralContext.some(
+        (section) =>
+          section.content.includes("## SKILLS") ||
+          section.content.trim().startsWith("# TOOLS")
+      )
+    ).toBe(false);
+
+    const scopedSections = normalizePrompt(
+      constructPromptMultiActions(authenticator1, {
+        ...baseParams,
+        hasSelectedSpacesOutsideAgentScope: true,
+      })
+    );
+    expect(scopedSections.instructions[0]?.content).not.toContain("## SKILLS");
+    expect(
+      scopedSections.sharedContext.some((section) =>
+        section.content.trim().startsWith("# TOOLS")
+      )
+    ).toBe(true);
+    expect(
+      scopedSections.ephemeralContext.some((section) =>
+        section.content.includes("## SKILLS")
+      )
+    ).toBe(true);
+    expect(
+      scopedSections.ephemeralContext.some((section) =>
+        section.content.trim().startsWith("# TOOLS")
+      )
+    ).toBe(false);
+  });
+
   it("should place workspace context in shared tier and user context in ephemeral tier for sidekick agent", () => {
     const sidekickConfig = {
       ...agentConfig1,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -394,6 +394,7 @@ export function constructPromptMultiActions(
     isNewFileExplorer = false,
     hasSandboxTools = false,
     disableFormattingPrompt = false,
+    hasSelectedSpacesOutsideAgentScope = false,
   }: {
     userMessage: AgentLoopExecutionData["userMessage"];
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
@@ -410,6 +411,7 @@ export function constructPromptMultiActions(
     isNewFileExplorer?: boolean;
     hasSandboxTools?: boolean;
     disableFormattingPrompt?: boolean;
+    hasSelectedSpacesOutsideAgentScope?: boolean;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -463,17 +465,18 @@ export function constructPromptMultiActions(
     // Structured form with 3 cache tiers, ordered from most stable to most volatile.
     //
     // Instructions (long cache): stable per agent config, covering agent instructions, skills,
-    // format docs, and guidelines.
+    // format docs, and guidelines. If selected conversation Spaces are active, skill
+    // instructions can depend on per-conversation scope and must stay out of this tier.
     //
-    // Shared context (short cache): workspace-scoped data shared across users, covering the tools
-    // section (directives + server listing), date, toolsets, and workspace info. A cache breakpoint
-    // here lets different users in the same workspace share this prefix.
+    // Shared context (short cache): workspace-scoped data shared across users, covering tool-use
+    // directives, date, toolsets, and workspace info. A cache breakpoint here lets different
+    // users in the same workspace share this prefix.
     //
-    // Ephemeral context (no breakpoint): per-call data, covering branch lineage,
-    // platform-specific context, and user profile.
+    // Ephemeral context (no breakpoint): per-call data, covering selected-space-scoped skill
+    // instructions, branch lineage, platform-specific context, and user profile.
     const fullInstructions = [
       instructionsContent,
-      skillsSection,
+      ...(hasSelectedSpacesOutsideAgentScope ? [] : [skillsSection]),
       attachmentsSection,
       pastedContentSection,
       guidelinesSection,
@@ -481,10 +484,8 @@ export function constructPromptMultiActions(
       .filter((s) => s.trim() !== "")
       .join("\n");
 
-    // The tools section (directives + available-servers overview) lives in the shared-context
-    // (5min) tier rather than the instructions (1h) tier: its per-server listing and instructions
-    // change whenever a (conditional) JIT server is added mid-run, so keeping it out of the
-    // instructions block lets that block stay cache-stable across server additions.
+    // The tools section lives in the shared-context (5min) tier rather than the instructions (1h)
+    // tier because conversation state can change its directives between runs.
     const sharedContext: SystemPromptContext[] = [
       { role: "context" as const, content: toolsSection },
       { role: "context" as const, content: contextSection },
@@ -493,6 +494,11 @@ export function constructPromptMultiActions(
     ].filter((s) => s.content.trim() !== "");
 
     const ephemeralContext: SystemPromptContext[] = [
+      ...(hasSelectedSpacesOutsideAgentScope
+        ? ([
+            { role: "context" as const, content: skillsSection },
+          ] satisfies SystemPromptContext[])
+        : []),
       { role: "context" as const, content: branchContextSection },
       { role: "context" as const, content: platformSpecificContextSection },
       { role: "context" as const, content: userContext ?? "" },

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -2,16 +2,106 @@ import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configur
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SKILL_COMPANY_DATA_SERVER_NAME } from "@app/lib/resources/skill/code_defined/shared";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { describe, expect, it } from "vitest";
 
 describe("resolveSkillMCPServers", () => {
+  it("includes selected Spaces in Discover Knowledge scope", async () => {
+    const { authenticator, globalSpace, user, workspace } =
+      await createResourceTest({ role: "admin" });
+    await FeatureFlagFactory.basic(
+      authenticator,
+      "restricted_spaces_in_input_bar"
+    );
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+    const selectedSpace = await SpaceFactory.regular(workspace);
+    const addMemberResult = await selectedSpace.addMembers(authenticator, {
+      userIds: [user.sId],
+    });
+    expect(addMemberResult.isOk()).toBe(true);
+    await authenticator.refresh();
+
+    const selectedDataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      selectedSpace,
+      user
+    );
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    await ConversationSelectedSpaceResource.upsertForConversation(
+      authenticator,
+      {
+        conversation,
+        origin: "input_bar",
+        spaces: [selectedSpace],
+      }
+    );
+
+    const [discoverKnowledge] = await SkillResource.fetchByIds(authenticator, [
+      "discover_knowledge",
+    ]);
+    expect(discoverKnowledge).toBeDefined();
+    if (!discoverKnowledge) {
+      throw new Error("Expected Discover Knowledge skill.");
+    }
+    await SkillResource.addManyToAgent(authenticator, {
+      agentConfiguration,
+      skills: [discoverKnowledge],
+    });
+
+    const { hasSelectedSpacesOutsideAgentScope } =
+      await SkillResource.listForAgentLoop(authenticator, {
+        agentConfiguration,
+        conversation,
+      });
+    expect(hasSelectedSpacesOutsideAgentScope).toBe(true);
+
+    const agentWithSelectedSpace =
+      await AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "Agent with selected Space in scope",
+        requestedSpaceIds: [globalSpace.id, selectedSpace.id],
+      });
+    const subsetScope = await SkillResource.listForAgentLoop(authenticator, {
+      agentConfiguration: agentWithSelectedSpace,
+      conversation,
+    });
+    expect(subsetScope.hasSelectedSpacesOutsideAgentScope).toBe(false);
+
+    const { systemSkillServers } = await resolveSkillMCPServers(authenticator, {
+      agentConfiguration,
+      conversation,
+    });
+    const companyDataServer = systemSkillServers
+      .filter(isServerSideMCPServerConfiguration)
+      .find((server) => server.name === SKILL_COMPANY_DATA_SERVER_NAME);
+
+    expect(companyDataServer?.dataSources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dataSourceViewId: selectedDataSourceView.sId,
+        }),
+      ])
+    );
+  });
+
   it("exposes one set of company data tools when Discover Knowledge and Go Deep are enabled", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -15,7 +15,6 @@ import {
   SkillResource,
 } from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
@@ -72,11 +71,11 @@ function skillMCPServerConfigToServerSideConfig(
 export async function getSkillServers(
   auth: Authenticator,
   {
-    agentConfiguration,
+    effectiveSpaceIds,
     enabledSkills,
     systemSkills,
   }: {
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    effectiveSpaceIds: string[];
     enabledSkills: SkillResource[];
     systemSkills: SkillResource[];
   }
@@ -86,7 +85,7 @@ export async function getSkillServers(
   if (skills.some((skill) => skill.inheritsAgentConfigurationDataSources)) {
     inheritedDataSourceViews = await DataSourceViewResource.listBySpaceIds(
       auth,
-      agentConfiguration.requestedSpaceIds,
+      effectiveSpaceIds,
       { includeGlobalSpace: true }
     );
   }
@@ -313,16 +312,14 @@ export async function resolveSkillMCPServers(
     conversation: ConversationType;
   }
 ): Promise<ResolvedSkillMCPServers> {
-  const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
-    auth,
-    {
+  const { effectiveSpaceIds, enabledSkills, systemSkills } =
+    await SkillResource.listForAgentLoop(auth, {
       agentConfiguration,
       conversation,
-    }
-  );
+    });
 
   return getSkillServers(auth, {
-    agentConfiguration,
+    effectiveSpaceIds,
     enabledSkills,
     systemSkills,
   });

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1689,6 +1689,7 @@ describe("SkillResource", () => {
             conversation,
             userMessage,
           },
+          effectiveSpaceIds: agentConfiguration.requestedSpaceIds,
           onlyActive: true,
         }
       );

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2,6 +2,7 @@ import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configurati
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
+import { getEffectiveSpaceIdsForAgentRun } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { updateConversationRequirementsForSkills } from "@app/lib/api/assistant/conversation/skill_permissions";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import {
@@ -571,11 +572,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
       transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
-    const { agentLoopData, transaction } = context;
+    const {
+      agentLoopData,
+      effectiveSpaceIds: providedEffectiveSpaceIds,
+      transaction,
+    } = context;
 
     const {
       where,
@@ -803,10 +809,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       (def) => !agentLoopData || !def.isDisabledForAgentLoop?.(agentLoopData)
     );
 
+    assert(
+      !agentLoopData || providedEffectiveSpaceIds !== undefined,
+      "effectiveSpaceIds must be provided with agentLoopData"
+    );
+    const effectiveSpaceIds = providedEffectiveSpaceIds ?? [];
     const requestedSpaceModelIds = removeNulls(
-      (agentLoopData?.agentConfiguration?.requestedSpaceIds ?? []).map(
-        getResourceIdFromSId
-      )
+      effectiveSpaceIds.map(getResourceIdFromSId)
     );
 
     // Batch-fetch MCP server views for all enabled global skills in a single query.
@@ -836,6 +845,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       (def) =>
         this.fromGlobalSkill(auth, def, {
           agentLoopData,
+          effectiveSpaceIds,
           mcpServerViews,
           withInstructions,
         }),
@@ -894,8 +904,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     sIds: string[],
     {
       agentLoopData,
+      effectiveSpaceIds,
       onlyActive = false,
-    }: { agentLoopData?: AgentLoopExecutionData; onlyActive?: boolean } = {}
+    }: {
+      agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
+      onlyActive?: boolean;
+    } = {}
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -929,14 +944,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           status: onlyActive ? ["active"] : ["active", "archived", "suggested"],
         },
       },
-      { agentLoopData }
+      { agentLoopData, effectiveSpaceIds }
     );
   }
 
   static async fetchByName(
     auth: Authenticator,
     name: string,
-    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
+    {
+      agentLoopData,
+      effectiveSpaceIds,
+    }: {
+      agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
+    } = {}
   ): Promise<SkillResource | null> {
     const resources = await this.baseFetch(
       auth,
@@ -946,7 +967,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         limit: 1,
       },
-      { agentLoopData }
+      { agentLoopData, effectiveSpaceIds }
     );
 
     if (resources.length === 0) {
@@ -1071,6 +1092,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }[],
     {
       agentLoopData,
+      effectiveSpaceIds,
       status,
       transaction,
       withInstructions,
@@ -1078,6 +1100,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
       withInstructions?: boolean;
@@ -1100,7 +1123,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         withTools,
         withFileAttachments,
       },
-      { agentLoopData, transaction }
+      { agentLoopData, effectiveSpaceIds, transaction }
     );
   }
 
@@ -1118,7 +1141,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async listByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
-    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
+    {
+      agentLoopData,
+      effectiveSpaceIds,
+    }: {
+      agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
+    } = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
@@ -1131,6 +1160,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
+      effectiveSpaceIds,
     });
   }
 
@@ -1320,8 +1350,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     {
       agentLoopData,
+      effectiveSpaceIds,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
     } = {}
   ): Promise<SkillResource[]> {
     return this.baseFetch(
@@ -1332,7 +1364,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           isDefault: true,
         },
       },
-      { agentLoopData }
+      { agentLoopData, effectiveSpaceIds }
     );
   }
 
@@ -1451,11 +1483,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       conversation,
       agentConfiguration,
       agentLoopData,
+      effectiveSpaceIds,
       transaction,
     }: {
       conversation: ConversationWithoutContentType;
       agentConfiguration?: AgentConfigurationWithoutModelType;
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
       transaction?: Transaction;
     }
   ): Promise<SkillResource[]> {
@@ -1481,6 +1515,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchBySkillReferences(auth, conversationSkills, {
       agentLoopData,
+      effectiveSpaceIds,
       transaction,
     });
   }
@@ -1490,9 +1525,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       conversation,
       agentLoopData,
+      effectiveSpaceIds,
     }: {
       conversation: ConversationWithoutContentType;
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
     }
   ): Promise<SkillResource[]> {
     if (!isPodConversation(conversation)) {
@@ -1506,6 +1543,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchByIds(auth, projectMetadata?.defaultSkillIds ?? [], {
       agentLoopData,
+      effectiveSpaceIds,
       onlyActive: true,
     });
   }
@@ -1520,6 +1558,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           conversation: ConversationWithoutContentType;
         }
   ): Promise<{
+    effectiveSpaceIds: string[];
+    hasSelectedSpacesOutsideAgentScope: boolean;
     enabledSkills: SkillResource[];
     systemSkills: SkillResource[];
     equippedSkills: SkillResource[];
@@ -1527,6 +1567,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const { agentConfiguration, conversation } = params;
     // Light type-guard to check whether we have a full AgentLoopExecutionData.
     const agentLoopData = "userMessage" in params ? params : undefined;
+    const effectiveSpaceIds = await getEffectiveSpaceIdsForAgentRun(auth, {
+      agentConfiguration,
+      conversation,
+    });
+    const requestedSpaceIds = new Set(agentConfiguration.requestedSpaceIds);
+    const hasSelectedSpacesOutsideAgentScope = effectiveSpaceIds.some(
+      (spaceId) => !requestedSpaceIds.has(spaceId)
+    );
 
     const conversationEnabledSkills = await this.listEnabledByConversation(
       auth,
@@ -1534,24 +1582,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversation,
         agentConfiguration,
         agentLoopData,
+        effectiveSpaceIds,
       }
     );
 
     const podDefaultSkills = await this.listPodDefaultSkillsForConversation(
       auth,
-      { conversation, agentLoopData }
+      { conversation, agentLoopData, effectiveSpaceIds }
     );
 
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      { agentLoopData }
+      { agentLoopData, effectiveSpaceIds }
     );
 
     let discoverableSkills: SkillResource[] = [];
     if (allAgentSkills.some((s) => s.globalSId === "discover_skills")) {
       discoverableSkills = await this.listDiscoverable(auth, {
         agentLoopData,
+        effectiveSpaceIds,
       });
     }
 
@@ -1600,12 +1650,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const autoEnabledSkills = autoEnabledSkillRefs.length
       ? await this.fetchBySkillReferences(auth, autoEnabledSkillRefs, {
           agentLoopData,
+          effectiveSpaceIds,
         })
       : [];
 
     const autoEquippedSkills = autoEquippedSkillRefs.length
       ? await this.fetchBySkillReferences(auth, autoEquippedSkillRefs, {
           agentLoopData,
+          effectiveSpaceIds,
           withInstructions: false,
           withTools: false,
           withFileAttachments: false,
@@ -1642,6 +1694,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return {
+      effectiveSpaceIds,
+      hasSelectedSpacesOutsideAgentScope,
       systemSkills: systemSkills.sort(sortByName),
       enabledSkills: conversationEnabledSkills
         .filter((s) => !systemSkillIds.has(s.sId))
@@ -1767,20 +1821,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: SkillDefinition,
     {
       agentLoopData,
+      effectiveSpaceIds,
       mcpServerViews,
       withInstructions = true,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds: string[];
       mcpServerViews: MCPServerViewResource[];
       withInstructions?: boolean;
     }
   ): Promise<SkillResource> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const { agentConfiguration } = agentLoopData ?? {};
-    const requestedSpaceIds = agentConfiguration?.requestedSpaceIds ?? [];
     const requestedSpaceModelIds = removeNulls(
-      requestedSpaceIds.map(getResourceIdFromSId)
+      effectiveSpaceIds.map(getResourceIdFromSId)
     );
 
     const viewsByServerId = groupBy(
@@ -1801,7 +1855,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const instructions = withInstructions
       ? def.fetchInstructions
         ? await def.fetchInstructions(auth, {
-            spaceIds: requestedSpaceIds,
+            spaceIds: effectiveSpaceIds,
             agentLoopData,
           })
         : def.instructions

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -101,14 +101,19 @@ makeScript(
       attachments,
     });
 
-    const { enabledSkills, systemSkills, equippedSkills } =
-      await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration,
-        conversation,
-      });
+    const {
+      effectiveSpaceIds,
+      enabledSkills,
+      systemSkills,
+      equippedSkills,
+      hasSelectedSpacesOutsideAgentScope,
+    } = await SkillResource.listForAgentLoop(auth, {
+      agentConfiguration,
+      conversation,
+    });
 
     const { skillServers, systemSkillServers } = await getSkillServers(auth, {
-      agentConfiguration,
+      effectiveSpaceIds,
       enabledSkills,
       systemSkills,
     });
@@ -189,6 +194,7 @@ makeScript(
       systemSkills,
       projectContext,
       isNewFileExplorer,
+      hasSelectedSpacesOutsideAgentScope,
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -168,13 +168,11 @@ async function listAvailableTools(
       userMessage.context.clientSideMCPServerIds
     );
 
-  const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
-    auth,
-    runAgentData
-  );
+  const { effectiveSpaceIds, enabledSkills, systemSkills } =
+    await SkillResource.listForAgentLoop(auth, runAgentData);
 
   const { skillServers, systemSkillServers } = await getSkillServers(auth, {
-    agentConfiguration,
+    effectiveSpaceIds,
     enabledSkills,
     systemSkills,
   });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -476,6 +476,7 @@ export async function runModel(
     systemSkills,
     equippedSkills,
     serverToolsAndInstructions: mcpActions,
+    hasSelectedSpacesOutsideAgentScope,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
     const jitServers = await getJITServers(auth, {
@@ -494,11 +495,16 @@ export async function runModel(
         clientSideMCPServerIds
       );
 
-    const { enabledSkills, systemSkills, equippedSkills } =
-      await SkillResource.listForAgentLoop(auth, runAgentData);
+    const {
+      effectiveSpaceIds,
+      enabledSkills,
+      systemSkills,
+      equippedSkills,
+      hasSelectedSpacesOutsideAgentScope,
+    } = await SkillResource.listForAgentLoop(auth, runAgentData);
 
     const { skillServers, systemSkillServers } = await getSkillServers(auth, {
-      agentConfiguration,
+      effectiveSpaceIds,
       enabledSkills,
       systemSkills,
     });
@@ -519,6 +525,7 @@ export async function runModel(
     );
 
     return {
+      hasSelectedSpacesOutsideAgentScope,
       enabledSkills,
       equippedSkills,
       systemSkills,
@@ -611,6 +618,7 @@ export async function runModel(
     isNewFileExplorer,
     hasSandboxTools,
     disableFormattingPrompt,
+    hasSelectedSpacesOutsideAgentScope,
   });
   const leadingMessages = removeNulls([
     renderEquippedSkillsUserMessage(equippedSkills),


### PR DESCRIPTION
## Stack

1. #29142 - Allow selecting open Spaces in conversations (merged)
2. #27545 - Add selected Space runtime validation helpers (merged)
3. **#28905 - Use selected Spaces for runtime skill scope**
4. #28906 - Inherit selected Spaces in sub-agent conversations
5. #28911 - Cover sub-agent cleanup boundaries

This PR is **374 changed lines** against `main`.

## Why

Selected Spaces are persisted in the conversation ACL, but runtime skill and tool resolution still uses only the agent configuration's Spaces. Runtime must use the same validated per-conversation scope without recomputing it at each consumer or moving selected-Space instructions into the long-lived prompt cache.

## What changed

- Computes effective Space IDs in `SkillResource.listForAgentLoop` using the merged validation helper.
- Threads that scope through custom and global skill loading, MCP server views, skill instructions, and skill-management lookups.
- Returns `hasSelectedSpacesOutsideAgentScope` from the same computation for prompt-cache placement.
- Applies the scope in the normal agent loop, prompt commands, investigation tooling, and the Poke conversation renderer.
- Requires callers with agent-loop data to provide the already-computed scope.
- Adds focused coverage for selected-Space data sources, subset handling, open Space transitions, and prompt placement.

## Risk

Runtime scope widens only with active selected regular Spaces that remain readable. Agent-configured Spaces remain included. Selected-Space-dependent instructions stay outside the long-lived cache tier only when the conversation adds Spaces outside the agent's configured scope. No API schema or migration changes are included.

## Deploy plan

- [x] Merge and deploy #29142 and #27545.
- [ ] Merge this PR.
- [ ] Deploy `front` and `front-api`.
- [ ] Monitor selected-Space access failures and skill or MCP resolution errors.
- [ ] Merge #28906, then test-only #28911.

## Verification

- Focused runtime stack suite: 116 tests
- `npm run tsgo -- --noEmit` in `front`
- `npm run tsgo -- --noEmit` in `front-api`
- `npx biome check` on changed TypeScript files
- `git diff --check`
