### PR TITLE
Inherit selected Spaces in sub-agent conversations

### DIFF
--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -377,7 +377,7 @@ describe("getOrCreateConversation", () => {
     const childConversation = {
       sId: generateRandomModelSId(),
     } as ConversationPublicType;
-    const childConversationResource = {} as ConversationResource;
+    const childConversationResource = ConversationResource.prototype;
     const mockCreateConversation = vi.fn().mockResolvedValue(
       new Ok({
         conversation: childConversation,

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -1,7 +1,9 @@
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { getOrCreateConversation } from "@app/lib/api/actions/servers/run_agent/conversation";
+import * as conversationDestroy from "@app/lib/api/assistant/conversation/destroy";
 import type { Authenticator } from "@app/lib/auth";
 import { getApiKeyNameHeader } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -9,13 +11,22 @@ import type {
   ConversationType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { decodeUtf8HeaderValue } from "@app/types/shared/utils/http_headers";
 import { getHeaderFromUserEmail } from "@app/types/user";
-import type { ConversationPublicType } from "@dust-tt/client";
+import type { APIError, ConversationPublicType } from "@dust-tt/client";
 import { DustAPI } from "@dust-tt/client";
 import assert from "assert";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCopySelectedConversationSpacesToChild } = vi.hoisted(() => ({
+  mockCopySelectedConversationSpacesToChild: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/conversation/selected_spaces", () => ({
+  copySelectedConversationSpacesToChild:
+    mockCopySelectedConversationSpacesToChild,
+}));
 
 function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
   mainConversation: ConversationType;
@@ -112,30 +123,42 @@ function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
 }
 
 function createMockApi(
-  createConversationImpl: DustAPI["createConversation"]
+  createConversationImpl: DustAPI["createConversation"],
+  conversation: ConversationPublicType
 ): DustAPI {
   return {
     createConversation: createConversationImpl,
-    getConversation: vi.fn(),
-    postUserMessage: vi.fn(),
+    getConversation: vi.fn().mockResolvedValue(new Ok(conversation)),
+    postUserMessage: vi.fn().mockResolvedValue(
+      new Ok({
+        sId: generateRandomModelSId(),
+      })
+    ),
   } as unknown as DustAPI;
 }
 
 describe("getOrCreateConversation", () => {
+  beforeEach(() => {
+    mockCopySelectedConversationSpacesToChild.mockReset();
+    mockCopySelectedConversationSpacesToChild.mockResolvedValue(
+      new Ok(undefined)
+    );
+  });
+
   it("forwards the parent conversation spaceId when creating a sub-conversation", async () => {
     const spaceId = generateRandomModelSId();
     const { mainConversation, originMessage, mainAgent, agentLoopContext } =
       buildRunAgentFixtures({ spaceId });
 
+    const childConversation = {
+      sId: generateRandomModelSId(),
+    } as ConversationPublicType;
     const mockCreateConversation = vi.fn().mockResolvedValue(
       new Ok({
-        conversation: {
-          sId: generateRandomModelSId(),
-        } as ConversationPublicType,
-        message: { sId: generateRandomModelSId() },
+        conversation: childConversation,
       })
     );
-    const api = createMockApi(mockCreateConversation);
+    const api = createMockApi(mockCreateConversation, childConversation);
 
     const result = await getOrCreateConversation(
       api,
@@ -163,21 +186,37 @@ describe("getOrCreateConversation", () => {
         depth: mainConversation.depth + 1,
       })
     );
+    expect(mockCreateConversation.mock.calls[0][0]).not.toHaveProperty(
+      "message"
+    );
+    expect(mockCopySelectedConversationSpacesToChild).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        parentConversation: mainConversation,
+        childConversationId: childConversation.sId,
+      }
+    );
+    expect(api.postUserMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: childConversation.sId })
+    );
+    expect(
+      mockCopySelectedConversationSpacesToChild.mock.invocationCallOrder[0]
+    ).toBeLessThan(vi.mocked(api.postUserMessage).mock.invocationCallOrder[0]);
   });
 
   it("omits spaceId when the parent conversation has no space", async () => {
     const { mainConversation, originMessage, mainAgent, agentLoopContext } =
       buildRunAgentFixtures({ spaceId: null });
 
+    const childConversation = {
+      sId: generateRandomModelSId(),
+    } as ConversationPublicType;
     const mockCreateConversation = vi.fn().mockResolvedValue(
       new Ok({
-        conversation: {
-          sId: generateRandomModelSId(),
-        } as ConversationPublicType,
-        message: { sId: generateRandomModelSId() },
+        conversation: childConversation,
       })
     );
-    const api = createMockApi(mockCreateConversation);
+    const api = createMockApi(mockCreateConversation, childConversation);
 
     const result = await getOrCreateConversation(
       api,
@@ -330,5 +369,103 @@ describe("getOrCreateConversation", () => {
         "jérôme.łukasz@example.com"
       );
     });
+  });
+
+  it("cleans up a new child conversation when selected Space inheritance fails", async () => {
+    const { mainConversation, originMessage, mainAgent, agentLoopContext } =
+      buildRunAgentFixtures({ spaceId: null });
+    const childConversation = {
+      sId: generateRandomModelSId(),
+    } as ConversationPublicType;
+    const childConversationResource = {} as ConversationResource;
+    const mockCreateConversation = vi.fn().mockResolvedValue(
+      new Ok({
+        conversation: childConversation,
+      })
+    );
+    const api = createMockApi(mockCreateConversation, childConversation);
+    const fetchChildSpy = vi
+      .spyOn(ConversationResource, "fetchById")
+      .mockResolvedValue(childConversationResource);
+    const destroyConversationSpy = vi
+      .spyOn(conversationDestroy, "destroyConversation")
+      .mockResolvedValue(new Ok(undefined));
+    mockCopySelectedConversationSpacesToChild.mockResolvedValueOnce(
+      new Err(new Error("copy failed"))
+    );
+
+    const result = await getOrCreateConversation(
+      api,
+      {} as Authenticator,
+      agentLoopContext,
+      {
+        childAgentBlob: { name: "ChildAgent", description: "A child agent" },
+        childAgentId: generateRandomModelSId(),
+        mainAgent,
+        originMessage,
+        mainConversation,
+        query: "Do something",
+        toolsetsToAdd: null,
+        fileOrContentFragmentIds: null,
+        filePaths: null,
+        conversationId: null,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(fetchChildSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      childConversation.sId
+    );
+    expect(destroyConversationSpy).toHaveBeenCalledWith(expect.anything(), {
+      conversation: childConversationResource,
+    });
+    expect(api.postUserMessage).not.toHaveBeenCalled();
+
+    fetchChildSpy.mockRestore();
+    destroyConversationSpy.mockRestore();
+  });
+
+  it("does not clean up a child conversation after an ambiguous post failure", async () => {
+    const { mainConversation, originMessage, mainAgent, agentLoopContext } =
+      buildRunAgentFixtures({ spaceId: null });
+    const childConversation = {
+      sId: generateRandomModelSId(),
+    } as ConversationPublicType;
+    const mockCreateConversation = vi.fn().mockResolvedValue(
+      new Ok({
+        conversation: childConversation,
+      })
+    );
+    const api = createMockApi(mockCreateConversation, childConversation);
+    vi.mocked(api.postUserMessage).mockResolvedValueOnce(
+      new Err({
+        type: "internal_server_error",
+        message: "socket hang up",
+      } as APIError)
+    );
+    const fetchChildSpy = vi.spyOn(ConversationResource, "fetchById");
+
+    const result = await getOrCreateConversation(
+      api,
+      {} as Authenticator,
+      agentLoopContext,
+      {
+        childAgentBlob: { name: "ChildAgent", description: "A child agent" },
+        childAgentId: generateRandomModelSId(),
+        mainAgent,
+        originMessage,
+        mainConversation,
+        query: "Do something",
+        toolsetsToAdd: null,
+        fileOrContentFragmentIds: null,
+        filePaths: null,
+        conversationId: null,
+      }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(fetchChildSpy).not.toHaveBeenCalled();
+    fetchChildSpy.mockRestore();
   });
 });

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -353,7 +353,7 @@ describe("getOrCreateConversation", () => {
       );
 
       assert(result.isOk());
-      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests).toHaveLength(3);
       const headers = capturedRequests[0].headers;
       // Values with characters above 0xFF (ł, emoji) travel as an RFC 2047
       // encoded-word and round-trip losslessly through the header.

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -12,9 +12,12 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
+import { copySelectedConversationSpacesToChild } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -26,6 +29,7 @@ import type {
   ConversationPublicType,
   DustAPI,
   PublicPostContentFragmentRequestBody,
+  PublicPostMessagesRequestBody,
 } from "@dust-tt/client";
 
 /**
@@ -40,6 +44,89 @@ function isUserSideError(error: APIError): boolean {
     error.type === "plan_message_limit_exceeded" ||
     error.type === "rate_limit_error"
   );
+}
+
+async function cleanupSubConversationAfterSetupFailure(
+  auth: Authenticator,
+  conversationId: string
+): Promise<void> {
+  try {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return;
+    }
+
+    const result = await destroyConversation(auth, { conversation });
+    if (result.isErr()) {
+      throw result.error;
+    }
+  } catch (error) {
+    logger.error(
+      { error, conversationId },
+      "Failed to clean up sub-conversation after setup failure"
+    );
+  }
+}
+
+async function postMessageAndFetchConversation(
+  api: DustAPI,
+  {
+    conversationId,
+    message,
+    onPostMessageError,
+  }: {
+    conversationId: string;
+    message: PublicPostMessagesRequestBody;
+    onPostMessageError?: () => Promise<void>;
+  }
+): Promise<
+  Result<
+    { conversation: ConversationPublicType; userMessageId: string },
+    MCPError
+  >
+> {
+  const messageRes = await api.postUserMessage({ conversationId, message });
+  if (messageRes.isErr()) {
+    const isUserSide = isUserSideError(messageRes.error);
+    const isTransient = isTransientNetworkError(messageRes.error);
+    if (!isTransient) {
+      await onPostMessageError?.();
+    }
+    return new Err(
+      new MCPError(
+        isUserSide ? messageRes.error.message : "Failed to create message",
+        {
+          cause: messageRes.error,
+          tracked: !isUserSide && !isTransient,
+        }
+      )
+    );
+  }
+
+  const conversationRes = await api.getConversation({ conversationId });
+  if (conversationRes.isErr()) {
+    const isUserSide = isUserSideError(conversationRes.error);
+    const isTransient = isTransientNetworkError(conversationRes.error);
+    return new Err(
+      new MCPError(
+        isUserSide
+          ? conversationRes.error.message
+          : "Failed to get conversation",
+        {
+          cause: conversationRes.error,
+          tracked: !isUserSide && !isTransient,
+        }
+      )
+    );
+  }
+
+  return new Ok({
+    conversation: conversationRes.value,
+    userMessageId: messageRes.value.sId,
+  });
 }
 
 export async function getOrCreateConversation(
@@ -181,66 +268,44 @@ export async function getOrCreateConversation(
 
   parentOrigin = parentMessage.context.origin ?? null;
 
+  const makeSubAgentMessage = (
+    type: "run_agent" | "agent_handover"
+  ): PublicPostMessagesRequestBody => ({
+    content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${queryWithFilePaths}`,
+    mentions: [{ configurationId: childAgentId }],
+    context: {
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      username: mainAgent.name,
+      fullName: `@${mainAgent.name}`,
+      email: null,
+      profilePictureUrl: mainAgent.pictureUrl,
+      origin: parentOrigin,
+      selectedMCPServerViewIds: toolsetsToAdd,
+    },
+    agenticMessageData: {
+      // `run_agent` type will skip adding the conversation to the user history.
+      type,
+      originMessageId: originMessage.sId,
+    },
+    skipToolsValidation:
+      type === "run_agent"
+        ? (agentMessage.skipToolsValidation ?? false)
+        : false,
+  });
+
   if (conversationId) {
     const agenticMessageType =
       mainConversation.sId !== conversationId ? "run_agent" : "agent_handover";
-    const messageRes = await api.postUserMessage({
+    const result = await postMessageAndFetchConversation(api, {
       conversationId,
-      message: {
-        content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${queryWithFilePaths}`,
-        mentions: [{ configurationId: childAgentId }],
-        context: {
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          username: mainAgent.name,
-          fullName: `@${mainAgent.name}`,
-          email: null,
-          profilePictureUrl: mainAgent.pictureUrl,
-          origin: parentOrigin,
-          selectedMCPServerViewIds: toolsetsToAdd,
-        },
-        agenticMessageData: {
-          // `run_agent` type will skip adding the conversation to the user history.
-          type: agenticMessageType,
-          originMessageId: originMessage.sId,
-        },
-      },
+      message: makeSubAgentMessage(agenticMessageType),
     });
-
-    if (messageRes.isErr()) {
-      const isUserSide = isUserSideError(messageRes.error);
-      const isTransient = isTransientNetworkError(messageRes.error);
-      const message = isUserSide
-        ? messageRes.error.message
-        : "Failed to create message";
-      return new Err(
-        new MCPError(message, {
-          cause: messageRes.error,
-          tracked: !isUserSide && !isTransient,
-        })
-      );
-    }
-
-    const convRes = await api.getConversation({
-      conversationId,
-    });
-
-    if (convRes.isErr()) {
-      const isUserSide = isUserSideError(convRes.error);
-      const isTransient = isTransientNetworkError(convRes.error);
-      const message = isUserSide
-        ? convRes.error.message
-        : "Failed to get conversation";
-      return new Err(
-        new MCPError(message, {
-          cause: convRes.error,
-          tracked: !isUserSide && !isTransient,
-        })
-      );
+    if (result.isErr()) {
+      return result;
     }
 
     return new Ok({
-      conversation: convRes.value,
-      userMessageId: messageRes.value.sId,
+      ...result.value,
       isNewConversation: true,
     });
   }
@@ -250,26 +315,7 @@ export async function getOrCreateConversation(
     visibility: "unlisted",
     depth: mainConversation.depth + 1,
     spaceId: mainConversation.spaceId ?? undefined,
-    message: {
-      content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${queryWithFilePaths}`,
-      mentions: [{ configurationId: childAgentId }],
-      context: {
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        username: mainAgent.name,
-        fullName: `@${mainAgent.name}`,
-        email: null,
-        profilePictureUrl: mainAgent.pictureUrl,
-        origin: parentOrigin,
-        selectedMCPServerViewIds: toolsetsToAdd,
-      },
-      agenticMessageData: {
-        // `run_agent` type will skip adding the conversation to the user history.
-        type: "run_agent",
-        originMessageId: originMessage.sId,
-      },
-    },
     contentFragments,
-    skipToolsValidation: agentMessage.skipToolsValidation ?? false,
   });
 
   if (convRes.isErr()) {
@@ -297,10 +343,22 @@ export async function getOrCreateConversation(
     );
   }
 
-  const { conversation, message: createdUserMessage } = convRes.value;
+  const { conversation } = convRes.value;
 
-  if (!createdUserMessage) {
-    return new Err(new MCPError("Failed to retrieve the created message."));
+  const selectedSpacesResult = await copySelectedConversationSpacesToChild(
+    auth,
+    {
+      parentConversation: mainConversation,
+      childConversationId: conversation.sId,
+    }
+  );
+  if (selectedSpacesResult.isErr()) {
+    await cleanupSubConversationAfterSetupFailure(auth, conversation.sId);
+    return new Err(
+      new MCPError("Failed to inherit selected Spaces", {
+        cause: selectedSpacesResult.error,
+      })
+    );
   }
 
   const copyRes = await copyConversationFilesIntoSub(auth, {
@@ -309,12 +367,22 @@ export async function getOrCreateConversation(
     filePaths: resolvedFilePaths,
   });
   if (copyRes.isErr()) {
+    await cleanupSubConversationAfterSetupFailure(auth, conversation.sId);
     return copyRes;
   }
 
+  const result = await postMessageAndFetchConversation(api, {
+    conversationId: conversation.sId,
+    message: makeSubAgentMessage("run_agent"),
+    onPostMessageError: () =>
+      cleanupSubConversationAfterSetupFailure(auth, conversation.sId),
+  });
+  if (result.isErr()) {
+    return result;
+  }
+
   return new Ok({
-    conversation,
+    ...result.value,
     isNewConversation: true,
-    userMessageId: createdUserMessage.sId,
   });
 }

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -61,7 +61,10 @@ async function cleanupSubConversationAfterSetupFailure(
 
     const result = await destroyConversation(auth, { conversation });
     if (result.isErr()) {
-      throw result.error;
+      logger.error(
+        { error: result.error, conversationId },
+        "Failed to clean up sub-conversation after setup failure"
+      );
     }
   } catch (error) {
     logger.error(
@@ -92,7 +95,7 @@ async function postMessageAndFetchConversation(
   if (messageRes.isErr()) {
     const isUserSide = isUserSideError(messageRes.error);
     const isTransient = isTransientNetworkError(messageRes.error);
-    if (!isTransient) {
+    if (isUserSide) {
       await onPostMessageError?.();
     }
     return new Err(


### PR DESCRIPTION
## Stack

1. #29142 - Allow selecting open Spaces in conversations (merged)
2. #27545 - Add selected Space runtime validation helpers (merged)
3. #28905 - Use selected Spaces for runtime skill scope (merged)
4. **#28906 - Inherit selected Spaces in sub-agent conversations**
5. #28911 - Cover sub-agent cleanup boundaries

This PR is **394 changed lines** against `main`.

## Why

A `run_agent` child starts a new agent loop. Its selected Spaces must be materialized before the first child message starts generation; copying them afterward is too late for runtime skill and tool resolution.

## What changed

- Creates new child conversations without their first message.
- Copies valid selected Spaces from the parent while preserving the original `selectedByUserId`, including userless and system-key runs.
- Copies conversation files after Space inheritance, then posts the first child message and fetches the current conversation.
- Cleans up a newly created child when selected-Space or file setup fails before posting.
- Cleans up user-side post rejections while retaining children after ambiguous server-side failures that may have committed and started generation.
- Preserves existing handover behavior and tool-validation semantics.
- Adds focused tests for inheritance ordering, setup cleanup, transient post failures, and existing Space propagation.

## Risk

Child creation becomes a deliberate multi-step operation. Definite pre-post and user-side post failures are cleaned up best-effort. Ambiguous server failures leave the child intact to avoid deleting an active generation. Existing conversations and handovers continue through the same message-post path. No schema or migration changes are included.

## Deploy plan

- [x] Merge and deploy #29142, #27545, and #28905.
- [ ] Merge this PR and deploy `front`.
- [ ] Monitor `run_agent` child-conversation creation, selected-Space inheritance, and cleanup errors.
- [ ] Merge test-only #28911.

## Verification

- `NODE_ENV=test npm test lib/api/actions/servers/run_agent/conversation.test.ts`: 5 tests in this PR, 9 with #28911
- Focused runtime stack suite at the stack tip: 116 tests
- `npm run tsgo -- --noEmit` in `front`
- `npx biome check` on changed TypeScript files
- `git diff --check`
