### PR TITLE
Filter sandbox function tools without an agent loop

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -236,30 +236,36 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     );
   });
 
-  it("creates actions for conversation-coupled servers too", async () => {
-    // No creation-time gating on the server: tools that require an agent-loop context error at
-    // execution based on the run context.
+  it("rejects tools that require an agent loop", async () => {
     const context =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
-    const search = await InternalMCPServerInMemoryResource.makeNew(
+    const agentMemory = await InternalMCPServerInMemoryResource.makeNew(
       context.auth,
-      { name: "search", useCase: null }
+      { name: "agent_memory", useCase: null }
     );
     const view = await MCPServerViewFactory.create(
       context.workspace,
-      search.id,
+      agentMemory.id,
       context.globalSpace
     );
 
     const response = await callSandboxTool(context.workspace, context.token, {
       serverViewId: view.sId,
-      toolName: "semantic_search",
+      toolName: "retrieve",
       arguments: {},
     });
 
-    expect(response.status).toBe(202);
-    const body = await response.json();
-    expect(body.status).toBe("pending");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Tool retrieve not found on server agent_memory.",
+      },
+    });
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
+    expect(
+      vi.mocked(publishSandboxFunctionInvocationEvent)
+    ).not.toHaveBeenCalled();
   });
 
   it("rejects unknown tools on an allowed server", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -28,6 +28,13 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
     for (const serverView of body.serverViews) {
       expect(serverView.server.availability).not.toBe("manual");
     }
+    const commonUtilities = body.serverViews.find(
+      (serverView: { server: { name: string } }) =>
+        serverView.server.name === "common_utilities"
+    );
+    expect(
+      commonUtilities.server.tools.map((tool: { name: string }) => tool.name)
+    ).toContain("set_conversation_title");
   });
 
   it("returns 403 when Computer is disabled", async () => {
@@ -64,6 +71,11 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
       useCase: null,
     });
     await MCPServerViewFactory.create(workspace, search.id, globalSpace);
+    const agentMemory = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "agent_memory",
+      useCase: null,
+    });
+    await MCPServerViewFactory.create(workspace, agentMemory.id, globalSpace);
     const remoteServer = await RemoteMCPServerFactory.create(workspace, {
       name: "remote_server",
     });
@@ -78,5 +90,15 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
         .map((sv: { server: { name: string } }) => sv.server.name)
         .sort()
     ).toEqual(["common_utilities", "remote_server", "search"]);
+
+    const commonUtilitiesView = body.serverViews.find(
+      (sv: { server: { name: string } }) =>
+        sv.server.name === "common_utilities"
+    );
+    const commonUtilitiesToolNames = commonUtilitiesView.server.tools.map(
+      (tool: { name: string }) => tool.name
+    );
+    expect(commonUtilitiesToolNames).toContain("generate_random_number");
+    expect(commonUtilitiesToolNames).not.toContain("set_conversation_title");
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -76,6 +76,11 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
       useCase: null,
     });
     await MCPServerViewFactory.create(workspace, agentMemory.id, globalSpace);
+    const runDustApp = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "run_dust_app",
+      useCase: null,
+    });
+    await MCPServerViewFactory.create(workspace, runDustApp.id, globalSpace);
     const remoteServer = await RemoteMCPServerFactory.create(workspace, {
       name: "remote_server",
     });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -10,6 +10,7 @@ import {
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
 } from "@app/lib/api/sandbox/access_tokens";
+import { listSandboxFunctionMCPServerViews } from "@app/lib/api/sandbox_functions/list_tools";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
@@ -68,19 +69,11 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   const claims = ctx.get("sandboxClaims");
 
   // Sandbox function invocations have no agent configuration or conversation: they see the
-  // servers of their pod space (+ global space). Tools that require an agent-loop context error
-  // at execution based on the run context.
+  // compatible tools from their pod space (+ global space).
   if (isSandboxFunctionInvocationTokenPayload(claims)) {
-    // Deliberately not the EnsuringAutoViews variant: token read paths must not write. Auto
-    // views not yet materialized in the global space stay invisible until another surface
-    // hydrates them.
-    const views = await MCPServerViewResource.listBySpaceIds(
-      auth,
-      [claims.spaceId],
-      { includeGlobalSpace: true }
-    );
-
-    const serverViews = views.map((view) => view.toJSON());
+    const serverViews = await listSandboxFunctionMCPServerViews(auth, {
+      spaceId: claims.spaceId,
+    });
 
     return ctx.json(
       { serverViews: filterServerViews(serverViews, ctx.req.query()) },

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -894,7 +894,7 @@ function makeClientSideMCPConnectionParams(
 
 type AgentLoopListToolsContextWithoutConfigurationType = Omit<
   AgentLoopListToolsContext,
-  "agentActionConfiguration"
+  "agentActionConfiguration" | "contextType"
 >;
 
 /**
@@ -1109,6 +1109,7 @@ export async function tryListMCPTools(
           action,
           {
             ...agentLoopListToolsContext,
+            contextType: "agent_loop",
             agentActionConfiguration: action,
           },
           connectionParams

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -108,9 +108,11 @@ import { slugify } from "@app/types/shared/utils/string_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
+  type CallToolResult,
   CallToolResultSchema,
+  ErrorCode,
+  McpError,
   ProgressNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Context, heartbeat } from "@temporalio/activity";
@@ -730,7 +732,7 @@ export async function* tryCallMCPTool(
   }
 }
 
-function makeServerSideMCPConnectionParams(
+export function makeServerSideMCPConnectionParams(
   mcpServerView: MCPServerViewResource
 ): ServerSideMCPConnectionParams {
   return {
@@ -894,7 +896,7 @@ function makeClientSideMCPConnectionParams(
 
 type AgentLoopListToolsContextWithoutConfigurationType = Omit<
   AgentLoopListToolsContext,
-  "agentActionConfiguration" | "contextType"
+  "agentActionConfiguration"
 >;
 
 /**
@@ -1109,7 +1111,6 @@ export async function tryListMCPTools(
           action,
           {
             ...agentLoopListToolsContext,
-            contextType: "agent_loop",
             agentActionConfiguration: action,
           },
           connectionParams
@@ -1395,16 +1396,45 @@ export async function buildToolConfigurationsFromRawTools(
   return new Ok(serverSideToolConfigs);
 }
 
-async function listMCPServerToolsAndServerInstructions(
+export async function listMCPServerToolsAndServerInstructions(
   auth: Authenticator,
   config: MCPServerConfigurationType,
-  agentLoopListToolsContext: AgentLoopListToolsContext,
-  connectionParams: MCPConnectionParams
+  agentLoopListToolsContext: AgentLoopListToolsContext | null,
+  connectionParams: MCPConnectionParams,
+  { cachedTools }: { cachedTools?: MCPToolType[] } = {}
 ): Promise<
   Result<{ instructions?: string; tools: MCPToolConfigurationType[] }, Error>
 > {
   const owner = auth.getNonNullableWorkspace();
   let mcpClient;
+
+  // A sandbox function has no agent loop in which to handle remote authentication or rate
+  // limits. Keep the normal listing pipeline, but use the view's cached remote tools in that
+  // context instead of making a third-party request.
+  if (agentLoopListToolsContext === null && cachedTools) {
+    assert(
+      isConnectViaMCPServerId(connectionParams) &&
+        isServerSideMCPServerConfiguration(config),
+      "Cached tools require a server-side MCP configuration."
+    );
+    const toolsRes = await buildToolConfigurationsFromRawTools(
+      auth,
+      connectionParams.mcpServerId,
+      config,
+      cachedTools
+    );
+    if (toolsRes.isErr()) {
+      return toolsRes;
+    }
+    return new Ok({ instructions: undefined, tools: toolsRes.value });
+  }
+
+  const agentLoopLogContext = agentLoopListToolsContext
+    ? {
+        conversationId: agentLoopListToolsContext.conversation.sId,
+        messageId: agentLoopListToolsContext.agentMessage.sId,
+      }
+    : {};
 
   try {
     // Connect to the MCP server.
@@ -1489,8 +1519,7 @@ async function listMCPServerToolsAndServerInstructions(
     logger.debug(
       {
         workspaceId: owner.sId,
-        conversationId: agentLoopListToolsContext.conversation.sId,
-        messageId: agentLoopListToolsContext.agentMessage.sId,
+        ...agentLoopLogContext,
         toolCount: toolsFromServer.length,
       },
       `Retrieved ${toolsFromServer.length} tools from MCP server`
@@ -1499,11 +1528,19 @@ async function listMCPServerToolsAndServerInstructions(
     // Return server instructions and the tools from this server.
     return new Ok({ instructions: serverInstructions, tools: toolsFromServer });
   } catch (error) {
+    // McpServer installs the tools/list handler only after its first tool is registered. It is
+    // valid for a context without an agent loop to filter every tool from an internal server.
+    if (
+      agentLoopListToolsContext === null &&
+      error instanceof McpError &&
+      error.code === ErrorCode.MethodNotFound
+    ) {
+      return new Ok({ instructions: undefined, tools: [] });
+    }
     logger.error(
       {
         workspaceId: owner.sId,
-        conversationId: agentLoopListToolsContext.conversation.sId,
-        messageId: agentLoopListToolsContext.agentMessage.sId,
+        ...agentLoopLogContext,
         error,
       },
       `Error listing tools from MCP server: ${normalizeError(error)}`
@@ -1518,8 +1555,7 @@ async function listMCPServerToolsAndServerInstructions(
         logger.warn(
           {
             workspaceId: owner.sId,
-            conversationId: agentLoopListToolsContext.conversation.sId,
-            messageId: agentLoopListToolsContext.agentMessage.sId,
+            ...agentLoopLogContext,
             error: closeError,
           },
           "Error closing MCP client connection"

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,6 +1,9 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  isAgentLoopListToolsContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -103,7 +106,7 @@ function isAdvancedSearchMode(toolContext?: ToolContext) {
         ADVANCED_SEARCH_SWITCH
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ] === true) ||
-    (toolContext?.listToolsContext &&
+    (isAgentLoopListToolsContext(toolContext?.listToolsContext) &&
       isServerSideMCPServerConfiguration(
         toolContext.listToolsContext.agentActionConfiguration
       ) &&

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -48,6 +48,9 @@ export interface ToolDefinition<
 > {
   name: TName;
   enableAlerting?: boolean;
+  // Tools that rely on conversation, agent, or message state are not exposed to sandbox
+  // functions, which run without an agent loop.
+  agentLoopContextRequired?: true;
   // When true, the tool is kept in the cached tools prefix (loaded upfront)
   // instead of being deferred behind tool search. Defaults to deferred.
   eager?: boolean;
@@ -131,12 +134,15 @@ export function buildClientTools<T extends Record<string, ClientToolMeta>>(
 
 export function buildTools<T extends Record<string, ToolMeta>>(
   metadata: T,
-  handlers: ToolHandlers<T>
+  handlers: ToolHandlers<T>,
+  { agentLoopContextRequired }: { agentLoopContextRequired?: true } = {}
 ): ToolDefinition[] {
   return (Object.keys(metadata) as (keyof T & string)[]).map(
     (key) =>
       ({
         ...metadata[key],
+        agentLoopContextRequired:
+          metadata[key].agentLoopContextRequired ?? agentLoopContextRequired,
         handler: handlers[key],
       }) as unknown as ToolDefinition
   );

--- a/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/utils.ts
@@ -1,4 +1,7 @@
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  isAgentLoopListToolsContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
@@ -15,7 +18,7 @@ function hasTagAutoMode(dataSourceConfigurations: DataSourceConfiguration[]) {
 export function shouldAutoGenerateTags(toolContext: ToolContext): boolean {
   const { listToolsContext, runContext } = toolContext;
   if (
-    !!listToolsContext?.agentActionConfiguration &&
+    isAgentLoopListToolsContext(listToolsContext) &&
     isServerSideMCPServerConfiguration(
       listToolsContext.agentActionConfiguration
     ) &&

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
+  isSandboxFunctionListToolsContext,
   isSandboxFunctionRunContext,
   type ToolContext,
   type ToolRunContext,
@@ -34,6 +35,13 @@ export function registerTool(
   tool: ToolDefinition,
   { monitoringName }: { monitoringName: string }
 ): void {
+  const isSandboxFunctionContext =
+    isSandboxFunctionRunContext(toolContext?.runContext) ||
+    isSandboxFunctionListToolsContext(toolContext?.listToolsContext);
+  if (isSandboxFunctionContext && tool.agentLoopContextRequired) {
+    return;
+  }
+
   server.registerTool(
     tool.name,
     {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,7 +5,6 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  isSandboxFunctionListToolsContext,
   isSandboxFunctionRunContext,
   type ToolContext,
   type ToolRunContext,
@@ -37,7 +36,7 @@ export function registerTool(
 ): void {
   const isSandboxFunctionContext =
     isSandboxFunctionRunContext(toolContext?.runContext) ||
-    isSandboxFunctionListToolsContext(toolContext?.listToolsContext);
+    toolContext?.listToolsContext === null;
   if (isSandboxFunctionContext && tool.agentLoopContextRequired) {
     return;
   }

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -184,6 +184,7 @@ export type SandboxFunctionRunContext = {
 };
 
 export type AgentLoopListToolsContext = {
+  contextType: "agent_loop";
   agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
@@ -193,11 +194,6 @@ export type AgentLoopListToolsContext = {
 
 export type SandboxFunctionListToolsContext = {
   contextType: "sandbox_function";
-  agentConfiguration?: never;
-  agentActionConfiguration?: never;
-  clientSideActionConfigurations?: never;
-  conversation?: never;
-  agentMessage?: never;
 };
 
 export type ToolListToolsContext =
@@ -223,17 +219,13 @@ export function isAgentLoopRunContext(
 export function isSandboxFunctionListToolsContext(
   value: ToolListToolsContext | undefined
 ): value is SandboxFunctionListToolsContext {
-  return (
-    value !== undefined &&
-    "contextType" in value &&
-    value.contextType === "sandbox_function"
-  );
+  return value?.contextType === "sandbox_function";
 }
 
 export function isAgentLoopListToolsContext(
   value: ToolListToolsContext | undefined
 ): value is AgentLoopListToolsContext {
-  return value !== undefined && !isSandboxFunctionListToolsContext(value);
+  return value?.contextType === "agent_loop";
 }
 
 export type ToolContext =

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -191,6 +191,19 @@ export type AgentLoopListToolsContext = {
   agentMessage: AgentMessageType;
 };
 
+export type SandboxFunctionListToolsContext = {
+  contextType: "sandbox_function";
+  agentConfiguration?: never;
+  agentActionConfiguration?: never;
+  clientSideActionConfigurations?: never;
+  conversation?: never;
+  agentMessage?: never;
+};
+
+export type ToolListToolsContext =
+  | AgentLoopListToolsContext
+  | SandboxFunctionListToolsContext;
+
 // Context available to tool handlers at execution time: tools only ever run on a connection
 // established with a run context, never on a listing-phase connection.
 export type ToolRunContext = AgentLoopRunContext | SandboxFunctionRunContext;
@@ -207,6 +220,22 @@ export function isAgentLoopRunContext(
   return value?.contextType === "agent_loop";
 }
 
+export function isSandboxFunctionListToolsContext(
+  value: ToolListToolsContext | undefined
+): value is SandboxFunctionListToolsContext {
+  return (
+    value !== undefined &&
+    "contextType" in value &&
+    value.contextType === "sandbox_function"
+  );
+}
+
+export function isAgentLoopListToolsContext(
+  value: ToolListToolsContext | undefined
+): value is AgentLoopListToolsContext {
+  return value !== undefined && !isSandboxFunctionListToolsContext(value);
+}
+
 export type ToolContext =
   | {
       runContext: ToolRunContext;
@@ -214,5 +243,5 @@ export type ToolContext =
     }
   | {
       runContext?: never;
-      listToolsContext: AgentLoopListToolsContext;
+      listToolsContext: ToolListToolsContext;
     };

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -184,21 +184,12 @@ export type SandboxFunctionRunContext = {
 };
 
 export type AgentLoopListToolsContext = {
-  contextType: "agent_loop";
   agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;
   agentMessage: AgentMessageType;
 };
-
-export type SandboxFunctionListToolsContext = {
-  contextType: "sandbox_function";
-};
-
-export type ToolListToolsContext =
-  | AgentLoopListToolsContext
-  | SandboxFunctionListToolsContext;
 
 // Context available to tool handlers at execution time: tools only ever run on a connection
 // established with a run context, never on a listing-phase connection.
@@ -216,16 +207,10 @@ export function isAgentLoopRunContext(
   return value?.contextType === "agent_loop";
 }
 
-export function isSandboxFunctionListToolsContext(
-  value: ToolListToolsContext | undefined
-): value is SandboxFunctionListToolsContext {
-  return value?.contextType === "sandbox_function";
-}
-
 export function isAgentLoopListToolsContext(
-  value: ToolListToolsContext | undefined
+  value: AgentLoopListToolsContext | null | undefined
 ): value is AgentLoopListToolsContext {
-  return value?.contextType === "agent_loop";
+  return value !== null && value !== undefined;
 }
 
 export type ToolContext =
@@ -235,5 +220,6 @@ export type ToolContext =
     }
   | {
       runContext?: never;
-      listToolsContext: ToolListToolsContext;
+      // Null when listing tools outside an agent loop, such as for a sandbox function.
+      listToolsContext: AgentLoopListToolsContext | null;
     };

--- a/front/lib/api/actions/servers/agent_memory/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
-  isSandboxFunctionListToolsContext,
   isSandboxFunctionRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -17,7 +16,7 @@ function createServer(
   const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
 
   if (
-    isSandboxFunctionListToolsContext(toolContext?.listToolsContext) ||
+    toolContext?.listToolsContext === null ||
     isSandboxFunctionRunContext(toolContext?.runContext)
   ) {
     return server;

--- a/front/lib/api/actions/servers/agent_memory/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/index.ts
@@ -1,6 +1,10 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  isSandboxFunctionListToolsContext,
+  isSandboxFunctionRunContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_memory/tools";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,6 +15,13 @@ function createServer(
   toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
+
+  if (
+    isSandboxFunctionListToolsContext(toolContext?.listToolsContext) ||
+    isSandboxFunctionRunContext(toolContext?.runContext)
+  ) {
+    return server;
+  }
 
   // For now we only support user-scoped memory, the code below allows to support agent-level memory
   // which is somewhat dangerous as it can leak data across users while use cases are not completely

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -164,4 +164,6 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
   },
 };
 
-export const TOOLS = buildTools(AGENT_MEMORY_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(AGENT_MEMORY_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/tools/index.ts
@@ -95,5 +95,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA> =
 
 export const TOOLS = buildTools(
   AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA,
-  handlers
+  handlers,
+  { agentLoopContextRequired: true }
 );

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -1815,5 +1815,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
 
 export const TOOLS = buildTools(
   AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
-  handlers
+  handlers,
+  { agentLoopContextRequired: true }
 );

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -61,4 +61,6 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   },
 };
 
-export const TOOLS = buildTools(ASK_USER_QUESTION_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(ASK_USER_QUESTION_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/common_utilities/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/index.ts
@@ -1,6 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -21,7 +22,10 @@ function createServer(
   const conversation =
     (isAgentLoopRunContext(toolContext?.runContext)
       ? toolContext.runContext.conversation
-      : null) ?? toolContext?.listToolsContext?.conversation;
+      : null) ??
+    (isAgentLoopListToolsContext(toolContext?.listToolsContext)
+      ? toolContext.listToolsContext.conversation
+      : null);
 
   for (const tool of TOOLS) {
     // Skip the conversation-title tool if there is no conversation in tool context.

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -104,6 +104,7 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
   [SET_CONVERSATION_TITLE_TOOL_NAME]: {
+    agentLoopContextRequired: true,
     description:
       "Update the title of the current conversation. Use this to give the conversation a descriptive name that summarizes its topic.",
     schema: {

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -1,6 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -21,7 +22,10 @@ async function createServer(
   const conversation =
     (isAgentLoopRunContext(toolContext?.runContext)
       ? toolContext.runContext.conversation
-      : null) ?? toolContext?.listToolsContext?.conversation;
+      : null) ??
+    (isAgentLoopListToolsContext(toolContext?.listToolsContext)
+      ? toolContext.listToolsContext.conversation
+      : null);
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
   for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -398,7 +398,9 @@ async function getFileFromConversation(
   });
 }
 
-export const TOOLS = buildTools(CONVERSATION_FILES_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(CONVERSATION_FILES_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});
 
 const handlersWithFilesystem: ToolHandlers<
   typeof CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM
@@ -411,5 +413,6 @@ const handlersWithFilesystem: ToolHandlers<
 
 export const TOOLS_WITH_FILESYSTEM = buildTools(
   CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM,
-  handlersWithFilesystem
+  handlersWithFilesystem,
+  { agentLoopContextRequired: true }
 );

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -128,6 +128,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
   },
   query: {
+    agentLoopContextRequired: true,
     description:
       "Run, execute, or write SQL queries on selected data warehouse tables to calculate metrics, aggregate results, analyze revenue, or answer business questions. " +
       "You MUST call describe_tables at least once before attempting to query tables to understand their structure. The query must respect the SQL dialect " +

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -5,6 +5,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -37,7 +38,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 function getServerSideConfiguration(toolContext?: ToolContext) {
   if (
-    toolContext?.listToolsContext &&
+    isAgentLoopListToolsContext(toolContext?.listToolsContext) &&
     isServerSideMCPServerConfiguration(
       toolContext.listToolsContext.agentActionConfiguration
     )
@@ -224,7 +225,9 @@ export function createExtractDataTools(
         return extractFunction(params);
       },
     };
-    return buildTools(toolsMetadata, handlers);
+    return buildTools(toolsMetadata, handlers, {
+      agentLoopContextRequired: true,
+    });
   }
 
   const toolsMetadata = makeExtractDataToolsWithTagsMetadata({
@@ -241,5 +244,7 @@ export function createExtractDataTools(
       return executeFindTags(auth, query, dataSources);
     },
   };
-  return buildTools(toolsMetadata, handlers);
+  return buildTools(toolsMetadata, handlers, {
+    agentLoopContextRequired: true,
+  });
 }

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -39,4 +39,6 @@ const HANDLERS = {
   [FILES_RESOLVE_ACTION_NAME]: resolveHandler,
 };
 
-export const TOOLS = buildTools(FILES_TOOLS_METADATA, HANDLERS);
+export const TOOLS = buildTools(FILES_TOOLS_METADATA, HANDLERS, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -45,8 +46,11 @@ export function getSidekickMetadataFromContext(
 ): SidekickMetadata | null {
   const metadata =
     (isAgentLoopRunContext(toolContext?.runContext)
-      ? toolContext?.runContext?.conversation.metadata
-      : null) ?? toolContext?.listToolsContext?.conversation.metadata;
+      ? toolContext.runContext.conversation.metadata
+      : null) ??
+    (isAgentLoopListToolsContext(toolContext?.listToolsContext)
+      ? toolContext.listToolsContext.conversation.metadata
+      : null);
 
   return metadata ? extractSidekickMetadata(metadata) : null;
 }

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -181,5 +181,7 @@ export function createImageGenerationTools(
     },
   };
 
-  return buildTools(IMAGE_GENERATION_TOOLS_METADATA, handlers);
+  return buildTools(IMAGE_GENERATION_TOOLS_METADATA, handlers, {
+    agentLoopContextRequired: true,
+  });
 }

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -42,6 +42,7 @@ export const FRAME_RECREATE_WASTE_RATIONALE =
 
 export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   [CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+    agentLoopContextRequired: true,
     description:
       "Create a new Frame: interactive content such as a dashboard, data visualization, or slideshow " +
       "presentation that users can run and interact with, beyond static viewing. Choose 'template' " +
@@ -158,6 +159,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
   },
   [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+    agentLoopContextRequired: true,
     description:
       "Revert a Frame to its previous version. " +
       "Each revert goes back one version in the file's history. ",

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -6,6 +6,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -467,7 +468,9 @@ export async function createInteractiveContentTools(
   const { runContext } = toolContext ?? {};
   const conversation = isAgentLoopRunContext(runContext)
     ? runContext.conversation
-    : toolContext?.listToolsContext?.conversation;
+    : isAgentLoopListToolsContext(toolContext?.listToolsContext)
+      ? toolContext.listToolsContext.conversation
+      : null;
   if (conversation?.metadata?.useFileSystem === true) {
     return tools.filter(
       (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -1,7 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
+  isSandboxFunctionListToolsContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import { Err, Ok } from "@app/types/shared/result";
@@ -15,10 +17,16 @@ const MAX_ATTEMPTED_ACTION_NAME_LENGTH = 256;
 export function createMissingActionCatcherTools(
   agentLoopContext?: ToolContext
 ): ToolDefinition[] {
+  if (isSandboxFunctionListToolsContext(agentLoopContext?.listToolsContext)) {
+    return [];
+  }
+
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext
       ? agentLoopContext.runContext.toolConfiguration.name
-      : agentLoopContext.listToolsContext?.agentActionConfiguration.name;
+      : isAgentLoopListToolsContext(agentLoopContext.listToolsContext)
+        ? agentLoopContext.listToolsContext.agentActionConfiguration.name
+        : null;
 
     if (!actionName) {
       throw new Error("No action name found");

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -3,7 +3,6 @@ import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_
 import {
   isAgentLoopListToolsContext,
   isAgentLoopRunContext,
-  isSandboxFunctionListToolsContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import { Err, Ok } from "@app/types/shared/result";
@@ -17,7 +16,7 @@ const MAX_ATTEMPTED_ACTION_NAME_LENGTH = 256;
 export function createMissingActionCatcherTools(
   agentLoopContext?: ToolContext
 ): ToolDefinition[] {
-  if (isSandboxFunctionListToolsContext(agentLoopContext?.listToolsContext)) {
+  if (agentLoopContext?.listToolsContext === null) {
     return [];
   }
 

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -165,4 +165,6 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
   },
 };
 
-export const TOOLS = buildTools(PLAN_MODE_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(PLAN_MODE_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -64,6 +64,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
+    agentLoopContextRequired: true,
     description:
       "Run and execute SQL against selected agent-configured structured data tables to analyze, aggregate, filter, join, or export result rows. " +
       "Before using this tool, the agent should have already called get_database_schema for every involved table URI and should use that inspected table structure to write the SQL. " +

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/lib/actions/tool_interruptions";
 import {
   type ActionGeneratedFileType,
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -762,7 +763,7 @@ function isRunAgentHandoffMode(toolContext?: ToolContext): boolean {
   }
 
   // Check if we're in the listToolsContext (when presenting tools to the model).
-  if (toolContext.listToolsContext) {
+  if (isAgentLoopListToolsContext(toolContext.listToolsContext)) {
     const agentActionConfig =
       toolContext.listToolsContext.agentActionConfiguration;
     if (
@@ -852,7 +853,7 @@ async function createServer(
   let childAgentId: string | null = null;
 
   if (
-    toolContext?.listToolsContext &&
+    isAgentLoopListToolsContext(toolContext?.listToolsContext) &&
     isServerSideMCPServerConfiguration(
       toolContext.listToolsContext.agentActionConfiguration
     ) &&
@@ -889,6 +890,7 @@ async function createServer(
       server,
       {
         name: "run_agent_tool_not_available",
+        agentLoopContextRequired: true,
         description:
           "No child agent configured for this tool, as the child agent was probably archived. " +
           "Do not attempt to run the tool and warn the user instead.",
@@ -942,6 +944,7 @@ async function createServer(
 
   const toolDefinition: ToolDefinition = {
     name: toolName,
+    agentLoopContextRequired: true,
     description: toolDescription,
     schema: schema,
     stake: "never_ask",

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -10,7 +10,6 @@ import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
   isAgentLoopListToolsContext,
   isAgentLoopRunContext,
-  isSandboxFunctionListToolsContext,
   isSandboxFunctionRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -60,7 +59,7 @@ export default async function createServer(
   const owner = auth.getNonNullableWorkspace();
 
   if (
-    isSandboxFunctionListToolsContext(toolContext?.listToolsContext) ||
+    toolContext?.listToolsContext === null ||
     isSandboxFunctionRunContext(toolContext?.runContext)
   ) {
     return server;

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -11,6 +11,7 @@ import {
   isAgentLoopListToolsContext,
   isAgentLoopRunContext,
   isSandboxFunctionListToolsContext,
+  isSandboxFunctionRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import {
@@ -58,7 +59,10 @@ export default async function createServer(
   const server = makeInternalMCPServer("run_dust_app");
   const owner = auth.getNonNullableWorkspace();
 
-  if (isSandboxFunctionListToolsContext(toolContext?.listToolsContext)) {
+  if (
+    isSandboxFunctionListToolsContext(toolContext?.listToolsContext) ||
+    isSandboxFunctionRunContext(toolContext?.runContext)
+  ) {
     return server;
   }
 

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -8,7 +8,9 @@ import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import {
+  isAgentLoopListToolsContext,
   isAgentLoopRunContext,
+  isSandboxFunctionListToolsContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import {
@@ -56,7 +58,11 @@ export default async function createServer(
   const server = makeInternalMCPServer("run_dust_app");
   const owner = auth.getNonNullableWorkspace();
 
-  if (toolContext?.listToolsContext) {
+  if (isSandboxFunctionListToolsContext(toolContext?.listToolsContext)) {
+    return server;
+  }
+
+  if (isAgentLoopListToolsContext(toolContext?.listToolsContext)) {
     // Context: Listing tools for an agent
     const { agentActionConfiguration } = toolContext.listToolsContext;
     if (

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -243,7 +243,9 @@ export async function createSandboxTools(
     [ADD_EGRESS_DOMAIN_TOOL_NAME]: addEgressDomainTool,
   };
 
-  const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers);
+  const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers, {
+    agentLoopContextRequired: true,
+  });
 
   // The add_egress_domain tool requires Computer access and the
   // per-workspace setting that admins toggle on top of it.

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -249,5 +249,7 @@ export function createSchedulesManagementTools(
     },
   };
 
-  return buildTools(SCHEDULES_MANAGEMENT_TOOLS_METADATA, handlers);
+  return buildTools(SCHEDULES_MANAGEMENT_TOOLS_METADATA, handlers, {
+    agentLoopContextRequired: true,
+  });
 }

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -170,4 +170,6 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
   },
 };
 
-export const TOOLS = buildTools(SKILL_MANAGEMENT_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(SKILL_MANAGEMENT_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -147,4 +147,6 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   },
 };
 
-export const TOOLS = buildTools(TOOLSETS_TOOLS_METADATA, handlers);
+export const TOOLS = buildTools(TOOLSETS_TOOLS_METADATA, handlers, {
+  agentLoopContextRequired: true,
+});

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -332,5 +332,7 @@ export function createWakeupsTools(
     },
   };
 
-  return buildTools(WAKEUPS_TOOLS_METADATA, handlers);
+  return buildTools(WAKEUPS_TOOLS_METADATA, handlers, {
+    agentLoopContextRequired: true,
+  });
 }

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -6,6 +6,7 @@ import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { listSandboxFunctionToolsForMCPServerView } from "@app/lib/api/sandbox_functions/list_tools";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -31,8 +32,8 @@ export class SandboxFunctionMCPActionError extends Error {
   }
 }
 
-// Resolves a tool for execution from a sandbox function invocation. The tool must exist and be
-// enabled. Tools that need an agent-loop context error at execution based on the run context.
+// Resolves a tool for execution from a sandbox function invocation. The tool must be compatible
+// with a conversation-free function context and enabled on the view.
 async function resolveSandboxFunctionTool(
   auth: Authenticator,
   view: MCPServerViewResource,
@@ -41,7 +42,20 @@ async function resolveSandboxFunctionTool(
   Result<ServerSideMCPToolConfigurationType, SandboxFunctionMCPActionError>
 > {
   const viewJSON = view.toJSON();
-  const tool = viewJSON.server.tools.find((t) => t.name === toolName);
+  const toolsResult = await listSandboxFunctionToolsForMCPServerView(
+    auth,
+    view
+  );
+  if (toolsResult.isErr()) {
+    return new Err(
+      new SandboxFunctionMCPActionError(
+        "tool_not_available",
+        `Could not list tools on server ${viewJSON.server.name}.`
+      )
+    );
+  }
+
+  const tool = toolsResult.value.find((t) => t.name === toolName);
   if (!tool) {
     return new Err(
       new SandboxFunctionMCPActionError(

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -6,13 +6,15 @@ import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { listSandboxFunctionToolsForMCPServerView } from "@app/lib/api/sandbox_functions/list_tools";
+import {
+  listSandboxFunctionToolsForMCPServerView,
+  makeSandboxFunctionMCPServerConfiguration,
+} from "@app/lib/api/sandbox_functions/list_tools";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -65,30 +67,11 @@ async function resolveSandboxFunctionTool(
     );
   }
 
-  // View-default server configuration: there is no agent configuration to inject settings from
-  // (same synthesized shape as JIT servers, see `jit/common_utilities.ts`).
+  // View-default server configuration: there is no agent configuration to inject settings from.
   const toolConfigurationsRes = await buildToolConfigurationsFromRawTools(
     auth,
     view.mcpServerId,
-    {
-      id: -1,
-      sId: generateRandomModelSId(),
-      type: "mcp_server_configuration",
-      name: viewJSON.name ?? viewJSON.server.name,
-      description: viewJSON.description ?? viewJSON.server.description,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      mcpServerViewId: viewJSON.sId,
-      dustAppConfiguration: null,
-      secretName: null,
-      dustProject: null,
-      // Null for remote servers, matching the agent path (see `configuration/actions.ts`).
-      internalMCPServerId: view.internalMCPServerId,
-    },
+    makeSandboxFunctionMCPServerConfiguration(view),
     [{ name: tool.name, description: tool.description }]
   );
   if (toolConfigurationsRes.isErr()) {

--- a/front/lib/api/sandbox_functions/list_tools.ts
+++ b/front/lib/api/sandbox_functions/list_tools.ts
@@ -12,6 +12,9 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 
+// Internal MCP servers are in-memory, but workspaces can expose many views at once.
+const SANDBOX_FUNCTION_TOOL_LISTING_CONCURRENCY = 8;
+
 /**
  * Returns the tools a sandbox function can call from a server view.
  *
@@ -29,23 +32,22 @@ export async function listSandboxFunctionToolsForMCPServerView(
     case "remote":
       return new Ok(viewJSON.server.tools);
     case "internal": {
-      let mcpClient: Client | undefined;
-      try {
-        const connectionResult = await connectToMCPServer(auth, {
-          params: {
-            type: "mcpServerId",
-            mcpServerId: view.mcpServerId,
-            oAuthUseCase: viewJSON.oAuthUseCase,
-          },
-          toolContext: {
-            listToolsContext: { contextType: "sandbox_function" },
-          },
-        });
-        if (connectionResult.isErr()) {
-          return new Err(connectionResult.error);
-        }
+      const connectionResult = await connectToMCPServer(auth, {
+        params: {
+          type: "mcpServerId",
+          mcpServerId: view.mcpServerId,
+          oAuthUseCase: viewJSON.oAuthUseCase,
+        },
+        toolContext: {
+          listToolsContext: { contextType: "sandbox_function" },
+        },
+      });
+      if (connectionResult.isErr()) {
+        return new Err(connectionResult.error);
+      }
 
-        mcpClient = connectionResult.value;
+      const mcpClient: Client = connectionResult.value;
+      try {
         const toolsResult = await mcpClient.listTools();
         const availableToolNames = new Set(
           toolsResult.tools.map((tool) => tool.name)
@@ -67,19 +69,17 @@ export async function listSandboxFunctionToolsForMCPServerView(
         }
         return new Err(normalizeError(error));
       } finally {
-        if (mcpClient) {
-          try {
-            await mcpClient.close();
-          } catch (error) {
-            logger.warn(
-              {
-                err: normalizeError(error),
-                mcpServerId: view.mcpServerId,
-                mcpServerViewId: view.sId,
-              },
-              "Failed to close sandbox function MCP listing client"
-            );
-          }
+        try {
+          await mcpClient.close();
+        } catch (error) {
+          logger.warn(
+            {
+              err: normalizeError(error),
+              mcpServerId: view.mcpServerId,
+              mcpServerViewId: view.sId,
+            },
+            "Failed to close sandbox function MCP listing client"
+          );
         }
       }
     }
@@ -131,7 +131,7 @@ export async function listSandboxFunctionMCPServerViews(
         },
       };
     },
-    { concurrency: 8 }
+    { concurrency: SANDBOX_FUNCTION_TOOL_LISTING_CONCURRENCY }
   );
 
   return removeNulls(serverViews);

--- a/front/lib/api/sandbox_functions/list_tools.ts
+++ b/front/lib/api/sandbox_functions/list_tools.ts
@@ -1,91 +1,78 @@
-import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import {
+  listMCPServerToolsAndServerInstructions,
+  makeServerSideMCPConnectionParams,
+} from "@app/lib/actions/mcp_actions";
 import type { MCPServerViewType, MCPToolType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 
 // Internal MCP servers are in-memory, but workspaces can expose many views at once.
 const SANDBOX_FUNCTION_TOOL_LISTING_CONCURRENCY = 8;
 
+export function makeSandboxFunctionMCPServerConfiguration(
+  view: MCPServerViewResource
+): ServerSideMCPServerConfigurationType {
+  const viewJSON = view.toJSON();
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: viewJSON.name ?? viewJSON.server.name,
+    description: viewJSON.description ?? viewJSON.server.description,
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: view.sId,
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: view.internalMCPServerId,
+  };
+}
+
 /**
  * Returns the tools a sandbox function can call from a server view.
  *
- * Remote server tools stay on their cached view metadata so listing functions never fan out to
- * third-party servers. Internal servers are listed live with a conversation-free context, which
- * lets their normal registration path remove tools that require an agent loop.
+ * This uses the same MCP listing path as the agent loop. Passing no agent-loop context makes
+ * internal servers omit context-dependent tools and makes remote servers use cached view tools.
  */
 export async function listSandboxFunctionToolsForMCPServerView(
   auth: Authenticator,
   view: MCPServerViewResource
 ): Promise<Result<MCPToolType[], Error>> {
   const viewJSON = view.toJSON();
-
-  switch (view.serverType) {
-    case "remote":
-      return new Ok(viewJSON.server.tools);
-    case "internal": {
-      const connectionResult = await connectToMCPServer(auth, {
-        params: {
-          type: "mcpServerId",
-          mcpServerId: view.mcpServerId,
-          oAuthUseCase: viewJSON.oAuthUseCase,
-        },
-        toolContext: {
-          listToolsContext: { contextType: "sandbox_function" },
-        },
-      });
-      if (connectionResult.isErr()) {
-        return new Err(connectionResult.error);
-      }
-
-      const mcpClient: Client = connectionResult.value;
-      try {
-        const toolsResult = await mcpClient.listTools();
-        const availableToolNames = new Set(
-          toolsResult.tools.map((tool) => tool.name)
-        );
-
-        return new Ok(
-          viewJSON.server.tools.filter((tool) =>
-            availableToolNames.has(tool.name)
-          )
-        );
-      } catch (error) {
-        // McpServer only installs the tools/list handler once at least one tool is registered.
-        // A sandbox-function context can legitimately filter every tool from an internal server.
-        if (
-          error instanceof McpError &&
-          error.code === ErrorCode.MethodNotFound
-        ) {
-          return new Ok([]);
-        }
-        return new Err(normalizeError(error));
-      } finally {
-        try {
-          await mcpClient.close();
-        } catch (error) {
-          logger.warn(
-            {
-              err: normalizeError(error),
-              mcpServerId: view.mcpServerId,
-              mcpServerViewId: view.sId,
-            },
-            "Failed to close sandbox function MCP listing client"
-          );
-        }
-      }
+  const config = makeSandboxFunctionMCPServerConfiguration(view);
+  const toolsResult = await listMCPServerToolsAndServerInstructions(
+    auth,
+    config,
+    null,
+    makeServerSideMCPConnectionParams(view),
+    {
+      cachedTools:
+        view.serverType === "remote" ? viewJSON.server.tools : undefined,
     }
-    default:
-      return assertNever(view.serverType);
+  );
+  if (toolsResult.isErr()) {
+    return toolsResult;
   }
+
+  const availableToolNames = new Set(
+    toolsResult.value.tools.map((tool) => tool.originalName)
+  );
+  return new Ok(
+    viewJSON.server.tools.filter((tool) => availableToolNames.has(tool.name))
+  );
 }
 
 export async function listSandboxFunctionMCPServerViews(

--- a/front/lib/api/sandbox_functions/list_tools.ts
+++ b/front/lib/api/sandbox_functions/list_tools.ts
@@ -1,0 +1,138 @@
+import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
+import type { MCPServerViewType, MCPToolType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Returns the tools a sandbox function can call from a server view.
+ *
+ * Remote server tools stay on their cached view metadata so listing functions never fan out to
+ * third-party servers. Internal servers are listed live with a conversation-free context, which
+ * lets their normal registration path remove tools that require an agent loop.
+ */
+export async function listSandboxFunctionToolsForMCPServerView(
+  auth: Authenticator,
+  view: MCPServerViewResource
+): Promise<Result<MCPToolType[], Error>> {
+  const viewJSON = view.toJSON();
+
+  switch (view.serverType) {
+    case "remote":
+      return new Ok(viewJSON.server.tools);
+    case "internal": {
+      let mcpClient: Client | undefined;
+      try {
+        const connectionResult = await connectToMCPServer(auth, {
+          params: {
+            type: "mcpServerId",
+            mcpServerId: view.mcpServerId,
+            oAuthUseCase: viewJSON.oAuthUseCase,
+          },
+          toolContext: {
+            listToolsContext: { contextType: "sandbox_function" },
+          },
+        });
+        if (connectionResult.isErr()) {
+          return new Err(connectionResult.error);
+        }
+
+        mcpClient = connectionResult.value;
+        const toolsResult = await mcpClient.listTools();
+        const availableToolNames = new Set(
+          toolsResult.tools.map((tool) => tool.name)
+        );
+
+        return new Ok(
+          viewJSON.server.tools.filter((tool) =>
+            availableToolNames.has(tool.name)
+          )
+        );
+      } catch (error) {
+        // McpServer only installs the tools/list handler once at least one tool is registered.
+        // A sandbox-function context can legitimately filter every tool from an internal server.
+        if (
+          error instanceof McpError &&
+          error.code === ErrorCode.MethodNotFound
+        ) {
+          return new Ok([]);
+        }
+        return new Err(normalizeError(error));
+      } finally {
+        if (mcpClient) {
+          try {
+            await mcpClient.close();
+          } catch (error) {
+            logger.warn(
+              {
+                err: normalizeError(error),
+                mcpServerId: view.mcpServerId,
+                mcpServerViewId: view.sId,
+              },
+              "Failed to close sandbox function MCP listing client"
+            );
+          }
+        }
+      }
+    }
+    default:
+      return assertNever(view.serverType);
+  }
+}
+
+export async function listSandboxFunctionMCPServerViews(
+  auth: Authenticator,
+  { spaceId }: { spaceId: string }
+): Promise<MCPServerViewType[]> {
+  // Invocation tokens are read-only: do not materialize missing automatic views here.
+  const views = await MCPServerViewResource.listBySpaceIds(auth, [spaceId], {
+    includeGlobalSpace: true,
+  });
+  const owner = auth.getNonNullableWorkspace();
+
+  const serverViews = await concurrentExecutor(
+    views,
+    async (view): Promise<MCPServerViewType | null> => {
+      const toolsResult = await listSandboxFunctionToolsForMCPServerView(
+        auth,
+        view
+      );
+      if (toolsResult.isErr()) {
+        logger.warn(
+          {
+            err: toolsResult.error,
+            mcpServerId: view.mcpServerId,
+            mcpServerViewId: view.sId,
+            workspaceId: owner.sId,
+          },
+          "Failed to list MCP server tools for a sandbox function"
+        );
+        return null;
+      }
+
+      if (toolsResult.value.length === 0) {
+        return null;
+      }
+
+      const serializedView = view.toJSON();
+      return {
+        ...serializedView,
+        server: {
+          ...serializedView.server,
+          tools: toolsResult.value,
+        },
+      };
+    },
+    { concurrency: 8 }
+  );
+
+  return removeNulls(serverViews);
+}


### PR DESCRIPTION
## Description

Sandbox function invocations currently list tools that require conversation or agent-loop state, then fail only after execution starts. This follows up on [the Slack discussion](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1784114491727339?thread_ts=1784101801.293519&cid=C0AGY9MTNJV) and #28435.

- mark internal tools that require an agent loop and filter them during registration
- reuse the existing MCP listing path, branching only when no agent-loop context is available
- keep remote server metadata cached when listing outside an agent loop
- reuse the same availability check before creating sandbox function actions
- omit internal servers with no compatible tools

## Tests

Added functional coverage for fully filtered servers, partially filtered servers, compatible calls, rejected calls, and unchanged conversation-backed listings. Ran the focused sandbox actions suite locally.

## Risk

Worst case, a compatible internal tool is marked too broadly and disappears from sandbox functions. Conversation-backed agents are unchanged, and the change is safe to roll back.

## Deploy Plan

Standard deploy.