### PR TITLE
fix(front): point offloaded tool-output snippets at the archived file

### DIFF
--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -11,7 +11,10 @@ import {
   getAugmentedInputs,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
-import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  BrowseResultResourceType,
+  DataSourceNodeContentType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolContext } from "@app/lib/actions/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
@@ -35,6 +38,19 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { assert, describe, expect, it, vi } from "vitest";
+
+// Cushion over FILE_OFFLOAD_SNIPPET_LENGTH for the "... (truncated)" marker and the
+// "[Full content archived at {scopedPath}]" pointer line appended to offload snippets.
+const SNIPPET_SUFFIX_CUSHION_LENGTH = 256;
+
+// Repeats `chunk` until the result exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (ASCII only:
+// 1 character = 1 byte) — and therefore also FILE_OFFLOAD_SNIPPET_LENGTH characters — so the
+// block qualifies for size-based offloading and its snippet gets the truncation marker.
+function makeTextAboveOffloadThreshold(chunk: string): string {
+  return chunk.repeat(
+    Math.ceil((FILE_OFFLOAD_TEXT_SIZE_BYTES + 1) / chunk.length)
+  );
+}
 
 // Mock file storage to avoid cloud storage interactions.
 vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
@@ -273,13 +289,20 @@ describe("processToolResults", () => {
     expect(outputItems).toHaveLength(1);
     const stored = outputItems[0].content;
 
-    // The large text block should be converted to a resource with a truncated snippet.
+    // The large text block should be converted to a resource with a truncated snippet
+    // pointing at the offloaded file.
     expect(stored.type).toBe("resource");
     if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
-        FILE_OFFLOAD_SNIPPET_LENGTH + 50
+        FILE_OFFLOAD_SNIPPET_LENGTH + SNIPPET_SUFFIX_CUSHION_LENGTH
       );
       expect(stored.resource.text).toContain("... (truncated)");
+      expect(stored.resource.text).toContain(
+        `[Full content archived at ${stored.resource.uri}]`
+      );
+      expect(stored.resource.uri).toMatch(
+        new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+      );
     }
 
     // Offloaded to DustFileSystem, so generatedFiles is empty.
@@ -309,9 +332,14 @@ describe("processToolResults", () => {
     expect(stored.type).toBe("resource");
     if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
-        FILE_OFFLOAD_SNIPPET_LENGTH + 50
+        FILE_OFFLOAD_SNIPPET_LENGTH + SNIPPET_SUFFIX_CUSHION_LENGTH
       );
       expect(stored.resource.text).toContain("... (truncated)");
+      expect(stored.resource.text).toMatch(
+        new RegExp(
+          `\\[Full content archived at .*${TOOL_OUTPUTS_FOLDER_NAME}/.*\\]`
+        )
+      );
     }
 
     // Offloaded to DustFileSystem, so generatedFiles is empty.
@@ -428,6 +456,101 @@ describe("processToolResults", () => {
     expect(toolOutputWrite?.content).toEqual(
       Buffer.from("# My Notion Page\n\nSome content here.")
     );
+  });
+
+  it("should offload small BROWSE_RESULT block keeping its full text in the snippet", async () => {
+    const { auth, toolContext } = await setupTest();
+
+    fileStorageMock.reset();
+
+    const pageText = "A short web page.";
+    const browseResult: BrowseResultResourceType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.BROWSE_RESULT,
+      requestedUrl: "https://example.com/short",
+      uri: "https://example.com/short",
+      text: pageText,
+      title: "Short Page",
+      responseCode: "200",
+    };
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [{ type: "resource", resource: browseResult }],
+    });
+
+    const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+    );
+    expect(toolOutputWrite).toBeDefined();
+    expect(toolOutputWrite?.content).toEqual(Buffer.from(pageText));
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    if (stored.type === "resource" && "text" in stored.resource) {
+      expect(stored.resource.text).toContain(pageText);
+      // Nothing was dropped, so no truncation marker — only the archive pointer.
+      expect(stored.resource.text).not.toContain("... (truncated)");
+      expect(stored.resource.text).toMatch(
+        new RegExp(
+          `\\[Full content archived at .*${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_short_page\\.md\\]`
+        )
+      );
+    }
+  });
+
+  it(`should offload large BROWSE_RESULT block to ${TOOL_OUTPUTS_FOLDER_NAME}/ with a snippet pointing at the archived file`, async () => {
+    const { auth, toolContext } = await setupTest();
+
+    fileStorageMock.reset();
+
+    const pageText = makeTextAboveOffloadThreshold(
+      "Interesting web page content. "
+    );
+    const browseResult: BrowseResultResourceType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.BROWSE_RESULT,
+      requestedUrl: "https://example.com/long",
+      uri: "https://example.com/long",
+      text: pageText,
+      title: "Long Page",
+      responseCode: "200",
+    };
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [{ type: "resource", resource: browseResult }],
+    });
+
+    const toolOutputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+    );
+    expect(toolOutputWrite).toBeDefined();
+    expect(toolOutputWrite?.filePath).toMatch(
+      new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_long_page\\.md$`)
+    );
+    expect(toolOutputWrite?.content).toEqual(Buffer.from(pageText));
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    if (stored.type === "resource" && "text" in stored.resource) {
+      expect(stored.resource.text.length).toBeLessThanOrEqual(
+        FILE_OFFLOAD_SNIPPET_LENGTH + SNIPPET_SUFFIX_CUSHION_LENGTH
+      );
+      expect(stored.resource.text).toContain("... (truncated)");
+      // The snippet must point at the archived file so the model can read the full page.
+      expect(stored.resource.text).toMatch(
+        new RegExp(
+          `\\[Full content archived at .*${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_long_page\\.md\\]`
+        )
+      );
+      // The browse resource keeps the browsed url as its uri.
+      if ("uri" in stored.resource) {
+        expect(stored.resource.uri).toBe("https://example.com/long");
+      }
+    }
   });
 
   it(`should persist large plain text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .txt`, async () => {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -69,6 +69,20 @@ function sanitizeStringsDeep<T>(input: T): T {
   return input;
 }
 
+/**
+ * Builds the model-visible snippet for a content block whose full text was offloaded to the
+ * file system by persistToolOutput. The scoped path pointer is what lets the model read the
+ * rest of the content back, so it must always be present.
+ */
+function makeOffloadedSnippet(text: string, scopedPath: string): string {
+  const head = text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH);
+  // The offload threshold is in bytes while the snippet cut is in characters, so multibyte
+  // content can be offloaded without losing any character here — only claim truncation when
+  // characters were actually dropped.
+  const truncatedSuffix = head.length < text.length ? "... (truncated)" : "";
+  return `${head}${truncatedSuffix}\n[Full content archived at ${scopedPath}]`;
+}
+
 export async function processToolNotification(
   auth: Authenticator,
   notification: MCPProgressNotificationType,
@@ -207,9 +221,10 @@ export async function processToolResults(
           // If persistToolOutput wrote this block to DustFileSystem (too large), return a resource
           // block pointing at the scoped path. The model reads it via the `cat` tool.
           if (res.value !== null) {
-            const snippet =
-              block.text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
-              "... (truncated)";
+            const snippet = makeOffloadedSnippet(
+              block.text,
+              res.value.scopedPath
+            );
             return {
               content: {
                 type: "resource",
@@ -390,8 +405,7 @@ export async function processToolResults(
             if (res.value !== null) {
               const snippet =
                 text !== null
-                  ? text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
-                    "... (truncated)"
+                  ? makeOffloadedSnippet(text, res.value.scopedPath)
                   : "";
               return {
                 content: {


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/9595
## Description

Since `27178` (June 10), tool output blocks offloaded to the conversation file system are replaced with an 8,000-character snippet — but for **resource-shaped** blocks (webbrowser `BROWSE_RESULT`, data-source `DATA_SOURCE_NODE_CONTENT`) the snippet dropped the pointer to the offloaded file: the resource keeps the web URL as `uri` and the scoped path returned by `persistToolOutput` was discarded. Plain-text blocks kept their pointer (`uri` = scoped path), resource blocks did not. Net effect: agents could not read any browsed page beyond 8,000 characters, and the `data_sources_file_system` `cat` pagination footer was silently cut off with no recovery path.

The offload + 8,000-char snippet itself is intended (keeps large content out of the model context; the model reads it back on demand) — this PR only restores the missing pointer:

- Offload snippets (both text blocks and resource blocks) are built by a shared `makeOffloadedSnippet` helper that appends `[Full content archived at {scopedPath}]`, so the model can always read the full content back from the conversation file system.
- The `... (truncated)` marker (referenced by prompts) is only emitted when characters were actually dropped — the offload threshold is in bytes while the snippet cut is in characters, so short/multibyte content could previously claim truncation that never happened.

## Tests

- The two existing snippet tests now assert the archived-file pointer is present in the snippet.
- New tests: a small `BROWSE_RESULT` is offloaded with its full text in the snippet, the archive pointer, and no truncation marker; a large `BROWSE_RESULT` is archived to `.tool_outputs/` as `.md` with a truncated snippet pointing at the archived file.
- `npm test lib/actions/mcp_execution.test.ts`: 15/15 pass. `tsgo --noEmit` and `biome check` clean.
Confirmed fix manually:
<img width="899" height="422" alt="Screenshot 2026-07-14 at 1 04 30 PM" src="https://github.com/user-attachments/assets/d0e57a25-6381-4dff-9547-282658593b3f" />
<img width="881" height="503" alt="Screenshot 2026-07-14 at 1 04 23 PM" src="https://github.com/user-attachments/assets/0d0efaba-86c5-4ed2-b27c-9242b4ee59b0" />

## Risk

Low. No change to what gets offloaded or when — only the snippet text the model sees gains the archive pointer (and loses a spurious truncation marker when nothing was dropped). Safe to rollback.

## Deploy Plan

deploy front

🤖 Generated with [Claude Code](https://claude.com/claude-code)