### PR TITLE
Route file HEAD requests through GET handler

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -243,12 +243,14 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
 
   it("returns metadata headers without a body", async () => {
     const { workspace, conversation } = await setup();
+    const createReadStream = vi.fn().mockReturnValue(makeReadStream());
 
     const bucket = makeBucket({
       existingFilePathSuffixes: ["/files/data.csv"],
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "text/csv", size: "512" }]),
+      createReadStream,
     });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
@@ -263,6 +265,7 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/csv");
+    expect(createReadStream).not.toHaveBeenCalled();
   });
 
   it("returns 404 when file does not exist", async () => {

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -108,10 +108,45 @@ async function resolveFs(
   return { fs: fsResult.value, err: null };
 }
 
+async function handleHeadRequest(
+  ctx: Context<WorkspaceAwareCtx>,
+  canonicalPath: string
+) {
+  const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+  if (err) {
+    return err;
+  }
+
+  const statResult = await dustFs.stat(canonicalPath);
+  if (statResult.isErr()) {
+    return apiError(ctx, mapDustFsError(statResult.error));
+  }
+  if (!statResult.value) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "Content-Type": statResult.value.contentType,
+      "Content-Length": String(statResult.value.sizeBytes),
+    },
+  });
+}
+
 /** @ignoreswagger */
 app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
-  const auth = ctx.get("auth");
   const { canonicalPath } = ctx.req.valid("param");
+
+  // Hono dispatches HEAD requests through the matching GET route.
+  if (ctx.req.method === "HEAD") {
+    return handleHeadRequest(ctx, canonicalPath);
+  }
+
+  const auth = ctx.get("auth");
   const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
   if (err) {
     return err;
@@ -266,38 +301,6 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
     headers,
   });
 });
-
-app.on(
-  "HEAD",
-  "/:canonicalPath{.+}",
-  validate("param", ParamsSchema),
-  async (ctx) => {
-    const { canonicalPath } = ctx.req.valid("param");
-    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
-    if (err) {
-      return err;
-    }
-
-    const statResult = await dustFs.stat(canonicalPath);
-    if (statResult.isErr()) {
-      return apiError(ctx, mapDustFsError(statResult.error));
-    }
-    if (!statResult.value) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: { type: "file_not_found", message: "File not found." },
-      });
-    }
-
-    return new Response(null, {
-      status: 200,
-      headers: {
-        "Content-Type": statResult.value.contentType,
-        "Content-Length": String(statResult.value.sizeBytes),
-      },
-    });
-  }
-);
 
 app.patch(
   "/:canonicalPath{.+}",


### PR DESCRIPTION
## Description

Hono 4.12 dispatches HEAD requests through GET routing while preserving the original request method. As a result, the existing `app.on("HEAD", ...)` route is never selected and HEAD requests execute the full GET content path.

see https://hono.dev/docs/guides/best-practices#head-request-best-practices

Move the existing metadata-only behavior into a helper reached early from the GET handler. This does not change the endpoint contract.

Stack: 1 of 4. Next: #28304.

## Tests

The endpoint suite now verifies that HEAD returns metadata without opening a content stream.

## Risk

Low. Response status and headers are unchanged. The implementation avoids unnecessary file reads for HEAD requests.

## Deploy Plan

Standard deploy.
