### PR TITLE
[CI] Fix react-doctor version skew failing every PR scan

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,11 +24,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      # Pinned to v2.1.0: the floating @v2 (v2.1.1+) passes `--scope`, which the
-      # react-doctor CLI that .npmrc `min-release-age=7` lets us install (<=0.5.1)
-      # doesn't support, crashing every PR scan. v2.1.0 uses only `--changed-files-from`.
-      - uses: millionco/react-doctor@v2.1.0
+      - uses: millionco/react-doctor@v2
         with:
+          version: "0.7.6"
           blocking: none
           scope: changed
           comment: false

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -2,8 +2,5 @@
   "$schema": "https://react.doctor/schema/config.json",
   "rules": {
     "react-doctor/only-export-components": "off"
-  },
-  "surfaces": {
-    "include": ["front/**", "front-spa/**", "marketing/**", "extension/**", "viz/**", "sparkle/**"]
   }
 }


### PR DESCRIPTION
## Description

The workflow pinned `millionco/react-doctor@v2.1.0` (whose report validator only accepts `schemaVersion` 1/2) while the CLI floated to `latest` and now emits `schemaVersion: 3` — so a successful scan (`ok: true`, exit 0) was rewritten by the action's `ensure-json-report.mjs` as a failure, forcing `SCAN_STATUS=1` and failing every PR. Moved to `@v2` (which accepts schema 1/2/3) and pinned the CLI to `0.7.6` so the action and CLI can no longer drift apart. Also removed the dead `surfaces.include` block from `doctor.config.json` (not a valid config key — react-doctor logged "ignoring" on every run).

## Tests

Now CI passes.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- CI-only change; takes effect on the next PR scan once merged to `main`