### PR TITLE
[front] enh: use array binds for skill listing queries

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -605,10 +605,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         )
       )
     );
-    const customSkillModelIds = customSkills.map((skill) => skill.id);
-    const allowedCustomSkillModelIds = allowedCustomSkills.map(
-      (skill) => skill.id
-    );
+    const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
     let allowedCustomSkillsRes: SkillResource[] = [];
     if (allowedCustomSkills.length > 0) {
@@ -621,7 +618,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             where: {
               workspaceId: workspace.id,
               skillConfigurationId: {
-                [Op.in]: allowedCustomSkillModelIds,
+                [Op.in]: allowedCustomSkillIds,
               },
             },
             transaction,
@@ -647,10 +644,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           where: {
             workspaceId: workspace.id,
             skillConfigurationId: {
-              [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
+              [Op.in]: customSkills.map((c) => c.id),
             },
           },
-          bind: { customSkillModelIds },
           transaction,
         });
 
@@ -663,12 +659,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         where: {
           workspaceId: workspace.id,
           skillConfigurationId: {
-            [Op.any]: Sequelize.literal(
-              "$allowedCustomSkillModelIds::bigint[]"
-            ),
+            [Op.in]: allowedCustomSkillIds,
           },
         },
-        bind: { allowedCustomSkillModelIds },
         transaction,
       });
 
@@ -692,14 +685,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const editorGroupSkills = await GroupSkillModel.findAll({
         where: {
           skillConfigurationId: {
-            [Op.any]: Sequelize.literal(
-              "$allowedCustomSkillModelIds::bigint[]"
-            ),
+            [Op.in]: allowedCustomSkillIds,
           },
           workspaceId: workspace.id,
         },
         attributes: ["groupId", "skillConfigurationId"],
-        bind: { allowedCustomSkillModelIds },
         transaction,
       });
 
@@ -964,12 +954,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       attributes: ["childCustomSkillId", "childGlobalSkillId", "parentSkillId"],
       where: {
         workspaceId: workspace.id,
-        parentSkillId: {
-          [Op.any]: Sequelize.literal("$parentSkillModelIds::bigint[]"),
-        },
-      },
-      bind: {
-        parentSkillModelIds: customParentSkills.map((skill) => skill.id),
+        parentSkillId: customParentSkills.map((skill) => skill.id),
       },
     });
 
@@ -2311,19 +2296,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         [Op.or]: [
           {
             childCustomSkillId: {
-              [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
+              [Op.in]: customSkills.map((skill) => skill.id),
             },
           },
           {
             childGlobalSkillId: {
-              [Op.any]: Sequelize.literal("$globalSkillIds::text[]"),
+              [Op.in]: globalSkills.map((skill) => skill.sId),
             },
           },
         ],
-      },
-      bind: {
-        customSkillModelIds: customSkills.map((skill) => skill.id),
-        globalSkillIds: globalSkills.map((skill) => skill.sId),
       },
     });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -568,29 +568,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...otherOptions
     } = options;
 
-    const customSkillModelIdsFilter =
-      where && !Array.isArray(where) && "id" in where && Array.isArray(where.id)
-        ? where.id
-        : null;
     const customSkills = await this.model.findAll({
       ...otherOptions,
       where: {
         // Fetch active by default, unless explicitly overridden by the caller.
         status: "active",
         ...omit(where, "sId"),
-        ...(customSkillModelIdsFilter
-          ? {
-              id: {
-                [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
-              },
-            }
-          : {}),
         workspaceId: workspace.id,
       },
       include: includes,
-      bind: customSkillModelIdsFilter
-        ? { customSkillModelIds: customSkillModelIdsFilter }
-        : undefined,
       transaction,
     });
 
@@ -863,7 +849,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<SkillResource[]> {
     return this.baseFetch(auth, {
       where: {
-        id: ids,
+        id: {
+          [Op.in]: ids,
+        },
       },
       onlyCustom: true,
       withTools,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -99,7 +99,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 
 export type SkillMCPServerConfiguration = {
   view: MCPServerViewResource;
@@ -568,15 +568,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...otherOptions
     } = options;
 
+    const customSkillModelIdsFilter =
+      where && !Array.isArray(where) && "id" in where && Array.isArray(where.id)
+        ? where.id
+        : null;
     const customSkills = await this.model.findAll({
       ...otherOptions,
       where: {
         // Fetch active by default, unless explicitly overridden by the caller.
         status: "active",
         ...omit(where, "sId"),
+        ...(customSkillModelIdsFilter
+          ? {
+              id: {
+                [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
+              },
+            }
+          : {}),
         workspaceId: workspace.id,
       },
       include: includes,
+      bind: customSkillModelIdsFilter
+        ? { customSkillModelIds: customSkillModelIdsFilter }
+        : undefined,
       transaction,
     });
 
@@ -605,7 +619,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         )
       )
     );
-    const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
+    const customSkillModelIds = customSkills.map((skill) => skill.id);
+    const allowedCustomSkillModelIds = allowedCustomSkills.map(
+      (skill) => skill.id
+    );
 
     let allowedCustomSkillsRes: SkillResource[] = [];
     if (allowedCustomSkills.length > 0) {
@@ -618,7 +635,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             where: {
               workspaceId: workspace.id,
               skillConfigurationId: {
-                [Op.in]: allowedCustomSkillIds,
+                [Op.in]: allowedCustomSkillModelIds,
               },
             },
             transaction,
@@ -644,9 +661,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           where: {
             workspaceId: workspace.id,
             skillConfigurationId: {
-              [Op.in]: customSkills.map((c) => c.id),
+              [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
             },
           },
+          bind: { customSkillModelIds },
           transaction,
         });
 
@@ -659,9 +677,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         where: {
           workspaceId: workspace.id,
           skillConfigurationId: {
-            [Op.in]: allowedCustomSkillIds,
+            [Op.any]: Sequelize.literal(
+              "$allowedCustomSkillModelIds::bigint[]"
+            ),
           },
         },
+        bind: { allowedCustomSkillModelIds },
         transaction,
       });
 
@@ -685,11 +706,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const editorGroupSkills = await GroupSkillModel.findAll({
         where: {
           skillConfigurationId: {
-            [Op.in]: allowedCustomSkillIds,
+            [Op.any]: Sequelize.literal(
+              "$allowedCustomSkillModelIds::bigint[]"
+            ),
           },
           workspaceId: workspace.id,
         },
         attributes: ["groupId", "skillConfigurationId"],
+        bind: { allowedCustomSkillModelIds },
         transaction,
       });
 
@@ -839,9 +863,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<SkillResource[]> {
     return this.baseFetch(auth, {
       where: {
-        id: {
-          [Op.in]: ids,
-        },
+        id: ids,
       },
       onlyCustom: true,
       withTools,
@@ -954,7 +976,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       attributes: ["childCustomSkillId", "childGlobalSkillId", "parentSkillId"],
       where: {
         workspaceId: workspace.id,
-        parentSkillId: customParentSkills.map((skill) => skill.id),
+        parentSkillId: {
+          [Op.any]: Sequelize.literal("$parentSkillModelIds::bigint[]"),
+        },
+      },
+      bind: {
+        parentSkillModelIds: customParentSkills.map((skill) => skill.id),
       },
     });
 
@@ -2176,12 +2203,24 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         workspaceId: workspace.id,
         [Op.or]: removeNulls([
           customSkillIds.length > 0
-            ? { customSkillId: { [Op.in]: customSkillIds } }
+            ? {
+                customSkillId: {
+                  [Op.any]: Sequelize.literal("$customSkillIds::bigint[]"),
+                },
+              }
             : null,
           globalSkillIds.length > 0
-            ? { globalSkillId: { [Op.in]: globalSkillIds } }
+            ? {
+                globalSkillId: {
+                  [Op.any]: Sequelize.literal("$globalSkillIds::text[]"),
+                },
+              }
             : null,
         ]),
+      },
+      bind: {
+        customSkillIds,
+        globalSkillIds,
       },
     });
 
@@ -2195,9 +2234,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ];
     const agentConfigs = await AgentConfigurationModel.findAll({
       where: {
-        id: { [Op.in]: uniqueAgentConfigIds },
+        id: {
+          [Op.any]: Sequelize.literal("$agentConfigurationIds::bigint[]"),
+        },
         workspaceId: workspace.id,
         status: "active",
+      },
+      bind: {
+        agentConfigurationIds: uniqueAgentConfigIds,
       },
     });
 
@@ -2279,15 +2323,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         [Op.or]: [
           {
             childCustomSkillId: {
-              [Op.in]: customSkills.map((skill) => skill.id),
+              [Op.any]: Sequelize.literal("$customSkillModelIds::bigint[]"),
             },
           },
           {
             childGlobalSkillId: {
-              [Op.in]: globalSkills.map((skill) => skill.sId),
+              [Op.any]: Sequelize.literal("$globalSkillIds::text[]"),
             },
           },
         ],
+      },
+      bind: {
+        customSkillModelIds: customSkills.map((skill) => skill.id),
+        globalSkillIds: globalSkills.map((skill) => skill.sId),
       },
     });
 


### PR DESCRIPTION
## Description

Trying to optimize `GET /w/:wId/skills?withRelations=true`.
Looking at a few traces (e.g. [here](https://app.datadoghq.eu/apm/traces?query=env%3Aprod%20%40http.route%3A%22%2Fapi%2Fw%2F%3AwId%2Fskills%22&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=4778829400064798737&spanType=all&storage=hot&target-span=a&timeHint=1784008649187&tq_query_translation_version=v0&trace=AwAAAZ9fM6njHfk7MQAAABhBWjlmTTdLekFBQXZhX0ZNRlVSRlhDWWUAAAAkMTE5ZjVmMzctNjk0Zi00MzA4LTljYjYtOTUzZjI5NjNiOWIyAAI7Vw&traceID=6a55cfc7000000001e260cef3a30ffc8&traceQuery=a&view=spans&viz=stream&start=1783932266201&end=1784105066201&paused=false)), we currently expands custom skill and agent IDs into several large `IN (...)` clauses. The SQL grows with workspace size, which creates distinct query strings for each combination, causing them to not be aggregated in Query Insights (some ppl don't like it but 🤷🏻 ) and exceeding the 2048-char limit.

Following https://github.com/dust-tt/dust/pull/25878, this PR replaces the variable-length `IN` clauses in `SkillResource` listing with array binds and `ANY(...)`. Query behavior and indexed predicates remain unchanged.

## Tests

- Covered by existing `SkillResource` and skills endpoint tests.

## Risk

- Medium but pattern already well tested at a few other places.

## Deploy Plan

- Deploy front.
