### PR TITLE
fix: scope knowledge picker search to selected category

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -7,6 +7,7 @@ import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
 import {
+  findCategoryFromNavigationHistory,
   findDataSourceViewFromNavigationHistory,
   findSpaceFromNavigationHistory,
   getLatestNodeFromNavigationHistory,
@@ -123,6 +124,11 @@ export const DataSourceBuilderSelector = ({
     [navigationHistory]
   );
 
+  const currentCategory = useMemo(
+    () => findCategoryFromNavigationHistory(navigationHistory),
+    [navigationHistory]
+  );
+
   // Automatically select the first space if there is only one
   useEffect(() => {
     if (filteredSpaces.length === 1) {
@@ -152,16 +158,20 @@ export const DataSourceBuilderSelector = ({
       parentId: undefined,
     };
 
-    if (searchScope === "node" && currentSpace) {
-      const dsv = dataSourceViews.filter(
-        (dsv) => dsv.spaceId === currentSpace.sId
-      );
-
-      if (currentDataSourceView) {
+    if (currentSpace) {
+      if (searchScope === "node" && currentDataSourceView) {
         filter.dataSourceViewIdsBySpaceId = {
           [currentSpace.sId]: [currentDataSourceView.sId],
         };
       } else {
+        // Restrict to the data source views of the currently browsed category
+        // (e.g. "Websites") so that search results aren't drowned in unrelated
+        // resource types (connectors, folders, etc.).
+        const dsv = dataSourceViews.filter(
+          (dsv) =>
+            dsv.spaceId === currentSpace.sId &&
+            (!currentCategory || dsv.category === currentCategory)
+        );
         filter.dataSourceViewIdsBySpaceId = {
           [currentSpace.sId]: dsv.map((dsv) => dsv.sId),
         };
@@ -182,6 +192,7 @@ export const DataSourceBuilderSelector = ({
 
     return filter;
   }, [
+    currentCategory,
     currentDataSourceView,
     currentNode,
     currentSpace,


### PR DESCRIPTION
## Description

search in the "Select Data Sources" knowledge picker was ignoring the active category filter (e.g. Websites), so results mixed in connectors/folders/etc. instead of staying scoped. fixes dust-tt/tasks#9561.

root cause: `searchFilter` in `DataSourceBuilderSelector.tsx` only restricted `dataSourceViewIdsBySpaceId` when drilled into a specific data source view (`searchScope === "node"`). at category level it fell through with no restriction at all, so the search hit every view in the space.

now it always scopes to the current space, and to the current category's views when one is selected, narrowing further to a single view only for explicit node-scope search.

## Tests

manual: browsed Company Data > Websites, typed a query, results now stay within website-type sources. also checked space-level search (no category picked yet) and node-scope search (drilled into a specific connector) still behave as before.

## Risk

low, scoped to one component's search filter memo. worst case search results are still too broad, same as before the fix. safe to rollback.

## Deploy Plan

none, standard front deploy.