### PR TITLE
Track successful sandbox function invocations

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -1,5 +1,6 @@
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import {
-  createSandboxFunctionInvocationTokenTestContext,
+  createPersistedSandboxFunctionInvocationTokenTestContext,
   createSandboxTokenTestContext,
 } from "@app/tests/utils/SandboxTokenFactory";
 import { honoApp } from "@front-api/app";
@@ -42,9 +43,8 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
   });
 
   it("returns success for sandbox function invocation result callbacks", async () => {
-    const { sandbox, token, workspace } =
-      await createSandboxFunctionInvocationTokenTestContext();
-    const invocationId = `test-invocation-${sandbox.sId}`;
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
 
     const response = await postSandboxFunctionResult(workspace, token, {
       function: "test_function",
@@ -53,21 +53,27 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true });
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       {
         type: "sandbox_function_invocation_result",
         created: expect.any(Number),
-        invocationId,
-        functionId: "sfn_test",
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
         result: { hello: "world" },
       },
-      { invocationId }
+      { invocationId: invocation.sId }
     );
   });
 
   it("keeps accepting callbacks without a function name", async () => {
     const { token, workspace } =
-      await createSandboxFunctionInvocationTokenTestContext();
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
 
     const response = await postSandboxFunctionResult(workspace, token, {
       result: { hello: "world" },

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -1,7 +1,9 @@
 import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/access_tokens";
-import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
@@ -37,16 +39,35 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    await publishSandboxFunctionInvocationEvent(
-      {
-        type: "sandbox_function_invocation_result",
-        created: Date.now(),
-        invocationId: sandboxClaims.invocationId,
-        functionId: sandboxClaims.sandboxFunctionId,
-        result,
-      },
-      { invocationId: sandboxClaims.invocationId }
+    const sandboxFunction = await SandboxFunctionResource.fetchById(
+      auth,
+      sandboxClaims.sandboxFunctionId
     );
+    if (!sandboxFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Sandbox function not found.",
+        },
+      });
+    }
+
+    const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+      sandboxFunction,
+      invocationId: sandboxClaims.invocationId,
+    });
+    if (!invocation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Sandbox function invocation not found.",
+        },
+      });
+    }
+
+    await invocation.succeed(result);
 
     return ctx.json({ success: true });
   }

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -105,6 +105,20 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
   }
 
+  async succeed(result: unknown): Promise<void> {
+    await this.update({ status: "succeeded" });
+    await publishSandboxFunctionInvocationEvent(
+      {
+        type: "sandbox_function_invocation_result",
+        created: Date.now(),
+        invocationId: this.sId,
+        functionId: this.sandboxFunction.sId,
+        result,
+      },
+      { invocationId: this.sId }
+    );
+  }
+
   async execute(
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -7,6 +7,7 @@ import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 export const SANDBOX_FUNCTION_INVOCATION_STATUSES = [
   "created",
   "errored",
+  "succeeded",
 ] as const;
 
 export type SandboxFunctionInvocationStatus =


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/28870.

Add a `succeeded` sandbox function invocation status and centralize successful completion in `SandboxFunctionInvocationResource.succeed()`. The sandbox result callback now resolves the persisted invocation, marks it succeeded, and emits the existing `sandbox_function_invocation_result` event.

## Tests

- `NODE_ENV=test npm test lib/resources/sandbox_function_invocation_resource.test.ts`
- `NODE_ENV=test npm test 'routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts'`

## Risk

Low. The result event shape and callback response remain unchanged.

## Deploy Plan

- deploy `front`
- deploy `front-api`