### PR TITLE
feat(analytics): filter graph per agent tag

### DIFF
--- a/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
+++ b/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
@@ -12,6 +12,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useKeys } from "@app/lib/swr/apps";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSearchMembers } from "@app/lib/swr/memberships";
+import { useTags } from "@app/lib/swr/tags";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
 import {
@@ -29,7 +30,7 @@ import {
 import { useMemo, useState } from "react";
 
 const DIMENSION_FILTERS: DropdownMenuFilterOption<AnalyticsScopeDimension>[] = (
-  ["user", "agent", "origin", "api_key"] as const
+  ["user", "agent", "origin", "api_key", "tag"] as const
 ).map((dimension) => ({
   value: dimension,
   label: SCOPE_DIMENSION_LABEL[dimension],
@@ -70,6 +71,11 @@ export function AnalyticsFilterDropdown({
     disabled: !isOpen || dimension !== "api_key",
   });
 
+  const { tags, isTagsLoading } = useTags({
+    owner,
+    disabled: !isOpen || dimension !== "tag",
+  });
+
   const entities: AnalyticsEntityFilter[] = useMemo(() => {
     const search = searchText.toLowerCase();
     const matches = (name: string) => name.toLowerCase().includes(search);
@@ -93,11 +99,15 @@ export function AnalyticsFilterDropdown({
         return keys
           .filter((key) => matches(key.name))
           .map((key) => ({ id: key.name, name: key.name }));
+      case "tag":
+        return tags
+          .filter((tag) => matches(tag.name))
+          .map((tag) => ({ id: tag.sId, name: tag.name }));
       default:
         assertNeverAndIgnore(dimension);
         return [];
     }
-  }, [dimension, searchText, members, agentConfigurations, keys]);
+  }, [dimension, searchText, members, agentConfigurations, keys, tags]);
 
   const selectedIds = useMemo(
     () => new Set((filter[dimension] ?? []).map((entity) => entity.id)),
@@ -107,7 +117,8 @@ export function AnalyticsFilterDropdown({
   const isLoading =
     (dimension === "user" && isMembersLoading) ||
     (dimension === "agent" && isAgentConfigurationsLoading) ||
-    (dimension === "api_key" && isKeysLoading);
+    (dimension === "api_key" && isKeysLoading) ||
+    (dimension === "tag" && isTagsLoading);
 
   return (
     <DropdownMenu

--- a/front/components/workspace/analytics/analyticsFilter.ts
+++ b/front/components/workspace/analytics/analyticsFilter.ts
@@ -19,6 +19,7 @@ export const SCOPE_DIMENSION_LABEL: Record<AnalyticsScopeDimension, string> = {
   user: "User",
   origin: "Source",
   api_key: "API Key",
+  tag: "Tag",
 };
 
 export const SCOPE_DIMENSIONS = Object.keys(

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -22,7 +22,11 @@ const TERMS_GROUP_BY_KEYS = [
 // user_id. The other groupings map directly to CreditBreakdownBy.
 const ANALYTICS_GROUP_BY_KEYS = ["usage_type", ...TERMS_GROUP_BY_KEYS] as const;
 
-export const ANALYTICS_SCOPE_DIMENSIONS = TERMS_GROUP_BY_KEYS;
+// Dimensions the graph can be scoped (filtered) to. Superset of the group-by terms.
+export const ANALYTICS_SCOPE_DIMENSIONS = [
+  ...TERMS_GROUP_BY_KEYS,
+  "tag", // Filter only: a message can have multiple tags, so grouping by tag can lead to double-counting.
+] as const;
 export type AnalyticsScopeDimension =
   (typeof ANALYTICS_SCOPE_DIMENSIONS)[number];
 
@@ -97,6 +101,7 @@ export async function getAwuUsageFromAnalytics(
   const agentIds = filter?.agent;
   const contextOrigin = filter?.origin;
   const apiKeyNames = filter?.api_key;
+  const agentTagIds = filter?.tag;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -109,6 +114,7 @@ export async function getAwuUsageFromAnalytics(
       agentIds,
       contextOrigin,
       apiKeyNames,
+      agentTagIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -137,6 +143,7 @@ export async function getAwuUsageFromAnalytics(
       agentIds,
       contextOrigin,
       apiKeyNames,
+      agentTagIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -172,6 +179,7 @@ export async function getAwuUsageFromAnalytics(
     agentIds,
     contextOrigin,
     apiKeyNames,
+    agentTagIds,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -246,6 +246,7 @@ export async function fetchCreditUsage(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   }: {
     startDate: string;
     endDate: string;
@@ -255,6 +256,7 @@ export async function fetchCreditUsage(
     agentIds?: string[];
     userIds?: string[];
     apiKeyNames?: string[];
+    agentTagIds?: string[];
   }
 ): Promise<Result<CreditUsageResult, ElasticsearchError>> {
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
@@ -277,6 +279,7 @@ export async function fetchCreditUsage(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
     extraFilters:
       // api_key buckets missing values under "Not API" instead of dropping
       // them, so the rows keep summing to the total.
@@ -336,6 +339,7 @@ export async function fetchCreditTimeseries(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
     fillWindow,
   }: {
     startDate: string;
@@ -346,6 +350,7 @@ export async function fetchCreditTimeseries(
     agentIds?: string[];
     userIds?: string[];
     apiKeyNames?: string[];
+    agentTagIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
@@ -356,6 +361,7 @@ export async function fetchCreditTimeseries(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesAggs>(query, {
@@ -407,6 +413,7 @@ export async function fetchCreditTimeseriesByUsageType(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
     fillWindow,
   }: {
     startDate: string;
@@ -417,6 +424,7 @@ export async function fetchCreditTimeseriesByUsageType(
     agentIds?: string[];
     userIds?: string[];
     apiKeyNames?: string[];
+    agentTagIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
@@ -427,6 +435,7 @@ export async function fetchCreditTimeseriesByUsageType(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   });
 
   const programmaticFilter = getProgrammaticUsageFilterClause();
@@ -491,6 +500,7 @@ export async function fetchCreditTimeseriesBreakdown(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
     fillWindow,
   }: {
     startDate: string;
@@ -503,6 +513,7 @@ export async function fetchCreditTimeseriesBreakdown(
     agentIds?: string[];
     userIds?: string[];
     apiKeyNames?: string[];
+    agentTagIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesBreakdown, ElasticsearchError>> {
@@ -515,6 +526,7 @@ export async function fetchCreditTimeseriesBreakdown(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   });
   if (ranking.isErr()) {
     return ranking;
@@ -536,6 +548,7 @@ export async function fetchCreditTimeseriesBreakdown(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesBreakdownAggs>(

--- a/front/lib/api/assistant/observability/utils.test.ts
+++ b/front/lib/api/assistant/observability/utils.test.ts
@@ -47,12 +47,50 @@ describe("buildAgentAnalyticsBaseQuery", () => {
     });
   });
 
+  it("adds an agent_tag_ids terms filter when several tag ids are provided", () => {
+    expect(
+      buildAgentAnalyticsBaseQuery({
+        workspaceId: "w1",
+        agentTagIds: ["tag_1", "tag_2"],
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      })
+    ).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: "w1" } },
+          { terms: { agent_tag_ids: ["tag_1", "tag_2"] } },
+          { range: { timestamp: { gte: "2026-01-01", lte: "2026-01-31" } } },
+        ],
+      },
+    });
+  });
+
+  it("adds an agent_tag_ids term filter for a single tag id", () => {
+    expect(
+      buildAgentAnalyticsBaseQuery({
+        workspaceId: "w1",
+        agentTagIds: ["tag_1"],
+        days: 30,
+      })
+    ).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: "w1" } },
+          { term: { agent_tag_ids: "tag_1" } },
+          { range: { timestamp: { gte: "now-30d/d" } } },
+        ],
+      },
+    });
+  });
+
   it("omits empty array filters", () => {
     expect(
       buildAgentAnalyticsBaseQuery({
         workspaceId: "w1",
         agentIds: [],
         userIds: [],
+        agentTagIds: [],
       })
     ).toEqual({ bool: { filter: [{ term: { workspace_id: "w1" } }] } });
   });

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -91,6 +91,7 @@ export function buildAgentAnalyticsBaseQuery({
   workspaceId,
   agentId,
   agentIds,
+  agentTagIds,
   userIds,
   apiKeyNames,
   contextOrigin,
@@ -101,6 +102,7 @@ export function buildAgentAnalyticsBaseQuery({
   feedbackNestedQuery,
 }: {
   workspaceId: string;
+  agentTagIds?: string[];
   userIds?: string[];
   apiKeyNames?: string[];
   contextOrigin?: string | string[];
@@ -117,6 +119,7 @@ export function buildAgentAnalyticsBaseQuery({
     { term: { workspace_id: workspaceId } },
     ...(agentId ? [{ term: { agent_id: agentId } }] : []),
     ...termFilter("agent_id", agentIds),
+    ...termFilter("agent_tag_ids", agentTagIds),
     ...termFilter("user_id", userIds),
     ...apiKeyNamesFilter(apiKeyNames),
     ...contextOriginFilter(contextOrigin),
@@ -162,6 +165,7 @@ export function buildCreditsScopeQuery(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
     extraFilters = [],
     extraMustNot = [],
   }: {
@@ -171,6 +175,7 @@ export function buildCreditsScopeQuery(
     agentIds?: string[];
     userIds?: string[];
     apiKeyNames?: string[];
+    agentTagIds?: string[];
     extraFilters?: estypes.QueryDslQueryContainer[];
     extraMustNot?: estypes.QueryDslQueryContainer[];
   }
@@ -183,6 +188,7 @@ export function buildCreditsScopeQuery(
     agentIds,
     userIds,
     apiKeyNames,
+    agentTagIds,
   });
   return {
     bool: {


### PR DESCRIPTION
## Description

Follow up to #28849, Refs https://github.com/dust-tt/tasks/issues/8167.

Add a way filter analytics graphs per agent tag. The tags are already indexed in ES (see #28823).

## Tests

<img width="1139" height="398" alt="Screenshot 2026-07-15 at 15 44 49" src="https://github.com/user-attachments/assets/dab4b050-ec26-4ce5-901a-891dbf501e7a" />
