### PR TITLE
[front] enh: expose conversation render token diagnostics

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -206,6 +206,34 @@ describe("renderConversationForModel", () => {
     expect(res.value.modelConversation.messages).toHaveLength(3);
     expect(res.value.tokensUsed).toBe(1071);
     expect(res.value.prunedContext).toBe(false);
+    expect(res.value.diagnostics).toEqual({
+      counts: {
+        modelMessageCount: 3,
+        renderedInteractionCount: 1,
+        renderedMessageCount: 3,
+        selectedInteractionCount: 1,
+      },
+      messageBreakdown: [
+        { index: 0, name: "user", role: "user", tokenCount: 10 },
+        { index: 1, name: "assistant", role: "assistant", tokenCount: 10 },
+        { index: 2, name: "tool_1", role: "function", tokenCount: 10 },
+      ],
+      pruning: {
+        currentInteractionPruned: false,
+        omittedInteractionCount: 0,
+        previousInteractionsPruned: false,
+      },
+      tokenCounts: {
+        allowed: 1171,
+        messages: 30,
+        prompt: 10,
+        remaining: 100,
+        safetyMargin: 1024,
+        toolDefinitionsAdjusted: 7,
+        toolDefinitionsRaw: 10,
+        total: 1071,
+      },
+    });
   });
 
   it("prunes old tool outputs beyond TOOL_RESULTS_TO_PRESERVE but keeps the most recent ones, across separate interactions", async () => {
@@ -544,6 +572,11 @@ describe("renderConversationForModel", () => {
     }
     expect(textOf(firstUser.content[0])).toBe("fragment_text");
     expect(textOf(firstUser.content[1])).toBe("user_text");
+    expect(res.value.diagnostics.messageBreakdown).toEqual([
+      { index: 0, name: "user", role: "user", tokenCount: 20 },
+      { index: 1, name: "assistant", role: "assistant", tokenCount: 10 },
+      { index: 2, name: "tool_1", role: "function", tokenCount: 10 },
+    ]);
   });
 
   it("returns an error when context window is still exceeded after every pruning layer", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -8,6 +8,7 @@ import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationRenderDiagnostics } from "@app/types/assistant/conversation_rendering";
 import type {
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActions,
@@ -192,6 +193,7 @@ export async function renderConversationForModel(
   Result<
     {
       modelConversation: ModelConversationTypeMultiActions;
+      diagnostics: ConversationRenderDiagnostics;
       tokensUsed: number;
       prunedContext: boolean;
     },
@@ -315,6 +317,11 @@ export async function renderConversationForModel(
     (interaction) => interaction.messages
   );
   const tokensUsed = baseTokens + totalTokens;
+  const selectedInteractionCount = prunedInteractions.length;
+
+  const selectedMessageTokenCounts = selected.map(
+    (message) => message.tokenCount
+  );
 
   // Merge content fragments into user messages.
   for (let i = selected.length - 1; i >= 0; i--) {
@@ -339,8 +346,13 @@ export async function renderConversationForModel(
         );
       }
 
-      userMessage.content = [...cfMessage.content, ...userMessage.content];
+      selected[i + 1] = {
+        ...userMessage,
+        content: [...cfMessage.content, ...userMessage.content],
+      };
+      selectedMessageTokenCounts[i + 1] += selectedMessageTokenCounts[i];
       selected.splice(i, 1);
+      selectedMessageTokenCounts.splice(i, 1);
     }
   }
 
@@ -374,6 +386,54 @@ export async function renderConversationForModel(
         message.role !== "content_fragment"
     );
 
+  const messageBreakdown = finalMessages.map((message, index) => ({
+    index,
+    name: "name" in message ? message.name : null,
+    role: message.role,
+    tokenCount: selectedMessageTokenCounts[index],
+  }));
+  const selectedMessagesTokenCount = selectedMessageTokenCounts.reduce(
+    (sum, tokenCount) => sum + tokenCount,
+    0
+  );
+  const adjustedToolDefinitionsCount = Math.floor(
+    toolDefinitionsCount * TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR
+  );
+  const originalPreviousInteractions = interactions.slice(0, -1);
+  const prunedPreviousInteractions = prunedInteractions.slice(0, -1);
+  const previousInteractionsPruned =
+    prunedPreviousInteractions.length < originalPreviousInteractions.length ||
+    sumInteractionTokens(prunedPreviousInteractions) <
+      sumInteractionTokens(originalPreviousInteractions);
+  const currentInteractionPruned =
+    getInteractionTokenCount(
+      prunedInteractions[prunedInteractions.length - 1]
+    ) < getInteractionTokenCount(interactions[interactions.length - 1]);
+
+  const diagnostics: ConversationRenderDiagnostics = {
+    counts: {
+      modelMessageCount: finalMessages.length,
+      renderedInteractionCount: interactions.length,
+      renderedMessageCount: messages.length,
+      selectedInteractionCount,
+    },
+    messageBreakdown,
+    pruning: {
+      currentInteractionPruned,
+      omittedInteractionCount: interactions.length - selectedInteractionCount,
+      previousInteractionsPruned,
+    },
+    tokenCounts: {
+      allowed: allowedTokenCount,
+      messages: selectedMessagesTokenCount,
+      prompt: promptCount,
+      remaining: Math.max(allowedTokenCount - tokensUsed, 0),
+      safetyMargin: TOKENS_MARGIN,
+      toolDefinitionsAdjusted: adjustedToolDefinitionsCount,
+      toolDefinitionsRaw: toolDefinitionsCount,
+      total: tokensUsed,
+    },
+  };
   const pruneSelectAndFinalizeMs = Date.now() - stepStart;
 
   logger.info(
@@ -397,6 +457,7 @@ export async function renderConversationForModel(
   );
 
   return new Ok({
+    diagnostics,
     modelConversation: {
       messages: finalMessages,
     },

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -1428,6 +1428,32 @@ describe("getEmailSummary", () => {
     // Set up consistent mock for renderConversationForModel
     vi.mocked(renderConversationForModel).mockResolvedValue(
       new Ok({
+        diagnostics: {
+          counts: {
+            modelMessageCount: 1,
+            renderedInteractionCount: 1,
+            renderedMessageCount: 1,
+            selectedInteractionCount: 1,
+          },
+          messageBreakdown: [
+            { index: 0, name: "Test User", role: "user", tokenCount: 100 },
+          ],
+          pruning: {
+            currentInteractionPruned: false,
+            omittedInteractionCount: 0,
+            previousInteractionsPruned: false,
+          },
+          tokenCounts: {
+            allowed: 1_000,
+            messages: 100,
+            prompt: 0,
+            remaining: 900,
+            safetyMargin: 0,
+            toolDefinitionsAdjusted: 0,
+            toolDefinitionsRaw: 0,
+            total: 100,
+          },
+        },
         modelConversation: {
           messages: [
             {

--- a/front/types/assistant/conversation_rendering.ts
+++ b/front/types/assistant/conversation_rendering.ts
@@ -1,0 +1,33 @@
+import type { ModelMessageTypeMultiActions } from "./generation";
+
+export type ConversationRenderMessageDiagnostic = {
+  index: number;
+  name: string | null;
+  role: ModelMessageTypeMultiActions["role"];
+  tokenCount: number;
+};
+
+export type ConversationRenderDiagnostics = {
+  counts: {
+    modelMessageCount: number;
+    renderedInteractionCount: number;
+    renderedMessageCount: number;
+    selectedInteractionCount: number;
+  };
+  messageBreakdown: ConversationRenderMessageDiagnostic[];
+  pruning: {
+    currentInteractionPruned: boolean;
+    omittedInteractionCount: number;
+    previousInteractionsPruned: boolean;
+  };
+  tokenCounts: {
+    allowed: number;
+    messages: number;
+    prompt: number;
+    remaining: number;
+    safetyMargin: number;
+    toolDefinitionsAdjusted: number;
+    toolDefinitionsRaw: number;
+    total: number;
+  };
+};


### PR DESCRIPTION
## Description

The Poke renderer needs exact context-budget diagnostics before the inspection UI can explain pruning. This adds shared diagnostics types and returns prompt, tool, and message token counts plus pruning state from `renderConversationForModel`, without changing its pruning decisions.

This is the first PR in the Poke render diagnostics stack.

## Tests

- Added coverage for token diagnostics and content-fragment aggregation.

## Risk

- Low. Adds diagnostics to an internal renderer result.

## Deploy Plan

- Deploy front.
