### PR TITLE
feat(microsoft_drive): target upload folders by id, remove folderPath

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1323,7 +1323,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
+    "create_folder": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "get_file_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_item_from_url": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -2943,7 +2951,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "microsoft_drive": {
     "copy_file": "never_ask",
+    "create_folder": "low",
     "get_file_content": "never_ask",
+    "get_item_from_url": "never_ask",
     "list_drive_items": "never_ask",
     "rename_drive_item": "low",
     "search_drive_items": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -154,7 +154,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "list files in my onedrive folder",
     expected: "microsoft_drive.list_drive_items",
-    maxRank: 3,
+    maxRank: 4, // get_item_from_url + create_folder dilute shared-token IDF
   },
   {
     query: "browse my sharepoint site",

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -37,12 +37,12 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
   },
   search_drive_items: {
     description:
-      "Find and locate a file or document by its name or title in Microsoft OneDrive and SharePoint, returned in relevance order. Use when you know the file name and want to look it up, such as a specific Word, Excel, or PowerPoint document.",
+      "Find and locate a file, folder, or document by its name or title in Microsoft OneDrive and SharePoint, returned in relevance order. Use when you know the item's name and want to look it up, such as a specific Word, Excel, or PowerPoint document, or a folder to upload into.",
     schema: {
       query: z
         .string()
         .describe(
-          "Search query matching the name or title of files in OneDrive and SharePoint."
+          "Search query matching the name or title of items in OneDrive and SharePoint."
         ),
     },
     stake: "never_ask",
@@ -100,6 +100,24 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Listing OneDrive/SharePoint items",
       done: "List OneDrive/SharePoint items",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  get_item_from_url: {
+    description:
+      "Resolve a Microsoft OneDrive or SharePoint URL (file, folder, or sharing link) to its drive item. Returns the item's id, driveId, name, type, and webUrl.",
+    schema: {
+      url: z
+        .string()
+        .describe(
+          "The URL to resolve. Accepts direct URLs and sharing links (e.g. 'https://contoso.sharepoint.com/:f:/s/...')."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Resolving OneDrive/SharePoint URL",
+      done: "Resolve OneDrive/SharePoint URL",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
@@ -181,9 +199,41 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
+  create_folder: {
+    description:
+      "Create a new folder in Microsoft OneDrive or SharePoint under a parent folder, or at the root of the drive. Uses driveId if provided, otherwise falls back to siteId. Returns the new folder's id.",
+    schema: {
+      name: z.string().describe("The name of the new folder."),
+      driveId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the drive to create the folder in. Takes priority over siteId if provided."
+        ),
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the SharePoint site to create the folder in. Used if driveId is not provided."
+        ),
+      parentFolderId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional ID of the parent folder to create the folder in. Use get_item_from_url when the user provides a folder URL, or list_drive_items to browse. If not provided, creates at the root of the drive."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Creating OneDrive/SharePoint folder",
+      done: "Create OneDrive/SharePoint folder",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
   upload_file: {
     description:
-      "Upload a file from the Dust conversation to Microsoft OneDrive or SharePoint. Supports files up to 250MB using the simple upload API. Uses driveId if provided, otherwise falls back to siteId. Automatically creates folders if they don't exist.",
+      "Upload a file from the Dust conversation to Microsoft OneDrive or SharePoint. Supports files up to 250MB using the simple upload API. Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
       fileId: z
         .string()
@@ -202,11 +252,11 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         .describe(
           "The ID of the SharePoint site to upload to. Used if driveId is not provided."
         ),
-      folderPath: z
+      parentFolderId: z
         .string()
         .optional()
         .describe(
-          "Optional path to folder where the file should be uploaded (e.g., 'Documents/Projects'). Folders will be created automatically if they don't exist. If not provided, uploads to the root of the drive."
+          "Optional ID of the folder to upload into. Use get_item_from_url when the user provides a folder URL, or list_drive_items to browse. If not provided, uploads to the root of the drive."
         ),
       fileName: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -217,6 +217,55 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
+  get_item_from_url: async ({ url }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      // Graph shares API: any OneDrive/SharePoint URL (including sharing
+      // links) is addressable as a share id of the form "u!" + base64url(url).
+      const shareId = `u!${Buffer.from(url)
+        .toString("base64")
+        .replace(/=+$/, "")
+        .replace(/\//g, "_")
+        .replace(/\+/g, "-")}`;
+
+      const item = await client
+        .api(`/shares/${shareId}/driveItem`)
+        .select("id,name,webUrl,folder,file,parentReference")
+        .get();
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              id: item.id,
+              name: item.name,
+              type: item.folder ? "folder" : "file",
+              webUrl: item.webUrl,
+              driveId: item.parentReference?.driveId,
+              siteId: item.parentReference?.siteId,
+              parentFolderId: item.parentReference?.id,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          normalizeError(err).message || "Failed to resolve URL to a drive item"
+        )
+      );
+    }
+  },
+
   update_word_document: async (
     { itemId, driveId, siteId, documentXml },
     { authInfo }
@@ -461,8 +510,59 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
+  create_folder: async (
+    { name, driveId, siteId, parentFolderId },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      const endpoint = await getDriveItemEndpoint(undefined, driveId, siteId);
+      const parentPath = parentFolderId
+        ? `${endpoint}/items/${parentFolderId}`
+        : `${endpoint}/root`;
+
+      const createdFolder = await client.api(`${parentPath}/children`).post({
+        name,
+        folder: {},
+        "@microsoft.graph.conflictBehavior": "fail",
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              id: createdFolder.id,
+              name: createdFolder.name,
+              webUrl: createdFolder.webUrl,
+              parentFolderId: createdFolder.parentReference?.id,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      const error = normalizeError(err);
+      if (error.message.toLowerCase().includes("namealreadyexists")) {
+        return new Err(
+          new MCPError(
+            `A folder named '${name}' already exists in this location. Use list_drive_items to get its id.`
+          )
+        );
+      }
+      return new Err(new MCPError(error.message || "Failed to create folder"));
+    }
+  },
+
   upload_file: async (
-    { fileId, driveId, siteId, folderPath, fileName },
+    { fileId, driveId, siteId, parentFolderId, fileName },
     { auth, authInfo, runContext }
   ) => {
     const client = await getGraphClient(authInfo);
@@ -497,119 +597,15 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       // Determine the upload endpoint
       const endpoint = await getDriveItemEndpoint(undefined, driveId, siteId);
 
-      // If folderPath is provided, ensure the folder exists (create if needed)
-      if (folderPath) {
-        const folders = folderPath
-          .split("/")
-          .filter((f: string) => f.length > 0);
-
-        // Fetch the drive root so we can strip the library name if the user
-        // included it in folderPath (e.g. "Documents partages/Sub"), which
-        // would otherwise cause a 403 when trying to create a folder named
-        // after the library root.
-        const root = await client
-          .api(`${endpoint}/root`)
-          .select("name,id")
-          .get();
-        let parentItemId: string = root.id;
-
-        const effectiveFolders =
-          root.name && folders[0]?.toLowerCase() === root.name.toLowerCase()
-            ? folders.slice(1)
-            : folders;
-
-        let currentPath = "";
-
-        for (const folder of effectiveFolders) {
-          currentPath = currentPath
-            ? `${currentPath}/${encodeURIComponent(folder)}`
-            : encodeURIComponent(folder);
-
-          try {
-            // Try to get the folder
-            const folderItem = await client
-              .api(`${endpoint}/root:/${currentPath}`)
-              .get();
-            // Update parent item ID for next iteration
-            parentItemId = folderItem.id;
-          } catch (err) {
-            const error = normalizeError(err);
-            const isNotFound =
-              error.message.toLowerCase().includes("could not be found") ||
-              error.message.toLowerCase().includes("not found");
-
-            if (isNotFound) {
-              // Folder doesn't exist, create it
-              try {
-                const createdFolder = await client
-                  .api(`${endpoint}/items/${parentItemId}/children`)
-                  .post({
-                    name: folder,
-                    folder: {},
-                    "@microsoft.graph.conflictBehavior": "fail",
-                  });
-                // Update parent item ID for next iteration
-                parentItemId = createdFolder.id;
-              } catch (createErr) {
-                const createError = normalizeError(createErr);
-                const alreadyExists =
-                  createError.message
-                    .toLowerCase()
-                    .includes("namealreadyexists") ||
-                  createError.message
-                    .toLowerCase()
-                    .includes("name already exists");
-
-                if (alreadyExists) {
-                  // Folder was created concurrently between our GET and POST
-                  // (or the GET error didn't match isNotFound). Fetch the
-                  // existing folder's ID and continue.
-                  const existingFolder = await client
-                    .api(`${endpoint}/root:/${currentPath}`)
-                    .get();
-                  parentItemId = existingFolder.id;
-                } else {
-                  return new Err(
-                    new MCPError(
-                      `Failed to create folder '${folder}': ${createError.message}`
-                    )
-                  );
-                }
-              }
-            } else {
-              return new Err(
-                new MCPError(
-                  `Failed to check folder '${currentPath}': ${normalizeError(err).message}`
-                )
-              );
-            }
-          }
-        }
-      }
-
-      // Build the upload path
       const uploadFileName = sanitizeFilename(fileName ?? filename);
-      // Reject if the original path contained traversal attempts
-      if (folderPath?.includes("..")) {
-        return new Err(
-          new MCPError(
-            "Invalid folder path: path traversal sequences are not allowed"
-          )
-        );
-      }
-      const uploadPath = folderPath
-        ? `${folderPath}/${uploadFileName}`
-        : uploadFileName;
+      const encodedFileName = encodeURIComponent(uploadFileName);
 
-      // Upload using PUT /drive/root:/{path}:/content
-      // Encode each path segment individually so "/" separators in nested
-      // paths are preserved (encoding the whole path would turn them into
-      // %2F and Graph would treat the result as a single flat filename).
-      const encodedUploadPath = uploadPath
-        .split("/")
-        .map(encodeURIComponent)
-        .join("/");
-      const uploadEndpoint = `${endpoint}/root:/${encodedUploadPath}:/content`;
+      // Upload into the target folder by item id; addressing folders by
+      // path is locale-dependent and lets Graph implicitly create folders
+      // on misresolved paths.
+      const uploadEndpoint = parentFolderId
+        ? `${endpoint}/items/${parentFolderId}:/${encodedFileName}:/content`
+        : `${endpoint}/root:/${encodedFileName}:/content`;
 
       const response = await client
         .api(uploadEndpoint)


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/8289
## Description

`microsoft_drive__upload_file` resolved its destination by interpreting the `folderPath` name string. Two customer reports (2026-07-10 and 2026-07-13/15) showed uploads reporting success while the file landed in a newly created duplicate folder named after the document library root (e.g. `"Documents partages"` on French sites): the folder walk resolved the path one way, the final upload re-walked the raw path, and Graph implicitly created the misresolved segments. The earlier 403 symptom fixed in `26438` was the same interpretation problem with an exact name collision.

Rather than hardening the name-interpretation heuristics, this aligns the server with the `google_drive` pattern: folders are addressed by id, never by assembling locale-dependent name paths.

- **`upload_file`**: targets `parentFolderId` directly (`PUT .../items/{id}:/{fileName}:/content`), or the drive root when omitted. The `folderPath` param and its folder walk — path resolution, implicit folder creation, library-root stripping — are removed. Implicit creation on misresolved paths is how uploads silently misfiled.
- **New `get_item_from_url`**: resolves any OneDrive/SharePoint URL (including `/:f:/s/...` sharing links) to its drive item via the Graph shares API, returning `id`, `driveId`, `siteId`, `name`, `type`, and `webUrl`.
- **New `create_folder`**: explicit folder creation under a parent id (or the drive root), returning the new folder's id.
- `search_drive_items` / `upload_file` descriptions updated so agents resolve folder ids by URL, browse, search, or creation.

**Behavior change**: `folderPath` no longer exists on `upload_file`. Tool schemas are model-facing and re-read every run, so no clients are pinned to the old shape; agents whose instructions relied on implicit path creation will compose `get_item_from_url` / `list_drive_items` / `create_folder` → `upload_file` instead.

## Tests
Manually verified improvement in behavior

## Risk

Low

## Deploy Plan

Deploy `front`. No feature flag or migration required.
