### PR TITLE
[front] fix: Support utf8 in api key name & user email

### DIFF
--- a/connectors/src/types/shared/headers.ts
+++ b/connectors/src/types/shared/headers.ts
@@ -31,6 +31,8 @@ export function getHeaderFromUserEmail(email: string | undefined) {
     return undefined;
   }
 
+  // The email may exceed Latin-1 (internationalized addresses); DustAPI
+  // encodes extra header values on the wire (see @dust-tt/client baseHeaders).
   return {
     [DustUserEmailHeader]: email,
   };

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -10,6 +10,7 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
+import { decodeUtf8HeaderValue } from "@app/types/shared/utils/http_headers";
 import { getHeaderFromUserEmail } from "@app/types/user";
 import type { ConversationPublicType } from "@dust-tt/client";
 import { DustAPI } from "@dust-tt/client";
@@ -214,10 +215,15 @@ describe("getOrCreateConversation", () => {
       const { mainConversation, originMessage, mainAgent, agentLoopContext } =
         buildRunAgentFixtures({ spaceId: null });
 
+      // Typed against the two methods getApiKeyNameHeader exercises; the cast
+      // to Authenticator only widens to the class type.
       const auth = {
-        attributionKey: () => ({ name: "Clé 🔑 złoty smørrebrød" }),
-        key: () => undefined,
-      } as unknown as Authenticator;
+        attributionKey: () => ({ id: 1, name: "Clé 🔑 złoty smørrebrød" }),
+        key: () => null,
+      } satisfies Pick<
+        Authenticator,
+        "attributionKey" | "key"
+      > as unknown as Authenticator;
 
       const cannedOwner = {
         id: 1,
@@ -310,10 +316,19 @@ describe("getOrCreateConversation", () => {
       assert(result.isOk());
       expect(capturedRequests).toHaveLength(1);
       const headers = capturedRequests[0].headers;
-      // Latin-1 characters (é, ø) are preserved; characters above 0xFF (ł, emoji)
-      // are replaced so the request can be sent at all.
-      expect(headers.get("x-dust-api-key-name")).toBe("Clé ? z?oty smørrebrød");
-      expect(headers.get("x-api-user-email")).toBe("jérôme.?ukasz@example.com");
+      // Values with characters above 0xFF (ł, emoji) travel as an RFC 2047
+      // encoded-word and round-trip losslessly through the header.
+      const keyNameHeader = headers.get("x-dust-api-key-name");
+      assert(keyNameHeader);
+      expect(keyNameHeader).toMatch(/^=\?utf-8\?B\?/);
+      expect(decodeUtf8HeaderValue(keyNameHeader)).toBe(
+        "Clé 🔑 złoty smørrebrød"
+      );
+      const emailHeader = headers.get("x-api-user-email");
+      assert(emailHeader);
+      expect(decodeUtf8HeaderValue(emailHeader)).toBe(
+        "jérôme.łukasz@example.com"
+      );
     });
   });
 });

--- a/front/lib/api/actions/servers/run_agent/conversation.test.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.test.ts
@@ -1,6 +1,7 @@
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { getOrCreateConversation } from "@app/lib/api/actions/servers/run_agent/conversation";
 import type { Authenticator } from "@app/lib/auth";
+import { getApiKeyNameHeader } from "@app/lib/auth";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -9,9 +10,11 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
-import type { ConversationPublicType, DustAPI } from "@dust-tt/client";
+import { getHeaderFromUserEmail } from "@app/types/user";
+import type { ConversationPublicType } from "@dust-tt/client";
+import { DustAPI } from "@dust-tt/client";
 import assert from "assert";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 function buildRunAgentFixtures({ spaceId }: { spaceId: string | null }): {
   mainConversation: ConversationType;
@@ -200,5 +203,117 @@ describe("getOrCreateConversation", () => {
         spaceId: undefined,
       })
     );
+  });
+
+  describe("attribution headers", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("creates the sub-conversation when the API key name and user email contain non-Latin-1 characters", async () => {
+      const { mainConversation, originMessage, mainAgent, agentLoopContext } =
+        buildRunAgentFixtures({ spaceId: null });
+
+      const auth = {
+        attributionKey: () => ({ name: "Clé 🔑 złoty smørrebrød" }),
+        key: () => undefined,
+      } as unknown as Authenticator;
+
+      const cannedOwner = {
+        id: 1,
+        sId: generateRandomModelSId(),
+        name: "workspace",
+        role: "user",
+        segmentation: null,
+        whiteListedProviders: null,
+        defaultEmbeddingProvider: null,
+        regionalModelsOnly: false,
+      };
+      const cannedResponseBody = {
+        conversation: {
+          id: 1,
+          created: Date.now(),
+          unread: false,
+          actionRequired: false,
+          owner: cannedOwner,
+          sId: generateRandomModelSId(),
+          title: null,
+          visibility: "unlisted",
+          content: [],
+          url: "http://front.test/conversation",
+        },
+        message: {
+          id: 1,
+          created: Date.now(),
+          type: "user_message",
+          sId: generateRandomModelSId(),
+          visibility: "visible",
+          version: 0,
+          user: null,
+          mentions: [],
+          content: "hello",
+          context: {
+            username: "MainAgent",
+            timezone: "UTC",
+            origin: "api",
+          },
+        },
+      };
+
+      const capturedRequests: Request[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          // The Request constructor applies the same header validation as a real
+          // fetch: unsanitized non-Latin-1 header values throw a TypeError here.
+          const request = new Request(input, init);
+          capturedRequests.push(request);
+          return new Response(JSON.stringify(cannedResponseBody), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        })
+      );
+
+      // Built the same way the run_agent tool handler builds its DustAPI.
+      const api = new DustAPI(
+        { url: "http://front.test" },
+        {
+          apiKey: "sk-test",
+          workspaceId: generateRandomModelSId(),
+          extraHeaders: {
+            ...getHeaderFromUserEmail("jérôme.łukasz@example.com"),
+            ...getApiKeyNameHeader(auth),
+          },
+        },
+        { error: vi.fn(), info: vi.fn(), trace: vi.fn(), warn: vi.fn() }
+      );
+
+      const result = await getOrCreateConversation(
+        api,
+        auth,
+        agentLoopContext,
+        {
+          childAgentBlob: { name: "ChildAgent", description: "A child agent" },
+          childAgentId: generateRandomModelSId(),
+          mainAgent,
+          originMessage,
+          mainConversation,
+          query: "Do something",
+          toolsetsToAdd: null,
+          fileOrContentFragmentIds: null,
+          filePaths: null,
+          conversationId: null,
+        }
+      );
+
+      assert(result.isOk());
+      expect(capturedRequests).toHaveLength(1);
+      const headers = capturedRequests[0].headers;
+      // Latin-1 characters (é, ø) are preserved; characters above 0xFF (ł, emoji)
+      // are replaced so the request can be sent at all.
+      expect(headers.get("x-dust-api-key-name")).toBe("Clé ? z?oty smørrebrød");
+      expect(headers.get("x-api-user-email")).toBe("jérôme.?ukasz@example.com");
+    });
   });
 });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -62,7 +62,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
-import { toLatin1SafeHeaderValue } from "@app/types/shared/utils/http_headers";
+import { decodeUtf8HeaderValue } from "@app/types/shared/utils/http_headers";
 import type {
   LightWorkspaceType,
   RoleType,
@@ -1856,7 +1856,7 @@ export function getApiKeyNameFromHeaders(headers: {
 }) {
   const apiKeyName = headers[DustApiKeyNameHeader];
   if (isString(apiKeyName)) {
-    return apiKeyName;
+    return decodeUtf8HeaderValue(apiKeyName);
   }
   return undefined;
 }
@@ -1871,7 +1871,9 @@ export function getApiKeyNameHeader(auth: Authenticator) {
     return undefined;
   }
 
+  // The name may exceed Latin-1 (emoji, non-Latin scripts); DustAPI encodes
+  // extra header values on the wire (see @dust-tt/client baseHeaders).
   return {
-    [DustApiKeyNameHeader]: toLatin1SafeHeaderValue(name),
+    [DustApiKeyNameHeader]: name,
   };
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -62,6 +62,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { toLatin1SafeHeaderValue } from "@app/types/shared/utils/http_headers";
 import type {
   LightWorkspaceType,
   RoleType,
@@ -1871,6 +1872,6 @@ export function getApiKeyNameHeader(auth: Authenticator) {
   }
 
   return {
-    [DustApiKeyNameHeader]: name,
+    [DustApiKeyNameHeader]: toLatin1SafeHeaderValue(name),
   };
 }

--- a/front/types/shared/utils/http_headers.test.ts
+++ b/front/types/shared/utils/http_headers.test.ts
@@ -1,0 +1,62 @@
+import { encodeUtf8HeaderValue } from "@dust-tt/client";
+import { describe, expect, it } from "vitest";
+
+import { decodeUtf8HeaderValue } from "./http_headers";
+
+// Contract test between the sender (DustAPI's `encodeUtf8HeaderValue` in
+// @dust-tt/client, applied to extra headers in `baseHeaders`) and the receiver
+// (`decodeUtf8HeaderValue`, used by the front-api auth middleware).
+describe("encodeUtf8HeaderValue / decodeUtf8HeaderValue", () => {
+  it("passes ASCII values through raw", () => {
+    expect(encodeUtf8HeaderValue("prod-key-01")).toBe("prod-key-01");
+    expect(encodeUtf8HeaderValue("user@example.com")).toBe("user@example.com");
+  });
+
+  it("passes Latin-1 values (é, ø, ü) through raw", () => {
+    expect(encodeUtf8HeaderValue("Clé de prod")).toBe("Clé de prod");
+    expect(encodeUtf8HeaderValue("søren.müller@example.com")).toBe(
+      "søren.müller@example.com"
+    );
+  });
+
+  it("encodes values with characters above 0xFF as an encoded-word", () => {
+    const encoded = encodeUtf8HeaderValue("Clé 🔑 złoty");
+    expect(encoded).toMatch(/^=\?utf-8\?B\?[A-Za-z0-9+/]*={0,2}\?=$/);
+    // The encoded form is a valid header value.
+    expect(() => new Headers({ "x-test": encoded })).not.toThrow();
+  });
+
+  it("round-trips non-Latin-1 values losslessly", () => {
+    for (const value of [
+      "Clé 🔑 złoty smørrebrød",
+      "иван@example.ru",
+      "田中@example.jp",
+      "line\nbreak",
+    ]) {
+      expect(decodeUtf8HeaderValue(encodeUtf8HeaderValue(value))).toBe(value);
+    }
+  });
+
+  it("returns raw values unchanged on decode", () => {
+    expect(decodeUtf8HeaderValue("user@example.com")).toBe("user@example.com");
+    expect(decodeUtf8HeaderValue("Clé de prod")).toBe("Clé de prod");
+    // '%' is legal in an email local part and must not be interpreted.
+    expect(decodeUtf8HeaderValue("a%40b@example.com")).toBe(
+      "a%40b@example.com"
+    );
+  });
+
+  it("round-trips a raw value that itself looks like an encoded-word", () => {
+    const tricky = "=?utf-8?B?bm90IHJlYWxseQ==?=";
+    expect(decodeUtf8HeaderValue(encodeUtf8HeaderValue(tricky))).toBe(tricky);
+  });
+
+  it("returns malformed encoded-word lookalikes unchanged", () => {
+    // Invalid base64 characters: does not match the envelope, comes back raw.
+    expect(decodeUtf8HeaderValue("=?utf-8?B?!!!?=")).toBe("=?utf-8?B?!!!?=");
+    // Unsupported charset: not ours, comes back raw.
+    expect(decodeUtf8HeaderValue("=?iso-8859-1?Q?a=E9?=")).toBe(
+      "=?iso-8859-1?Q?a=E9?="
+    );
+  });
+});

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -16,11 +16,20 @@ export function sanitizeHeadersArray(rows: HeaderRow[]): HeaderRow[] {
     .filter(({ key, value }) => key.length > 0 && value.length > 0);
 }
 
-// HTTP header values must fit in ISO-8859-1: fetch throws on any code point above
-// 0xFF, and Node rejects control characters. Replace offending characters so
-// attribution values such as API key names or user emails never fail the request.
-export function toLatin1SafeHeaderValue(value: string): string {
-  return value.replace(/[^\x20-\x7e\x80-\xff]/gu, "?");
+// Counterpart of `encodeUtf8HeaderValue` in @dust-tt/client
+// (sdks/js/src/http_headers.ts): DustAPI carries non-Latin-1 extra header
+// values (emoji or non-Latin scripts in API key names, internationalized user
+// emails) as RFC 2047 encoded-words (`=?utf-8?B?<base64>?=`) since HTTP header
+// values must fit in ISO-8859-1. This decodes them on the receiving end;
+// anything that isn't a well-formed encoded-word is returned as-is.
+const ENCODED_WORD_REGEX = /^=\?utf-8\?B\?([A-Za-z0-9+/]*={0,2})\?=$/i;
+
+export function decodeUtf8HeaderValue(value: string): string {
+  const match = value.match(ENCODED_WORD_REGEX);
+  if (!match) {
+    return value;
+  }
+  return Buffer.from(match[1], "base64").toString("utf8");
 }
 
 export function headersArrayToRecord(

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -16,6 +16,13 @@ export function sanitizeHeadersArray(rows: HeaderRow[]): HeaderRow[] {
     .filter(({ key, value }) => key.length > 0 && value.length > 0);
 }
 
+// HTTP header values must fit in ISO-8859-1: fetch throws on any code point above
+// 0xFF, and Node rejects control characters. Replace offending characters so
+// attribution values such as API key names or user emails never fail the request.
+export function toLatin1SafeHeaderValue(value: string): string {
+  return value.replace(/[^\x20-\x7e\x80-\xff]/gu, "?");
+}
+
 export function headersArrayToRecord(
   rows: HeaderRow[] | null | undefined
 ): Record<string, string> {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -10,7 +10,7 @@ import type { MembershipOriginType, MembershipSeatType } from "./memberships";
 import type { ModelId } from "./shared/model_id";
 import { DbModelIdSchema } from "./shared/model_id";
 import { assertNever } from "./shared/utils/assert_never";
-import { toLatin1SafeHeaderValue } from "./shared/utils/http_headers";
+import { decodeUtf8HeaderValue } from "./shared/utils/http_headers";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 
@@ -359,7 +359,7 @@ export function getUserEmailFromHeaders(headers: {
 }) {
   const email = headers[DustUserEmailHeader];
   if (typeof email === "string") {
-    return email;
+    return decodeUtf8HeaderValue(email);
   }
 
   return undefined;
@@ -370,7 +370,9 @@ export function getHeaderFromUserEmail(email: string | undefined) {
     return undefined;
   }
 
+  // The email may exceed Latin-1 (internationalized addresses); DustAPI
+  // encodes extra header values on the wire (see @dust-tt/client baseHeaders).
   return {
-    [DustUserEmailHeader]: toLatin1SafeHeaderValue(email),
+    [DustUserEmailHeader]: email,
   };
 }

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -10,6 +10,7 @@ import type { MembershipOriginType, MembershipSeatType } from "./memberships";
 import type { ModelId } from "./shared/model_id";
 import { DbModelIdSchema } from "./shared/model_id";
 import { assertNever } from "./shared/utils/assert_never";
+import { toLatin1SafeHeaderValue } from "./shared/utils/http_headers";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 
@@ -370,6 +371,6 @@ export function getHeaderFromUserEmail(email: string | undefined) {
   }
 
   return {
-    [DustUserEmailHeader]: email,
+    [DustUserEmailHeader]: toLatin1SafeHeaderValue(email),
   };
 }

--- a/sdks/js/src/http_headers.ts
+++ b/sdks/js/src/http_headers.ts
@@ -1,0 +1,33 @@
+// HTTP header values must fit in ISO-8859-1: fetch throws on any code point
+// above 0xFF, and Node rejects control characters. Extra header values that
+// don't fit (emoji or non-Latin scripts in API key names, internationalized
+// user emails) are carried as an RFC 2047 encoded-word (`=?utf-8?B?<base64>?=`)
+// and decoded on the receiving end (`decodeUtf8HeaderValue` in
+// front/types/shared/utils/http_headers.ts). Latin-1-safe values pass through
+// raw, so the common case stays readable in logs and unencoded for receivers
+// that don't decode.
+const NON_LATIN1_HEADER_VALUE_REGEX = /[^\x20-\x7e\x80-\xff]/u;
+const ENCODED_WORD_REGEX = /^=\?utf-8\?B\?[A-Za-z0-9+/]*={0,2}\?=$/i;
+
+// btoa over TextEncoder bytes rather than Buffer: this runs in browser
+// consumers of the SDK where Buffer is not available.
+function toBase64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function encodeUtf8HeaderValue(value: string): string {
+  // A raw value that itself looks like an encoded-word is also encoded, so
+  // decoding is unambiguous.
+  if (
+    !NON_LATIN1_HEADER_VALUE_REGEX.test(value) &&
+    !ENCODED_WORD_REGEX.test(value)
+  ) {
+    return value;
+  }
+  return `=?utf-8?B?${toBase64Utf8(value)}?=`;
+}

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -6,6 +6,7 @@ import { AgentsAPI } from "./high_level/agents";
 import { ConversationsAPI } from "./high_level/conversations";
 import { FilesAPI } from "./high_level/files";
 import type { DustAPIOptions } from "./high_level/types";
+import { encodeUtf8HeaderValue } from "./http_headers";
 import type {
   AgentConfigurationViewType,
   AgentMessageEventData,
@@ -104,6 +105,7 @@ import {
 export * from "./error_utils";
 export * from "./errors/errors";
 export * from "./high_level";
+export * from "./http_headers";
 export * from "./internal_mime_types";
 export * from "./mcp_transport";
 export * from "./output_schemas";
@@ -294,11 +296,17 @@ export class DustAPI {
   }
 
   async baseHeaders() {
-    const headers: RequestInit["headers"] = {
+    const headers: Record<string, string> = {
       Authorization: `Bearer ${await this.getApiKey()}`,
     };
     if (this._credentials.extraHeaders) {
-      Object.assign(headers, this._credentials.extraHeaders);
+      // Header values must fit in ISO-8859-1 or fetch throws; non-Latin-1
+      // values are carried as RFC 2047 encoded-words (decoded server-side).
+      for (const [key, value] of Object.entries(
+        this._credentials.extraHeaders
+      )) {
+        headers[key] = encodeUtf8HeaderValue(value);
+      }
     }
     return headers;
   }


### PR DESCRIPTION
## Description

Internal calls (run_agent & co) forward the caller's API key name and user email as headers. fetch throws on header values with chars above 0xFF, so a key named Prod 🔑 or an email containing иван broke every sub-agent call.
Most people don't use utf8 in their email address, because of legacy, but in key names it's already the case, and it will break in any call involving those. So I'm fixing both in one pass.

Values that don't fit in Latin-1 are now sent as RFC 2047 encoded-words (=?utf-8?B?…?=) and decoded in the front-api auth middleware — the only place that reads these headers. Everything Latin-1-safe stays raw, so the wire is unchanged for existing values and no deploy ordering is needed (encoded values were unsendable before).

Notes:
- x-api-user-email drives system-key impersonation (exact-string lookup), so lossy sanitization wasn't an option.
- x-dust-api-key-name is attribution-only; billing resolves key names from the DB via userContextApiKeyId, never from the header.
- No Node built-in for this;
- Checked that the encoded form isn't logged anywhere before decode (request logger, error handlers, statsd, SDK).

## Tests

Unit tests

## Risk

Low
Blast radius - at least all run_agent calls, but probably all api call with impersonation 😬 

## Deploy Plan

- [x] Frontedge it
- [x] merge
- [x] deploy front & front-sse