### PR TITLE
feat(analytics): job-type cohorts and anonymity floor for user_analytics

### DIFF
--- a/front/lib/api/actions/servers/user_analytics/index.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.ts
@@ -1,3 +1,4 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -26,7 +27,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { JOB_TYPE_LABELS } from "@app/types/job_type";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const DAYS = 30;
@@ -58,7 +59,7 @@ async function resolveAccessibleSkills(
 // workspace_analytics tools. Scoping is entirely by `userIds`, so the same
 // renderer serves both the caller's own usage and an anonymized job-type
 // cohort.
-async function buildDetailedUsageLines(
+async function buildDetailedUsageSections(
   auth: Authenticator,
   { userIds, window }: { userIds: string[]; window: ResolvedTimeWindow }
 ): Promise<string[]> {
@@ -157,7 +158,7 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       "last_30_days"
     );
     if (window.isErr()) {
-      return new Ok([{ type: "text" as const, text: window.error }]);
+      return new Err(new MCPError(window.error, { tracked: false }));
     }
     const { label } = window.value;
 
@@ -174,14 +175,14 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
             type: "text" as const,
             text:
               `Usage for the ${jobTypeLabel} job type is not available: it has ` +
-              `${cohort.userCount} user${cohort.userCount === 1 ? "" : "s"}, ` +
-              `below the ${MIN_USERS_FOR_ANONYMITY}-user minimum ` +
-              "required to keep individual usage anonymous.",
+              `${cohort.userCount} user${cohort.userCount === 1 ? "" : "s"} — ` +
+              `fewer than the ${MIN_USERS_FOR_ANONYMITY} required ` +
+              "to keep individual usage anonymous.",
           },
         ]);
       }
 
-      const sections = await buildDetailedUsageLines(auth, {
+      const sections = await buildDetailedUsageSections(auth, {
         userIds: cohort.userIds,
         window: window.value,
       });
@@ -205,7 +206,7 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
-    const sections = await buildDetailedUsageLines(auth, {
+    const sections = await buildDetailedUsageSections(auth, {
       userIds: [user.sId],
       window: window.value,
     });

--- a/front/lib/api/actions/servers/user_analytics/index.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.ts
@@ -7,29 +7,35 @@ import {
   USER_ANALYTICS_SERVER_NAME,
   USER_ANALYTICS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/user_analytics/metadata";
+import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
+import { fetchJobTypeCohort } from "@app/lib/api/assistant/observability/job_type_cohorts";
 import { fetchAvailableSkillsBySkillId } from "@app/lib/api/assistant/observability/skill_usage";
 import {
   fetchAvailableTools,
   resolveToolDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
+import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import {
   buildAgentAnalyticsBaseQuery,
   daysToInstantRange,
 } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { JOB_TYPE_LABELS } from "@app/types/job_type";
 import { Ok } from "@app/types/shared/result";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const DAYS = 30;
 const TOP_ITEMS_LIMIT = 100;
 
-async function resolveAccessibleSkillNames(
+async function resolveAccessibleSkills(
   auth: Authenticator,
-  rows: { skillId: string }[]
-): Promise<string[]> {
+  rows: { skillId: string; totalExecutions: number }[]
+): Promise<{ name: string; totalExecutions: number }[]> {
   if (rows.length === 0) {
     return [];
   }
@@ -38,13 +44,104 @@ async function resolveAccessibleSkillNames(
     rows.map((r) => r.skillId)
   );
   const byId = new Map(resources.map((s) => [s.sId, s]));
-  return rows
-    .map((r) => byId.get(r.skillId)?.name)
-    .filter((n): n is string => n !== undefined);
+  return rows.flatMap((r) => {
+    const name = byId.get(r.skillId)?.name;
+    return name !== undefined
+      ? [{ name, totalExecutions: r.totalExecutions }]
+      : [];
+  });
+}
+
+// Builds the detailed usage summary sections (top agents, skills, and tools)
+// for a set of users over a window. Each section is a titled block of numbered
+// lines ordered most-used first, mirroring the formatting of the
+// workspace_analytics tools. Scoping is entirely by `userIds`, so the same
+// renderer serves both the caller's own usage and an anonymized job-type
+// cohort.
+async function buildDetailedUsageLines(
+  auth: Authenticator,
+  { userIds, window }: { userIds: string[]; window: ResolvedTimeWindow }
+): Promise<string[]> {
+  const ws = auth.getNonNullableWorkspace();
+  const { startDate, endDate } = window;
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: ws.sId,
+    startDate,
+    endDate,
+    userIds,
+  });
+
+  const [skillsResult, toolsResult, agentsResult] = await Promise.all([
+    fetchAvailableSkillsBySkillId(baseQuery),
+    fetchAvailableTools(baseQuery),
+    fetchTopAgents(auth, {
+      startDate,
+      endDate,
+      limit: TOP_ITEMS_LIMIT,
+      userIds,
+    }),
+  ]);
+
+  const sections: string[] = [];
+
+  // Filter to agents the caller can actually access — fetchTopAgents is
+  // workspace-scoped and its internal label resolver has a fallback that leaks
+  // names from private spaces.
+  const candidateAgents = (agentsResult.isOk() ? agentsResult.value : []).slice(
+    0,
+    TOP_ITEMS_LIMIT
+  );
+  let topAgents = candidateAgents;
+  if (candidateAgents.length > 0) {
+    const accessible = await getAgentConfigurations(auth, {
+      agentIds: candidateAgents.map((a) => a.agentId),
+      variant: "extra_light",
+    });
+    const accessibleIds = new Set(accessible.map((a) => a.sId));
+    topAgents = candidateAgents.filter((a) => accessibleIds.has(a.agentId));
+  }
+  if (topAgents.length > 0) {
+    const lines = topAgents.map(
+      (a, i) =>
+        `${i + 1}. ${a.name} [${a.agentId}] — ${a.messageCount} messages`
+    );
+    sections.push(`Top agents (most used first):\n${lines.join("\n")}`);
+  }
+
+  const topSkillRows = (skillsResult.isOk() ? skillsResult.value : []).slice(
+    0,
+    TOP_ITEMS_LIMIT
+  );
+  const skills = await resolveAccessibleSkills(auth, topSkillRows);
+  if (skills.length > 0) {
+    const lines = skills.map(
+      (s, i) => `${i + 1}. ${s.name} — ${s.totalExecutions} executions`
+    );
+    sections.push(`Top skills (most used first):\n${lines.join("\n")}`);
+  }
+
+  const topTools = (toolsResult.isOk() ? toolsResult.value : []).slice(
+    0,
+    TOP_ITEMS_LIMIT
+  );
+  if (topTools.length > 0) {
+    const resolved = await resolveToolDisplayNames(auth, topTools).catch(
+      () => topTools
+    );
+    const lines = resolved.map(
+      (t, i) => `${i + 1}. ${t.displayName} — ${t.totalExecutions} executions`
+    );
+    sections.push(`Top tools (most used first):\n${lines.join("\n")}`);
+  }
+
+  return sections;
 }
 
 const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
-  get_personal_usage: async (_params, { auth }) => {
+  get_personal_usage: async (
+    { jobType, period, startDate, endDate, timezone },
+    { auth }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Ok([
@@ -55,57 +152,75 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
-    const ws = auth.getNonNullableWorkspace();
-    const { startDate, endDate } = daysToInstantRange(DAYS);
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: ws.sId,
-      startDate,
-      endDate,
-      userIds: [user.sId],
-    });
-
-    const [skillsResult, toolsResult] = await Promise.all([
-      fetchAvailableSkillsBySkillId(baseQuery),
-      fetchAvailableTools(baseQuery),
-    ]);
-
-    const lines: string[] = [];
-
-    const topSkillRows = (skillsResult.isOk() ? skillsResult.value : []).slice(
-      0,
-      TOP_ITEMS_LIMIT
+    const window = resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      "last_30_days"
     );
-    const skillNames = await resolveAccessibleSkillNames(auth, topSkillRows);
-    if (skillNames.length > 0) {
-      lines.push(`Your top skills: ${skillNames.join(", ")}`);
+    if (window.isErr()) {
+      return new Ok([{ type: "text" as const, text: window.error }]);
     }
+    const { label } = window.value;
 
-    const topTools = (toolsResult.isOk() ? toolsResult.value : []).slice(
-      0,
-      TOP_ITEMS_LIMIT
-    );
-    if (topTools.length > 0) {
-      const resolved = await resolveToolDisplayNames(auth, topTools).catch(
-        () => topTools
-      );
-      lines.push(
-        `Your top tools: ${resolved.map((t) => t.displayName).join(", ")}`
-      );
-    }
+    // Job-type breakdown: report aggregated usage for everyone in the workspace
+    // sharing this job type, but only when the cohort is large enough to keep
+    // individuals anonymous.
+    if (jobType) {
+      const cohort = await fetchJobTypeCohort(auth, jobType);
+      const jobTypeLabel = JOB_TYPE_LABELS[jobType];
 
-    if (lines.length === 0) {
+      if (cohort.kind === "below_anonymity_floor") {
+        return new Ok([
+          {
+            type: "text" as const,
+            text:
+              `Usage for the ${jobTypeLabel} job type is not available: it has ` +
+              `${cohort.userCount} user${cohort.userCount === 1 ? "" : "s"}, ` +
+              `below the ${MIN_USERS_FOR_ANONYMITY}-user minimum ` +
+              "required to keep individual usage anonymous.",
+          },
+        ]);
+      }
+
+      const sections = await buildDetailedUsageLines(auth, {
+        userIds: cohort.userIds,
+        window: window.value,
+      });
+      if (sections.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text:
+              `No usage recorded for the ${jobTypeLabel} job type ` +
+              `(${cohort.userCount} users) over ${label}.`,
+          },
+        ]);
+      }
       return new Ok([
         {
           type: "text" as const,
-          text: "No personal usage recorded in the last 30 days.",
+          text:
+            `Usage for the ${jobTypeLabel} job type (${cohort.userCount} users) ` +
+            `— ${label}:\n\n${sections.join("\n\n")}`,
         },
       ]);
     }
 
+    const sections = await buildDetailedUsageLines(auth, {
+      userIds: [user.sId],
+      window: window.value,
+    });
+    if (sections.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No personal usage recorded over ${label}.`,
+        },
+      ]);
+    }
     return new Ok([
       {
         type: "text" as const,
-        text: `Personal usage — last 30 days:\n${lines.join("\n")}`,
+        text: `Personal usage — ${label}:\n\n${sections.join("\n\n")}`,
       },
     ]);
   },
@@ -119,12 +234,39 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       endDate,
     });
 
+    // Anonymity floor: a workspace-wide aggregate can de-anonymize individuals
+    // when only a handful of people are active, so require a minimum number of
+    // distinct active users before surfacing anything. Fetching the top users
+    // capped at the floor is enough to decide — the count saturates at the
+    // threshold.
+    const activeUsersResult = await fetchTopUsers(auth, {
+      startDate,
+      endDate,
+      limit: MIN_USERS_FOR_ANONYMITY,
+    });
+    const activeUserCount = activeUsersResult.isOk()
+      ? activeUsersResult.value.length
+      : 0;
+    if (activeUserCount < MIN_USERS_FOR_ANONYMITY) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            "Workspace activity is not available: only " +
+            `${activeUserCount} user${activeUserCount === 1 ? "" : "s"} ` +
+            `active in the last ${DAYS} days, below the ` +
+            `${MIN_USERS_FOR_ANONYMITY}-user minimum required to keep ` +
+            "individual activity anonymous.",
+        },
+      ]);
+    }
+
     const [agentsResult, skillsResult] = await Promise.all([
       fetchTopAgents(auth, { days: DAYS, limit: TOP_ITEMS_LIMIT }),
       fetchAvailableSkillsBySkillId(baseQuery),
     ]);
 
-    const lines: string[] = [];
+    const sections: string[] = [];
 
     const candidateAgents = (
       agentsResult.isOk() ? agentsResult.value : []
@@ -141,8 +283,12 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       topAgents = candidateAgents.filter((a) => accessibleIds.has(a.agentId));
     }
     if (topAgents.length > 0) {
-      lines.push(
-        `Most popular agents: ${topAgents.map((a, i) => `${i + 1}. ${a.name} (${a.messageCount} messages)`).join(", ")}`
+      const lines = topAgents.map(
+        (a, i) =>
+          `${i + 1}. ${a.name} [${a.agentId}] — ${a.messageCount} messages`
+      );
+      sections.push(
+        `Most popular agents (most used first):\n${lines.join("\n")}`
       );
     }
 
@@ -150,12 +296,15 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       0,
       TOP_ITEMS_LIMIT
     );
-    const skillNames = await resolveAccessibleSkillNames(auth, topSkillRows);
-    if (skillNames.length > 0) {
-      lines.push(`Trending skills: ${skillNames.join(", ")}`);
+    const skills = await resolveAccessibleSkills(auth, topSkillRows);
+    if (skills.length > 0) {
+      const lines = skills.map(
+        (s, i) => `${i + 1}. ${s.name} — ${s.totalExecutions} executions`
+      );
+      sections.push(`Trending skills (most used first):\n${lines.join("\n")}`);
     }
 
-    if (lines.length === 0) {
+    if (sections.length === 0) {
       return new Ok([
         {
           type: "text" as const,
@@ -167,7 +316,7 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: `Workspace activity — last 30 days:\n${lines.join("\n")}`,
+        text: `Workspace activity — last 30 days:\n\n${sections.join("\n\n")}`,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -1,5 +1,8 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { timeWindowSchemaShape } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
+import { JOB_TYPES } from "@app/types/job_type";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -9,8 +12,25 @@ export const USER_ANALYTICS_SERVER_NAME = "user_analytics" as const;
 export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_personal_usage: {
     description:
-      "Get the authenticated user's personal usage over the last 30 days: their top skills and top tools ranked by execution count.",
-    schema: {},
+      "Get the authenticated user's personal usage over a time window " +
+      "(defaults to the last 30 days): top agents, top skills, and top tools " +
+      "ranked by execution count. Set jobType to instead " +
+      "get aggregated usage across all workspace " +
+      "members sharing that job type — only returned when at least " +
+      `${MIN_USERS_FOR_ANONYMITY} members share it, to keep ` +
+      "individuals anonymous.",
+    schema: {
+      ...timeWindowSchemaShape,
+      jobType: z
+        .enum(JOB_TYPES)
+        .optional()
+        .describe(
+          "When set, return aggregated usage for all workspace members with " +
+            "this job type instead of the caller's own usage. Only returned " +
+            `when at least ${MIN_USERS_FOR_ANONYMITY} members ` +
+            "share the job type, to keep individuals anonymous."
+        ),
+    },
     stake: "never_ask",
     toolCostCategory: "basic",
     freeUsage: true,
@@ -22,7 +42,10 @@ export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_workspace_activity: {
     description:
       "Get anonymized workspace-wide activity over the last 30 days: " +
-      "most popular agents by usage rank and trending skills. No individual user attribution.",
+      "most popular agents by usage rank and trending skills. No individual " +
+      "user attribution, and only returned when at least " +
+      `${MIN_USERS_FOR_ANONYMITY} users were active, to keep individuals ` +
+      "anonymous.",
     schema: {},
     stake: "never_ask",
     toolCostCategory: "basic",

--- a/front/lib/api/assistant/observability/anonymity.ts
+++ b/front/lib/api/assistant/observability/anonymity.ts
@@ -1,0 +1,6 @@
+// Minimum number of distinct users that must stand behind any aggregated usage
+// figure before it may be surfaced. Below this floor a single person's activity
+// could be isolated from the aggregate, so we decline instead. This is a static
+// k-anonymity floor shared by every analytics surface that reports pooled usage
+// (job-type cohorts, workspace-wide activity).
+export const MIN_USERS_FOR_ANONYMITY = 5;

--- a/front/lib/api/assistant/observability/job_type_cohorts.test.ts
+++ b/front/lib/api/assistant/observability/job_type_cohorts.test.ts
@@ -1,0 +1,103 @@
+import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
+import { fetchJobTypeCohort } from "@app/lib/api/assistant/observability/job_type_cohorts";
+import { Authenticator } from "@app/lib/auth";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function makeMember(
+  workspace: WorkspaceType,
+  jobType: string | null
+): Promise<UserResource> {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "user" });
+  if (jobType) {
+    await user.setMetadata("job_type", jobType);
+  }
+  return user;
+}
+
+describe("fetchJobTypeCohort", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+  });
+
+  it("declines when the cohort is below the anonymity floor", async () => {
+    for (let i = 0; i < MIN_USERS_FOR_ANONYMITY - 1; i++) {
+      await makeMember(workspace, "engineering");
+    }
+
+    const cohort = await fetchJobTypeCohort(auth, "engineering");
+
+    expect(cohort.kind).toBe("below_anonymity_floor");
+    if (cohort.kind === "below_anonymity_floor") {
+      expect(cohort.userCount).toBe(MIN_USERS_FOR_ANONYMITY - 1);
+    }
+  });
+
+  it("returns the cohort user sIds when the floor is met", async () => {
+    const members: UserResource[] = [];
+    for (let i = 0; i < MIN_USERS_FOR_ANONYMITY; i++) {
+      members.push(await makeMember(workspace, "engineering"));
+    }
+
+    const cohort = await fetchJobTypeCohort(auth, "engineering");
+
+    expect(cohort.kind).toBe("cohort");
+    if (cohort.kind === "cohort") {
+      expect(cohort.userCount).toBe(MIN_USERS_FOR_ANONYMITY);
+      expect(new Set(cohort.userIds)).toEqual(
+        new Set(members.map((m) => m.sId))
+      );
+    }
+  });
+
+  it("only counts members with the requested job type", async () => {
+    for (let i = 0; i < MIN_USERS_FOR_ANONYMITY; i++) {
+      await makeMember(workspace, "engineering");
+    }
+    // Different job type and no job type — must not inflate the sales cohort.
+    for (let i = 0; i < MIN_USERS_FOR_ANONYMITY; i++) {
+      await makeMember(workspace, "marketing");
+    }
+    await makeMember(workspace, null);
+
+    const cohort = await fetchJobTypeCohort(auth, "sales");
+
+    expect(cohort.kind).toBe("below_anonymity_floor");
+    if (cohort.kind === "below_anonymity_floor") {
+      expect(cohort.userCount).toBe(0);
+    }
+  });
+
+  it("excludes users who have the job type but are not workspace members", async () => {
+    for (let i = 0; i < MIN_USERS_FOR_ANONYMITY; i++) {
+      await makeMember(workspace, "engineering");
+    }
+    // A user with the job type set but no membership in this workspace.
+    const nonMember = await UserFactory.basic();
+    await nonMember.setMetadata("job_type", "engineering");
+
+    const cohort = await fetchJobTypeCohort(auth, "engineering");
+
+    expect(cohort.kind).toBe("cohort");
+    if (cohort.kind === "cohort") {
+      expect(cohort.userCount).toBe(MIN_USERS_FOR_ANONYMITY);
+      expect(cohort.userIds).not.toContain(nonMember.sId);
+    }
+  });
+});

--- a/front/lib/api/assistant/observability/job_type_cohorts.ts
+++ b/front/lib/api/assistant/observability/job_type_cohorts.ts
@@ -28,14 +28,13 @@ export async function fetchJobTypeCohort(
     return { kind: "below_anonymity_floor", userCount: 0 };
   }
 
-  const jobTypeByUserModelId =
+  const matchingByModelId =
     await UserResource.fetchUserScopedMetadataValuesByUserModelIds(
       "job_type",
-      memberModelIds
+      memberModelIds,
+      { value: jobType }
     );
-  const matchingModelIds = memberModelIds.filter(
-    (modelId) => jobTypeByUserModelId.get(modelId) === jobType
-  );
+  const matchingModelIds = [...matchingByModelId.keys()];
 
   if (matchingModelIds.length < MIN_USERS_FOR_ANONYMITY) {
     return {

--- a/front/lib/api/assistant/observability/job_type_cohorts.ts
+++ b/front/lib/api/assistant/observability/job_type_cohorts.ts
@@ -1,0 +1,53 @@
+import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { JobType } from "@app/types/job_type";
+
+// Result of resolving a job-type cohort. `cohort` carries the user sIds to scope
+// analytics queries by; `below_anonymity_floor` means the cohort is too small
+// to surface without risking de-anonymization.
+export type JobTypeCohort =
+  | { kind: "cohort"; userIds: string[]; userCount: number }
+  | { kind: "below_anonymity_floor"; userCount: number };
+
+// Resolves the active workspace members whose (user-scoped) `job_type` metadata
+// matches `jobType`, returning their sIds only when the cohort meets the
+// anonymity floor.
+export async function fetchJobTypeCohort(
+  auth: Authenticator,
+  jobType: JobType
+): Promise<JobTypeCohort> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  const memberModelIds = memberships.map((membership) => membership.userId);
+  if (memberModelIds.length === 0) {
+    return { kind: "below_anonymity_floor", userCount: 0 };
+  }
+
+  const jobTypeByUserModelId =
+    await UserResource.fetchUserScopedMetadataValuesByUserModelIds(
+      "job_type",
+      memberModelIds
+    );
+  const matchingModelIds = memberModelIds.filter(
+    (modelId) => jobTypeByUserModelId.get(modelId) === jobType
+  );
+
+  if (matchingModelIds.length < MIN_USERS_FOR_ANONYMITY) {
+    return {
+      kind: "below_anonymity_floor",
+      userCount: matchingModelIds.length,
+    };
+  }
+
+  const users = await UserResource.fetchByModelIds(matchingModelIds);
+  return {
+    kind: "cohort",
+    userIds: users.map((user) => user.sId),
+    userCount: users.length,
+  };
+}

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -176,21 +176,26 @@ export class UserResource extends BaseResource<UserModel> {
 
   // Batch-reads a single user-scoped metadata value for
   // many users in one query. Returns a Map keyed by user model id, omitting
-  // users that have no value for the key.
+  // users that have no value for the key. Pass `value` to filter in the DB.
   static async fetchUserScopedMetadataValuesByUserModelIds(
     key: string,
-    userModelIds: ModelId[]
+    userModelIds: ModelId[],
+    { value }: { value?: string } = {}
   ): Promise<Map<ModelId, string>> {
     if (userModelIds.length === 0) {
       return new Map();
     }
+    const where: Record<string, unknown> = {
+      key,
+      userId: { [Op.in]: userModelIds },
+      workspaceId: null,
+    };
+    if (value !== undefined) {
+      where["value"] = value;
+    }
     const rows = await UserMetadataModel.findAll({
       attributes: ["userId", "value"],
-      where: {
-        key,
-        userId: { [Op.in]: userModelIds },
-        workspaceId: null,
-      },
+      where,
     });
     return new Map(rows.map((row) => [row.userId, row.value]));
   }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -174,6 +174,27 @@ export class UserResource extends BaseResource<UserModel> {
     return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
+  // Batch-reads a single user-scoped metadata value for
+  // many users in one query. Returns a Map keyed by user model id, omitting
+  // users that have no value for the key.
+  static async fetchUserScopedMetadataValuesByUserModelIds(
+    key: string,
+    userModelIds: ModelId[]
+  ): Promise<Map<ModelId, string>> {
+    if (userModelIds.length === 0) {
+      return new Map();
+    }
+    const rows = await UserMetadataModel.findAll({
+      attributes: ["userId", "value"],
+      where: {
+        key,
+        userId: { [Op.in]: userModelIds },
+        workspaceId: null,
+      },
+    });
+    return new Map(rows.map((row) => [row.userId, row.value]));
+  }
+
   static async listByUsername(username: string): Promise<UserResource[]> {
     const users = await UserModel.findAll({
       where: {


### PR DESCRIPTION
## Summary

Extends the `user_analytics` internal MCP server with anonymized cohort reporting, gated by a shared k-anonymity floor.

- **`get_personal_usage`** — reformatted to match `workspace_analytics`: numbered, most-used-first sections for top agents / skills / tools.
- **`get_personal_usage({ jobType })`** — aggregates usage across all workspace members sharing a job type, returned only when the cohort meets the anonymity floor (otherwise a "not available" message).
- **`get_workspace_activity`** — now gated on a minimum number of **distinct active users** in the window, so a quiet/small workspace can't de-anonymize individuals via the workspace-wide aggregate.

## Testing

<img width="599" height="735" alt="Screenshot 2026-07-14 at 7 31 55 PM" src="https://github.com/user-attachments/assets/70d82c67-e384-4301-a941-c72f4e51c524" />

## Risk

Low, not customer facing yet

## Deploy

* Deploy Front