### PR TITLE
Batch interaction drops so conversations at the context ceiling stop paying a full cache miss on every call

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -602,6 +602,28 @@ describe("renderConversationForModel", () => {
     }
   });
 
+  it("handles an empty conversation gracefully even when the budget is already negative", async () => {
+    // Regression: baseTokens (prompt + tools + margin) exceeding allowedTokenCount makes the
+    // interactions budget negative. With no interactions at all, the escalation layers used to
+    // dereference the last interaction of an empty array and throw instead of returning an Err.
+    vi.mocked(renderAllMessages).mockResolvedValue([]);
+    mockTokenCounter({ byContains: {} });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: 100,
+    });
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("Conversation contains no messages");
+    }
+  });
+
   it("bubbles prompt/tools tokenization errors", async () => {
     vi.mocked(renderAllMessages).mockResolvedValue([userMessage("u1")]);
     vi.mocked(tokenCountForTexts).mockImplementation(async (texts) => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -56,12 +56,11 @@ export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
  * pruningBudget), drop old interactions entirely (never the current one), force pruning into the
  * protected floor, then force dropping past the protected floor.
  *
- * pruneToolResults and dropInteractionsToFit are each called twice, once with their normal floor
- * and once with a floor of 0. This is safe because both floors work off the CURRENT state: a
- * message pruneToolResults already pruned is already at the placeholder size, so pruning it
- * again would save nothing and its own eligibility check excludes it, and an interaction
- * dropInteractionsToFit already dropped is simply gone from the array, so there's nothing left
- * for the second call to reconsider. Each call only ever reaches further than the one before it.
+ * pruneToolResults and dropInteractionsToFit each run twice, first with their normal floor and
+ * then with a floor of 0. The second call never conflicts with the first. An already-pruned
+ * message sits at placeholder size, so re-pruning it saves nothing and the eligibility check
+ * skips it. An already-dropped interaction is gone from the array, so there is nothing left to
+ * reconsider. The second call can only ever reach further than the first.
  */
 function pruneConversationToBudget(
   interactions: InteractionWithTokens[],
@@ -78,6 +77,11 @@ function pruneConversationToBudget(
   { interactions: InteractionWithTokens[]; prunedContext: boolean },
   Error
 > {
+  // An empty conversation trivially fits, and the layers below assume at least one interaction.
+  if (interactions.length === 0) {
+    return new Ok({ interactions, prunedContext: false });
+  }
+
   // Layer 1: proactive pruning, within the protected floor, up to pruningBudget.
   let pruned = pruneToolResults(interactions, {
     maxTokens: pruningBudget,
@@ -91,16 +95,17 @@ function pruneConversationToBudget(
   if (totalTokens > budgetForInteractions) {
     const currentInteraction = pruned[pruned.length - 1];
     const previousBefore = pruned.slice(0, -1);
-    const previousAfter = dropInteractionsToFit(
-      previousBefore,
-      budgetForInteractions - getInteractionTokenCount(currentInteraction),
-      PREVIOUS_INTERACTIONS_TO_PRESERVE
-    );
+    const previousAfter = dropInteractionsToFit(previousBefore, {
+      maxTokens:
+        budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      interactionsToPreserve: PREVIOUS_INTERACTIONS_TO_PRESERVE,
+      batchToCheckpoint: true,
+    });
     if (previousAfter !== previousBefore) {
       prunedContext = true;
+      pruned = [...previousAfter, currentInteraction];
+      totalTokens = sumInteractionTokens(pruned);
     }
-    pruned = [...previousAfter, currentInteraction];
-    totalTokens = sumInteractionTokens(pruned);
   }
 
   // Layer 3: reaching here means layer 2 dropped every previous interaction it was allowed to,
@@ -111,17 +116,21 @@ function pruneConversationToBudget(
       { ...logDetails, totalTokens, budgetForInteractions },
       "Dropped every eligible previous interaction; still over budget, forcing floor pruning."
     );
+    const beforeFloorPruning = pruned;
     pruned = pruneToolResults(pruned, {
       maxTokens: budgetForInteractions,
       toolResultsToPreserve: 0,
     });
-    prunedContext = true;
+    if (pruned !== beforeFloorPruning) {
+      prunedContext = true;
+    }
     totalTokens = sumInteractionTokens(pruned);
   }
 
   // Layer 4: still over budget with every tool result already at placeholder size. Drop previous
   // interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE, down to the current interaction alone
-  // if needed.
+  // if needed. Minimal drops here, not batched: the head moves on this call regardless, and the
+  // interactions a batched over-drop would additionally erase are the most recent ones.
   if (totalTokens > budgetForInteractions) {
     logger.warn(
       { ...logDetails, totalTokens, budgetForInteractions },
@@ -129,16 +138,17 @@ function pruneConversationToBudget(
     );
     const currentInteraction = pruned[pruned.length - 1];
     const previousBefore = pruned.slice(0, -1);
-    const previousAfter = dropInteractionsToFit(
-      previousBefore,
-      budgetForInteractions - getInteractionTokenCount(currentInteraction),
-      0
-    );
+    const previousAfter = dropInteractionsToFit(previousBefore, {
+      maxTokens:
+        budgetForInteractions - getInteractionTokenCount(currentInteraction),
+      interactionsToPreserve: 0,
+      batchToCheckpoint: false,
+    });
     if (previousAfter !== previousBefore) {
       prunedContext = true;
+      pruned = [...previousAfter, currentInteraction];
+      totalTokens = sumInteractionTokens(pruned);
     }
-    pruned = [...previousAfter, currentInteraction];
-    totalTokens = sumInteractionTokens(pruned);
   }
 
   // Last resort exhausted: even the current interaction alone doesn't fit.

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -547,7 +547,7 @@ describe("dropInteractionsToFit", () => {
         dropInteractionsToFit(historyOf(10), {
           maxTokens: 33_000,
           interactionsToPreserve: 0,
-      batchToCheckpoint: true,
+          batchToCheckpoint: true,
         })
       )
     ).toBe("u6");
@@ -556,7 +556,7 @@ describe("dropInteractionsToFit", () => {
         dropInteractionsToFit(historyOf(11), {
           maxTokens: 33_000,
           interactionsToPreserve: 0,
-      batchToCheckpoint: true,
+          batchToCheckpoint: true,
         })
       )
     ).toBe("u6");
@@ -569,7 +569,7 @@ describe("dropInteractionsToFit", () => {
         dropInteractionsToFit(historyOf(15), {
           maxTokens: 33_000,
           interactionsToPreserve: 0,
-      batchToCheckpoint: true,
+          batchToCheckpoint: true,
         })
       )
     ).toBe("u11");
@@ -624,11 +624,7 @@ describe("dropInteractionsToFit", () => {
     // 10_000). Batched would extend to the crossing at i3 (prefix sum 29_000 vs 19_000) and
     // return nothing at all.
     const interactions = interactionsFromMessages(
-      [
-        turn(1, 4980),
-        turn(2, 13_980),
-        turn(3, 9980),
-      ].flat()
+      [turn(1, 4980), turn(2, 13_980), turn(3, 9980)].flat()
     );
 
     const minimal = dropInteractionsToFit(interactions, {

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -454,25 +454,8 @@ describe("dropInteractionsToFit", () => {
     return groupMessagesIntoInteractions(messages);
   }
 
-  it("returns the same reference when nothing needs to be dropped", () => {
-    const interactions = interactionsFromMessages(
-      [1, 2, 3].flatMap((i) => turn(i, 10))
-    );
-    const result = dropInteractionsToFit(interactions, HUGE_BUDGET, 3);
-    expect(result).toBe(interactions);
-  });
-
-  it("drops whole interactions oldest-first until the budget fits", () => {
-    const interactions = interactionsFromMessages(
-      [1, 2, 3, 4, 5].flatMap((i) => turn(i, 100))
-    );
-    // Each interaction costs 120 tokens (10+10+100). Budget only fits 2.
-    const result = dropInteractionsToFit(interactions, 240, 0);
-
-    expect(result).toHaveLength(2);
-    expect(result.map((i) => getInteractionTokenCount(i))).toEqual([120, 120]);
-    // The two that survive are the most recent (i4, i5), oldest dropped first.
-    const survivingUserTexts = result.flatMap((i) =>
+  function survivingUserTexts(interactions: InteractionWithTokens[]) {
+    return interactions.flatMap((i) =>
       i.messages
         .filter(
           (m): m is Extract<MessageWithTokens, { role: "user" }> =>
@@ -482,7 +465,36 @@ describe("dropInteractionsToFit", () => {
           m.content.map((c) => (c.type === "text" ? c.text : "")).join("")
         )
     );
-    expect(survivingUserTexts).toEqual(["u4", "u5"]);
+  }
+
+  it("returns the same reference when nothing needs to be dropped", () => {
+    const interactions = interactionsFromMessages(
+      [1, 2, 3].flatMap((i) => turn(i, 10))
+    );
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: HUGE_BUDGET,
+      interactionsToPreserve: 3,
+      batchToCheckpoint: true,
+    });
+    expect(result).toBe(interactions);
+  });
+
+  it("drops whole interactions oldest-first until the budget fits", () => {
+    const interactions = interactionsFromMessages(
+      [1, 2, 3, 4, 5].flatMap((i) => turn(i, 100))
+    );
+    // Each interaction costs 120 tokens (10+10+100). Budget only fits 2. Total prefix sums (600
+    // max) never cross a 20k checkpoint, so the drop stays exactly minimal.
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: 240,
+      interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => getInteractionTokenCount(i))).toEqual([120, 120]);
+    // The two that survive are the most recent (i4, i5), oldest dropped first.
+    expect(survivingUserTexts(result)).toEqual(["u4", "u5"]);
   });
 
   it("never drops into the protected floor, even if that means staying over budget", () => {
@@ -490,7 +502,147 @@ describe("dropInteractionsToFit", () => {
       [1, 2, 3].flatMap((i) => turn(i, 100))
     );
     // Budget is impossibly small, but interactionsToPreserve=3 protects all 3 interactions here.
-    const result = dropInteractionsToFit(interactions, 1, 3);
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: 1,
+      interactionsToPreserve: 3,
+      batchToCheckpoint: true,
+    });
     expect(result).toHaveLength(3);
+  });
+
+  it("rounds the drop forward to the next checkpoint, buying headroom beyond the minimal fit", () => {
+    // 10 interactions of 4000 tokens each (turn = 10 + 10 + 3980), prefix sums 4k, 8k, ..., 40k.
+    const interactions = interactionsFromMessages(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].flatMap((i) => turn(i, 3980))
+    );
+    // Hand-verified: total 40_000 over a 33_000 budget. Minimal fit drops i1-i2 (remaining
+    // 32_000). The first checkpoint at or past that point is i5, whose prefix sum 20_000 crosses
+    // the 20k bucket (its predecessor sits at 16_000). The drop extends there: i1-i5 dropped,
+    // survivors i6-i10 total 20_000, leaving 13_000 of headroom below the budget instead of
+    // 1_000. That headroom is the point: several future turns fit before the head moves again.
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: 33_000,
+      interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+    });
+
+    expect(survivingUserTexts(result)).toEqual(["u6", "u7", "u8", "u9", "u10"]);
+  });
+
+  it("keeps the same head while growth stays within a checkpoint, then jumps a whole bucket", () => {
+    const historyOf = (count: number) =>
+      interactionsFromMessages(
+        Array.from({ length: count }, (_, i) => i + 1).flatMap((i) =>
+          turn(i, 3980)
+        )
+      );
+    const headOf = (interactions: InteractionWithTokens[]) =>
+      survivingUserTexts(interactions)[0];
+
+    // Hand-verified at 4000 tokens per interaction and a fixed 33_000 budget. With 10
+    // interactions the minimal fit is 2 drops, with 11 it is 3: both round forward to the same
+    // checkpoint at prefix sum 20_000, so the head stays at i6 while the conversation grows.
+    expect(
+      headOf(
+        dropInteractionsToFit(historyOf(10), {
+          maxTokens: 33_000,
+          interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+        })
+      )
+    ).toBe("u6");
+    expect(
+      headOf(
+        dropInteractionsToFit(historyOf(11), {
+          maxTokens: 33_000,
+          interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+        })
+      )
+    ).toBe("u6");
+
+    // At 15 interactions (60_000 total) the minimal fit passes the 20k checkpoint, so the head
+    // jumps a whole bucket to the next crossing: i10's prefix sum 40_000 crosses the 40k bucket,
+    // putting the head at i11. One batched move instead of five single-interaction slides.
+    expect(
+      headOf(
+        dropInteractionsToFit(historyOf(15), {
+          maxTokens: 33_000,
+          interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+        })
+      )
+    ).toBe("u11");
+  });
+
+  it("falls back to the minimal drop when no checkpoint exists in the droppable range", () => {
+    // 8 interactions of 2000 tokens each: every prefix sum stays under 20k, so there is no
+    // checkpoint anywhere. Rounding forward here would mean dropping all the way to the floor,
+    // erasing content for no stability gain, so the drop must stay exactly minimal.
+    const interactions = interactionsFromMessages(
+      [1, 2, 3, 4, 5, 6, 7, 8].flatMap((i) => turn(i, 1980))
+    );
+    // Hand-verified: total 16_000 over a 13_000 budget, dropping i1-i2 lands at 12_000.
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: 13_000,
+      interactionsToPreserve: 3,
+      batchToCheckpoint: true,
+    });
+
+    expect(survivingUserTexts(result)).toEqual([
+      "u3",
+      "u4",
+      "u5",
+      "u6",
+      "u7",
+      "u8",
+    ]);
+  });
+
+  it("lands the very first drop on a real checkpoint instead of paying a minimal drop and re-dropping next call", () => {
+    // 10 interactions of 4000 tokens. Hand-verified: total 40_000 over a 39_000 budget, the
+    // minimal fit drops only i1 (remaining 36_000). Treating index 0's predecessor as prefix sum
+    // 0, no crossing exists until i5 (prefix sum 20_000 vs 16_000), so the first-ever drop
+    // already extends there. Same head as a much tighter budget would produce (see the test
+    // above): drop onset lands directly on the stable geometry, one full cache miss, not two.
+    const interactions = interactionsFromMessages(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].flatMap((i) => turn(i, 3980))
+    );
+    const result = dropInteractionsToFit(interactions, {
+      maxTokens: 39_000,
+      interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+    });
+
+    expect(survivingUserTexts(result)).toEqual(["u6", "u7", "u8", "u9", "u10"]);
+  });
+
+  it("drops exactly the minimum when batchToCheckpoint is false, never rounding into recent interactions", () => {
+    // The last-resort path (index.ts layer 4) uses this mode: the head moves on this call no
+    // matter what, so rounding forward would erase recent interactions for zero cache benefit.
+    // Hand-verified: sizes 5000/14000/10000, budget 12_000. Minimal drops i1-i2 (remaining
+    // 10_000). Batched would extend to the crossing at i3 (prefix sum 29_000 vs 19_000) and
+    // return nothing at all.
+    const interactions = interactionsFromMessages(
+      [
+        turn(1, 4980),
+        turn(2, 13_980),
+        turn(3, 9980),
+      ].flat()
+    );
+
+    const minimal = dropInteractionsToFit(interactions, {
+      maxTokens: 12_000,
+      interactionsToPreserve: 0,
+      batchToCheckpoint: false,
+    });
+    expect(survivingUserTexts(minimal)).toEqual(["u3"]);
+
+    const batched = dropInteractionsToFit(interactions, {
+      maxTokens: 12_000,
+      interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+    });
+    expect(batched).toHaveLength(0);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -18,11 +18,17 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "</dust_system>";
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
-// Batch size for the pruning checkpoint: like provider-native `clear_at_least`, don't move the
-// frontier for a handful of tokens, only once enough has accumulated to be worth invalidating the
-// cached prefix. Flat rather than a percentage of contextSize since no model in our fleet sits
-// between 16k-64k tokens. Starting point, tune against production cache-miss metrics.
+// Pruning advances through history in batches of this size, not message by message. Every move
+// of the pruning frontier invalidates the provider cache from that point on. Moving it for a
+// handful of tokens costs more than it saves, so it only moves once a batch has accumulated.
+// Flat rather than a percentage of contextSize since no model in our fleet sits between 16k-64k
+// tokens. Starting point, tune against production cache-miss metrics.
 export const PRUNING_CHECKPOINT_TOKENS = 20_000;
+
+// Batch size for drops. Same starting value as PRUNING_CHECKPOINT_TOKENS but a separate knob.
+// A drop invalidates the cache from the very first message, pruning only from its frontier, so
+// a drop miss costs more and may deserve a larger batch. Tune independently.
+export const DROP_CHECKPOINT_TOKENS = 20_000;
 
 // How many of the most recent tool results pruneToolResults never prunes, regardless of budget.
 // Counted in tool results, not turns: a single turn's own long tool-call chain is eligible for
@@ -206,12 +212,13 @@ function pruneToolResultsFlat(
  * turns when pruning alone isn't enough is a separate operation (dropInteractionsToFit) for
  * exactly that reason.
  *
- * The pruning boundary is a pure function of the (immutable) history and this call's inputs, so
- * the same input always prunes the same way, stable enough to survive the model provider's
- * prompt cache. maxTokens should be stable across turns for that to hold. It doesn't have to be
- * byte-identical: the caller derives it from prompt and tool-definition sizes that drift a little
- * between turns, and the checkpoint rounding absorbs drift well below PRUNING_CHECKPOINT_TOKENS.
- * What it must not be is a fast-moving live quantity (remaining budget, time, message count).
+ * Everything here is recomputed from scratch on every call. Cache stability therefore depends
+ * on this function making the same decisions every time. It does, provided its inputs hold
+ * still: the history is immutable by nature, and maxTokens must be roughly stable across turns.
+ * Small drift in maxTokens is fine (the caller derives it from prompt and tool sizes, which
+ * move a little), because the checkpoint rounding absorbs anything well below
+ * PRUNING_CHECKPOINT_TOKENS. What breaks stability is a maxTokens that changes on every call,
+ * like a remaining budget, a timestamp, or a message count.
  */
 export function pruneToolResults(
   interactions: InteractionWithTokens[],
@@ -235,26 +242,82 @@ export function pruneToolResults(
  *
  * Never drops into the last interactionsToPreserve. A caller still over budget after that can
  * retry with a smaller floor, or force pruneToolResults deeper.
+ *
+ * batchToCheckpoint decides how much to drop beyond the strict minimum.
+ *
+ * With batchToCheckpoint true, the drop extends past the minimal fit to the next checkpoint (a
+ * DROP_CHECKPOINT_TOKENS multiple in the prefix sums). Why: any drop invalidates the provider
+ * cache entirely, since the cache matches on prefixes and a drop changes the first message.
+ * Batching cannot make one drop cheaper. What it does is make drops rare. The extra room means
+ * the next several turns fit without dropping again. A conversation sitting at its budget would
+ * otherwise re-drop, and pay a full cache miss, on every single call. Exception: when no
+ * checkpoint exists before the floor, the drop stays minimal. Extending to the floor would
+ * erase content without gaining any stability.
+ *
+ * With batchToCheckpoint false, the drop is exactly minimal. This is for last-resort callers
+ * that are already cutting into recent interactions and should cut as few as possible.
+ *
+ * One ordering rule keeps the checkpoints meaningful: this function must run after pruning,
+ * with a budget at most as tight as pruning's. Checkpoints only stabilize the drop boundary if
+ * the prefix sums are identical from one call to the next. That holds because by the time a
+ * conversation drops at all, everything prunable in the droppable range was already pruned, so
+ * the token counts there no longer change. Dropping with a looser budget than pruning would
+ * silently bring back a moving drop boundary on every call.
  */
 export function dropInteractionsToFit(
   interactions: InteractionWithTokens[],
-  maxTokens: number,
-  interactionsToPreserve: number
+  {
+    maxTokens,
+    interactionsToPreserve,
+    batchToCheckpoint,
+  }: {
+    maxTokens: number;
+    interactionsToPreserve: number;
+    batchToCheckpoint: boolean;
+  }
 ): InteractionWithTokens[] {
-  let result = interactions;
-  const n = result.length;
+  const n = interactions.length;
   const floorStart = Math.max(n - interactionsToPreserve, 0);
 
-  let totalTokens = sumInteractionTokens(result);
+  // Prefix sum over interactions, from the start of the conversation.
+  const prefixSum: number[] = [];
+  let running = 0;
+  for (const interaction of interactions) {
+    running += getInteractionTokenCount(interaction);
+    prefixSum.push(running);
+  }
 
+  if (n === 0 || prefixSum[n - 1] <= maxTokens) {
+    return interactions;
+  }
+
+  // Minimal drop needed: walk oldest-to-newest until the remaining total fits.
+  let remaining = prefixSum[n - 1];
   let dropUpToIndex = -1;
-  for (let i = 0; i < floorStart && totalTokens > maxTokens; i++) {
-    totalTokens -= getInteractionTokenCount(result[i]);
+  for (let i = 0; i < floorStart && remaining > maxTokens; i++) {
+    remaining -= getInteractionTokenCount(interactions[i]);
     dropUpToIndex = i;
   }
-  if (dropUpToIndex >= 0) {
-    result = result.slice(dropUpToIndex + 1);
+  if (dropUpToIndex < 0) {
+    return interactions;
   }
 
-  return result;
+  if (batchToCheckpoint) {
+    // Extend the drop to the first checkpoint at or past the minimal point. The minimal point
+    // moves with the caller's budget. The checkpoints don't, so consecutive calls land on the
+    // same boundary. Index 0 compares against prefix sum 0, which lets the very first drop of a
+    // conversation reach a real checkpoint too, instead of dropping one interaction now and
+    // re-dropping on the next call.
+    for (let i = dropUpToIndex; i < floorStart; i++) {
+      const bucketAtIdx = Math.floor(prefixSum[i] / DROP_CHECKPOINT_TOKENS);
+      const bucketBefore =
+        i === 0 ? 0 : Math.floor(prefixSum[i - 1] / DROP_CHECKPOINT_TOKENS);
+      if (bucketAtIdx !== bucketBefore) {
+        dropUpToIndex = i;
+        break;
+      }
+    }
+  }
+
+  return interactions.slice(dropUpToIndex + 1);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We observed in production that once a conversation fills its token budget, every call evicts the oldest interaction to make room for the new turn. Removing the head of the conversation shifts every message, so the provider's prompt cache misses entirely and the full conversation is re-ingested at full price on every request, often seconds apart, for as long as the conversation stays at the ceiling.

This change batches those evictions. When dropping is needed, instead of removing the strict minimum, we drop forward to a stable boundary derived from the conversation's token situation, the same batching idea already used for tool result pruning. Consecutive calls agree on where the head sits, and each drop buys enough headroom that the next several turns fit without dropping again. One deliberate full miss then amortizes over many calls instead of recurring on each one. When no such boundary exists in the droppable range, the drop stays minimal, since over-dropping a small conversation would erase content without gaining stability. The last-resort path that cuts past the protected floor also keeps minimal drops on purpose: the cache is already lost at that point and what remains is the most recent context, so it should shrink as little as possible.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
