### PR TITLE
[front] enh: explain knowledge tags in the skills prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -518,7 +518,10 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       '`<knowledge id="..." title="..." ... />` tags, which point to specific workspace knowledge attached to the skill'
     );
     expect(text).toContain(
-      "use the skill's `cat` tool with `nodeId` set to the tag's `id`"
+      "The tag's `id` can be passed as `nodeId` to the skill's knowledge tools"
+    );
+    expect(text).toContain(
+      "`semantic_search` can search within the node and `list` can show its direct children"
     );
     expect(text).not.toContain(
       "Create a git commit with a descriptive message."

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -514,6 +514,12 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       "Skills are modular capabilities that extend your abilities for specific tasks."
     );
     expect(text).toContain("skill_management__enable_skill");
+    expect(text).toContain(
+      '`<knowledge id="..." title="..." ... />` tags, which point to specific workspace knowledge attached to the skill'
+    );
+    expect(text).toContain(
+      "use the skill's `cat` tool with `nodeId` set to the tag's `id`"
+    );
     expect(text).not.toContain(
       "Create a git commit with a descriptive message."
     );

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -223,7 +223,8 @@ function constructSkillsSection({
     "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
     "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
     `Enabled skill instructions can also contain \`<knowledge id=\"...\" title=\"...\" ... />\` tags, which point to specific workspace knowledge attached to the skill. ` +
-    `For document knowledge, use the skill's \`cat\` tool with \`nodeId\` set to the tag's \`id\` to read it directly; when \`hasChildren=\"true\"\`, use \`list\` or \`semantic_search\` to explore its contents.\n` +
+    `The tag's \`id\` can be passed as \`nodeId\` to the skill's knowledge tools: \`cat\` can read a document directly. ` +
+    `For nodes with \`hasChildren=\"true\"\`, \`semantic_search\` can search within the node and \`list\` can show its direct children.\n` +
     `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
     "These mean the instructions used to reference another skill, but that skill is no longer available to this conversation, for example because skill scope or permissions changed. " +
     "Do not try to enable unavailable skill tags.\n" +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -222,6 +222,8 @@ function constructSkillsSection({
     "It is not useful to enable skills that are already enabled, this would only output the skill's content again.\n" +
     "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
     "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
+    `Enabled skill instructions can also contain \`<knowledge id=\"...\" title=\"...\" ... />\` tags, which point to specific workspace knowledge attached to the skill. ` +
+    `For document knowledge, use the skill's \`cat\` tool with \`nodeId\` set to the tag's \`id\` to read it directly; when \`hasChildren=\"true\"\`, use \`list\` or \`semantic_search\` to explore its contents.\n` +
     `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
     "These mean the instructions used to reference another skill, but that skill is no longer available to this conversation, for example because skill scope or permissions changed. " +
     "Do not try to enable unavailable skill tags.\n" +


### PR DESCRIPTION
## Description

Agents can find `<knowledge ... />` tags in enabled skill instructions, and sometimes fail to understand exactly how they can leverage them.
Example [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3BE9IA4IBFCQ&peek=83b989b195435612e0a30e06673bb625&timestamp=2026-07-13T13%3A02%3A31.727Z) where the agent runs a semantic search instead of directly reading the file.

This PR adds guidance explaining that the data can be read with the skill-attached `cat` tool using the tag `id` as `nodeId`, and that `list` or `semantic_search` can explore nodes with children.

## Tests

- Updated existing tests.

## Risk

- Low. Prompt-only change.
- Will burst the cache.

## Deploy Plan

- Deploy front.
