### PR TITLE
fix(front): make pruned-context chip 'Learn more' link clickable

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -122,6 +122,9 @@ import {
   InfoCircle,
   InteractiveImageGrid,
   Link01,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
   RefreshCw02,
   Stop,
   Tooltip,
@@ -147,48 +150,54 @@ import { mutate } from "swr";
 
 const RUN_AGENT_TOOL_NAME = "run_agent";
 
+// Popover (not Tooltip) so the "Learn more" link inside stays reachable.
 function PrunedContextChip() {
   return (
-    <Tooltip
-      label={
-        <div className="flex flex-col gap-2 py-2">
-          <div className="font-semibold">
-            This conversation reached its size limit
-          </div>
-          <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground">
-            <p>
-              Dust had to trim part of the tool output used to generate this
-              message to fit the model&apos;s context window. This usually
-              happens when a search or other tool returns more data than the
-              model can process at once.
-            </p>
-            <p>
-              For best accuracy, start a fresh conversation or narrow the
-              request.
-            </p>
-            <p>
-              <a
-                href={CONTEXT_WINDOW_DOC_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-foreground"
-              >
-                Learn more
-              </a>
-            </p>
-          </div>
+    <PopoverRoot>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="cursor-pointer rounded-lg border-0 bg-transparent p-0 outline-hidden ring-offset-background transition focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
+          aria-label="Context limit reached. Open details."
+        >
+          <Chip
+            label="Context limit reached"
+            size="xs"
+            color="primary"
+            icon={InfoCircle}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="flex w-[min(24rem,calc(100vw-1.5rem))] flex-col gap-2"
+      >
+        <div className="font-semibold">
+          This conversation reached its size limit
         </div>
-      }
-      className="max-w-sm"
-      trigger={
-        <Chip
-          label="Context limit reached"
-          size="xs"
-          color="primary"
-          icon={InfoCircle}
-        />
-      }
-    />
+        <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground">
+          <p>
+            Dust had to trim part of the tool output used to generate this
+            message to fit the model&apos;s context window. This usually happens
+            when a search or other tool returns more data than the model can
+            process at once.
+          </p>
+          <p>
+            For best accuracy, start a fresh conversation or narrow the request.
+          </p>
+          <p>
+            <a
+              href={CONTEXT_WINDOW_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              Learn more
+            </a>
+          </p>
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
   );
 }
 


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/9594
## Description

The "Context limit reached" chip shown on agent messages when context-window pruning occurs used a Sparkle `Tooltip` for its explanation. Sparkle's `Tooltip` hardcodes Radix's `disableHoverableContent`, so the tooltip closes as soon as the pointer leaves the chip — the "Learn more" link inside could never be reached with the mouse. It was also unreachable by keyboard, since Radix tooltips close on blur and can't be tabbed into (this is the real bug behind issue `#9594`, which was misfiled against `ReachedLimitPopup.tsx`).

This switches `PrunedContextChip` to a click-triggered `Popover`, following the existing chip-with-interactive-content pattern in `TaskDirectiveChipInner` (`front/components/markdown/TaskDirectiveBlock.tsx`): the chip is wrapped in a native `<button>` with an `aria-label` and focus-visible ring as the popover trigger. Content is unchanged; the popover width matches the tooltip's old `max-w-sm` and clamps on narrow viewports. The link is now reachable by both mouse and keyboard (Enter opens, Tab reaches the link, Escape closes).

## Tests

- `tsgo --noEmit` and biome pass on `front`.
- Not exercised against a live pruned conversation (reproducing a context-window prune end-to-end is impractical); the change is presentational and mirrors an established pattern.

## Risk

Low — UI-only change to a single informational chip. Interaction changes from hover to click. Safe to rollback.

## Deploy Plan

Standard front deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)