### PR TITLE
Run sandbox function invocations in Temporal

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -34,6 +34,9 @@ vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
     await importOriginal<typeof import("@app/temporal/agent_loop/client")>();
   return {
     ...mod,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
     launchSandboxFunctionToolWorkflow: vi.fn(async () => new Ok(undefined)),
   };
 });
@@ -49,7 +52,10 @@ vi.mock("@app/lib/actions/tool_status", async (importOriginal) => {
 
 import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchSandboxFunctionInvocationWorkflow,
+  launchSandboxFunctionToolWorkflow,
+} from "@app/temporal/agent_loop/client";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -67,10 +73,6 @@ const outputSchema: JSONSchema = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.spyOn(
-    SandboxFunctionInvocationResource.prototype,
-    "execute"
-  ).mockResolvedValue(new Ok(undefined));
 });
 
 afterEach(() => {
@@ -210,7 +212,7 @@ function postInvocation({
 }
 
 describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () => {
-  it("creates and executes an invocation", async () => {
+  it("creates an invocation and starts its workflow", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
 
     const response = await postInvocation({
@@ -232,11 +234,16 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       }),
     });
     const invocation = body.invocation;
-    expect(
-      SandboxFunctionInvocationResource.prototype.execute
-    ).toHaveBeenCalledWith(expect.anything(), {
-      input: { message: "hello" },
-    });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        sandboxFunction: expect.objectContaining({ id: sandboxFunction.id }),
+        invocation: expect.objectContaining({ sId: invocation.sId }),
+        body: {
+          input: { message: "hello" },
+        },
+      }
+    );
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       {
         type: "sandbox_function_invocation_created",
@@ -259,11 +266,13 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     });
 
     expect(response.status).toBe(201);
-    expect(
-      SandboxFunctionInvocationResource.prototype.execute
-    ).toHaveBeenCalledWith(expect.anything(), {
-      input: { message: "hello" },
-    });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sandboxFunction: expect.objectContaining({ id: sandboxFunction.id }),
+        body: { input: { message: "hello" } },
+      })
+    );
   });
 
   it("returns 404 when the user cannot access the function space", async () => {
@@ -293,12 +302,12 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(response.status).toBe(201);
   });
 
-  it("returns 500 when invocation execution fails", async () => {
+  it("returns 500 when starting the invocation workflow fails", async () => {
     const { workspace, sandboxFunction, adminAuth } =
       await setupSandboxFunction();
-    vi.mocked(
-      SandboxFunctionInvocationResource.prototype.execute
-    ).mockResolvedValueOnce(new Err(new Error("sandbox unavailable")));
+    vi.mocked(launchSandboxFunctionInvocationWorkflow).mockResolvedValueOnce(
+      new Err(new Error("temporal unavailable"))
+    );
 
     const response = await postInvocation({
       workspaceId: workspace.sId,
@@ -317,7 +326,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         type: "sandbox_function_invocation_error",
         invocationId: expect.stringMatching(/^sfi_/),
         functionId: sandboxFunction.sId,
-        message: "sandbox unavailable",
+        message: "temporal unavailable",
       }),
       { invocationId: expect.stringMatching(/^sfi_/) }
     );

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -237,11 +237,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
       expect.anything(),
       {
-        sandboxFunction: expect.objectContaining({ id: sandboxFunction.id }),
         invocation: expect.objectContaining({ sId: invocation.sId }),
-        body: {
-          input: { message: "hello" },
-        },
       }
     );
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
@@ -269,8 +265,9 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        sandboxFunction: expect.objectContaining({ id: sandboxFunction.id }),
-        body: { input: { message: "hello" } },
+        invocation: expect.objectContaining({
+          sId: expect.stringMatching(/^sfi_/),
+        }),
       })
     );
   });

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -237,6 +237,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
       expect.anything(),
       {
+        sandboxFunction: expect.objectContaining({ sId: sandboxFunction.sId }),
         invocation: expect.objectContaining({ sId: invocation.sId }),
       }
     );
@@ -265,6 +266,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
+        sandboxFunction: expect.objectContaining({ sId: sandboxFunction.sId }),
         invocation: expect.objectContaining({
           sId: expect.stringMatching(/^sfi_/),
         }),

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -1,7 +1,6 @@
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import type { SandboxFunctionInvocationStreamEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -21,7 +20,19 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   return { ...actual, getSandboxFunctionInvocationEvents: vi.fn() };
 });
 
+vi.mock("@app/temporal/agent_loop/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/temporal/agent_loop/client")>();
+  return {
+    ...actual,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
+  };
+});
+
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/agent_loop/client";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -90,10 +101,6 @@ async function setup(): Promise<{
   const space = await SpaceFactory.project(workspace);
   const fn = await makeFunction(authenticator, space);
   const invocationId = "sfi_test";
-  vi.spyOn(
-    SandboxFunctionInvocationResource.prototype,
-    "execute"
-  ).mockResolvedValue(new Ok(undefined));
   return { auth: authenticator, fn, invocationId };
 }
 
@@ -275,11 +282,11 @@ describe("callSandboxFunction", () => {
     });
   });
 
-  it("propagates an Err from execute()", async () => {
+  it("propagates an Err from the workflow launch", async () => {
     const { auth, fn } = await setup();
-    vi.mocked(
-      SandboxFunctionInvocationResource.prototype.execute
-    ).mockResolvedValueOnce(new Err(new Error("sandbox unavailable")));
+    vi.mocked(launchSandboxFunctionInvocationWorkflow).mockResolvedValueOnce(
+      new Err(new Error("temporal unavailable"))
+    );
 
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -25,9 +25,8 @@ const resultEnvelopeSchema = z.discriminatedUnion("ok", [
   }),
 ]);
 
-// Safety ceiling on waiting for the result event (delivered over the stream, not execute()'s
-// return). Under blocking exec it is already in history when we subscribe, so this rarely bites.
-const CALL_RESULT_WAIT_TIMEOUT_MS = 2 * 60 * 1_000;
+// Safety ceiling on waiting for the result event delivered over the invocation stream.
+const CALL_RESULT_WAIT_TIMEOUT_MS = 3 * 60 * 1_000;
 
 export type SandboxFunctionCallOutcome =
   | { ok: true; status: number; output: string }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -216,9 +216,7 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.sId).toMatch(/^sfi_/);
     expect(Date.parse(invocation.toJSON().createdAt)).not.toBeNaN();
 
-    const executionResult = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-    });
+    const executionResult = await invocation.execute(authenticator);
     if (executionResult.isErr()) {
       throw executionResult.error;
     }
@@ -286,9 +284,7 @@ describe("SandboxFunctionInvocationResource", () => {
       })
     );
 
-    const result = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-    });
+    const result = await invocation.execute(authenticator);
 
     expect(result.isErr()).toBe(true);
     if (result.isOk()) {
@@ -310,9 +306,7 @@ describe("SandboxFunctionInvocationResource", () => {
       })
     );
 
-    const result = await invocation.execute(authenticator, {
-      input: { message: "hello" },
-    });
+    const result = await invocation.execute(authenticator);
 
     expect(result.isErr()).toBe(true);
     if (result.isOk()) {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -27,6 +27,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
+import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionInvocationType,
@@ -398,10 +399,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       { invocationId: invocation.sId }
     );
 
-    const executionResult = await invocation.execute(auth, body);
-    if (executionResult.isErr()) {
-      await invocation.fail(executionResult.error);
-      return new Err(executionResult.error);
+    const launchResult = await launchSandboxFunctionInvocationWorkflow(auth, {
+      sandboxFunction,
+      invocation,
+      body,
+    });
+    if (launchResult.isErr()) {
+      await invocation.fail(launchResult.error);
+      return new Err(launchResult.error);
     }
 
     return new Ok(invocation);

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -191,10 +191,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
   }
 
-  async execute(
-    auth: Authenticator,
-    body: PostSandboxFunctionInvocationRequestBody
-  ): Promise<Result<undefined, Error>> {
+  async execute(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
       const { sandboxFunction } = this;
       const ensureResult = await ensurePodSandboxReady(
@@ -224,9 +221,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           "x-dust-sandbox-function-id": sandboxFunction.sId,
           "x-dust-sandbox-function-invocation-id": this.sId,
         },
-        ...(body.input === undefined
+        ...(this.input === undefined
           ? {}
-          : { body: JSON.stringify(body.input) }),
+          : { body: JSON.stringify(this.input) }),
         encoding: "utf8",
       };
 
@@ -400,9 +397,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
 
     const launchResult = await launchSandboxFunctionInvocationWorkflow(auth, {
-      sandboxFunction,
       invocation,
-      body,
     });
     if (launchResult.isErr()) {
       await invocation.fail(launchResult.error);

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -397,6 +397,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
 
     const launchResult = await launchSandboxFunctionInvocationWorkflow(auth, {
+      sandboxFunction,
       invocation,
     });
     if (launchResult.isErr()) {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -231,12 +231,24 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
-  // This lives here because the invocation resource value-imports the sandbox function resource,
-  // so it cannot fetch the parent function itself without introducing a circular dependency.
-  private static async fetchInvocation(
+  // Lives here rather than on SandboxFunctionMCPActionResource: that resource can only type-import
+  // the invocation resource (the invocation resource value-imports it for cascade deletion), so it
+  // cannot construct an invocation. Takes the action rather than its FK id so callers don't thread
+  // a ModelId around.
+  static async fetchInvocationForAction(
     auth: Authenticator,
-    invocation: SandboxFunctionInvocationModel
+    action: SandboxFunctionMCPActionResource
   ): Promise<SandboxFunctionInvocationResource | null> {
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        id: action.sandboxFunctionInvocationId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
     const sandboxFunction = await this.fetchById(
       auth,
       this.modelIdToSId({
@@ -255,50 +267,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         workspaceId: invocation.workspaceId,
       }),
     });
-  }
-
-  static async fetchInvocationById(
-    auth: Authenticator,
-    invocationId: string
-  ): Promise<SandboxFunctionInvocationResource | null> {
-    if (!isResourceSId("sandbox_function_invocation", invocationId)) {
-      return null;
-    }
-
-    const invocationModelId = getResourceIdFromSId(invocationId);
-    if (invocationModelId === null) {
-      return null;
-    }
-
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        id: invocationModelId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-    if (!invocation) {
-      return null;
-    }
-
-    return this.fetchInvocation(auth, invocation);
-  }
-
-  // This takes the action rather than its foreign key so callers do not thread a ModelId around.
-  static async fetchInvocationForAction(
-    auth: Authenticator,
-    action: SandboxFunctionMCPActionResource
-  ): Promise<SandboxFunctionInvocationResource | null> {
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        id: action.sandboxFunctionInvocationId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-    if (!invocation) {
-      return null;
-    }
-
-    return this.fetchInvocation(auth, invocation);
   }
 
   static async listBySpace(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -231,24 +231,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
-  // Lives here rather than on SandboxFunctionMCPActionResource: that resource can only type-import
-  // the invocation resource (the invocation resource value-imports it for cascade deletion), so it
-  // cannot construct an invocation. Takes the action rather than its FK id so callers don't thread
-  // a ModelId around.
-  static async fetchInvocationForAction(
+  // This lives here because the invocation resource value-imports the sandbox function resource,
+  // so it cannot fetch the parent function itself without introducing a circular dependency.
+  private static async fetchInvocation(
     auth: Authenticator,
-    action: SandboxFunctionMCPActionResource
+    invocation: SandboxFunctionInvocationModel
   ): Promise<SandboxFunctionInvocationResource | null> {
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        id: action.sandboxFunctionInvocationId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-    if (!invocation) {
-      return null;
-    }
-
     const sandboxFunction = await this.fetchById(
       auth,
       this.modelIdToSId({
@@ -267,6 +255,50 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         workspaceId: invocation.workspaceId,
       }),
     });
+  }
+
+  static async fetchInvocationById(
+    auth: Authenticator,
+    invocationId: string
+  ): Promise<SandboxFunctionInvocationResource | null> {
+    if (!isResourceSId("sandbox_function_invocation", invocationId)) {
+      return null;
+    }
+
+    const invocationModelId = getResourceIdFromSId(invocationId);
+    if (invocationModelId === null) {
+      return null;
+    }
+
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        id: invocationModelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    return this.fetchInvocation(auth, invocation);
+  }
+
+  // This takes the action rather than its foreign key so callers do not thread a ModelId around.
+  static async fetchInvocationForAction(
+    auth: Authenticator,
+    action: SandboxFunctionMCPActionResource
+  ): Promise<SandboxFunctionInvocationResource | null> {
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        id: action.sandboxFunctionInvocationId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    return this.fetchInvocation(auth, invocation);
   }
 
   static async listBySpace(

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
@@ -46,7 +46,7 @@ async function setup() {
   });
   const invocation = await SandboxFunctionInvocationResource.makeNew(
     authenticator,
-    { sandboxFunction }
+    { sandboxFunction, input: { message: "hello" } }
   );
 
   return { authenticator, sandboxFunction, invocation };
@@ -62,19 +62,21 @@ afterEach(() => {
 
 describe("runSandboxFunctionInvocationActivity", () => {
   it("executes the existing invocation", async () => {
-    const { authenticator, sandboxFunction, invocation } = await setup();
+    const { authenticator, invocation } = await setup();
     const executeSpy = vi
       .spyOn(SandboxFunctionInvocationResource.prototype, "execute")
-      .mockResolvedValue(new Ok(undefined));
-    const body = { input: { message: "hello" } };
+      .mockImplementation(async function (
+        this: SandboxFunctionInvocationResource
+      ) {
+        expect(this.input).toEqual({ message: "hello" });
+        return new Ok(undefined);
+      });
 
     await runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
-      sandboxFunctionId: sandboxFunction.sId,
       invocationId: invocation.sId,
-      body,
     });
 
-    expect(executeSpy).toHaveBeenCalledWith(expect.anything(), body);
+    expect(executeSpy).toHaveBeenCalledWith(expect.anything());
   });
 
   it("fails the invocation when execution fails", async () => {
@@ -86,9 +88,7 @@ describe("runSandboxFunctionInvocationActivity", () => {
 
     await expect(
       runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
-        sandboxFunctionId: sandboxFunction.sId,
         invocationId: invocation.sId,
-        body: {},
       })
     ).rejects.toThrow("sandbox unavailable");
 

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
@@ -62,7 +62,7 @@ afterEach(() => {
 
 describe("runSandboxFunctionInvocationActivity", () => {
   it("executes the existing invocation", async () => {
-    const { authenticator, invocation } = await setup();
+    const { authenticator, sandboxFunction, invocation } = await setup();
     const executeSpy = vi
       .spyOn(SandboxFunctionInvocationResource.prototype, "execute")
       .mockImplementation(async function (
@@ -73,6 +73,7 @@ describe("runSandboxFunctionInvocationActivity", () => {
       });
 
     await runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
+      sandboxFunctionId: sandboxFunction.sId,
       invocationId: invocation.sId,
     });
 
@@ -88,6 +89,7 @@ describe("runSandboxFunctionInvocationActivity", () => {
 
     await expect(
       runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
+        sandboxFunctionId: sandboxFunction.sId,
         invocationId: invocation.sId,
       })
     ).rejects.toThrow("sandbox unavailable");

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.test.ts
@@ -1,0 +1,109 @@
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { runSandboxFunctionInvocationActivity } from "@app/temporal/agent_loop/activities/run_sandbox_function_invocation";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+  return {
+    ...actual,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
+  };
+});
+
+const schema: JSONSchema = { type: "object" };
+
+async function setup() {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
+  const file = await FileFactory.create(authenticator, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: "function.ts",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+  const sandboxFunction = await SandboxFunctionResource.makeNew(authenticator, {
+    space,
+    file,
+    slug: "run-function",
+    description: "Run the function.",
+    inputSchema: schema,
+    outputSchema: schema,
+  });
+  const invocation = await SandboxFunctionInvocationResource.makeNew(
+    authenticator,
+    { sandboxFunction }
+  );
+
+  return { authenticator, sandboxFunction, invocation };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runSandboxFunctionInvocationActivity", () => {
+  it("executes the existing invocation", async () => {
+    const { authenticator, sandboxFunction, invocation } = await setup();
+    const executeSpy = vi
+      .spyOn(SandboxFunctionInvocationResource.prototype, "execute")
+      .mockResolvedValue(new Ok(undefined));
+    const body = { input: { message: "hello" } };
+
+    await runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
+      sandboxFunctionId: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      body,
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(expect.anything(), body);
+  });
+
+  it("fails the invocation when execution fails", async () => {
+    const { authenticator, sandboxFunction, invocation } = await setup();
+    vi.spyOn(
+      SandboxFunctionInvocationResource.prototype,
+      "execute"
+    ).mockResolvedValue(new Err(new Error("sandbox unavailable")));
+
+    await expect(
+      runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+        body: {},
+      })
+    ).rejects.toThrow("sandbox unavailable");
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sandbox_function_invocation_error",
+        invocationId: invocation.sId,
+        message: "sandbox unavailable",
+      }),
+      { invocationId: invocation.sId }
+    );
+  });
+});

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
@@ -1,41 +1,25 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
-import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
 
 export type RunSandboxFunctionInvocationActivityArgs = {
-  sandboxFunctionId: string;
   invocationId: string;
-  body: PostSandboxFunctionInvocationRequestBody;
 };
 
 export async function runSandboxFunctionInvocationActivity(
   authType: AuthenticatorType,
-  {
-    sandboxFunctionId,
-    invocationId,
-    body,
-  }: RunSandboxFunctionInvocationActivityArgs
+  { invocationId }: RunSandboxFunctionInvocationActivityArgs
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const invocation = await SandboxFunctionResource.fetchInvocationById(
     auth,
-    sandboxFunctionId
+    invocationId
   );
-  if (!sandboxFunction) {
-    throw new Error(`Sandbox function not found: ${sandboxFunctionId}`);
-  }
-
-  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
-    sandboxFunction,
-    invocationId,
-  });
   if (!invocation) {
     throw new Error(`Sandbox function invocation not found: ${invocationId}`);
   }
 
-  const executionResult = await invocation.execute(auth, body);
+  const executionResult = await invocation.execute(auth);
   if (executionResult.isErr()) {
     await invocation.fail(executionResult.error);
     throw executionResult.error;

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
@@ -1,20 +1,30 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 
 export type RunSandboxFunctionInvocationActivityArgs = {
+  sandboxFunctionId: string;
   invocationId: string;
 };
 
 export async function runSandboxFunctionInvocationActivity(
   authType: AuthenticatorType,
-  { invocationId }: RunSandboxFunctionInvocationActivityArgs
+  { sandboxFunctionId, invocationId }: RunSandboxFunctionInvocationActivityArgs
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  const invocation = await SandboxFunctionResource.fetchInvocationById(
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
-    invocationId
+    sandboxFunctionId
   );
+  if (!sandboxFunction) {
+    throw new Error(`Sandbox function not found: ${sandboxFunctionId}`);
+  }
+
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+  });
   if (!invocation) {
     throw new Error(`Sandbox function invocation not found: ${invocationId}`);
   }

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
@@ -3,14 +3,15 @@ import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 
-export type RunSandboxFunctionInvocationActivityArgs = {
-  sandboxFunctionId: string;
-  invocationId: string;
-};
-
 export async function runSandboxFunctionInvocationActivity(
   authType: AuthenticatorType,
-  { sandboxFunctionId, invocationId }: RunSandboxFunctionInvocationActivityArgs
+  {
+    sandboxFunctionId,
+    invocationId,
+  }: {
+    sandboxFunctionId: string;
+    invocationId: string;
+  }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
   const sandboxFunction = await SandboxFunctionResource.fetchById(

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
@@ -1,0 +1,43 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
+
+export type RunSandboxFunctionInvocationActivityArgs = {
+  sandboxFunctionId: string;
+  invocationId: string;
+  body: PostSandboxFunctionInvocationRequestBody;
+};
+
+export async function runSandboxFunctionInvocationActivity(
+  authType: AuthenticatorType,
+  {
+    sandboxFunctionId,
+    invocationId,
+    body,
+  }: RunSandboxFunctionInvocationActivityArgs
+): Promise<void> {
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
+    auth,
+    sandboxFunctionId
+  );
+  if (!sandboxFunction) {
+    throw new Error(`Sandbox function not found: ${sandboxFunctionId}`);
+  }
+
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+  });
+  if (!invocation) {
+    throw new Error(`Sandbox function invocation not found: ${invocationId}`);
+  }
+
+  const executionResult = await invocation.execute(auth, body);
+  if (executionResult.isErr()) {
+    await invocation.fail(executionResult.error);
+    throw executionResult.error;
+  }
+}

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -4,7 +4,6 @@ import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
-import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumentation";
@@ -15,7 +14,6 @@ import {
   makeSandboxFunctionInvocationWorkflowId,
   makeSandboxFunctionToolWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
-import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
 import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
@@ -306,13 +304,9 @@ export async function launchSandboxFunctionToolWorkflow(
 export async function launchSandboxFunctionInvocationWorkflow(
   auth: Authenticator,
   {
-    sandboxFunction,
     invocation,
-    body,
   }: {
-    sandboxFunction: SandboxFunctionResource;
     invocation: SandboxFunctionInvocationResource;
-    body: PostSandboxFunctionInvocationRequestBody;
   }
 ): Promise<Result<undefined, Error>> {
   const authType = auth.toJSON();
@@ -325,21 +319,13 @@ export async function launchSandboxFunctionInvocationWorkflow(
   try {
     const client = await getTemporalClientForAgentNamespace();
     await client.workflow.start(runSandboxFunctionInvocationWorkflow, {
-      args: [
-        authType,
-        {
-          sandboxFunctionId: sandboxFunction.sId,
-          invocationId: invocation.sId,
-          body,
-        },
-      ],
+      args: [{ authType, invocationId: invocation.sId }],
       taskQueue: QUEUE_NAME,
       workflowId,
       searchAttributes: {
         workspaceId: [workspaceId],
       },
       memo: {
-        sandboxFunctionId: sandboxFunction.sId,
         invocationId: invocation.sId,
         workspaceId,
       },

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -2,7 +2,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumentation";
@@ -10,8 +12,10 @@ import {
   makeAgentLoopWorkflowId,
   makeCompactionWorkflowId,
   makeSandboxChildToolWorkflowId,
+  makeSandboxFunctionInvocationWorkflowId,
   makeSandboxFunctionToolWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
+import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
 import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
@@ -20,12 +24,14 @@ import type { CompactionSourceConversation } from "@app/types/assistant/compacti
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import { QUEUE_NAME } from "./config";
 import {
   agentLoopWorkflow,
   compactionWorkflow,
   runSandboxChildToolWorkflow,
+  runSandboxFunctionInvocationWorkflow,
   runSandboxFunctionToolWorkflow,
 } from "./workflows";
 
@@ -292,6 +298,57 @@ export async function launchSandboxFunctionToolWorkflow(
       return new Ok(undefined);
     }
     throw error;
+  }
+
+  return new Ok(undefined);
+}
+
+export async function launchSandboxFunctionInvocationWorkflow(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    invocation,
+    body,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    invocation: SandboxFunctionInvocationResource;
+    body: PostSandboxFunctionInvocationRequestBody;
+  }
+): Promise<Result<undefined, Error>> {
+  const authType = auth.toJSON();
+  const { workspaceId } = authType;
+  const workflowId = makeSandboxFunctionInvocationWorkflowId({
+    workspaceId,
+    invocationModelId: invocation.id,
+  });
+
+  try {
+    const client = await getTemporalClientForAgentNamespace();
+    await client.workflow.start(runSandboxFunctionInvocationWorkflow, {
+      args: [
+        authType,
+        {
+          sandboxFunctionId: sandboxFunction.sId,
+          invocationId: invocation.sId,
+          body,
+        },
+      ],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        workspaceId: [workspaceId],
+      },
+      memo: {
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+        workspaceId,
+      },
+    });
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      return new Ok(undefined);
+    }
+    return new Err(normalizeError(error));
   }
 
   return new Ok(undefined);

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -4,6 +4,7 @@ import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumentation";
@@ -304,8 +305,10 @@ export async function launchSandboxFunctionToolWorkflow(
 export async function launchSandboxFunctionInvocationWorkflow(
   auth: Authenticator,
   {
+    sandboxFunction,
     invocation,
   }: {
+    sandboxFunction: SandboxFunctionResource;
     invocation: SandboxFunctionInvocationResource;
   }
 ): Promise<Result<undefined, Error>> {
@@ -313,19 +316,26 @@ export async function launchSandboxFunctionInvocationWorkflow(
   const { workspaceId } = authType;
   const workflowId = makeSandboxFunctionInvocationWorkflowId({
     workspaceId,
-    invocationModelId: invocation.id,
+    invocationId: invocation.sId,
   });
 
   try {
     const client = await getTemporalClientForAgentNamespace();
     await client.workflow.start(runSandboxFunctionInvocationWorkflow, {
-      args: [{ authType, invocationId: invocation.sId }],
+      args: [
+        {
+          authType,
+          sandboxFunctionId: sandboxFunction.sId,
+          invocationId: invocation.sId,
+        },
+      ],
       taskQueue: QUEUE_NAME,
       workflowId,
       searchAttributes: {
         workspaceId: [workspaceId],
       },
       memo: {
+        sandboxFunctionId: sandboxFunction.sId,
         invocationId: invocation.sId,
         workspaceId,
       },

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -55,10 +55,10 @@ export function makeSandboxFunctionToolWorkflowId({
 
 export function makeSandboxFunctionInvocationWorkflowId({
   workspaceId,
-  invocationModelId,
+  invocationId,
 }: {
   workspaceId: string;
-  invocationModelId: number;
+  invocationId: string;
 }) {
-  return `sandbox-function-invocation-workflow-${workspaceId}-${invocationModelId}`;
+  return `sandbox-function-invocation-workflow-${workspaceId}-${invocationId}`;
 }

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -52,3 +52,13 @@ export function makeSandboxFunctionToolWorkflowId({
 }) {
   return `sandbox-function-tool-workflow-${workspaceId}-${actionModelId}`;
 }
+
+export function makeSandboxFunctionInvocationWorkflowId({
+  workspaceId,
+  invocationModelId,
+}: {
+  workspaceId: string;
+  invocationModelId: number;
+}) {
+  return `sandbox-function-invocation-workflow-${workspaceId}-${invocationModelId}`;
+}

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/temporal/agent_loop/activities/finalize";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import { runSandboxFunctionInvocationActivity } from "@app/temporal/agent_loop/activities/run_sandbox_function_invocation";
 import { runSandboxFunctionToolActivity } from "@app/temporal/agent_loop/activities/run_sandbox_function_tool";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
@@ -71,6 +72,7 @@ export async function runAgentLoopWorker() {
       checkCreditsActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
+      runSandboxFunctionInvocationActivity,
       runSandboxFunctionToolActivity,
       runToolActivity,
     },

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -562,17 +562,14 @@ export async function runSandboxFunctionToolWorkflow({
   await runSandboxFunctionToolActivity(authType, { actionModelId });
 }
 
-export async function runSandboxFunctionInvocationWorkflow(
-  authType: AuthenticatorType,
-  {
-    sandboxFunctionId,
-    invocationId,
-    body,
-  }: runSandboxFunctionInvocationActivities.RunSandboxFunctionInvocationActivityArgs
-) {
+export async function runSandboxFunctionInvocationWorkflow({
+  authType,
+  invocationId,
+}: {
+  authType: AuthenticatorType;
+  invocationId: string;
+}) {
   await runSandboxFunctionInvocationActivity(authType, {
-    sandboxFunctionId,
     invocationId,
-    body,
   });
 }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -10,6 +10,7 @@ import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import type * as runSandboxFunctionInvocationActivities from "@app/temporal/agent_loop/activities/run_sandbox_function_invocation";
 import type * as runSandboxFunctionToolActivities from "@app/temporal/agent_loop/activities/run_sandbox_function_tool";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
 import {
@@ -104,6 +105,16 @@ const { runSandboxFunctionToolActivity } = proxyActivities<
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   retry: {
     // Do not retry tool activities. Those are not idempotent.
+    maximumAttempts: 1,
+  },
+});
+
+const { runSandboxFunctionInvocationActivity } = proxyActivities<
+  typeof runSandboxFunctionInvocationActivities
+>({
+  startToCloseTimeout: "3 minutes",
+  retry: {
+    // Sandbox functions may have non-idempotent side effects.
     maximumAttempts: 1,
   },
 });
@@ -549,4 +560,19 @@ export async function runSandboxFunctionToolWorkflow({
   actionModelId: number;
 }) {
   await runSandboxFunctionToolActivity(authType, { actionModelId });
+}
+
+export async function runSandboxFunctionInvocationWorkflow(
+  authType: AuthenticatorType,
+  {
+    sandboxFunctionId,
+    invocationId,
+    body,
+  }: runSandboxFunctionInvocationActivities.RunSandboxFunctionInvocationActivityArgs
+) {
+  await runSandboxFunctionInvocationActivity(authType, {
+    sandboxFunctionId,
+    invocationId,
+    body,
+  });
 }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -564,12 +564,15 @@ export async function runSandboxFunctionToolWorkflow({
 
 export async function runSandboxFunctionInvocationWorkflow({
   authType,
+  sandboxFunctionId,
   invocationId,
 }: {
   authType: AuthenticatorType;
+  sandboxFunctionId: string;
   invocationId: string;
 }) {
   await runSandboxFunctionInvocationActivity(authType, {
+    sandboxFunctionId,
     invocationId,
   });
 }


### PR DESCRIPTION
## Description

Follow-up to #28870.

- Launch sandbox function invocations in a dedicated Temporal workflow after creating and publishing the invocation.
- Execute the existing invocation in a non-retrying activity registered on the agent-loop worker.
- Mark the invocation errored and publish its terminal event when workflow launch or execution fails.

A sandbox function can block while a tool waits for approval, but the visualization cannot subscribe to its event stream until the invocation POST returns. Moving the outer execution to Temporal returns the invocation ID first, allowing approval and authentication events to reach the UI while execution is blocked.

## Tests

- Focused front and front-api tests (26 tests)
- Front TypeScript check
- Temporal workflow bundle build (27 workers)
- Biome formatting/checks

## RIsks

- None (not live product)

## Deploy

- deploy `front`