### PR TITLE
Fix MCP tab isolation: random server IDs + rate limiting

### DIFF
--- a/front-api/routes/v1/w/[wId]/mcp/register.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/register.ts
@@ -1,4 +1,9 @@
-import { registerMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import {
+  getMCPRegisterRateLimitKey,
+  MCP_REGISTER_RATE_LIMIT,
+  MCP_REGISTER_RATE_LIMIT_ERROR,
+  registerMCPServer,
+} from "@app/lib/api/actions/mcp/client_side_registry";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { RegisterMCPResponseType } from "@dust-tt/client";
@@ -84,9 +89,8 @@ app.post(
 
     const userId = auth.getNonNullableUser().id;
     const remaining = await rateLimiter({
-      key: `mcp:register:${userId}`,
-      maxPerTimeframe: 100,
-      timeframeSeconds: 60,
+      key: getMCPRegisterRateLimitKey(userId),
+      ...MCP_REGISTER_RATE_LIMIT,
       logger,
     });
     if (remaining <= 0) {
@@ -94,7 +98,7 @@ app.post(
         status_code: 429,
         api_error: {
           type: "rate_limit_error",
-          message: "Too many MCP server registrations. Please try again later.",
+          message: MCP_REGISTER_RATE_LIMIT_ERROR,
         },
       });
     }

--- a/front-api/routes/v1/w/[wId]/mcp/register.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/register.ts
@@ -1,7 +1,6 @@
-import {
-  MCPServerInstanceLimitError,
-  registerMCPServer,
-} from "@app/lib/api/actions/mcp/client_side_registry";
+import { registerMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
 import type { RegisterMCPResponseType } from "@dust-tt/client";
 import { PublicRegisterMCPRequestBodySchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -83,6 +82,23 @@ app.post(
 
     const { serverName } = ctx.req.valid("json");
 
+    const userId = auth.getNonNullableUser().id;
+    const remaining = await rateLimiter({
+      key: `mcp:register:${userId}`,
+      maxPerTimeframe: 100,
+      timeframeSeconds: 60,
+      logger,
+    });
+    if (remaining <= 0) {
+      return apiError(ctx, {
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message: "Too many MCP server registrations. Please try again later.",
+        },
+      });
+    }
+
     // Register the server.
     const registration = await registerMCPServer(auth, {
       serverName,
@@ -90,24 +106,11 @@ app.post(
     });
 
     if (registration.isErr()) {
-      const error = registration.error;
-      // Check if this is a server instance limit error.
-      if (error instanceof MCPServerInstanceLimitError) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
-      }
-
-      // Other errors are treated as server errors.
       return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: error.message,
+          message: registration.error.message,
         },
       });
     }

--- a/front-api/routes/w/[wId]/mcp/register.test.ts
+++ b/front-api/routes/w/[wId]/mcp/register.test.ts
@@ -1,0 +1,106 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  rateLimiter: vi.fn(),
+}));
+
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+
+async function setup() {
+  return createPrivateApiMockRequest({ method: "POST", role: "user" });
+}
+
+function postRegister(wId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/mcp/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/mcp/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimiter).mockResolvedValue(100);
+  });
+
+  it("returns a unique serverId and expiresAt on success", async () => {
+    const { workspace } = await setup();
+
+    const response = await postRegister(workspace.sId, {
+      serverName: "my sidekick",
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      serverId: string;
+      expiresAt: string;
+    };
+    expect(body.serverId).toMatch(
+      /^mcp-client-side:my_sidekick\.[0-9a-f]{16}$/
+    );
+    expect(new Date(body.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("allocates distinct serverIds for concurrent registrations of the same name", async () => {
+    const { workspace } = await setup();
+
+    const [first, second] = await Promise.all([
+      postRegister(workspace.sId, { serverName: "my sidekick" }),
+      postRegister(workspace.sId, { serverName: "my sidekick" }),
+    ]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const firstBody = (await first.json()) as { serverId: string };
+    const secondBody = (await second.json()) as { serverId: string };
+    expect(firstBody.serverId).not.toBe(secondBody.serverId);
+  });
+
+  it("returns 429 when rate limit is exhausted", async () => {
+    const { workspace } = await setup();
+    vi.mocked(rateLimiter).mockResolvedValue(0);
+
+    const response = await postRegister(workspace.sId, {
+      serverName: "my sidekick",
+    });
+
+    expect(response.status).toBe(429);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("rate_limit_error");
+  });
+
+  it("returns 400 when serverName is too short", async () => {
+    const { workspace } = await setup();
+
+    const response = await postRegister(workspace.sId, { serverName: "abc" });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when serverName is too long", async () => {
+    const { workspace } = await setup();
+
+    const response = await postRegister(workspace.sId, {
+      serverName: "a".repeat(31),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when serverName is missing", async () => {
+    const { workspace } = await setup();
+
+    const response = await postRegister(workspace.sId, {});
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/register.ts
+++ b/front-api/routes/w/[wId]/mcp/register.ts
@@ -1,7 +1,6 @@
-import {
-  MCPServerInstanceLimitError,
-  registerMCPServer,
-} from "@app/lib/api/actions/mcp/client_side_registry";
+import { registerMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -36,22 +35,35 @@ app.post(
     const auth = ctx.get("auth");
     const { serverName } = ctx.req.valid("json");
 
+    const userId = auth.getNonNullableUser().id;
+    const remaining = await rateLimiter({
+      key: `mcp:register:${userId}`,
+      maxPerTimeframe: 100,
+      timeframeSeconds: 60,
+      logger,
+    });
+    if (remaining <= 0) {
+      return apiError(ctx, {
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message: "Too many MCP server registrations. Please try again later.",
+        },
+      });
+    }
+
     const registration = await registerMCPServer(auth, {
       serverName,
       workspaceId: auth.getNonNullableWorkspace().sId,
     });
 
     if (registration.isErr()) {
-      const error = registration.error;
-      if (error instanceof MCPServerInstanceLimitError) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      }
       return apiError(ctx, {
         status_code: 500,
-        api_error: { type: "internal_server_error", message: error.message },
+        api_error: {
+          type: "internal_server_error",
+          message: registration.error.message,
+        },
       });
     }
 

--- a/front-api/routes/w/[wId]/mcp/register.ts
+++ b/front-api/routes/w/[wId]/mcp/register.ts
@@ -1,4 +1,9 @@
-import { registerMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import {
+  getMCPRegisterRateLimitKey,
+  MCP_REGISTER_RATE_LIMIT,
+  MCP_REGISTER_RATE_LIMIT_ERROR,
+  registerMCPServer,
+} from "@app/lib/api/actions/mcp/client_side_registry";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -37,9 +42,8 @@ app.post(
 
     const userId = auth.getNonNullableUser().id;
     const remaining = await rateLimiter({
-      key: `mcp:register:${userId}`,
-      maxPerTimeframe: 100,
-      timeframeSeconds: 60,
+      key: getMCPRegisterRateLimitKey(userId),
+      ...MCP_REGISTER_RATE_LIMIT,
       logger,
     });
     if (remaining <= 0) {
@@ -47,7 +51,7 @@ app.post(
         status_code: 429,
         api_error: {
           type: "rate_limit_error",
-          message: "Too many MCP server registrations. Please try again later.",
+          message: MCP_REGISTER_RATE_LIMIT_ERROR,
         },
       });
     }

--- a/front/lib/api/actions/mcp/client_side_registry.test.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.test.ts
@@ -1,0 +1,96 @@
+import {
+  deregisterMCPServer,
+  getBaseServerId,
+  registerMCPServer,
+} from "@app/lib/api/actions/mcp/client_side_registry";
+import { Authenticator } from "@app/lib/auth";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("registerMCPServer", () => {
+  let auth: Authenticator;
+  let workspaceId: string;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    workspaceId = workspace.sId;
+  });
+
+  it("allocates a distinct serverId per registration of the same server name", async () => {
+    // Two registrations with the same name simulate two browser tabs of the
+    // same user: each must get its own serverId so their request channels
+    // never overlap.
+    const first = await registerMCPServer(auth, {
+      serverName: "my server",
+      workspaceId,
+    });
+    const second = await registerMCPServer(auth, {
+      serverName: "my server",
+      workspaceId,
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value.serverId).toMatch(
+        /^mcp-client-side:my_server\.[0-9a-f]{16}$/
+      );
+      expect(second.value.serverId).toMatch(
+        /^mcp-client-side:my_server\.[0-9a-f]{16}$/
+      );
+      expect(first.value.serverId).not.toBe(second.value.serverId);
+    }
+  });
+
+  it("does not recycle serverIds after deregistration", async () => {
+    // A new registration must never inherit the serverId (and thus the request
+    // channel and its pending request history) of a previous registration.
+    const first = await registerMCPServer(auth, {
+      serverName: "my server",
+      workspaceId,
+    });
+    expect(first.isOk()).toBe(true);
+    if (!first.isOk()) {
+      return;
+    }
+
+    await deregisterMCPServer(auth, { serverId: first.value.serverId });
+
+    const second = await registerMCPServer(auth, {
+      serverName: "my server",
+      workspaceId,
+    });
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) {
+      expect(second.value.serverId).not.toBe(first.value.serverId);
+    }
+  });
+});
+
+describe("getBaseServerId", () => {
+  it("strips the random hex suffix", () => {
+    expect(getBaseServerId("mcp-client-side:my_server.a1b2c3d4e5f60718")).toBe(
+      "mcp-client-side:my_server"
+    );
+  });
+
+  it("strips legacy numeric suffixes", () => {
+    expect(getBaseServerId("mcp-client-side:my_server.1")).toBe(
+      "mcp-client-side:my_server"
+    );
+  });
+
+  it("leaves legacy unsuffixed serverIds unchanged", () => {
+    expect(getBaseServerId("mcp-client-side:my_server")).toBe(
+      "mcp-client-side:my_server"
+    );
+  });
+});

--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -14,6 +14,16 @@ const MCP_SERVER_REGISTRATION_TTL_SECONDS = 10 * 60;
 // characters, so a collision is virtually impossible
 const MAX_REGISTRATION_ATTEMPTS = 3;
 
+export const MCP_REGISTER_RATE_LIMIT = {
+  maxPerTimeframe: 100,
+  timeframeSeconds: 60,
+} as const;
+export const MCP_REGISTER_RATE_LIMIT_ERROR =
+  "Too many MCP server registrations. Please try again later.";
+export function getMCPRegisterRateLimitKey(userId: number): string {
+  return `mcp:register:${userId}`;
+}
+
 /**
  * Generate a Redis key for MCP server registration.
  */

--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -3,22 +3,16 @@ import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
+import { randomBytes } from "crypto";
 
 // TTL for MCP server registrations (10 minutes).
 // Refreshed on every access via EXPIRE in validateMCPServerAccess, and by the client heartbeat
 // (every 5 minutes) as a fallback.
 const MCP_SERVER_REGISTRATION_TTL_SECONDS = 10 * 60;
 
-const MAX_SERVER_INSTANCES = 256;
-
-export class MCPServerInstanceLimitError extends Error {
-  constructor(serverName: string) {
-    super(
-      `Maximum number of servers (${MAX_SERVER_INSTANCES}) with name "${serverName}" reached`
-    );
-    this.name = "MCPServerInstanceLimitError";
-  }
-}
+// Number of attempts to allocate a serverId before giving up. Suffixes are 16 random hex
+// characters, so a collision is virtually impossible
+const MAX_REGISTRATION_ATTEMPTS = 3;
 
 /**
  * Generate a Redis key for MCP server registration.
@@ -36,16 +30,18 @@ export function getMCPServerRegistryKey({
 }
 
 /**
- * Get the base serverId by removing any numeric suffix.
- * For example: "mcp-client-side:my-server.1" -> "mcp-client-side:my-server"
+ * Get the base serverId by removing the per-registration suffix.
+ * For example: "mcp-client-side:my-server.a1b2c3d4e5f60718" -> "mcp-client-side:my-server"
+ * (legacy numeric suffixes like "mcp-client-side:my-server.1" are stripped too).
  * This is safe because:
  * 1. The suffix is always prefixed with a dot
  * 2. The base serverId is generated using slugify which removes dots
  * 3. The serverId format is strictly controlled by our code
  */
 export function getBaseServerId(serverId: string): string {
-  // Only remove suffix if it matches our strict pattern (dot followed by numbers)
-  return serverId.replace(/\.\d+$/, "");
+  // Only remove suffix if it matches our strict pattern (dot followed by hex characters,
+  // which also covers legacy numeric suffixes).
+  return serverId.replace(/\.[0-9a-f]+$/, "");
 }
 
 export function getMCPServerIdFromServerName({
@@ -71,9 +67,11 @@ export interface MCPServerRegistration {
 /**
  * Register a new MCP server.
  * Multiple servers can share the same serverName, but each must have a unique serverId.
- * If a serverName is already in use, a numeric suffix will be added to the serverId
- * to ensure uniqueness (e.g., "my-server", "my-server.1", "my-server.2").
- * The suffix is prefixed with a dot to ensure it can't be confused with the base serverId.
+ * The serverId is the slugified serverName followed by a dot and a random hex suffix
+ * (e.g., "mcp-client-side:my-server.a1b2c3d4e5f60718").
+ *
+ * The random suffix is what isolates concurrent registrations (e.g. multiple browser tabs
+ * of the same user) from each other.
  */
 export async function registerMCPServer(
   auth: Authenticator,
@@ -88,20 +86,15 @@ export async function registerMCPServer(
   const userId = auth.getNonNullableUser().id.toString();
   const now = Date.now();
 
-  // Find an available serverId by adding a suffix if needed.
-  let serverId = getMCPServerIdFromServerName({ serverName });
-  let suffix = 1;
-  let key = getMCPServerRegistryKey({
-    workspaceId,
-    userId,
-    serverId,
-  });
+  for (let attempt = 0; attempt < MAX_REGISTRATION_ATTEMPTS; attempt++) {
+    const suffix = randomBytes(8).toString("hex");
+    const serverId = `${getMCPServerIdFromServerName({ serverName })}.${suffix}`;
+    const key = getMCPServerRegistryKey({
+      workspaceId,
+      userId,
+      serverId,
+    });
 
-  // Keep trying with incremented suffixes until we find an available serverId.
-  let serverIdFound = false;
-  let attempts = 0;
-
-  while (!serverIdFound && attempts < MAX_SERVER_INSTANCES) {
     const metadata: MCPServerRegistration = {
       lastHeartbeat: now,
       registeredAt: now,
@@ -121,32 +114,20 @@ export async function registerMCPServer(
     );
 
     if (result !== null) {
-      serverIdFound = true;
-    } else {
-      // Key already exists, try the next suffix.
-      serverId = `${getMCPServerIdFromServerName({ serverName })}.${suffix}`;
-      key = getMCPServerRegistryKey({
-        workspaceId,
-        userId,
+      const expiresAt = new Date(
+        now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000
+      ).toISOString();
+
+      return new Ok({
+        expiresAt,
         serverId,
       });
-      suffix++;
-      attempts++;
     }
   }
 
-  if (!serverIdFound) {
-    return new Err(new MCPServerInstanceLimitError(serverName));
-  }
-
-  const expiresAt = new Date(
-    now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000
-  ).toISOString();
-
-  return new Ok({
-    expiresAt,
-    serverId,
-  });
+  return new Err(
+    new Error(`Failed to allocate a serverId for server "${serverName}"`)
+  );
 }
 
 /**

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -85,11 +85,11 @@ export class BrowserMCPTransport implements Transport {
   private async registerServer(): Promise<boolean> {
     try {
       // If we already hold a registration (e.g. re-registering after a failed
-      // heartbeat), release it first so the server reuses the same slot instead
-      // of allocating a new serverId suffix that would linger until its TTL
-      // expires. Without this, repeated re-registrations leak slots and
-      // eventually exhaust the per-user limit ("Maximum number of servers
-      // reached").
+      // heartbeat), release it first. serverIds are random and never recycled,
+      // so the new registration always gets a fresh id — deregistering here just
+      // frees the old id's Redis key immediately instead of waiting for its TTL
+      // to expire, and detaches us from the old request channel before we
+      // subscribe to the new one.
       if (this.serverId) {
         const previousServerId = this.serverId;
         this.serverId = null;
@@ -129,10 +129,54 @@ export class BrowserMCPTransport implements Transport {
       // Setup heartbeat to keep the server registration alive.
       this.setupHeartbeat(data.serverId);
 
+      // If an SSE stream was already opened (re-registration after a lost
+      // registration), it is still attached to the previous serverId's channel
+      // and would keep receiving requests that no longer
+      // belong to this transport. Reconnect to the new serverId's channel. The
+      // lastEventId belongs to the old channel's stream, so drop it.
+      if (this.eventSource) {
+        this.lastEventId = null;
+        await this.connectToRequestsStream();
+      }
+
       return true;
     } catch (error) {
       console.error(
         "[BrowserMCPTransport] Failed to register MCP server:",
+        error
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Send a single heartbeat for the given serverId.
+   * Returns true if the registration is still alive, false if it is gone or
+   * the request failed.
+   */
+  private async sendHeartbeat(serverId: string): Promise<boolean> {
+    try {
+      const response = await clientFetch(
+        `/api/w/${this.workspaceId}/mcp/heartbeat`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({ serverId }),
+        }
+      );
+
+      if (!response.ok) {
+        return false;
+      }
+
+      const data = (await response.json()) as { success: boolean };
+      return data.success;
+    } catch (error) {
+      console.error(
+        "[BrowserMCPTransport] Failed to heartbeat MCP server:",
         error
       );
       return false;
@@ -154,36 +198,10 @@ export class BrowserMCPTransport implements Transport {
         return;
       }
 
-      try {
-        const response = await clientFetch(
-          `/api/w/${this.workspaceId}/mcp/heartbeat`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            credentials: "include",
-            body: JSON.stringify({ serverId }),
-          }
-        );
-
-        if (!response.ok) {
-          console.error("[BrowserMCPTransport] Failed to heartbeat MCP server");
-          await this.registerServer();
-          return;
-        }
-
-        const data = (await response.json()) as { success: boolean };
-        if (!data.success) {
-          console.error(
-            "[BrowserMCPTransport] Server not registered, re-registering"
-          );
-          await this.registerServer();
-        }
-      } catch (error) {
+      const alive = await this.sendHeartbeat(serverId);
+      if (!alive && !this.isClosing) {
         console.error(
-          "[BrowserMCPTransport] Failed to heartbeat MCP server:",
-          error
+          "[BrowserMCPTransport] Server not registered, re-registering"
         );
         await this.registerServer();
       }
@@ -317,28 +335,68 @@ export class BrowserMCPTransport implements Transport {
           );
         });
       } else {
-        // Actual connection error. Propagate and reconnect after a delay.
+        // Actual connection error. Propagate and recover after a delay.
         console.error(
           "[BrowserMCPTransport] Error in MCP EventSource connection"
         );
         this.onerror?.(new Error("SSE connection error"));
 
-        setTimeout(() => {
-          if (!this.isClosing && this.serverId) {
-            void this.connectToRequestsStream().catch((reconnectError) => {
-              console.error(
-                "[BrowserMCPTransport] Failed to reconnect after error:",
-                reconnectError
-              );
-            });
-          }
-        }, RECONNECT_DELAY_MS);
+        this.scheduleStreamRecovery();
       }
     };
 
     this.eventSource.onopen = () => {
       console.log("[BrowserMCPTransport] MCP SSE connection established");
     };
+  }
+
+  private scheduleStreamRecovery(): void {
+    setTimeout(() => {
+      void this.recoverStream();
+    }, RECONNECT_DELAY_MS);
+  }
+
+  /**
+   * Recover from an SSE stream error.
+   *
+   * The error may be caused by an expired registration (e.g. the tab was
+   * frozen or the machine slept past the registration TTL), in which case
+   * reconnecting with the current serverId would keep failing. Verify the
+   * registration first: if it is still alive, reconnect the stream; otherwise
+   * re-register. If recovery fails entirely (e.g. network down), retry after a
+   * delay.
+   */
+  private async recoverStream(): Promise<void> {
+    if (this.isClosing) {
+      return;
+    }
+
+    try {
+      // serverId can be null if a previous re-registration attempt failed
+      // mid-way; in that case skip the liveness check and re-register.
+      const alive = this.serverId
+        ? await this.sendHeartbeat(this.serverId)
+        : false;
+      if (this.isClosing) {
+        return;
+      }
+
+      if (alive) {
+        await this.connectToRequestsStream();
+        return;
+      }
+
+      const registered = await this.registerServer();
+      if (!registered) {
+        this.scheduleStreamRecovery();
+      }
+    } catch (error) {
+      console.error(
+        "[BrowserMCPTransport] Failed to recover MCP SSE connection:",
+        error
+      );
+      this.scheduleStreamRecovery();
+    }
   }
 
   /**

--- a/sdks/js/src/mcp_transport.ts
+++ b/sdks/js/src/mcp_transport.ts
@@ -55,6 +55,14 @@ export class DustMcpServerTransport implements Transport {
     // Setup heartbeat to keep the server registration alive.
     this.setupHeartbeat(serverId);
 
+    // If an SSE stream was already open (re-registration after a lost
+    // heartbeat), it is still subscribed to the previous serverId's channel.
+    // Reconnect to the new serverId's channel and drop the stale lastEventId.
+    if (this.eventSource) {
+      this.lastEventId = null;
+      await this.connectToRequestsStream();
+    }
+
     return true;
   }
 


### PR DESCRIPTION
## Summary
- https://github.com/dust-tt/tasks/issues/9566

Bug:
 The serverId is passed in the user message context (clientSideMCPServerIds) when
  the message is sent. That exact serverId is baked into the agent configuration for that conversation's run — the
  backend dispatches all tool calls to that specific channel for the lifetime of the run.

  So the actual bug:
  1. Tab A sends a message → serverId = mcp-client-side:sidekick.1 is baked into that conversation run
  2. Tab A's registration expires (or it closes and deregisters)
  3. Tab B opens and claims slot .1 (first free slot)
  4. The agent is still dispatching tool calls for Tab A's conversation to the .1 channel
  5. Tab B receives them — it's on the wrong agent's channel

  It doesn't require explicit close+reopen. It happens whenever any tab loses its registration (TTL expiry, SSE
  drop, crash) while another tab simultaneously claims the same slot.

- **Fix**: Replace the numeric suffix with a random 8-byte hex suffix (`randomBytes(8).toString("hex")`). Each registration gets a globally unique channel, so concurrent tabs are fully isolated.
- **Rate limiting**: The old scheme relied on a 256-slot cap to prevent abuse. With random IDs there is no natural slot limit, so added a 100/min per-user rate limit on both register endpoints instead.
- **SSE recovery**: On SSE stream errors, the transport now heartbeats the existing registration first. If still alive it reconnects the stream; if dead it re-registers (getting a new serverId) and reconnects to the new channel. Previously it blindly reconnected the stream to the old channel even after re-registration.

## Testing
* Added unit tests
<img width="802" height="785" alt="Screenshot 2026-07-14 at 3 29 40 PM" src="https://github.com/user-attachments/assets/16d7036e-7d93-4b73-af7d-25ad7073f328" />

## Risk

Some risk in unintended consequences with the client tool logic

## Deploy
1. Deploy front