### PR TITLE
[front] fix: protect equipped skills from context pruning

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -47,10 +47,7 @@ function createConversation() {
   } as any;
 }
 
-function userMessage(
-  text: string,
-  name = "user"
-): ModelMessageTypeMultiActions {
+function userMessage(text: string, name = "user"): UserMessageTypeModel {
   return {
     role: "user" as const,
     name,
@@ -829,5 +826,56 @@ describe("renderConversationForModel", () => {
       leadingMessage,
       userMessage("rendered"),
     ]);
+  });
+
+  it("never drops leading messages when pruning old interactions", async () => {
+    const leadingMessage = userMessage("equipped_skills");
+    vi.mocked(renderAllMessages).mockResolvedValue([
+      userMessage("old_user_1"),
+      assistantMessage("old_assistant_1"),
+      userMessage("old_user_2"),
+      assistantMessage("old_assistant_2"),
+      userMessage("old_user_3"),
+      assistantMessage("old_assistant_3"),
+      userMessage("new_user"),
+      assistantMessage("new_assistant"),
+    ]);
+    mockTokenCounter({
+      byContains: {
+        equipped_skills: 10,
+        old_user_1: 200,
+        old_assistant_1: 200,
+        old_user_2: 200,
+        old_assistant_2: 200,
+        old_user_3: 200,
+        old_assistant_3: 200,
+        new_user: 10,
+        new_assistant: 10,
+      },
+    });
+
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 450,
+      }),
+      leadingMessages: [leadingMessage],
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    expect(res.value.modelConversation.messages[0]).toEqual(leadingMessage);
+    expect(res.value.modelConversation.messages).not.toContainEqual(
+      userMessage("old_user_1")
+    );
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -790,7 +790,7 @@ describe("renderConversationForModel", () => {
   it("prepends leading messages", async () => {
     const leadingMessage = {
       role: "user" as const,
-      name: "user",
+      name: "system",
       content: [{ type: "text" as const, text: "preface" }],
     };
 
@@ -828,8 +828,39 @@ describe("renderConversationForModel", () => {
     ]);
   });
 
+  it("rejects leading messages that are not system user messages", async () => {
+    const leadingMessage = userMessage("preface");
+
+    vi.mocked(renderAllMessages).mockResolvedValue([userMessage("rendered")]);
+    mockTokenCounter({
+      byContains: {
+        preface: 10,
+        rendered: 10,
+      },
+    });
+
+    await expect(
+      renderConversationForModel(auth, {
+        conversation: createConversation(),
+        model,
+        prompt: "PROMPT",
+        enabledSkills: [],
+        tools: "TOOLS",
+        allowedTokenCount: computeAllowedTokenCount({
+          promptTokens: 10,
+          toolsTokens: 10,
+          interactionTokens: 20,
+          availableDelta: 100,
+        }),
+        leadingMessages: [leadingMessage],
+      })
+    ).rejects.toThrow(
+      "Expected every leading message to be a system user message."
+    );
+  });
+
   it("never drops leading messages when pruning old interactions", async () => {
-    const leadingMessage = userMessage("equipped_skills");
+    const leadingMessage = userMessage("equipped_skills", "system");
     vi.mocked(renderAllMessages).mockResolvedValue([
       userMessage("old_user_1"),
       assistantMessage("old_assistant_1"),

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -828,41 +828,6 @@ describe("renderConversationForModel", () => {
     ]);
   });
 
-  it("falls back to normal pruning when leading messages are not system user messages", async () => {
-    const leadingMessage = userMessage("preface");
-    const renderedMessage = userMessage("rendered");
-
-    vi.mocked(renderAllMessages).mockResolvedValue([renderedMessage]);
-    mockTokenCounter({
-      byContains: {
-        preface: 100,
-        rendered: 10,
-      },
-    });
-
-    const res = await renderConversationForModel(auth, {
-      conversation: createConversation(),
-      model,
-      prompt: "PROMPT",
-      enabledSkills: [],
-      tools: "TOOLS",
-      allowedTokenCount: computeAllowedTokenCount({
-        promptTokens: 10,
-        toolsTokens: 10,
-        interactionTokens: 10,
-      }),
-      leadingMessages: [leadingMessage],
-    });
-
-    expect(res.isOk()).toBe(true);
-    if (res.isErr()) {
-      return;
-    }
-
-    expect(res.value.modelConversation.messages).toEqual([renderedMessage]);
-    expect(res.value.prunedContext).toBe(true);
-  });
-
   it("never drops leading messages when pruning old interactions", async () => {
     const leadingMessage = userMessage("equipped_skills", "system");
     vi.mocked(renderAllMessages).mockResolvedValue([

--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -828,35 +828,39 @@ describe("renderConversationForModel", () => {
     ]);
   });
 
-  it("rejects leading messages that are not system user messages", async () => {
+  it("falls back to normal pruning when leading messages are not system user messages", async () => {
     const leadingMessage = userMessage("preface");
+    const renderedMessage = userMessage("rendered");
 
-    vi.mocked(renderAllMessages).mockResolvedValue([userMessage("rendered")]);
+    vi.mocked(renderAllMessages).mockResolvedValue([renderedMessage]);
     mockTokenCounter({
       byContains: {
-        preface: 10,
+        preface: 100,
         rendered: 10,
       },
     });
 
-    await expect(
-      renderConversationForModel(auth, {
-        conversation: createConversation(),
-        model,
-        prompt: "PROMPT",
-        enabledSkills: [],
-        tools: "TOOLS",
-        allowedTokenCount: computeAllowedTokenCount({
-          promptTokens: 10,
-          toolsTokens: 10,
-          interactionTokens: 20,
-          availableDelta: 100,
-        }),
-        leadingMessages: [leadingMessage],
-      })
-    ).rejects.toThrow(
-      "Expected every leading message to be a system user message."
-    );
+    const res = await renderConversationForModel(auth, {
+      conversation: createConversation(),
+      model,
+      prompt: "PROMPT",
+      enabledSkills: [],
+      tools: "TOOLS",
+      allowedTokenCount: computeAllowedTokenCount({
+        promptTokens: 10,
+        toolsTokens: 10,
+        interactionTokens: 10,
+      }),
+      leadingMessages: [leadingMessage],
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      return;
+    }
+
+    expect(res.value.modelConversation.messages).toEqual([renderedMessage]);
+    expect(res.value.prunedContext).toBe(true);
   });
 
   it("never drops leading messages when pruning old interactions", async () => {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -194,20 +194,32 @@ export async function renderConversationForModel(
     0,
     leadingMessages.length
   );
-  if (
-    leadingMessagesWithTokens.length !== leadingMessages.length ||
-    leadingMessagesWithTokens.some(
-      (message) => message.role !== "user" || message.name !== "system"
-    )
-  ) {
-    throw new Error(
-      "Expected every leading message to be a system user message."
+  const shouldProtectLeadingMessages =
+    leadingMessagesWithTokens.length === leadingMessages.length &&
+    leadingMessagesWithTokens.every(
+      (message) => message.role === "user" && message.name === "system"
+    );
+  if (!shouldProtectLeadingMessages) {
+    logger.warn(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        leadingMessagesCount: leadingMessages.length,
+        tokenizedLeadingMessages: leadingMessagesWithTokens.map((message) => ({
+          role: message.role,
+          name: "name" in message ? message.name : undefined,
+        })),
+      },
+      "Leading messages did not match the expected system user messages; falling back to normal conversation pruning."
     );
   }
-  const renderedMessagesWithTokens = messagesWithTokens.slice(
-    leadingMessages.length
-  );
-  const leadingMessagesTokenCount = leadingMessagesWithTokens.reduce(
+  const protectedLeadingMessagesWithTokens = shouldProtectLeadingMessages
+    ? leadingMessagesWithTokens
+    : [];
+  const renderedMessagesWithTokens = shouldProtectLeadingMessages
+    ? messagesWithTokens.slice(leadingMessages.length)
+    : messagesWithTokens;
+  const leadingMessagesTokenCount = protectedLeadingMessagesWithTokens.reduce(
     (sum, message) => sum + message.tokenCount,
     0
   );
@@ -289,7 +301,7 @@ export async function renderConversationForModel(
     leadingMessagesTokenCount + sumInteractionTokens(prunedInteractions);
 
   const selected: MessageWithTokens[] = [
-    ...leadingMessagesWithTokens,
+    ...protectedLeadingMessagesWithTokens,
     ...prunedInteractions.flatMap((interaction) => interaction.messages),
   ];
   const tokensUsed = baseTokens + totalTokens;

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -186,6 +186,20 @@ export async function renderConversationForModel(
   const messagesWithTokens = messagesWithTokensRes.value;
   const [promptCount, toolDefinitionsCount] = promptToolsRes.value;
 
+  // Leading messages include equipped skills. Keep them outside the prunable interactions while
+  // still charging their tokens against both the hard ceiling and the proactive pruning target.
+  const leadingMessagesWithTokens = messagesWithTokens.slice(
+    0,
+    leadingMessages.length
+  );
+  const renderedMessagesWithTokens = messagesWithTokens.slice(
+    leadingMessages.length
+  );
+  const leadingMessagesTokenCount = leadingMessagesWithTokens.reduce(
+    (sum, message) => sum + message.tokenCount,
+    0
+  );
+
   // Calculate base token usage.
   const baseTokens =
     promptCount +
@@ -194,17 +208,22 @@ export async function renderConversationForModel(
     ) +
     TOKENS_MARGIN;
 
-  const interactions = groupMessagesIntoInteractions(messagesWithTokens);
+  const interactions = groupMessagesIntoInteractions(
+    renderedMessagesWithTokens
+  );
 
   // Hard ceiling shared by every interaction combined: previous history plus the current,
   // still-in-progress turn.
-  const budgetForInteractions = allowedTokenCount - baseTokens;
+  const budgetForInteractions =
+    allowedTokenCount - baseTokens - leadingMessagesTokenCount;
 
   // Only applied when positive: a small-context model with a large prompt/tools footprint can
   // push baseTokens past the target alone, and a negative value would make the floor prune by
   // default instead of as a last resort.
   const pruningTargetCeiling =
-    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
+    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION -
+    baseTokens -
+    leadingMessagesTokenCount;
   const pruningBudget =
     pruningTargetCeiling > 0
       ? Math.min(budgetForInteractions, pruningTargetCeiling)
@@ -224,6 +243,7 @@ export async function renderConversationForModel(
       tokenizer: model.tokenizer,
     },
     baseTokens,
+    leadingMessagesTokenCount,
     promptCount,
     toolDefinitionsCount,
     tokensMargin: TOKENS_MARGIN,
@@ -253,11 +273,13 @@ export async function renderConversationForModel(
     prunedContext,
     stats: pruningStats,
   } = pruneRes.value;
-  const totalTokens = sumInteractionTokens(prunedInteractions);
+  const totalTokens =
+    leadingMessagesTokenCount + sumInteractionTokens(prunedInteractions);
 
-  const selected: MessageWithTokens[] = prunedInteractions.flatMap(
-    (interaction) => interaction.messages
-  );
+  const selected: MessageWithTokens[] = [
+    ...leadingMessagesWithTokens,
+    ...prunedInteractions.flatMap((interaction) => interaction.messages),
+  ];
   const tokensUsed = baseTokens + totalTokens;
 
   // Merge content fragments into user messages.

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -186,10 +186,8 @@ export async function renderConversationForModel(
   const messagesWithTokens = messagesWithTokensRes.value;
   const [promptCount, toolDefinitionsCount] = promptToolsRes.value;
 
-  // The leading messages contain the list of equipped skills available to the model. Keep them
-  // outside the prunable interactions so the model always sees that list and can enable a skill
-  // at any point in the conversation. Their tokens still count against both the hard ceiling and
-  // the proactive pruning target.
+  // The leading messages contain the list of equipped skills available to the model. Protect them
+  // so the model always sees that list and can enable a skill at any point in the conversation.
   const leadingMessagesWithTokens = messagesWithTokens.slice(
     0,
     leadingMessages.length
@@ -213,16 +211,13 @@ export async function renderConversationForModel(
       "Leading messages did not match the expected system user messages; falling back to normal conversation pruning."
     );
   }
-  const protectedLeadingMessagesWithTokens = shouldProtectLeadingMessages
-    ? leadingMessagesWithTokens
-    : [];
-  const renderedMessagesWithTokens = shouldProtectLeadingMessages
-    ? messagesWithTokens.slice(leadingMessages.length)
+  const messagesWithPruningProtection = shouldProtectLeadingMessages
+    ? messagesWithTokens.map((message, index) =>
+        index < leadingMessages.length
+          ? { ...message, isProtectedFromPruning: true }
+          : message
+      )
     : messagesWithTokens;
-  const leadingMessagesTokenCount = protectedLeadingMessagesWithTokens.reduce(
-    (sum, message) => sum + message.tokenCount,
-    0
-  );
 
   // Calculate base token usage.
   const baseTokens =
@@ -233,21 +228,18 @@ export async function renderConversationForModel(
     TOKENS_MARGIN;
 
   const interactions = groupMessagesIntoInteractions(
-    renderedMessagesWithTokens
+    messagesWithPruningProtection
   );
 
   // Hard ceiling shared by every interaction combined: previous history plus the current,
   // still-in-progress turn.
-  const budgetForInteractions =
-    allowedTokenCount - baseTokens - leadingMessagesTokenCount;
+  const budgetForInteractions = allowedTokenCount - baseTokens;
 
   // Only applied when positive: a small-context model with a large prompt/tools footprint can
   // push baseTokens past the target alone, and a negative value would make the floor prune by
   // default instead of as a last resort.
   const pruningTargetCeiling =
-    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION -
-    baseTokens -
-    leadingMessagesTokenCount;
+    model.contextSize * PRUNING_TARGET_CONTEXT_UTILIZATION - baseTokens;
   const pruningBudget =
     pruningTargetCeiling > 0
       ? Math.min(budgetForInteractions, pruningTargetCeiling)
@@ -267,7 +259,6 @@ export async function renderConversationForModel(
       tokenizer: model.tokenizer,
     },
     baseTokens,
-    leadingMessagesTokenCount,
     promptCount,
     toolDefinitionsCount,
     tokensMargin: TOKENS_MARGIN,
@@ -297,13 +288,11 @@ export async function renderConversationForModel(
     prunedContext,
     stats: pruningStats,
   } = pruneRes.value;
-  const totalTokens =
-    leadingMessagesTokenCount + sumInteractionTokens(prunedInteractions);
+  const totalTokens = sumInteractionTokens(prunedInteractions);
 
-  const selected: MessageWithTokens[] = [
-    ...protectedLeadingMessagesWithTokens,
-    ...prunedInteractions.flatMap((interaction) => interaction.messages),
-  ];
+  const selected: MessageWithTokens[] = prunedInteractions.flatMap(
+    (interaction) => interaction.messages
+  );
   const tokensUsed = baseTokens + totalTokens;
 
   // Merge content fragments into user messages.
@@ -362,7 +351,13 @@ export async function renderConversationForModel(
 
   // Remove tokenCount from final messages and remove content fragments from return type
   const finalMessages = selected
-    .map(({ tokenCount: _tokenCount, ...msg }) => msg)
+    .map(
+      ({
+        tokenCount: _tokenCount,
+        isProtectedFromPruning: _isProtectedFromPruning,
+        ...msg
+      }) => msg
+    )
     // There should be no content fragments as they have been merged into user messages
     // TODO: refactor how we define the selected array
     .filter(

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -186,8 +186,10 @@ export async function renderConversationForModel(
   const messagesWithTokens = messagesWithTokensRes.value;
   const [promptCount, toolDefinitionsCount] = promptToolsRes.value;
 
-  // Leading messages include equipped skills. Keep them outside the prunable interactions while
-  // still charging their tokens against both the hard ceiling and the proactive pruning target.
+  // The leading messages contain the list of equipped skills available to the model. Keep them
+  // outside the prunable interactions so the model always sees that list and can enable a skill
+  // at any point in the conversation. Their tokens still count against both the hard ceiling and
+  // the proactive pruning target.
   const leadingMessagesWithTokens = messagesWithTokens.slice(
     0,
     leadingMessages.length

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -194,6 +194,16 @@ export async function renderConversationForModel(
     0,
     leadingMessages.length
   );
+  if (
+    leadingMessagesWithTokens.length !== leadingMessages.length ||
+    leadingMessagesWithTokens.some(
+      (message) => message.role !== "user" || message.name !== "system"
+    )
+  ) {
+    throw new Error(
+      "Expected every leading message to be a system user message."
+    );
+  }
   const renderedMessagesWithTokens = messagesWithTokens.slice(
     leadingMessages.length
   );

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -38,6 +38,8 @@ export const TOOL_RESULTS_TO_PRESERVE = 10;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
+  // Protected messages keep both their own content and the interaction containing them.
+  isProtectedFromPruning?: boolean;
 };
 
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
@@ -140,7 +142,10 @@ function pruneToolResultsFlat(
 
   const functionIndices: number[] = [];
   for (let i = 0; i < n; i++) {
-    if (messages[i].role === "function") {
+    if (
+      messages[i].role === "function" &&
+      !messages[i].isProtectedFromPruning
+    ) {
       functionIndices.push(i);
     }
   }
@@ -242,6 +247,7 @@ export function pruneToolResults(
  *
  * Never drops into the last interactionsToPreserve. A caller still over budget after that can
  * retry with a smaller floor, or force pruneToolResults deeper.
+ * Interactions containing a protected message never count toward that floor and are never dropped.
  *
  * batchToCheckpoint decides how much to drop beyond the strict minimum.
  *
@@ -276,26 +282,42 @@ export function dropInteractionsToFit(
     batchToCheckpoint: boolean;
   }
 ): InteractionWithTokens[] {
-  const n = interactions.length;
+  const protectedTokenCount = interactions.reduce(
+    (sum, interaction) =>
+      interaction.messages.some((message) => message.isProtectedFromPruning)
+        ? sum + getInteractionTokenCount(interaction)
+        : sum,
+    0
+  );
+  const droppableInteractions = interactions.filter(
+    (interaction) =>
+      !interaction.messages.some((message) => message.isProtectedFromPruning)
+  );
+  const maxTokensForDroppableInteractions = maxTokens - protectedTokenCount;
+  const n = droppableInteractions.length;
   const floorStart = Math.max(n - interactionsToPreserve, 0);
 
   // Prefix sum over interactions, from the start of the conversation.
   const prefixSum: number[] = [];
   let running = 0;
-  for (const interaction of interactions) {
+  for (const interaction of droppableInteractions) {
     running += getInteractionTokenCount(interaction);
     prefixSum.push(running);
   }
 
-  if (n === 0 || prefixSum[n - 1] <= maxTokens) {
+  if (n === 0 || prefixSum[n - 1] <= maxTokensForDroppableInteractions) {
     return interactions;
   }
 
   // Minimal drop needed: walk oldest-to-newest until the remaining total fits.
   let remaining = prefixSum[n - 1];
   let dropUpToIndex = -1;
-  for (let i = 0; i < floorStart && remaining > maxTokens; i++) {
-    remaining -= getInteractionTokenCount(interactions[i]);
+  for (
+    let i = 0;
+    i < floorStart && remaining > maxTokensForDroppableInteractions;
+    i++
+  ) {
+    remaining -= getInteractionTokenCount(droppableInteractions[i]);
     dropUpToIndex = i;
   }
   if (dropUpToIndex < 0) {
@@ -319,5 +341,14 @@ export function dropInteractionsToFit(
     }
   }
 
-  return interactions.slice(dropUpToIndex + 1);
+  let droppableIndex = 0;
+  return interactions.filter((interaction) => {
+    if (
+      interaction.messages.some((message) => message.isProtectedFromPruning)
+    ) {
+      return true;
+    }
+
+    return droppableIndex++ > dropUpToIndex;
+  });
 }


### PR DESCRIPTION
## Description

Equipped skills are rendered as part of a leading user message. Our pruning currently sometimes drops it, it's treated as one interaction like any other, leaving the model without the list of skills available to enable.

Keep leading messages outside the prunable interaction history while still counting their tokens against both the hard context ceiling and proactive pruning target. Had considered using `role: "user", name: "system"` as a criterion for not dropping a message, but it's also used by enabled-skill instructions later in the conversation so cannot be used like this (these are dropped at compaction).

## Tests

- Updated tests. Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
