### PR TITLE
feat(poke): searchable user selection for Join Activation Pod

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -267,7 +267,7 @@ export function PluginForm({
                             workspaceId && (
                               <ServerSideSearchEnumSelect
                                 label={arg.label}
-                                multiple={arg.multiple}
+                                allowMultiple={arg.multiple}
                                 onValuesChange={(values) =>
                                   field.onChange(values)
                                 }

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -267,6 +267,7 @@ export function PluginForm({
                             workspaceId && (
                               <ServerSideSearchEnumSelect
                                 label={arg.label}
+                                multiple={arg.multiple}
                                 onValuesChange={(values) =>
                                   field.onChange(values)
                                 }

--- a/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
+++ b/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
@@ -32,7 +32,7 @@ interface ServerSideSearchEnumSelectProps {
   label?: string;
   // When true, allows selecting several values; the popover stays open on
   // select and previously selected values are toggled on/off.
-  multiple?: boolean;
+  allowMultiple?: boolean;
   onValuesChange: (values: string[]) => void;
   placeholder?: string;
   staticOptions?: readonly EnumValue[];
@@ -42,7 +42,7 @@ interface ServerSideSearchEnumSelectProps {
 
 export function ServerSideSearchEnumSelect({
   label,
-  multiple = false,
+  allowMultiple = false,
   onValuesChange,
   placeholder = "Select value",
   staticOptions = [],
@@ -109,7 +109,7 @@ export function ServerSideSearchEnumSelect({
 
   const handleSelect = React.useCallback(
     (value: string) => {
-      if (multiple) {
+      if (allowMultiple) {
         const next = selectedValuesSet.has(value)
           ? selectedValues.filter((v) => v !== value)
           : [...selectedValues, value];
@@ -120,7 +120,7 @@ export function ServerSideSearchEnumSelect({
       onValuesChange([value]);
       setOpen(false);
     },
-    [multiple, onValuesChange, selectedValues, selectedValuesSet]
+    [allowMultiple, onValuesChange, selectedValues, selectedValuesSet]
   );
 
   const title =

--- a/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
+++ b/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
@@ -72,6 +72,10 @@ export function ServerSideSearchEnumSelect({
   });
 
   const selectedValues = React.useMemo(() => values ?? [], [values]);
+  const selectedValuesSet = React.useMemo(
+    () => new Set(selectedValues),
+    [selectedValues]
+  );
 
   const staticOptionByValue = React.useMemo(
     () => new Map(staticOptions.map((option) => [option.value, option])),
@@ -106,7 +110,7 @@ export function ServerSideSearchEnumSelect({
   const handleSelect = React.useCallback(
     (value: string) => {
       if (multiple) {
-        const next = selectedValues.includes(value)
+        const next = selectedValuesSet.has(value)
           ? selectedValues.filter((v) => v !== value)
           : [...selectedValues, value];
         onValuesChange(next);
@@ -116,7 +120,7 @@ export function ServerSideSearchEnumSelect({
       onValuesChange([value]);
       setOpen(false);
     },
-    [multiple, onValuesChange, selectedValues]
+    [multiple, onValuesChange, selectedValues, selectedValuesSet]
   );
 
   const title =
@@ -177,7 +181,7 @@ export function ServerSideSearchEnumSelect({
                 <PokeCommandEmpty>No members found.</PokeCommandEmpty>
                 <PokeCommandGroup>
                   {staticOptions.map((option) => {
-                    const isSelected = selectedValues.includes(option.value);
+                    const isSelected = selectedValuesSet.has(option.value);
                     return (
                       <PokeCommandItem
                         value={option.label}
@@ -205,7 +209,7 @@ export function ServerSideSearchEnumSelect({
                     .filter((member) => !staticOptionByValue.has(member.sId))
                     .map((member) => {
                       const memberLabel = formatMemberLabel(member);
-                      const isSelected = selectedValues.includes(member.sId);
+                      const isSelected = selectedValuesSet.has(member.sId);
 
                       return (
                         <PokeCommandItem

--- a/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
+++ b/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
@@ -19,7 +19,7 @@ import {
   PopoverRoot,
   PopoverTrigger,
 } from "@dust-tt/sparkle";
-import { Loader2 } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 import React from "react";
 
 function formatMemberLabel(member: PokeSearchWorkspaceMember) {
@@ -30,6 +30,9 @@ function formatMemberLabel(member: PokeSearchWorkspaceMember) {
 
 interface ServerSideSearchEnumSelectProps {
   label?: string;
+  // When true, allows selecting several values; the popover stays open on
+  // select and previously selected values are toggled on/off.
+  multiple?: boolean;
   onValuesChange: (values: string[]) => void;
   placeholder?: string;
   staticOptions?: readonly EnumValue[];
@@ -39,6 +42,7 @@ interface ServerSideSearchEnumSelectProps {
 
 export function ServerSideSearchEnumSelect({
   label,
+  multiple = false,
   onValuesChange,
   placeholder = "Select value",
   staticOptions = [],
@@ -51,9 +55,11 @@ export function ServerSideSearchEnumSelect({
     inputValue: searchQuery,
     setValue: setSearchQuery,
   } = useDebounce("");
-  const [selectedMemberLabel, setSelectedMemberLabel] = React.useState<
-    string | null
-  >(null);
+  // Cache of value -> label so selected entries keep their label even once they
+  // scroll out of the current search results.
+  const [labelCache, setLabelCache] = React.useState<Record<string, string>>(
+    {}
+  );
 
   const {
     members: searchResults,
@@ -65,7 +71,7 @@ export function ServerSideSearchEnumSelect({
     disabled: !open,
   });
 
-  const selectedValue = values?.[0] ?? "";
+  const selectedValues = React.useMemo(() => values ?? [], [values]);
 
   const staticOptionByValue = React.useMemo(
     () => new Map(staticOptions.map((option) => [option.value, option])),
@@ -79,29 +85,44 @@ export function ServerSideSearchEnumSelect({
   }, [open, setSearchQuery]);
 
   React.useEffect(() => {
-    if (!selectedValue) {
-      setSelectedMemberLabel(null);
-      return;
-    }
+    setLabelCache((prev) => {
+      const next = { ...prev };
+      for (const option of staticOptions) {
+        next[option.value] = option.label;
+      }
+      for (const member of searchResults) {
+        next[member.sId] = formatMemberLabel(member);
+      }
+      return next;
+    });
+  }, [searchResults, staticOptions]);
 
-    const staticOption = staticOptionByValue.get(selectedValue);
-    if (staticOption) {
-      setSelectedMemberLabel(staticOption.label);
-      return;
-    }
+  const labelForValue = React.useCallback(
+    (value: string) =>
+      labelCache[value] ?? staticOptionByValue.get(value)?.label ?? value,
+    [labelCache, staticOptionByValue]
+  );
 
-    const matchingResult = searchResults.find(
-      (member) => member.sId === selectedValue
-    );
-    if (matchingResult) {
-      setSelectedMemberLabel(formatMemberLabel(matchingResult));
-    }
-  }, [searchResults, selectedValue, staticOptionByValue]);
+  const handleSelect = React.useCallback(
+    (value: string) => {
+      if (multiple) {
+        const next = selectedValues.includes(value)
+          ? selectedValues.filter((v) => v !== value)
+          : [...selectedValues, value];
+        onValuesChange(next);
+        return;
+      }
+
+      onValuesChange([value]);
+      setOpen(false);
+    },
+    [multiple, onValuesChange, selectedValues]
+  );
 
   const title =
-    selectedMemberLabel ??
-    staticOptionByValue.get(selectedValue)?.label ??
-    placeholder;
+    selectedValues.length === 0
+      ? placeholder
+      : selectedValues.map(labelForValue).join(", ");
 
   return (
     <PopoverRoot modal={false} open={open} onOpenChange={setOpen}>
@@ -112,7 +133,7 @@ export function ServerSideSearchEnumSelect({
             role="combobox"
             className={cn(
               "w-auto justify-between border-border-dark bg-background " + "",
-              !selectedValue && "text-muted-foreground"
+              selectedValues.length === 0 && "text-muted-foreground"
             )}
           >
             {title}
@@ -156,17 +177,19 @@ export function ServerSideSearchEnumSelect({
                 <PokeCommandEmpty>No members found.</PokeCommandEmpty>
                 <PokeCommandGroup>
                   {staticOptions.map((option) => {
-                    const isSelected = selectedValue === option.value;
+                    const isSelected = selectedValues.includes(option.value);
                     return (
                       <PokeCommandItem
                         value={option.label}
                         key={`static-${option.value}`}
-                        onSelect={() => {
-                          onValuesChange([option.value]);
-                          setSelectedMemberLabel(option.label);
-                          setOpen(false);
-                        }}
+                        onSelect={() => handleSelect(option.value)}
                       >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            isSelected ? "opacity-100" : "opacity-0"
+                          )}
+                        />
                         <span
                           className={cn(
                             isSelected && "font-medium",
@@ -182,18 +205,20 @@ export function ServerSideSearchEnumSelect({
                     .filter((member) => !staticOptionByValue.has(member.sId))
                     .map((member) => {
                       const memberLabel = formatMemberLabel(member);
-                      const isSelected = selectedValue === member.sId;
+                      const isSelected = selectedValues.includes(member.sId);
 
                       return (
                         <PokeCommandItem
                           value={memberLabel}
                           key={member.sId}
-                          onSelect={() => {
-                            onValuesChange([member.sId]);
-                            setSelectedMemberLabel(memberLabel);
-                            setOpen(false);
-                          }}
+                          onSelect={() => handleSelect(member.sId)}
                         >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              isSelected ? "opacity-100" : "opacity-0"
+                            )}
+                          />
                           <span
                             className={cn(
                               isSelected && "font-medium",

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -44,15 +44,6 @@ function activationPodNameForCreator(
   return `${label}${ACTIVATION_POD_NAME_PREFIX}`;
 }
 
-function parseUserIds(rawUserIds: string): string[] {
-  const ids = rawUserIds
-    .split(",")
-    .map((id) => id.trim())
-    .filter((id) => id.length > 0);
-
-  return [...new Set(ids)];
-}
-
 async function markPodAsActivation(
   auth: Authenticator,
   pod: SpaceResource
@@ -159,15 +150,32 @@ export const joinActivationPodPlugin = createPlugin({
     id: "join-activation-pod",
     name: "Join Activation Pod",
     description:
-      "Create an Activation Pod and add one or more workspace members to it as editors.",
+      "Create an Activation Pod with a chosen editor and optional additional members.",
     resourceTypes: ["workspaces"],
     args: {
-      userIds: {
-        type: "string",
-        label: "User ID(s)",
+      editorUserId: {
+        type: "enum",
+        label: "Pod editor",
         description:
-          "Comma-separated sId(s) of the workspace member(s) to add to the " +
+          "Search by name or email. This member becomes the Pod editor, and " +
+          "the Pod is named after them by default.",
+        // Options are loaded from the workspace member search API as the user
+        // types; no static values are needed.
+        async: true,
+        values: [],
+        multiple: false,
+        serverSideSearch: true,
+      },
+      memberUserIds: {
+        type: "enum",
+        label: "Additional members",
+        description:
+          "Optional. Search and select more workspace members to add to the " +
           "Activation Pod as members.",
+        async: true,
+        values: [],
+        multiple: true,
+        serverSideSearch: true,
       },
       podName: {
         type: "string",
@@ -216,18 +224,35 @@ export const joinActivationPodPlugin = createPlugin({
   execute: async (
     auth,
     _resource,
-    { userIds, podName: podNameInput, defaultSkillIds, agentsMdInstructions }
-  ) => {
-    const requestedUserIds = parseUserIds(userIds);
-    if (requestedUserIds.length === 0) {
-      return new Err(new Error("At least one user ID is required."));
+    {
+      editorUserId,
+      memberUserIds,
+      podName: podNameInput,
+      defaultSkillIds,
+      agentsMdInstructions,
     }
+  ) => {
+    const editorId = editorUserId?.[0]?.trim();
+    if (!editorId) {
+      return new Err(new Error("A Pod editor is required."));
+    }
+
+    // Additional members, deduped and never including the editor (who is added
+    // separately as the Pod creator/editor).
+    const memberIds = [
+      ...new Set(
+        (memberUserIds ?? [])
+          .map((id) => id.trim())
+          .filter((id) => id.length > 0 && id !== editorId)
+      ),
+    ];
 
     const selectedSkillIds = defaultSkillIds ?? [];
     const agentsMd = agentsMdInstructions ?? "";
 
     const workspace = auth.getNonNullableWorkspace();
 
+    const requestedUserIds = [editorId, ...memberIds];
     const users = await UserResource.fetchByIds(requestedUserIds);
     const foundUserIds = new Set(users.map((u) => u.sId));
     const missingUserIds = requestedUserIds.filter(
@@ -254,7 +279,13 @@ export const joinActivationPodPlugin = createPlugin({
       );
     }
 
-    const [creator, ...otherUsers] = users;
+    // The editor is the Pod creator (added as editor on creation and used for
+    // naming); everyone else is added as a member.
+    const creator = users.find((u) => u.sId === editorId);
+    if (!creator) {
+      return new Err(new Error(`Pod editor not found: ${editorId}.`));
+    }
+    const otherUsers = users.filter((u) => u.sId !== editorId);
     const trimmedPodName = podNameInput?.trim();
     const podName =
       trimmedPodName && trimmedPodName.length > 0
@@ -378,7 +409,8 @@ export const joinActivationPodPlugin = createPlugin({
     return new Ok({
       display: "textWithLink",
       value:
-        `Created Activation Pod with 1 editor and ${otherUsers.length} member(s).` +
+        `Created Activation Pod "${podName}" with ${creator.fullName()} as editor ` +
+        `and ${otherUsers.length} additional member(s).` +
         formatDefaultSkillsSuffix(skillsResult.value.skillNames) +
         formatAgentsMdSuffix(agentsMdResult.value.written) +
         " Triggered the activation conversation.",


### PR DESCRIPTION
## Summary
* Replaces the free-text, comma-separated **User ID(s)** field on the *Join Activation Pod* poke plugin with searchable member pickers, so operators no longer need to copy/paste sIds, and makes the Pod editor explicit.

- **Pod editor** — required, single-select member search. This member is added as the Pod editor and drives the Pod name.
- **Additional members** — optional, multi-select member search.

## Risk

Low - poke only changes, not customer facing

## Testing
<img width="524" height="614" alt="Screenshot 2026-07-15 at 12 14 57 PM" src="https://github.com/user-attachments/assets/7903192c-3085-49de-846d-45a4fd7733ab" />

## Deploy
1. Deploy front