### PR TITLE
[front] enh: add Langfuse-backed Poke traces

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -1,12 +1,10 @@
 import { fetchLLMTrace, isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
+import { fetchLangfuseTraceByDustTraceId } from "@app/lib/api/llm/traces/langfuse";
+import type { GetPokeLLMTraceResponseBody } from "@app/types/api/poke/llm_traces";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-interface GetLLMTraceResponseBody {
-  trace: unknown | null;
-}
 
 const ParamsSchema = z.object({
   runId: z.string(),
@@ -19,7 +17,7 @@ const app = pokeApp();
 app.get(
   "/",
   validate("param", ParamsSchema),
-  async (ctx): HandlerResult<GetLLMTraceResponseBody> => {
+  async (ctx): HandlerResult<GetPokeLLMTraceResponseBody> => {
     const auth = ctx.get("auth");
     const { runId } = ctx.req.valid("param");
 
@@ -34,9 +32,18 @@ app.get(
       });
     }
 
-    const trace = await fetchLLMTrace(auth, { runId });
+    const [trace, langfuseTraceRes] = await Promise.all([
+      fetchLLMTrace(auth, { runId }),
+      fetchLangfuseTraceByDustTraceId(auth, { dustTraceId: runId }),
+    ]);
 
-    return ctx.json({ trace });
+    return ctx.json({
+      langfuseError: langfuseTraceRes.isErr()
+        ? langfuseTraceRes.error.message
+        : null,
+      langfuseTrace: langfuseTraceRes.isOk() ? langfuseTraceRes.value : null,
+      trace,
+    });
   }
 );
 

--- a/front/components/poke/llm_traces/LangfuseTraceView.tsx
+++ b/front/components/poke/llm_traces/LangfuseTraceView.tsx
@@ -1,0 +1,160 @@
+import type {
+  PokeLangfuseObservation,
+  PokeLangfuseTrace,
+} from "@app/types/api/poke/llm_traces";
+import {
+  Chip,
+  CodeBlock,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@dust-tt/sparkle";
+
+function formatDurationSeconds(durationSeconds: number | null): string {
+  if (durationSeconds === null) {
+    return "unknown";
+  }
+  if (durationSeconds >= 1) {
+    return `${durationSeconds.toFixed(2)}s`;
+  }
+  return `${Math.round(durationSeconds * 1_000)}ms`;
+}
+
+function formatCost(costUsd: number | null): string {
+  if (costUsd === null) {
+    return "unknown";
+  }
+  return `$${costUsd.toFixed(costUsd < 0.01 ? 5 : 3)}`;
+}
+
+function getGenerationObservation(
+  trace: PokeLangfuseTrace
+): PokeLangfuseObservation | undefined {
+  return trace.observations.find(
+    (observation) =>
+      observation.type.toLowerCase() === "generation" ||
+      observation.name === "llm-completion"
+  );
+}
+
+function getUsage(
+  observation: PokeLangfuseObservation | undefined,
+  key: string
+): number {
+  return observation?.usageDetails[key] ?? 0;
+}
+
+export function LangfuseTraceView({ trace }: { trace: PokeLangfuseTrace }) {
+  const generation = getGenerationObservation(trace);
+  const inputTokens = getUsage(generation, "input");
+  const outputTokens = getUsage(generation, "output");
+  const cacheReadTokens = getUsage(generation, "cache_read_input_tokens");
+  const cacheCreationTokens = getUsage(
+    generation,
+    "cache_creation_input_tokens"
+  );
+  const totalCostUsd =
+    trace.totalCostUsd ?? generation?.costDetails.total ?? null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-foreground">
+              Recorded Langfuse generation
+            </h2>
+            <Chip color="success" label="Historical data" size="xs" />
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {new Date(trace.timestamp).toLocaleString()} · {trace.id}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {generation?.model && (
+            <Chip color="highlight" label={generation.model} size="sm" />
+          )}
+          <Chip
+            color="info"
+            label={`${inputTokens.toLocaleString()} input → ${outputTokens.toLocaleString()} output`}
+            size="sm"
+          />
+          <Chip
+            color="primary"
+            label={`${cacheReadTokens.toLocaleString()} cache read`}
+            size="sm"
+          />
+          {cacheCreationTokens > 0 && (
+            <Chip
+              color="primary"
+              label={`${cacheCreationTokens.toLocaleString()} cache write`}
+              size="sm"
+            />
+          )}
+          <Chip
+            color="info"
+            label={formatDurationSeconds(
+              generation?.latencySeconds ?? trace.latencySeconds
+            )}
+            size="sm"
+          />
+          <Chip color="success" label={formatCost(totalCostUsd)} size="sm" />
+        </div>
+      </div>
+
+      {generation?.statusMessage && (
+        <div className="rounded-lg border border-warning-300 bg-warning-50 p-3 text-sm text-warning-900">
+          {generation.statusMessage}
+        </div>
+      )}
+
+      <Tabs defaultValue="input">
+        <TabsList>
+          <TabsTrigger value="input" label="Provider input" />
+          <TabsTrigger value="output" label="Provider output" />
+          <TabsTrigger value="metadata" label="Metadata" />
+          <TabsTrigger value="raw" label="Raw Langfuse trace" />
+        </TabsList>
+        <TabsContent value="input">
+          <div className="pt-3">
+            <CodeBlock wrapLongLines className="language-json">
+              {JSON.stringify(generation?.input ?? trace.input, null, 2)}
+            </CodeBlock>
+          </div>
+        </TabsContent>
+        <TabsContent value="output">
+          <div className="pt-3">
+            <CodeBlock wrapLongLines className="language-json">
+              {JSON.stringify(generation?.output ?? trace.output, null, 2)}
+            </CodeBlock>
+          </div>
+        </TabsContent>
+        <TabsContent value="metadata">
+          <div className="pt-3">
+            <CodeBlock wrapLongLines className="language-json">
+              {JSON.stringify(
+                {
+                  generation: generation?.metadata,
+                  trace: trace.metadata,
+                  usage: generation?.usageDetails,
+                  cost: generation?.costDetails,
+                  timeToFirstTokenSeconds: generation?.timeToFirstTokenSeconds,
+                },
+                null,
+                2
+              )}
+            </CodeBlock>
+          </div>
+        </TabsContent>
+        <TabsContent value="raw">
+          <div className="pt-3">
+            <CodeBlock wrapLongLines className="language-json">
+              {JSON.stringify(trace, null, 2)}
+            </CodeBlock>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -1,4 +1,5 @@
 import { InputTab } from "@app/components/poke/llm_traces/InputTab";
+import { LangfuseTraceView } from "@app/components/poke/llm_traces/LangfuseTraceView";
 import { OutputTab } from "@app/components/poke/llm_traces/OutputTab";
 import { RawJsonTab } from "@app/components/poke/llm_traces/RawJsonTab";
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
@@ -48,10 +49,13 @@ export function LLMTracePage() {
 
   const runId = useRequiredPathParam("runId");
   usePokePageMetadata({ name: owner.name, subtitle: "LLM Trace", sId: runId });
-  const { trace, isLLMTraceLoading, isLLMTraceError } = usePokeLLMTrace({
-    workspace: owner,
-    runId,
-  });
+  const {
+    langfuseError,
+    langfuseTrace,
+    trace,
+    isLLMTraceLoading,
+    isLLMTraceError,
+  } = usePokeLLMTrace({ workspace: owner, runId });
 
   if (isLLMTraceLoading) {
     return (
@@ -61,17 +65,38 @@ export function LLMTracePage() {
     );
   }
 
-  if (isLLMTraceError || !trace) {
+  if (isLLMTraceError || (!trace && !langfuseTrace)) {
     return (
       <div className="flex h-64 flex-col items-center justify-center">
         <div className="text-lg font-medium text-warning">
           Failed to load LLM trace
         </div>
         <div className="mt-2 text-sm text-muted-foreground">
-          The trace may not exist or there was an error fetching it from GCS.
+          {langfuseError ??
+            "The trace was not found in either the trace buffer or Langfuse."}
         </div>
       </div>
     );
+  }
+
+  if (langfuseTrace && !trace) {
+    return (
+      <div className="max-w-6xl">
+        <Page.Vertical align="stretch">
+          <div>
+            <h1 className="text-2xl font-bold">LLM Trace</h1>
+            <div className="text-sm text-muted-foreground">
+              Run ID: <code className="text-xs">{runId}</code>
+            </div>
+          </div>
+          <LangfuseTraceView trace={langfuseTrace} />
+        </Page.Vertical>
+      </div>
+    );
+  }
+
+  if (!trace) {
+    return null;
   }
 
   const toolCallCount = trace?.output?.toolCalls?.length;
@@ -200,6 +225,13 @@ export function LLMTracePage() {
             <RawJsonTab trace={trace} />
           </TabsContent>
         </Tabs>
+
+        {langfuseTrace && <LangfuseTraceView trace={langfuseTrace} />}
+        {langfuseError && (
+          <div className="rounded-lg border border-warning-300 bg-warning-50 p-4 text-sm text-warning-900">
+            Langfuse data could not be loaded: {langfuseError}
+          </div>
+        )}
       </Page.Vertical>
     </div>
   );

--- a/front/lib/api/llm/traces/langfuse.test.ts
+++ b/front/lib/api/llm/traces/langfuse.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getLangfuseClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/langfuse_client", () => ({
+  getLangfuseClient: getLangfuseClientMock,
+}));
+
+import { fetchLangfuseTraceByDustTraceId } from "./langfuse";
+
+const auth = {
+  getNonNullableWorkspace: () => ({ sId: "workspace-1" }),
+};
+
+describe("fetchLangfuseTraceByDustTraceId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when Langfuse is disabled", async () => {
+    getLangfuseClientMock.mockReturnValue(null);
+
+    const result = await fetchLangfuseTraceByDustTraceId(auth, {
+      dustTraceId: "llm_trace_1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  it("does not expose a trace from another workspace", async () => {
+    const getTraceMock = vi.fn();
+    getLangfuseClientMock.mockReturnValue({
+      api: {
+        trace: {
+          get: getTraceMock,
+          list: vi.fn().mockResolvedValue({
+            data: [{ id: "langfuse-trace-1", userId: "workspace-2" }],
+          }),
+        },
+      },
+    });
+
+    const result = await fetchLangfuseTraceByDustTraceId(auth, {
+      dustTraceId: "llm_trace_1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
+    expect(getTraceMock).not.toHaveBeenCalled();
+  });
+
+  it("returns normalized provider input, output, usage, cost, and timing", async () => {
+    const listTraceMock = vi.fn().mockResolvedValue({
+      data: [{ id: "langfuse-trace-1", userId: "workspace-1" }],
+    });
+    getLangfuseClientMock.mockReturnValue({
+      api: {
+        trace: {
+          get: vi.fn().mockResolvedValue({
+            id: "langfuse-trace-1",
+            input: { prompt: "system prompt" },
+            latency: 1.25,
+            metadata: { dustTraceId: "llm_trace_1" },
+            name: "Agent conversation",
+            observations: [
+              {
+                costDetails: { total: 0.012 },
+                endTime: "2026-07-13T10:00:01.250Z",
+                id: "generation-1",
+                input: [{ role: "user", content: "Hello" }],
+                latency: 1.25,
+                level: "DEFAULT",
+                metadata: { tools: ["search"] },
+                model: "claude-sonnet-4-5",
+                name: "llm-completion",
+                output: { content: "Hi" },
+                startTime: "2026-07-13T10:00:00.000Z",
+                statusMessage: null,
+                timeToFirstToken: 0.2,
+                type: "GENERATION",
+                usageDetails: { input: 120, output: 12 },
+              },
+            ],
+            output: { content: "Hi" },
+            tags: ["agent_conversation"],
+            timestamp: "2026-07-13T10:00:00.000Z",
+            totalCost: 0.012,
+          }),
+          list: listTraceMock,
+        },
+      },
+    });
+
+    const result = await fetchLangfuseTraceByDustTraceId(auth, {
+      dustTraceId: "llm_trace_1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toMatchObject({
+        id: "langfuse-trace-1",
+        latencySeconds: 1.25,
+        observations: [
+          {
+            costDetails: { total: 0.012 },
+            input: [{ role: "user", content: "Hello" }],
+            output: { content: "Hi" },
+            timeToFirstTokenSeconds: 0.2,
+            usageDetails: { input: 120, output: 12 },
+          },
+        ],
+        totalCostUsd: 0.012,
+      });
+    }
+    expect(listTraceMock).toHaveBeenCalledWith({
+      filter: JSON.stringify([
+        {
+          type: "stringObject",
+          column: "metadata",
+          key: "dustTraceId",
+          operator: "=",
+          value: "llm_trace_1",
+        },
+      ]),
+      limit: 1,
+    });
+  });
+});

--- a/front/lib/api/llm/traces/langfuse.ts
+++ b/front/lib/api/llm/traces/langfuse.ts
@@ -1,0 +1,68 @@
+import { getLangfuseClient } from "@app/lib/api/langfuse_client";
+import type { PokeLangfuseTrace } from "@app/types/api/poke/llm_traces";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function fetchLangfuseTraceByDustTraceId(
+  auth: { getNonNullableWorkspace: () => { sId: string } },
+  { dustTraceId }: { dustTraceId: string }
+): Promise<Result<PokeLangfuseTrace | null, Error>> {
+  const client = getLangfuseClient();
+  if (!client) {
+    return new Ok(null);
+  }
+
+  const filter = JSON.stringify([
+    {
+      type: "stringObject",
+      column: "metadata",
+      key: "dustTraceId",
+      operator: "=",
+      value: dustTraceId,
+    },
+  ]);
+
+  try {
+    const traces = await client.api.trace.list({ filter, limit: 1 });
+    const traceSummary = traces.data?.[0];
+    if (
+      !traceSummary ||
+      traceSummary.userId !== auth.getNonNullableWorkspace().sId
+    ) {
+      return new Ok(null);
+    }
+
+    const trace = await client.api.trace.get(traceSummary.id);
+    return new Ok({
+      id: trace.id,
+      input: trace.input,
+      latencySeconds: trace.latency ?? null,
+      metadata: trace.metadata,
+      name: trace.name,
+      observations: trace.observations.map((observation) => ({
+        costDetails: observation.costDetails,
+        endTime: observation.endTime,
+        id: observation.id,
+        input: observation.input,
+        latencySeconds: observation.latency,
+        level: observation.level,
+        metadata: observation.metadata,
+        model: observation.model,
+        name: observation.name,
+        output: observation.output,
+        startTime: observation.startTime,
+        statusMessage: observation.statusMessage,
+        timeToFirstTokenSeconds: observation.timeToFirstToken,
+        type: observation.type,
+        usageDetails: observation.usageDetails,
+      })),
+      output: trace.output,
+      tags: trace.tags,
+      timestamp: trace.timestamp,
+      totalCostUsd: trace.totalCost ?? null,
+    });
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -7,6 +7,7 @@ import type {
   GetDocumentsResponseBody,
   GetTablesResponseBody,
 } from "@app/types/api/poke/data_sources";
+import type { GetPokeLLMTraceResponseBody } from "@app/types/api/poke/llm_traces";
 import type { PullTemplatesResponseBody } from "@app/types/api/poke/templates";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
@@ -129,7 +130,8 @@ export function usePokeLLMTrace({
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const llmTraceFetcher: Fetcher<{ trace: LLMTrace | null }> = fetcher;
+  const llmTraceFetcher: Fetcher<GetPokeLLMTraceResponseBody<LLMTrace>> =
+    fetcher;
 
   const { data, error, mutate } = useSWR(
     runId && !disabled
@@ -139,6 +141,8 @@ export function usePokeLLMTrace({
   );
 
   return {
+    langfuseError: data?.langfuseError ?? null,
+    langfuseTrace: data?.langfuseTrace ?? null,
     trace: data ? data.trace : null,
     isLLMTraceLoading: !error && !data && !disabled,
     isLLMTraceError: error,

--- a/front/types/api/poke/llm_traces.ts
+++ b/front/types/api/poke/llm_traces.ts
@@ -1,0 +1,36 @@
+export type PokeLangfuseObservation = {
+  costDetails: Record<string, number>;
+  endTime: string | null;
+  id: string;
+  input?: unknown;
+  latencySeconds: number | null;
+  level: string;
+  metadata?: unknown;
+  model: string | null;
+  name: string | null;
+  output?: unknown;
+  startTime: string;
+  statusMessage: string | null;
+  timeToFirstTokenSeconds: number | null;
+  type: string;
+  usageDetails: Record<string, number>;
+};
+
+export type PokeLangfuseTrace = {
+  id: string;
+  input?: unknown;
+  latencySeconds: number | null;
+  metadata?: unknown;
+  name: string | null;
+  observations: PokeLangfuseObservation[];
+  output?: unknown;
+  tags: string[];
+  timestamp: string;
+  totalCostUsd: number | null;
+};
+
+export type GetPokeLLMTraceResponseBody<TTrace = unknown> = {
+  langfuseError: string | null;
+  langfuseTrace: PokeLangfuseTrace | null;
+  trace: TTrace | null;
+};


### PR DESCRIPTION
## Description

Poke LLM traces currently expose only the locally recorded trace. This enriches them with workspace-scoped Langfuse data and presents normalized provider input and output, token and cache usage, cost, and timing when available.

The existing trace remains available when Langfuse is disabled or has no matching workspace-owned trace.

## Tests

- Added coverage for the disabled state, workspace isolation, and trace normalization.

## Risk

- Low. Poke-only and falls back to the existing trace.

## Deploy Plan

- Deploy front-api and front-spa.
