### PR TITLE
fix(oauth): audience field + clearer DCR error for MCP static OAuth

### DIFF
--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -527,21 +527,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       }
     }
 
-    // Some authorization servers only support pre-registered (static) clients and don't
-    // advertise a registration endpoint at all. Attempting DCR in that case always fails and
-    // the resulting error is misleading (it looks like a failed registration attempt rather
-    // than "this server doesn't support automatic setup").
-    if (!metadata.registration_endpoint) {
-      return new Err(
-        new DustError(
-          "internal_error",
-          "This server does not support automatic OAuth setup (no dynamic client " +
-            "registration endpoint). Please use Static OAuth with the client ID/secret " +
-            "provided by the server's OAuth application."
-        )
-      );
-    }
-
     try {
       // Try DCR.
       const fullInformation = await registerClient(serverUrl, {
@@ -574,16 +559,16 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       };
       return new Ok(connectionMetadata);
     } catch (e) {
-      logger.error(
-        { error: e },
-        "Failed to register client, this server might require a pre-approval process."
-      );
-      return new Err(
-        new DustError(
-          "internal_error",
-          "Failed to register client, this server might require a pre-approval process. Please contact support@dust.com."
-        )
-      );
+      // Servers that don't advertise a registration_endpoint don't support DCR at all — the
+      // failure isn't a broken registration attempt, it's expected, and Static OAuth is the
+      // right path.
+      const message = metadata.registration_endpoint
+        ? "Failed to register client, this server might require a pre-approval process. Please contact support@dust.com."
+        : "This server does not support automatic OAuth setup (no dynamic client registration " +
+          "endpoint). Please use Static OAuth with the client ID/secret provided by the " +
+          "server's OAuth application.";
+      logger.error({ error: e }, message);
+      return new Err(new DustError("internal_error", message));
     }
   }
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -527,6 +527,21 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       }
     }
 
+    // Some authorization servers only support pre-registered (static) clients and don't
+    // advertise a registration endpoint at all. Attempting DCR in that case always fails and
+    // the resulting error is misleading (it looks like a failed registration attempt rather
+    // than "this server doesn't support automatic setup").
+    if (!metadata.registration_endpoint) {
+      return new Err(
+        new DustError(
+          "internal_error",
+          "This server does not support automatic OAuth setup (no dynamic client " +
+            "registration endpoint). Please use Static OAuth with the client ID/secret " +
+            "provided by the server's OAuth application."
+        )
+      );
+    }
+
     try {
       // Try DCR.
       const fullInformation = await registerClient(serverUrl, {

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -409,6 +409,15 @@ export function getProviderRequiredOAuthCredentialInputs({
             helpMessage: "The scope(s) to request (space separated list).",
             validator: isValidScope,
           },
+          resource: {
+            label: "OAuth Resource / Audience",
+            value: undefined,
+            helpMessage:
+              "The resource or audience identifier (RFC 8707) your MCP " +
+              "server expects in the access token. Required if your OAuth " +
+              "server issues audience-scoped tokens.",
+            validator: isValidOptionalResource,
+          },
           token_endpoint_auth_method: {
             label: "Token Endpoint Authentication Method",
             value: "client_secret_post",
@@ -566,6 +575,11 @@ export function isValidTokenEndpointAuthMethod(s: unknown): s is string {
     typeof s === "string" &&
     (s === "client_secret_post" || s === "client_secret_basic")
   );
+}
+
+export function isValidOptionalResource(s: unknown): s is string {
+  // Optional (RFC 8707): most OAuth servers do not require an audience/resource.
+  return typeof s === "string";
 }
 
 export function isValidSnowflakeAccount(s: unknown): s is string {


### PR DESCRIPTION
## Description

Two small follow-ups from unblocking a customer on tasks#9540 (Static OAuth against an audience-scoped Auth0 tenant):

1. Adds an optional `resource`/`audience` field to the MCP static OAuth setup form. Some OAuth servers issue audience-scoped tokens (RFC 8707) and reject requests that omit this parameter; the backend already supports passing it through `extraConfig`, it just wasn't exposed in the form.
2. When discovering OAuth metadata for a remote MCP server, skip the dynamic client registration attempt if the server doesn't advertise a `registration_endpoint` at all, and return a clearer message pointing at Static OAuth instead of the generic "failed to register client" error (which reads as a bug rather than an expected limitation).

## Tests

Typecheck passes on the changed files. Not manually tested end-to-end against a real audience-scoped OAuth server.

## Risk

Low 

## Deploy Plan

Standard deploy, no migration or ordering concerns.