### PR TITLE
[LLM] surface Anthropic prompt-cache diagnostics in the new router

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -25,7 +25,7 @@
     "tsgo": "tsgo"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.2",
+    "@anthropic-ai/sdk": "^0.110.0",
     "@novu/framework": "^2.11.1",
     "umzug": "3.8.3",
     "@hono/mcp": "^0.3.0",

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -247,6 +247,51 @@ describe("convertToOldEvent", () => {
       metadata: llmMetadata,
     });
   });
+
+  it("maps response_id to interaction_id, carrying the cache miss reason", () => {
+    expect(
+      convertToOldEvent(
+        {
+          type: "response_id",
+          content: { responseId: "msg_123" },
+          metadata: {
+            ...endpointMetadata,
+            content: {
+              cacheMissReason: {
+                type: "system_changed",
+                cacheMissedInputTokens: 42,
+              },
+            },
+          },
+        },
+        llmMetadata
+      )
+    ).toEqual({
+      type: "interaction_id",
+      content: {
+        modelInteractionId: "msg_123",
+        cacheMissReason: { type: "system_changed", cacheMissedInputTokens: 42 },
+      },
+      metadata: llmMetadata,
+    });
+  });
+
+  it("maps response_id to interaction_id without a cache miss reason", () => {
+    expect(
+      convertToOldEvent(
+        {
+          type: "response_id",
+          content: { responseId: "msg_123" },
+          metadata: endpointMetadata,
+        },
+        llmMetadata
+      )
+    ).toEqual({
+      type: "interaction_id",
+      content: { modelInteractionId: "msg_123", cacheMissReason: undefined },
+      metadata: llmMetadata,
+    });
+  });
 });
 
 describe("reasoningContentToLegacyMetadata — persistence write path", () => {

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -55,6 +55,7 @@ import type {
   NonDeltaResponseEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { isCacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type {
   AgentFunctionCallContentType,
@@ -341,12 +342,19 @@ export function convertToOldEvent(
   metadata: LLMClientMetadata
 ): LLMEvent {
   switch (event.type) {
-    case "response_id":
+    case "response_id": {
+      const cacheMissReason = event.metadata.content?.cacheMissReason;
       return {
         type: "interaction_id",
-        content: { modelInteractionId: event.content.responseId },
+        content: {
+          modelInteractionId: event.content.responseId,
+          cacheMissReason: isCacheMissReason(cacheMissReason)
+            ? cacheMissReason
+            : undefined,
+        },
         metadata,
       };
+    }
 
     case "text_delta":
       return {
@@ -595,8 +603,13 @@ abstract class BaseTransition extends LLM {
     streamParameters: LLMStreamParameters,
     configSchema: BaseEndpointConfiguration["configSchema"]
   ): InputConfig {
-    const { specifications, forceToolCall, disableToolUse, toolSearchEnabled } =
-      streamParameters;
+    const {
+      specifications,
+      forceToolCall,
+      disableToolUse,
+      toolSearchEnabled,
+      previousMessageId,
+    } = streamParameters;
 
     return configSchema.parse({
       tools: specifications as ToolSpecification[],
@@ -614,6 +627,9 @@ abstract class BaseTransition extends LLM {
         this.responseFormat,
         this.metadata.clientId
       ),
+      // Prompt-cache diagnostics opt-in. Kept only by the Anthropic (direct)
+      // config schema; other surfaces' schemas strip this unknown key.
+      previousMessageId,
     });
   }
 }

--- a/front/lib/model_constructors/batch/clients/anthropic.ts
+++ b/front/lib/model_constructors/batch/clients/anthropic.ts
@@ -1,5 +1,5 @@
 import AnthropicClient from "@anthropic-ai/sdk";
-import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
+import type { BetaMessageBatchResult } from "@anthropic-ai/sdk/resources/beta/messages/batches";
 import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   BatchEndpoint,
@@ -30,7 +30,7 @@ export abstract class AnthropicBatch extends WithAnthropicAIInputConverter(
   WithAnthropicAIOutputConverter(
     BatchEndpoint<
       MessageCreateParamsNonStreaming,
-      MessageBatchResult,
+      BetaMessageBatchResult,
       AnthropicInputConfig
     >
   )
@@ -47,7 +47,9 @@ export abstract class AnthropicBatch extends WithAnthropicAIInputConverter(
     });
   }
 
-  rawBatchOutputToEvents(result: MessageBatchResult): NonDeltaResponseEvent[] {
+  rawBatchOutputToEvents(
+    result: BetaMessageBatchResult
+  ): NonDeltaResponseEvent[] {
     return batchResultToEvents(result, this.metadata(), this);
   }
 
@@ -63,21 +65,21 @@ export abstract class AnthropicBatch extends WithAnthropicAIInputConverter(
       { concurrency: BUILD_PAYLOAD_CONCURRENCY }
     );
 
-    const batch = await this.client.messages.batches.create({
+    const batch = await this.client.beta.messages.batches.create({
       requests: batchRequests,
     });
     return batch.id;
   }
 
   async getBatchStatus(batchId: string): Promise<BatchStatus> {
-    const batch = await this.client.messages.batches.retrieve(batchId);
+    const batch = await this.client.beta.messages.batches.retrieve(batchId);
     return batch.processing_status === "ended" ? "ready" : "computing";
   }
 
   async getBatchResult(
     batchId: string
   ): Promise<Map<string, NonDeltaResponseEvent[]>> {
-    const results = await this.client.messages.batches.results(batchId);
+    const results = await this.client.beta.messages.batches.results(batchId);
 
     const batchResult = new Map<string, NonDeltaResponseEvent[]>();
     for await (const item of results) {
@@ -87,7 +89,7 @@ export abstract class AnthropicBatch extends WithAnthropicAIInputConverter(
   }
 
   async deleteBatch(batchId: string): Promise<boolean> {
-    await this.client.messages.batches.delete(batchId);
+    await this.client.beta.messages.batches.delete(batchId);
     return true;
   }
 }

--- a/front/lib/model_constructors/providers/anthropic/inputConfig.ts
+++ b/front/lib/model_constructors/providers/anthropic/inputConfig.ts
@@ -11,6 +11,9 @@ export const anthropicConfigSchema = inputConfigSchema.extend({
       ]),
     })
     .optional(),
+  // Prompt-cache diagnostics (Claude API only): undefined = off, null = on
+  // (first call), string = previous response id to diagnose against.
+  previousMessageId: z.string().nullable().optional(),
 });
 
 export type AnthropicInputConfig = z.infer<typeof anthropicConfigSchema>;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -3,18 +3,18 @@ import {
   APIConnectionError,
   APIError,
 } from "@anthropic-ai/sdk";
-import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
+import type { BetaMessageBatchResult } from "@anthropic-ai/sdk/resources/beta/messages/batches";
 import type {
-  CacheCreation,
-  Message,
-  MessageDeltaUsage,
-  RawContentBlockDeltaEvent,
-  RawContentBlockStartEvent,
-  RawContentBlockStopEvent,
-  RawMessageDeltaEvent,
-  RawMessageStartEvent,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources/messages/messages";
+  BetaCacheCreation,
+  BetaMessage,
+  BetaMessageDeltaUsage,
+  BetaRawContentBlockDeltaEvent,
+  BetaRawContentBlockStartEvent,
+  BetaRawContentBlockStopEvent,
+  BetaRawMessageDeltaEvent,
+  BetaRawMessageStartEvent,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import type { OutputEventConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
 import {
   accumulatedReasoningToReasoningEvent,
@@ -149,9 +149,9 @@ function makeStubConverters(): OutputEventConverters {
 
 // Yields the provided events as an async stream, optionally throwing at the end.
 async function* streamOf(
-  events: RawMessageStreamEvent[],
+  events: BetaRawMessageStreamEvent[],
   throwAtEnd?: unknown
-): AsyncGenerator<RawMessageStreamEvent> {
+): AsyncGenerator<BetaRawMessageStreamEvent> {
   for (const event of events) {
     yield event;
   }
@@ -277,7 +277,7 @@ describe("messageStartToResponseIdEvent", () => {
     const event = {
       type: "message_start",
       message: { id: "msg_123" },
-    } as RawMessageStartEvent;
+    } as BetaRawMessageStartEvent;
     expect(messageStartToResponseIdEvent(metadata, event)).toEqual({
       type: "response_id",
       content: { responseId: "msg_123" },
@@ -399,15 +399,16 @@ describe("invalidJsonToolCallToToolCallEvent", () => {
 
 describe("messageDeltaUsageToTokenUsageEvent", () => {
   it("splits cache creation by TTL when the breakdown is present", () => {
-    const usage: MessageDeltaUsage = {
+    const usage: BetaMessageDeltaUsage = {
       cache_creation_input_tokens: 10,
       cache_read_input_tokens: 20,
       input_tokens: 100,
+      iterations: null,
       output_tokens: 50,
       output_tokens_details: { thinking_tokens: 15 },
       server_tool_use: null,
     };
-    const cacheCreation: CacheCreation = {
+    const cacheCreation: BetaCacheCreation = {
       ephemeral_1h_input_tokens: 6,
       ephemeral_5m_input_tokens: 4,
     };
@@ -429,10 +430,11 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
   });
 
   it("reports the flat cache-creation total as cacheCreated when no breakdown is present", () => {
-    const usage: MessageDeltaUsage = {
+    const usage: BetaMessageDeltaUsage = {
       cache_creation_input_tokens: 10,
       cache_read_input_tokens: 20,
       input_tokens: 100,
+      iterations: null,
       output_tokens: 50,
       output_tokens_details: { thinking_tokens: 15 },
       server_tool_use: null,
@@ -453,10 +455,11 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
   });
 
   it("rolls reasoning into standardOutput when there is no breakdown", () => {
-    const usage: MessageDeltaUsage = {
+    const usage: BetaMessageDeltaUsage = {
       cache_creation_input_tokens: null,
       cache_read_input_tokens: null,
       input_tokens: null,
+      iterations: null,
       output_tokens: 40,
       output_tokens_details: null,
       server_tool_use: null,
@@ -597,7 +600,7 @@ describe("contentBlockStartToEvents", () => {
       type: "content_block_start",
       index: 0,
       content_block: { type: "text", text: "", citations: [] },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const [events, state] = contentBlockStartToEvents(
       event,
       null,
@@ -613,7 +616,7 @@ describe("contentBlockStartToEvents", () => {
       type: "content_block_start",
       index: 1,
       content_block: { type: "thinking", thinking: "", signature: "" },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const [events, state] = contentBlockStartToEvents(
       event,
       null,
@@ -635,7 +638,7 @@ describe("contentBlockStartToEvents", () => {
         name: "lookup",
         input: {},
       },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const [events, state] = contentBlockStartToEvents(
       event,
       null,
@@ -663,7 +666,7 @@ describe("contentBlockStartToEvents", () => {
       type: "content_block_start",
       index: 4,
       content_block: { type: "redacted_thinking", data: "xxx" },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const prior = { index: 0, accumulator: "abc", type: "text" as const };
     const [events, state] = contentBlockStartToEvents(
       event,
@@ -685,7 +688,7 @@ describe("contentBlockStartToEvents", () => {
         name: "tool_search_tool_bm25",
         input: {},
       },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const [events, state] = contentBlockStartToEvents(
       event,
       null,
@@ -716,7 +719,7 @@ describe("contentBlockStartToEvents", () => {
           ],
         },
       },
-    } as RawContentBlockStartEvent;
+    } as BetaRawContentBlockStartEvent;
     const [events, state] = contentBlockStartToEvents(
       event,
       null,
@@ -752,7 +755,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "text_delta", text: "x" },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     expect(
       contentBlockDeltaToEvents(event, null, metadata, realConverters)
     ).toEqual([[], null]);
@@ -763,7 +766,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "text_delta", text: "lo" },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = { index: 0, accumulator: "hel", type: "text" as const };
     const [events, nextState] = contentBlockDeltaToEvents(
       event,
@@ -782,7 +785,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "thinking_delta", thinking: "more" },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = {
       index: 0,
       accumulator: "think ",
@@ -805,7 +808,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "input_json_delta", partial_json: '{"a":' },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = {
       index: 0,
       accumulator: "",
@@ -828,7 +831,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "signature_delta", signature: "abc" },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = {
       index: 0,
       accumulator: "",
@@ -850,7 +853,7 @@ describe("contentBlockDeltaToEvents", () => {
       type: "content_block_delta",
       index: 0,
       delta: { type: "signature_delta", signature: "abc" },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = { index: 0, accumulator: "x", type: "text" as const };
     const [events, nextState] = contentBlockDeltaToEvents(
       event,
@@ -877,7 +880,7 @@ describe("contentBlockDeltaToEvents", () => {
           end_char_index: 1,
         },
       },
-    } as RawContentBlockDeltaEvent;
+    } as BetaRawContentBlockDeltaEvent;
     const state = { index: 0, accumulator: "x", type: "text" as const };
     const [events, nextState] = contentBlockDeltaToEvents(
       event,
@@ -894,7 +897,7 @@ describe("contentBlockStopToEvents", () => {
   const stopEvent = {
     type: "content_block_stop",
     index: 0,
-  } as RawContentBlockStopEvent;
+  } as BetaRawContentBlockStopEvent;
 
   it("returns no events when there is no open block", () => {
     expect(
@@ -1098,10 +1101,11 @@ describe("contentBlockStopToEvents", () => {
 });
 
 describe("messageDeltaToEvents", () => {
-  const usage: MessageDeltaUsage = {
+  const usage: BetaMessageDeltaUsage = {
     cache_creation_input_tokens: null,
     cache_read_input_tokens: null,
     input_tokens: null,
+    iterations: null,
     output_tokens: 5,
     output_tokens_details: null,
     server_tool_use: null,
@@ -1112,7 +1116,8 @@ describe("messageDeltaToEvents", () => {
       type: "message_delta",
       delta: { stop_reason: "end_turn", stop_sequence: null },
       usage,
-    } as RawMessageDeltaEvent;
+      context_management: null,
+    } as BetaRawMessageDeltaEvent;
     expect(messageDeltaToEvents(event, metadata, realConverters)).toEqual([
       [],
       usage,
@@ -1124,7 +1129,8 @@ describe("messageDeltaToEvents", () => {
       type: "message_delta",
       delta: { stop_reason: "max_tokens", stop_sequence: null },
       usage,
-    } as RawMessageDeltaEvent;
+      context_management: null,
+    } as BetaRawMessageDeltaEvent;
     const [events, forwardedUsage] = messageDeltaToEvents(
       event,
       metadata,
@@ -1140,7 +1146,8 @@ describe("messageDeltaToEvents", () => {
       type: "message_delta",
       delta: { stop_reason: null, stop_sequence: null },
       usage,
-    } as RawMessageDeltaEvent;
+      context_management: null,
+    } as BetaRawMessageDeltaEvent;
     expect(messageDeltaToEvents(event, metadata, realConverters)[0]).toEqual(
       []
     );
@@ -1148,10 +1155,11 @@ describe("messageDeltaToEvents", () => {
 });
 
 describe("rawOutputToEvents", () => {
-  const tokenUsage: MessageDeltaUsage = {
+  const tokenUsage: BetaMessageDeltaUsage = {
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     input_tokens: 3,
+    iterations: null,
     output_tokens: 2,
     output_tokens_details: null,
     server_tool_use: null,
@@ -1164,27 +1172,27 @@ describe("rawOutputToEvents", () => {
           {
             type: "message_start",
             message: { id: "msg_1" },
-          } as RawMessageStartEvent,
+          } as BetaRawMessageStartEvent,
           {
             type: "content_block_start",
             index: 0,
             content_block: { type: "text", text: "", citations: [] },
-          } as RawMessageStreamEvent,
+          } as BetaRawMessageStreamEvent,
           {
             type: "content_block_delta",
             index: 0,
             delta: { type: "text_delta", text: "Hi" },
-          } as RawMessageStreamEvent,
+          } as BetaRawMessageStreamEvent,
           {
             type: "content_block_stop",
             index: 0,
-          } as RawMessageStreamEvent,
+          } as BetaRawMessageStreamEvent,
           {
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
             usage: tokenUsage,
-          } as RawMessageStreamEvent,
-          { type: "message_stop" } as RawMessageStreamEvent,
+          } as BetaRawMessageStreamEvent,
+          { type: "message_stop" } as BetaRawMessageStreamEvent,
         ]),
         metadata,
         realConverters
@@ -1227,7 +1235,7 @@ describe("rawOutputToEvents", () => {
                 output_tokens: 1,
               },
             },
-          } as RawMessageStartEvent,
+          } as BetaRawMessageStartEvent,
           {
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
@@ -1239,8 +1247,8 @@ describe("rawOutputToEvents", () => {
               output_tokens_details: { thinking_tokens: 0 },
               server_tool_use: null,
             },
-          } as RawMessageStreamEvent,
-          { type: "message_stop" } as RawMessageStreamEvent,
+          } as BetaRawMessageStreamEvent,
+          { type: "message_stop" } as BetaRawMessageStreamEvent,
         ]),
         metadata,
         realConverters
@@ -1269,7 +1277,7 @@ describe("rawOutputToEvents", () => {
             {
               type: "message_start",
               message: { id: "msg_1" },
-            } as RawMessageStartEvent,
+            } as BetaRawMessageStartEvent,
           ],
           new APIError(429, {}, "slow down", undefined, null)
         ),
@@ -1295,12 +1303,12 @@ describe("rawOutputToEvents", () => {
                 name: "search",
                 input: {},
               },
-            } as RawMessageStreamEvent,
+            } as BetaRawMessageStreamEvent,
             {
               type: "content_block_delta",
               index: 0,
               delta: { type: "input_json_delta", partial_json: "{bad" },
-            } as RawMessageStreamEvent,
+            } as BetaRawMessageStreamEvent,
           ],
           new AnthropicError(INVALID_TOOL_JSON_MESSAGE)
         ),
@@ -1340,12 +1348,12 @@ describe("rawOutputToEvents", () => {
                 name: "search",
                 input: {},
               },
-            } as RawMessageStreamEvent,
+            } as BetaRawMessageStreamEvent,
             {
               type: "content_block_delta",
               index: 0,
               delta: { type: "input_json_delta", partial_json: "{bad" },
-            } as RawMessageStreamEvent,
+            } as BetaRawMessageStreamEvent,
           ],
           bareToolJsonParseError()
         ),
@@ -1375,7 +1383,7 @@ describe("rawOutputToEvents", () => {
             {
               type: "message_start",
               message: { id: "msg_1" },
-            } as RawMessageStartEvent,
+            } as BetaRawMessageStartEvent,
           ],
           bareToolJsonParseError()
         ),
@@ -1389,7 +1397,7 @@ describe("rawOutputToEvents", () => {
   it("omits the token_usage event when no message_delta carried usage", async () => {
     const events = await collect(
       rawOutputToEvents(
-        streamOf([{ type: "message_stop" } as RawMessageStreamEvent]),
+        streamOf([{ type: "message_stop" } as BetaRawMessageStreamEvent]),
         metadata,
         realConverters
       )
@@ -1399,7 +1407,7 @@ describe("rawOutputToEvents", () => {
 });
 
 describe("messageToEvents", () => {
-  function messageWith(overrides: Partial<Message>): Message {
+  function messageWith(overrides: Partial<BetaMessage>): BetaMessage {
     return {
       id: "msg_1",
       type: "message",
@@ -1417,7 +1425,7 @@ describe("messageToEvents", () => {
         server_tool_use: null,
       },
       ...overrides,
-    } as Message;
+    } as BetaMessage;
   }
 
   it("converts text, thinking and tool_use blocks in order", () => {
@@ -1427,7 +1435,7 @@ describe("messageToEvents", () => {
         { type: "thinking", thinking: "hmm", signature: "sig-1" },
         { type: "tool_use", id: "tu-1", name: "search", input: { q: "cats" } },
       ],
-    } as Partial<Message>);
+    } as Partial<BetaMessage>);
 
     const events = messageToEvents(message, metadata, realConverters);
     expect(events.map((e) => e.type)).toEqual([
@@ -1451,7 +1459,7 @@ describe("messageToEvents", () => {
         { type: "text", text: "hi", citations: [] },
         { type: "tool_use", id: "tu-1", name: "n", input: {} },
       ],
-    } as Partial<Message>);
+    } as Partial<BetaMessage>);
     const events = messageToEvents(message, metadata, realConverters);
     const success = events.find((e) => e.type === "success");
     expect(success).toMatchObject({
@@ -1475,7 +1483,7 @@ describe("messageToEvents", () => {
   it("skips block types that are not surfaced", () => {
     const message = messageWith({
       content: [{ type: "redacted_thinking", data: "xxx" }],
-    } as Partial<Message>);
+    } as Partial<BetaMessage>);
     const events = messageToEvents(message, metadata, realConverters);
     expect(events.map((e) => e.type)).toEqual([
       "response_id",
@@ -1501,7 +1509,7 @@ describe("messageToEvents", () => {
     };
     const message = messageWith({
       content: [serverToolUseBlock, toolSearchResultBlock],
-    } as Partial<Message>);
+    } as Partial<BetaMessage>);
     const events = messageToEvents(message, metadata, realConverters);
     expect(events.filter((e) => e.type === "provider_passthrough")).toEqual([
       {
@@ -1519,7 +1527,7 @@ describe("messageToEvents", () => {
 });
 
 describe("batchResultToEvents", () => {
-  function succeededResult(): MessageBatchResult {
+  function succeededResult(): BetaMessageBatchResult {
     const message = {
       id: "msg_1",
       type: "message",
@@ -1529,6 +1537,8 @@ describe("batchResultToEvents", () => {
       stop_reason: "end_turn",
       stop_sequence: null,
       container: null,
+      context_management: null,
+      diagnostics: null,
       stop_details: null,
       usage: {
         cache_creation: null,
@@ -1536,12 +1546,14 @@ describe("batchResultToEvents", () => {
         cache_read_input_tokens: 0,
         inference_geo: null,
         input_tokens: 1,
+        iterations: null,
         output_tokens: 1,
         output_tokens_details: null,
         server_tool_use: null,
         service_tier: null,
+        speed: null,
       },
-    } as Message;
+    } as BetaMessage;
     return { type: "succeeded", message };
   }
 
@@ -1566,7 +1578,7 @@ describe("batchResultToEvents", () => {
         type: "error",
         error: { type: "api_error", message: "upstream blew up" },
       },
-    } as MessageBatchResult;
+    } as BetaMessageBatchResult;
     const events = batchResultToEvents(result, metadata, realConverters);
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
@@ -1576,7 +1588,7 @@ describe("batchResultToEvents", () => {
   });
 
   it("maps a canceled result to a stream_error event", () => {
-    const result = { type: "canceled" } as MessageBatchResult;
+    const result = { type: "canceled" } as BetaMessageBatchResult;
     const events = batchResultToEvents(result, metadata, realConverters);
     expect(events[0]).toMatchObject({
       type: "error",
@@ -1585,7 +1597,7 @@ describe("batchResultToEvents", () => {
   });
 
   it("maps an expired result to a stream_error event", () => {
-    const result = { type: "expired" } as MessageBatchResult;
+    const result = { type: "expired" } as BetaMessageBatchResult;
     const events = batchResultToEvents(result, metadata, realConverters);
     expect(events[0]).toMatchObject({
       type: "error",

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -3,18 +3,18 @@ import {
   APIConnectionError,
   APIError,
 } from "@anthropic-ai/sdk";
-import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
+import type { BetaMessageBatchResult } from "@anthropic-ai/sdk/resources/beta/messages/batches";
 import type {
-  CacheCreation,
-  Message,
-  MessageDeltaUsage,
-  RawContentBlockDeltaEvent,
-  RawContentBlockStartEvent,
-  RawContentBlockStopEvent,
-  RawMessageDeltaEvent,
-  RawMessageStartEvent,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources/messages/messages";
+  BetaCacheCreation,
+  BetaMessage,
+  BetaMessageDeltaUsage,
+  BetaRawContentBlockDeltaEvent,
+  BetaRawContentBlockStartEvent,
+  BetaRawContentBlockStopEvent,
+  BetaRawMessageDeltaEvent,
+  BetaRawMessageStartEvent,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import { parseToolArguments } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import {
   logToolSearchQuery,
@@ -168,7 +168,7 @@ export type BlockState =
 export interface OutputEventConverters {
   messageStartToResponseIdEvent(
     metadata: EndpointMetadata,
-    event: RawMessageStartEvent
+    event: BetaRawMessageStartEvent
   ): ResponseIdEvent;
   textDeltaToTextDeltaEvent(
     metadata: EndpointMetadata,
@@ -214,8 +214,8 @@ export interface OutputEventConverters {
   ): ProviderPassthroughEvent;
   messageDeltaUsageToTokenUsageEvent(
     metadata: EndpointMetadata,
-    usage: MessageDeltaUsage,
-    cacheCreation: CacheCreation | null
+    usage: BetaMessageDeltaUsage,
+    cacheCreation: BetaCacheCreation | null
   ): TokenUsageEvent;
   stopReasonToErrorEvent(
     metadata: EndpointMetadata,
@@ -231,7 +231,7 @@ export interface OutputEventConverters {
 
 export function messageStartToResponseIdEvent(
   metadata: EndpointMetadata,
-  event: RawMessageStartEvent
+  event: BetaRawMessageStartEvent
 ): ResponseIdEvent {
   return {
     type: "response_id",
@@ -337,8 +337,8 @@ export function serverToolBlockToProviderPassthroughEvent(
 
 export function messageDeltaUsageToTokenUsageEvent(
   metadata: EndpointMetadata,
-  usage: MessageDeltaUsage,
-  cacheCreation: CacheCreation | null
+  usage: BetaMessageDeltaUsage,
+  cacheCreation: BetaCacheCreation | null
 ): TokenUsageEvent {
   const cacheHit = usage.cache_read_input_tokens ?? 0;
   const uncachedInput = usage.input_tokens ?? 0;
@@ -658,7 +658,7 @@ function bareStreamErrorToErrorEvent(
 // Returns the events to emit alongside the next block state, so the caller owns
 // the cursor instead of us mutating it in place.
 export function contentBlockStartToEvents(
-  event: RawContentBlockStartEvent,
+  event: BetaRawContentBlockStartEvent,
   state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters,
@@ -732,6 +732,11 @@ export function contentBlockStartToEvents(
     case "bash_code_execution_tool_result":
     case "text_editor_code_execution_tool_result":
     case "container_upload":
+    case "advisor_tool_result":
+    case "mcp_tool_use":
+    case "mcp_tool_result":
+    case "compaction":
+    case "fallback":
       return [[], state];
     default:
       // Anthropic may add new block types before we redeploy; ignore them
@@ -742,7 +747,7 @@ export function contentBlockStartToEvents(
 }
 
 export function contentBlockDeltaToEvents(
-  event: RawContentBlockDeltaEvent,
+  event: BetaRawContentBlockDeltaEvent,
   state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
@@ -782,6 +787,7 @@ export function contentBlockDeltaToEvents(
       }
       return [[], state];
     case "citations_delta":
+    case "compaction_delta":
       return [[], state];
     default:
       // Anthropic may add new delta types before we redeploy; ignore them
@@ -794,7 +800,7 @@ export function contentBlockDeltaToEvents(
 // Flushes the in-progress block as an event and clears the cursor (returns the
 // next state as `null`), so the caller resets its own variable.
 export function contentBlockStopToEvents(
-  _event: RawContentBlockStopEvent,
+  _event: BetaRawContentBlockStopEvent,
   state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
@@ -893,10 +899,10 @@ function toolSearchLogFields(metadata: EndpointMetadata) {
 // Returns the events to emit alongside the latest usage snapshot, so the caller
 // tracks token usage in its own variable instead of us writing into a wrapper.
 export function messageDeltaToEvents(
-  event: RawMessageDeltaEvent,
+  event: BetaRawMessageDeltaEvent,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
-): [ModelResponseEvent[], MessageDeltaUsage] {
+): [ModelResponseEvent[], BetaMessageDeltaUsage] {
   const stopReason = event.delta.stop_reason;
   if (stopReason) {
     // Anthropic pauses a turn when the server-side sampling loop reaches its
@@ -928,20 +934,20 @@ export function messageDeltaToEvents(
 // -- Entry point: drive the raw stream into unified events --
 
 export async function* rawOutputToEvents(
-  stream: AsyncGenerator<RawMessageStreamEvent>,
+  stream: AsyncGenerator<BetaRawMessageStreamEvent>,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
 ): AsyncGenerator<ModelResponseEvent> {
   const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
   let blockState: BlockState | null = null;
-  let tokenUsage: MessageDeltaUsage | null = null;
+  let tokenUsage: BetaMessageDeltaUsage | null = null;
   const toolSearchQueriesByToolUseId = new Map<string, string | undefined>();
   // The per-TTL cache-creation breakdown is only emitted on `message_start`;
   // capture it so the trailing `message_delta` usage can be split by TTL.
-  let cacheCreation: CacheCreation | null = null;
+  let cacheCreation: BetaCacheCreation | null = null;
 
   while (true) {
-    let result: IteratorResult<RawMessageStreamEvent>;
+    let result: IteratorResult<BetaRawMessageStreamEvent>;
     try {
       result = await stream.next();
     } catch (err) {
@@ -1092,7 +1098,7 @@ export async function* rawOutputToEvents(
 // Turns a completed (non-streaming) Anthropic `Message` into the unified event
 // array, mirroring `rawOutputToEvents` minus the streaming-only delta heartbeats.
 export function messageToEvents(
-  message: Message,
+  message: BetaMessage,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
 ): NonDeltaResponseEvent[] {
@@ -1165,6 +1171,12 @@ export function messageToEvents(
       case "bash_code_execution_tool_result":
       case "text_editor_code_execution_tool_result":
       case "container_upload":
+      // Beta-only blocks (both clients use the beta API); also unsurfaced.
+      case "advisor_tool_result":
+      case "mcp_tool_use":
+      case "mcp_tool_result":
+      case "compaction":
+      case "fallback":
         break;
       default:
         // Anthropic may add new block types before we redeploy; ignore them
@@ -1199,7 +1211,7 @@ export function messageToEvents(
 
 // Converts a single Anthropic batch result into unified events.
 export function batchResultToEvents(
-  result: MessageBatchResult,
+  result: BetaMessageBatchResult,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
 ): NonDeltaResponseEvent[] {

--- a/front/lib/model_constructors/sdk/anthropic_ai/tool_search_dangling_server_tool_use.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/tool_search_dangling_server_tool_use.test.ts
@@ -1,8 +1,8 @@
 import type {
-  MessageParam,
-  RawMessageStartEvent,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources/messages/messages";
+  BetaRawMessageStartEvent,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   parseAnthropicToolSearchBlock,
   stripUnreplayableToolSearchBlocks,
@@ -98,17 +98,17 @@ const inputConverters: MessageBlockConverters = {
 
 // The incident stream: two tool searches and a client tool call in one burst,
 // ending on stop_reason "tool_use" with NO tool_search_tool_result blocks.
-function incidentStreamEvents(): RawMessageStreamEvent[] {
+function incidentStreamEvents(): BetaRawMessageStreamEvent[] {
   return [
     {
       type: "message_start",
       message: { id: "msg_incident" },
-    } as RawMessageStartEvent,
+    } as BetaRawMessageStartEvent,
     {
       type: "content_block_start",
       index: 0,
       content_block: { type: "text", text: "", citations: [] },
-    } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
     {
       type: "content_block_delta",
       index: 0,
@@ -116,8 +116,8 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         type: "text_delta",
         text: "Let me find the right tools and enable Go Deep.",
       },
-    } as RawMessageStreamEvent,
-    { type: "content_block_stop", index: 0 } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
+    { type: "content_block_stop", index: 0 } as BetaRawMessageStreamEvent,
     {
       type: "content_block_start",
       index: 1,
@@ -127,7 +127,7 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         name: "tool_search_tool_bm25",
         input: {},
       },
-    } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
     {
       type: "content_block_delta",
       index: 1,
@@ -135,8 +135,8 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         type: "input_json_delta",
         partial_json: '{"limit":10,"query":"search retrieve documents"}',
       },
-    } as RawMessageStreamEvent,
-    { type: "content_block_stop", index: 1 } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
+    { type: "content_block_stop", index: 1 } as BetaRawMessageStreamEvent,
     {
       type: "content_block_start",
       index: 2,
@@ -146,7 +146,7 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         name: "tool_search_tool_bm25",
         input: {},
       },
-    } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
     {
       type: "content_block_delta",
       index: 2,
@@ -154,8 +154,8 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         type: "input_json_delta",
         partial_json: '{"limit":10,"query":"Google Calendar list events"}',
       },
-    } as RawMessageStreamEvent,
-    { type: "content_block_stop", index: 2 } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
+    { type: "content_block_stop", index: 2 } as BetaRawMessageStreamEvent,
     {
       type: "content_block_start",
       index: 3,
@@ -165,7 +165,7 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         name: "skill_management__enable_skill",
         input: {},
       },
-    } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
     {
       type: "content_block_delta",
       index: 3,
@@ -173,8 +173,8 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         type: "input_json_delta",
         partial_json: '{"skillName":"Go Deep"}',
       },
-    } as RawMessageStreamEvent,
-    { type: "content_block_stop", index: 3 } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
+    { type: "content_block_stop", index: 3 } as BetaRawMessageStreamEvent,
     {
       type: "message_delta",
       delta: { stop_reason: "tool_use", stop_sequence: null },
@@ -186,14 +186,14 @@ function incidentStreamEvents(): RawMessageStreamEvent[] {
         output_tokens_details: null,
         server_tool_use: null,
       },
-    } as RawMessageStreamEvent,
-    { type: "message_stop" } as RawMessageStreamEvent,
+    } as BetaRawMessageStreamEvent,
+    { type: "message_stop" } as BetaRawMessageStreamEvent,
   ];
 }
 
 async function* streamOf(
-  events: RawMessageStreamEvent[]
-): AsyncGenerator<RawMessageStreamEvent> {
+  events: BetaRawMessageStreamEvent[]
+): AsyncGenerator<BetaRawMessageStreamEvent> {
   for (const event of events) {
     yield event;
   }

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -1,6 +1,8 @@
 import AnthropicClient from "@anthropic-ai/sdk";
 import type {
+  BetaMessage,
   BetaMessageStreamParams,
+  BetaRawMessageStartEvent,
   BetaRawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources/messages/messages";
@@ -10,12 +12,42 @@ import {
 } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { WithAnthropicAIInputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input";
 import { WithAnthropicAIOutputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output";
-import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import {
+  messageStartToResponseIdEvent as baseMessageStartToResponseIdEvent,
+  rawOutputToEvents,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type {
+  ModelResponseEvent,
+  ResponseIdEvent,
+} from "@app/lib/model_constructors/types/output/events";
 import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import type { CacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
+
+// Opts into prompt-cache diagnostics (Claude API only, not Vertex/agent).
+// https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics
+const CACHE_DIAGNOSTICS_BETA_HEADER = "cache-diagnosis-2026-04-07";
+
+// Extract the cache-miss reason from a message_start (null when nothing to
+// compare or the background comparison is still pending).
+function toCacheMissReason(message: BetaMessage): CacheMissReason | undefined {
+  const reason = message.diagnostics?.cache_miss_reason;
+  if (!reason) {
+    return undefined;
+  }
+  return {
+    type: reason.type,
+    // Only the `*_changed` reasons carry the lost-cache magnitude.
+    cacheMissedInputTokens:
+      "cache_missed_input_tokens" in reason
+        ? reason.cache_missed_input_tokens
+        : undefined,
+  };
+}
 
 export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   WithAnthropicAIOutputConverter(
@@ -33,6 +65,12 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
 
   private readonly client: AnthropicClient;
 
+  // Cache-diagnostics state, threaded across a stream: recorded in
+  // `buildRequestPayload`, captured off `message_start` in `streamRaw`, attached
+  // to the `response_id` event. Reset at the start of each stream.
+  private previousMessageId: string | null | undefined;
+  private lastCacheMissReason: CacheMissReason | undefined;
+
   constructor({ ANTHROPIC_API_KEY }: Credentials) {
     super();
     this.client = new AnthropicClient({
@@ -40,22 +78,71 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
     });
   }
 
+  async buildRequestPayload(
+    payload: Payload,
+    config: AnthropicInputConfig
+  ): Promise<MessageCreateParamsNonStreaming> {
+    // `diagnostics` and the beta header live on the beta Messages API, so they
+    // are attached in `streamRaw` from this opt-in rather than in the payload.
+    this.previousMessageId = config.previousMessageId;
+    return super.buildRequestPayload(payload, config);
+  }
+
+  // Cache diagnostics opt-in is tri-state: `undefined` = off; `null`/string =
+  // on (Anthropic direct only).
+  private get cacheDiagnosticsEnabled(): boolean {
+    return this.previousMessageId !== undefined;
+  }
+
   async *streamRaw(
     input: MessageCreateParamsNonStreaming
   ): AsyncGenerator<BetaRawMessageStreamEvent> {
+    this.lastCacheMissReason = undefined;
+
     // `buildRequestPayload` is shared with batch and omits `stream`; the beta
     // `.stream()` opts in. Non-beta payloads are assignable to the beta params.
     const streamingInput: BetaMessageStreamParams = {
       ...input,
       cache_control: { type: "ephemeral" },
+      ...(this.cacheDiagnosticsEnabled
+        ? {
+            betas: [CACHE_DIAGNOSTICS_BETA_HEADER],
+            diagnostics: { previous_message_id: this.previousMessageId },
+          }
+        : {}),
     };
     const stream = this.client.beta.messages.stream(streamingInput);
 
-    // The SDK reuses and mutates event objects, so deep-copy each one.
     for await (const event of stream) {
+      if (event.type === "message_start") {
+        this.lastCacheMissReason = toCacheMissReason(event.message);
+      }
+      // The SDK reuses and mutates event objects, so deep-copy each one.
       yield structuredClone(event);
     }
   }
+
+  // Attach the captured cache-miss reason (if any) to the response id event's
+  // metadata bag, alongside other provider-specific event metadata.
+  messageStartToResponseIdEvent = (
+    metadata: EndpointMetadata,
+    event: BetaRawMessageStartEvent
+  ): ResponseIdEvent => {
+    const base = baseMessageStartToResponseIdEvent(metadata, event);
+    if (!this.lastCacheMissReason) {
+      return base;
+    }
+    return {
+      ...base,
+      metadata: {
+        ...base.metadata,
+        content: {
+          ...base.metadata.content,
+          cacheMissReason: this.lastCacheMissReason,
+        },
+      },
+    };
+  };
 
   async *rawStreamOutputToEvents(
     stream: AsyncGenerator<BetaRawMessageStreamEvent>

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -1,9 +1,9 @@
 import AnthropicClient from "@anthropic-ai/sdk";
 import type {
-  MessageCreateParamsNonStreaming,
-  MessageCreateParamsStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources/messages/messages";
+  BetaMessageStreamParams,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   type AnthropicInputConfig,
   anthropicConfigSchema,
@@ -21,7 +21,7 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   WithAnthropicAIOutputConverter(
     StreamEndpoint<
       MessageCreateParamsNonStreaming,
-      RawMessageStreamEvent,
+      BetaRawMessageStreamEvent,
       AnthropicInputConfig
     >
   )
@@ -42,14 +42,14 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
 
   async *streamRaw(
     input: MessageCreateParamsNonStreaming
-  ): AsyncGenerator<RawMessageStreamEvent> {
-    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
-    const streamingInput: MessageCreateParamsStreaming = {
+  ): AsyncGenerator<BetaRawMessageStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; the beta
+    // `.stream()` opts in. Non-beta payloads are assignable to the beta params.
+    const streamingInput: BetaMessageStreamParams = {
       ...input,
-      stream: true,
       cache_control: { type: "ephemeral" },
     };
-    const stream = this.client.messages.stream(streamingInput);
+    const stream = this.client.beta.messages.stream(streamingInput);
 
     // The SDK reuses and mutates event objects, so deep-copy each one.
     for await (const event of stream) {
@@ -58,7 +58,7 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   }
 
   async *rawStreamOutputToEvents(
-    stream: AsyncGenerator<RawMessageStreamEvent>
+    stream: AsyncGenerator<BetaRawMessageStreamEvent>
   ): AsyncGenerator<ModelResponseEvent> {
     yield* rawOutputToEvents(stream, this.metadata(), this);
   }

--- a/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
@@ -1,8 +1,10 @@
 import type {
+  BetaMessageStreamParams,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type {
   MessageCreateParamsNonStreaming,
-  MessageCreateParamsStreaming,
   Model,
-  RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import AnthropicVertex from "@anthropic-ai/vertex-sdk";
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
@@ -47,7 +49,7 @@ export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputC
   WithAnthropicAIOutputConverter(
     StreamEndpoint<
       MessageCreateParamsNonStreaming,
-      RawMessageStreamEvent,
+      BetaRawMessageStreamEvent,
       AnthropicInputConfig
     >
   )
@@ -84,12 +86,9 @@ export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputC
 
   async *streamRaw(
     input: MessageCreateParamsNonStreaming
-  ): AsyncGenerator<RawMessageStreamEvent> {
-    const streamingInput: MessageCreateParamsStreaming = {
-      ...input,
-      stream: true,
-    };
-    const stream = this.client.messages.stream(streamingInput);
+  ): AsyncGenerator<BetaRawMessageStreamEvent> {
+    const streamingInput: BetaMessageStreamParams = { ...input };
+    const stream = this.client.beta.messages.stream(streamingInput);
 
     // SDK mutates/reuses events; deep-copy.
     for await (const event of stream) {
@@ -98,7 +97,7 @@ export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputC
   }
 
   async *rawStreamOutputToEvents(
-    stream: AsyncGenerator<RawMessageStreamEvent>
+    stream: AsyncGenerator<BetaRawMessageStreamEvent>
   ): AsyncGenerator<ModelResponseEvent> {
     yield* rawOutputToEvents(stream, this.metadata(), this);
   }

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import {
   type ClaudeFableFive,
   WithAnthropicClaudeFableFiveConfig,
@@ -31,6 +29,6 @@ export class AnthropicGlobalClaudeFableFiveStream extends WithAnthropicClaudeFab
 
 AnthropicGlobalClaudeFableFiveStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   ClaudeFableFive
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import {
   type ClaudeHaikuFourDotFive,
   WithAnthropicClaudeHaikuFourDotFiveConfig,
@@ -31,6 +29,6 @@ export class AnthropicGlobalClaudeHaikuFourDotFiveStream extends WithAnthropicCl
 
 AnthropicGlobalClaudeHaikuFourDotFiveStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   ClaudeHaikuFourDotFive
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import { WithAnthropicClaudeOpusFourDotEightConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight";
 import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
@@ -29,6 +27,6 @@ export class AnthropicGlobalClaudeOpusFourDotEightStream extends WithAnthropicCl
 
 AnthropicGlobalClaudeOpusFourDotEightStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   AnthropicOpusInputConfig
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import { WithAnthropicClaudeOpusFourDotSevenConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven";
 import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
@@ -28,6 +26,6 @@ export class AnthropicGlobalClaudeOpusFourDotSevenStream extends WithAnthropicCl
 
 AnthropicGlobalClaudeOpusFourDotSevenStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   AnthropicOpusInputConfig
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import { WithAnthropicClaudeOpusFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six";
 import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
@@ -28,6 +26,6 @@ export class AnthropicGlobalClaudeOpusFourDotSixStream extends WithAnthropicClau
 
 AnthropicGlobalClaudeOpusFourDotSixStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   AnthropicOpusInputConfig
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_five.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import {
   type ClaudeSonnetFive,
   WithAnthropicClaudeSonnetFiveConfig,
@@ -34,6 +32,6 @@ export class AnthropicGlobalClaudeSonnetFiveStream extends WithAnthropicClaudeSo
 
 AnthropicGlobalClaudeSonnetFiveStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   ClaudeSonnetFive
 >;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -1,7 +1,5 @@
-import type {
-  MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import {
   type ClaudeSonnetFourDotSix,
   WithAnthropicClaudeSonnetFourDotSixConfig,
@@ -31,6 +29,6 @@ export class AnthropicGlobalClaudeSonnetFourDotSixStream extends WithAnthropicCl
 
 AnthropicGlobalClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
-  RawMessageStreamEvent,
+  BetaRawMessageStreamEvent,
   ClaudeSonnetFourDotSix
 >;

--- a/front/lib/model_constructors/utils/cache_miss_reason.test.ts
+++ b/front/lib/model_constructors/utils/cache_miss_reason.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+
+import { isCacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
+import { describe, expect, it } from "vitest";
+
+describe("isCacheMissReason", () => {
+  it("accepts a reason with the optional token count", () => {
+    expect(
+      isCacheMissReason({ type: "system_changed", cacheMissedInputTokens: 42 })
+    ).toBe(true);
+  });
+
+  it("accepts a reason without the token count", () => {
+    expect(isCacheMissReason({ type: "no_previous_message" })).toBe(true);
+  });
+
+  it("rejects malformed input", () => {
+    expect(isCacheMissReason(undefined)).toBe(false);
+    expect(isCacheMissReason({})).toBe(false);
+    expect(isCacheMissReason({ type: 1 })).toBe(false);
+  });
+});

--- a/front/lib/model_constructors/utils/cache_miss_reason.ts
+++ b/front/lib/model_constructors/utils/cache_miss_reason.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+// Prompt-cache miss diagnostics surfaced by providers that support them
+// (currently Claude API only). Attached to the `response_id` event metadata.
+// https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics
+export const CacheMissReasonSchema = z.object({
+  type: z.string(),
+  // Only the `*_changed` reasons carry the lost-cache magnitude.
+  cacheMissedInputTokens: z.number().optional(),
+});
+
+export type CacheMissReason = z.infer<typeof CacheMissReasonSchema>;
+
+// Narrow an unknown value (e.g. read back from the metadata content bag) to a
+// CacheMissReason.
+export function isCacheMissReason(value: unknown): value is CacheMissReason {
+  return CacheMissReasonSchema.safeParse(value).success;
+}

--- a/front/package.json
+++ b/front/package.json
@@ -39,8 +39,8 @@
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.2",
-    "@anthropic-ai/vertex-sdk": "^0.17.1",
+    "@anthropic-ai/sdk": "^0.110.0",
+    "@anthropic-ai/vertex-sdk": "^0.19.0",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,8 +317,8 @@
       "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.104.2",
-        "@anthropic-ai/vertex-sdk": "^0.17.1",
+        "@anthropic-ai/sdk": "^0.110.0",
+        "@anthropic-ai/vertex-sdk": "^0.19.0",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -562,7 +562,7 @@
       "name": "@dust-tt/front-api",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.104.2",
+        "@anthropic-ai/sdk": "^0.110.0",
         "@hono/mcp": "^0.3.0",
         "@hono/node-server": "^1.19.10",
         "@hono/zod-validator": "^0.7.6",
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -1307,13 +1307,67 @@
       }
     },
     "node_modules/@anthropic-ai/vertex-sdk": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.17.1.tgz",
-      "integrity": "sha512-+am1LjqEpb7Qq/fKDdu0PTE2U9+XSPXSSr9Fa5dvJ8FtJ5L9XOroNBnr7iecT+6iGlbiV6BYgMIGkAwPuly/jA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.19.0.tgz",
+      "integrity": "sha512-Ja5NkDAmdCcvCJCvkY/6uJ+9krOiXFN56dzb+8n5apElHrYpUMlOCHCVRuLLsJCVWTsN8w60sgN9RSXZ+LPqNA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",
-        "google-auth-library": "^9.4.2"
+        "google-auth-library": "^10.2.0"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {


### PR DESCRIPTION
## Description

Adds Anthropic prompt-cache diagnostics to the new `model_constructors` router: the stream client opts in via `previousMessageId`, extracts the cache-miss reason from `message_start`, and the transition layer surfaces it as `cacheMissReason` on the interaction-id event (with a `CacheMissReason` type predicate + SDK bumps to support it).

## Tests

Added unit tests: `cache_miss_reason`, the Anthropic stream client diagnostics, and the transition-layer mapping. Tested locally.

## Risk

Low. Diagnostics are opt-in (`previousMessageId` undefined = off).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`