### PR TITLE
[front] perf: skip attachment queries for skill summaries

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1,5 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
-import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import {
+  SkillFileAttachmentModel,
+  SkillMCPServerConfigurationModel,
+} from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -239,6 +242,10 @@ describe("GET /api/w/:wId/skills", () => {
       name: "Picker Skill",
       userFacingDescription: "Shown in the capabilities picker",
     });
+    const fileAttachmentFindAllSpy = vi.spyOn(
+      SkillFileAttachmentModel,
+      "findAll"
+    );
 
     const response = await getSkills(workspace);
 
@@ -270,6 +277,8 @@ describe("GET /api/w/:wId/skills", () => {
       "instructionsHtml"
     );
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty("tools");
+    expect(fileAttachmentFindAllSpy).not.toHaveBeenCalled();
+    fileAttachmentFindAllSpy.mockRestore();
   });
 
   it("should not fetch dynamic global instructions", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -122,6 +122,7 @@ app.get(
       isDefault: isDefault === "true" ? true : undefined,
       withInstructions: false,
       withTools: false,
+      withFileAttachments: false,
     });
 
     if (withRelations === "true") {

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
@@ -21,6 +21,7 @@ app.get(
       onlyCustom: true,
       withInstructions: false,
       withTools: false,
+      withFileAttachments: false,
     });
 
     const spentByModelId =

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -235,6 +235,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
         onlyCustom: false,
         withInstructions: false,
         withTools: false,
+        withFileAttachments: false,
       });
       skills =
         resolvedFilter === "writable"

--- a/front/lib/api/analytics/skills_export.ts
+++ b/front/lib/api/analytics/skills_export.ts
@@ -33,6 +33,7 @@ export async function fetchSkillExportRows(
     onlyCustom: true,
     withInstructions: false,
     withTools: false,
+    withFileAttachments: false,
   });
 
   const usedSkillsResult = await fetchUsedSkills(baseQuery);

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -201,6 +201,7 @@ export const joinActivationPodPlugin = createPlugin({
       globalSpaceOnly: true,
       withInstructions: false,
       withTools: false,
+      withFileAttachments: false,
     });
 
     return new Ok({

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -565,6 +565,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       onlyCustom,
       withInstructions = true,
       withTools = true,
+      withFileAttachments = true,
       ...otherOptions
     } = options;
 
@@ -655,8 +656,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         "skillConfigurationId"
       );
 
-      const shouldFetchFileAttachments = withInstructions || withTools;
-      const fileAttachmentModels = shouldFetchFileAttachments
+      const fileAttachmentModels = withFileAttachments
         ? await SkillFileAttachmentModel.findAll({
             where: {
               workspaceId: workspace.id,
@@ -668,7 +668,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           })
         : [];
 
-      const allFileResources = shouldFetchFileAttachments
+      const allFileResources = withFileAttachments
         ? await FileResource.fetchByModelIdsWithAuth(
             auth,
             fileAttachmentModels.map((a) => a.fileId),
@@ -975,7 +975,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         customSkillId: reference.childCustomSkillId,
         globalSkillId: reference.childGlobalSkillId,
       })),
-      { withInstructions: false, withTools: false }
+      {
+        withInstructions: false,
+        withTools: false,
+        withFileAttachments: false,
+      }
     );
     const childSkillsById = new Map(
       childSkills.map((skill) => [skill.sId, skill])
@@ -1044,12 +1048,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
       withInstructions,
       withTools,
+      withFileAttachments,
     }: {
       agentLoopData?: AgentLoopExecutionData;
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
       withInstructions?: boolean;
       withTools?: boolean;
+      withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
@@ -1065,6 +1071,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         withInstructions,
         withTools,
+        withFileAttachments,
       },
       { agentLoopData, transaction }
     );
@@ -1241,6 +1248,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       reinforcementNotOff,
       withInstructions = true,
       withTools = true,
+      withFileAttachments = true,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
@@ -1251,6 +1259,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       reinforcementNotOff?: boolean;
       withInstructions?: boolean;
       withTools?: boolean;
+      withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
@@ -1264,6 +1273,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       onlyCustom,
       withInstructions,
       withTools,
+      withFileAttachments,
     });
 
     if (globalSpaceOnly) {
@@ -1571,6 +1581,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentLoopData,
           withInstructions: false,
           withTools: false,
+          withFileAttachments: false,
         })
       : [];
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -655,21 +655,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         "skillConfigurationId"
       );
 
-      const fileAttachmentModels = await SkillFileAttachmentModel.findAll({
-        where: {
-          workspaceId: workspace.id,
-          skillConfigurationId: {
-            [Op.in]: allowedCustomSkillIds,
-          },
-        },
-        transaction,
-      });
+      const shouldFetchFileAttachments = withInstructions || withTools;
+      const fileAttachmentModels = shouldFetchFileAttachments
+        ? await SkillFileAttachmentModel.findAll({
+            where: {
+              workspaceId: workspace.id,
+              skillConfigurationId: {
+                [Op.in]: allowedCustomSkillIds,
+              },
+            },
+            transaction,
+          })
+        : [];
 
-      const allFileResources = await FileResource.fetchByModelIdsWithAuth(
-        auth,
-        fileAttachmentModels.map((a) => a.fileId),
-        transaction
-      );
+      const allFileResources = shouldFetchFileAttachments
+        ? await FileResource.fetchByModelIdsWithAuth(
+            auth,
+            fileAttachmentModels.map((a) => a.fileId),
+            transaction
+          )
+        : [];
 
       const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
 

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -17,6 +17,7 @@ export type AllSkillConfigurationFindOptions = Omit<
   onlyCustom?: false; // Default: include global skills.
   withTools?: boolean;
   withInstructions?: boolean;
+  withFileAttachments?: boolean;
 };
 
 // Full find options only custom skills from database.
@@ -25,6 +26,7 @@ type CustomSkillConfigurationFindOptions =
     onlyCustom: true; // Explicit: only custom skills.
     withTools?: boolean;
     withInstructions?: boolean;
+    withFileAttachments?: boolean;
   };
 
 export type SkillConfigurationFindOptions =

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -68,6 +68,7 @@ async function fetchSkillEditorsForWorkspace({
     status: "active",
     withInstructions: false,
     withTools: false,
+    withFileAttachments: false,
   });
 
   if (skills.length === 0) {


### PR DESCRIPTION
## Description

We have a few occurrences where listing skill attachment files takes some time, in a context where they are not needed (listing skills). Example of trace [here](https://app.datadoghq.eu/apm/traces?query=env%3Aprod%20%40http.route%3A%22%2Fapi%2Fw%2F%3AwId%2Fskills%22%20%40http.method%3AGET&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=4778829400064798737&spanType=all&storage=hot&target-span=a&timeHint=1784008649187&tq_query_translation_version=v0&trace=AwAAAZ9fM6njHfk7MQAAABhBWjlmTTdLekFBQXZhX0ZNRlVSRlhDWWUAAAAkMTE5ZjVmMzctNjk0Zi00MzA4LTljYjYtOTUzZjI5NjNiOWIyAAI7Vw&traceID=6a55cfc7000000001e260cef3a30ffc8&traceQuery=a&view=spans&viz=stream&start=1783946678480&end=1784119478480&paused=false).

This PR skips attachment lookup and file hydration when `withInstructions` and `withTools` are both false. Full skill loads keeps the existing behavior.

## Tests

- Updated the tests, tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
