### PR TITLE
chore(sdk): bump @dust-tt/client to 1.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58222,7 +58222,7 @@
     },
     "sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -27,3 +27,34 @@
     "watch": "npm-watch",
     "tsgo": "tsgo"
   },
+  "devDependencies": {
+    "@tsconfig/recommended": "^1.0.3",
+    "@typescript/native-preview": "^7.0.0-dev.20260224.1",
+    "@types/event-source-polyfill": "^1.0.5",
+    "@types/node": "^24.12.2",
+    "@types/uuid": "^9.0.7",
+    "esbuild": "^0.27.3",
+    "npm-watch": "^0.11.0",
+    "tslib": "^2.6.2",
+    "tsx": "^4.19.1"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@types/json-schema": "^7.0.15",
+    "event-source-polyfill": "^1.0.31",
+    "eventsource-parser": "^1.1.1",
+    "zod": "^3.23.8"
+  },
+  "browser": {
+    "tls": false,
+    "net": false,
+    "hot-shots": false
+  },
+  "watch": {
+    "build": {
+      "patterns": ["src"],
+      "extensions": "ts",
+      "ignore": ""
+    }
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "engines": {
     "node": ">=24.16.0"
   },
@@ -27,34 +27,3 @@
     "watch": "npm-watch",
     "tsgo": "tsgo"
   },
-  "devDependencies": {
-    "@tsconfig/recommended": "^1.0.3",
-    "@typescript/native-preview": "^7.0.0-dev.20260224.1",
-    "@types/event-source-polyfill": "^1.0.5",
-    "@types/node": "^24.12.2",
-    "@types/uuid": "^9.0.7",
-    "esbuild": "^0.27.3",
-    "npm-watch": "^0.11.0",
-    "tslib": "^2.6.2",
-    "tsx": "^4.19.1"
-  },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
-    "@types/json-schema": "^7.0.15",
-    "event-source-polyfill": "^1.0.31",
-    "eventsource-parser": "^1.1.1",
-    "zod": "^3.23.8"
-  },
-  "browser": {
-    "tls": false,
-    "net": false,
-    "hot-shots": false
-  },
-  "watch": {
-    "build": {
-      "patterns": ["src"],
-      "extensions": "ts",
-      "ignore": ""
-    }
-  }
-}


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/9598

## Description

Bumps `@dust-tt/client` (the JS SDK) from `1.2.6` to `1.2.7` in `sdks/js/package.json` and `package-lock.json`.

No source change: the fix already landed in `sdks/js/src/types.ts` via #28704 (`ActionGeneratedFileSchema` now accepts a union of `{ fileId: string }` or `{ fileId: null, filePath: string }`), but the package version on `main` was never bumped, so the published npm package (still `1.2.6`) rejects any conversation containing a path-backed generated file with a Zod `invalid_union` error.

Fixes #9598. Related: #28803 (same root cause via the CLI).

## Tests

Local validation was not run in the Computer (no npm toolchain available in this sandbox session). This is a pure version-number change with no source edits; validation is delegated to PR CI (typecheck/build/lint on `sdks/js`).

## Risk

Low. Only the `version` field changes in `sdks/js/package.json` and its corresponding workspace entry in the root `package-lock.json`. No behavior change; the schema fix itself was already reviewed and merged in #28704. Safe to roll back by reverting.

## Deploy Plan

- Merge this PR.
- Manually trigger the **Publish SDK Client** GitHub Action (`workflow_dispatch` on `main`) to publish `1.2.7` to npm.
- Notify affected consumers that a fresh `npm install`/reinstall will pick up the fix once published.