### PR TITLE
Instrument conversation pruning and prompt-cache usage for Datadog

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -24,6 +24,13 @@ vi.mock(
   })
 );
 
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
+    distribution: vi.fn(),
+    increment: vi.fn(),
+  }),
+}));
+
 vi.mock("@app/lib/api/provider_credentials", () => ({
   getLlmCredentials: vi.fn(),
 }));

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -1,4 +1,12 @@
 import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
+import type {
+  ConversationPruningStats,
+  ConversationRenderingMetricsCaller,
+} from "@app/lib/api/assistant/conversation_rendering/instrumentation";
+import {
+  emitConversationRenderingError,
+  emitConversationRenderingMetrics,
+} from "@app/lib/api/assistant/conversation_rendering/instrumentation";
 import { renderAllMessages } from "@app/lib/api/assistant/conversation_rendering/message_rendering";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
@@ -74,13 +82,34 @@ function pruneConversationToBudget(
     logDetails: Record<string, unknown>;
   }
 ): Result<
-  { interactions: InteractionWithTokens[]; prunedContext: boolean },
+  {
+    interactions: InteractionWithTokens[];
+    prunedContext: boolean;
+    stats: ConversationPruningStats;
+  },
   Error
 > {
   // An empty conversation trivially fits, and the layers below assume at least one interaction.
   if (interactions.length === 0) {
-    return new Ok({ interactions, prunedContext: false });
+    return new Ok({
+      interactions,
+      prunedContext: false,
+      stats: {
+        totalTokensBefore: 0,
+        totalTokensAfterPruning: 0,
+        totalTokensAfterDropping: 0,
+        totalTokensAfterFloorPruning: 0,
+        totalTokensAfterFloorDropping: 0,
+        interactionsBefore: 0,
+        interactionsAfterDropping: 0,
+        interactionsAfterFloorDropping: 0,
+        pruningBudget,
+        budgetForInteractions,
+      },
+    });
   }
+
+  const totalTokensBefore = sumInteractionTokens(interactions);
 
   // Layer 1: proactive pruning, within the protected floor, up to pruningBudget.
   let pruned = pruneToolResults(interactions, {
@@ -89,6 +118,7 @@ function pruneConversationToBudget(
   });
   let prunedContext = pruned !== interactions;
   let totalTokens = sumInteractionTokens(pruned);
+  const totalTokensAfterPruning = totalTokens;
 
   // Layer 2: drop whole previous interactions, oldest first. The last
   // PREVIOUS_INTERACTIONS_TO_PRESERVE of them are protected, and the current one always survives.
@@ -107,6 +137,8 @@ function pruneConversationToBudget(
       totalTokens = sumInteractionTokens(pruned);
     }
   }
+  const totalTokensAfterDropping = totalTokens;
+  const interactionsAfterDropping = pruned.length;
 
   // Layer 3: reaching here means layer 2 dropped every previous interaction it was allowed to,
   // and what remains (the last PREVIOUS_INTERACTIONS_TO_PRESERVE plus the current interaction)
@@ -126,6 +158,7 @@ function pruneConversationToBudget(
     }
     totalTokens = sumInteractionTokens(pruned);
   }
+  const totalTokensAfterFloorPruning = totalTokens;
 
   // Layer 4: still over budget with every tool result already at placeholder size. Drop previous
   // interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE, down to the current interaction alone
@@ -167,7 +200,22 @@ function pruneConversationToBudget(
     );
   }
 
-  return new Ok({ interactions: pruned, prunedContext });
+  return new Ok({
+    interactions: pruned,
+    prunedContext,
+    stats: {
+      totalTokensBefore,
+      totalTokensAfterPruning,
+      totalTokensAfterDropping,
+      totalTokensAfterFloorPruning,
+      totalTokensAfterFloorDropping: totalTokens,
+      interactionsBefore: interactions.length,
+      interactionsAfterDropping,
+      interactionsAfterFloorDropping: pruned.length,
+      pruningBudget,
+      budgetForInteractions,
+    },
+  });
 }
 
 export async function renderConversationForModel(
@@ -184,6 +232,7 @@ export async function renderConversationForModel(
     onMissingAction = "inject-placeholder",
     agentConfiguration,
     enabledSkills,
+    metricsCaller,
   }: {
     leadingMessages?: ModelMessageTypeMultiActionsWithoutContentFragment[];
     conversation: ConversationType;
@@ -197,6 +246,10 @@ export async function renderConversationForModel(
     enablePreviousInteractionsPruning?: boolean;
     agentConfiguration?: AgentLoopExecutionData["agentConfiguration"];
     enabledSkills: EnabledSkill[];
+    // Opt-in StatsD emission. This function has callers with very different budgets (Dust app
+    // history injection, reinforcement batches, scripts) whose renders would skew the pruning
+    // dashboards, so only callers that name themselves are measured.
+    metricsCaller?: ConversationRenderingMetricsCaller;
   }
 ): Promise<
   Result<
@@ -316,9 +369,21 @@ export async function renderConversationForModel(
     logDetails,
   });
   if (pruneRes.isErr()) {
+    if (metricsCaller) {
+      emitConversationRenderingError({
+        kind: "context_overflow",
+        caller: metricsCaller,
+        providerId: model.providerId,
+        modelId: model.modelId,
+      });
+    }
     return pruneRes;
   }
-  const { interactions: prunedInteractions, prunedContext } = pruneRes.value;
+  const {
+    interactions: prunedInteractions,
+    prunedContext,
+    stats: pruningStats,
+  } = pruneRes.value;
   const totalTokens = sumInteractionTokens(prunedInteractions);
 
   const selected: MessageWithTokens[] = prunedInteractions.flatMap(
@@ -367,6 +432,14 @@ export async function renderConversationForModel(
       },
       "Render Conversation V2: conversation has no messages to render."
     );
+    if (metricsCaller) {
+      emitConversationRenderingError({
+        kind: "no_messages",
+        caller: metricsCaller,
+        providerId: model.providerId,
+        modelId: model.modelId,
+      });
+    }
     return new Err(
       new Error("Conversation contains no messages: at least one is required")
     );
@@ -385,6 +458,17 @@ export async function renderConversationForModel(
     );
 
   const pruneSelectAndFinalizeMs = Date.now() - stepStart;
+
+  if (metricsCaller) {
+    emitConversationRenderingMetrics({
+      stats: pruningStats,
+      caller: metricsCaller,
+      providerId: model.providerId,
+      modelId: model.modelId,
+      contextSize: model.contextSize,
+      tokensUsed,
+    });
+  }
 
   logger.info(
     {

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
@@ -1,0 +1,109 @@
+import type { ConversationPruningStats } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
+import { computeConversationRenderingMetrics } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
+import { describe, expect, it } from "vitest";
+
+// A render where nothing happened: every snapshot equals the starting total.
+function statsWhereNothingHappened(): ConversationPruningStats {
+  return {
+    totalTokensBefore: 50_000,
+    totalTokensAfterPruning: 50_000,
+    totalTokensAfterDropping: 50_000,
+    totalTokensAfterFloorPruning: 50_000,
+    totalTokensAfterFloorDropping: 50_000,
+    interactionsBefore: 12,
+    interactionsAfterDropping: 12,
+    interactionsAfterFloorDropping: 12,
+    pruningBudget: 100_000,
+    budgetForInteractions: 160_000,
+  };
+}
+
+describe("computeConversationRenderingMetrics", () => {
+  it("reports a clean fit when no layer changed anything", () => {
+    const metrics = computeConversationRenderingMetrics(
+      statsWhereNothingHappened()
+    );
+
+    expect(metrics.outcome).toBe("fits");
+    expect(metrics.saturated).toBe(false);
+    expect(metrics.prunedTokens).toBe(0);
+    expect(metrics.droppedTokens).toBe(0);
+    expect(metrics.dropSlackTokens).toBeNull();
+  });
+
+  it("attributes reclaimed tokens to the layer whose snapshot moved", () => {
+    const metrics = computeConversationRenderingMetrics({
+      ...statsWhereNothingHappened(),
+      totalTokensBefore: 150_000,
+      totalTokensAfterPruning: 90_000,
+      totalTokensAfterDropping: 90_000,
+      totalTokensAfterFloorPruning: 90_000,
+      totalTokensAfterFloorDropping: 90_000,
+    });
+
+    expect(metrics.outcome).toBe("pruned");
+    expect(metrics.prunedTokens).toBe(60_000);
+    expect(metrics.droppedTokens).toBe(0);
+    expect(metrics.saturated).toBe(false);
+  });
+
+  it("flags saturation when pruning ran out of eligible results while still over its budget", () => {
+    // Pruning reclaimed what it could (150k to 110k) but 110k still exceeds the 100k pruning
+    // budget: the preserved window is now the only unpruned tool content, and it slides on every
+    // new tool step. This is the regime the dashboard exists to size.
+    const metrics = computeConversationRenderingMetrics({
+      ...statsWhereNothingHappened(),
+      totalTokensBefore: 150_000,
+      totalTokensAfterPruning: 110_000,
+      totalTokensAfterDropping: 110_000,
+      totalTokensAfterFloorPruning: 110_000,
+      totalTokensAfterFloorDropping: 110_000,
+    });
+
+    expect(metrics.outcome).toBe("pruned");
+    expect(metrics.saturated).toBe(true);
+  });
+
+  it("measures drop slack, the headroom that predicts when the next full cache miss comes", () => {
+    // The batched drop landed at 140k against a 160k hard budget: 20k of slack, so roughly a
+    // checkpoint's worth of turns fit before the head must move again.
+    const metrics = computeConversationRenderingMetrics({
+      ...statsWhereNothingHappened(),
+      totalTokensBefore: 200_000,
+      totalTokensAfterPruning: 180_000,
+      totalTokensAfterDropping: 140_000,
+      totalTokensAfterFloorPruning: 140_000,
+      totalTokensAfterFloorDropping: 140_000,
+      interactionsBefore: 40,
+      interactionsAfterDropping: 30,
+      interactionsAfterFloorDropping: 30,
+    });
+
+    expect(metrics.outcome).toBe("dropped");
+    expect(metrics.droppedTokens).toBe(40_000);
+    expect(metrics.droppedInteractions).toBe(10);
+    expect(metrics.dropSlackTokens).toBe(20_000);
+    expect(metrics.saturated).toBe(true);
+  });
+
+  it("reports the deepest acting layer as the outcome when the escalation runs all the way down", () => {
+    const metrics = computeConversationRenderingMetrics({
+      ...statsWhereNothingHappened(),
+      totalTokensBefore: 300_000,
+      totalTokensAfterPruning: 250_000,
+      totalTokensAfterDropping: 200_000,
+      totalTokensAfterFloorPruning: 170_000,
+      totalTokensAfterFloorDropping: 150_000,
+      interactionsBefore: 50,
+      interactionsAfterDropping: 20,
+      interactionsAfterFloorDropping: 5,
+    });
+
+    expect(metrics.outcome).toBe("floor_dropped");
+    expect(metrics.prunedTokens).toBe(50_000);
+    expect(metrics.droppedTokens).toBe(50_000);
+    expect(metrics.floorPrunedTokens).toBe(30_000);
+    expect(metrics.floorDroppedTokens).toBe(20_000);
+    expect(metrics.floorDroppedInteractions).toBe(15);
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.ts
@@ -1,0 +1,209 @@
+/**
+ * Datadog instrumentation for conversation pruning. The pruning code itself only produces
+ * ConversationPruningStats as plain data. This module derives the metrics from that data and is
+ * the only file here that talks to StatsD, so the decision logic stays free of I/O and tests can
+ * assert on data instead of mocking a metrics client.
+ */
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
+
+// Token totals and interaction counts snapshotted after each escalation layer, plus the budgets
+// the layers ran against. Layers that did nothing leave their snapshot equal to the previous one.
+export type ConversationPruningStats = {
+  totalTokensBefore: number;
+  totalTokensAfterPruning: number;
+  totalTokensAfterDropping: number;
+  totalTokensAfterFloorPruning: number;
+  totalTokensAfterFloorDropping: number;
+  interactionsBefore: number;
+  interactionsAfterDropping: number;
+  interactionsAfterFloorDropping: number;
+  pruningBudget: number;
+  budgetForInteractions: number;
+};
+
+export type ConversationRenderingOutcome =
+  | "fits"
+  | "pruned"
+  | "dropped"
+  | "floor_pruned"
+  | "floor_dropped";
+
+export type ConversationRenderingMetrics = {
+  // The deepest escalation layer that changed anything.
+  outcome: ConversationRenderingOutcome;
+  // True when pruning ran out of eligible tool results while still over its budget. Those
+  // renders sit in the regime where every new tool step slides the preserved window and rewrites
+  // bytes, the population the quantized-floor follow-up would fix.
+  saturated: boolean;
+  prunedTokens: number;
+  floorPrunedTokens: number;
+  droppedTokens: number;
+  floorDroppedTokens: number;
+  droppedInteractions: number;
+  floorDroppedInteractions: number;
+  // Headroom below the hard budget right after the batched drop. Small slack means the next
+  // drop, and its full cache miss, comes soon.
+  dropSlackTokens: number | null;
+};
+
+export function computeConversationRenderingMetrics(
+  stats: ConversationPruningStats
+): ConversationRenderingMetrics {
+  const prunedTokens = stats.totalTokensBefore - stats.totalTokensAfterPruning;
+  const droppedTokens =
+    stats.totalTokensAfterPruning - stats.totalTokensAfterDropping;
+  const floorPrunedTokens =
+    stats.totalTokensAfterDropping - stats.totalTokensAfterFloorPruning;
+  const floorDroppedTokens =
+    stats.totalTokensAfterFloorPruning - stats.totalTokensAfterFloorDropping;
+  const droppedInteractions =
+    stats.interactionsBefore - stats.interactionsAfterDropping;
+  const floorDroppedInteractions =
+    stats.interactionsAfterDropping - stats.interactionsAfterFloorDropping;
+
+  let outcome: ConversationRenderingOutcome = "fits";
+  if (prunedTokens > 0) {
+    outcome = "pruned";
+  }
+  if (droppedTokens > 0) {
+    outcome = "dropped";
+  }
+  if (floorPrunedTokens > 0) {
+    outcome = "floor_pruned";
+  }
+  if (floorDroppedTokens > 0) {
+    outcome = "floor_dropped";
+  }
+
+  return {
+    outcome,
+    saturated: stats.totalTokensAfterPruning > stats.pruningBudget,
+    prunedTokens,
+    floorPrunedTokens,
+    droppedTokens,
+    floorDroppedTokens,
+    droppedInteractions,
+    floorDroppedInteractions,
+    dropSlackTokens:
+      droppedTokens > 0
+        ? stats.budgetForInteractions - stats.totalTokensAfterDropping
+        : null,
+  };
+}
+
+// renderConversationForModel has several callers with different budgets (the agent loop, Dust
+// app history injection, reinforcement batches, operator scripts). Mixing them into one series
+// would skew the outcome and saturation distributions, so emission is opt-in: callers that want
+// their renders measured pass a caller name, everyone else emits nothing.
+export type ConversationRenderingMetricsCaller = "agent_loop";
+
+export function emitConversationRenderingMetrics({
+  stats,
+  caller,
+  providerId,
+  modelId,
+  contextSize,
+  tokensUsed,
+}: {
+  stats: ConversationPruningStats;
+  caller: ConversationRenderingMetricsCaller;
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  contextSize: number;
+  tokensUsed: number;
+}): void {
+  const metrics = computeConversationRenderingMetrics(stats);
+  const statsD = getStatsDClient();
+  const baseTags = [
+    `client_id:${providerId}`,
+    `model_id:${modelId}`,
+    `caller:${caller}`,
+  ];
+
+  statsD.increment("conversation_rendering.renders", 1, [
+    ...baseTags,
+    `outcome:${metrics.outcome}`,
+    `saturated:${metrics.saturated}`,
+  ]);
+
+  if (contextSize > 0) {
+    statsD.distribution(
+      "conversation_rendering.context_utilization",
+      tokensUsed / contextSize,
+      baseTags
+    );
+  }
+
+  if (metrics.prunedTokens > 0) {
+    statsD.distribution(
+      "conversation_rendering.pruned_tokens",
+      metrics.prunedTokens,
+      [...baseTags, "layer:proactive"]
+    );
+  }
+  if (metrics.floorPrunedTokens > 0) {
+    statsD.distribution(
+      "conversation_rendering.pruned_tokens",
+      metrics.floorPrunedTokens,
+      [...baseTags, "layer:floor"]
+    );
+  }
+  if (metrics.droppedTokens > 0) {
+    statsD.distribution(
+      "conversation_rendering.dropped_tokens",
+      metrics.droppedTokens,
+      [...baseTags, "layer:standard"]
+    );
+    statsD.distribution(
+      "conversation_rendering.dropped_interactions",
+      metrics.droppedInteractions,
+      [...baseTags, "layer:standard"]
+    );
+  }
+  if (metrics.floorDroppedTokens > 0) {
+    statsD.distribution(
+      "conversation_rendering.dropped_tokens",
+      metrics.floorDroppedTokens,
+      [...baseTags, "layer:floor"]
+    );
+    statsD.distribution(
+      "conversation_rendering.dropped_interactions",
+      metrics.floorDroppedInteractions,
+      [...baseTags, "layer:floor"]
+    );
+  }
+  if (metrics.dropSlackTokens !== null) {
+    statsD.distribution(
+      "conversation_rendering.drop_slack_tokens",
+      metrics.dropSlackTokens,
+      baseTags
+    );
+  }
+}
+
+// Renders that fail never reach the success emission above, so without this counter the metric
+// family would be silent about its own worst cases (a conversation the escalation could not
+// fit, or one with nothing to render). Pairs with the renders counter the way llm_error.count
+// pairs with llm_success.count.
+export function emitConversationRenderingError({
+  kind,
+  caller,
+  providerId,
+  modelId,
+}: {
+  kind: "context_overflow" | "no_messages";
+  caller: ConversationRenderingMetricsCaller;
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+}): void {
+  getStatsDClient().increment("conversation_rendering.errors", 1, [
+    `client_id:${providerId}`,
+    `model_id:${modelId}`,
+    `caller:${caller}`,
+    `kind:${kind}`,
+  ]);
+}

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -21,6 +21,7 @@ import type {
   LLMStreamMetadata,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
+import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -226,6 +227,15 @@ export abstract class LLM<TPayload = unknown> {
         }
         currentEvent = event;
         buffer.addEvent(currentEvent);
+
+        // Providers report usage exactly once per response, at end of stream. Emitting here in
+        // the base class covers both the new router and the legacy clients.
+        if (currentEvent.type === "token_usage") {
+          emitTokenUsageMetrics(currentEvent.content, [
+            ...metricTags,
+            "surface:stream",
+          ]);
+        }
 
         if (currentEvent.type === "interaction_id") {
           const { modelInteractionId, cacheMissReason } = currentEvent.content;
@@ -603,6 +613,13 @@ export abstract class LLM<TPayload = unknown> {
       let hasError = false;
       for (const event of events) {
         buffer.addEvent(event);
+
+        if (event.type === "token_usage") {
+          emitTokenUsageMetrics(event.content, [
+            ...metricTags,
+            "surface:batch",
+          ]);
+        }
 
         if (event.type === "error") {
           hasError = true;

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -18,6 +18,7 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
+import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import {
   extractEncryptedContentFromMetadata,
   parseReasoningMetadata,
@@ -503,6 +504,10 @@ async function* convertToOldEvents(
   metadata: LLMClientMetadata
 ): AsyncGenerator<LLMEvent> {
   for await (const event of newEvents) {
+    // Providers yield exactly one token_usage per response, so this fires once per model call.
+    if (event.type === "token_usage") {
+      emitTokenUsageMetrics(event.content, metadata, "stream");
+    }
     yield convertToOldEvent(event, metadata);
   }
 }
@@ -515,6 +520,11 @@ function convertBatchEventsToOld(
   events: NonDeltaResponseEvent[],
   metadata: LLMClientMetadata
 ): LLMEvent[] {
+  for (const event of events) {
+    if (event.type === "token_usage") {
+      emitTokenUsageMetrics(event.content, metadata, "batch");
+    }
+  }
   return events.map((event) => convertToOldEvent(event, metadata));
 }
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -18,7 +18,6 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
-import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import {
   extractEncryptedContentFromMetadata,
   parseReasoningMetadata,
@@ -504,10 +503,6 @@ async function* convertToOldEvents(
   metadata: LLMClientMetadata
 ): AsyncGenerator<LLMEvent> {
   for await (const event of newEvents) {
-    // Providers yield exactly one token_usage per response, so this fires once per model call.
-    if (event.type === "token_usage") {
-      emitTokenUsageMetrics(event.content, metadata, "stream");
-    }
     yield convertToOldEvent(event, metadata);
   }
 }
@@ -520,11 +515,6 @@ function convertBatchEventsToOld(
   events: NonDeltaResponseEvent[],
   metadata: LLMClientMetadata
 ): LLMEvent[] {
-  for (const event of events) {
-    if (event.type === "token_usage") {
-      emitTokenUsageMetrics(event.content, metadata, "batch");
-    }
-  }
   return events.map((event) => convertToOldEvent(event, metadata));
 }
 

--- a/front/lib/api/llm/usage_metrics.ts
+++ b/front/lib/api/llm/usage_metrics.ts
@@ -1,46 +1,39 @@
 /**
- * StatsD emission for per-call LLM token usage. Called once per model response, at the single
- * point where every provider's usage report has been normalized into TokenUsageContent. The
- * cache split (hit vs created vs uncached) is the ground truth for prompt-cache health: the
+ * StatsD emission for per-call LLM token usage. Called from the base LLM class's stream and
+ * batch pipelines, which both the new router and the legacy per-provider clients flow through,
+ * so every model call is covered regardless of routing.
+ *
+ * The cache split (hit vs created vs uncached) is the ground truth for prompt-cache health: the
  * conversation pruning system's whole goal is keeping the hit share high, so these series are
  * what its checkpoint constants get tuned against.
- *
- * Tag keys follow the llm_* metric family (client_id, model_id) so these series join with
- * llm_interaction.count and friends in Datadog. The operation tag separates streaming traffic
- * from batch: batch entries never benefit from a warm prompt cache, so mixing them in would
- * dilute the hit-ratio series this exists to track.
  *
  * Zero values are skipped. They contribute nothing to the sum aggregations the dashboards use,
  * and they would distort per-kind averages and mint constant-zero series for cache kinds a
  * provider never reports.
  */
-import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
-import type { TokenUsageContent } from "@app/lib/model_constructors/types/output/events";
+import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 
-export function emitTokenUsageMetrics(
-  content: TokenUsageContent,
-  metadata: LLMClientMetadata,
-  operation: "stream" | "batch"
-): void {
+export function emitTokenUsageMetrics(usage: TokenUsage, tags: string[]): void {
   const statsD = getStatsDClient();
-  const tags = [
-    `client_id:${metadata.clientId}`,
-    `model_id:${metadata.modelId}`,
-    `operation:${operation}`,
-  ];
 
-  // `cacheCreated` is only set when the provider reports a flat total with no per-duration
-  // breakdown. Otherwise the split lives in long/short.
+  const cacheHit = usage.cachedTokens ?? 0;
+  // The flat total is only set when the provider reports no per-duration breakdown. Otherwise
+  // the split lives in long/short.
   const cacheCreated =
-    content.cacheCreated > 0
-      ? content.cacheCreated
-      : content.longCacheCreated + content.shortCacheCreated;
+    usage.cacheCreationTokens ??
+    (usage.longCacheCreationTokens ?? 0) +
+      (usage.shortCacheCreationTokens ?? 0);
+  // Providers that support caching report uncached input directly. For the rest, inputTokens is
+  // the whole prompt.
+  const uncached =
+    usage.uncachedInputTokens ??
+    Math.max(0, usage.inputTokens - cacheHit - cacheCreated);
 
   const inputByKind: Array<[string, number]> = [
-    ["cache_hit", content.cacheHit],
+    ["cache_hit", cacheHit],
     ["cache_created", cacheCreated],
-    ["uncached", content.standardInput],
+    ["uncached", uncached],
   ];
   for (const [kind, value] of inputByKind) {
     if (value > 0) {
@@ -50,11 +43,7 @@ export function emitTokenUsageMetrics(
       ]);
     }
   }
-  if (content.standardOutput > 0) {
-    statsD.distribution(
-      "llm_usage.output_tokens",
-      content.standardOutput,
-      tags
-    );
+  if (usage.outputTokens > 0) {
+    statsD.distribution("llm_usage.output_tokens", usage.outputTokens, tags);
   }
 }

--- a/front/lib/api/llm/usage_metrics.ts
+++ b/front/lib/api/llm/usage_metrics.ts
@@ -1,0 +1,60 @@
+/**
+ * StatsD emission for per-call LLM token usage. Called once per model response, at the single
+ * point where every provider's usage report has been normalized into TokenUsageContent. The
+ * cache split (hit vs created vs uncached) is the ground truth for prompt-cache health: the
+ * conversation pruning system's whole goal is keeping the hit share high, so these series are
+ * what its checkpoint constants get tuned against.
+ *
+ * Tag keys follow the llm_* metric family (client_id, model_id) so these series join with
+ * llm_interaction.count and friends in Datadog. The operation tag separates streaming traffic
+ * from batch: batch entries never benefit from a warm prompt cache, so mixing them in would
+ * dilute the hit-ratio series this exists to track.
+ *
+ * Zero values are skipped. They contribute nothing to the sum aggregations the dashboards use,
+ * and they would distort per-kind averages and mint constant-zero series for cache kinds a
+ * provider never reports.
+ */
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import type { TokenUsageContent } from "@app/lib/model_constructors/types/output/events";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+
+export function emitTokenUsageMetrics(
+  content: TokenUsageContent,
+  metadata: LLMClientMetadata,
+  operation: "stream" | "batch"
+): void {
+  const statsD = getStatsDClient();
+  const tags = [
+    `client_id:${metadata.clientId}`,
+    `model_id:${metadata.modelId}`,
+    `operation:${operation}`,
+  ];
+
+  // `cacheCreated` is only set when the provider reports a flat total with no per-duration
+  // breakdown. Otherwise the split lives in long/short.
+  const cacheCreated =
+    content.cacheCreated > 0
+      ? content.cacheCreated
+      : content.longCacheCreated + content.shortCacheCreated;
+
+  const inputByKind: Array<[string, number]> = [
+    ["cache_hit", content.cacheHit],
+    ["cache_created", cacheCreated],
+    ["uncached", content.standardInput],
+  ];
+  for (const [kind, value] of inputByKind) {
+    if (value > 0) {
+      statsD.distribution("llm_usage.input_tokens", value, [
+        ...tags,
+        `kind:${kind}`,
+      ]);
+    }
+  }
+  if (content.standardOutput > 0) {
+    statsD.distribution(
+      "llm_usage.output_tokens",
+      content.standardOutput,
+      tags
+    );
+  }
+}

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -1,6 +1,5 @@
-import { StatsD } from "hot-shots";
-
 import logger from "@app/logger/logger";
+import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
 

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -1,5 +1,6 @@
-import logger from "@app/logger/logger";
 import { StatsD } from "hot-shots";
+
+import logger from "@app/logger/logger";
 
 let statsDClient: StatsD | undefined = undefined;
 
@@ -7,9 +8,9 @@ export function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
     statsDClient = new StatsD({
-      // DD_ENTITY_ID, DD_ENV, DD_SERVICE and DD_VERSION are auto-injected as tags by hot-shots
-      // (includeDataDogTags defaults to true), so no globalTags are needed here.
-      //
+      globalTags: process.env.DD_ENTITY_ID
+        ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
+        : {},
       // Without an errorHandler, hot-shots emits "error" on its dgram socket with no listener
       // attached, which crashes the process on the rare send failure. Metrics are best-effort,
       // so log and move on.

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -1,3 +1,4 @@
+import logger from "@app/logger/logger";
 import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
@@ -6,9 +7,15 @@ export function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
     statsDClient = new StatsD({
-      globalTags: process.env.DD_ENTITY_ID
-        ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
-        : {},
+      // DD_ENTITY_ID, DD_ENV, DD_SERVICE and DD_VERSION are auto-injected as tags by hot-shots
+      // (includeDataDogTags defaults to true), so no globalTags are needed here.
+      //
+      // Without an errorHandler, hot-shots emits "error" on its dgram socket with no listener
+      // attached, which crashes the process on the rare send failure. Metrics are best-effort,
+      // so log and move on.
+      errorHandler: (err) => {
+        logger.warn({ err }, "StatsD send error");
+      },
     });
   }
   return statsDClient;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -650,6 +650,7 @@ export async function runModel(
           agentConfiguration,
           leadingMessages,
           enabledSkills,
+          metricsCaller: "agent_loop",
         })
       )
   );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The conversation pruning system now makes cache-relevant decisions on every render, batched pruning of old tool results and batched dropping of old interactions, and until now we had no way to see how often each mechanism fires in production, how much it reclaims, or whether the prompt cache actually benefits. This adds the metrics a dashboard needs to answer those questions and to tune the system's constants against real traffic.

Two families of series are emitted:
- On the decision side, each agent-loop render reports its outcome (nothing needed, pruned, dropped, or the forced last-resort variants), how many tokens each layer reclaimed, the headroom a batched drop bought before the next full cache miss becomes necessary, context utilization, and a saturation flag marking conversations where pruning has exhausted everything it may touch
- On the outcome side, every model call reports its input tokens split into cache hits, cache writes, and uncached, which yields the cache hit ratio, the ground truth the whole pruning effort answers to, and separates streaming from batch traffic since batch never benefits from a warm cache.

The design keeps instrumentation out of the decision logic.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
