### PR TITLE
[front] enh: align Poke rendering with runModel

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -1,52 +1,43 @@
-import { buildToolSpecification } from "@app/lib/actions/mcp";
-import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
-import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
-import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
-import { getJITServers } from "@app/lib/api/assistant/jit_actions";
-import { listAttachments } from "@app/lib/api/assistant/jit_utils";
-import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
-import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
-import { systemPromptToText } from "@app/lib/api/llm/types/options";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import { constructProjectContext } from "@app/lib/resources/skill/code_defined/global/projects";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { tokenCountForTexts } from "@app/lib/tokenization";
-import type {
-  AgentMessageType,
-  ConversationType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
-import { isUserMessageType } from "@app/types/assistant/conversation";
-import { removeNulls } from "@app/types/shared/utils/general";
+import {
+  buildSpecificationsWithReplayPlaceholders,
+  getMissingActionCatcherFunctionCallIds,
+  prepareModelRender,
+} from "@app/lib/api/assistant/model_rendering";
+import {
+  getHistoricalRunAgentData,
+  getPreviewRunAgentData,
+  RenderTargetError,
+} from "@app/lib/api/poke/conversation_render";
+import { getFeatureFlags } from "@app/lib/auth";
+import type { PostRenderConversationResponseBody } from "@app/types/api/poke/conversation_render";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-const RenderConversationBodySchema = z.object({
-  agentId: z.string(),
-  contextSizeOverride: z.number().positive().nullable().optional(),
-  excludeActions: z.boolean().optional(),
-  excludeImages: z.boolean().optional(),
-  onMissingAction: z.enum(["inject-placeholder", "skip"]).optional(),
-});
+const RenderConversationBodySchema = z
+  .object({
+    agentId: z.string().optional(),
+    agentMessageId: z.string().optional(),
+    agentMessageVersion: z.number().int().nonnegative().optional(),
+    contextSizeOverride: z.number().positive().nullable().optional(),
+    excludeActions: z.boolean().optional(),
+    excludeImages: z.boolean().optional(),
+    onMissingAction: z.enum(["inject-placeholder", "skip"]).optional(),
+    step: z.number().int().nonnegative().optional(),
+  })
+  .refine(
+    (body) => body.agentId !== undefined || body.agentMessageId !== undefined,
+    {
+      message: "Either agentId or agentMessageId is required.",
+    }
+  );
 
 const ParamsSchema = z.object({
   cId: z.string(),
 });
-
-export type PostRenderConversationResponseBody = {
-  tokensUsed: number;
-  modelConversation: unknown;
-  modelContextSizeUsed: number;
-  promptTokenCountApprox: number;
-  toolsTokenCountApprox: number;
-};
 
 // Mounted at /api/poke/workspaces/:wId/conversations/:cId/render.
 const app = pokeApp();
@@ -61,17 +52,16 @@ app.post(
     const { cId } = ctx.req.valid("param");
     const {
       agentId,
+      agentMessageId,
+      agentMessageVersion,
       contextSizeOverride,
       excludeActions,
       excludeImages,
       onMissingAction,
+      step = 0,
     } = ctx.req.valid("json");
 
-    const [conversationRes, agentConfiguration] = await Promise.all([
-      getConversation(auth, cId, true),
-      getAgentConfiguration(auth, { agentId, variant: "full" }),
-    ]);
-
+    const conversationRes = await getConversation(auth, cId, true);
     if (conversationRes.isErr()) {
       return apiError(ctx, {
         status_code: 404,
@@ -81,179 +71,62 @@ app.post(
         },
       });
     }
-    const conversation: ConversationType = conversationRes.value;
+    const conversation = conversationRes.value;
 
-    if (!agentConfiguration) {
+    const renderTarget = agentMessageId
+      ? await getHistoricalRunAgentData(auth, {
+          agentMessageId,
+          agentMessageVersion,
+          conversation,
+          step,
+        })
+      : await getPreviewRunAgentData(auth, {
+          agentId: agentId ?? "",
+          conversation,
+        });
+    if (renderTarget instanceof RenderTargetError) {
       return apiError(ctx, {
-        status_code: 404,
+        status_code: renderTarget.statusCode,
         api_error: {
-          type: "agent_configuration_not_found",
-          message: `Agent configuration not found for sId ${agentId}.`,
+          type: renderTarget.errorType,
+          message: renderTarget.message,
         },
       });
     }
 
-    const model = getSupportedModelConfig(agentConfiguration.model);
-    if (!model) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Model ${agentConfiguration.model.modelId} is not supported for rendering.`,
-        },
-      });
-    }
-
-    const lastUserMessage = conversation.content
-      .map((tuple) => tuple[0])
-      .filter((m): m is UserMessageType => isUserMessageType(m))
-      .at(-1);
-    if (!lastUserMessage) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "No user message found in conversation content.",
-        },
-      });
-    }
-    const userMessage: UserMessageType = lastUserMessage;
-
-    const attachments = await listAttachments(auth, { conversation });
-    const jitServers = await getJITServers(auth, {
-      agentConfiguration,
-      conversation,
-      attachments,
+    const {
+      agentMessage,
+      conversation: conversationForRender,
+      runAgentData,
+      reconstruction,
+    } = renderTarget;
+    const featureFlags = await getFeatureFlags(auth);
+    const preparedRender = await prepareModelRender(auth, {
+      featureFlags,
+      runAgentData,
+      conversation: conversationForRender,
+      agentMessage,
     });
 
-    const { enabledSkills, systemSkills, equippedSkills } =
-      await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration,
-        conversation,
-      });
-
-    const { skillServers, systemSkillServers } = await getSkillServers(auth, {
-      agentConfiguration,
-      systemSkills,
-      enabledSkills,
-    });
-
-    const clientSideMCPActionConfigurations =
-      await createClientSideMCPServerConfigurations(
-        auth,
-        userMessage.context.clientSideMCPServerIds
-      );
-
-    const placeholderAgentMessage: AgentMessageType = {
-      type: "agent_message",
-      sId: generateRandomModelSId("msg"),
-      version: 0,
-      rank: 0,
-      branchId: null,
-      created: Date.now(),
-      completedTs: null,
-      parentMessageId: userMessage.sId,
-      parentAgentMessageId: null,
-      status: "created",
-      content: null,
-      chainOfThought: null,
-      error: null,
-      id: -1,
-      agentMessageId: -1,
-      visibility: "visible",
-      configuration: agentConfiguration,
-      skipToolsValidation: false,
-      actions: [],
-      contents: [],
-      modelInteractionDurationMs: null,
-      completionDurationMs: null,
-      richMentions: [],
-      reactions: [],
-      costCredits: null,
-      resolvedModel: null,
-      modelResolutionMethod: null,
-    };
-
-    const serverToolsAndInstructions = await tryListMCPTools(
-      auth,
-      {
-        agentConfiguration,
-        conversation,
-        agentMessage: placeholderAgentMessage,
-        clientSideActionConfigurations: clientSideMCPActionConfigurations,
-      },
-      { jitServers, skillServers, systemSkillServers }
-    );
-
-    const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);
-
-    let fallbackPrompt = "You are a conversational agent";
-    if (agentConfiguration.actions.length || availableActions.length > 0) {
-      fallbackPrompt += " with access to tool use.";
-    } else {
-      fallbackPrompt += ".";
-    }
-
-    const projectContext = await constructProjectContext(auth, {
-      conversation,
-    });
-
-    const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
-
-    const promptSections = constructPromptMultiActions(auth, {
-      userMessage,
-      agentConfiguration,
-      fallbackPrompt,
-      model: {
-        ...agentConfiguration.model,
-        ...model,
-      },
-      hasAvailableActions: availableActions.length > 0,
-      conversation,
-      serverToolsAndInstructions,
-      systemSkills,
-      projectContext,
-      isNewFileExplorer,
-    });
-    const prompt = systemPromptToText(promptSections);
-    const leadingMessages = removeNulls([
-      renderEquippedSkillsUserMessage(equippedSkills),
-    ]);
-
-    const specifications = availableActions.map((t) =>
-      buildToolSpecification(t)
-    );
-    const tools = JSON.stringify(
-      specifications.map((s) => ({
-        name: s.name,
-        description: s.description,
-        inputSchema: s.inputSchema,
-      }))
-    );
-
-    const contextSize =
-      typeof contextSizeOverride === "number" && contextSizeOverride > 0
-        ? contextSizeOverride
-        : model.contextSize;
+    const { agentConfiguration, model } = runAgentData;
+    const contextSize = contextSizeOverride ?? model.contextSize;
     const allowedTokenCount = Math.max(
       0,
       contextSize - model.generationTokensCount
     );
-
     const convoRes = await renderConversationForModel(auth, {
-      conversation,
+      conversation: conversationForRender,
       model,
-      prompt,
-      tools,
+      prompt: preparedRender.promptText,
+      tools: preparedRender.tools,
       allowedTokenCount,
       excludeActions,
       excludeImages,
       onMissingAction,
       agentConfiguration,
-      leadingMessages,
-      enabledSkills,
+      leadingMessages: preparedRender.leadingMessages,
+      enabledSkills: preparedRender.enabledSkills,
     });
-
     if (convoRes.isErr()) {
       return apiError(ctx, {
         status_code: 400,
@@ -264,28 +137,43 @@ app.post(
       });
     }
 
-    const { modelConversation, tokensUsed } = convoRes.value;
-
-    let promptTokenCountApprox = 0;
-    let toolsTokenCountApprox = 0;
-    const credentials = await getLlmCredentials(auth, {
-      skipEmbeddingApiKeyRequirement: true,
-    });
-    const tokenCountsRes = await tokenCountForTexts(
-      [prompt, tools],
-      model,
-      credentials
+    const parsedToolDefinitions: unknown = JSON.parse(preparedRender.tools);
+    const { diagnostics, modelConversation, prunedContext, tokensUsed } =
+      convoRes.value;
+    const { specifications } = buildSpecificationsWithReplayPlaceholders(
+      preparedRender.baseSpecifications,
+      {
+        modelConversation,
+        missingActionCatcherFunctionCallIds:
+          getMissingActionCatcherFunctionCallIds(conversationForRender),
+      }
     );
-    if (tokenCountsRes.isOk()) {
-      [promptTokenCountApprox, toolsTokenCountApprox] = tokenCountsRes.value;
-    }
 
     return ctx.json({
-      tokensUsed,
-      modelConversation,
+      diagnostics,
+      model: {
+        contextSize: model.contextSize,
+        generationTokensCount: model.generationTokensCount,
+        modelId: model.modelId,
+        providerId: model.providerId,
+      },
       modelContextSizeUsed: contextSize,
-      promptTokenCountApprox,
-      toolsTokenCountApprox,
+      modelConversation,
+      prompt: preparedRender.promptText,
+      promptTokenCountApprox: diagnostics.tokenCounts.prompt,
+      prunedContext,
+      reconstruction,
+      runtimeContext: {
+        equippedSkillCount: preparedRender.equippedSkillCount,
+        systemSkillCount: preparedRender.systemSkillCount,
+        toolSearchEnabled: preparedRender.toolSearchEnabled,
+      },
+      tokensUsed,
+      toolDefinitionsInContext: Array.isArray(parsedToolDefinitions)
+        ? parsedToolDefinitions
+        : [],
+      toolSpecifications: specifications,
+      toolsTokenCountApprox: diagnostics.tokenCounts.toolDefinitionsRaw,
     });
   }
 );


### PR DESCRIPTION
## Description

The Poke render endpoint currently rebuilds only part of the model input and can drift from `runModel`. This switches it to the shared preparation path and supports reconstructing a historical agent-message step as well as a live preview.

The response now exposes the exact prompt, tool specifications, model context, pruning diagnostics, and reconstruction caveats used for inspection.

## Tests

- Tested locally.

## Risk

- Medium. Changes a Poke-only diagnostics endpoint.

## Deploy Plan

- Deploy front-api.
