### PR TITLE
[front] Make sandbox invocation GCS paths non-null

### DIFF
--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -36,7 +37,6 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
 import { z } from "zod";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
@@ -296,19 +296,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   private async loadDataFromGcs(): Promise<void> {
-    // TODO: Remove null support after running
-    // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
-    const { gcsPath } = this;
-    if (!gcsPath) {
-      this.data = {
-        version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
-        input: undefined,
-      };
-      return;
-    }
-
     const downloadResult = await withRetry(() =>
-      getPrivateUploadBucket().file(gcsPath).download()
+      getPrivateUploadBucket().file(this.gcsPath).download()
     );
     if (downloadResult.isErr()) {
       throw downloadResult.error;
@@ -319,16 +308,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   private async writeDataToGcs(): Promise<void> {
-    // TODO: Remove null support after running
-    // `20260715_backfill_sandbox_function_invocation_gcs_paths.ts`.
-    const { gcsPath } = this;
-    if (!gcsPath) {
-      return;
-    }
-
     const writeResult = await withRetry(() =>
       getPrivateUploadBucket()
-        .file(gcsPath)
+        .file(this.gcsPath)
         .save(Buffer.from(JSON.stringify(this.data), "utf-8"), {
           contentType: "application/json",
         })
@@ -365,29 +347,33 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
-    const invocation = await this.model.create(
-      {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sandboxFunctionId: sandboxFunction.id,
-        status: "created",
-        gcsPath: null,
-      },
-      { transaction }
-    );
+    return withTransaction(async (t) => {
+      const invocation = await this.model.create(
+        {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          sandboxFunctionId: sandboxFunction.id,
+          status: "created",
+          // The final path contains the database-generated invocation sId. This placeholder is
+          // replaced in the same transaction before the row becomes visible.
+          gcsPath: "",
+        },
+        { transaction: t }
+      );
 
-    const data: SandboxFunctionInvocationData = {
-      version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
-      input,
-    };
-    const resource = new this(this.model, invocation.get(), {
-      sandboxFunction,
-      data,
-    });
-    const gcsPath = resource.buildGcsPath(auth);
-    await resource.update({ gcsPath }, transaction);
-    await resource.writeDataToGcs();
+      const data: SandboxFunctionInvocationData = {
+        version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+        input,
+      };
+      const resource = new this(this.model, invocation.get(), {
+        sandboxFunction,
+        data,
+      });
+      const gcsPath = resource.buildGcsPath(auth);
+      await resource.update({ gcsPath }, t);
+      await resource.writeDataToGcs();
 
-    return resource;
+      return resource;
+    }, transaction);
   }
 
   static async createAndStartExecution(
@@ -495,15 +481,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     };
     const invocations = await this.model.findAll({
       attributes: ["gcsPath"],
-      where: {
-        ...where,
-        gcsPath: { [Op.ne]: null },
-      },
+      where,
       transaction,
     });
-    const gcsPaths = invocations.flatMap(({ gcsPath }) =>
-      gcsPath ? [gcsPath] : []
-    );
+    const gcsPaths = invocations.map(({ gcsPath }) => gcsPath);
 
     // MCP actions FK invocations with RESTRICT: delete them (rows + output GCS objects) first.
     await SandboxFunctionMCPActionResource.deleteAllForSandboxFunction(
@@ -537,11 +518,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         },
         transaction,
       });
-      if (this.gcsPath) {
-        await SandboxFunctionInvocationResource.deleteDataFromGcs([
-          this.gcsPath,
-        ]);
-      }
+      await SandboxFunctionInvocationResource.deleteDataFromGcs([this.gcsPath]);
 
       return new Ok(undefined);
     } catch (error) {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -451,6 +451,7 @@ describe("SandboxFunctionResource", () => {
       workspaceId: workspace.id,
       sandboxFunctionId: sandboxFunction.id,
       status: "created",
+      gcsPath: "sandbox-function-invocations/test-invocation",
     });
 
     const deleteResult = await SandboxFunctionResource.deleteAllForSpace(

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -55,7 +55,7 @@ export class SandboxFunctionInvocationModel extends WorkspaceAwareModel<SandboxF
 
   declare sandboxFunctionId: ForeignKey<SandboxFunctionModel["id"]>;
   declare status: SandboxFunctionInvocationStatus;
-  declare gcsPath: string | null;
+  declare gcsPath: string;
 
   declare sandboxFunction: NonAttribute<SandboxFunctionModel>;
 }
@@ -180,8 +180,7 @@ SandboxFunctionInvocationModel.init(
     },
     gcsPath: {
       type: DANGEROUSLY_UNBOUNDED_TEXT,
-      allowNull: true,
-      defaultValue: null,
+      allowNull: false,
     },
   },
   {

--- a/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
+++ b/front/migrations/20260715_backfill_sandbox_function_invocation_gcs_paths.ts
@@ -46,6 +46,7 @@ makeScript(
     for (;;) {
       const invocations: SandboxFunctionInvocationModel[] =
         await SandboxFunctionInvocationModel.findAll({
+          // @ts-expect-error This migration intentionally queries rows from before the constraint.
           where: {
             workspaceId: workspace.id,
             gcsPath: null,
@@ -94,6 +95,7 @@ makeScript(
             await SandboxFunctionInvocationModel.update(
               { gcsPath },
               {
+                // @ts-expect-error This migration intentionally updates rows from before the constraint.
                 where: {
                   id: invocation.id,
                   workspaceId: workspace.id,

--- a/front/migrations/post-deploy/20260715161734_make_sandbox_function_invocation_gcs_path_not_null.sql
+++ b/front/migrations/post-deploy/20260715161734_make_sandbox_function_invocation_gcs_path_not_null.sql
@@ -1,0 +1,27 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ADD CONSTRAINT "sandbox_function_invocations_gcs_path_not_null" CHECK("gcsPath" IS NOT NULL) NOT VALID;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" VALIDATE CONSTRAINT "sandbox_function_invocations_gcs_path_not_null";
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ALTER COLUMN "gcsPath" SET NOT NULL;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" DROP CONSTRAINT "sandbox_function_invocations_gcs_path_not_null";


### PR DESCRIPTION
## Description

Makes sandbox function invocation `gcsPath` mandatory now that the production backfill has completed.

- Adds the post-deploy `NOT NULL` constraint.
- Removes temporary nullable fallbacks from the model and invocation resource.
- Creates invocations transactionally so the database-generated invocation ID can be included in the final GCS path before the row becomes visible.
- Keeps the completed backfill script type-safe against the now non-null model.

## Tests

- Covered by existing tests
- Tested locally

## RIsks

None

## Deploy Plan

- deploy `front`
- run post-deploy migration

(backfill was already run as part of https://github.com/dust-tt/dust/pull/28957)
