### PR TITLE
Assign free seats first, then committed

### DIFF
--- a/front/lib/api/membership.test.ts
+++ b/front/lib/api/membership.test.ts
@@ -142,8 +142,31 @@ describe("createAndTrackMembership", () => {
     expect(membership.seatType).toBe("none");
   });
 
-  it("still assigns a committed paid seat on a paid plan", async () => {
+  it("assigns free on a paid plan even when a committed pro seat has open slots", async () => {
     setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.creditPriced();
+    const upsertResult = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+      maxSeats: null,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+    });
+
+    expect(membership.seatType).toBe("free");
+  });
+
+  it("falls back to a committed paid seat on a paid plan when free is not entitled", async () => {
+    setupEntitledSeats(["pro"]);
 
     const workspace = await WorkspaceFactory.creditPriced();
     const upsertResult = await WorkspaceSeatLimitResource.upsert({

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -68,13 +68,14 @@ import type { Transaction } from "sequelize";
  *
  * On non-free plans, the assignment follows three phases:
  *
- *  1. **Committed seats** — the cheapest seat tier whose committed allocation
- *     (`workspace_seat_limits.minSeats`) still has unassigned slots is picked.
- *  2. **Free seat** — if no committed slot is available and `free` is on the
- *     contract, it is assigned unless any of the following are true:
+ *  1. **Free seat** — if `free` is on the contract, it is assigned unless any
+ *     of the following are true:
  *       - `isReturningMember` is true (one-shot: returning members cannot get `free`).
  *       - `plan.limits.users.maxFreeUsers` reached.
  *       - `plan.limits.users.maxLifetimeFreeUsers` reached.
+ *  2. **Committed seats** — if `free` is unavailable, the cheapest seat tier
+ *     whose committed allocation (`workspace_seat_limits.minSeats`) still has
+ *     unassigned slots is picked.
  *  3. **None** — if both phases are exhausted the member is assigned `"none"`
  *     (no-seat tier; cannot send messages).
  *

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -34,7 +34,7 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ],
   });
 
-  it("assigns a committed seat when slots remain", () => {
+  it("assigns free even when a committed seat has open slots", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
       ["pro", { minSeats: 5, maxSeats: null }],
     ]);
@@ -43,22 +43,23 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
         seatLimits,
         seatCounts: { pro: 3 },
       })
-    ).toBe("pro");
+    ).toBe("free");
   });
 
-  it("falls through to free when all committed slots are taken", () => {
+  it("falls back to a committed seat when free is blocked (returning member)", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
       ["pro", { minSeats: 5, maxSeats: null }],
     ]);
     expect(
       getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        isReturningMember: true,
         seatLimits,
-        seatCounts: { pro: 5 },
+        seatCounts: { pro: 3 },
       })
-    ).toBe("free");
+    ).toBe("pro");
   });
 
-  it("returns none when committed exhausted and free blocked (returning member)", () => {
+  it("returns none when free is blocked and committed slots are exhausted", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
       ["pro", { minSeats: 5, maxSeats: null }],
     ]);
@@ -85,7 +86,7 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     );
   });
 
-  it("skips max even when it has committed slots, falls through to free", () => {
+  it("skips max even when it has committed slots, falls through to none when free is blocked", () => {
     const { contract: maxContract, productSeatTypes: maxProductSeatTypes } =
       buildCachedContractMock({
         seats: [
@@ -98,13 +99,14 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ]);
     expect(
       getDefaultSeatTypeForContract(maxContract, maxProductSeatTypes, {
+        isReturningMember: true,
         seatLimits,
         seatCounts: { max: 0 },
       })
-    ).toBe("free");
+    ).toBe("none");
   });
 
-  it("auto-assigns workspace_yearly when committed slots remain (pooled enterprise)", () => {
+  it("auto-assigns workspace_yearly when committed slots remain and free is blocked (pooled enterprise)", () => {
     const { contract: wsContract, productSeatTypes: wsProductSeatTypes } =
       buildCachedContractMock({
         seats: [
@@ -117,13 +119,14 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ]);
     expect(
       getDefaultSeatTypeForContract(wsContract, wsProductSeatTypes, {
+        isReturningMember: true,
         seatLimits,
         seatCounts: { workspace_yearly: 4 },
       })
     ).toBe("workspace_yearly");
   });
 
-  it("falls through to free once workspace_yearly committed slots are taken", () => {
+  it("returns none once workspace_yearly committed slots are taken and free is blocked", () => {
     const { contract: wsContract, productSeatTypes: wsProductSeatTypes } =
       buildCachedContractMock({
         seats: [
@@ -136,10 +139,11 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ]);
     expect(
       getDefaultSeatTypeForContract(wsContract, wsProductSeatTypes, {
+        isReturningMember: true,
         seatLimits,
         seatCounts: { workspace_yearly: 10 },
       })
-    ).toBe("free");
+    ).toBe("none");
   });
 
   it("legacy: no-seat-subscription contract returns none", () => {

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -168,19 +168,20 @@ function canAssignFreeSeat({
  *
  * The seat is chosen in three phases:
  *
- *  1. **Committed seats** — iterate `pro`, `pro_yearly`, `workspace`, and
- *     `workspace_yearly` seat types ordered by AWU allowance ascending. For each
- *     type that has a committed allocation (`seatLimits.minSeats > 0`) with
- *     remaining slots (`assignedCount < minSeats`), assign it. `max` /
- *     `max_yearly` are never auto-assigned; they must be set manually.
- *
- *  2. **Free seat** — if `free` is on the contract and all of the following
+ *  1. **Free seat** — if `free` is on the contract and all of the following
  *     hold, assign `free`:
  *       - `isReturningMember` is false (`free` is a one-shot starter tier).
  *       - Active free-seat cap not exceeded.
  *       - Lifetime free-seat cap not exceeded.
  *
- *  3. **None** — all committed slots are taken and `free` is unavailable:
+ *  2. **Committed seats** — if `free` is unavailable, iterate `pro`,
+ *     `pro_yearly`, `workspace`, and `workspace_yearly` seat types ordered by
+ *     AWU allowance ascending. For each type that has a committed allocation
+ *     (`seatLimits.minSeats > 0`) with remaining slots
+ *     (`assignedCount < minSeats`), assign it. `max` / `max_yearly` are never
+ *     auto-assigned; they must be set manually.
+ *
+ *  3. **None** — `free` is unavailable and all committed slots are taken:
  *     return `"none"` (no-seat tier).
  *
  * Legacy contracts that carry no seat subscriptions return `"workspace"` early
@@ -208,6 +209,20 @@ export function getDefaultSeatTypeForContract(
   if (seatTypesOnContract.length === 0) {
     return "none";
   }
+
+  // Phase 1: try "free" first if it's on the contract and the
+  // caller/workspace conditions allow it.
+  if (
+    canAssignFreeSeat({
+      seatTypesOnContract,
+      isReturningMember,
+      freeSeatCounts,
+      freeSeatLimits,
+    })
+  ) {
+    return "free";
+  }
+
   const ordered = seatTypesOnContract
     .map((seatType) => ({
       seatType,
@@ -225,9 +240,9 @@ export function getDefaultSeatTypeForContract(
     "workspace_yearly",
   ]);
 
-  // Phase 1: assign to the cheapest committed seat type with remaining slots.
-  // A seat type is committed if seatLimits.minSeats > 0. The commitment is
-  // exhausted once assignedCount >= minSeats.
+  // Phase 2: "free" unavailable — assign to the cheapest committed seat type
+  // with remaining slots. A seat type is committed if seatLimits.minSeats > 0.
+  // The commitment is exhausted once assignedCount >= minSeats.
   for (const { seatType } of ordered) {
     if (!AUTO_ASSIGNABLE.has(seatType)) {
       continue;
@@ -242,20 +257,7 @@ export function getDefaultSeatTypeForContract(
     }
   }
 
-  // Phase 2: committed seats exhausted — try "free" if on the contract and
-  // the caller/workspace conditions allow it.
-  if (
-    canAssignFreeSeat({
-      seatTypesOnContract,
-      isReturningMember,
-      freeSeatCounts,
-      freeSeatLimits,
-    })
-  ) {
-    return "free";
-  }
-
-  // Phase 3: no committed seat or free available.
+  // Phase 3: no free seat and no committed seat available.
   return "none";
 }
 


### PR DESCRIPTION
## Description

Change the default seat assignation order : first, give a free seat if it's available - then committed seat - finally, none, if nothing applies. Admin to choose if a user has to be upgraded or not.

Only real change is in front/lib/metronome/seat_types.ts , rest is tests/comments

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
