### PR TITLE
Return sandbox function outputs directly to Frames

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.35"
+version = "0.1.36"
 edition = "2021"
 
 [[bin]]

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -13,6 +13,7 @@ import datadogLogger from "@app/logger/datadogLogger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
+  SandboxFunctionCallError,
   SandboxFunctionInvocationEvent,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
@@ -89,6 +90,22 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
   );
 };
 
+const sendErrorToIframe = (
+  request: { command: "callFunction" } & VisualizationRPCRequest,
+  error: SandboxFunctionCallError,
+  target: MessageEventSource
+) => {
+  target.postMessage(
+    {
+      command: "answer",
+      messageUniqueId: request.messageUniqueId,
+      identifier: request.identifier,
+      error,
+    },
+    { targetOrigin: "*" }
+  );
+};
+
 const getExtensionFromBlob = (blob: Blob): string => {
   const mimeToExt: Record<string, string> = {
     "image/png": "png",
@@ -105,7 +122,7 @@ interface SandboxFunctionInvocationProps {
   invocationId: string;
   onSettle: (
     invocationId: string,
-    response: CommandResultMap["callFunction"]
+    result: Result<unknown, SandboxFunctionCallError>
   ) => void;
 }
 
@@ -180,13 +197,10 @@ function SandboxFunctionInvocation({
             // NO-OP
             break;
           case "sandbox_function_invocation_result":
-            onSettle(invocationId, { result: eventPayload.data.result });
+            onSettle(invocationId, new Ok(eventPayload.data.result));
             break;
           case "sandbox_function_invocation_error":
-            onSettle(invocationId, {
-              result: null,
-              error: eventPayload.data.error.message,
-            });
+            onSettle(invocationId, new Err(eventPayload.data.error));
             break;
           case "tool_approve_execution":
           case "tool_personal_auth_required":
@@ -196,22 +210,28 @@ function SandboxFunctionInvocation({
             assertNeverAndIgnore(eventPayload.data);
         }
       } catch (error) {
-        onSettle(invocationId, {
-          result: null,
-          error:
-            "Failed to parse function invocation event: " +
-            normalizeError(error).message,
-        });
+        onSettle(
+          invocationId,
+          new Err({
+            code: "transport_error",
+            message:
+              "Failed to parse function invocation event: " +
+              normalizeError(error).message,
+          })
+        );
       }
     },
     [invocationId, onSettle, enqueueBlockedAction]
   );
 
   const onTerminalError = useCallback(() => {
-    onSettle(invocationId, {
-      result: null,
-      error: "Failed to listen to function invocation events.",
-    });
+    onSettle(
+      invocationId,
+      new Err({
+        code: "transport_error",
+        message: "Failed to listen to function invocation events.",
+      })
+    );
   }, [invocationId, onSettle]);
 
   useEventSource(
@@ -277,7 +297,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation: (
     functionIdOrSlug: string,
     input?: unknown
-  ) => Promise<Result<SandboxFunctionInvocationType, Error>>;
+  ) => Promise<Result<SandboxFunctionInvocationType, SandboxFunctionCallError>>;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
@@ -288,7 +308,7 @@ function useVisualizationDataHandler({
   waitForSandboxFunctionInvocationResult: (params: {
     functionId: string;
     invocationId: string;
-  }) => Promise<CommandResultMap["callFunction"]>;
+  }) => Promise<Result<unknown, SandboxFunctionCallError>>;
 }) {
   const sendNotification = useSendNotification();
   const { code } = visualization;
@@ -352,15 +372,7 @@ function useVisualizationDataHandler({
           );
 
           if (invocationRes.isErr()) {
-            sendResponseToIframe(
-              data,
-              {
-                result: null,
-                error:
-                  "Failed to call function: " + invocationRes.error.message,
-              },
-              event.source
-            );
+            sendErrorToIframe(data, invocationRes.error, event.source);
             break;
           }
 
@@ -369,7 +381,11 @@ function useVisualizationDataHandler({
             invocationId: invocationRes.value.sId,
           });
 
-          sendResponseToIframe(data, result, event.source);
+          if (result.isErr()) {
+            sendErrorToIframe(data, result.error, event.source);
+          } else {
+            sendResponseToIframe(data, result.value, event.source);
+          }
           break;
         }
 
@@ -515,7 +531,7 @@ export const VisualizationActionIframe = forwardRef<
   >([]);
   const invocationResolversRef = useRef<Map<
     string,
-    (response: CommandResultMap["callFunction"]) => void
+    (result: Result<unknown, SandboxFunctionCallError>) => void
   > | null>(null);
   if (invocationResolversRef.current === null) {
     invocationResolversRef.current = new Map();
@@ -530,7 +546,7 @@ export const VisualizationActionIframe = forwardRef<
       functionId: string;
       invocationId: string;
     }) =>
-      new Promise<CommandResultMap["callFunction"]>((resolve) => {
+      new Promise<Result<unknown, SandboxFunctionCallError>>((resolve) => {
         invocationResolvers.set(invocationId, resolve);
         setActiveInvocations((prev) => [...prev, { functionId, invocationId }]);
       }),
@@ -538,13 +554,16 @@ export const VisualizationActionIframe = forwardRef<
   );
 
   const settleSandboxFunctionInvocation = useCallback(
-    (invocationId: string, response: CommandResultMap["callFunction"]) => {
+    (
+      invocationId: string,
+      result: Result<unknown, SandboxFunctionCallError>
+    ) => {
       const resolve = invocationResolvers.get(invocationId);
       invocationResolvers.delete(invocationId);
       setActiveInvocations((prev) =>
         prev.filter((invocation) => invocation.invocationId !== invocationId)
       );
-      resolve?.(response);
+      resolve?.(result);
     },
     [invocationResolvers]
   );
@@ -624,10 +643,15 @@ export const VisualizationActionIframe = forwardRef<
     async (
       functionIdOrSlug: string,
       input?: unknown
-    ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
+    ): Promise<
+      Result<SandboxFunctionInvocationType, SandboxFunctionCallError>
+    > => {
       try {
         if (frameAccess === "public-anonymous") {
-          throw new Error("Pod functions are not supported in shared frames.");
+          return new Err({
+            code: "not_supported",
+            message: "Pod functions are not supported in shared frames.",
+          });
         }
 
         const body: PostSandboxFunctionInvocationRequestBody = {
@@ -648,7 +672,14 @@ export const VisualizationActionIframe = forwardRef<
 
         if (!response.ok) {
           const error = await getErrorFromResponse(response);
-          throw new Error(error.message);
+          return new Err({
+            code:
+              "type" in error && error.type === "sandbox_function_not_found"
+                ? "function_not_found"
+                : "invocation_failed",
+            message: error.message,
+            status: response.status,
+          });
         }
 
         const result: PostSandboxFunctionInvocationResponseBody =
@@ -656,7 +687,10 @@ export const VisualizationActionIframe = forwardRef<
 
         return new Ok(result.invocation);
       } catch (error) {
-        return new Err(normalizeError(error));
+        return new Err({
+          code: "transport_error",
+          message: normalizeError(error).message,
+        });
       }
     },
     [frameAccess, workspaceId]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.56",
+      tag: "0.8.57",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.35/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.36/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.56";
-const DSBX_CLI_VERSION = "0.1.35";
+const DUST_BASE_IMAGE_VERSION = "0.8.57";
+const DSBX_CLI_VERSION = "0.1.36";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -180,14 +180,15 @@ the mount-path form \`pod-<podId>/<slug>\` resolves from a Frame.
 \`\`\`ts
 import { callFunction } from "@dust/react-hooks";
 
-const { result, error } = await callFunction("<podId>/<slug>", input);
+const output = await callFunction("<podId>/<slug>", input);
 \`\`\`
 
-\`input\` must match the function's declared input schema (see \`get\`). Check \`error\` and render
-loading/error state, since this is a network call like any other in the Frame. \`result\` is
-currently the raw sandbox runner envelope (\`{ ok, response: { status, body, encoding, ... } }\`)
-rather than the parsed \`schema.output\`, so parse \`response.body\` yourself. Pod functions are
-only reachable from authenticated Pod Frames, not from public or shared Frames.`,
+\`input\` must match the function's declared input schema (see \`get\`). The promise resolves to
+the parsed and validated \`schema.output\`. It rejects with a \`SandboxFunctionCallError\` (also
+exported by \`@dust/react-hooks\`) whose \`code\` distinguishes missing functions, invalid
+input/output, handler failures, HTTP errors, and transport failures; render loading and error
+states like for any other network call. Pod functions are only reachable from authenticated
+Pod Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
   version: 3,
   icon: "PuzzleIcon",

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -134,7 +134,7 @@ export type VisualizationRPCRequestMap = {
 
 // Command results.
 export interface CommandResultMap {
-  callFunction: { result: unknown; error?: string };
+  callFunction: unknown;
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/viz/app/components/VisualizationWrapper.test.ts
+++ b/viz/app/components/VisualizationWrapper.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { makeSendCrossDocumentMessage } from "@viz/app/components/VisualizationWrapper";
+import { describe, expect, it, vi } from "vitest";
+
+const ALLOWED_ORIGIN = "https://app.dust.tt";
+
+function hasMessageUniqueId(
+  value: unknown
+): value is { messageUniqueId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "messageUniqueId" in value &&
+    typeof value.messageUniqueId === "string"
+  );
+}
+
+describe("makeSendCrossDocumentMessage", () => {
+  it("returns a direct callFunction result from the parent", async () => {
+    vi.spyOn(window, "postMessage").mockImplementation((message) => {
+      if (!hasMessageUniqueId(message)) {
+        throw new Error("RPC request has no message id.");
+      }
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            messageUniqueId: message.messageUniqueId,
+            result: { greeting: "Hello" },
+          },
+        })
+      );
+    });
+    const sendMessage = makeSendCrossDocumentMessage({
+      identifier: "frame",
+      allowedOrigins: [ALLOWED_ORIGIN],
+    });
+
+    await expect(
+      sendMessage("callFunction", {
+        functionIdOrSlug: "greet",
+        input: { name: "Dust" },
+      })
+    ).resolves.toEqual({ greeting: "Hello" });
+  });
+
+  it("rejects with the structured error sent by the parent", async () => {
+    vi.spyOn(window, "postMessage").mockImplementation((message) => {
+      if (!hasMessageUniqueId(message)) {
+        throw new Error("RPC request has no message id.");
+      }
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            messageUniqueId: message.messageUniqueId,
+            error: {
+              code: "http_error",
+              message: "Function returned HTTP 503.",
+              status: 503,
+            },
+          },
+        })
+      );
+    });
+    const sendMessage = makeSendCrossDocumentMessage({
+      identifier: "frame",
+      allowedOrigins: [ALLOWED_ORIGIN],
+    });
+
+    await expect(
+      sendMessage("callFunction", {
+        functionIdOrSlug: "greet",
+      })
+    ).rejects.toEqual({
+      code: "http_error",
+      message: "Function returned HTTP 503.",
+      status: 503,
+    });
+  });
+});

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -3,6 +3,7 @@
 import { EditableFrame } from "@viz/app/components/EditableFrame";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
 import { VizContext } from "@viz/app/components/VizContext";
+import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
 import { transformEditableText } from "@viz/app/lib/transformEditableText";
 import type {
@@ -439,6 +440,7 @@ export function VisualizationWrapper({
           "@dust/slideshow/v1": dustSlideshowV1,
           "@dust/slideshow/v2": dustSlideshowV2,
           "@dust/react-hooks": {
+            SandboxFunctionCallError,
             callFunction: (functionId: string, input?: unknown) =>
               api.data.callFunction(functionId, input),
             captureScreenshot: handleScreenshotDownload,

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -1,3 +1,4 @@
+import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 
 export interface PreFetchedFile {
@@ -41,14 +42,11 @@ export class CacheDataAPI implements VisualizationDataAPI {
     }
   }
 
-  async callFunction(functionId: string) {
-    console.error(
-      `Sandbox function ${functionId} is not supported in public frames.`
-    );
-    return {
-      result: null,
-      error: "Sandbox functions are not supported in public frames.",
-    };
+  async callFunction(functionId: string): Promise<unknown> {
+    throw new SandboxFunctionCallError({
+      code: "not_supported",
+      message: `Sandbox function ${functionId} is not supported in public frames.`,
+    });
   }
 
   async fetchFile(fileId: string): Promise<File | null> {

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { CacheDataAPI } from "@viz/app/lib/data-apis/cache-data-api";
+import { RPCDataAPI } from "@viz/app/lib/data-apis/rpc-data-api";
+import {
+  SANDBOX_FUNCTION_CALL_ERROR_CODES,
+  SandboxFunctionCallError,
+} from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import { describe, expect, it } from "vitest";
+
+function extractStringArray(source: string, constantName: string): string[] {
+  const match = source.match(
+    new RegExp(`export const ${constantName} = \\[([\\s\\S]*?)\\] as const;`)
+  );
+  if (!match?.[1]) {
+    throw new Error(`Could not find ${constantName}.`);
+  }
+  return Array.from(match[1].matchAll(/"([^"]+)"/g), ([, value]) => value);
+}
+
+describe("sandbox function data APIs", () => {
+  it("keeps Frame error codes aligned with front", () => {
+    const runnerSource = readFileSync(
+      new URL(
+        "../../../../cli/dust-sandbox/functions-runner/protocol.ts",
+        import.meta.url
+      ),
+      "utf8"
+    );
+    const frontSource = readFileSync(
+      new URL(
+        "../../../../front/types/api/sandbox_functions.ts",
+        import.meta.url
+      ),
+      "utf8"
+    );
+    const frontCodes = [
+      ...extractStringArray(runnerSource, "RUNNER_ERROR_CODES"),
+      ...extractStringArray(frontSource, "SANDBOX_FUNCTION_CALL_ERROR_CODES"),
+    ];
+
+    expect(SANDBOX_FUNCTION_CALL_ERROR_CODES).toEqual(frontCodes);
+  });
+
+  it("rejects RPC calls with a typed sandbox function error", async () => {
+    const api = new RPCDataAPI(async () => {
+      throw {
+        code: "invalid_output",
+        message: "Function output does not match schema.output.",
+      };
+    });
+
+    const promise = api.callFunction("pod/function");
+
+    await expect(promise).rejects.toBeInstanceOf(SandboxFunctionCallError);
+    await expect(promise).rejects.toMatchObject({ code: "invalid_output" });
+  });
+
+  it("rejects calls from public frames as unsupported", async () => {
+    const api = new CacheDataAPI();
+
+    await expect(api.callFunction("pod/function")).rejects.toMatchObject({
+      code: "not_supported",
+    });
+  });
+});

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -1,3 +1,4 @@
+import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import type {
   CommandResultMap,
@@ -24,23 +25,14 @@ export class RPCDataAPI implements VisualizationDataAPI {
     this.sendMessage = sendMessage;
   }
 
-  async callFunction(functionId: string, input?: unknown) {
+  async callFunction(functionId: string, input?: unknown): Promise<unknown> {
     try {
-      const result = await this.sendMessage("callFunction", {
+      return await this.sendMessage("callFunction", {
         functionIdOrSlug: functionId,
         input,
       });
-
-      return result;
     } catch (error) {
-      console.error(`Failed to call sandbox function ${functionId}:`, error);
-      return {
-        result: null,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to call sandbox function.",
-      };
+      throw normalizeSandboxFunctionCallError(error);
     }
   }
 

--- a/viz/app/lib/data-apis/sandbox-function-call-error.ts
+++ b/viz/app/lib/data-apis/sandbox-function-call-error.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+export const SANDBOX_FUNCTION_CALL_ERROR_CODES = [
+  "bad_input",
+  "invalid_input",
+  "import_failed",
+  "threw",
+  "bad_return",
+  "http_error",
+  "invalid_output",
+  "function_not_found",
+  "invocation_failed",
+  "transport_error",
+  "not_supported",
+] as const;
+
+const SandboxFunctionCallErrorPayloadSchema = z.object({
+  code: z.enum(SANDBOX_FUNCTION_CALL_ERROR_CODES),
+  message: z.string(),
+  status: z.number().optional(),
+});
+
+type SandboxFunctionCallErrorPayload = z.infer<
+  typeof SandboxFunctionCallErrorPayloadSchema
+>;
+
+export class SandboxFunctionCallError extends Error {
+  readonly code: SandboxFunctionCallErrorPayload["code"];
+  readonly status?: number;
+
+  constructor(payload: SandboxFunctionCallErrorPayload) {
+    super(payload.message);
+    this.name = "SandboxFunctionCallError";
+    this.code = payload.code;
+    this.status = payload.status;
+  }
+}
+
+export function normalizeSandboxFunctionCallError(
+  error: unknown
+): SandboxFunctionCallError {
+  if (error instanceof SandboxFunctionCallError) {
+    return error;
+  }
+
+  const parsed = SandboxFunctionCallErrorPayloadSchema.safeParse(error);
+  if (parsed.success) {
+    return new SandboxFunctionCallError(parsed.data);
+  }
+
+  return new SandboxFunctionCallError({
+    code: "transport_error",
+    message:
+      error instanceof Error
+        ? error.message
+        : "Failed to call sandbox function.",
+  });
+}

--- a/viz/app/lib/visualization-api.ts
+++ b/viz/app/lib/visualization-api.ts
@@ -1,4 +1,3 @@
-import type { CommandResultMap } from "@viz/app/types";
 import type {
   SupportedEventType,
   SupportedMessage,
@@ -12,10 +11,7 @@ export interface VisualizationDataAPI {
   /**
    * Call a sandbox function.
    */
-  callFunction(
-    functionId: string,
-    input?: unknown
-  ): Promise<CommandResultMap["callFunction"]>;
+  callFunction(functionId: string, input?: unknown): Promise<unknown>;
 
   /**
    * Fetch a file by ID.

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -53,7 +53,7 @@ export type VisualizationRPCCommand = keyof VisualizationRPCRequestMap;
 // Command results.
 
 export interface CommandResultMap {
-  callFunction: { result: unknown; error?: string };
+  callFunction: unknown;
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };


### PR DESCRIPTION
## Description

This is the final PR for the [Frames sandbox functions discussion](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1784105075929679). The runner and server rollout PRs (#28962 and #28963) are already merged into `main`; this PR is standalone on top of that state.

Frames now receive the parsed `schema.output` value directly from `callFunction`. Failures reject with `SandboxFunctionCallError`, which preserves a stable error code, message, and optional HTTP status across the parent-to-iframe boundary. Public Frames report `not_supported`.

Existing Frame compatibility is intentionally not preserved. This PR pins `dsbx` v0.1.36 and bumps the sandbox base image from v0.8.56 to v0.8.57 so the new runner is deployed with the Frame API. The image build downloads and verifies the `dsbx-v0.1.36` release artifacts.

## Tests

- Front typecheck with `npm run tsgo`
- 5 focused Viz tests covering direct results, structured cross-document errors, public Frame rejection, and error-code parity
- 16 sandbox image registry tests covering the image and CLI pins
- Viz production build
- Biome checks on changed files

## Risk

The Frame `callFunction` contract is breaking by design. The new sandbox image must not be built until the `dsbx-v0.1.36` release artifacts and checksum exist. The server compatibility layer from #28963 is already on `main` and accepts both the prior and new runner callback envelopes during the rolling image deployment.

## Deploy Plan

- [x] Merge #28962 and #28963. (Already complete.)
- [ ] Merge this PR.
- [ ] On the resulting `main`, run the **Release dsbx CLI** workflow; it reads the Cargo package version and should create `dsbx-v0.1.36`.
- [ ] Confirm `dsbx-linux-x86_64` and `checksums-sha256.txt` exist for v0.1.36.
- [ ] Build and publish `dust-base:0.8.57` after the dsbx release artifacts exist.
- [ ] Deploy the app containing the new registry pin only after the image is available.
- [ ] Open `/poke/kill` → **Kill Switches** and request **Kill older versions** for `dust-base:0.8.57`, so existing sandboxes are reaped and recreated from the new image.

Rollback by restoring the `dust-base:0.8.56` / `dsbx` v0.1.35 pins, deploying that configuration, and requesting **Kill older versions** for the restored image.
