### PR TITLE
[front] enh: add context diagnostics to Poke conversation render

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -3,7 +3,10 @@ import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import {
+  type ConversationRenderTokenBreakdown,
+  renderConversationForModel,
+} from "@app/lib/api/assistant/conversation_rendering";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
@@ -49,6 +52,7 @@ export type PostRenderConversationResponseBody = {
     providerId: string;
     prunedContext: boolean;
     remainingInputTokens: number;
+    tokenBreakdown: ConversationRenderTokenBreakdown;
     toolDefinitions: unknown[];
   };
   tokensUsed: number;
@@ -273,7 +277,8 @@ app.post(
       });
     }
 
-    const { modelConversation, prunedContext, tokensUsed } = convoRes.value;
+    const { modelConversation, prunedContext, tokenBreakdown, tokensUsed } =
+      convoRes.value;
 
     let promptTokenCountApprox = 0;
     let toolsTokenCountApprox = 0;
@@ -298,6 +303,7 @@ app.post(
         providerId: model.providerId,
         prunedContext,
         remainingInputTokens: Math.max(0, allowedTokenCount - tokensUsed),
+        tokenBreakdown,
         toolDefinitions,
       },
       tokensUsed,

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -41,6 +41,16 @@ const ParamsSchema = z.object({
 });
 
 export type PostRenderConversationResponseBody = {
+  diagnostics: {
+    generationTokensReserved: number;
+    inputTokenBudget: number;
+    modelId: string;
+    prompt: string;
+    providerId: string;
+    prunedContext: boolean;
+    remainingInputTokens: number;
+    toolDefinitions: unknown[];
+  };
   tokensUsed: number;
   modelConversation: unknown;
   modelContextSizeUsed: number;
@@ -223,13 +233,12 @@ app.post(
     const specifications = availableActions.map((t) =>
       buildToolSpecification(t)
     );
-    const tools = JSON.stringify(
-      specifications.map((s) => ({
-        name: s.name,
-        description: s.description,
-        inputSchema: s.inputSchema,
-      }))
-    );
+    const toolDefinitions = specifications.map((s) => ({
+      name: s.name,
+      description: s.description,
+      inputSchema: s.inputSchema,
+    }));
+    const tools = JSON.stringify(toolDefinitions);
 
     const contextSize =
       typeof contextSizeOverride === "number" && contextSizeOverride > 0
@@ -264,7 +273,7 @@ app.post(
       });
     }
 
-    const { modelConversation, tokensUsed } = convoRes.value;
+    const { modelConversation, prunedContext, tokensUsed } = convoRes.value;
 
     let promptTokenCountApprox = 0;
     let toolsTokenCountApprox = 0;
@@ -281,6 +290,16 @@ app.post(
     }
 
     return ctx.json({
+      diagnostics: {
+        generationTokensReserved: model.generationTokensCount,
+        inputTokenBudget: allowedTokenCount,
+        modelId: model.modelId,
+        prompt,
+        providerId: model.providerId,
+        prunedContext,
+        remainingInputTokens: Math.max(0, allowedTokenCount - tokensUsed),
+        toolDefinitions,
+      },
       tokensUsed,
       modelConversation,
       modelContextSizeUsed: contextSize,

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -910,6 +910,16 @@ export function ConversationPage() {
       providerId: string;
       prunedContext: boolean;
       remainingInputTokens: number;
+      tokenBreakdown: {
+        assistantMessages: number;
+        compactionMessages: number;
+        contentFragments: number;
+        margin: number;
+        prompt: number;
+        toolDefinitions: number;
+        toolResults: number;
+        userMessages: number;
+      };
       toolDefinitions: unknown[];
     };
     tokensUsed: number;

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -902,6 +902,16 @@ export function ConversationPage() {
   const [isRendering, setIsRendering] = useState(false);
   const [renderError, setRenderError] = useState<string | null>(null);
   const [renderResult, setRenderResult] = useState<null | {
+    diagnostics: null | {
+      generationTokensReserved: number;
+      inputTokenBudget: number;
+      modelId: string;
+      prompt: string;
+      providerId: string;
+      prunedContext: boolean;
+      remainingInputTokens: number;
+      toolDefinitions: unknown[];
+    };
     tokensUsed: number;
     modelContextSizeUsed: number;
     modelConversation: unknown;
@@ -950,6 +960,7 @@ export function ConversationPage() {
         throw new Error(data.error?.message || "Failed to render conversation");
       }
       setRenderResult({
+        diagnostics: data.diagnostics ?? null,
         tokensUsed: data.tokensUsed,
         modelContextSizeUsed: data.modelContextSizeUsed,
         modelConversation: data.modelConversation,
@@ -1130,7 +1141,7 @@ export function ConversationPage() {
               {renderError && <div className="text-warning">{renderError}</div>}
               {renderResult && (
                 <div className="flex flex-col space-y-2">
-                  <div className="flex items-center space-x-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <Chip
                       color="highlight"
                       label={`Tokens used: ${renderResult.tokensUsed}`}
@@ -1151,19 +1162,35 @@ export function ConversationPage() {
                       label={`Tools tokens: ${renderResult.toolsTokenCountApprox}`}
                       size="xs"
                     />
+                    {renderResult.diagnostics && (
+                      <>
+                        <Chip
+                          color="primary"
+                          label={`${renderResult.diagnostics.providerId}/${renderResult.diagnostics.modelId}`}
+                          size="xs"
+                        />
+                        <Chip
+                          color="info"
+                          label={`Input budget: ${renderResult.diagnostics.inputTokenBudget}`}
+                          size="xs"
+                        />
+                        <Chip
+                          color="success"
+                          label={`Remaining: ${renderResult.diagnostics.remainingInputTokens}`}
+                          size="xs"
+                        />
+                        {renderResult.diagnostics.prunedContext && (
+                          <Chip color="warning" label="Pruned" size="xs" />
+                        )}
+                      </>
+                    )}
                     <Button
                       label={isCopiedJSON ? "Copied" : "Copy JSON"}
                       variant="outline"
                       size="xs"
                       icon={isCopiedJSON ? ClipboardCheck : Clipboard}
                       onClick={() =>
-                        copyJSON(
-                          JSON.stringify(
-                            renderResult.modelConversation,
-                            null,
-                            2
-                          )
-                        )
+                        copyJSON(JSON.stringify(renderResult, null, 2))
                       }
                     />
                     <Button
@@ -1178,7 +1205,7 @@ export function ConversationPage() {
                     />
                   </div>
                   <CodeBlock wrapLongLines className="language-json">
-                    {JSON.stringify(renderResult.modelConversation, null, 2)}
+                    {JSON.stringify(renderResult, null, 2)}
                   </CodeBlock>
                 </div>
               )}

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -204,6 +204,21 @@ describe("renderConversationForModel", () => {
     }
 
     expect(res.value.modelConversation.messages).toHaveLength(3);
+    expect(res.value.tokenBreakdown).toEqual({
+      assistantMessages: 10,
+      compactionMessages: 0,
+      contentFragments: 0,
+      margin: 1024,
+      prompt: 10,
+      toolDefinitions: 7,
+      toolResults: 10,
+      userMessages: 10,
+    });
+    expect(
+      Object.values(res.value.tokenBreakdown).reduce(
+        (sum, count) => sum + count
+      )
+    ).toBe(res.value.tokensUsed);
     expect(res.value.tokensUsed).toBe(1071);
     expect(res.value.prunedContext).toBe(false);
   });
@@ -544,6 +559,7 @@ describe("renderConversationForModel", () => {
     }
     expect(textOf(firstUser.content[0])).toBe("fragment_text");
     expect(textOf(firstUser.content[1])).toBe("user_text");
+    expect(res.value.tokenBreakdown.contentFragments).toBe(10);
   });
 
   it("returns an error when context window is still exceeded after every pruning layer", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -49,6 +49,17 @@ export const TOKENS_MARGIN = 1024;
 // conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
+export type ConversationRenderTokenBreakdown = {
+  assistantMessages: number;
+  compactionMessages: number;
+  contentFragments: number;
+  margin: number;
+  prompt: number;
+  toolDefinitions: number;
+  toolResults: number;
+  userMessages: number;
+};
+
 /**
  * Escalates through pruning and dropping until the conversation fits budgetForInteractions, or
  * returns an error if even the last resort isn't enough. Four layers, each tried only if the
@@ -192,6 +203,7 @@ export async function renderConversationForModel(
   Result<
     {
       modelConversation: ModelConversationTypeMultiActions;
+      tokenBreakdown: ConversationRenderTokenBreakdown;
       tokensUsed: number;
       prunedContext: boolean;
     },
@@ -255,12 +267,10 @@ export async function renderConversationForModel(
   const [promptCount, toolDefinitionsCount] = promptToolsRes.value;
 
   // Calculate base token usage.
-  const baseTokens =
-    promptCount +
-    Math.floor(
-      toolDefinitionsCount * TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR
-    ) +
-    TOKENS_MARGIN;
+  const adjustedToolDefinitionsCount = Math.floor(
+    toolDefinitionsCount * TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR
+  );
+  const baseTokens = promptCount + adjustedToolDefinitionsCount + TOKENS_MARGIN;
 
   const interactions = groupMessagesIntoInteractions(messagesWithTokens);
 
@@ -314,6 +324,37 @@ export async function renderConversationForModel(
   const selected: MessageWithTokens[] = prunedInteractions.flatMap(
     (interaction) => interaction.messages
   );
+  const tokenBreakdown: ConversationRenderTokenBreakdown = {
+    assistantMessages: 0,
+    compactionMessages: 0,
+    contentFragments: 0,
+    margin: TOKENS_MARGIN,
+    prompt: promptCount,
+    toolDefinitions: adjustedToolDefinitionsCount,
+    toolResults: 0,
+    userMessages: 0,
+  };
+  for (const message of selected) {
+    switch (message.role) {
+      case "assistant":
+        tokenBreakdown.assistantMessages += message.tokenCount;
+        break;
+      case "compaction":
+        tokenBreakdown.compactionMessages += message.tokenCount;
+        break;
+      case "content_fragment":
+        tokenBreakdown.contentFragments += message.tokenCount;
+        break;
+      case "function":
+        tokenBreakdown.toolResults += message.tokenCount;
+        break;
+      case "user":
+        tokenBreakdown.userMessages += message.tokenCount;
+        break;
+      default:
+        assertNever(message);
+    }
+  }
   const tokensUsed = baseTokens + totalTokens;
 
   // Merge content fragments into user messages.
@@ -400,6 +441,7 @@ export async function renderConversationForModel(
     modelConversation: {
       messages: finalMessages,
     },
+    tokenBreakdown,
     tokensUsed,
     prunedContext,
   });

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -1439,7 +1439,17 @@ describe("getEmailSummary", () => {
             },
           ],
         },
-        tokensUsed: 100,
+        tokenBreakdown: {
+          assistantMessages: 0,
+          compactionMessages: 0,
+          contentFragments: 0,
+          margin: 1024,
+          prompt: 10,
+          toolDefinitions: 7,
+          toolResults: 0,
+          userMessages: 10,
+        },
+        tokensUsed: 1051,
         prunedContext: false,
       })
     );


### PR DESCRIPTION
## Description

The Poke conversation renderer currently shows the rendered messages and aggregate token counts, but not enough context to understand the model budget or whether pruning occurred.

This keeps the existing endpoint and rendering flow intact. It adds an additive diagnostics object with the model, prompt, tool definitions, input budget, remaining tokens, generation reserve, and pruning state, then exposes the same data in the existing inline render panel. There is no `runModel` refactor, shared preparation helper, or new route.

## Tests

- Tested locally.

## Risk

- Low. Additive change to a Poke-only endpoint and UI.

## Deploy Plan

- Deploy front-api and front-spa.
