### PR TITLE
[connectors] fix: Make Notion GC more respecful of temporal's limits

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1030,7 +1030,11 @@ export async function completeGarbageCollectionRun(
 ) {
   const redisKey = redisGarbageCollectorKey(connectorId);
   // Generate all the keys
-  const keysToDelete = [`${redisKey}-pages`, `${redisKey}-databases`];
+  const keysToDelete = [
+    `${redisKey}-pages`,
+    `${redisKey}-databases`,
+    `${redisKey}-batch-resume-state`,
+  ];
   for (let i = 0; i < nbOfBatches; i++) {
     keysToDelete.push(`${redisKey}-resources-not-seen-batch-${i}`);
   }
@@ -1056,6 +1060,56 @@ export async function completeGarbageCollectionRun(
   await notionConnectorState.update({
     lastGarbageCollectionFinishTime: new Date(),
   });
+}
+
+export type GarbageCollectionBatchResumeState = {
+  runTimestamp: number;
+  nbOfBatches: number;
+  nextBatchIndex: number;
+};
+
+// Stores where the batch-deletion phase stopped when the garbage collection workflow has to
+// continue-as-new before all batches are processed.
+export async function setGarbageCollectionBatchResumeState({
+  connectorId,
+  resumeState,
+}: {
+  connectorId: ModelId;
+  resumeState: GarbageCollectionBatchResumeState;
+}) {
+  const redisKey = redisGarbageCollectorKey(connectorId);
+  const redisCli = await redisClient({ origin: "notion_gc" });
+  await redisCli.set(
+    `${redisKey}-batch-resume-state`,
+    JSON.stringify(resumeState)
+  );
+}
+
+export async function getGarbageCollectionBatchResumeState({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<GarbageCollectionBatchResumeState | null> {
+  const redisKey = redisGarbageCollectorKey(connectorId);
+  const redisCli = await redisClient({ origin: "notion_gc" });
+
+  const rawState = await redisCli.get(`${redisKey}-batch-resume-state`);
+  if (!rawState) {
+    return null;
+  }
+
+  const resumeState = JSON.parse(rawState) as GarbageCollectionBatchResumeState;
+
+  // Stale state (eg the batches it points to were already processed and cleared): ignore it and
+  // let the run start from scratch.
+  const nextBatchExists = await redisCli.exists(
+    `${redisKey}-resources-not-seen-batch-${resumeState.nextBatchIndex}`
+  );
+  if (!nextBatchExists) {
+    return null;
+  }
+
+  return resumeState;
 }
 
 export async function deletionCrawlAddSignalsToRedis({

--- a/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
@@ -11,6 +11,7 @@ import { performUpserts } from "@connectors/connectors/notion/temporal/workflows
 import type { ModelId } from "@connectors/types";
 import {
   continueAsNew,
+  deprecatePatch,
   patched,
   proxyActivities,
   sleep,
@@ -39,10 +40,14 @@ const {
   startToCloseTimeout: "10 minute",
 });
 
-const { isFullSyncPendingOrOngoing, logMaxSearchPageIndexReached } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "1 minute",
-  });
+const {
+  isFullSyncPendingOrOngoing,
+  logMaxSearchPageIndexReached,
+  getGarbageCollectionBatchResumeState,
+  setGarbageCollectionBatchResumeState,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minute",
+});
 
 // This is the garbage collector workflow that continuously runs for each notion connector.
 export async function notionGarbageCollectionWorkflow({
@@ -76,171 +81,221 @@ export async function notionGarbageCollectionWorkflow({
     return;
   }
 
-  // clear the connector cache before each sync
-  await clearWorkflowCache({ connectorId, topLevelWorkflowId });
+  // Set (in redis) when the previous run continued-as-new in the middle of the batch-deletion
+  // phase to reset the event history. Not a workflow param: branching on a new input would break
+  // replay determinism for histories produced by other deploys.
+  const batchResumeState = patched("gc-batch-deletion-continue-as-new")
+    ? await getGarbageCollectionBatchResumeState({ connectorId })
+    : null;
 
-  const runTimestamp = Date.now();
+  let runTimestamp: number;
+  let nbOfBatches: number;
+  let startBatchIndex: number;
 
-  const childWorkflowQueue = new PQueue({
-    concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
-  });
+  if (batchResumeState) {
+    // The batches of the interrupted run are still in redis: skip straight to deleting.
+    runTimestamp = batchResumeState.runTimestamp;
+    nbOfBatches = batchResumeState.nbOfBatches;
+    startBatchIndex = batchResumeState.nextBatchIndex;
+  } else {
+    // clear the connector cache before each sync
+    await clearWorkflowCache({ connectorId, topLevelWorkflowId });
 
-  const promises: Promise<void>[] = [];
+    runTimestamp = Date.now();
 
-  async function runSearch(
-    cursorType: "pages" | "databases"
-  ): Promise<{ isComplete: boolean; pageIndex: number }> {
-    let pageIndex = pageIndexes[cursorType];
-    const { last: lastCursor } = cursors[cursorType];
-    if (pageIndex > 0 && !lastCursor) {
-      // We are already done
-      return {
-        isComplete: true,
-        pageIndex,
-      };
+    const childWorkflowQueue = new PQueue({
+      concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
+    });
+
+    const promises: Promise<void>[] = [];
+
+    async function runSearch(
+      cursorType: "pages" | "databases"
+    ): Promise<{ isComplete: boolean; pageIndex: number }> {
+      let pageIndex = pageIndexes[cursorType];
+      const { last: lastCursor } = cursors[cursorType];
+      if (pageIndex > 0 && !lastCursor) {
+        // We are already done
+        return {
+          isComplete: true,
+          pageIndex,
+        };
+      }
+      // we go through each result page of the notion search API
+      do {
+        // It's a garbage collection, we want to fetch all pages.
+        const { pageIds, databaseIds, nextCursor } =
+          await getPagesAndDatabasesToSync({
+            connectorId,
+            lastSyncedAt: null,
+            // Only pass non-null cursors.
+            cursors: cursors[cursorType],
+            excludeUpToDatePages: false,
+            loggerArgs: {
+              pageIndex,
+              runType: "garbageCollection",
+            },
+            filter: cursorType === "pages" ? "page" : "database",
+          });
+
+        // Update the cursors object to keep both the previous and last cursors.
+        const newPreviousCursor = cursors[cursorType].last;
+        const newLastCursor = nextCursor;
+        cursors[cursorType] = {
+          previous: newPreviousCursor,
+          last: newLastCursor,
+        };
+
+        pageIndex += 1;
+
+        // this function triggers child workflows to process batches of pages and databases.
+        // the worflow that processes databases will itself trigger child workflows to process
+        // batches of child pages.
+        promises.push(
+          // First mark the page and databases as "seen" in the GC run.
+          // The activity returns a potential list of new pages and databases that  we never seen before.
+          // We upsert those.
+          markAsSeenAndUpsertNewResources({
+            connectorId,
+            pageIds,
+            databaseIds,
+            runTimestamp,
+            childWorkflowQueue,
+            topLevelWorkflowId,
+          })
+        );
+
+        deprecatePatch("reduce-gc-batches-per-run");
+        if (pageIndex % GC_BATCHES_PER_RUN === 0) {
+          return { isComplete: false, pageIndex };
+        }
+        // There are too many search result pages, we're likely in an infinite loop (notion bug).
+        if (pageIndex > MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX) {
+          // Run activity to log that we had to stop early because we hit the max page index.
+          await logMaxSearchPageIndexReached({
+            connectorId,
+            searchPageIndex: pageIndex,
+            maxSearchPageIndex: MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX,
+          });
+          break;
+        }
+      } while (cursors[cursorType].last);
+
+      return { isComplete: true, pageIndex };
     }
-    // we go through each result page of the notion search API
+
+    const [pagesResult, databasesResult] = await Promise.all([
+      runSearch("pages"),
+      runSearch("databases"),
+    ]);
+
+    const isComplete = pagesResult.isComplete && databasesResult.isComplete;
+
+    if (!isComplete) {
+      await Promise.all(promises);
+      await continueAsNew<typeof notionGarbageCollectionWorkflow>({
+        connectorId,
+        cursors,
+        pageIndexes: {
+          pages: pagesResult.pageIndex,
+          databases: databasesResult.pageIndex,
+        },
+      });
+      return;
+    }
+
+    // wait for all child workflows to finish
+    await Promise.all(promises);
+
+    // These are resources (pages/DBs) that we didn't get from the search API but that are
+    // child/parent pages/DBs of other pages that we did get from the search API. We upsert those as
+    // well.
+    let discoveredResources: {
+      pageIds: string[];
+      databaseIds: string[];
+    } | null;
     do {
-      // It's a garbage collection, we want to fetch all pages.
-      const { pageIds, databaseIds, nextCursor } =
-        await getPagesAndDatabasesToSync({
+      discoveredResources = await getDiscoveredResourcesFromCache({
+        connectorId,
+        topLevelWorkflowId,
+      });
+      if (discoveredResources) {
+        await markAsSeenAndUpsertNewResources({
           connectorId,
-          lastSyncedAt: null,
-          // Only pass non-null cursors.
-          cursors: cursors[cursorType],
-          excludeUpToDatePages: false,
-          loggerArgs: {
-            pageIndex,
-            runType: "garbageCollection",
-          },
-          filter: cursorType === "pages" ? "page" : "database",
-        });
-
-      // Update the cursors object to keep both the previous and last cursors.
-      const newPreviousCursor = cursors[cursorType].last;
-      const newLastCursor = nextCursor;
-      cursors[cursorType] = {
-        previous: newPreviousCursor,
-        last: newLastCursor,
-      };
-
-      pageIndex += 1;
-
-      // this function triggers child workflows to process batches of pages and databases.
-      // the worflow that processes databases will itself trigger child workflows to process
-      // batches of child pages.
-      promises.push(
-        // First mark the page and databases as "seen" in the GC run.
-        // The activity returns a potential list of new pages and databases that  we never seen before.
-        // We upsert those.
-        markAsSeenAndUpsertNewResources({
-          connectorId,
-          pageIds,
-          databaseIds,
+          pageIds: discoveredResources.pageIds,
+          databaseIds: discoveredResources.databaseIds,
           runTimestamp,
           childWorkflowQueue,
           topLevelWorkflowId,
-        })
-      );
-
-      const batchesPerRun = patched("reduce-gc-batches-per-run")
-        ? GC_BATCHES_PER_RUN
-        : 512;
-      if (pageIndex % batchesPerRun === 0) {
-        return { isComplete: false, pageIndex };
-      }
-      // There are too many search result pages, we're likely in an infinite loop (notion bug).
-      if (pageIndex > MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX) {
-        // Run activity to log that we had to stop early because we hit the max page index.
-        await logMaxSearchPageIndexReached({
-          connectorId,
-          searchPageIndex: pageIndex,
-          maxSearchPageIndex: MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX,
         });
-        break;
       }
-    } while (cursors[cursorType].last);
+    } while (discoveredResources && PROCESS_ALL_DISCOVERED_RESOURCES);
 
-    return { isComplete: true, pageIndex };
-  }
+    // Look at pages and databases that were not visited in this run, check with the notion API if
+    // they were really deleted and delete them from the database if they were.
+    // Find the resources not seen in the GC run
 
-  const [pagesResult, databasesResult] = await Promise.all([
-    runSearch("pages"),
-    runSearch("databases"),
-  ]);
-
-  const isComplete = pagesResult.isComplete && databasesResult.isComplete;
-
-  if (!isComplete) {
-    await Promise.all(promises);
-    await continueAsNew<typeof notionGarbageCollectionWorkflow>({
-      connectorId,
-      cursors,
-      pageIndexes: {
-        pages: pagesResult.pageIndex,
-        databases: databasesResult.pageIndex,
-      },
-    });
-    return;
-  }
-
-  // wait for all child workflows to finish
-  await Promise.all(promises);
-
-  // These are resources (pages/DBs) that we didn't get from the search API but that are
-  // child/parent pages/DBs of other pages that we did get from the search API. We upsert those as
-  // well.
-  let discoveredResources: {
-    pageIds: string[];
-    databaseIds: string[];
-  } | null;
-  do {
-    discoveredResources = await getDiscoveredResourcesFromCache({
-      connectorId,
-      topLevelWorkflowId,
-    });
-    if (discoveredResources) {
-      await markAsSeenAndUpsertNewResources({
-        connectorId,
-        pageIds: discoveredResources.pageIds,
-        databaseIds: discoveredResources.databaseIds,
-        runTimestamp,
-        childWorkflowQueue,
-        topLevelWorkflowId,
-      });
-    }
-  } while (discoveredResources && PROCESS_ALL_DISCOVERED_RESOURCES);
-
-  // Look at pages and databases that were not visited in this run, check with the notion API if
-  // they were really deleted and delete them from the database if they were.
-  // Find the resources not seen in the GC run
-
-  // Create batches of resources to check, by chunk of 100
-  const nbOfBatches = await createResourcesNotSeenInGarbageCollectionRunBatches(
-    {
+    // Create batches of resources to check, by chunk of 100
+    nbOfBatches = await createResourcesNotSeenInGarbageCollectionRunBatches({
       connectorId,
       batchSize: 100,
-    }
-  );
-
-  // For each chunk, run a garbage collection activity
-  const queue = new PQueue({
-    concurrency: MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES,
-  });
-  const gbPromises: Promise<void>[] = [];
-  for (let batchIndex = 0; batchIndex < nbOfBatches; batchIndex++) {
-    gbPromises.push(
-      queue.add(async () =>
-        garbageCollectBatch({
-          connectorId,
-          runTimestamp,
-          batchIndex,
-        })
-      )
-    );
+    });
+    startBatchIndex = 0;
   }
 
-  await Promise.all(gbPromises);
+  if (patched("gc-batch-deletion-continue-as-new")) {
+    // Sequential on purpose (MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES is 1) so we can check
+    // continueAsNewSuggested between batches: continue-as-new before thousands of batches fill
+    // the event history and kill the workflow.
+    for (
+      let batchIndex = startBatchIndex;
+      batchIndex < nbOfBatches;
+      batchIndex++
+    ) {
+      await garbageCollectBatch({
+        connectorId,
+        runTimestamp,
+        batchIndex,
+      });
+
+      if (
+        workflowInfo().continueAsNewSuggested &&
+        batchIndex + 1 < nbOfBatches
+      ) {
+        await setGarbageCollectionBatchResumeState({
+          connectorId,
+          resumeState: {
+            runTimestamp,
+            nbOfBatches,
+            nextBatchIndex: batchIndex + 1,
+          },
+        });
+        await continueAsNew<typeof notionGarbageCollectionWorkflow>({
+          connectorId,
+        });
+        return;
+      }
+    }
+  } else {
+    // For each chunk, run a garbage collection activity
+    const queue = new PQueue({
+      concurrency: MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES,
+    });
+    const gbPromises: Promise<void>[] = [];
+    for (let batchIndex = 0; batchIndex < nbOfBatches; batchIndex++) {
+      gbPromises.push(
+        queue.add(async () =>
+          garbageCollectBatch({
+            connectorId,
+            runTimestamp,
+            batchIndex,
+          })
+        )
+      );
+    }
+
+    await Promise.all(gbPromises);
+  }
 
   // Once done, clear all the redis keys used for garbage collection
   await completeGarbageCollectionRun(connectorId, nbOfBatches);


### PR DESCRIPTION
## Description

Big Notion GC workflows can cross the 51k events limit after which temporal terminates it.
This is problematic because in such case, it need to be caught by oncall eng (we have a production check but it can and is missed) AND restarted manually (from temporal)

This PR leverages the `workflowInfo().continueAsNewSuggested` introduced by temporal and proven to work (I used it in some temporal workflows) - to limit the unbounded growth of `garbageCollectBatch`.

## Tests

N/A

## Risk

Low
Blast radius: Notion connector :/


## Deploy Plan


- Deploy connectors
- In 3 days, deprecate the patch
- In one week, remove it and the former activity