### PR TITLE
[extension] fix pod conversation stuck loading and client-side MCP tools

### DIFF
--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -2,6 +2,8 @@ import { cn, Spinner } from "@dust-tt/sparkle";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import type { RouteChangeMesssage } from "@extension/shared/messages";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
+import { ExtensionClientSideMCPServerProvider } from "@extension/ui/components/conversation/ExtensionClientSideMCPServerProvider";
+import { ExtensionInputBarProvider } from "@extension/ui/components/conversation/ExtensionInputBarProvider";
 import { ExtensionQuickActionsProvider } from "@extension/ui/components/quick_actions/ExtensionQuickActionsProvider";
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
@@ -59,7 +61,11 @@ export const ProtectedRoute = () => {
       )}
     >
       <ExtensionQuickActionsProvider owner={workspace}>
-        <Outlet />
+        <ExtensionClientSideMCPServerProvider>
+          <ExtensionInputBarProvider workspace={workspace}>
+            <Outlet />
+          </ExtensionInputBarProvider>
+        </ExtensionClientSideMCPServerProvider>
       </ExtensionQuickActionsProvider>
     </div>
   );

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -8,8 +8,8 @@ import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { Button, cn, Menu01 } from "@dust-tt/sparkle";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { sendGetSessionInfoMessage } from "@extension/shared/messages";
-import { ExtensionInputBarProvider } from "@extension/ui/components/conversation/ExtensionInputBarProvider";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useClientSideMCPServerIds } from "@extension/ui/components/conversation/ExtensionClientSideMCPServerProvider";
+import { useContext, useEffect, useState } from "react";
 
 interface ConversationContainerProps {
   workspace: LightWorkspaceType;
@@ -17,7 +17,6 @@ interface ConversationContainerProps {
   subscription: SubscriptionType;
   conversationId: string | null;
   conversation?: ConversationWithoutContentType;
-  serverId?: string;
 }
 
 const SUGGESTIONS = {
@@ -41,16 +40,12 @@ export const ConversationContainer = ({
   subscription,
   conversationId,
   conversation,
-  serverId,
 }: ConversationContainerProps) => {
   const platform = usePlatform();
   const { currentPanel } = useConversationSidePanelContext();
   const { setSidebarOpen } = useContext(SidebarContext);
 
-  const clientSideMCPServerIds = useMemo(
-    () => (serverId ? [serverId] : undefined),
-    [serverId]
-  );
+  const clientSideMCPServerIds = useClientSideMCPServerIds();
 
   const [suggestion, setSuggestion] = useState<
     | {
@@ -100,10 +95,7 @@ export const ConversationContainer = ({
   }, []);
 
   return (
-    <ExtensionInputBarProvider
-      workspace={workspace}
-      conversationId={conversationId}
-    >
+    <>
       <div className={currentPanel ? "hidden" : "flex flex-col h-full w-full"}>
         <ConversationContainerVirtuoso
           owner={workspace}
@@ -136,6 +128,6 @@ export const ConversationContainer = ({
           />
         </div>
       )}
-    </ExtensionInputBarProvider>
+    </>
   );
 };

--- a/extension/ui/components/conversation/ExtensionClientSideMCPServerProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionClientSideMCPServerProvider.tsx
@@ -1,0 +1,32 @@
+import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
+import type { ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
+
+const ClientSideMCPServerContext = createContext<string[] | undefined>(
+  undefined
+);
+
+export function useClientSideMCPServerIds(): string[] | undefined {
+  return useContext(ClientSideMCPServerContext);
+}
+
+interface ExtensionClientSideMCPServerProviderProps {
+  children: ReactNode;
+}
+
+export function ExtensionClientSideMCPServerProvider({
+  children,
+}: ExtensionClientSideMCPServerProviderProps) {
+  const { serverId } = useMcpServer();
+
+  const clientSideMCPServerIds = useMemo(
+    () => (serverId ? [serverId] : undefined),
+    [serverId]
+  );
+
+  return (
+    <ClientSideMCPServerContext.Provider value={clientSideMCPServerIds}>
+      {children}
+    </ClientSideMCPServerContext.Provider>
+  );
+}

--- a/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
@@ -2,6 +2,7 @@ import {
   InputBarContext,
   InputBarContextProvider,
 } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -15,17 +16,21 @@ import { useCallback, useContext, useEffect, useState } from "react";
 
 interface ExtensionInputBarProviderProps {
   workspace: LightWorkspaceType;
-  conversationId?: string | null;
   children: ReactNode;
 }
 
+/**
+ * Mounted once above the router's page routes (see `ProtectedRoute`), so the
+ * input bar context — including the deferred first message — survives
+ * navigation between the pod and conversation routes.
+ */
 export function ExtensionInputBarProvider({
   workspace,
-  conversationId = null,
   children,
 }: ExtensionInputBarProviderProps) {
   const platform = usePlatform();
   const quickActions = useExtensionQuickActions();
+  const conversationId = useActiveConversationId();
   const fileUploaderService = useFileUploaderService(
     platform.capture,
     conversationId

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -11,7 +11,6 @@ import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { getPodRoute } from "@app/lib/utils/router";
 import { Attachment01, Button, DotsHorizontal } from "@dust-tt/sparkle";
-import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
 import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { useMemo } from "react";
@@ -19,7 +18,6 @@ import { ConversationContainer } from "../components/conversation/ConversationCo
 
 export const MainPage = () => {
   const { user, workspace, subscription } = useAuth();
-  const { serverId } = useMcpServer();
   useSetupNotifications();
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";
@@ -109,7 +107,6 @@ export const MainPage = () => {
             subscription={subscription}
             conversationId={conversationId}
             conversation={conversation}
-            serverId={serverId}
           />
         </GenerationContextProvider>
       </BlockedActionsProvider>

--- a/extension/ui/pages/PodMainPage.tsx
+++ b/extension/ui/pages/PodMainPage.tsx
@@ -19,12 +19,13 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
-import { ExtensionInputBarProvider } from "@extension/ui/components/conversation/ExtensionInputBarProvider";
+import { useClientSideMCPServerIds } from "@extension/ui/components/conversation/ExtensionClientSideMCPServerProvider";
 import { useParams } from "react-router-dom";
 
 export const PodMainPage = () => {
   const { workspace } = useAuth();
   const { podId } = useParams<{ podId: string }>();
+  const clientSideMCPServerIds = useClientSideMCPServerIds();
 
   const {
     spaceInfo: podInfo,
@@ -114,15 +115,14 @@ export const PodMainPage = () => {
       >
         <BlockedActionsProvider owner={workspace}>
           <GenerationContextProvider>
-            <ExtensionInputBarProvider workspace={workspace}>
-              <PodPageContent
-                podInfo={podInfo}
-                onTabChange={handleTabChange}
-                podUiPreferences={podUiPreferences}
-                setPodUiPreferences={setPodUiPreferences}
-                mutatePodInfo={mutatePodInfo}
-              />
-            </ExtensionInputBarProvider>
+            <PodPageContent
+              podInfo={podInfo}
+              onTabChange={handleTabChange}
+              podUiPreferences={podUiPreferences}
+              setPodUiPreferences={setPodUiPreferences}
+              mutatePodInfo={mutatePodInfo}
+              clientSideMCPServerIds={clientSideMCPServerIds}
+            />
           </GenerationContextProvider>
         </BlockedActionsProvider>
       </ConversationLayout>

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -34,6 +34,7 @@ interface PodPageContentProps {
   podUiPreferences: PodUiScopedPreferences;
   setPodUiPreferences: (value: PodUiScopedPreferences) => void;
   mutatePodInfo: () => Promise<unknown>;
+  clientSideMCPServerIds?: string[];
 }
 
 export function PodPageContent({
@@ -42,6 +43,7 @@ export function PodPageContent({
   podUiPreferences,
   setPodUiPreferences,
   mutatePodInfo,
+  clientSideMCPServerIds,
 }: PodPageContentProps) {
   const owner = useWorkspace();
   const { user } = useAuth();
@@ -115,6 +117,7 @@ export function PodPageContent({
           input,
           mentions: mentions.map(toMentionType),
           contentFragments,
+          clientSideMCPServerIds,
           selectedMCPServerViewIds,
           richMentions: mentions,
           modelSelection,
@@ -163,6 +166,7 @@ export function PodPageContent({
       router,
       mutateConversations,
       createConversationWithMessage,
+      clientSideMCPServerIds,
     ]
   );
 


### PR DESCRIPTION
## Description

This PR fixes two bugs of the chrome extension when creating a conversation from a pod's input bar: the conversation page was stuck loading, and the conversation had no client-side MCP tools.

Root cause: the input-bar context (holding the deferred first message) and the client-side MCP server (`useMcpServer()`) were mounted per page. Navigating from the pod route to the conversation route unmounted them.

Fix: hoist both into `ProtectedRoute`, a layout route that survives the swap between the two pages. `ExtensionInputBarProvider` now mounts once and reads the conversation id via `useActiveConversationId()`; a new `ExtensionClientSideMCPServerProvider` owns the single `useMcpServer()` call and exposes the ids through an extension-only context.

Moreover `PodPageContent` takes an optional `clientSideMCPServerIds?: string[]` prop (same convention as `ConversationContainerVirtuoso`), supplied by the extension. The web app passes nothing, so its behavior is unchanged.

## Tests
Manually.

## Risk

Low, scoped to the extension. Moves provider mount points rather than changing logic; the only `front` change is one optional prop defaulting to today's web behavior.

## Deploy Plan

Standard deployment.
