### PR TITLE
[marketing] Fix heading alignment across website pages

### DIFF
--- a/marketing/components/home/ContentComponents.tsx
+++ b/marketing/components/home/ContentComponents.tsx
@@ -57,11 +57,11 @@ export const FullWidthSection = ({
 );
 
 const hClasses = {
-  h1: "heading-5xl md:heading-6xl lg:heading-8xl py-2 text-left",
-  h2: "heading-3xl lg:heading-4xl xl:heading-5xl py-2 text-left",
-  h3: "heading-xl lg:heading-2xl xl:heading-3xl py-1 text-left",
-  h4: "heading-lg lg:heading-xl xl:heading-2xl text-left",
-  h5: "heading-lg lg:heading-xl xl:heading-xl text-left",
+  h1: "heading-5xl md:heading-6xl lg:heading-8xl py-2",
+  h2: "heading-3xl lg:heading-4xl xl:heading-5xl py-2",
+  h3: "heading-xl lg:heading-2xl xl:heading-3xl py-1",
+  h4: "heading-lg lg:heading-xl xl:heading-2xl",
+  h5: "heading-lg lg:heading-xl xl:heading-xl",
 };
 
 interface ContentProps {
@@ -96,7 +96,7 @@ const createHeadingComponent = (Tag: TagName) => {
         )
       : classNames(hClasses[Tag], "font-sans");
     return (
-      <Tag id={id} className={classNames(className, baseClasses)} style={style}>
+      <Tag id={id} className={classNames(baseClasses, className)} style={style}>
         {children}
       </Tag>
     );
@@ -248,7 +248,7 @@ export function CloudConnectorsSection() {
 export function SecurityComplianceSection() {
   return (
     <div>
-      <H2 className="mb-6 text-left">Security & compliance</H2>
+      <H2 className="mb-6">Security & compliance</H2>
       <div className="grid gap-6 sm:gap-8 md:grid-cols-3">
         <div className="rounded-2xl bg-gray-50 p-6">
           <div className="mb-6 flex h-12 w-12 items-center justify-center">

--- a/marketing/components/home/content/Industry/IndustryTemplate.tsx
+++ b/marketing/components/home/content/Industry/IndustryTemplate.tsx
@@ -218,7 +218,7 @@ const PainPointsSection = ({
 }) => (
   <div className="py-12 md:py-16">
     <div className="container mx-auto px-6">
-      <H2 className="mb-8 text-left text-3xl sm:text-4xl md:mb-12 md:text-5xl lg:text-6xl">
+      <H2 className="mb-8 text-center text-3xl sm:text-4xl md:mb-12 md:text-5xl lg:text-6xl">
         {config.title}
       </H2>
       <div className="grid gap-6 sm:gap-8 md:grid-cols-3">

--- a/marketing/pages/home/enterprise.tsx
+++ b/marketing/pages/home/enterprise.tsx
@@ -1094,7 +1094,7 @@ function MosaicQuoteCard({
 function SocialProofMosaicSection() {
   return (
     <section className="w-full">
-      <H1 mono className="mb-12 text-left text-3xl md:text-4xl lg:text-5xl">
+      <H1 mono className="mb-12 text-center text-3xl md:text-4xl lg:text-5xl">
         Don't take our word for it
       </H1>
       <div className="grid auto-rows-auto grid-cols-1 gap-4 md:grid-cols-3">

--- a/marketing/pages/home/product.tsx
+++ b/marketing/pages/home/product.tsx
@@ -42,8 +42,8 @@ export function Landing() {
         <SecurityFeaturesSection />
       </div>
       <div className="mt-16 w-full">
-        <div className="mb-8 flex max-w-4xl flex-col gap-6 text-left sm:gap-2">
-          <H2 className="text-left text-3xl font-medium md:text-4xl xl:text-5xl">
+        <div className="mb-8 flex max-w-4xl flex-col gap-6 text-center sm:gap-2">
+          <H2 className="text-center text-3xl font-medium md:text-4xl xl:text-5xl">
             Driving AI ROI Together
           </H2>
         </div>

--- a/marketing/pages/home/slack/slack-integration.tsx
+++ b/marketing/pages/home/slack/slack-integration.tsx
@@ -217,7 +217,7 @@ function InstallationSection() {
     <div className="py-16 md:py-20">
       <div className={CONTAINER_CLASSES}>
         <div className="mb-12">
-          <H2 className="text-left text-3xl font-bold md:text-4xl lg:text-5xl">
+          <H2 className="text-center text-3xl font-bold md:text-4xl lg:text-5xl">
             Installation
           </H2>
         </div>


### PR DESCRIPTION
## Summary

- Remove hardcoded `text-left` from the `hClasses` defaults in `ContentComponents.tsx` (H1–H5), so callers can properly override alignment via `className`
- Fix class merging order so caller `className` wins over base classes
- Fix specific pages where titles were left-aligned in full-width centered sections:
  - `enterprise.tsx`: "Don't take our word for it" → `text-center`
  - `product.tsx`: "Driving AI ROI Together" → `text-center`
  - `slack-integration.tsx`: "Installation" → `text-center`
  - `IndustryTemplate.tsx`: pain points section title → `text-center`

## Test plan

- [ ] `/home/enterprise` — "Don't take our word for it" is centered
- [ ] `/home/product` — "Driving AI ROI Together" is centered
- [ ] `/home/slack/slack-integration` — "Installation" is centered
- [ ] `/home/industry/[industry]` — pain points title is centered
- [ ] Other sections with intentional left-aligned headings (split-column layouts) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)