### PR TITLE
Sandbox functions: tool personal-authentication resolution endpoint

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -130,8 +130,12 @@ async function setupSandboxFunction({
 // approval-requiring tools (created without a workflow launch).
 async function setupBlockedAction({
   permission = "high",
+  blockedStatus = "blocked_validation_required",
 }: {
   permission?: MCPToolStakeLevelType;
+  blockedStatus?:
+    | "blocked_validation_required"
+    | "blocked_authentication_required";
 } = {}) {
   const { workspace, sandboxFunction, adminAuth, space } =
     await setupSandboxFunction();
@@ -157,7 +161,7 @@ async function setupBlockedAction({
     permission,
   });
   const [blockedCount] = await action.updateStatusFromExpected(adminAuth, {
-    status: "blocked_validation_required",
+    status: blockedStatus,
     expectedStatus: "running",
   });
   expect(blockedCount).toBe(1);
@@ -180,6 +184,29 @@ function postValidate({
 }) {
   return honoApp.request(
     `/api/w/${workspaceId}/sandbox-functions/${encodeURIComponent(functionIdOrSlug)}/invocations/${invocationId}/actions/${actionId}/validate-action`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function postResolveAuthentication({
+  workspaceId,
+  functionIdOrSlug,
+  invocationId,
+  actionId,
+  body,
+}: {
+  workspaceId: string;
+  functionIdOrSlug: string;
+  invocationId: string;
+  actionId: string;
+  body: unknown;
+}) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/sandbox-functions/${encodeURIComponent(functionIdOrSlug)}/invocations/${invocationId}/actions/${actionId}/resolve-authentication`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -552,6 +579,150 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({
       error: { type: "action_not_blocked" },
+    });
+  });
+});
+
+describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/resolve-authentication", () => {
+  it("completes authentication and relaunches the workflow", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction({
+        blockedStatus: "blocked_authentication_required",
+      });
+    const removeEventSpy = vi
+      .spyOn(getRedisHybridManager(), "removeEvent")
+      .mockResolvedValue(undefined);
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { outcome: "completed" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    expect(refetched?.status).toBe("running");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledWith(
+      expect.anything(),
+      { action: expect.objectContaining({ sId: action.sId }) }
+    );
+    expect(removeEventSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      `sandbox-function-invocation-${invocation.sId}`
+    );
+  });
+
+  it("denies authentication without relaunching the workflow", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction({
+        blockedStatus: "blocked_authentication_required",
+      });
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { outcome: "denied" },
+    });
+
+    expect(response.status).toBe(200);
+
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    // The poll endpoint surfaces `denied` as a 403 rejection to the in-sandbox caller.
+    expect(refetched?.status).toBe("denied");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
+  });
+
+  it("marks the action errored when the workflow relaunch throws", async () => {
+    const { workspace, sandboxFunction, invocation, action, adminAuth } =
+      await setupBlockedAction({
+        blockedStatus: "blocked_authentication_required",
+      });
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+    vi.mocked(launchSandboxFunctionToolWorkflow).mockRejectedValueOnce(
+      new Error("temporal unavailable")
+    );
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { outcome: "completed" },
+    });
+
+    expect(response.status).toBe(500);
+
+    // Compensated to a terminal status instead of hanging `running` with no workflow.
+    const refetched =
+      await SandboxFunctionMCPActionResource.fetchByModelIdWithAuth(
+        adminAuth,
+        action.id
+      );
+    expect(refetched?.status).toBe("errored");
+  });
+
+  it("returns action_not_blocked when the action is not awaiting authentication", async () => {
+    // A validation-blocked action is not an authentication block.
+    const { workspace, sandboxFunction, invocation, action } =
+      await setupBlockedAction();
+    vi.spyOn(getRedisHybridManager(), "removeEvent").mockResolvedValue(
+      undefined
+    );
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: invocation.sId,
+      actionId: action.sId,
+      body: { outcome: "completed" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "action_not_blocked" },
+    });
+  });
+
+  it("scopes actions to the invocation in the path", async () => {
+    const { workspace, sandboxFunction, action, adminAuth } =
+      await setupBlockedAction({
+        blockedStatus: "blocked_authentication_required",
+      });
+    const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
+      adminAuth,
+      { sandboxFunction }
+    );
+
+    const response = await postResolveAuthentication({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+      invocationId: otherInvocation.sId,
+      actionId: action.sId,
+      body: { outcome: "completed" },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: { type: "action_not_found" },
     });
   });
 });

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,4 +1,5 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
+import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
@@ -16,7 +17,8 @@ const ParamsSchema = z.object({
   functionIdOrSlug: z.string().min(1),
 });
 
-const ValidateActionParamsSchema = z.object({
+// Shared by the two action-resolution routes (validate-action, resolve-authentication).
+const ActionResolutionParamsSchema = z.object({
   functionIdOrSlug: z.string().min(1),
   invocationId: z.string().min(1),
   actionId: z.string().min(1),
@@ -25,6 +27,12 @@ const ValidateActionParamsSchema = z.object({
 const ValidateActionBodySchema = z
   .object({
     approved: z.enum(MCP_VALIDATION_OUTPUTS),
+  })
+  .strict();
+
+const ResolveAuthenticationBodySchema = z
+  .object({
+    outcome: z.enum(["completed", "denied"]),
   })
   .strict();
 
@@ -139,7 +147,7 @@ app.post(
 /** @ignoreswagger */
 app.post(
   "/:invocationId/actions/:actionId/validate-action",
-  validate("param", ValidateActionParamsSchema),
+  validate("param", ActionResolutionParamsSchema),
   validate("json", ValidateActionBodySchema),
   async (ctx): HandlerResult<{ success: boolean }> => {
     const auth = ctx.get("auth");
@@ -178,6 +186,65 @@ app.post(
           });
         case "action_not_blocked":
           // The client treats this error type as an already-successful validation (multi-client
+          // races).
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "action_not_blocked",
+              message: result.error.message,
+            },
+          });
+        default:
+          return assertNever(result.error.type);
+      }
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/:invocationId/actions/:actionId/resolve-authentication",
+  validate("param", ActionResolutionParamsSchema),
+  validate("json", ResolveAuthenticationBodySchema),
+  async (ctx): HandlerResult<{ success: boolean }> => {
+    const auth = ctx.get("auth");
+    const { functionIdOrSlug, invocationId, actionId } = ctx.req.valid("param");
+    const { outcome } = ctx.req.valid("json");
+
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+      auth,
+      functionIdOrSlug
+    );
+    if (!sandboxFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Sandbox function not found.",
+        },
+      });
+    }
+
+    const result = await resolveSandboxFunctionActionAuthentication(auth, {
+      sandboxFunction,
+      invocationId,
+      actionId,
+      outcome,
+    });
+    if (result.isErr()) {
+      switch (result.error.type) {
+        case "action_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: result.error.message,
+            },
+          });
+        case "action_not_blocked":
+          // The client treats this error type as an already-resolved authentication (multi-client
           // races).
           return apiError(ctx, {
             status_code: 400,

--- a/front/lib/api/sandbox_functions/resolve_authentication.ts
+++ b/front/lib/api/sandbox_functions/resolve_authentication.ts
@@ -78,6 +78,10 @@ export async function resolveSandboxFunctionActionAuthentication(
     );
   }
 
+  // TODO(2026-07-16 SECURITY): enforce resolver == initiating user here. The invocation does not
+  // yet persist an initiating user; a follow-up adds a userId to the invocation model, then this
+  // gates via canCurrentUserRespondToParentUserMessage so the tool cannot re-run under another
+  // member's personal connection.
   const [updatedCount] = await action.updateStatusFromExpected(auth, {
     status: outcome === "completed" ? "running" : "denied",
     expectedStatus: "blocked_authentication_required",

--- a/front/lib/api/sandbox_functions/resolve_authentication.ts
+++ b/front/lib/api/sandbox_functions/resolve_authentication.ts
@@ -1,0 +1,129 @@
+import { isToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { getSandboxFunctionInvocationChannelId } from "@app/lib/api/sandbox_functions/events";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import logger from "@app/logger/logger";
+import { launchSandboxFunctionToolWorkflow } from "@app/temporal/agent_loop/client";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ResolveAuthenticationOutcome = "completed" | "denied";
+
+export class SandboxFunctionActionAuthenticationError extends Error {
+  constructor(
+    readonly type: "action_not_found" | "action_not_blocked",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Resolves a personal-authentication block on a sandbox function tool action. On `completed` the
+ * blocked action flips back to `running` and its workflow is relaunched: the tool re-runs from
+ * scratch and now finds the personal connection (the block happened at connection time, before the
+ * tool call, so there are no partial side effects to worry about). On `denied` the action becomes
+ * terminal `denied`, which the in-sandbox poll surfaces as a 403 rejection.
+ */
+export async function resolveSandboxFunctionActionAuthentication(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    invocationId,
+    actionId,
+    outcome,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    invocationId: string;
+    actionId: string;
+    outcome: ResolveAuthenticationOutcome;
+  }
+): Promise<Result<undefined, SandboxFunctionActionAuthenticationError>> {
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+  });
+  // Out-of-scope lookups report as not-found, same shape as truly missing ones.
+  if (!invocation) {
+    return new Err(
+      new SandboxFunctionActionAuthenticationError(
+        "action_not_found",
+        "Action not found."
+      )
+    );
+  }
+
+  const action = await SandboxFunctionMCPActionResource.fetchById(
+    auth,
+    actionId
+  );
+  if (!action || action.invocationId !== invocation.sId) {
+    return new Err(
+      new SandboxFunctionActionAuthenticationError(
+        "action_not_found",
+        "Action not found."
+      )
+    );
+  }
+
+  if (action.status !== "blocked_authentication_required") {
+    return new Err(
+      new SandboxFunctionActionAuthenticationError(
+        "action_not_blocked",
+        `Action is not blocked on authentication: ${action.status}.`
+      )
+    );
+  }
+
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: outcome === "completed" ? "running" : "denied",
+    expectedStatus: "blocked_authentication_required",
+  });
+
+  // Concurrent resolutions have exactly one winner through the compare-and-swap; losers succeed
+  // silently, the action already reached the state a resolution produces.
+  if (updatedCount === 0) {
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+        actionId,
+      },
+      "Sandbox function action authentication already resolved"
+    );
+    return new Ok(undefined);
+  }
+
+  // Remove the pending authentication event from the invocation channel so SSE history replay
+  // does not resurface the authentication card.
+  await getRedisHybridManager().removeEvent(
+    (event) => {
+      const payload = JSON.parse(event.message["payload"]);
+      return isToolPersonalAuthRequiredEvent(payload)
+        ? payload.actionId === actionId
+        : false;
+    },
+    getSandboxFunctionInvocationChannelId({ invocationId: invocation.sId })
+  );
+
+  if (outcome === "completed") {
+    try {
+      await launchSandboxFunctionToolWorkflow(auth, { action });
+    } catch (err) {
+      // The action is already `running`; a failed launch would otherwise leave the poll hanging
+      // until token expiry with no workflow. Compensate to a terminal `errored` (CAS-guarded so a
+      // workflow that did start and already moved the status is not clobbered), then rethrow.
+      await action.updateStatusFromExpected(auth, {
+        status: "errored",
+        expectedStatus: "running",
+      });
+      throw err;
+    }
+  }
+
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description 

Follow up of #28863, which blocks a sandbox function tool action on `blocked_authentication_required` and publishes the `tool_personal_auth_required` event to the invocation stream when a tool needs personal OAuth. This PR adds the resolution half, mirroring the validate-action endpoint (#28829): the endpoint the merged personal-auth card already calls.

`POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invocationId/actions/:actionId/resolve-authentication` with `{ outcome: "completed" | "denied" }`:

- Completed: compare-and-swap `blocked_authentication_required` -> `running`, then relaunch `launchSandboxFunctionToolWorkflow`. The tool re-runs from scratch and now finds the personal connection the user just created. Safe to re-run: the block happens at connection time, before the tool call, so there are no partial side effects.
- Denied: CAS -> `denied`; the poll surfaces it as `403 rejected` and the in-sandbox tool call fails.
- The pending `tool_personal_auth_required` event is removed from the invocation Redis channel so SSE history replay does not resurface the authentication card.
- Concurrent resolutions have exactly one winner through the CAS; losers succeed silently, and a late duplicate gets `action_not_blocked`, which the client treats as success.
- Launch failure after the CAS compensates the action to a terminal `errored` (CAS-guarded) then rethrows, so the poll doesn't hang until token expiry with no workflow. Same shape as the validate endpoint; the create/validate/resolve launch sites all share this exposure until launch is made durable.

Authorization: anyone who can read the pod space can resolve, same as the validate endpoint and the invocation SSE route. Invocations record no initiating user.

The params schema is now shared by both action-resolution routes (`ActionResolutionParamsSchema`).

## Tests

Endpoint tests: completed (status -> running, workflow relaunch, event removal), denied (denied, no relaunch), wrong status -> `action_not_blocked` 400, cross-invocation action -> 404.

## Risk

None, SandboxFunction is not live yet. The endpoint is unreachable until a tool call blocks on authentication (#28863).

## Deploy Plan

- [ ] Deploy front