### PR TITLE
Parse and validate sandbox function outputs

### DIFF
--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -49,7 +49,7 @@ cargo build
 Functions are self-contained Bun bundles in `$DUST_FUNCTIONS_DIR`, named
 `<name>.ts`. `dsbx` executes them via an embedded runner (`bun` required).
 
-- `dsbx function run <name>` — request envelope JSON on stdin → response JSON
+- `dsbx function run <name>` — request envelope JSON on stdin → parsed output or error envelope
   on stdout (`{ok, response}` / `{ok:false, error}`).
 - `dsbx function get <name>` — prints `{name, description, input_schema,
   output_schema}` (JSON Schema).

--- a/cli/dust-sandbox/functions-runner/fixtures/bad-schema.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/bad-schema.ts
@@ -6,6 +6,6 @@ export const schema = {
 
 export default {
   async fetch(_req: Request): Promise<Response> {
-    return new Response("ok");
+    return Response.json("ok");
   },
 };

--- a/cli/dust-sandbox/functions-runner/fixtures/default-output.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/default-output.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const schema = {
+  output: z.object({
+    greeting: z.string(),
+    tone: z.string().default("friendly"),
+  }),
+};
+
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({ greeting: "Hi" });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/echo.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/echo.ts
@@ -1,8 +1,6 @@
 export default {
   async fetch(req: Request): Promise<Response> {
     const body = await req.text();
-    return new Response(`echo:${req.method}:${body}`, {
-      headers: { "x-echo": "1" },
-    });
+    return Response.json(`echo:${req.method}:${body}`);
   },
 };

--- a/cli/dust-sandbox/functions-runner/fixtures/invalid-output.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/invalid-output.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const schema = {
+  output: z.object({ greeting: z.string() }),
+};
+
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({ greeting: 42 });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/throwing-output-schema.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/throwing-output-schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const schema = {
+  output: z.any().superRefine(() => {
+    throw new Error("refinement failed");
+  }),
+};
+
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({ ok: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/throwing-schema.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/throwing-schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const schema = {
+  input: z.any().superRefine(() => {
+    throw new Error("refinement failed");
+  }),
+};
+
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({ ok: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/unserializable-output.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/unserializable-output.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const schema = {
+  output: z.any().transform(() => 1n),
+};
+
+export default {
+  async fetch(_req: Request): Promise<Response> {
+    return Response.json({ ok: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/invoke.test.ts
+++ b/cli/dust-sandbox/functions-runner/invoke.test.ts
@@ -13,7 +13,7 @@ const req = (o: Partial<RequestInput> = {}): RequestInput => ({
 });
 
 describe("invoke", () => {
-  test("runs a handler and returns its 200 response", async () => {
+  test("runs a handler and returns its parsed output", async () => {
     const out = await invoke(
       fx("hello.ts"),
       req({ url: "http://localhost/?name=bun" })
@@ -22,15 +22,14 @@ describe("invoke", () => {
     if (!out.ok) {
       return;
     }
-    expect(out.response.status).toBe(200);
-    expect(JSON.parse(out.response.body!)).toEqual({ hello: "bun" });
+    expect(out.output).toEqual({ hello: "bun" });
   });
 
-  test("a 404 is still ok:true", async () => {
+  test("returns http_error for a non-2xx response", async () => {
     const out = await invoke(fx("notfound.ts"), req());
-    expect(out.ok).toBe(true);
-    if (out.ok) {
-      expect(out.response.status).toBe(404);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error).toMatchObject({ code: "http_error", status: 404 });
     }
   });
 
@@ -41,15 +40,15 @@ describe("invoke", () => {
     );
     expect(out.ok).toBe(true);
     if (out.ok) {
-      expect(out.response.body).toBe("echo:POST:payload");
+      expect(out.output).toBe("echo:POST:payload");
     }
   });
 
-  test("binary response encodes as base64", async () => {
+  test("returns invalid_output for a non-JSON response", async () => {
     const out = await invoke(fx("binary.ts"), req());
-    expect(out.ok).toBe(true);
-    if (out.ok) {
-      expect(out.response.encoding).toBe("base64");
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe("invalid_output");
     }
   });
 
@@ -57,7 +56,7 @@ describe("invoke", () => {
     const out = await invoke(fx("throws.ts"), req());
     expect(out.ok).toBe(false);
     if (!out.ok) {
-      expect(out.error.kind).toBe("threw");
+      expect(out.error.code).toBe("threw");
     }
   });
 
@@ -65,7 +64,7 @@ describe("invoke", () => {
     const out = await invoke(fx("nope.ts"), req());
     expect(out.ok).toBe(false);
     if (!out.ok) {
-      expect(out.error.kind).toBe("import_failed");
+      expect(out.error.code).toBe("import_failed");
     }
   });
 
@@ -73,7 +72,7 @@ describe("invoke", () => {
     const out = await invoke(fx("no-fetch.ts"), req());
     expect(out.ok).toBe(false);
     if (!out.ok) {
-      expect(out.error.kind).toBe("import_failed");
+      expect(out.error.code).toBe("import_failed");
     }
   });
 
@@ -81,42 +80,48 @@ describe("invoke", () => {
     const out = await invoke(fx("bad-return.ts"), req());
     expect(out.ok).toBe(false);
     if (!out.ok) {
-      expect(out.error.kind).toBe("bad_return");
+      expect(out.error.code).toBe("bad_return");
     }
   });
 
-  test("valid body satisfies schema.input → 200", async () => {
-    const out = await invoke(
-      fx("greet.ts"),
-      req({ method: "POST", body: JSON.stringify({ name: "David" }) })
-    );
+  test("returns schema.output with defaults applied", async () => {
+    const out = await invoke(fx("default-output.ts"), req());
     expect(out.ok).toBe(true);
     if (out.ok) {
-      expect(JSON.parse(out.response.body!)).toEqual({ greeting: "Hi, David" });
+      expect(out.output).toEqual({
+        greeting: "Hi",
+        tone: "friendly",
+      });
     }
   });
 
-  test("missing required field → 400 without calling handler", async () => {
+  test("returns invalid_input for a missing required field", async () => {
     const out = await invoke(
       fx("greet.ts"),
       req({ method: "POST", body: "{}" })
     );
-    expect(out.ok).toBe(true);
+    expect(out.ok).toBe(false);
     if (!out.ok) {
-      return;
+      expect(out.error.code).toBe("invalid_input");
     }
-    expect(out.response.status).toBe(400);
-    expect(JSON.parse(out.response.body!).error).toBe("invalid input");
   });
 
-  test("non-JSON body with a schema → 400", async () => {
+  test("returns invalid_input for a non-JSON body", async () => {
     const out = await invoke(
       fx("greet.ts"),
       req({ method: "POST", body: "not json" })
     );
-    expect(out.ok).toBe(true);
-    if (out.ok) {
-      expect(out.response.status).toBe(400);
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe("invalid_input");
+    }
+  });
+
+  test("returns invalid_output when the response fails schema.output", async () => {
+    const out = await invoke(fx("invalid-output.ts"), req());
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe("invalid_output");
     }
   });
 
@@ -127,7 +132,7 @@ describe("invoke", () => {
     );
     expect(out.ok).toBe(true);
     if (out.ok) {
-      expect(out.response.body).toBe("ok");
+      expect(out.output).toBe("ok");
     }
   });
 });

--- a/cli/dust-sandbox/functions-runner/invoke.ts
+++ b/cli/dust-sandbox/functions-runner/invoke.ts
@@ -1,10 +1,9 @@
-// Import a function handler, optionally validate the request body against its
-// declared schema, call its default fetch, and serialize the Response.
+// Import a function handler, validate its input and output, and call its default fetch.
 
 import {
   decodeRequestBody,
-  type ErrorCode,
   type InvocationError,
+  type NonHttpErrorCode,
   type Output,
   type RequestInput,
 } from "./protocol.ts";
@@ -17,32 +16,54 @@ interface ZodLike {
     | { success: false; error: { issues: unknown } };
 }
 
+interface FunctionHandler {
+  fetch(request: Request): unknown;
+}
+
 function isValidator(value: unknown): value is ZodLike {
   return (
     typeof value === "object" &&
     value !== null &&
-    typeof (value as { safeParse?: unknown }).safeParse === "function"
+    "safeParse" in value &&
+    typeof value.safeParse === "function"
   );
+}
+
+function isFunctionHandler(value: unknown): value is FunctionHandler {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "fetch" in value &&
+    typeof value.fetch === "function"
+  );
+}
+
+function getProperty(value: unknown, property: string): unknown {
+  if (typeof value !== "object" || value === null || !(property in value)) {
+    return undefined;
+  }
+  return value[property];
 }
 
 export async function invoke(
   handlerPath: string,
   input: RequestInput
 ): Promise<Output> {
-  let handler: { fetch?: unknown };
+  let handler: FunctionHandler;
   let schemaInput: unknown;
   let schemaOutput: unknown;
   try {
-    const mod = await import(handlerPath);
-    const def = mod.default;
-    if (typeof def?.fetch !== "function") {
+    const mod: unknown = await import(handlerPath);
+    const def = getProperty(mod, "default");
+    if (!isFunctionHandler(def)) {
       throw new Error(
         "function must `export default { fetch(req) {...} }` with a fetch function"
       );
     }
     handler = def;
-    schemaInput = (mod.schema as { input?: unknown } | undefined)?.input;
-    schemaOutput = (mod.schema as { output?: unknown } | undefined)?.output;
+    const schema = getProperty(mod, "schema");
+    schemaInput = getProperty(schema, "input");
+    schemaOutput = getProperty(schema, "output");
   } catch (e) {
     return fail("import_failed", e);
   }
@@ -64,7 +85,7 @@ export async function invoke(
 
   let response: unknown;
   try {
-    response = await (handler.fetch as (req: Request) => unknown)(request);
+    response = await handler.fetch(request);
   } catch (e) {
     return fail("threw", e);
   }
@@ -92,14 +113,21 @@ function validateBody(
       };
     }
   }
-  const parsed = schema.safeParse(data);
-  if (parsed.success) {
-    return null;
+  try {
+    const parsed = schema.safeParse(data);
+    if (parsed.success) {
+      return null;
+    }
+    return {
+      code: "invalid_input",
+      message: `Function input does not match schema.input: ${JSON.stringify(parsed.error.issues)}`,
+    };
+  } catch (error) {
+    return makeError(
+      "invalid_input",
+      new Error(`schema.input validation threw: ${errorMessage(error)}`)
+    );
   }
-  return {
-    code: "invalid_input",
-    message: `Function input does not match schema.input: ${JSON.stringify(parsed.error.issues)}`,
-  };
 }
 
 async function parseOutput(
@@ -108,8 +136,7 @@ async function parseOutput(
 ): Promise<Output> {
   const body = await response.text();
   if (!response.ok) {
-    return fail(
-      "http_error",
+    return failHttp(
       new Error(
         `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`
       ),
@@ -128,31 +155,63 @@ async function parseOutput(
   }
 
   if (isValidator(schemaOutput)) {
-    const parsed = schemaOutput.safeParse(output);
-    if (!parsed.success) {
+    try {
+      const parsed = schemaOutput.safeParse(output);
+      if (!parsed.success) {
+        return fail(
+          "invalid_output",
+          new Error(
+            `Function output does not match schema.output: ${JSON.stringify(parsed.error.issues)}`
+          )
+        );
+      }
+      output = parsed.data;
+    } catch (error) {
       return fail(
         "invalid_output",
-        new Error(
-          `Function output does not match schema.output: ${JSON.stringify(parsed.error.issues)}`
-        )
+        new Error(`schema.output validation threw: ${errorMessage(error)}`)
       );
     }
-    output = parsed.data;
   }
 
-  return { ok: true, output };
+  let serializedOutput: string | undefined;
+  try {
+    serializedOutput = JSON.stringify(output);
+  } catch (error) {
+    return fail(
+      "invalid_output",
+      new Error(
+        `Function output is not JSON-serializable: ${errorMessage(error)}`
+      )
+    );
+  }
+  if (serializedOutput === undefined) {
+    return fail(
+      "invalid_output",
+      new Error("Function output is not JSON-serializable.")
+    );
+  }
+
+  return { ok: true, output: JSON.parse(serializedOutput) };
 }
 
-function fail(code: ErrorCode, e: unknown, status?: number): Output {
-  const err = e instanceof Error ? e : new Error(String(e));
+function makeError(code: NonHttpErrorCode, error: unknown): InvocationError {
+  return { code, message: errorMessage(error) };
+}
+
+function fail(code: NonHttpErrorCode, error: unknown): Output {
+  return { ok: false, error: makeError(code, error) };
+}
+
+function failHttp(error: unknown, status: number): Output {
   return {
     ok: false,
-    error: {
-      code,
-      message: err.message,
-      ...(status !== undefined ? { status } : {}),
-    },
+    error: { code: "http_error", message: errorMessage(error), status },
   };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function typeOf(v: unknown): string {

--- a/cli/dust-sandbox/functions-runner/invoke.ts
+++ b/cli/dust-sandbox/functions-runner/invoke.ts
@@ -3,7 +3,8 @@
 
 import {
   decodeRequestBody,
-  encodeResponseBody,
+  type ErrorCode,
+  type InvocationError,
   type Output,
   type RequestInput,
 } from "./protocol.ts";
@@ -11,7 +12,9 @@ import {
 interface ZodLike {
   safeParse(
     data: unknown
-  ): { success: true } | { success: false; error: { issues: unknown } };
+  ):
+    | { success: true; data: unknown }
+    | { success: false; error: { issues: unknown } };
 }
 
 function isValidator(value: unknown): value is ZodLike {
@@ -28,6 +31,7 @@ export async function invoke(
 ): Promise<Output> {
   let handler: { fetch?: unknown };
   let schemaInput: unknown;
+  let schemaOutput: unknown;
   try {
     const mod = await import(handlerPath);
     const def = mod.default;
@@ -38,6 +42,7 @@ export async function invoke(
     }
     handler = def;
     schemaInput = (mod.schema as { input?: unknown } | undefined)?.input;
+    schemaOutput = (mod.schema as { output?: unknown } | undefined)?.output;
   } catch (e) {
     return fail("import_failed", e);
   }
@@ -45,9 +50,9 @@ export async function invoke(
   const body = decodeRequestBody(input);
 
   if (isValidator(schemaInput)) {
-    const rejection = validateBody(body, schemaInput);
-    if (rejection) {
-      return serialize(rejection);
+    const validationError = validateBody(body, schemaInput);
+    if (validationError) {
+      return { ok: false, error: validationError };
     }
   }
 
@@ -69,57 +74,85 @@ export async function invoke(
       new Error(`function returned ${typeOf(response)}, expected a Response`)
     );
   }
-  return serialize(response);
+  return parseOutput(response, schemaOutput);
 }
 
 function validateBody(
   body: Uint8Array | undefined,
   schema: ZodLike
-): Response | null {
+): InvocationError | null {
   let data: unknown;
   if (body !== undefined) {
     try {
       data = JSON.parse(new TextDecoder().decode(body));
     } catch {
-      return Response.json(
-        {
-          error: "invalid input",
-          issues: [{ message: "body is not valid JSON" }],
-        },
-        { status: 400 }
-      );
+      return {
+        code: "invalid_input",
+        message: "Function input is not valid JSON.",
+      };
     }
   }
   const parsed = schema.safeParse(data);
   if (parsed.success) {
     return null;
   }
-  return Response.json(
-    { error: "invalid input", issues: parsed.error.issues },
-    { status: 400 }
-  );
-}
-
-async function serialize(response: Response): Promise<Output> {
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  const { body, encoding } = encodeResponseBody(bytes);
   return {
-    ok: true,
-    response: {
-      status: response.status,
-      headers: Object.fromEntries(response.headers),
-      body,
-      encoding,
-    },
+    code: "invalid_input",
+    message: `Function input does not match schema.input: ${JSON.stringify(parsed.error.issues)}`,
   };
 }
 
-function fail(
-  kind: "import_failed" | "threw" | "bad_return",
-  e: unknown
-): Output {
+async function parseOutput(
+  response: Response,
+  schemaOutput: unknown
+): Promise<Output> {
+  const body = await response.text();
+  if (!response.ok) {
+    return fail(
+      "http_error",
+      new Error(
+        `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`
+      ),
+      response.status
+    );
+  }
+
+  let output: unknown;
+  try {
+    output = JSON.parse(body);
+  } catch {
+    return fail(
+      "invalid_output",
+      new Error("Function response body is not valid JSON.")
+    );
+  }
+
+  if (isValidator(schemaOutput)) {
+    const parsed = schemaOutput.safeParse(output);
+    if (!parsed.success) {
+      return fail(
+        "invalid_output",
+        new Error(
+          `Function output does not match schema.output: ${JSON.stringify(parsed.error.issues)}`
+        )
+      );
+    }
+    output = parsed.data;
+  }
+
+  return { ok: true, output };
+}
+
+function fail(code: ErrorCode, e: unknown, status?: number): Output {
   const err = e instanceof Error ? e : new Error(String(e));
-  return { ok: false, error: { kind, message: err.message, stack: err.stack } };
+  return {
+    ok: false,
+    error: {
+      code,
+      message: err.message,
+      ...(status !== undefined ? { status } : {}),
+    },
+  };
 }
 
 function typeOf(v: unknown): string {

--- a/cli/dust-sandbox/functions-runner/protocol.test.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  BadInputError,
-  decodeRequestBody,
-  encodeResponseBody,
-  parseInput,
-} from "./protocol.ts";
+import { BadInputError, decodeRequestBody, parseInput } from "./protocol.ts";
 
 describe("parseInput", () => {
   test("defaults method to GET and encoding to utf8", () => {
@@ -36,7 +31,7 @@ describe("parseInput", () => {
   });
 });
 
-describe("decodeRequestBody / encodeResponseBody", () => {
+describe("decodeRequestBody", () => {
   test("utf8 round-trip", () => {
     const bytes = decodeRequestBody({
       method: "POST",
@@ -57,11 +52,5 @@ describe("decodeRequestBody / encodeResponseBody", () => {
       encoding: "base64",
     });
     expect(Array.from(bytes!)).toEqual([0, 1, 255]);
-  });
-
-  test("non-UTF8 response bytes encode as base64", () => {
-    const { body, encoding } = encodeResponseBody(new Uint8Array([0xff, 0xfe]));
-    expect(encoding).toBe("base64");
-    expect(Array.from(Buffer.from(body!, "base64"))).toEqual([0xff, 0xfe]);
   });
 });

--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -1,5 +1,5 @@
 // Wire protocol for the function runner: JSON shapes exchanged on stdin/stdout
-// and helpers translating request/response bodies to and from bytes.
+// and the helper translating request bodies to bytes.
 
 export type Encoding = "utf8" | "base64";
 
@@ -20,11 +20,11 @@ export type ErrorCode =
   | "http_error"
   | "invalid_output";
 
-export interface InvocationError {
-  code: ErrorCode;
-  message: string;
-  status?: number;
-}
+export type NonHttpErrorCode = Exclude<ErrorCode, "http_error">;
+
+export type InvocationError =
+  | { code: NonHttpErrorCode; message: string }
+  | { code: "http_error"; message: string; status: number };
 
 export type Output =
   | { ok: true; output: unknown }

--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -11,14 +11,17 @@ export interface RequestInput {
   encoding: Encoding;
 }
 
-export type ErrorCode =
-  | "bad_input"
-  | "invalid_input"
-  | "import_failed"
-  | "threw"
-  | "bad_return"
-  | "http_error"
-  | "invalid_output";
+export const RUNNER_ERROR_CODES = [
+  "bad_input",
+  "invalid_input",
+  "import_failed",
+  "threw",
+  "bad_return",
+  "http_error",
+  "invalid_output",
+] as const;
+
+export type ErrorCode = (typeof RUNNER_ERROR_CODES)[number];
 
 export type NonHttpErrorCode = Exclude<ErrorCode, "http_error">;
 

--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -11,23 +11,23 @@ export interface RequestInput {
   encoding: Encoding;
 }
 
-export interface ResponseOutput {
-  status: number;
-  headers: Record<string, string>;
-  body: string | null;
-  encoding: Encoding;
-}
-
-export type ErrorKind = "bad_input" | "import_failed" | "threw" | "bad_return";
+export type ErrorCode =
+  | "bad_input"
+  | "invalid_input"
+  | "import_failed"
+  | "threw"
+  | "bad_return"
+  | "http_error"
+  | "invalid_output";
 
 export interface InvocationError {
-  kind: ErrorKind;
+  code: ErrorCode;
   message: string;
-  stack?: string;
+  status?: number;
 }
 
 export type Output =
-  | { ok: true; response: ResponseOutput }
+  | { ok: true; output: unknown }
   | { ok: false; error: InvocationError };
 
 export class BadInputError extends Error {}
@@ -84,16 +84,4 @@ export function decodeRequestBody(input: RequestInput): Uint8Array | undefined {
     return new Uint8Array(Buffer.from(input.body, "base64"));
   }
   return new TextEncoder().encode(input.body);
-}
-
-export function encodeResponseBody(bytes: Uint8Array): {
-  body: string | null;
-  encoding: Encoding;
-} {
-  try {
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    return { body: text, encoding: "utf8" };
-  } catch {
-    return { body: Buffer.from(bytes).toString("base64"), encoding: "base64" };
-  }
 }

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -42,6 +42,33 @@ describe("runner run", () => {
     expect(code).toBe(2);
     expect(JSON.parse(stdout).error.code).toBe("bad_input");
   });
+
+  test("returns invalid_input when schema.input validation throws", async () => {
+    const { stdout, code } = await run(
+      ["run", fx("throwing-schema.ts")],
+      JSON.stringify({ body: "{}" })
+    );
+    expect(code).toBe(1);
+    expect(JSON.parse(stdout).error.code).toBe("invalid_input");
+  });
+
+  test("returns invalid_output when parsed output cannot be serialized", async () => {
+    const { stdout, code } = await run(
+      ["run", fx("unserializable-output.ts")],
+      JSON.stringify({})
+    );
+    expect(code).toBe(1);
+    expect(JSON.parse(stdout).error.code).toBe("invalid_output");
+  });
+
+  test("returns invalid_output when schema.output validation throws", async () => {
+    const { stdout, code } = await run(
+      ["run", fx("throwing-output-schema.ts")],
+      JSON.stringify({})
+    );
+    expect(code).toBe(1);
+    expect(JSON.parse(stdout).error.code).toBe("invalid_output");
+  });
 });
 
 describe("runner get", () => {

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -25,7 +25,7 @@ describe("runner run", () => {
     );
     expect(code).toBe(0);
     const out = JSON.parse(stdout);
-    expect(JSON.parse(out.response.body)).toEqual({ hello: "r" });
+    expect(out.output).toEqual({ hello: "r" });
   });
 
   test("exits 1 with ok:false when handler throws", async () => {
@@ -34,13 +34,13 @@ describe("runner run", () => {
       JSON.stringify({ url: "http://localhost/" })
     );
     expect(code).toBe(1);
-    expect(JSON.parse(stdout).error.kind).toBe("threw");
+    expect(JSON.parse(stdout).error.code).toBe("threw");
   });
 
   test("exits 2 with bad_input when stdin is malformed JSON", async () => {
     const { stdout, code } = await run(["run", fx("hello.ts")], "not json");
     expect(code).toBe(2);
-    expect(JSON.parse(stdout).error.kind).toBe("bad_input");
+    expect(JSON.parse(stdout).error.code).toBe("bad_input");
   });
 });
 

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -26,7 +26,7 @@ async function runHandler(handlerPath: string): Promise<number> {
   } catch (e) {
     const message = e instanceof BadInputError ? e.message : String(e);
     process.stdout.write(
-      `${JSON.stringify({ ok: false, error: { kind: "bad_input", message } })}\n`
+      `${JSON.stringify({ ok: false, error: { code: "bad_input", message } })}\n`
     );
     return 2;
   }


### PR DESCRIPTION
## Description

Sandbox function callers currently receive a raw HTTP response envelope and output schema declarations are ignored. This is PR 1 of 3 following the [Frames sandbox functions discussion](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1784105075929679).

This updates the embedded `dsbx` runner to parse successful JSON responses, validate and transform them through `schema.output`, and return structured errors for invalid input, handler failures, non-2xx responses, and invalid output. Schema exceptions and values that cannot cross the JSON wire are also normalized as structured validation errors. The CLI release version becomes 0.1.34.

Follow-ups: #28963 normalizes server callbacks, then #28968 exposes direct output to Frames and consumes the new runner image.

## Tests

- `bun test` in `cli/dust-sandbox/functions-runner` (84 tests)
- `bun run build`
- `cargo fmt --check`
- `cargo test` in `cli/dust-sandbox` (262 tests)
- Biome checks on changed files

## Risk

The runner wire contract changes. No production sandbox image references v0.1.34 yet, so merging this PR alone does not change running sandboxes. Safe to rollback before the release is consumed.

## Deploy Plan

- [ ] Merge this PR.
- [ ] Run the `Release dsbx CLI` workflow for v0.1.34.
- [ ] Confirm the v0.1.34 release artifacts and checksums exist.
- [ ] Merge #28963, then #28968, which bumps the sandbox image and CLI pin.
