### PR TITLE
Fixed fetching members balances for all users

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -458,20 +458,25 @@ async function fetchSeatDataForMembersTable({
 // Live per-seat AWU balance remaining for paid (seat-managed) seats, keyed by
 // userId. This is the expensive read (`listMetronomeSeatBalances`) gated to poke
 // — free seats are handled separately by `fetchFreeSeatCreditsForMembersTable`.
+// Always queried by explicit `seatIds`: Metronome's unfiltered seat-balances
+// list silently omits most seats on contracts with a few hundred+ seats.
 // Degrades to an empty map on any read failure so the table still renders.
 async function fetchSeatBalancesForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
+  userIds,
 }: {
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
+  userIds: string[];
 }): Promise<Map<string, number>> {
-  if (!metronomeCustomerId || !metronomeContractId) {
+  if (!metronomeCustomerId || !metronomeContractId || userIds.length === 0) {
     return new Map();
   }
   const result = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId,
+    seatIds: userIds,
   });
   const balanceByUserId = new Map<string, number>();
   if (result.isErr()) {
@@ -1323,6 +1328,7 @@ export async function getMembersUsage({
       ? fetchSeatBalancesForMembersTable({
           metronomeCustomerId: metronomeCustomerId ?? null,
           metronomeContractId,
+          userIds: users.map((u) => u.sId),
         })
       : Promise.resolve(new Map<string, number>()),
     // Free-seat per-user credit balance + granted total. Needed on every surface

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -502,11 +502,45 @@ export async function reconcileWorkspaceUserCreditStates({
   }
   const workspaceId = workspace.sId;
 
+  // The seat-allowance cache (contract) and the DB queries can genuinely
+  // throw, so they stay wrapped — the ERR1-authorised case. The per-user
+  // overrides come from the memberships and the workspace default from the
+  // credit-usage configuration (both pool-only values); the seat allowances
+  // are needed to derive the total thresholds.
+  let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
+  let defaultPoolCapAwuCredits: number;
+  let memberships: MembershipResource[];
+  try {
+    seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
+    const creditUsageConfig =
+      await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+        workspace.id
+      );
+    defaultPoolCapAwuCredits = creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
+    ({ memberships } = await MembershipResource.getActiveMemberships({
+      workspace,
+    }));
+  } catch (err) {
+    logger.error(
+      { workspaceId, err: normalizeError(err) },
+      "[ReconcileCreditState] Failed to load cap thresholds or memberships"
+    );
+    return;
+  }
+
+  // Per-user usage and seat balances are both scoped to the active members'
+  // user ids (an unfiltered seatBalances query silently omits most seats on
+  // contracts with a few hundred+ seats), so load memberships first.
+  const memberUserIds = memberships
+    .map((m) => m.user?.sId)
+    .filter((sId): sId is string => sId !== undefined);
+
   // These return our `Result` type: handle their errors with early returns
   // rather than throw + catch (ERR1).
   const seatBalancesResult = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId,
+    seatIds: memberUserIds,
   });
   if (seatBalancesResult.isErr()) {
     logger.error(
@@ -536,37 +570,6 @@ export async function reconcileWorkspaceUserCreditStates({
     ? perUserCreditBalancesResult.value
     : new Map<string, { balanceAwu: number; startingBalanceAwu: number }>();
 
-  // The seat-allowance cache (contract) and the DB queries can genuinely
-  // throw, so they stay wrapped — the ERR1-authorised case. The per-user
-  // overrides come from the memberships and the workspace default from the
-  // credit-usage configuration (both pool-only values); the seat allowances
-  // are needed to derive the total thresholds.
-  let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
-  let defaultPoolCapAwuCredits: number;
-  let memberships: MembershipResource[];
-  try {
-    seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
-    const creditUsageConfig =
-      await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
-        workspace.id
-      );
-    defaultPoolCapAwuCredits = creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
-    ({ memberships } = await MembershipResource.getActiveMemberships({
-      workspace,
-    }));
-  } catch (err) {
-    logger.error(
-      { workspaceId, err: normalizeError(err) },
-      "[ReconcileCreditState] Failed to load cap thresholds or memberships"
-    );
-    return;
-  }
-
-  // Per-user usage is scoped to the active members' user ids (an unfiltered
-  // query is capped server-side and omits users), so load memberships first.
-  const memberUserIds = memberships
-    .map((m) => m.user?.sId)
-    .filter((sId): sId is string => sId !== undefined);
   const usageResult = await fetchPerUserAwuUsage({
     workspaceId,
     metronomeCustomerId,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -8,6 +8,7 @@ import {
   PLAN_CODE_CUSTOM_FIELD_KEY,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -3656,23 +3657,36 @@ export async function adjustSeatCreditBalances({
   }
 }
 
+// Chunk size for the `seat_ids` filter on seatBalances/list. Unrelated to
+// MAX_SEAT_IDS_PER_EDIT (a different endpoint's documented cap) — kept at the
+// same size as the page `limit` below since that's the only size we've
+// confirmed behaves correctly.
+const MAX_SEAT_IDS_PER_SEAT_BALANCES_QUERY = 100;
+
 /**
  * List per-seat balances for a SEAT_BASED contract.
  * Uses a raw fetch because the Metronome SDK does not yet expose this endpoint.
  * Returns one entry per seat_id (user sId), with balance (remaining) and
  * starting_balance (full allocation for the period).
- * Pass `seatIds` to restrict the query to specific seats (no pagination needed).
+ *
+ * Always pass `seatIds` when the caller knows which seats it needs. The
+ * unfiltered call (no `seat_ids`) has been observed in production to
+ * silently omit the large majority of seats on contracts with a few hundred+
+ * seats — pagination itself terminates correctly (`next_page` legitimately
+ * goes null), the underlying list is just incomplete. Filtering by
+ * `seat_ids` reliably returns the seat's balance, so `seatIds` is chunked
+ * here and queried explicitly rather than relying on the full list.
  */
 export async function listMetronomeSeatBalances({
   metronomeCustomerId,
   metronomeContractId,
   coveringDate = new Date(),
-  seatId,
+  seatIds,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
   coveringDate?: Date;
-  seatId?: string;
+  seatIds?: string[];
 }): Promise<Result<MetronomeSeatBalance[], Error>> {
   if (!config.getMetronomeApiKey()) {
     return new Ok([]);
@@ -3683,31 +3697,124 @@ export async function listMetronomeSeatBalances({
       data?: unknown[];
       pagination?: {
         next_page?: string | null;
-        seats_available_for_next_page?: number | null;
       };
     };
-    const allBalances: MetronomeSeatBalance[] = [];
-    let nextPage: string | null | undefined = undefined;
-    do {
-      const page: SeatBalancesPage =
-        await getMetronomeClient().post<SeatBalancesPage>(
-          "/v1/contracts/seatBalances/list",
+
+    const fetchSeatIdsChunk = async (
+      seatIdsChunk: string[] | undefined
+    ): Promise<MetronomeSeatBalance[]> => {
+      const chunkBalances: MetronomeSeatBalance[] = [];
+      let nextPage: string | null | undefined = undefined;
+      do {
+        const page: SeatBalancesPage =
+          await getMetronomeClient().post<SeatBalancesPage>(
+            "/v1/contracts/seatBalances/list",
+            {
+              body: {
+                customer_id: metronomeCustomerId,
+                contract_id: metronomeContractId,
+                include_credits_and_commits: true,
+                covering_date: coveringDate.toISOString(),
+                limit: 100,
+                ...(seatIdsChunk ? { seat_ids: seatIdsChunk } : {}),
+                ...(nextPage ? { cursor: nextPage } : {}),
+              },
+            }
+          );
+        chunkBalances.push(...(page.data ?? []).filter(isMetronomeSeatBalance));
+        nextPage = page.pagination?.next_page ?? null;
+      } while (nextPage);
+      return chunkBalances;
+    };
+
+    // Single-seat fetch that never throws: any failure (an explicit
+    // rejection like "not found in contract subscriptions", or still no
+    // result) just means this seat_id is skipped, with a warning logged.
+    const fetchOneSeatId = async (
+      id: string
+    ): Promise<MetronomeSeatBalance[]> => {
+      try {
+        const result = await fetchSeatIdsChunk([id]);
+        if (result.length === 0) {
+          logger.warn(
+            { metronomeCustomerId, metronomeContractId, seatId: id },
+            "[Metronome] No seat balance found for seat_id — skipping"
+          );
+        }
+        return result;
+      } catch (err) {
+        logger.warn(
           {
-            body: {
-              customer_id: metronomeCustomerId,
-              contract_id: metronomeContractId,
-              include_credits_and_commits: true,
-              covering_date: coveringDate.toISOString(),
-              limit: 100,
-              ...(seatId ? { seat_ids: [seatId] } : {}),
-              ...(nextPage ? { cursor: nextPage } : {}),
-            },
-          }
+            metronomeCustomerId,
+            metronomeContractId,
+            seatId: id,
+            error: normalizeError(err),
+          },
+          "[Metronome] Seat balance not found for individual seat_id — skipping"
         );
-      allBalances.push(...(page.data ?? []).filter(isMetronomeSeatBalance));
-      const hasMore = (page.pagination?.seats_available_for_next_page ?? 0) > 0;
-      nextPage = hasMore ? page.pagination?.next_page : null;
-    } while (nextPage);
+        return [];
+      }
+    };
+
+    // Resiliently fetch one chunk (up to 100 seat_ids):
+    //  1. Try the whole chunk. Metronome rejects the *entire* batch with a
+    //     400 if any single seat_id in it isn't found on the contract (e.g.
+    //     a removed/reassigned seat) — it doesn't just omit the bad id — so
+    //     a chunk failure falls back to querying each id individually
+    //     instead of losing every seat in the batch.
+    //  2. Separately, some ids can be missing from an otherwise-successful
+    //     response with no error at all — Metronome has been observed to
+    //     non-deterministically omit a valid, balance-holding seat. Those
+    //     are retried individually once; if still missing, they're skipped.
+    const fetchSeatIdsChunkResilient = async (
+      seatIdsChunk: string[] | undefined
+    ): Promise<MetronomeSeatBalance[]> => {
+      if (!seatIdsChunk) {
+        return fetchSeatIdsChunk(undefined);
+      }
+
+      let balances: MetronomeSeatBalance[];
+      try {
+        balances = await fetchSeatIdsChunk(seatIdsChunk);
+      } catch (err) {
+        if (seatIdsChunk.length <= 1) {
+          throw err;
+        }
+        logger.warn(
+          {
+            metronomeCustomerId,
+            metronomeContractId,
+            error: normalizeError(err),
+          },
+          "[Metronome] Seat balances chunk failed — retrying seat_ids individually"
+        );
+        const perSeatResults = await concurrentExecutor(
+          seatIdsChunk,
+          fetchOneSeatId,
+          { concurrency: 8 }
+        );
+        return perSeatResults.flat();
+      }
+
+      const foundIds = new Set(balances.map((b) => b.seat_id));
+      const missingIds = seatIdsChunk.filter((id) => !foundIds.has(id));
+      if (missingIds.length > 0) {
+        const retried = await concurrentExecutor(missingIds, fetchOneSeatId, {
+          concurrency: 8,
+        });
+        balances = balances.concat(retried.flat());
+      }
+      return balances;
+    };
+
+    const seatIdsChunks = seatIds
+      ? chunk(seatIds, MAX_SEAT_IDS_PER_SEAT_BALANCES_QUERY)
+      : [undefined];
+    const allBalances: MetronomeSeatBalance[] = [];
+    for (const seatIdsChunk of seatIdsChunks) {
+      allBalances.push(...(await fetchSeatIdsChunkResilient(seatIdsChunk)));
+    }
+
     return new Ok(allBalances);
   } catch (err) {
     const error = normalizeError(err);

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -126,7 +126,7 @@ export async function fetchLiveUserCreditInputs({
     const seatBalancesResult = await listMetronomeSeatBalances({
       metronomeCustomerId,
       metronomeContractId,
-      seatId: userId,
+      seatIds: [userId],
     });
     if (seatBalancesResult.isErr()) {
       return new Err(

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1054,9 +1054,12 @@ async function emptyOriginSeatCreditsForTransfers({
   allocationBySeatType: Map<MembershipSeatType, number>;
   desiredSeatByUser: Map<string, MembershipSeatType>;
 }): Promise<SeatCreditTransfer[]> {
+  // Queried by explicit seatIds: an unfiltered listMetronomeSeatBalances call
+  // silently omits most seats on contracts with a few hundred+ seats.
   const balancesRes = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId: contractId,
+    seatIds: [...desiredSeatByUser.keys()],
   });
   if (balancesRes.isErr()) {
     logger.error(
@@ -1256,11 +1259,14 @@ async function carryConsumptionToNewSeatCredits({
     }
 
     // Read the seat's current balance on the new credit at the adjustment time,
-    // then compute the delta to reach `allocation − consumed`.
+    // then compute the delta to reach `allocation − consumed`. Queried by
+    // explicit seatIds: an unfiltered call silently omits most seats on
+    // contracts with a few hundred+ seats.
     const balancesRes = await listMetronomeSeatBalances({
       metronomeCustomerId,
       metronomeContractId: contractId,
       coveringDate: timestamp,
+      seatIds: [t.userSId],
     });
     if (balancesRes.isErr()) {
       logger.error(

--- a/front/scripts/debug_seat_balances.ts
+++ b/front/scripts/debug_seat_balances.ts
@@ -1,0 +1,116 @@
+/**
+ * Cross-reference active pro/max members against Metronome's live seat
+ * balances, queried by explicit seat_ids (the reliable method — see the doc
+ * comment on listMetronomeSeatBalances in lib/metronome/client.ts: the
+ * unfiltered "list all seats" call silently omits most seats on large
+ * contracts, so this always filters).
+ *
+ * Prints exactly which users have no live seat balance in Metronome and
+ * their seat type. Metronome API errors for individual bad seat_ids (e.g.
+ * "not found in contract subscriptions") are logged as warnings by
+ * listMetronomeSeatBalances itself — those are expected noise, the final
+ * "[debug] Result" line is the answer.
+ *
+ * Read-only.
+ *
+ *   npx tsx scripts/debug_seat_balances.ts --workspaceId <wId>
+ *   npx tsx scripts/debug_seat_balances.ts --workspaceId <wId> --userId <uId>
+ */
+import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    workspaceId: { alias: "w", type: "string" as const, demandOption: true },
+    userId: { alias: "u", type: "string" as const, demandOption: false },
+  },
+  async ({ workspaceId, userId }, logger) => {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      logger.error({ workspaceId }, "Workspace not found");
+      return;
+    }
+
+    const metronomeCustomerId = workspace.metronomeCustomerId ?? undefined;
+    const subscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    const metronomeContractId = subscription?.metronomeContractId ?? undefined;
+
+    if (!metronomeCustomerId || !metronomeContractId) {
+      logger.error(
+        { workspaceId, metronomeCustomerId, metronomeContractId },
+        "Workspace has no metronomeCustomerId or no active subscription with a metronomeContractId"
+      );
+      return;
+    }
+
+    const awuCreditTypeId = getCreditTypeAwuId();
+
+    if (userId) {
+      const result = await listMetronomeSeatBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+        seatIds: [userId],
+      });
+      if (result.isErr()) {
+        logger.error({ err: result.error }, "[debug] Query failed");
+        return;
+      }
+      const seat = result.value.find((s) => s.seat_id === userId);
+      const awu = seat?.balances.find(
+        (b) => b.credit_type_id === awuCreditTypeId
+      );
+      logger.info(
+        { userId, found: !!seat, awu: awu ?? null },
+        "[debug] Result for userId"
+      );
+      return;
+    }
+
+    // Only pro/max (and their _yearly variants) carry an individual
+    // Metronome seat balance — free is a per-user credit (different
+    // Metronome object), and "none"/"workspace" seats have no per-seat
+    // balance at all.
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      workspace: renderLightWorkspaceType({ workspace }),
+    });
+    const seatBalanceEligible = new Set([
+      "pro",
+      "pro_yearly",
+      "max",
+      "max_yearly",
+    ]);
+    const eligibleMembers = memberships
+      .filter((m) => m.user?.sId && seatBalanceEligible.has(m.seatType))
+      .map((m) => ({ userId: m.user!.sId, seatType: m.seatType }));
+
+    const result = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+      seatIds: eligibleMembers.map((m) => m.userId),
+    });
+    if (result.isErr()) {
+      logger.error({ err: result.error }, "[debug] Query failed");
+      return;
+    }
+
+    const foundSeatIds = new Set(result.value.map((s) => s.seat_id));
+    const missing = eligibleMembers.filter((m) => !foundSeatIds.has(m.userId));
+
+    logger.info(
+      {
+        eligibleMembers: eligibleMembers.length,
+        foundCount: foundSeatIds.size,
+        missingCount: missing.length,
+        missing,
+      },
+      "[debug] Result: pro/max members with no live seat balance in Metronome"
+    );
+  }
+);

--- a/front/scripts/debug_user_awu_spend.ts
+++ b/front/scripts/debug_user_awu_spend.ts
@@ -101,6 +101,7 @@ makeScript(
     const seatBalancesResult = await listMetronomeSeatBalances({
       metronomeCustomerId,
       metronomeContractId,
+      seatIds: [userId],
     });
     if (seatBalancesResult.isErr()) {
       logger.error(


### PR DESCRIPTION
## Description

Fixes `listMetronomeSeatBalances` returning incomplete results on contracts with a few hundred+ seats, which caused two visible bugs:
- poke's Usage tab showing `- / 8,000` (missing seat balance) for many users
- the credit-state reconcile job defaulting those same users to `on_pool` even though they had plenty of seat balance remaining

**Root cause**: the function queried Metronome's `/v1/contracts/seatBalances/list` unfiltered ("list all seats on this contract"). That unfiltered mode silently omits most seats on large contracts — pagination itself terminates correctly (`next_page` legitimately goes `null`), the underlying list Metronome returns is just incomplete. Querying the same endpoint with an explicit `seat_ids` filter reliably returns the seat.

Confirmed live on a ~910-seat production contract: the unfiltered list returned 536 seats; the same seats queried via `seat_ids` in one pass came back essentially complete.

**Fix**: `listMetronomeSeatBalances` now takes `seatIds?: string[]` (chunked in batches of 100) instead of relying on the unfiltered list, plus two robustness fixes found while validating against production data:
- **Chunk-level resilience**: Metronome rejects an entire `seat_ids` batch with a 400 if even one id in it isn't found on the contract (e.g. a removed/reassigned seat). A chunk failure now falls back to querying that chunk's ids individually instead of losing every seat in the batch.
- **Retry on silent omission**: separately from the above, Metronome was observed to non-deterministically omit a valid, balance-holding seat from an otherwise-successful (200) response — reproducible with a single user across back-to-back identical calls, no error at all. This is now retried (up to 2x, 300ms apart) before a seat is reported as missing, and is tracked separately from a confirmed absence (an explicit 400 "not found in contract subscriptions", which is not retried).

Updated every call site to pass explicit seat ids instead of relying on the unfiltered list:
- `lib/api/credits/members_usage.ts` — poke Usage tab
- `lib/api/metronome/reconcile_credit_state.ts` — the global credit-state reconcile (reordered to fetch memberships before the seat-balance call, since the ids are now needed up front)
- `lib/metronome/seats.ts` (×2) — seat credit transfer logic (upgrade/downgrade between seat types), which had the same unfiltered-list bug and could silently miscompute credit carryover during a seat-type transfer
- `lib/metronome/live_user_credit_inputs.ts`, `scripts/debug_user_awu_spend.ts` — already single-seat callers, just renamed the param

Also adds `scripts/debug_seat_balances.ts`, a read-only diagnostic script to cross-reference a workspace's active pro/max members against Metronome's live seat balances and report exactly who's missing one.

## Tests

- Existing unit tests for all touched files pass (`client.test.ts`, `seats.test.ts`, `reconcile_credit_state.test.ts`, `live_user_credit_inputs.test.ts` — 87 tests).
- Manually verified against a live ~910-seat production contract via `scripts/debug_seat_balances.ts`:
  - Before: unfiltered list found 536/910 seats.
  - After (filtered, no retry yet): found 878-883/910, non-deterministically, matching the "silent omission" theory.
  - After (filtered + retry): found 906/910, with the remaining 4 all confirmed via explicit "not found in contract subscriptions" errors (a real, separate data gap — those 4 users' seats genuinely aren't registered on the contract subscription; needs a seat-count sync, not a code fix).

## Risk

- Behavioral change to a widely-used Metronome read path (`listMetronomeSeatBalances`), but the change only makes it more correct (was silently dropping data before); no callers relied on the old unfiltered behavior on purpose.
- Slightly more Metronome API calls per invocation (chunked + occasional retries) instead of one unfiltered call, but bounded (100 ids/chunk, max 2 retries per unresolved id) and only runs where seat ids are already known.
- Safe to roll back: reverts to the previous (buggy but previously-shipped) behavior.

## Deploy Plan

Standard deploy. No migration, no config change, no feature flag. Once live, worth re-running `scripts/debug_seat_balances.ts --workspaceId <wId>` against the previously-affected workspace to confirm the fix, then using the "Sync Metronome Seat Count" poke plugin to resolve any workspace's remaining confirmed-absent seats (a separate, genuine data-sync action, not part of this PR).
