### PR TITLE
[front] fix: pass transaction to cancelled AgentMessage row's delete stmt

### DIFF
--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -358,13 +358,16 @@ export const createAgentMessages = async (
         // instead of an UPDATE. MessageModel's exclusivity constraint forces us to anchor the v+1
         // row with a new AgentMessageModel (status "cancelled", it never ran).
         const agentConfiguration = metadata.agentMessage.configuration;
-        const agentMessageRow = await AgentMessageModel.create({
-          status: "cancelled",
-          agentConfigurationId: agentConfiguration.sId,
-          agentConfigurationVersion: agentConfiguration.version,
-          workspaceId: owner.id,
-          skipToolsValidation: metadata.agentMessage.skipToolsValidation,
-        });
+        const agentMessageRow = await AgentMessageModel.create(
+          {
+            status: "cancelled",
+            agentConfigurationId: agentConfiguration.sId,
+            agentConfigurationVersion: agentConfiguration.version,
+            workspaceId: owner.id,
+            skipToolsValidation: metadata.agentMessage.skipToolsValidation,
+          },
+          { transaction }
+        );
         const messageRow = await MessageModel.create(
           {
             sId: generateRandomModelSId(),


### PR DESCRIPTION
## Description

In the `delete` branch of `createAgentMessages`, the placeholder `AgentMessageModel` row (status `"cancelled"`) was created **outside** the caller's transaction — unlike the sibling `retry` branch a few lines above, and unlike the `MessageModel.create` right below it, which both pass `{ transaction }`.

Both `delete` callers (`softDeleteUserMessageAndReplies` and `softDeleteAgentMessage`) run inside `withTransaction`. So whenever the subsequent `MessageModel.create` throws — e.g. the documented `(rank, version)` unique-constraint race in `softDeleteUserMessageAndReplies` — the transaction rolls back but the cancelled agent-message row stays committed, orphaned with no `MessageModel` row pointing at it.

Fix: pass `{ transaction }` to the `AgentMessageModel.create` call, matching the `retry` branch.

## Tests

- `npx tsgo --noEmit` passes
- `lib/api/assistant/conversation/messages.test.ts` — 31/31 pass

## Risk

Low — single call-site now joins the transaction it was always meant to be part of.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)