### PR TITLE
[front] Improve fair use UX & make policy credit-based

### DIFF
--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -30,13 +30,14 @@ function getFairUseContent(
     creditLimit > 0 &&
     creditLimitTimeframe !== undefined;
 
+  const timeframeLabel = hasDynamicLimit
+    ? formatCreditsTimeframe(creditLimitTimeframe)
+    : "";
+
   const limitLine = hasDynamicLimit
-    ? (() => {
-        const timeframeLabel = formatCreditsTimeframe(creditLimitTimeframe);
-        return `On your current plan, a limit of **${formatCredits(creditLimit)} credits${
-          timeframeLabel ? ` ${timeframeLabel}` : ""
-        }** applies to each user seat.`;
-      })()
+    ? `On your current plan, a limit of **${formatCredits(creditLimit)} credits${
+        timeframeLabel ? ` ${timeframeLabel}` : ""
+      }** applies to each user seat.`
     : `The credit limit that applies to each user seat depends on your plan.`;
 
   return `

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -1,5 +1,10 @@
-import { formatCredits, formatCreditsTimeframe } from "@app/lib/client/credits";
-import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
+import { formatCredits, formatFairUseTimeframe } from "@app/lib/client/credits";
+import type {
+  MaxAwuCreditsTimeframeType,
+  MaxMessagesTimeframeType,
+  PlanType,
+} from "@app/types/plan";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Attachment01,
   Icon,
@@ -11,43 +16,82 @@ import {
   SheetTitle,
 } from "@dust-tt/sparkle";
 
+// The per-seat fair-use limit that applies to a plan. Credit-priced plans budget
+// per-user credits; other (Pro/Enterprise) plans still cap per-seat messages.
+export type FairUseSeatLimit =
+  | { kind: "credits"; limit: number; timeframe: MaxAwuCreditsTimeframeType }
+  | { kind: "messages"; limit: number; timeframe: MaxMessagesTimeframeType };
+
+// Resolve the fair-use limit that applies to a plan, or undefined when none is
+// configured (both limits are the -1 unlimited sentinel).
+export function fairUseSeatLimitFromPlan(
+  plan: PlanType
+): FairUseSeatLimit | undefined {
+  const {
+    maxAwuCredits,
+    maxAwuCreditsTimeframe,
+    maxMessages,
+    maxMessagesTimeframe,
+  } = plan.limits.assistant;
+
+  if (maxAwuCredits !== -1) {
+    return {
+      kind: "credits",
+      limit: maxAwuCredits,
+      timeframe: maxAwuCreditsTimeframe,
+    };
+  }
+  if (maxMessages !== -1) {
+    return {
+      kind: "messages",
+      limit: maxMessages,
+      timeframe: maxMessagesTimeframe,
+    };
+  }
+  return undefined;
+}
+
 interface FairUsageModalProps {
   isOpened: boolean;
   onClose: () => void;
-  // When known, the fair-use credit limit and its recurring timeframe for the
-  // current plan are rendered in the policy. Omitted on generic surfaces (e.g.
-  // the pricing page) where no single plan is in context.
-  creditLimit?: number;
-  creditLimitTimeframe?: MaxAwuCreditsTimeframeType;
+  // The fair-use limit for the current plan, when known. Omitted on generic
+  // surfaces (e.g. the pricing page) where no single plan is in context.
+  seatLimit?: FairUseSeatLimit;
 }
 
-function getFairUseContent(
-  creditLimit?: number,
-  creditLimitTimeframe?: MaxAwuCreditsTimeframeType
-): string {
-  const hasDynamicLimit =
-    creditLimit !== undefined &&
-    creditLimit > 0 &&
-    creditLimitTimeframe !== undefined;
-
-  const timeframeLabel = hasDynamicLimit
-    ? formatCreditsTimeframe(creditLimitTimeframe)
-    : "";
-
-  const limitLine = hasDynamicLimit
-    ? `On your current plan, a limit of **${formatCredits(creditLimit)} credits${
+function getFairUseContent(seatLimit?: FairUseSeatLimit): string {
+  let limitLine: string;
+  switch (seatLimit?.kind) {
+    case "credits": {
+      const timeframeLabel = formatFairUseTimeframe(seatLimit.timeframe);
+      limitLine = `On your current plan, that is **${formatCredits(seatLimit.limit)} credits${
         timeframeLabel ? ` ${timeframeLabel}` : ""
-      }** applies to each user seat.`
-    : `The credit limit that applies to each user seat depends on your plan.`;
+      }**.`;
+      break;
+    }
+    case "messages": {
+      const timeframeLabel = formatFairUseTimeframe(seatLimit.timeframe);
+      limitLine = `On your current plan, that is **${seatLimit.limit} messages${
+        timeframeLabel ? ` ${timeframeLabel}` : ""
+      }**.`;
+      break;
+    }
+    case undefined:
+      limitLine = `The exact limit depends on your plan.`;
+      break;
+    default:
+      assertNeverAndIgnore(seatLimit);
+      limitLine = `The exact limit depends on your plan.`;
+  }
 
   return `
 # **Fair use principles for user seats**
 
 Each user seat at Dust is tied to a specific human user, and is destined to be used by that person only, for the purposes of typing and sending messages manually (as opposed to using programmatic methods such as scripts, API calls, etc. which is covered separately).
 
-To prevent abuse, a "fair use" limit on credit consumption applies to each user seat. ${limitLine}
+To prevent abuse, a "fair use" limit applies to each user seat. ${limitLine}
 
-This limit should be understood as a way to prevent abuse, not as an allowed quota of credits. In particular, it is considered unfair to share a single seat between multiple people.
+This limit should be understood as a way to prevent abuse, not as an allowed quota. In particular, it is considered unfair to share a single seat between multiple people.
 
 ___
 # **Can messages be sent programmatically with Dust?**
@@ -62,8 +106,7 @@ Dust plans already include monthly credits for programmatic usage, and more cred
 export function FairUsageModal({
   isOpened,
   onClose,
-  creditLimit,
-  creditLimitTimeframe,
+  seatLimit,
 }: FairUsageModalProps) {
   return (
     <Sheet
@@ -81,7 +124,7 @@ export function FairUsageModal({
         <SheetContainer>
           <Icon visual={Attachment01} size="lg" className="text-success-500" />
           <Markdown
-            content={getFairUseContent(creditLimit, creditLimitTimeframe)}
+            content={getFairUseContent(seatLimit)}
             forcedTextSize="text-sm"
           />
         </SheetContainer>

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -1,3 +1,5 @@
+import { formatCredits, formatCreditsTimeframe } from "@app/lib/client/credits";
+import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
 import {
   Attachment01,
   Icon,
@@ -12,29 +14,56 @@ import {
 interface FairUsageModalProps {
   isOpened: boolean;
   onClose: () => void;
+  // When known, the fair-use credit limit and its recurring timeframe for the
+  // current plan are rendered in the policy. Omitted on generic surfaces (e.g.
+  // the pricing page) where no single plan is in context.
+  creditLimit?: number;
+  creditLimitTimeframe?: MaxAwuCreditsTimeframeType;
 }
 
-const FAIR_USE_CONTENT = `
+function getFairUseContent(
+  creditLimit?: number,
+  creditLimitTimeframe?: MaxAwuCreditsTimeframeType
+): string {
+  const hasDynamicLimit =
+    creditLimit !== undefined &&
+    creditLimit > 0 &&
+    creditLimitTimeframe !== undefined;
+
+  const limitLine = hasDynamicLimit
+    ? (() => {
+        const timeframeLabel = formatCreditsTimeframe(creditLimitTimeframe);
+        return `On your current plan, a limit of **${formatCredits(creditLimit)} credits${
+          timeframeLabel ? ` ${timeframeLabel}` : ""
+        }** applies to each user seat.`;
+      })()
+    : `The credit limit that applies to each user seat depends on your plan.`;
+
+  return `
 # **Fair use principles for user seats**
 
 Each user seat at Dust is tied to a specific human user, and is destined to be used by that person only, for the purposes of typing and sending messages manually (as opposed to using programmatic methods such as scripts, API calls, etc. which is covered separately).
 
-"Fair use" limits apply to each user seat, as follows:
-- For **Pro plans**, a limit at 100 messages / seat / day is applied.
-- For **Enterprise plans**, a limit at 200 messages / seat / day is applied.
+To prevent abuse, a "fair use" limit on credit consumption applies to each user seat. ${limitLine}
 
-These limits should be understood as a way to prevent abuse, not as an allowed quota of messages. In particular, it is considered unfair to share a single seat between multiple people.
+This limit should be understood as a way to prevent abuse, not as an allowed quota of credits. In particular, it is considered unfair to share a single seat between multiple people.
 
 ___
 # **Can messages be sent programmatically with Dust?**
 
-Yes, and this usage is encouraged. However, such messages are not covered by individual user seats and fair use limits, and are billed separately. 
+Yes, and this usage is encouraged. However, such messages are not covered by individual user seats and fair use limits, and are billed separately.
 
 Dust plans already include monthly credits for programmatic usage, and more credits can be purchased if needed, see [Programmatic usage at Dust](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e).
 
 `;
+}
 
-export function FairUsageModal({ isOpened, onClose }: FairUsageModalProps) {
+export function FairUsageModal({
+  isOpened,
+  onClose,
+  creditLimit,
+  creditLimitTimeframe,
+}: FairUsageModalProps) {
   return (
     <Sheet
       open={isOpened}
@@ -50,7 +79,10 @@ export function FairUsageModal({ isOpened, onClose }: FairUsageModalProps) {
         </SheetHeader>
         <SheetContainer>
           <Icon visual={Attachment01} size="lg" className="text-success-500" />
-          <Markdown content={FAIR_USE_CONTENT} forcedTextSize="text-sm" />
+          <Markdown
+            content={getFairUseContent(creditLimit, creditLimitTimeframe)}
+            forcedTextSize="text-sm"
+          />
         </SheetContainer>
       </SheetContent>
     </Sheet>

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -16,14 +16,14 @@ import {
   SheetTitle,
 } from "@dust-tt/sparkle";
 
-// The per-seat fair-use limit that applies to a plan. Credit-priced plans budget
-// per-user credits; other (Pro/Enterprise) plans still cap per-seat messages.
+// The per-seat fair-use limit for a plan: if the plan sets maxAwuCredits it's a
+// credit limit, otherwise it's a max number of messages.
 export type FairUseSeatLimit =
   | { kind: "credits"; limit: number; timeframe: MaxAwuCreditsTimeframeType }
   | { kind: "messages"; limit: number; timeframe: MaxMessagesTimeframeType };
 
-// Resolve the fair-use limit that applies to a plan, or undefined when none is
-// configured (both limits are the -1 unlimited sentinel).
+// If the plan has maxAwuCredits, it's an AWU credit limit; otherwise it's a max
+// number of messages. Undefined when neither is set (both are the -1 sentinel).
 export function fairUseSeatLimitFromPlan(
   plan: PlanType
 ): FairUseSeatLimit | undefined {

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -1,5 +1,5 @@
 import { FairUsageModal } from "@app/components/FairUsageModal";
-import { formatCredits, formatCreditsTimeframe } from "@app/lib/client/credits";
+import { formatCredits, formatFairUseTimeframe } from "@app/lib/client/credits";
 import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
 import { cn, Hoverable } from "@dust-tt/sparkle";
@@ -62,15 +62,14 @@ export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
   }
 
   const isCritical = percentage >= CREDITS_USAGE_CRITICAL_THRESHOLD;
-  const timeframeLabel = formatCreditsTimeframe(timeframe);
+  const timeframeLabel = formatFairUseTimeframe(timeframe);
 
   return (
     <>
       <FairUsageModal
         isOpened={isFairUsageModalOpened}
         onClose={() => setIsFairUsageModalOpened(false)}
-        creditLimit={limit}
-        creditLimitTimeframe={timeframe}
+        seatLimit={{ kind: "credits", limit, timeframe }}
       />
       <div
         className={cn(

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -1,8 +1,9 @@
-import { formatCredits } from "@app/lib/client/credits";
+import { FairUsageModal } from "@app/components/FairUsageModal";
+import { formatCredits, formatCreditsTimeframe } from "@app/lib/client/credits";
 import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
-import { cn } from "@dust-tt/sparkle";
-import { useEffect, useRef } from "react";
+import { cn, Hoverable } from "@dust-tt/sparkle";
+import { useEffect, useRef, useState } from "react";
 
 const CREDITS_USAGE_DISPLAY_THRESHOLD = 0.75;
 const CREDITS_USAGE_CRITICAL_THRESHOLD = 0.9;
@@ -19,6 +20,8 @@ export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
   const { fairUseAwuCreditsState, mutateFairUseCredits } = useFairUseCredits({
     workspaceId,
   });
+
+  const [isFairUsageModalOpened, setIsFairUsageModalOpened] = useState(false);
 
   const mutateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -52,48 +55,66 @@ export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
     return null;
   }
 
-  const { count, limit } = fairUseAwuCreditsState;
+  const { count, limit, timeframe } = fairUseAwuCreditsState;
   const percentage = count / limit;
   if (percentage < CREDITS_USAGE_DISPLAY_THRESHOLD) {
     return null;
   }
 
   const isCritical = percentage >= CREDITS_USAGE_CRITICAL_THRESHOLD;
+  const timeframeLabel = formatCreditsTimeframe(timeframe);
 
   return (
-    <div
-      className={cn(
-        // Spacing lives here rather than on a wrapper so that it only applies when the gauge is
-        // actually visible.
-        "mx-3 mb-3",
-        "rounded-lg border p-3",
-        "border-border",
-        "bg-background"
-      )}
-    >
-      <div className="mb-2 flex items-center justify-between text-sm">
-        <span className="font-semibold text-foreground">Fair usage</span>
-        <span className="font-medium text-foreground">
-          <span className={cn(isCritical && "text-warning-600")}>
-            {formatCredits(count)}
-          </span>{" "}
-          / {formatCredits(limit)} cr.
-        </span>
-      </div>
+    <>
+      <FairUsageModal
+        isOpened={isFairUsageModalOpened}
+        onClose={() => setIsFairUsageModalOpened(false)}
+        creditLimit={limit}
+        creditLimitTimeframe={timeframe}
+      />
       <div
         className={cn(
-          "h-2 w-full overflow-hidden rounded-full",
-          "bg-primary-100"
+          // Spacing lives here rather than on a wrapper so that it only applies when the gauge is
+          // actually visible.
+          "mx-3 mb-3",
+          "rounded-lg border p-3",
+          "border-border",
+          "bg-background"
         )}
       >
+        <div className="mb-2 flex items-center justify-between text-sm">
+          <span className="font-semibold text-foreground">Fair usage</span>
+          <span className="font-medium text-foreground">
+            <span className={cn(isCritical && "text-warning-600")}>
+              {formatCredits(count)}
+            </span>{" "}
+            / {formatCredits(limit)} credits
+            {timeframeLabel ? ` ${timeframeLabel}` : ""}
+          </span>
+        </div>
         <div
           className={cn(
-            "h-full rounded-full transition-all",
-            isCritical ? "bg-warning-700" : "bg-foreground"
+            "h-2 w-full overflow-hidden rounded-full",
+            "bg-primary-100"
           )}
-          style={{ width: `${Math.min(percentage * 100, 100)}%` }}
-        />
+        >
+          <div
+            className={cn(
+              "h-full rounded-full transition-all",
+              isCritical ? "bg-warning-700" : "bg-foreground"
+            )}
+            style={{ width: `${Math.min(percentage * 100, 100)}%` }}
+          />
+        </div>
+        <div className="mt-2 text-xs">
+          <Hoverable
+            variant="primary"
+            onClick={() => setIsFairUsageModalOpened(true)}
+          >
+            Fair Use policy
+          </Hoverable>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -107,7 +107,7 @@ export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
         </div>
         <div className="mt-2 text-xs">
           <Hoverable
-            variant="primary"
+            variant="highlight"
             onClick={() => setIsFairUsageModalOpened(true)}
           >
             Fair Use policy

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -385,6 +385,10 @@ export function ReachedLimitPopup({
       <FairUsageModal
         isOpened={isFairUsageModalOpened}
         onClose={() => setIsFairUsageModalOpened(false)}
+        creditLimit={subscription.plan.limits.assistant.maxAwuCredits}
+        creditLimitTimeframe={
+          subscription.plan.limits.assistant.maxAwuCreditsTimeframe
+        }
       />
       <Dialog
         open={isOpened}
@@ -400,15 +404,21 @@ export function ReachedLimitPopup({
           </DialogHeader>
           <DialogContainer>{children}</DialogContainer>
           <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-            }}
+            // When there is no distinct action (onValidate), the validate button
+            // just closes the dialog, so a separate Cancel button would be
+            // redundant — render a single button in that case.
+            leftButtonProps={
+              onValidate
+                ? {
+                    label: "Cancel",
+                    variant: "outline",
+                  }
+                : undefined
+            }
             rightButtonProps={{
               label: validateLabel,
               variant: "highlight",
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              onClick: onValidate || (() => onClose()),
+              onClick: onValidate ?? (() => onClose()),
             }}
           />
         </DialogContent>

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -1,4 +1,7 @@
-import { FairUsageModal } from "@app/components/FairUsageModal";
+import {
+  FairUsageModal,
+  fairUseSeatLimitFromPlan,
+} from "@app/components/FairUsageModal";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
@@ -385,10 +388,7 @@ export function ReachedLimitPopup({
       <FairUsageModal
         isOpened={isFairUsageModalOpened}
         onClose={() => setIsFairUsageModalOpened(false)}
-        creditLimit={subscription.plan.limits.assistant.maxAwuCredits}
-        creditLimitTimeframe={
-          subscription.plan.limits.assistant.maxAwuCreditsTimeframe
-        }
+        seatLimit={fairUseSeatLimitFromPlan(subscription.plan)}
       />
       <Dialog
         open={isOpened}

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -1,8 +1,31 @@
+import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+
 // Format a number of AWU credits for display (thousands separators, at most
 // one decimal). Shared across the credits usage table and the message /
 // conversation cost menu entries.
 export function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
+}
+
+// Short recurring-period label for a fair-use credit timeframe (e.g. "per day").
+// Returns an empty string for the "lifetime" sentinel, which has no period.
+export function formatCreditsTimeframe(
+  timeframe: MaxAwuCreditsTimeframeType
+): string {
+  switch (timeframe) {
+    case "day":
+      return "per day";
+    case "week":
+      return "per week";
+    case "month":
+      return "per month";
+    case "lifetime":
+      return "";
+    default:
+      assertNeverAndIgnore(timeframe);
+      return "";
+  }
 }
 
 export function formatCreditsCompact(credits: number): string {

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -8,9 +8,9 @@ export function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
 
-// Short recurring-period label for a fair-use credit timeframe (e.g. "per day").
+// Short recurring-period label for a fair-use timeframe (e.g. "per day").
 // Returns an empty string for the "lifetime" sentinel, which has no period.
-export function formatCreditsTimeframe(
+export function formatFairUseTimeframe(
   timeframe: MaxAwuCreditsTimeframeType
 ): string {
   switch (timeframe) {


### PR DESCRIPTION
## Description

Addresses [tasks#9544](https://github.com/dust-tt/tasks/issues/9544): improves the fair use UX and updates the policy to be credit-based.

### Changes

**Fair usage banner** (`FairUseCreditsUsage.tsx`)
- Shows the limit period, e.g. `18 / 20 credits per day`.
- Replaces the `cr.` abbreviation with `credits`.
- Adds a **Fair Use policy** link opening the policy panel with the current plan's credit limit + timeframe.

<img width="471" height="175" alt="Screenshot 2026-07-15 at 16 51 38" src="https://github.com/user-attachments/assets/8054ea4d-acb1-4305-a62a-4332eae9c78f" />



**Limit-reached popup** (`ReachedLimitPopup.tsx`)
- Removes the redundant **Cancel** button when the primary button only closes the dialog (fair-use cases), leaving a single action button. The Cancel button is kept when there's a real action (e.g. "Manage your subscription").

<img width="503" height="248" alt="Screenshot 2026-07-15 at 16 51 49" src="https://github.com/user-attachments/assets/0f8e72dc-935e-47b6-bc5c-f0566f80f8e0" />

**Fair Use policy panel** (`FairUsageModal.tsx`)
- Rewritten to be **credit-based** instead of the old hardcoded "100/200 messages/seat/day" text.
- Limit is pulled **dynamically from the plan**; falls back to generic wording on surfaces with no single plan in context (the pricing page).

<img width="428" height="651" alt="Screenshot 2026-07-15 at 16 51 55" src="https://github.com/user-attachments/assets/22e1ef94-9204-468f-bfde-375d3f707ef0" />

**Shared helper** (`lib/client/credits.ts`)
- Adds `formatCreditsTimeframe()` (`per day` / `per week` / `per month`, empty for `lifetime`).

### Notes
- The limit-reached popup keeps a single **Ok** button plus the dialog's standard corner **✕** (kept for consistency with all other dialogs).
- On the pricing page (`PlansTables.tsx`), the policy panel shows generic "depends on your plan" wording since no single plan is in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)