### PR TITLE
Expose linked file ids to browser clients

### DIFF
--- a/front-api/middlewares/cors.test.ts
+++ b/front-api/middlewares/cors.test.ts
@@ -1,0 +1,40 @@
+import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import { cors } from "@front-api/middlewares/cors";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+const APP_ORIGIN = "https://app.dust.tt";
+
+function createApp() {
+  const app = new Hono();
+  app.use("*", cors);
+  app.get("/", (ctx) => ctx.text("ok"));
+  return app;
+}
+
+function getExposedHeaders(response: Response): string[] {
+  return (
+    response.headers.get("Access-Control-Expose-Headers")?.split(", ") ?? []
+  );
+}
+
+describe("cors middleware", () => {
+  it("exposes the linked file id header on cross-origin responses", async () => {
+    const response = await createApp().request("/", {
+      headers: { Origin: APP_ORIGIN },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+  });
+
+  it("exposes the linked file id header on preflight responses", async () => {
+    const response = await createApp().request("/", {
+      method: "OPTIONS",
+      headers: { Origin: APP_ORIGIN },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+  });
+});

--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -4,12 +4,18 @@ import {
   isAllowedOrigin,
 } from "@app/config/cors";
 import logger from "@app/logger/logger";
+import { DUST_FILE_ID_HEADER } from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { MiddlewareHandler } from "hono";
 
 const ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
-const EXPOSE_HEADERS =
-  "X-Reload-Required, WWW-Authenticate, mcp-session-id, mcp-protocol-version";
+const EXPOSE_HEADERS = [
+  "X-Reload-Required",
+  "WWW-Authenticate",
+  "mcp-session-id",
+  "mcp-protocol-version",
+  DUST_FILE_ID_HEADER,
+].join(", ");
 
 /**
  * Adds the cross-origin headers expected by browser clients to every


### PR DESCRIPTION
## Description

Expose `X-Dust-File-Id` through the Front API CORS middleware. Without this, the path metadata endpoint returns the linked Frame file ID but `app.dust.tt` cannot read it, so Frame directives report that no linked file exists.

## Tests

Added middleware coverage for normal cross-origin and preflight responses. Reproduced the mismatch against production conversation data before applying the fix.

## Risk

Low. This only exposes an existing response header to allowed browser origins.

## Deploy Plan

Standard deploy.