### PR TITLE
Allow to set user pool usage to 0

### DIFF
--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-const MIN_AWU_CREDITS = 1;
+const MIN_AWU_CREDITS = 0;
 const MAX_AWU_CREDITS = 1_000_000;
 
 type SpendLimitKind = "default" | "override";

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -22,7 +22,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useRef, useState } from "react";
 
-const MIN_AWU_CREDITS = 1;
+const MIN_AWU_CREDITS = 0;
 const MAX_AWU_CREDITS = 1_000_000;
 
 type SpendLimitKind = "default" | "override";
@@ -109,7 +109,7 @@ export function EditSpendLimitModal({
   }
 
   function handleCreditsChange(value: string) {
-    // Keep only digits — credits are integers and the API range starts at 1.
+    // Keep only digits — credits are integers and the API range starts at 0.
     const cleaned = value.replace(/[^\d]/g, "");
     setCreditsInput(cleaned);
     setValidationMessage(null);

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -29,8 +29,9 @@ interface GroupCapCellProps {
   onSave: (group: GroupRowData, limit: GroupSpendLimit) => Promise<void>;
 }
 
-// Per-row editable cap cell. Empty input clears the cap (unlimited); a positive
-// integer sets it. Reverts to the current value when nothing is persisted.
+// Per-row editable cap cell. Empty input clears the cap (unlimited); 0 blocks
+// the group's pool access; a positive integer sets a custom limit. Reverts to
+// the current value when nothing is persisted.
 function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const current = group.poolCapAwuCredits;
@@ -45,7 +46,7 @@ function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
       return;
     }
     const parsed = Number(trimmed);
-    if (!Number.isInteger(parsed) || parsed < 1 || parsed === current) {
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed === current) {
       return;
     }
     await onSave(group, { kind: "limited", awuCredits: parsed });

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -386,8 +386,12 @@ export function AwuUsageBar({
       <div className="flex justify-between text-xs tabular-nums text-foreground">
         <span>
           {isFreeWithBalance
-            ? formatCredits(lifetimeConsumed! + overage)
-            : formatCredits(consumed)}
+            ? formatCredits(Math.min(lifetimeConsumed! + overage, allowance))
+            : formatCredits(
+                effectiveLimit !== null
+                  ? Math.min(consumed, effectiveLimit)
+                  : consumed
+              )}
         </span>
         {isPending ? (
           <Spinner size="xs" />

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -34,7 +34,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
-export const MIN_GROUP_SPEND_LIMIT_AWU_CREDITS = 1;
+export const MIN_GROUP_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_GROUP_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
 
 export type GroupSpendLimitErrorType =

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -26,7 +26,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 1;
+export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
 
 export type UserSpendLimitErrorType =


### PR DESCRIPTION
## Description

Allow to disable pool usage by setting spend limit to 0 (individual, group and batch)

Update the usage bar to not show overage (was actually more confusing than helpful). Keep the tooltip to see the actual overage if any,

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front
