### PR TITLE
Persist sandbox function invocation data in GCS

### DIFF
--- a/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
@@ -72,6 +72,7 @@ async function setupSandboxFunctionInvocation({
   });
   const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
     sandboxFunction,
+    input: undefined,
   });
 
   return { workspace, sandboxFunction, invocation };

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -118,7 +118,7 @@ describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () =
     // An action of another invocation of the same function is not visible.
     const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
       auth,
-      { sandboxFunction }
+      { sandboxFunction, input: undefined }
     );
     const otherAction = await SandboxFunctionMCPActionFactory.create(auth, {
       invocation: otherInvocation,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -149,7 +149,7 @@ async function setupBlockedAction({
 
   const invocation = await SandboxFunctionInvocationResource.makeNew(
     adminAuth,
-    { sandboxFunction }
+    { sandboxFunction, input: undefined }
   );
   const action = await SandboxFunctionMCPActionFactory.create(adminAuth, {
     invocation,
@@ -516,7 +516,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       await setupBlockedAction();
     const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
       adminAuth,
-      { sandboxFunction }
+      { sandboxFunction, input: undefined }
     );
 
     const response = await postValidate({

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1,10 +1,12 @@
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
@@ -22,6 +24,18 @@ vi.mock("@app/lib/api/sandbox/access_tokens", async (importOriginal) => {
   return {
     ...actual,
     generateSandboxFunctionInvocationToken: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/events")
+    >();
+
+  return {
+    ...actual,
+    publishSandboxFunctionInvocationEvent: vi.fn(),
   };
 });
 
@@ -43,6 +57,7 @@ const outputSchema: JSONSchema = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  fileStorageMock.reset();
 });
 
 async function setupExecutionTest() {
@@ -80,7 +95,7 @@ async function setupExecutionTest() {
   );
   const invocation = await SandboxFunctionInvocationResource.makeNew(
     authenticator,
-    { sandboxFunction }
+    { sandboxFunction, input: { message: "hello" } }
   );
 
   return {
@@ -94,6 +109,78 @@ async function setupExecutionTest() {
 }
 
 describe("SandboxFunctionInvocationResource", () => {
+  it("stores and reloads its input from GCS", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    expect(invocation.gcsPath).toBe(
+      `w/${authenticator.getNonNullableWorkspace().sId}/sandbox_functions/${sandboxFunction.sId}/invocations/${invocation.sId}`
+    );
+    expect(invocation.input).toEqual({ message: "hello" });
+    expect(invocation.result).toBeUndefined();
+    expect(invocation.error).toBeUndefined();
+    expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
+      JSON.stringify({ input: { message: "hello" } })
+    );
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.input).toEqual({ message: "hello" });
+  });
+
+  it("stores and reloads its result from GCS on success", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const result = { commentId: "comment-123" };
+
+    await invocation.succeed(result);
+
+    expect(invocation.status).toBe("succeeded");
+    expect(invocation.result).toEqual(result);
+    expect(invocation.error).toBeUndefined();
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.result).toEqual(result);
+    expect(refetched?.error).toBeUndefined();
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sandbox_function_invocation_result",
+        invocationId: invocation.sId,
+        result,
+      }),
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("stores and reloads its error from GCS on failure", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    await invocation.fail(new Error("sandbox unavailable"));
+
+    expect(invocation.status).toBe("errored");
+    expect(invocation.result).toBeUndefined();
+    expect(invocation.error).toBe("sandbox unavailable");
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.result).toBeUndefined();
+    expect(refetched?.error).toBe("sandbox unavailable");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sandbox_function_invocation_error",
+        invocationId: invocation.sId,
+        message: "sandbox unavailable",
+      }),
+      { invocationId: invocation.sId }
+    );
+  });
+
   it("executes an invocation on the pod sandbox", async () => {
     const { authenticator, space, file, sandboxFunction, sandbox, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1,6 +1,7 @@
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -120,7 +121,7 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.result).toBeUndefined();
     expect(invocation.error).toBeUndefined();
     expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
-      JSON.stringify({ input: { message: "hello" } })
+      JSON.stringify({ version: 1, input: { message: "hello" } })
     );
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
@@ -128,6 +129,22 @@ describe("SandboxFunctionInvocationResource", () => {
       { sandboxFunction, invocationId: invocation.sId }
     );
     expect(refetched?.input).toEqual({ message: "hello" });
+  });
+
+  it("rejects unsupported stored data versions", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    await getPrivateUploadBucket()
+      .file(invocation.gcsPath!)
+      .save(Buffer.from(JSON.stringify({ version: 2 }), "utf-8"));
+
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      })
+    ).rejects.toThrow("Invalid sandbox function invocation data");
   });
 
   it("stores and reloads its result from GCS on success", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -11,6 +11,7 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -23,6 +24,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -34,6 +36,7 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
@@ -42,6 +45,52 @@ const DSBX_BIN_PATH = "/opt/bin/dsbx";
 // a larger one for the log fields.
 const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
 const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
+const GCS_CONCURRENCY = 4;
+
+type SandboxFunctionInvocationData = {
+  input: unknown;
+  result?: unknown;
+  error?: string;
+};
+
+type StoredSandboxFunctionInvocationData = {
+  input?: unknown;
+  result?: unknown;
+  error?: string;
+};
+
+function isStoredSandboxFunctionInvocationData(
+  data: unknown
+): data is StoredSandboxFunctionInvocationData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    !Array.isArray(data) &&
+    (!("error" in data) || typeof data.error === "string")
+  );
+}
+
+function parseSandboxFunctionInvocationData(
+  content: string
+): SandboxFunctionInvocationData {
+  const data: unknown = JSON.parse(content);
+  if (!isStoredSandboxFunctionInvocationData(data)) {
+    throw new Error("Invalid sandbox function invocation data.");
+  }
+
+  return {
+    input: data.input,
+    ...(Object.hasOwn(data, "result") ? { result: data.result } : {}),
+    ...(typeof data.error === "string" ? { error: data.error } : {}),
+  };
+}
+
+function gcsPathForInvocation(
+  auth: Authenticator,
+  invocation: SandboxFunctionInvocationResource
+): string {
+  return `w/${auth.getNonNullableWorkspace().sId}/sandbox_functions/${invocation.sandboxFunction.sId}/invocations/${invocation.sId}`;
+}
 
 function dustAPIBaseUrlForSandbox(): string {
   return isDevelopment() && config.getSandboxDevFrontHostName()
@@ -65,14 +114,22 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     SandboxFunctionInvocationModel;
 
   readonly sandboxFunction: SandboxFunctionResource;
+  private data: SandboxFunctionInvocationData;
 
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionInvocationModel>,
     blob: Attributes<SandboxFunctionInvocationModel>,
-    { sandboxFunction }: { sandboxFunction: SandboxFunctionResource }
+    {
+      sandboxFunction,
+      data,
+    }: {
+      sandboxFunction: SandboxFunctionResource;
+      data: SandboxFunctionInvocationData;
+    }
   ) {
     super(model, blob);
     this.sandboxFunction = sandboxFunction;
+    this.data = data;
   }
 
   get sId(): string {
@@ -80,6 +137,18 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  get input(): unknown {
+    return this.data.input;
+  }
+
+  get result(): unknown {
+    return this.data.result;
+  }
+
+  get error(): string | undefined {
+    return this.data.error;
   }
 
   toJSON(): SandboxFunctionInvocationType {
@@ -92,6 +161,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async fail(error: Error): Promise<void> {
+    await this.writeData({ input: this.input, error: error.message });
     await this.update({ status: "errored" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -106,6 +176,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async succeed(result: unknown): Promise<void> {
+    await this.writeData({ input: this.input, result });
     await this.update({ status: "succeeded" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -224,12 +295,73 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return makeSId("sandbox_function_invocation", { id, workspaceId });
   }
 
+  private static async loadDataFromGcs(
+    gcsPath: string | null
+  ): Promise<SandboxFunctionInvocationData> {
+    if (!gcsPath) {
+      return { input: undefined };
+    }
+
+    const downloadResult = await withRetry(() =>
+      getPrivateUploadBucket().file(gcsPath).download()
+    );
+    if (downloadResult.isErr()) {
+      throw downloadResult.error;
+    }
+
+    const [buffer] = downloadResult.value;
+    return parseSandboxFunctionInvocationData(buffer.toString("utf-8"));
+  }
+
+  private static async writeDataToGcs(
+    gcsPath: string,
+    data: SandboxFunctionInvocationData
+  ): Promise<void> {
+    const writeResult = await withRetry(() =>
+      getPrivateUploadBucket()
+        .file(gcsPath)
+        .save(Buffer.from(JSON.stringify(data), "utf-8"), {
+          contentType: "application/json",
+        })
+    );
+    if (writeResult.isErr()) {
+      throw writeResult.error;
+    }
+  }
+
+  private async writeData(data: SandboxFunctionInvocationData): Promise<void> {
+    if (!this.gcsPath) {
+      throw new Error("Sandbox function invocation has no GCS path.");
+    }
+
+    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
+    this.data = data;
+  }
+
+  private static async deleteDataFromGcs(gcsPaths: string[]): Promise<void> {
+    try {
+      const bucket = getPrivateUploadBucket();
+      await concurrentExecutor(
+        gcsPaths,
+        (gcsPath) => bucket.delete(gcsPath, { ignoreNotFound: true }),
+        { concurrency: GCS_CONCURRENCY }
+      );
+    } catch (error) {
+      logger.error(
+        { err: normalizeError(error), pathCount: gcsPaths.length },
+        "Failed to delete sandbox function invocation data from GCS"
+      );
+    }
+  }
+
   static async makeNew(
     auth: Authenticator,
     {
       sandboxFunction,
+      input,
     }: {
       sandboxFunction: SandboxFunctionResource;
+      input: unknown;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
@@ -238,11 +370,21 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         workspaceId: auth.getNonNullableWorkspace().id,
         sandboxFunctionId: sandboxFunction.id,
         status: "created",
+        gcsPath: null,
       },
       { transaction }
     );
 
-    return new this(this.model, invocation.get(), { sandboxFunction });
+    const data = { input };
+    const resource = new this(this.model, invocation.get(), {
+      sandboxFunction,
+      data,
+    });
+    const gcsPath = gcsPathForInvocation(auth, resource);
+    await this.writeDataToGcs(gcsPath, data);
+    await resource.update({ gcsPath }, transaction);
+
+    return resource;
   }
 
   static async createAndStartExecution(
@@ -255,7 +397,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       body: PostSandboxFunctionInvocationRequestBody;
     }
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
-    const invocation = await this.makeNew(auth, { sandboxFunction });
+    const invocation = await this.makeNew(auth, {
+      sandboxFunction,
+      input: body.input,
+    });
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_created",
@@ -293,9 +438,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       ...rest,
     });
 
-    return invocations.map(
-      (invocation) =>
-        new this(this.model, invocation.get(), { sandboxFunction })
+    return concurrentExecutor(
+      invocations,
+      async (invocation) => {
+        const blob = invocation.get();
+        const data = await this.loadDataFromGcs(blob.gcsPath);
+        return new this(this.model, blob, { sandboxFunction, data });
+      },
+      { concurrency: GCS_CONCURRENCY }
     );
   }
 
@@ -335,19 +485,32 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<number> {
+    const where = {
+      sandboxFunctionId: sandboxFunction.id,
+      workspaceId: sandboxFunction.workspaceId,
+    };
+    const invocations = await this.model.findAll({
+      attributes: ["gcsPath"],
+      where: {
+        ...where,
+        gcsPath: { [Op.ne]: null },
+      },
+      transaction,
+    });
+    const gcsPaths = invocations.flatMap(({ gcsPath }) =>
+      gcsPath ? [gcsPath] : []
+    );
+
     // MCP actions FK invocations with RESTRICT: delete them (rows + output GCS objects) first.
     await SandboxFunctionMCPActionResource.deleteAllForSandboxFunction(
       sandboxFunction,
       { transaction }
     );
 
-    return this.model.destroy({
-      where: {
-        sandboxFunctionId: sandboxFunction.id,
-        workspaceId: sandboxFunction.workspaceId,
-      },
-      transaction,
-    });
+    const deletedCount = await this.model.destroy({ where, transaction });
+    await this.deleteDataFromGcs(gcsPaths);
+
+    return deletedCount;
   }
 
   async delete(
@@ -370,6 +533,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         },
         transaction,
       });
+      if (this.gcsPath) {
+        await SandboxFunctionInvocationResource.deleteDataFromGcs([
+          this.gcsPath,
+        ]);
+      }
 
       return new Ok(undefined);
     } catch (error) {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -48,20 +48,14 @@ const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
 
 type SandboxFunctionInvocationData = {
-  input: unknown;
-  result?: unknown;
-  error?: string;
-};
-
-type StoredSandboxFunctionInvocationData = {
   input?: unknown;
   result?: unknown;
   error?: string;
 };
 
-function isStoredSandboxFunctionInvocationData(
+function isSandboxFunctionInvocationData(
   data: unknown
-): data is StoredSandboxFunctionInvocationData {
+): data is SandboxFunctionInvocationData {
   return (
     typeof data === "object" &&
     data !== null &&
@@ -74,15 +68,11 @@ function parseSandboxFunctionInvocationData(
   content: string
 ): SandboxFunctionInvocationData {
   const data: unknown = JSON.parse(content);
-  if (!isStoredSandboxFunctionInvocationData(data)) {
+  if (!isSandboxFunctionInvocationData(data)) {
     throw new Error("Invalid sandbox function invocation data.");
   }
 
-  return {
-    input: data.input,
-    ...(Object.hasOwn(data, "result") ? { result: data.result } : {}),
-    ...(typeof data.error === "string" ? { error: data.error } : {}),
-  };
+  return data;
 }
 
 function gcsPathForInvocation(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -161,7 +161,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async fail(error: Error): Promise<void> {
-    await this.writeData({ input: this.input, error: error.message });
+    const data = { input: this.input, error: error.message };
+    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
+    this.data = data;
     await this.update({ status: "errored" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -176,7 +178,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async succeed(result: unknown): Promise<void> {
-    await this.writeData({ input: this.input, result });
+    const data = { input: this.input, result };
+    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
+    this.data = data;
     await this.update({ status: "succeeded" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -298,6 +302,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   private static async loadDataFromGcs(
     gcsPath: string | null
   ): Promise<SandboxFunctionInvocationData> {
+    // TODO: Remove null support after running
+    // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
     if (!gcsPath) {
       return { input: undefined };
     }
@@ -314,9 +320,15 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   private static async writeDataToGcs(
-    gcsPath: string,
+    gcsPath: string | null,
     data: SandboxFunctionInvocationData
   ): Promise<void> {
+    // TODO: Remove null support after running
+    // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
+    if (!gcsPath) {
+      return;
+    }
+
     const writeResult = await withRetry(() =>
       getPrivateUploadBucket()
         .file(gcsPath)
@@ -327,15 +339,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (writeResult.isErr()) {
       throw writeResult.error;
     }
-  }
-
-  private async writeData(data: SandboxFunctionInvocationData): Promise<void> {
-    if (!this.gcsPath) {
-      throw new Error("Sandbox function invocation has no GCS path.");
-    }
-
-    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
-    this.data = data;
   }
 
   private static async deleteDataFromGcs(gcsPaths: string[]): Promise<void> {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -37,6 +37,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
@@ -46,33 +47,32 @@ const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
 const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
+const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
 
-type SandboxFunctionInvocationData = {
-  input?: unknown;
-  result?: unknown;
-  error?: string;
-};
+const SandboxFunctionInvocationDataSchema = z.object({
+  version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
+  input: z.unknown().optional(),
+  result: z.unknown().optional(),
+  error: z.string().optional(),
+});
 
-function isSandboxFunctionInvocationData(
-  data: unknown
-): data is SandboxFunctionInvocationData {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    !Array.isArray(data) &&
-    (!("error" in data) || typeof data.error === "string")
-  );
-}
+type SandboxFunctionInvocationData = z.infer<
+  typeof SandboxFunctionInvocationDataSchema
+>;
 
 function parseSandboxFunctionInvocationData(
   content: string
 ): SandboxFunctionInvocationData {
-  const data: unknown = JSON.parse(content);
-  if (!isSandboxFunctionInvocationData(data)) {
-    throw new Error("Invalid sandbox function invocation data.");
+  const result = SandboxFunctionInvocationDataSchema.safeParse(
+    JSON.parse(content)
+  );
+  if (!result.success) {
+    throw new Error(
+      `Invalid sandbox function invocation data: ${result.error.message}`
+    );
   }
 
-  return data;
+  return result.data;
 }
 
 function gcsPathForInvocation(
@@ -151,7 +151,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async fail(error: Error): Promise<void> {
-    const data = { input: this.input, error: error.message };
+    const data: SandboxFunctionInvocationData = {
+      version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+      input: this.input,
+      error: error.message,
+    };
     await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
     this.data = data;
     await this.update({ status: "errored" });
@@ -168,7 +172,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async succeed(result: unknown): Promise<void> {
-    const data = { input: this.input, result };
+    const data: SandboxFunctionInvocationData = {
+      version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+      input: this.input,
+      result,
+    };
     await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
     this.data = data;
     await this.update({ status: "succeeded" });
@@ -295,7 +303,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     // TODO: Remove null support after running
     // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
     if (!gcsPath) {
-      return { input: undefined };
+      return {
+        version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+        input: undefined,
+      };
     }
 
     const downloadResult = await withRetry(() =>
@@ -368,7 +379,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       { transaction }
     );
 
-    const data = { input };
+    const data: SandboxFunctionInvocationData = {
+      version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+      input,
+    };
     const resource = new this(this.model, invocation.get(), {
       sandboxFunction,
       data,

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -75,13 +75,6 @@ function parseSandboxFunctionInvocationData(
   return result.data;
 }
 
-function gcsPathForInvocation(
-  auth: Authenticator,
-  invocation: SandboxFunctionInvocationResource
-): string {
-  return `w/${auth.getNonNullableWorkspace().sId}/sandbox_functions/${invocation.sandboxFunction.sId}/invocations/${invocation.sId}`;
-}
-
 function dustAPIBaseUrlForSandbox(): string {
   return isDevelopment() && config.getSandboxDevFrontHostName()
     ? `https://${config.getSandboxDevFrontHostName()}`
@@ -111,10 +104,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     blob: Attributes<SandboxFunctionInvocationModel>,
     {
       sandboxFunction,
-      data,
+      data = {
+        version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+        input: undefined,
+      },
     }: {
       sandboxFunction: SandboxFunctionResource;
-      data: SandboxFunctionInvocationData;
+      data?: SandboxFunctionInvocationData;
     }
   ) {
     super(model, blob);
@@ -127,6 +123,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  private buildGcsPath(auth: Authenticator): string {
+    return `w/${auth.getNonNullableWorkspace().sId}/sandbox_functions/${this.sandboxFunction.sId}/invocations/${this.sId}`;
   }
 
   get input(): unknown {
@@ -151,13 +151,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async fail(error: Error): Promise<void> {
-    const data: SandboxFunctionInvocationData = {
+    this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       error: error.message,
     };
-    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
-    this.data = data;
+    await this.writeDataToGcs();
     await this.update({ status: "errored" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -172,13 +171,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async succeed(result: unknown): Promise<void> {
-    const data: SandboxFunctionInvocationData = {
+    this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       result,
     };
-    await SandboxFunctionInvocationResource.writeDataToGcs(this.gcsPath, data);
-    this.data = data;
+    await this.writeDataToGcs();
     await this.update({ status: "succeeded" });
     await publishSandboxFunctionInvocationEvent(
       {
@@ -297,16 +295,16 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return makeSId("sandbox_function_invocation", { id, workspaceId });
   }
 
-  private static async loadDataFromGcs(
-    gcsPath: string | null
-  ): Promise<SandboxFunctionInvocationData> {
+  private async loadDataFromGcs(): Promise<void> {
     // TODO: Remove null support after running
     // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
+    const { gcsPath } = this;
     if (!gcsPath) {
-      return {
+      this.data = {
         version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
         input: undefined,
       };
+      return;
     }
 
     const downloadResult = await withRetry(() =>
@@ -317,15 +315,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     }
 
     const [buffer] = downloadResult.value;
-    return parseSandboxFunctionInvocationData(buffer.toString("utf-8"));
+    this.data = parseSandboxFunctionInvocationData(buffer.toString("utf-8"));
   }
 
-  private static async writeDataToGcs(
-    gcsPath: string | null,
-    data: SandboxFunctionInvocationData
-  ): Promise<void> {
+  private async writeDataToGcs(): Promise<void> {
     // TODO: Remove null support after running
     // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
+    const { gcsPath } = this;
     if (!gcsPath) {
       return;
     }
@@ -333,7 +329,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     const writeResult = await withRetry(() =>
       getPrivateUploadBucket()
         .file(gcsPath)
-        .save(Buffer.from(JSON.stringify(data), "utf-8"), {
+        .save(Buffer.from(JSON.stringify(this.data), "utf-8"), {
           contentType: "application/json",
         })
     );
@@ -387,9 +383,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       sandboxFunction,
       data,
     });
-    const gcsPath = gcsPathForInvocation(auth, resource);
-    await this.writeDataToGcs(gcsPath, data);
+    const gcsPath = resource.buildGcsPath(auth);
     await resource.update({ gcsPath }, transaction);
+    await resource.writeDataToGcs();
 
     return resource;
   }
@@ -449,8 +445,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       invocations,
       async (invocation) => {
         const blob = invocation.get();
-        const data = await this.loadDataFromGcs(blob.gcsPath);
-        return new this(this.model, blob, { sandboxFunction, data });
+        const resource = new this(this.model, blob, { sandboxFunction });
+        await resource.loadDataFromGcs();
+        return resource;
       },
       { concurrency: GCS_CONCURRENCY }
     );

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -74,7 +74,7 @@ async function setup() {
   });
   const invocation = await SandboxFunctionInvocationResource.makeNew(
     authenticator,
-    { sandboxFunction }
+    { sandboxFunction, input: undefined }
   );
 
   const server = await RemoteMCPServerFactory.create(workspace);
@@ -185,7 +185,7 @@ describe("SandboxFunctionMCPActionResource", () => {
     await action.createOutputItems(authenticator, [
       { content: { type: "text", text: "4" } },
     ]);
-    expect(gcsStore.size).toBe(1);
+    expect(gcsStore.size).toBe(2);
 
     // The action FKs the invocation with RESTRICT: deletion must not throw.
     const deleteResult = await invocation.delete(authenticator);
@@ -232,9 +232,10 @@ describe("SandboxFunctionMCPActionResource", () => {
     await action.createOutputItems(authenticator, [
       { content: { type: "text", text: "4" } },
     ]);
-    expect(gcsStore.size).toBe(1);
+    expect(gcsStore.size).toBe(2);
 
-    // GCS deletion is deferred to afterCommit: on rollback, neither the rows nor the objects go.
+    // The invocation data is deleted immediately, while action output deletion remains deferred
+    // to afterCommit and the database rows are restored by the rollback.
     await expect(
       frontSequelize.transaction(async (transaction) => {
         await invocation.delete(authenticator, { transaction });
@@ -260,7 +261,7 @@ describe("SandboxFunctionMCPActionResource", () => {
     await action.createOutputItems(authenticator, [
       { content: { type: "text", text: "4" } },
     ]);
-    expect(gcsStore.size).toBe(1);
+    expect(gcsStore.size).toBe(2);
 
     // The action FKs the view with RESTRICT: hard-deleting the view (e.g. sharing a server to
     // the company space, remote server deletion) must not throw.
@@ -273,6 +274,6 @@ describe("SandboxFunctionMCPActionResource", () => {
         action.sId
       )
     ).toBeNull();
-    expect(gcsStore.size).toBe(0);
+    expect(gcsStore.size).toBe(1);
   });
 });

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -260,11 +260,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    return new SandboxFunctionInvocationResource(
-      SandboxFunctionInvocationModel,
-      invocation.get(),
-      { sandboxFunction }
-    );
+    return SandboxFunctionInvocationResource.fetchById(auth, {
+      sandboxFunction,
+      invocationId: SandboxFunctionInvocationResource.modelIdToSId({
+        id: invocation.id,
+        workspaceId: invocation.workspaceId,
+      }),
+    });
   }
 
   static async listBySpace(

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -1,5 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -52,6 +55,7 @@ export class SandboxFunctionInvocationModel extends WorkspaceAwareModel<SandboxF
 
   declare sandboxFunctionId: ForeignKey<SandboxFunctionModel["id"]>;
   declare status: SandboxFunctionInvocationStatus;
+  declare gcsPath: string | null;
 
   declare sandboxFunction: NonAttribute<SandboxFunctionModel>;
 }
@@ -173,6 +177,11 @@ SandboxFunctionInvocationModel.init(
       validate: {
         isIn: [SANDBOX_FUNCTION_INVOCATION_STATUSES],
       },
+    },
+    gcsPath: {
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
+++ b/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
@@ -80,7 +80,7 @@ makeScript(
           if (execute) {
             try {
               await bucket.uploadSmallRawContentToBucketAsNewFile({
-                content: "{}",
+                content: JSON.stringify({ version: 1 }),
                 contentType: "application/json",
                 filePath: gcsPath,
               });

--- a/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
+++ b/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
@@ -1,0 +1,125 @@
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Op } from "sequelize";
+
+const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_CONCURRENCY = 4;
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      required: true,
+      describe: "Restrict the backfill to a single workspace sId",
+    },
+    batchSize: {
+      type: "number",
+      default: DEFAULT_BATCH_SIZE,
+      describe: "Number of invocations to process per database batch",
+    },
+    concurrency: {
+      type: "number",
+      default: DEFAULT_CONCURRENCY,
+      describe: "Number of invocations to process concurrently per batch",
+    },
+  },
+  async ({ execute, workspaceId, batchSize, concurrency }, logger) => {
+    const workspaceResource = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspaceResource) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+    const workspace = renderLightWorkspaceType({
+      workspace: workspaceResource,
+    });
+    const bucket = getPrivateUploadBucket();
+    let lastInvocationModelId: ModelId | null = null;
+    let backfilledCount = 0;
+
+    for (;;) {
+      const invocations: SandboxFunctionInvocationModel[] =
+        await SandboxFunctionInvocationModel.findAll({
+          where: {
+            workspaceId: workspace.id,
+            gcsPath: null,
+            ...(lastInvocationModelId
+              ? { id: { [Op.gt]: lastInvocationModelId } }
+              : {}),
+          },
+          order: [["id", "ASC"]],
+          limit: batchSize,
+        });
+
+      if (invocations.length === 0) {
+        break;
+      }
+      lastInvocationModelId = invocations[invocations.length - 1].id;
+
+      await concurrentExecutor(
+        invocations,
+        async (invocation) => {
+          const sandboxFunctionId = SandboxFunctionResource.modelIdToSId({
+            id: invocation.sandboxFunctionId,
+            workspaceId: workspace.id,
+          });
+          const invocationId = SandboxFunctionInvocationResource.modelIdToSId({
+            id: invocation.id,
+            workspaceId: workspace.id,
+          });
+          const gcsPath =
+            `w/${workspace.sId}/sandbox_functions/${sandboxFunctionId}` +
+            `/invocations/${invocationId}`;
+
+          if (execute) {
+            try {
+              await bucket.uploadSmallRawContentToBucketAsNewFile({
+                content: "{}",
+                contentType: "application/json",
+                filePath: gcsPath,
+              });
+            } catch (error) {
+              // A concurrent invocation write wins over the empty backfill payload.
+              if (!isGCSPreconditionFailedError(error)) {
+                throw error;
+              }
+            }
+
+            await SandboxFunctionInvocationModel.update(
+              { gcsPath },
+              {
+                where: {
+                  id: invocation.id,
+                  workspaceId: workspace.id,
+                  gcsPath: null,
+                },
+                silent: true,
+              }
+            );
+          }
+
+          backfilledCount += 1;
+        },
+        { concurrency }
+      );
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          lastInvocationModelId,
+          backfilledCount,
+          execute,
+        },
+        execute
+          ? "Backfill batch completed"
+          : "Backfill dry-run batch completed"
+      );
+    }
+  }
+);

--- a/front/migrations/pre-deploy/20260715111106_add_gcs_path_to_sandbox_function_invocations.sql
+++ b/front/migrations/pre-deploy/20260715111106_add_gcs_path_to_sandbox_function_invocations.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ADD COLUMN "gcsPath" text COLLATE "pg_catalog"."default";

--- a/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_tool.test.ts
@@ -65,8 +65,6 @@ async function setupActivityRun() {
     mcpServerView: view,
   });
 
-  fileStorageMock.reset();
-
   return { auth, workspace, action };
 }
 

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -178,6 +178,7 @@ export async function createPersistedSandboxFunctionInvocationTokenTestContext()
   });
   const invocation = await SandboxFunctionInvocationResource.makeNew(auth, {
     sandboxFunction,
+    input: undefined,
   });
 
   const token = await generateSandboxFunctionInvocationToken(auth, {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -184,8 +184,14 @@ class FileStorageMock {
           });
           return new PassThrough();
         }),
-      delete: vi.fn().mockResolvedValue(undefined),
-      download: vi.fn().mockResolvedValue([Buffer.from("", "utf-8")]),
+      delete: vi.fn().mockImplementation(() => {
+        this._objectStore.delete(filePath ?? "unknown");
+        return Promise.resolve(undefined);
+      }),
+      download: vi.fn().mockImplementation(() => {
+        const content = this._objectStore.get(filePath ?? "unknown") ?? "";
+        return Promise.resolve([Buffer.from(content, "utf-8")]);
+      }),
       exists: vi.fn(() =>
         Promise.resolve([this._existsPredicate(filePath ?? "")])
       ),
@@ -214,6 +220,7 @@ class FileStorageMock {
               content,
               contentType: opts?.contentType,
             });
+            this._objectStore.set(path, content.toString());
             return Promise.resolve(undefined);
           }
         ),


### PR DESCRIPTION
## Description

Persist sandbox function invocation inputs, results, and errors in GCS and store the object path on the invocation.

Invocation data is loaded with the resource, updated before success or failure events are emitted, and deleted with the invocation. This provides durable inputs and outputs for the upcoming Temporal execution workflow without passing invocation payloads through Temporal.

## Tests

- 14 sandbox function resource tests.
- 20 sandbox function API and SSE endpoint tests.
- Tested locally
```
dust_front=# SELECT * FROM sandbox_function_invocations;
         createdAt          |         updatedAt          | sandboxFunctionId |  status   | workspaceId | id |                                 gcsPath                                  
----------------------------+----------------------------+-------------------+-----------+-------------+----+--------------------------------------------------------------------------
 2026-07-15 11:10:13.898+00 | 2026-07-15 11:10:15.841+00 |                 2 | succeeded |           1 |  1 | w/DevWkSpace/sandbox_functions/sfn_M3noynRxIM/invocations/sfi_Q8Ac4uf35L
(1 row)
```

## Risk

None, not a live product

## Deploy Plan

- Run pre-deploy migration `20260715111106_add_gcs_path_to_sandbox_function_invocations.sql`.
- Deploy `front` and `front-api`.
- Backfill the production workspace with:
  `cd front && npx tsx migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts --workspaceId <workspace-sId> --execute`.
