### PR TITLE
feat(front): use compact input bar layout in the extension

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -105,7 +105,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   onAttachmentsPickerOpenChange,
 }: InputBarButtonsProps) {
   const router = useAppRouter();
-  const isMobile = useIsMobile();
+  const isWidthConstrained = useIsMobile() || clientType === "extension";
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
@@ -146,14 +146,14 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             aria-disabled={isInputDisabled}
             className={cn(
               "inline-flex box-border items-center rounded-lg h-7 heading-xs px-2 gap-1.5 bg-muted-background border-border text-primary-900 transition-colors duration-200",
-              isMobile && "pl-1",
+              isWidthConstrained && "pl-1",
               isInputDisabled
                 ? "opacity-50 pointer-events-none"
                 : "cursor-pointer hover:bg-hover"
             )}
           >
             <Avatar size="xxs" visual={selectedAgent.pictureUrl} />
-            {!isMobile && (
+            {!isWidthConstrained && (
               <span className="grow truncate notranslate">
                 {selectedAgent.label}
               </span>
@@ -185,7 +185,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             variant="ghost-secondary"
             size={buttonSize}
             icon={Robot}
-            label={!isMobile ? "Agent" : undefined}
+            label={!isWidthConstrained ? "Agent" : undefined}
             disabled={isInputDisabled}
             className={cn(disableAgentSelector && "bg-primary-150")}
           />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -350,6 +350,7 @@ const InputBarContainer = ({
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const clientType = useClientType();
+  const isWidthConstrained = isMobile || clientType === "extension";
   const shouldEnableSlashSuggestion = actions.includes("capabilities");
 
   const [selectedNode, setSelectedNode] =
@@ -1647,7 +1648,7 @@ const InputBarContainer = ({
                   <div
                     className={cn(
                       "flex items-center",
-                      isMobile ? "gap-0.5" : "gap-1"
+                      isWidthConstrained ? "gap-0.5" : "gap-1"
                     )}
                   >
                     <InputBarButtons
@@ -1693,7 +1694,7 @@ const InputBarContainer = ({
                 <div
                   className={cn(
                     "flex items-center",
-                    isMobile ? "gap-1" : "gap-1.5"
+                    isWidthConstrained ? "gap-1" : "gap-1.5"
                   )}
                 >
                   {clientType === "extension" && (
@@ -1809,7 +1810,7 @@ const InputBarContainer = ({
                   <div
                     className={cn(
                       "flex items-center",
-                      isMobile ? "gap-0.5" : "gap-1"
+                      isWidthConstrained ? "gap-0.5" : "gap-1"
                     )}
                   >
                     {conversation && (
@@ -1830,7 +1831,7 @@ const InputBarContainer = ({
                           onRecordStart={activeVoiceService.startRecording}
                           onRecordStop={activeVoiceService.stopRecording}
                           size={buttonSize}
-                          showStopLabel={!isMobile}
+                          showStopLabel={!isWidthConstrained}
                           disabled={disableInput}
                         />
                       )}

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -19,6 +19,7 @@ import {
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
@@ -63,6 +64,8 @@ export function InputBarModelPicker({
   const hasModelsPicker = hasFeature("models_picker");
   const { isDark } = useTheme();
   const isMobile = useIsMobile();
+  const clientType = useClientType();
+  const isWidthConstrained = isMobile || clientType === "extension";
 
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -275,12 +278,12 @@ export function InputBarModelPicker({
 
   const auto = showAuto ? { isOn: isAutoOn } : null;
 
-  const label = isMobile
+  const label = isWidthConstrained
     ? "Model"
     : `Model: ${getModelWithReasoningEffortLabel(shown)}`;
 
   const buttonIcon =
-    isMobile && shown.kind !== "auto"
+    isWidthConstrained && shown.kind !== "auto"
       ? getModelProviderLogo(shown.model.providerId, isDark)
       : undefined;
 

--- a/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerList.tsx
@@ -7,6 +7,7 @@ import type {
 import { getModelWithReasoningEffortKey } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
@@ -30,8 +31,8 @@ interface ModelPickerListProps {
   listState: ModelPickerListState;
   selectedKey?: string;
   onSelectModel: (modelWithEffort: ModelWithReasoningEffort) => void;
-  // On mobile the "More models" providers expand inline; this tracks the single
-  // provider currently expanded.
+  // On width-constrained clients (mobile, extension) the "More models" providers
+  // expand inline; this tracks the single provider currently expanded.
   expandedProvider: ModelProviderIdType | null;
   onToggleProvider: (providerId: ModelProviderIdType) => void;
 }
@@ -45,6 +46,9 @@ export function ModelPickerList({
 }: ModelPickerListProps) {
   const { isDark } = useTheme();
   const isMobile = useIsMobile();
+  const clientType = useClientType();
+
+  const expandProvidersInline = isMobile || clientType === "extension";
 
   switch (listState.kind) {
     case "hidden":
@@ -132,10 +136,10 @@ export function ModelPickerList({
               <DropdownMenuSeparator />
               <DropdownMenuLabel label="More models" />
               {listState.moreByProvider.map((provider) =>
-                isMobile ? (
-                  // On mobile the provider expands inline below its name
-                  // instead of opening a nested submenu (which is awkward to
-                  // reach on touch).
+                expandProvidersInline ? (
+                  // On width-constrained clients (mobile, extension) the
+                  // provider expands inline below its name instead of opening a
+                  // nested submenu.
                   <Fragment key={provider.providerId}>
                     <DropdownMenuItem
                       label={getProviderDisplayName(provider.providerId)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

The extension renders the input bar in a narrow panel, but it was using the full desktop layout. This makes the input bar treat the extension as width-constrained (like mobile) for layout purposes only.

Introduces `isWidthConstrained = isMobile || clientType === "extension"` and applies it where the decision is about horizontal space:

- `InputBarButtons`: compact agent pill (icon only, tighter padding, no "Agent"/label text).
- `InputBarContainer`: tighter button-group gaps and a hidden "Stop" label on the voice picker.
- `InputBarModelPicker`: short `"Model"` label + provider-logo icon instead of the full `"Model: <name>"` text.

Touch/soft-keyboard/hover behaviors stay gated on `isMobile` alone (the extension has a mouse and physical keyboard): button touch-target sizing, keyboard-close delays, the BubbleMenu vs. mobile toolbar toggle, search `autoFocus`, and hover tooltips.

## Tests

Manually verified in the extension that the input bar renders in its compact form and that the web app layout is unchanged.
