### PR TITLE
fix(sidekick): eagerly load client-side get_agent_config under Anthropic tool search

### DIFF
--- a/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
@@ -34,6 +34,13 @@ The response includes:
       _meta: {
         dust: {
           timeoutMs: 10_000,
+          // Keep this tool in the eagerly loaded set when Anthropic tool search
+          // is enabled. It is Sidekick's primary tool (the prompt mandates
+          // calling it), and deferring it behind tool search makes it invisible
+          // when the model skips discovery. Completes #28691, which made the
+          // server-side sidekick tools eager but could not cover this
+          // client-side registration.
+          eager: true,
         },
       },
     },

--- a/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
@@ -34,12 +34,7 @@ The response includes:
       _meta: {
         dust: {
           timeoutMs: 10_000,
-          // Keep this tool in the eagerly loaded set when Anthropic tool search
-          // is enabled. It is Sidekick's primary tool (the prompt mandates
-          // calling it), and deferring it behind tool search makes it invisible
-          // when the model skips discovery. Completes #28691, which made the
-          // server-side sidekick tools eager but could not cover this
-          // client-side registration.
+          // Never defer behind tool search: this is Sidekick's primary tool.
           eager: true,
         },
       },


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9591.

With `anthropic_tool_search` enabled, tools without the `eager` flag are sent to Anthropic with `defer_loading: true` and only become visible to the model if it discovers them via BM25 tool search — which it often skips. Sidekick's `get_agent_config` is registered client-side (through the browser MCP transport) without `eager`, so it is deferred, and the model frequently reports it as unavailable ("I don't have a get_agent_config tool available in this session") even though the client-side MCP connection is healthy. Since Sidekick's prompt mandates calling this tool, this effectively breaks Sidekick until a page reload lands the model on a luckier path.

Observed in production: workspace `rptM9SyP2l`, Sidekick conversation `TAgsCiN7sT` (2026-07-13 ~09:36-09:41 UTC) — server-side sidekick tools (eager since #28691) were visible and executed fine, while `get_agent_config` was never surfaced to the model.

Fix: mark `get_agent_config` as `eager: true` in its `_meta.dust` registration metadata so it stays in the eagerly loaded tool set. The extraction and propagation paths already exist (`mcp_metadata.ts` reads `_meta.dust.eager`, `mcp_actions.ts` propagates it, `conversation_to_anthropic.ts` skips `defer_loading` for eager tools); the `timeoutMs` in the same `_meta.dust` block already flows through this channel for this tool. This aligns the only client-side sidekick tool with the server-side sidekick tools made eager in #28691.

## Tests

Local validation was not run in the Computer (no unit coverage for browser-side tool registration); validation is delegated to PR CI. Manual check: on a workspace with `anthropic_tool_search`, open the agent builder, ask Sidekick "can you see my full instructions?", and confirm `get_agent_config` executes.

## Risk

Very low. One tool, one agent (Sidekick), front-only. Adds one small, stable tool schema to the cached tool prefix; the client-side server is attached at Sidekick conversation creation and is stable for the session, so this does not introduce mid-conversation prefix changes. Safe to rollback.

## Deploy Plan

Standard front deploy. No migration, no feature flag change.
