### PR TITLE
[cli] Support API key auth in headless chat

### DIFF
--- a/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import { useFileSystemServer } from "../../mcp/servers/fsServer.js";
 import { getDustClient } from "../../utils/dustClient.js";
 import { normalizeError } from "../../utils/errors.js";
+import { getMe } from "../../utils/me.js";
 import {
   fetchAgentMessageFromConversation,
   sendNonInteractiveMessage,
@@ -83,8 +84,8 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
           return;
         }
 
-        // Get current user info
-        const meRes = await dustClient.me();
+        // Get current user info (handles API key auth transparently).
+        const meRes = await getMe(dustClient);
         if (meRes.isErr()) {
           setError(`Authentication error: ${meRes.error.message}`);
           return;

--- a/cli/dust-cli/src/utils/hooks/use_me.ts
+++ b/cli/dust-cli/src/utils/hooks/use_me.ts
@@ -2,6 +2,7 @@ import type { MeResponseType } from "@dust-tt/client";
 import { useEffect, useState } from "react";
 
 import { getDustClient } from "../dustClient.js";
+import { getMe } from "../me.js";
 
 export function useMe() {
   const [me, setMe] = useState<MeResponseType["user"] | null>(null);
@@ -30,30 +31,8 @@ export function useMe() {
         return;
       }
 
-      // Check if using API key authentication
-      const apiKey = await dustClient.getApiKey();
-      if (apiKey?.startsWith("sk-")) {
-        // For API key auth, create a mock user object since .me() won't work
-        // API keys don't have access to user information, so we create a placeholder
-        setMe({
-          sId: "api-user",
-          id: 0, // ModelId type, using 0 as placeholder
-          createdAt: Date.now(),
-          provider: "google", // Default provider
-          username: "api-user",
-          email: "api-user@workspace",
-          firstName: "API",
-          lastName: "User",
-          fullName: "API User",
-          image: null,
-          workspaces: [], // Will be empty for API keys
-        });
-        setIsLoading(false);
-        return;
-      }
-
-      // For OAuth tokens, use existing .me() call
-      const meRes = await dustClient.me();
+      // Resolves the user, handling API key auth (where .me() won't work).
+      const meRes = await getMe(dustClient);
 
       if (meRes.isErr()) {
         setError(`Failed to get user information: ${meRes.error.message}`);

--- a/cli/dust-cli/src/utils/me.ts
+++ b/cli/dust-cli/src/utils/me.ts
@@ -1,0 +1,31 @@
+import type { DustAPI } from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+
+/**
+ * Resolves the current user, transparently handling API key authentication.
+ *
+ * `dustClient.me()` requires an OAuth token and always fails with a workspace
+ * API key (which authenticates as a workspace, not a user). For API key auth we
+ * return a placeholder user so callers can still resolve identity fields
+ * (username / fullName / email) without a failing round-trip.
+ */
+export async function getMe(dustClient: DustAPI): ReturnType<DustAPI["me"]> {
+  const apiKey = await dustClient.getApiKey();
+  if (apiKey?.startsWith("sk-")) {
+    return new Ok({
+      sId: "api-user",
+      id: 0, // ModelId type, using 0 as placeholder
+      createdAt: Date.now(),
+      provider: "google", // Default provider
+      username: "api-user",
+      email: "api-user@workspace",
+      firstName: "API",
+      lastName: "User",
+      fullName: "API User",
+      image: null,
+      workspaces: [], // Will be empty for API keys
+    });
+  }
+
+  return dustClient.me();
+}


### PR DESCRIPTION
## Problem

Running the non-interactive chat with a workspace API key fails with a 401,
so `chat -m` is unusable in headless/CI setups:

```
$ DUST_API_KEY=sk-... DUST_WORKSPACE_ID=... dust chat -a <agent> -m "hi"
Error: Authentication error: The request does not have valid authentication credentials.
```

## Root cause

`NonInteractiveChat` calls `dustClient.me()` directly to resolve the current
user. But `me()` requires an OAuth token and, per its own docstring, *"will
always fail with a workspace API key."* The interactive path (`useMe`) already
worked around this by substituting a placeholder user for `sk-` keys — the
headless path never got that treatment, so it 401s before it can send anything.

## Fix

Extract the workaround into a small shared helper `getMe(dustClient)`
(`utils/me.ts`): it returns the placeholder user for `sk-` keys and otherwise
delegates to `dustClient.me()`. Both the interactive hook and the headless
command now call it, which also de-duplicates the placeholder that was
previously inlined in `useMe`.

`me` is only read for the message-context fields `username` / `fullName` /
`email`, all of which the placeholder supplies (`api-user` / `API User` /
`api-user@workspace`) — identical to what interactive API-key chat already
sends today.

## Tests

Built with `NODE_ENV=production` and run against a real EU workspace using a
workspace API key.

**Before** (helper absent):

```
GET https://eu.dust.tt/api/v1/me  → 401 not_authenticated
Error: Authentication error: The request does not have valid authentication credentials.
```

**After**:

```
(no /api/v1/me call)
GET  .../assistant/agent_configurations  → 200
POST .../assistant/conversations         → proceeds to conversation creation
```

The headless `me()` gate is gone; auth now proceeds exactly like the
interactive client. (In my test workspace the `conversations` call then stopped
on an unrelated out-of-credits `429` — i.e. no longer an authentication
failure.)

`tsc --noEmit`, the `tsup` production build, and `biome check` all pass.
