### PR TITLE
Normalize sandbox function invocation results

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -12393,7 +12393,7 @@
             "type": "string"
           },
           "result": {
-            "description": "Result returned by the sandbox function."
+            "description": "Parsed result validated against the sandbox function output schema."
           }
         }
       },
@@ -12404,7 +12404,7 @@
           "created",
           "invocationId",
           "functionId",
-          "message"
+          "error"
         ],
         "properties": {
           "type": {
@@ -12422,9 +12422,37 @@
           "functionId": {
             "type": "string"
           },
-          "message": {
-            "type": "string",
-            "description": "Why the invocation failed before producing a result."
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "bad_input",
+                  "invalid_input",
+                  "import_failed",
+                  "threw",
+                  "bad_return",
+                  "http_error",
+                  "invalid_output",
+                  "function_not_found",
+                  "invocation_failed",
+                  "transport_error",
+                  "not_supported"
+                ]
+              },
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "integer"
+              }
+            },
+            "description": "A structured error describing why the invocation failed."
           }
         }
       },

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1479,10 +1479,10 @@
  *         functionId:
  *           type: string
  *         result:
- *           description: Result returned by the sandbox function.
+ *           description: Parsed result validated against the sandbox function output schema.
  *     PrivateSandboxFunctionInvocationErrorEvent:
  *       type: object
- *       required: [type, created, invocationId, functionId, message]
+ *       required: [type, created, invocationId, functionId, error]
  *       properties:
  *         type:
  *           type: string
@@ -1493,9 +1493,18 @@
  *           type: string
  *         functionId:
  *           type: string
- *         message:
- *           type: string
- *           description: Why the invocation failed before producing a result.
+ *         error:
+ *           type: object
+ *           required: [code, message]
+ *           properties:
+ *             code:
+ *               type: string
+ *               enum: [bad_input, invalid_input, import_failed, threw, bad_return, http_error, invalid_output, function_not_found, invocation_failed, transport_error, not_supported]
+ *             message:
+ *               type: string
+ *             status:
+ *               type: integer
+ *           description: A structured error describing why the invocation failed.
  *     PrivateAgentMessageEvent:
  *       type: object
  *       description: Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -48,7 +48,7 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
 
     const response = await postSandboxFunctionResult(workspace, token, {
       function: "test_function",
-      result: { hello: "world" },
+      result: { ok: true, output: { hello: "world" } },
     });
 
     expect(response.status).toBe(200);
@@ -76,11 +76,114 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
       await createPersistedSandboxFunctionInvocationTokenTestContext();
 
     const response = await postSandboxFunctionResult(workspace, token, {
-      result: { hello: "world" },
+      result: { ok: true, output: { hello: "world" } },
     });
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("publishes structured runner errors as invocation errors", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        ok: false,
+        error: {
+          code: "invalid_output",
+          message: "Function output does not match schema.output.",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_error",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        error: {
+          code: "invalid_output",
+          message: "Function output does not match schema.output.",
+        },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("normalizes successful callbacks from the previous runner image", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        ok: true,
+        response: {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: Buffer.from(JSON.stringify({ hello: "legacy" })).toString(
+            "base64"
+          ),
+          encoding: "base64",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_result",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        result: { hello: "legacy" },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("fails the invocation when the runner callback is malformed", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: { ok: true },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_error",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        error: {
+          code: "invocation_failed",
+          message: "Sandbox function returned an invalid result envelope.",
+        },
+      },
+      { invocationId: invocation.sId }
+    );
   });
 
   it("rejects sandbox action tokens", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -1,12 +1,120 @@
 import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
+
+type JsonValue = null | boolean | number | string | object;
+const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
+const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+          message: z.string(),
+          status: z.number().int().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      response: z
+        .object({
+          status: z.number().int(),
+          headers: z.record(z.string(), z.string()),
+          body: z.string().nullable(),
+          encoding: z.enum(["utf8", "base64"]),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
+          message: z.string(),
+          stack: z.string().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+type NormalizedRunnerOutput =
+  | { ok: true; output: unknown }
+  | { ok: false; error: SandboxFunctionCallError };
+
+function normalizeRunnerOutput(result: unknown): NormalizedRunnerOutput {
+  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (current.success) {
+    return current.data;
+  }
+
+  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (!legacy.success) {
+    return {
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Sandbox function returned an invalid result envelope.",
+      },
+    };
+  }
+
+  if (!legacy.data.ok) {
+    return {
+      ok: false,
+      error: {
+        code: legacy.data.error.kind,
+        message: legacy.data.error.message,
+      },
+    };
+  }
+
+  const { response } = legacy.data;
+  const body =
+    response.body === null
+      ? ""
+      : Buffer.from(response.body, response.encoding).toString("utf8");
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      ok: false,
+      error: {
+        code: "http_error",
+        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
+        status: response.status,
+      },
+    };
+  }
+
+  try {
+    return { ok: true, output: JSON.parse(body) };
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function response body is not valid JSON.",
+      },
+    };
+  }
+}
 
 const PostSandboxFunctionResultRequestBodySchema = z
   .object({
@@ -67,7 +175,12 @@ app.post(
       });
     }
 
-    await invocation.succeed(result);
+    const normalized = normalizeRunnerOutput(result);
+    if (normalized.ok) {
+      await invocation.succeed(normalized.output);
+    } else {
+      await invocation.fail(normalized.error);
+    }
 
     return ctx.json({ success: true });
   }

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -386,7 +386,10 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         type: "sandbox_function_invocation_error",
         invocationId: expect.stringMatching(/^sfi_/),
         functionId: sandboxFunction.sId,
-        message: "temporal unavailable",
+        error: {
+          code: "invocation_failed",
+          message: "temporal unavailable",
+        },
       }),
       { invocationId: expect.stringMatching(/^sfi_/) }
     );

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -185,7 +185,7 @@ function SandboxFunctionInvocation({
           case "sandbox_function_invocation_error":
             onSettle(invocationId, {
               result: null,
-              error: eventPayload.data.message,
+              error: eventPayload.data.error.message,
             });
             break;
           case "tool_approve_execution":

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -32,16 +32,13 @@ export async function callHandler(
 
   const result = await callSandboxFunction(auth, sandboxFunction, input);
   if (result.isErr()) {
-    return new Err(new MCPError(result.error.message));
-  }
-
-  const outcome = result.value;
-  if (!outcome.ok) {
-    // The function ran but returned an error: model- or builder-correctable, not internal.
+    const { code, message } = result.error;
     return new Err(
       new MCPError(
-        `Pod function "${slug}" returned an error (${outcome.errorKind}): ${outcome.message}`,
-        { tracked: false }
+        `Pod function "${slug}" returned an error (${code}): ${message}`,
+        {
+          tracked: code === "invocation_failed" || code === "transport_error",
+        }
       )
     );
   }
@@ -49,12 +46,7 @@ export async function callHandler(
   return new Ok([
     {
       type: "text",
-      text: [
-        `HTTP ${outcome.status}`,
-        "",
-        "Response Body:",
-        outcome.output,
-      ].join("\n"),
+      text: JSON.stringify(result.value, null, 2) ?? "null",
     },
   ]);
 }

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -115,20 +115,9 @@ afterEach(() => {
 });
 
 describe("callSandboxFunction", () => {
-  it("returns the decoded body on a successful result", async () => {
+  it("returns the parsed output on a successful result", async () => {
     const { auth, fn, invocationId } = await setup();
-    mockResult(
-      {
-        ok: true,
-        response: {
-          status: 200,
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ greeting: "Hi, Soupinou" }),
-          encoding: "utf8",
-        },
-      },
-      invocationId
-    );
+    mockResult({ greeting: "Hi, Soupinou" }, invocationId);
 
     const result = await callSandboxFunction(auth, fn, { name: "Soupinou" });
 
@@ -136,68 +125,32 @@ describe("callSandboxFunction", () => {
     if (result.isErr()) {
       return;
     }
-    expect(result.value).toEqual({
-      ok: true,
-      status: 200,
-      output: JSON.stringify({ greeting: "Hi, Soupinou" }),
-    });
+    expect(result.value).toEqual({ greeting: "Hi, Soupinou" });
   });
 
-  it("decodes a base64-encoded body", async () => {
+  it("returns a typed invocation error", async () => {
     const { auth, fn, invocationId } = await setup();
-    mockResult(
-      {
-        ok: true,
-        response: {
-          status: 200,
-          headers: {},
-          body: Buffer.from("plain text", "utf8").toString("base64"),
-          encoding: "base64",
-        },
-      },
-      invocationId
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      eventStream({
+        type: "sandbox_function_invocation_error",
+        created: 0,
+        invocationId,
+        functionId: "sfn_x",
+        error: { code: "http_error", message: "boom", status: 503 },
+      })
     );
-
-    const result = await callSandboxFunction(auth, fn, undefined);
-
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      return;
-    }
-    expect(result.value).toEqual({
-      ok: true,
-      status: 200,
-      output: "plain text",
-    });
-  });
-
-  it("surfaces a function error envelope as ok: false", async () => {
-    const { auth, fn, invocationId } = await setup();
-    mockResult(
-      { ok: false, error: { kind: "threw", message: "boom" } },
-      invocationId
-    );
-
-    const result = await callSandboxFunction(auth, fn, { name: "x" });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      return;
-    }
-    expect(result.value).toEqual({
-      ok: false,
-      errorKind: "threw",
-      message: "boom",
-    });
-  });
-
-  it("errors on an unexpected result envelope", async () => {
-    const { auth, fn, invocationId } = await setup();
-    mockResult({ not: "an envelope" }, invocationId);
 
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 
     expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error).toEqual({
+      code: "http_error",
+      message: "boom",
+      status: 503,
+    });
   });
 
   it("errors when no result event arrives", async () => {
@@ -209,33 +162,33 @@ describe("callSandboxFunction", () => {
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 
     expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error).toEqual({
+      code: "transport_error",
+      message: "Pod function did not return a result in time.",
+    });
   });
 
-  it("returns a non-2xx response as ok with its status", async () => {
-    const { auth, fn, invocationId } = await setup();
-    mockResult(
-      {
-        ok: true,
-        response: {
-          status: 400,
-          headers: {},
-          body: JSON.stringify({ error: "invalid input" }),
-          encoding: "utf8",
-        },
-      },
-      invocationId
+  it("returns a transport error when the event stream fails", async () => {
+    const { auth, fn } = await setup();
+    async function* failingEventStream() {
+      throw new Error("stream disconnected");
+    }
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      failingEventStream()
     );
 
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
       return;
     }
-    expect(result.value).toEqual({
-      ok: true,
-      status: 400,
-      output: JSON.stringify({ error: "invalid input" }),
+    expect(result.error).toEqual({
+      code: "transport_error",
+      message: "Failed to receive sandbox function events: stream disconnected",
     });
   });
 
@@ -258,15 +211,7 @@ describe("callSandboxFunction", () => {
           created: 1,
           invocationId,
           functionId: "sfn_x",
-          result: {
-            ok: true,
-            response: {
-              status: 200,
-              headers: {},
-              body: JSON.stringify({ greeting: "Hi" }),
-              encoding: "utf8",
-            },
-          },
+          result: { greeting: "Hi" },
         }
       )
     );
@@ -277,11 +222,7 @@ describe("callSandboxFunction", () => {
     if (result.isErr()) {
       return;
     }
-    expect(result.value).toEqual({
-      ok: true,
-      status: 200,
-      output: JSON.stringify({ greeting: "Hi" }),
-    });
+    expect(result.value).toEqual({ greeting: "Hi" });
   });
 
   it("propagates an Err from the workflow launch", async () => {
@@ -293,5 +234,12 @@ describe("callSandboxFunction", () => {
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 
     expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error).toEqual({
+      code: "invocation_failed",
+      message: "temporal unavailable",
+    });
   });
 });

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,105 +1,57 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
-
-// The runner Output envelope dsbx POSTs back as the result event. Mirrors Output in
-// cli/dust-sandbox/functions-runner/protocol.ts.
-const responseOutputSchema = z.object({
-  status: z.number(),
-  headers: z.record(z.string()),
-  body: z.string().nullable(),
-  encoding: z.enum(["utf8", "base64"]),
-});
-const resultEnvelopeSchema = z.discriminatedUnion("ok", [
-  z.object({ ok: z.literal(true), response: responseOutputSchema }),
-  z.object({
-    ok: z.literal(false),
-    error: z.object({
-      kind: z.string(),
-      message: z.string(),
-      stack: z.string().optional(),
-    }),
-  }),
-]);
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // Safety ceiling on waiting for the result event delivered over the invocation stream.
 const CALL_RESULT_WAIT_TIMEOUT_MS = 3 * 60 * 1_000;
 
-export type SandboxFunctionCallOutcome =
-  | { ok: true; status: number; output: string }
-  | { ok: false; errorKind: string; message: string };
-
-function decodeResponseBody(
-  body: string | null,
-  encoding: "utf8" | "base64"
-): string {
-  if (body === null) {
-    return "";
-  }
-  return encoding === "base64"
-    ? Buffer.from(body, "base64").toString("utf8")
-    : body;
-}
-
 /**
  * Invoke a sandbox function and wait for its result.
- *
- * Returns Err for infra failures (sandbox unavailable, exec failure, missing/unparseable result),
- * and Ok with `ok: false` when the function ran but returned an error envelope, so the caller can
- * surface that as a correctable tool error. Input is validated by the runner, not here.
  */
 export async function callSandboxFunction(
   auth: Authenticator,
   sandboxFunction: SandboxFunctionResource,
   input: unknown
-): Promise<Result<SandboxFunctionCallOutcome, Error>> {
+): Promise<Result<unknown, SandboxFunctionCallError>> {
   const invocationResult = await sandboxFunction.invoke(auth, { input });
   if (invocationResult.isErr()) {
-    return invocationResult;
+    return new Err({
+      code: "invocation_failed",
+      message: invocationResult.error.message,
+    });
   }
   const invocation = invocationResult.value;
   const { sId: invocationId } = invocation;
 
-  for await (const { data } of getSandboxFunctionInvocationEvents({
-    invocationId,
-    lastEventId: null,
-    signal: AbortSignal.timeout(CALL_RESULT_WAIT_TIMEOUT_MS),
-  })) {
-    // Terminal error published when the invocation failed before producing a result.
-    if (data.type === "sandbox_function_invocation_error") {
-      return new Err(new Error(data.message));
-    }
+  try {
+    for await (const { data } of getSandboxFunctionInvocationEvents({
+      invocationId,
+      lastEventId: null,
+      signal: AbortSignal.timeout(CALL_RESULT_WAIT_TIMEOUT_MS),
+    })) {
+      if (data.type === "sandbox_function_invocation_error") {
+        return new Err(data.error);
+      }
 
-    if (data.type !== "sandbox_function_invocation_result") {
-      continue;
-    }
+      if (data.type !== "sandbox_function_invocation_result") {
+        continue;
+      }
 
-    const parsed = resultEnvelopeSchema.safeParse(data.result);
-    if (!parsed.success) {
-      return new Err(
-        new Error("Pod function returned an unexpected result envelope.")
-      );
+      return new Ok(data.result);
     }
-    if (!parsed.data.ok) {
-      return new Ok({
-        ok: false,
-        errorKind: parsed.data.error.kind,
-        message: parsed.data.error.message,
-      });
-    }
-
-    // A non-2xx (e.g. the runner's 400 on invalid input) is a valid response, not a tool error;
-    // the handler surfaces the status so the model can react.
-    const { response } = parsed.data;
-    return new Ok({
-      ok: true,
-      status: response.status,
-      output: decodeResponseBody(response.body, response.encoding),
+  } catch (error) {
+    return new Err({
+      code: "transport_error",
+      message: `Failed to receive sandbox function events: ${normalizeError(error).message}`,
     });
   }
 
-  return new Err(new Error("Pod function did not return a result in time."));
+  return new Err({
+    code: "transport_error",
+    message: "Pod function did not return a result in time.",
+  });
 }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -303,7 +303,7 @@ describe("SandboxFunctionInvocationResource", () => {
       expect.objectContaining({
         type: "sandbox_function_invocation_error",
         invocationId: invocation.sId,
-        message: "sandbox unavailable",
+        error: { code: "invocation_failed", message: "sandbox unavailable" },
       }),
       { invocationId: invocation.sId }
     );

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -30,6 +30,7 @@ import logger from "@app/logger/logger";
 import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
 import type {
   PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionCallError,
   SandboxFunctionInvocationStatus,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
@@ -153,11 +154,15 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.error;
   }
 
-  async fail(error: Error): Promise<void> {
+  async fail(error: Error | SandboxFunctionCallError): Promise<void> {
+    const callError: SandboxFunctionCallError =
+      error instanceof Error
+        ? { code: "invocation_failed", message: error.message }
+        : error;
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
-      error: error.message,
+      error: callError.message,
     };
     await this.writeDataToGcs();
     await this.update({ status: "errored" });
@@ -167,7 +172,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         created: Date.now(),
         invocationId: this.sId,
         functionId: this.sandboxFunction.sId,
-        message: error.message,
+        error: callError,
       },
       { invocationId: this.sId }
     );

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
@@ -103,7 +103,7 @@ describe("runSandboxFunctionInvocationActivity", () => {
       expect.objectContaining({
         type: "sandbox_function_invocation_error",
         invocationId: invocation.sId,
-        message: "sandbox unavailable",
+        error: { code: "invocation_failed", message: "sandbox unavailable" },
       }),
       { invocationId: invocation.sId }
     );

--- a/front/types/api/sandbox_functions.test.ts
+++ b/front/types/api/sandbox_functions.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { RUNNER_ERROR_CODES } from "../../../cli/dust-sandbox/functions-runner/protocol";
+import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "./sandbox_functions";
+
+describe("SANDBOX_FUNCTION_RUNNER_ERROR_CODES", () => {
+  it("stays aligned with the runner protocol", () => {
+    expect(SANDBOX_FUNCTION_RUNNER_ERROR_CODES).toEqual(RUNNER_ERROR_CODES);
+  });
+});

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -32,6 +32,33 @@ export type SandboxFunctionInvocationType = {
   createdAt: string;
 };
 
+export const SANDBOX_FUNCTION_RUNNER_ERROR_CODES = [
+  "bad_input",
+  "invalid_input",
+  "import_failed",
+  "threw",
+  "bad_return",
+  "http_error",
+  "invalid_output",
+] as const;
+
+export const SANDBOX_FUNCTION_CALL_ERROR_CODES = [
+  ...SANDBOX_FUNCTION_RUNNER_ERROR_CODES,
+  "function_not_found",
+  "invocation_failed",
+  "transport_error",
+  "not_supported",
+] as const;
+
+export type SandboxFunctionCallErrorCode =
+  (typeof SANDBOX_FUNCTION_CALL_ERROR_CODES)[number];
+
+export type SandboxFunctionCallError = {
+  code: SandboxFunctionCallErrorCode;
+  message: string;
+  status?: number;
+};
+
 export type SandboxFunctionMCPActionType = {
   sId: string;
   createdAt: number;
@@ -58,14 +85,14 @@ export type SandboxFunctionInvocationResultEvent = {
   result: unknown;
 };
 
-// Published when the invocation failed before producing a result, so listeners settle instead of
+// Published when the invocation cannot produce a valid result, so listeners settle instead of
 // waiting forever.
 export type SandboxFunctionInvocationErrorEvent = {
   type: "sandbox_function_invocation_error";
   created: number;
   invocationId: string;
   functionId: string;
-  message: string;
+  error: SandboxFunctionCallError;
 };
 
 export type SandboxFunctionInvocationEvent =


### PR DESCRIPTION
## Description

The sandbox callback currently publishes the runner's raw response envelope and can leave an invocation pending if a callback has an unexpected shape. This is PR 2 of 3 following the [Frames sandbox functions discussion](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1784105075929679), stacked on #28962.

This PR normalizes runner callbacks into parsed result events or structured terminal error events. It accepts both the v0.1.33 response envelope and the new v0.1.34 envelope during rollout; malformed callbacks terminally fail the invocation instead of leaving listeners hanging. The MCP caller now returns output directly on success and a typed `SandboxFunctionCallError` on failure, preserving optional HTTP status. Error-code parity with the runner protocol is asserted in tests, and the private API Swagger schemas are updated.

Follow-up: #28968 changes the Frame API and bumps the sandbox image.

## Tests

- Front typecheck with `npm run tsgo`
- Front API typecheck with `npm run tsgo`
- Callback route tests for new, legacy, structured-error, and malformed envelopes
- Sandbox function caller tests for direct output and typed terminal errors
- Runner/front error-code parity test
- Swagger generation and strict validation
- Biome checks on changed files

## Risk

This is a rollout compatibility layer. It accepts both deployed runner contracts and guarantees a terminal invocation state for callbacks that reach the endpoint. Rolling back before PR 3 is safe; rolling back after the image deployment should be paired with restoring the previous image pin.

## Deploy Plan

- [ ] Merge #28962 and release `dsbx` v0.1.34.
- [ ] Merge this PR before changing the sandbox image.
- [ ] Merge #28968 and build sandbox base image v0.8.55.
- [ ] Recycle Pod sandboxes onto the new image.
