### PR TITLE
feat(pod-manager): split pinned-frame into its own never_ask tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1790,6 +1790,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "set_pinned_frame": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "update_members": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -3074,6 +3078,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "remove_content_node": "low",
     "retrieve_recent_documents": "never_ask",
     "semantic_search": "never_ask",
+    "set_pinned_frame": "never_ask",
     "update_members": "low",
   },
   "pod_tasks": {

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -84,8 +84,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     description:
       "Edit Pod information: title, description, and/or access. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
-      "Access can be set to open or restricted; open Pods are subject to workspace policy. " +
-      `To pin or unpin the Pod banner frame, use \`${SET_PINNED_FRAME_TOOL_NAME}\` instead.`,
+      "Access can be set to open or restricted; open Pods are subject to workspace policy.",
     schema: {
       title: z.string().optional().describe("New Pod title"),
       description: z

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -22,6 +22,7 @@ export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
 export const LIST_MEMBERS_TOOL_NAME = "list_members" as const;
 export const SEMANTIC_SEARCH_TOOL_NAME = "semantic_search" as const;
 export const EDIT_INFORMATION_TOOL_NAME = "edit_information" as const;
+export const SET_PINNED_FRAME_TOOL_NAME = "set_pinned_frame" as const;
 export const MOVE_CONVERSATION_TOOL_NAME = "move_conversation" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
@@ -81,10 +82,10 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [EDIT_INFORMATION_TOOL_NAME]: {
     description:
-      "Edit Pod information: title, description, access, and/or pinned frame. " +
+      "Edit Pod information: title, description, and/or access. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
-      "The pinned frame must be an existing Pod file path under `pod/` (use null to unpin). " +
-      "Access can be set to open or restricted; open Pods are subject to workspace policy.",
+      "Access can be set to open or restricted; open Pods are subject to workspace policy. " +
+      `To pin or unpin the Pod banner frame, use \`${SET_PINNED_FRAME_TOOL_NAME}\` instead.`,
     schema: {
       title: z.string().optional().describe("New Pod title"),
       description: z
@@ -99,13 +100,6 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Pod access. restricted = limited to invited members; open = all workspace members can join. Open Pods are subject to workspace policy."
         ),
-      pinnedFramePath: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          `Path to a Pod file to pin as the Pod banner frame (e.g. ${SCOPED_PREFIX_POD}<id>/banner.html). Pass null to unpin.`
-        ),
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
       ]
@@ -118,6 +112,33 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Editing Pod information",
       done: "Edit Pod information",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  [SET_PINNED_FRAME_TOOL_NAME]: {
+    description:
+      "Set or clear the Pod banner frame — the frame pinned to the top of the Pod. " +
+      "The pinned frame must be an existing Pod file path under `pod/` (pass null to unpin).",
+    schema: {
+      pinnedFramePath: z
+        .string()
+        .nullable()
+        .describe(
+          `Path to a Pod file to pin as the Pod banner frame (e.g. ${SCOPED_PREFIX_POD}<id>/banner.html). Pass null to unpin.`
+        ),
+      dustPod: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
+      ]
+        .optional()
+        .describe(
+          "Optional Pod to update, will fallback to the conversation's Pod."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Updating pinned frame",
+      done: "Update pinned frame",
     },
     toolCostCategory: "basic",
     freeUsage: true,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -32,6 +32,7 @@ import {
   MOVE_CONVERSATION_TOOL_NAME,
   POD_MANAGER_TOOLS_METADATA,
   SEMANTIC_SEARCH_TOOL_NAME,
+  SET_PINNED_FRAME_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { partitionMembersToAdd } from "@app/lib/api/actions/servers/pod_manager/types";
@@ -263,16 +264,15 @@ export function createProjectManagerTools(
           );
         }
 
-        const { title, description, pinnedFramePath, access } = params;
+        const { title, description, access } = params;
         if (
           title === undefined &&
           description === undefined &&
-          pinnedFramePath === undefined &&
           access === undefined
         ) {
           return new Err(
             new MCPError(
-              "At least one of title, description, access, or pinnedFramePath must be provided",
+              "At least one of title, description, or access must be provided",
               { tracked: false }
             )
           );
@@ -295,22 +295,6 @@ export function createProjectManagerTools(
 
         if (description !== undefined) {
           updates.description = description;
-        }
-
-        if (pinnedFramePath !== undefined) {
-          const validation = await validatePinnedFramePath(
-            auth,
-            pod,
-            pinnedFramePath
-          );
-          if (validation.isErr()) {
-            return new Err(
-              new MCPError(validation.error.message, { tracked: false })
-            );
-          }
-
-          // Use the normalized path.
-          updates.pinnedFramePath = validation.value;
         }
 
         if (access !== undefined) {
@@ -369,6 +353,62 @@ export function createProjectManagerTools(
           })
         );
       }, "Failed to edit Pod information");
+    },
+
+    [SET_PINNED_FRAME_TOOL_NAME]: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getPod(auth, {
+          toolContext,
+          dustPod: params.dustPod,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { pod } = contextRes.value;
+
+        if (!pod.canAdministrate(auth)) {
+          return new Err(
+            new MCPError(
+              "You do not have permission to edit this Pod's information",
+              { tracked: false }
+            )
+          );
+        }
+
+        const validation = await validatePinnedFramePath(
+          auth,
+          pod,
+          params.pinnedFramePath
+        );
+        if (validation.isErr()) {
+          return new Err(
+            new MCPError(validation.error.message, { tracked: false })
+          );
+        }
+
+        // Use the normalized path.
+        const pinnedFramePath = validation.value;
+
+        let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+        if (!metadata) {
+          metadata = await ProjectMetadataResource.makeNew(auth, pod, {
+            pinnedFramePath,
+          });
+        } else {
+          await metadata.updatePinnedFramePath(pinnedFramePath);
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            pinnedFramePath,
+            message: pinnedFramePath
+              ? "Pinned frame updated successfully."
+              : "Pinned frame cleared successfully.",
+          })
+        );
+      }, "Failed to set Pod pinned frame");
     },
 
     [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {


### PR DESCRIPTION
## Summary

* Extracts pinned-frame pinning/unpinning out of the `edit_information` pod_manager tool into a dedicated **`set_pinned_frame`** tool with `never_ask` stake, so updating the Pod banner frame no longer prompts for approval.
* Motivation: the activation flow refreshes the pinned Frame every turn; a `low`-stake approval prompt on each refresh is disruptive. Pinning/unpinning a Pod-owned file the agent just created is a safe, high-frequency operation, so it warrants `never_ask` — while `edit_information` (title/description/access) keeps its `low` stake untouched.

## Risk

Low, but note a **behavior change for the `edit_information` tool contract**: it no longer accepts `pinnedFramePath`. Callers that previously pinned via `edit_information` must switch to `set_pinned_frame`. Grep shows no other in-repo callers pass `pinnedFramePath` to this tool.

## Testing
* Locally called tools

## Deployment
1. Deploy front