### PR TITLE
[front] fix: prevent user answer submission blink + add animation

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -330,6 +330,42 @@ describe("UserAnswerRequired", () => {
     expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
+  it("keeps the submission state visible until the agent retry completes", async () => {
+    const user = userEvent.setup();
+    let resolveRetry = () => {};
+    retryHandlerMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Alpha/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: /Alpha/i })
+    ).not.toBeInTheDocument();
+    expect(removeCompletedActionMock).not.toHaveBeenCalled();
+
+    resolveRetry();
+
+    await waitFor(() => {
+      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    });
+  });
+
   it("skips when Escape is pressed while the component is focused", async () => {
     const { container } = render(
       <UserAnswerRequired

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -262,6 +262,7 @@ async function finishExitAnimation(container: HTMLElement) {
   await waitFor(() => {
     expect(keyboardContainer).toHaveClass(
       "animate-out",
+      "fill-mode-forwards",
       "duration-exit",
       "ease-enter"
     );

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -422,7 +422,15 @@ describe("UserAnswerRequired", () => {
     expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
-  it("skips when Escape is pressed while the component is focused", async () => {
+  it("disables controls and skips when Escape is pressed", async () => {
+    let resolveAnswer = (_result: { success: boolean }) => {};
+    answerQuestionMock.mockImplementationOnce(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveAnswer = resolve;
+        })
+    );
+
     const { container } = render(
       <UserAnswerRequired
         blockedAction={makeBlockedAction()}
@@ -445,6 +453,21 @@ describe("UserAnswerRequired", () => {
         answer: { selectedOptions: [] },
       });
     });
+
+    const status = await screen.findByRole("status");
+    const hiddenOption = screen.getByRole("button", {
+      name: /Alpha/i,
+      hidden: true,
+    });
+
+    expect(status).toHaveTextContent("Skipping question");
+    expect(status).toHaveClass("duration-exit");
+    expect(hiddenOption.parentElement).toHaveClass("duration-exit");
+    expect(hiddenOption).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Skip" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send answer" })).toBeDisabled();
+
+    await act(async () => resolveAnswer({ success: true }));
     await finishExitAnimation(container);
     expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -256,6 +256,19 @@ function getKeyboardContainer(container: HTMLElement) {
   return element;
 }
 
+async function finishExitAnimation(container: HTMLElement) {
+  const keyboardContainer = getKeyboardContainer(container);
+
+  await waitFor(() => {
+    expect(keyboardContainer).toHaveClass(
+      "animate-out",
+      "duration-exit",
+      "ease-enter"
+    );
+  });
+  fireEvent.animationEnd(keyboardContainer);
+}
+
 describe("UserAnswerRequired", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -338,9 +351,8 @@ describe("UserAnswerRequired", () => {
         answer: { selectedOptions: [1] },
       });
     });
-    await waitFor(() => {
-      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
-    });
+    await finishExitAnimation(container);
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
   it("keeps the submission state visible until the agent retry completes", async () => {
@@ -353,7 +365,7 @@ describe("UserAnswerRequired", () => {
         })
     );
 
-    render(
+    const { container } = render(
       <UserAnswerRequired
         blockedAction={makeBlockedAction()}
         triggeringUser={null}
@@ -365,18 +377,17 @@ describe("UserAnswerRequired", () => {
     await user.click(screen.getByRole("button", { name: /Alpha/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("Loading")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
     });
     expect(
       screen.queryByRole("button", { name: /Alpha/i })
     ).not.toBeInTheDocument();
     expect(removeCompletedActionMock).not.toHaveBeenCalled();
 
-    resolveRetry();
+    await act(async () => resolveRetry());
 
-    await waitFor(() => {
-      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
-    });
+    await finishExitAnimation(container);
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
   it("removes immediately after retry when motion is reduced", async () => {
@@ -402,7 +413,7 @@ describe("UserAnswerRequired", () => {
     await user.click(screen.getByRole("button", { name: /Alpha/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("Loading")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
     });
 
     await act(async () => resolveRetry());
@@ -433,9 +444,8 @@ describe("UserAnswerRequired", () => {
         answer: { selectedOptions: [] },
       });
     });
-    await waitFor(() => {
-      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
-    });
+    await finishExitAnimation(container);
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
   it("toggles options with Space and Enter, then submits with Cmd+Enter in multi-select mode", async () => {

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -16,6 +16,16 @@ import { UserAnswerRequired } from "./UserAnswerRequired";
 const removeCompletedActionMock = vi.fn();
 const answerQuestionMock = vi.fn();
 const retryHandlerMock = vi.fn().mockResolvedValue(undefined);
+let shouldReduceMotionMock = false;
+
+vi.mock("framer-motion", async (importOriginal) => {
+  const original = await importOriginal<typeof import("framer-motion")>();
+
+  return {
+    ...original,
+    useReducedMotion: () => shouldReduceMotionMock,
+  };
+});
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({
@@ -249,6 +259,7 @@ function getKeyboardContainer(container: HTMLElement) {
 describe("UserAnswerRequired", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    shouldReduceMotionMock = false;
     answerQuestionMock.mockResolvedValue({ success: true });
   });
 
@@ -327,7 +338,9 @@ describe("UserAnswerRequired", () => {
         answer: { selectedOptions: [1] },
       });
     });
-    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    await waitFor(() => {
+      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    });
   });
 
   it("keeps the submission state visible until the agent retry completes", async () => {
@@ -366,6 +379,37 @@ describe("UserAnswerRequired", () => {
     });
   });
 
+  it("removes immediately after retry when motion is reduced", async () => {
+    const user = userEvent.setup();
+    let resolveRetry = () => {};
+    shouldReduceMotionMock = true;
+    retryHandlerMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Alpha/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading")).toBeInTheDocument();
+    });
+
+    await act(async () => resolveRetry());
+
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+  });
+
   it("skips when Escape is pressed while the component is focused", async () => {
     const { container } = render(
       <UserAnswerRequired
@@ -389,7 +433,9 @@ describe("UserAnswerRequired", () => {
         answer: { selectedOptions: [] },
       });
     });
-    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    await waitFor(() => {
+      expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    });
   });
 
   it("toggles options with Space and Enter, then submits with Cmd+Enter in multi-select mode", async () => {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -7,7 +7,7 @@ import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ArrowUp, Button, cn, OptionCard, Spinner } from "@dust-tt/sparkle";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useReducedMotion } from "framer-motion";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -275,31 +275,24 @@ export function UserAnswerRequired({
   }
 
   return (
-    <motion.div
+    <div
       ref={containerRef}
       tabIndex={0}
       aria-busy={isSubmitting}
       onKeyDownCapture={handleContainerKeyDownCapture}
       onKeyDown={handleContainerKeyDown}
       onMouseMove={() => setIsKeyboardNavigating(false)}
-      initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.985, y: 8 }}
-      animate={
-        isCompleted
-          ? { opacity: 0, scale: 0.985, y: -6 }
-          : { opacity: 1, scale: 1, y: 0 }
-      }
-      transition={{
-        duration: shouldReduceMotion ? 0 : isCompleted ? 0.16 : 0.2,
-        ease: "easeOut",
-      }}
-      onAnimationComplete={() => {
-        if (isCompleted) {
+      onAnimationEnd={(event) => {
+        if (isCompleted && event.currentTarget === event.target) {
           removeCompletedAction(blockedAction.actionId);
         }
       }}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
-        "",
+        "ease-enter motion-reduce:animate-none",
+        isCompleted
+          ? "animate-out fade-out-0 zoom-out-[98.5%] slide-out-to-top-[6px] duration-exit"
+          : "animate-in fade-in-0 zoom-in-[98.5%] slide-in-from-bottom-2 duration-enter",
         isKeyboardNavigating && "cursor-none"
       )}
     >
@@ -307,18 +300,14 @@ export function UserAnswerRequired({
         {question.question}
       </div>
       <div className="relative min-h-16">
-        <motion.div
+        <div
           aria-hidden={isSubmitting}
-          animate={
+          className={cn(
+            "flex flex-col gap-2 transition-[opacity,transform] ease-enter motion-reduce:transition-none",
             isSubmitting
-              ? { opacity: 0, scale: 0.985 }
-              : { opacity: 1, scale: 1 }
-          }
-          transition={{
-            duration: shouldReduceMotion ? 0 : 0.15,
-            ease: "easeOut",
-          }}
-          className="flex flex-col gap-2"
+              ? "scale-[.985] opacity-0 duration-exit"
+              : "scale-100 opacity-100 duration-enter"
+          )}
         >
           {question.options.map((option, index) => (
             <OptionCard
@@ -362,25 +351,20 @@ export function UserAnswerRequired({
             onChange={(value) => answerDraft.updateCustomResponse(value)}
             onKeyDown={handleCustomResponseKeyDown}
           />
-        </motion.div>
-        <AnimatePresence initial={false}>
-          {isSubmitting && (
-            <motion.div
-              role="status"
-              className="absolute inset-0 flex items-center justify-center"
-              initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.96 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.96 }}
-              transition={{
-                duration: shouldReduceMotion ? 0 : 0.15,
-                ease: "easeOut",
-              }}
-            >
-              <Spinner size="lg" />
-              <span className="sr-only">Submitting answer</span>
-            </motion.div>
+        </div>
+        <div
+          role={isSubmitting ? "status" : undefined}
+          aria-hidden={!isSubmitting}
+          className={cn(
+            "absolute inset-0 flex items-center justify-center transition-[opacity,transform] ease-enter motion-reduce:transition-none",
+            isSubmitting
+              ? "scale-100 opacity-100 duration-enter"
+              : "pointer-events-none scale-[.96] opacity-0 duration-exit"
           )}
-        </AnimatePresence>
+        >
+          <Spinner size="lg" />
+          <span className="sr-only">Submitting answer</span>
+        </div>
       </div>
       {errorMessage && (
         <div className="text-sm font-medium text-warning-800">
@@ -405,6 +389,6 @@ export function UserAnswerRequired({
           aria-label="Send answer"
         />
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -328,7 +328,7 @@ export function UserAnswerRequired({
                 isKeyboardNavigating && "cursor-none"
               )}
               onClick={() => handleOptionClick(index)}
-              disabled={isAnswerSubmitting}
+              disabled={isSubmitting}
             />
           ))}
           <OptionCard
@@ -358,12 +358,14 @@ export function UserAnswerRequired({
           className={cn(
             "absolute inset-0 flex items-center justify-center transition-opacity ease-enter motion-reduce:transition-none",
             isSubmitting
-              ? "opacity-100 duration-enter"
-              : "pointer-events-none opacity-0 duration-exit"
+              ? "opacity-100 duration-exit"
+              : "pointer-events-none opacity-0 duration-enter"
           )}
         >
           <Spinner size="lg" />
-          <span className="sr-only">Submitting answer</span>
+          <span className="sr-only">
+            {isSkipSubmitting ? "Skipping question" : "Submitting answer"}
+          </span>
         </div>
       </div>
       {errorMessage && (
@@ -378,13 +380,14 @@ export function UserAnswerRequired({
           size="sm"
           onClick={handleSkip}
           isLoading={isSkipSubmitting}
+          disabled={isSubmitting}
         />
         <Button
           icon={ArrowUp}
           variant="highlight"
           size="sm"
           isLoading={isAnswerSubmitting}
-          disabled={answerDraft.answerToSubmit === null}
+          disabled={isSubmitting || answerDraft.answerToSubmit === null}
           onClick={handleSubmit}
           aria-label="Send answer"
         />

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -41,14 +41,14 @@ export function UserAnswerRequired({
 }: UserAnswerRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
-  const { answerQuestion, isSubmitting, errorMessage } = useAnswerUserQuestion({
-    owner,
-  });
+  const { answerQuestion, errorMessage } = useAnswerUserQuestion({ owner });
 
   const answerDraft = useUserAnswerDraft({
     multiSelect: blockedAction.question.multiSelect,
   });
-  const [isSkipPending, setIsSkipPending] = useState(false);
+  const [pendingSubmission, setPendingSubmission] = useState<
+    "answer" | "skip" | null
+  >(null);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
@@ -65,8 +65,9 @@ export function UserAnswerRequired({
     isCustomResponseFocused ||
     answerDraft.answerToSubmit?.customResponse !== undefined;
 
-  const isAnswerSubmitting = isSubmitting && !isSkipPending;
-  const isSkipSubmitting = isSubmitting && isSkipPending;
+  const isSubmitting = pendingSubmission !== null;
+  const isAnswerSubmitting = pendingSubmission === "answer";
+  const isSkipSubmitting = pendingSubmission === "skip";
 
   // Reset the keyboard cursor and focus when a new blocked action replaces the current one.
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
@@ -81,7 +82,7 @@ export function UserAnswerRequired({
     answer: UserQuestionAnswer,
     { isSkip = false }: { isSkip?: boolean } = {}
   ) {
-    setIsSkipPending(isSkip);
+    setPendingSubmission(isSkip ? "skip" : "answer");
     // Submit against the action's own conversation/message: for a sub-agent
     // question these are the child's ids (the action lives in the child
     // conversation). For a direct question they equal the current conversation.
@@ -95,11 +96,15 @@ export function UserAnswerRequired({
     if (result.success) {
       // Resume the agent run. For a sub-agent question this also relaunches the
       // blocked parent run (the child retry is a no-op once the answer is in).
-      await retryHandler();
-      removeCompletedAction(blockedAction.actionId);
+      try {
+        await retryHandler();
+        removeCompletedAction(blockedAction.actionId);
+      } finally {
+        setPendingSubmission(null);
+      }
+    } else {
+      setPendingSubmission(null);
     }
-
-    setIsSkipPending(false);
   }
 
   function activateOption(index: number) {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -291,7 +291,7 @@ export function UserAnswerRequired({
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
         isCompleted
-          ? "animate-out fade-out-0 zoom-out-95 duration-exit"
+          ? "animate-out fill-mode-forwards fade-out-0 zoom-out-95 duration-exit"
           : "animate-in fade-in-0 zoom-in-95 duration-enter",
         isKeyboardNavigating && "cursor-none"
       )}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -7,6 +7,7 @@ import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ArrowUp, Button, cn, OptionCard, Spinner } from "@dust-tt/sparkle";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -49,11 +50,13 @@ export function UserAnswerRequired({
   const [pendingSubmission, setPendingSubmission] = useState<
     "answer" | "skip" | null
   >(null);
+  const [isCompleted, setIsCompleted] = useState(false);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const customResponseInputRef = useRef<HTMLInputElement>(null);
+  const shouldReduceMotion = useReducedMotion();
 
   const { question } = blockedAction;
   const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
@@ -82,6 +85,7 @@ export function UserAnswerRequired({
     answer: UserQuestionAnswer,
     { isSkip = false }: { isSkip?: boolean } = {}
   ) {
+    containerRef.current?.focus({ preventScroll: true });
     setPendingSubmission(isSkip ? "skip" : "answer");
     // Submit against the action's own conversation/message: for a sub-agent
     // question these are the child's ids (the action lives in the child
@@ -96,11 +100,19 @@ export function UserAnswerRequired({
     if (result.success) {
       // Resume the agent run. For a sub-agent question this also relaunches the
       // blocked parent run (the child retry is a no-op once the answer is in).
+      let shouldWaitForExitAnimation = false;
       try {
         await retryHandler();
-        removeCompletedAction(blockedAction.actionId);
+        if (shouldReduceMotion) {
+          removeCompletedAction(blockedAction.actionId);
+        } else {
+          shouldWaitForExitAnimation = true;
+          setIsCompleted(true);
+        }
       } finally {
-        setPendingSubmission(null);
+        if (!shouldWaitForExitAnimation) {
+          setPendingSubmission(null);
+        }
       }
     } else {
       setPendingSubmission(null);
@@ -263,12 +275,28 @@ export function UserAnswerRequired({
   }
 
   return (
-    <div
+    <motion.div
       ref={containerRef}
       tabIndex={0}
+      aria-busy={isSubmitting}
       onKeyDownCapture={handleContainerKeyDownCapture}
       onKeyDown={handleContainerKeyDown}
       onMouseMove={() => setIsKeyboardNavigating(false)}
+      initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.985, y: 8 }}
+      animate={
+        isCompleted
+          ? { opacity: 0, scale: 0.985, y: -6 }
+          : { opacity: 1, scale: 1, y: 0 }
+      }
+      transition={{
+        duration: shouldReduceMotion ? 0 : isCompleted ? 0.16 : 0.2,
+        ease: "easeOut",
+      }}
+      onAnimationComplete={() => {
+        if (isCompleted) {
+          removeCompletedAction(blockedAction.actionId);
+        }
+      }}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "",
@@ -278,12 +306,20 @@ export function UserAnswerRequired({
       <div className="text-base font-medium leading-tight text-foreground">
         {question.question}
       </div>
-      {isAnswerSubmitting ? (
-        <div className="flex min-h-64 items-center justify-center">
-          <Spinner size="lg" />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2">
+      <div className="relative min-h-16">
+        <motion.div
+          aria-hidden={isSubmitting}
+          animate={
+            isSubmitting
+              ? { opacity: 0, scale: 0.985 }
+              : { opacity: 1, scale: 1 }
+          }
+          transition={{
+            duration: shouldReduceMotion ? 0 : 0.15,
+            ease: "easeOut",
+          }}
+          className="flex flex-col gap-2"
+        >
           {question.options.map((option, index) => (
             <OptionCard
               key={index}
@@ -326,8 +362,26 @@ export function UserAnswerRequired({
             onChange={(value) => answerDraft.updateCustomResponse(value)}
             onKeyDown={handleCustomResponseKeyDown}
           />
-        </div>
-      )}
+        </motion.div>
+        <AnimatePresence initial={false}>
+          {isSubmitting && (
+            <motion.div
+              role="status"
+              className="absolute inset-0 flex items-center justify-center"
+              initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{
+                duration: shouldReduceMotion ? 0 : 0.15,
+                ease: "easeOut",
+              }}
+            >
+              <Spinner size="lg" />
+              <span className="sr-only">Submitting answer</span>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
       {errorMessage && (
         <div className="text-sm font-medium text-warning-800">
           {errorMessage}
@@ -351,6 +405,6 @@ export function UserAnswerRequired({
           aria-label="Send answer"
         />
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -71,9 +71,6 @@ export function UserAnswerRequired({
     answerDraft.answerToSubmit?.customResponse !== undefined;
 
   const isSubmitting = submission !== null;
-  const isExiting = submission?.phase === "exiting";
-  const isAnswerSubmitting = submission?.kind === "answer";
-  const isSkipSubmitting = submission?.kind === "skip";
 
   // Reset the keyboard cursor and focus when a new blocked action replaces the current one.
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
@@ -283,14 +280,17 @@ export function UserAnswerRequired({
       onKeyDown={handleContainerKeyDown}
       onMouseMove={() => setIsKeyboardNavigating(false)}
       onAnimationEnd={(event) => {
-        if (isExiting && event.currentTarget === event.target) {
+        if (
+          submission?.phase === "exiting" &&
+          event.currentTarget === event.target
+        ) {
           removeCompletedAction(blockedAction.actionId);
         }
       }}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
-        isExiting
+        submission?.phase === "exiting"
           ? "animate-out fill-mode-forwards fade-out-0 duration-exit"
           : "animate-in fade-in-0 duration-enter",
         isKeyboardNavigating && "cursor-none"
@@ -364,7 +364,9 @@ export function UserAnswerRequired({
         >
           <Spinner size="lg" />
           <span className="sr-only">
-            {isSkipSubmitting ? "Skipping question" : "Submitting answer"}
+            {submission?.kind === "skip"
+              ? "Skipping question"
+              : "Submitting answer"}
           </span>
         </div>
       </div>
@@ -379,14 +381,14 @@ export function UserAnswerRequired({
           variant="outline"
           size="sm"
           onClick={handleSkip}
-          isLoading={isSkipSubmitting}
+          isLoading={submission?.kind === "skip"}
           disabled={isSubmitting}
         />
         <Button
           icon={ArrowUp}
           variant="highlight"
           size="sm"
-          isLoading={isAnswerSubmitting}
+          isLoading={submission?.kind === "answer"}
           disabled={isSubmitting || answerDraft.answerToSubmit === null}
           onClick={handleSubmit}
           aria-label="Send answer"

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -291,8 +291,8 @@ export function UserAnswerRequired({
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
         isCompleted
-          ? "animate-out fill-mode-forwards fade-out-0 zoom-out-95 duration-exit"
-          : "animate-in fade-in-0 zoom-in-95 duration-enter",
+          ? "animate-out fill-mode-forwards fade-out-0 duration-exit"
+          : "animate-in fade-in-0 duration-enter",
         isKeyboardNavigating && "cursor-none"
       )}
     >

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -291,8 +291,8 @@ export function UserAnswerRequired({
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
         isCompleted
-          ? "animate-out fade-out-0 zoom-out-[98.5%] slide-out-to-top-[6px] duration-exit"
-          : "animate-in fade-in-0 zoom-in-[98.5%] slide-in-from-bottom-2 duration-enter",
+          ? "animate-out fade-out-0 zoom-out-95 duration-exit"
+          : "animate-in fade-in-0 zoom-in-95 duration-enter",
         isKeyboardNavigating && "cursor-none"
       )}
     >
@@ -303,10 +303,10 @@ export function UserAnswerRequired({
         <div
           aria-hidden={isSubmitting}
           className={cn(
-            "flex flex-col gap-2 transition-[opacity,transform] ease-enter motion-reduce:transition-none",
+            "flex flex-col gap-2 transition-opacity ease-enter motion-reduce:transition-none",
             isSubmitting
-              ? "scale-[.985] opacity-0 duration-exit"
-              : "scale-100 opacity-100 duration-enter"
+              ? "opacity-0 duration-exit"
+              : "opacity-100 duration-enter"
           )}
         >
           {question.options.map((option, index) => (
@@ -356,10 +356,10 @@ export function UserAnswerRequired({
           role={isSubmitting ? "status" : undefined}
           aria-hidden={!isSubmitting}
           className={cn(
-            "absolute inset-0 flex items-center justify-center transition-[opacity,transform] ease-enter motion-reduce:transition-none",
+            "absolute inset-0 flex items-center justify-center transition-opacity ease-enter motion-reduce:transition-none",
             isSubmitting
-              ? "scale-100 opacity-100 duration-enter"
-              : "pointer-events-none scale-[.96] opacity-0 duration-exit"
+              ? "opacity-100 duration-enter"
+              : "pointer-events-none opacity-0 duration-exit"
           )}
         >
           <Spinner size="lg" />

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -50,7 +50,7 @@ export function UserAnswerRequired({
   const [pendingSubmission, setPendingSubmission] = useState<
     "answer" | "skip" | null
   >(null);
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
@@ -85,38 +85,40 @@ export function UserAnswerRequired({
     answer: UserQuestionAnswer,
     { isSkip = false }: { isSkip?: boolean } = {}
   ) {
+    // Move focus out of the controls before disabling and hiding them.
     containerRef.current?.focus({ preventScroll: true });
     setPendingSubmission(isSkip ? "skip" : "answer");
-    // Submit against the action's own conversation/message: for a sub-agent
-    // question these are the child's ids (the action lives in the child
-    // conversation). For a direct question they equal the current conversation.
-    const result = await answerQuestion({
-      conversationId: blockedAction.conversationId,
-      messageId: blockedAction.messageId,
-      actionId: blockedAction.actionId,
-      answer,
-    });
+    try {
+      // Submit against the action's own conversation/message: for a sub-agent
+      // question these are the child's ids (the action lives in the child
+      // conversation). For a direct question they equal the current conversation.
+      const result = await answerQuestion({
+        conversationId: blockedAction.conversationId,
+        messageId: blockedAction.messageId,
+        actionId: blockedAction.actionId,
+        answer,
+      });
 
-    if (result.success) {
+      if (!result.success) {
+        setPendingSubmission(null);
+        return;
+      }
+
       // Resume the agent run. For a sub-agent question this also relaunches the
       // blocked parent run (the child retry is a no-op once the answer is in).
-      let shouldWaitForExitAnimation = false;
-      try {
-        await retryHandler();
-        if (shouldReduceMotion) {
-          removeCompletedAction(blockedAction.actionId);
-        } else {
-          shouldWaitForExitAnimation = true;
-          setIsCompleted(true);
-        }
-      } finally {
-        if (!shouldWaitForExitAnimation) {
-          setPendingSubmission(null);
-        }
-      }
-    } else {
+      await retryHandler();
+    } catch (error) {
       setPendingSubmission(null);
+      throw error;
     }
+
+    if (shouldReduceMotion) {
+      removeCompletedAction(blockedAction.actionId);
+      return;
+    }
+
+    // Keep the submission state visible until the exit animation removes the card.
+    setIsExiting(true);
   }
 
   function activateOption(index: number) {
@@ -283,14 +285,14 @@ export function UserAnswerRequired({
       onKeyDown={handleContainerKeyDown}
       onMouseMove={() => setIsKeyboardNavigating(false)}
       onAnimationEnd={(event) => {
-        if (isCompleted && event.currentTarget === event.target) {
+        if (isExiting && event.currentTarget === event.target) {
           removeCompletedAction(blockedAction.actionId);
         }
       }}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
-        isCompleted
+        isExiting
           ? "animate-out fill-mode-forwards fade-out-0 duration-exit"
           : "animate-in fade-in-0 duration-enter",
         isKeyboardNavigating && "cursor-none"

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -20,6 +20,11 @@ interface UserAnswerRequiredProps {
   retryHandler: () => Promise<void>;
 }
 
+type SubmissionState = {
+  kind: "answer" | "skip";
+  phase: "pending" | "exiting";
+} | null;
+
 function isPrintableKey(e: KeyboardEvent<HTMLDivElement>) {
   return (
     e.key.length === 1 && e.key !== " " && !e.altKey && !e.ctrlKey && !e.metaKey
@@ -47,10 +52,7 @@ export function UserAnswerRequired({
   const answerDraft = useUserAnswerDraft({
     multiSelect: blockedAction.question.multiSelect,
   });
-  const [pendingSubmission, setPendingSubmission] = useState<
-    "answer" | "skip" | null
-  >(null);
-  const [isExiting, setIsExiting] = useState(false);
+  const [submission, setSubmission] = useState<SubmissionState>(null);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
   const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
@@ -68,9 +70,10 @@ export function UserAnswerRequired({
     isCustomResponseFocused ||
     answerDraft.answerToSubmit?.customResponse !== undefined;
 
-  const isSubmitting = pendingSubmission !== null;
-  const isAnswerSubmitting = pendingSubmission === "answer";
-  const isSkipSubmitting = pendingSubmission === "skip";
+  const isSubmitting = submission !== null;
+  const isExiting = submission?.phase === "exiting";
+  const isAnswerSubmitting = submission?.kind === "answer";
+  const isSkipSubmitting = submission?.kind === "skip";
 
   // Reset the keyboard cursor and focus when a new blocked action replaces the current one.
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
@@ -87,38 +90,33 @@ export function UserAnswerRequired({
   ) {
     // Move focus out of the controls before disabling and hiding them.
     containerRef.current?.focus({ preventScroll: true });
-    setPendingSubmission(isSkip ? "skip" : "answer");
-    try {
-      // Submit against the action's own conversation/message: for a sub-agent
-      // question these are the child's ids (the action lives in the child
-      // conversation). For a direct question they equal the current conversation.
-      const result = await answerQuestion({
-        conversationId: blockedAction.conversationId,
-        messageId: blockedAction.messageId,
-        actionId: blockedAction.actionId,
-        answer,
-      });
+    const submissionKind = isSkip ? "skip" : "answer";
+    setSubmission({ kind: submissionKind, phase: "pending" });
 
-      if (!result.success) {
-        setPendingSubmission(null);
-        return;
-      }
+    // Submit against the action's own conversation/message: for a sub-agent
+    // question these are the child's ids (the action lives in the child
+    // conversation). For a direct question they equal the current conversation.
+    const result = await answerQuestion({
+      conversationId: blockedAction.conversationId,
+      messageId: blockedAction.messageId,
+      actionId: blockedAction.actionId,
+      answer,
+    });
 
+    if (result.success) {
       // Resume the agent run. For a sub-agent question this also relaunches the
       // blocked parent run (the child retry is a no-op once the answer is in).
       await retryHandler();
-    } catch (error) {
-      setPendingSubmission(null);
-      throw error;
-    }
 
-    if (shouldReduceMotion) {
-      removeCompletedAction(blockedAction.actionId);
-      return;
+      if (shouldReduceMotion) {
+        removeCompletedAction(blockedAction.actionId);
+      } else {
+        // Keep the submission state visible until the exit animation removes the card.
+        setSubmission({ kind: submissionKind, phase: "exiting" });
+      }
+    } else {
+      setSubmission(null);
     }
-
-    // Keep the submission state visible until the exit animation removes the card.
-    setIsExiting(true);
   }
 
   function activateOption(index: number) {


### PR DESCRIPTION
## Description

User answers could briefly show the question options again between the answer request completing and the agent retry finishing.

Keep the submitted state active through the full retry lifecycle, preserve the card layout while the options transition to progress, then animate the card out before removing it. Reduced-motion preferences skip the transitions.

Before
<img width="1566" height="1144" alt="Jul-15-2026 2-10-16 PM" src="https://github.com/user-attachments/assets/38e7ceeb-6d16-4c7f-b239-efc4f215d594" />

After
<img width="1566" height="1144" alt="Jul-15-2026 2-08-55 PM" src="https://github.com/user-attachments/assets/168f10b2-ddb4-456c-9f09-9f3d5341bb90" />


## Tests

- Updated component tests to cover the retry gap and reduced-motion completion.

## Risk

- Low. Affects the ask user question response UI.

## Deploy Plan

- Deploy front.
