### PR TITLE
feat(schedules): scope schedule tool to the current Pod

### DIFF
--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_schedule: {
     description:
-      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. Limit: 20 schedule creations per user per day.",
+      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. When created inside a Pod, the schedule is attached to that Pod and its runs land there. Limit: 20 schedule creations per user per day.",
     schema: {
       name: z
         .string()
@@ -43,7 +43,7 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   },
   list_schedules: {
     description:
-      "List all schedules created for this agent and for the current user.",
+      "List the current user's schedules. Inside a Pod, lists all of your schedules attached to that Pod (across agents); otherwise lists your schedules for this agent.",
     schema: {},
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -49,15 +49,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   },
   list_schedules: {
     description:
-      "List the current user's schedules. Pass podId to narrow the list to schedules attached to that Pod; omit it to list all of your schedules.",
-    schema: {
-      podId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional Pod ID (sId) to narrow the list to that Pod's schedules. Omit to list all of your schedules."
-        ),
-    },
+      "List all of the current user's schedules. Each entry shows the Pod it is attached to, if any.",
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Listing schedules",

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -49,7 +49,7 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   },
   list_schedules: {
     description:
-      "List all of the current user's schedules. Each entry shows the Pod it is attached to, if any.",
+      "List all schedules for this agent and the current user. Each entry shows the Pod it is attached to, if any.",
     schema: {},
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -49,13 +49,13 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   },
   list_schedules: {
     description:
-      "List the current user's schedules. Pass podId to list all of your schedules attached to that Pod (across agents); otherwise lists your schedules for this agent.",
+      "List the current user's schedules. Pass podId to narrow the list to schedules attached to that Pod; omit it to list all of your schedules.",
     schema: {
       podId: z
         .string()
         .optional()
         .describe(
-          "Optional Pod ID (sId) to list schedules for. Omit to list this agent's schedules."
+          "Optional Pod ID (sId) to narrow the list to that Pod's schedules. Omit to list all of your schedules."
         ),
     },
     stake: "never_ask",
@@ -72,12 +72,6 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       scheduleId: z
         .string()
         .describe("The schedule ID (get this from list_schedules)"),
-      podId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional Pod ID (sId) the schedule belongs to. Pass the same podId used with list_schedules."
-        ),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -7,13 +7,19 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_schedule: {
     description:
-      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. When created inside a Pod, the schedule is attached to that Pod and its runs land there. Limit: 20 schedule creations per user per day.",
+      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. Pass podId to attach the schedule to a Pod so its runs land there. Limit: 20 schedule creations per user per day.",
     schema: {
       name: z
         .string()
         .max(255)
         .describe(
           "A short, descriptive name for the schedule (max 255 chars). Examples: 'Daily email summary', 'Weekly PR review', 'Morning standup prep'. Schedule name MUST be unique."
+        ),
+      podId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Pod ID (sId) to attach this schedule to, so its runs land in that Pod. Omit for a schedule not tied to a Pod."
         ),
       schedule: z
         .string()
@@ -43,8 +49,15 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   },
   list_schedules: {
     description:
-      "List the current user's schedules. Inside a Pod, lists all of your schedules attached to that Pod (across agents); otherwise lists your schedules for this agent.",
-    schema: {},
+      "List the current user's schedules. Pass podId to list all of your schedules attached to that Pod (across agents); otherwise lists your schedules for this agent.",
+    schema: {
+      podId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Pod ID (sId) to list schedules for. Omit to list this agent's schedules."
+        ),
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Listing schedules",
@@ -59,6 +72,12 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       scheduleId: z
         .string()
         .describe("The schedule ID (get this from list_schedules)"),
+      podId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Pod ID (sId) the schedule belongs to. Pass the same podId used with list_schedules."
+        ),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -8,6 +8,7 @@ import {
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
 import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   resolveTriggerSpaceId,
   TriggerResource,
@@ -22,7 +23,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { UniqueConstraintError } from "sequelize";
 
-function renderSchedule(schedule: ScheduleTriggerType): string {
+function renderSchedule(
+  schedule: ScheduleTriggerType,
+  podName?: string | null
+): string {
   const config = schedule.configuration;
   const scheduleDesc =
     schedule.naturalLanguageDescription ?? describeScheduleConfig(config);
@@ -31,6 +35,9 @@ function renderSchedule(schedule: ScheduleTriggerType): string {
     `- **${schedule.name}** (ID: ${schedule.sId})`,
     `  Schedule: ${scheduleInfo}`,
   ];
+  if (podName) {
+    lines.push(`  Pod: ${podName}`);
+  }
   if (schedule.customPrompt) {
     lines.push(`  Prompt: ${schedule.customPrompt}`);
   }
@@ -163,7 +170,7 @@ export function createSchedulesManagementTools(
       ]);
     },
 
-    list_schedules: async ({ podId }) => {
+    list_schedules: async () => {
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"
@@ -172,16 +179,8 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      // List the user's schedules, optionally narrowed to a single Pod.
-      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
-      if (spaceIdRes.isErr()) {
-        return new Err(new MCPError(spaceIdRes.error));
-      }
-      const spaceId = spaceIdRes.value;
-
       const schedulesResult = await TriggerResource.listByEditors(auth, {
         editorIds: [userId],
-        spaceModelId: spaceId,
       });
 
       if (schedulesResult.isErr()) {
@@ -192,28 +191,44 @@ export function createSchedulesManagementTools(
         `workspace_id:${owner.sId}`,
       ]);
 
-      const heading =
-        spaceId !== null ? "Schedules for this Pod" : "Your schedules";
+      const schedules = schedulesResult.value
+        .map((s) => s.toJSON())
+        .filter(isScheduleTrigger);
 
-      if (schedulesResult.value.length === 0) {
+      if (schedules.length === 0) {
         return new Ok([
           {
             type: "text" as const,
-            text: `${heading}: none found.`,
+            text: "You have no schedules.",
           },
         ]);
       }
 
-      const scheduleList = schedulesResult.value
-        .map((s) => s.toJSON())
-        .filter(isScheduleTrigger)
-        .map((schedule) => renderSchedule(schedule))
+      // Resolve Pod names for schedules attached to a Pod (single batch query).
+      const podSIds = [
+        ...new Set(
+          schedules
+            .map((s) => s.spaceId)
+            .filter((id): id is string => id !== null)
+        ),
+      ];
+      const pods =
+        podSIds.length > 0 ? await SpaceResource.fetchByIds(auth, podSIds) : [];
+      const podNameBySId = new Map(pods.map((p) => [p.sId, p.name]));
+
+      const scheduleList = schedules
+        .map((schedule) =>
+          renderSchedule(
+            schedule,
+            schedule.spaceId ? podNameBySId.get(schedule.spaceId) : null
+          )
+        )
         .join("\n\n");
 
       return new Ok([
         {
           type: "text" as const,
-          text: `${heading}:\n\n${scheduleList}`,
+          text: `Your schedules:\n\n${scheduleList}`,
         },
       ]);
     },

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -8,7 +8,10 @@ import {
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
 import type { Authenticator } from "@app/lib/auth";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import {
+  resolveTriggerSpaceId,
+  TriggerResource,
+} from "@app/lib/resources/trigger_resource";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -63,7 +66,18 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
 
-      const { agentConfiguration } = toolContext.runContext;
+      const { agentConfiguration, conversation } = toolContext.runContext;
+
+      // When the schedule is created inside a Pod, attach its trigger to that
+      // Pod so the scheduled run lands in the Pod (where the pinned view lives).
+      const spaceIdRes = await resolveTriggerSpaceId(
+        auth,
+        conversation.spaceId
+      );
+      if (spaceIdRes.isErr()) {
+        return new Err(new MCPError(spaceIdRes.error));
+      }
+      const spaceId = spaceIdRes.value;
 
       const resolvedTimezone = timezone ?? getUserTimezone(toolContext);
 
@@ -109,6 +123,7 @@ export function createSchedulesManagementTools(
           executionPerDayLimitOverride: null,
           executionMode: "fair_use",
           origin: "agent",
+          spaceId,
         });
 
         if (result.isErr()) {
@@ -143,7 +158,9 @@ export function createSchedulesManagementTools(
             `Created schedule "${name}"!\n\n` +
             `Schedule: ${schedule}\n` +
             `Configuration: ${configDesc} (${scheduleConfig.timezone})\n\n` +
-            `The agent will execute "${prompt}" according to this schedule.\n\n` +
+            `The agent will execute "${prompt}" according to this schedule.` +
+            (spaceId !== null ? " Its runs will land in this Pod." : "") +
+            `\n\n` +
             renderSchedule(trigger),
         },
       ]);
@@ -158,17 +175,37 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration } = toolContext.runContext;
+      const { agentConfiguration, conversation } = toolContext.runContext;
+
+      // Inside a Pod, list all of the user's schedules scoped to that Pod
+      // (across agents). Otherwise, fall back to this agent's schedules.
+      const spaceIdRes = await resolveTriggerSpaceId(
+        auth,
+        conversation.spaceId
+      );
+      if (spaceIdRes.isErr()) {
+        return new Err(new MCPError(spaceIdRes.error));
+      }
+      const spaceId = spaceIdRes.value;
 
       const schedulesResult =
-        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-          agentConfigurationId: agentConfiguration.sId,
-          editorIds: [userId],
-        });
+        spaceId !== null
+          ? await TriggerResource.listBySpaceAndEditors(auth, {
+              spaceModelId: spaceId,
+              editorIds: [userId],
+            })
+          : await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+              agentConfigurationId: agentConfiguration.sId,
+              editorIds: [userId],
+            });
 
       if (schedulesResult.isErr()) {
         return new Err(
-          new MCPError("Error while fetching schedules for this agent")
+          new MCPError(
+            spaceId !== null
+              ? "Error while fetching schedules for this Pod"
+              : "Error while fetching schedules for this agent"
+          )
         );
       }
 
@@ -177,11 +214,13 @@ export function createSchedulesManagementTools(
         `agent_id:${agentConfiguration.sId}`,
       ]);
 
+      const scope = spaceId !== null ? "Pod" : "agent";
+
       if (schedulesResult.value.length === 0) {
         return new Ok([
           {
             type: "text" as const,
-            text: "No schedules configured for this agent.",
+            text: `No schedules configured for this ${scope}.`,
           },
         ]);
       }
@@ -195,7 +234,7 @@ export function createSchedulesManagementTools(
       return new Ok([
         {
           type: "text" as const,
-          text: `Schedules for this agent:\n\n${scheduleList}`,
+          text: `Schedules for this ${scope}:\n\n${scheduleList}`,
         },
       ]);
     },
@@ -209,13 +248,29 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration } = toolContext.runContext;
+      const { agentConfiguration, conversation } = toolContext.runContext;
+
+      // Match the scope used by list_schedules so any schedule the user can see
+      // in this context can also be disabled.
+      const spaceIdRes = await resolveTriggerSpaceId(
+        auth,
+        conversation.spaceId
+      );
+      if (spaceIdRes.isErr()) {
+        return new Err(new MCPError(spaceIdRes.error));
+      }
+      const spaceId = spaceIdRes.value;
 
       const triggersResult =
-        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-          agentConfigurationId: agentConfiguration.sId,
-          editorIds: [userId],
-        });
+        spaceId !== null
+          ? await TriggerResource.listBySpaceAndEditors(auth, {
+              spaceModelId: spaceId,
+              editorIds: [userId],
+            })
+          : await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+              agentConfigurationId: agentConfiguration.sId,
+              editorIds: [userId],
+            });
       if (triggersResult.isErr()) {
         return new Err(new MCPError("Error fetching schedules"));
       }

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -172,49 +172,34 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration } = toolContext.runContext;
-
-      // When a podId is provided, list all of the user's schedules scoped to
-      // that Pod (across agents). Otherwise, list this agent's schedules.
+      // List the user's schedules, optionally narrowed to a single Pod.
       const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
       if (spaceIdRes.isErr()) {
         return new Err(new MCPError(spaceIdRes.error));
       }
       const spaceId = spaceIdRes.value;
 
-      const schedulesResult =
-        spaceId !== null
-          ? await TriggerResource.listBySpaceAndEditors(auth, {
-              spaceModelId: spaceId,
-              editorIds: [userId],
-            })
-          : await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-              agentConfigurationId: agentConfiguration.sId,
-              editorIds: [userId],
-            });
+      const schedulesResult = await TriggerResource.listByEditors(auth, {
+        editorIds: [userId],
+        spaceModelId: spaceId,
+      });
 
       if (schedulesResult.isErr()) {
-        return new Err(
-          new MCPError(
-            spaceId !== null
-              ? "Error while fetching schedules for this Pod"
-              : "Error while fetching schedules for this agent"
-          )
-        );
+        return new Err(new MCPError("Error while fetching schedules"));
       }
 
       getStatsDClient().increment("tools.schedules_management.listed", 1, [
         `workspace_id:${owner.sId}`,
-        `agent_id:${agentConfiguration.sId}`,
       ]);
 
-      const scope = spaceId !== null ? "Pod" : "agent";
+      const heading =
+        spaceId !== null ? "Schedules for this Pod" : "Your schedules";
 
       if (schedulesResult.value.length === 0) {
         return new Ok([
           {
             type: "text" as const,
-            text: `No schedules configured for this ${scope}.`,
+            text: `${heading}: none found.`,
           },
         ]);
       }
@@ -228,12 +213,12 @@ export function createSchedulesManagementTools(
       return new Ok([
         {
           type: "text" as const,
-          text: `Schedules for this ${scope}:\n\n${scheduleList}`,
+          text: `${heading}:\n\n${scheduleList}`,
         },
       ]);
     },
 
-    disable_schedule: async ({ scheduleId, podId }) => {
+    disable_schedule: async ({ scheduleId }) => {
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"
@@ -242,33 +227,13 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration } = toolContext.runContext;
-
-      // Match the scope used by list_schedules so any schedule the user can see
-      // there can also be disabled: pass the same podId.
-      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
-      if (spaceIdRes.isErr()) {
-        return new Err(new MCPError(spaceIdRes.error));
-      }
-      const spaceId = spaceIdRes.value;
-
-      const triggersResult =
-        spaceId !== null
-          ? await TriggerResource.listBySpaceAndEditors(auth, {
-              spaceModelId: spaceId,
-              editorIds: [userId],
-            })
-          : await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-              agentConfigurationId: agentConfiguration.sId,
-              editorIds: [userId],
-            });
-      if (triggersResult.isErr()) {
-        return new Err(new MCPError("Error fetching schedules"));
-      }
-      const schedule = triggersResult.value.find(
-        (t) => t.kind === "schedule" && t.sId === scheduleId
-      );
-      if (!schedule) {
+      // Disable by id; only the schedule's own editor may disable it.
+      const schedule = await TriggerResource.fetchById(auth, scheduleId);
+      if (
+        !schedule ||
+        schedule.kind !== "schedule" ||
+        schedule.editor !== userId
+      ) {
         return new Err(new MCPError("Schedule not found"));
       }
 
@@ -283,7 +248,6 @@ export function createSchedulesManagementTools(
 
       getStatsDClient().increment("tools.schedules_management.disabled", 1, [
         `workspace_id:${owner.sId}`,
-        `agent_id:${agentConfiguration.sId}`,
       ]);
 
       return new Ok([

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -35,8 +35,8 @@ function renderSchedule(
     `- **${schedule.name}** (ID: ${schedule.sId})`,
     `  Schedule: ${scheduleInfo}`,
   ];
-  if (podName) {
-    lines.push(`  Pod: ${podName}`);
+  if (podName && schedule.spaceId) {
+    lines.push(`  Pod: ${podName} (${schedule.spaceId})`);
   }
   if (schedule.customPrompt) {
     lines.push(`  Prompt: ${schedule.customPrompt}`);

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -57,7 +57,7 @@ export function createSchedulesManagementTools(
   toolContext?: ToolContext
 ) {
   const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
-    create_schedule: async ({ name, schedule, prompt, timezone }) => {
+    create_schedule: async ({ name, schedule, prompt, timezone, podId }) => {
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"
@@ -66,14 +66,11 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
 
-      const { agentConfiguration, conversation } = toolContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
-      // When the schedule is created inside a Pod, attach its trigger to that
-      // Pod so the scheduled run lands in the Pod (where the pinned view lives).
-      const spaceIdRes = await resolveTriggerSpaceId(
-        auth,
-        conversation.spaceId
-      );
+      // When a podId is provided, attach the trigger to that Pod so the
+      // scheduled run lands in the Pod (where the pinned view lives).
+      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
       if (spaceIdRes.isErr()) {
         return new Err(new MCPError(spaceIdRes.error));
       }
@@ -159,14 +156,14 @@ export function createSchedulesManagementTools(
             `Schedule: ${schedule}\n` +
             `Configuration: ${configDesc} (${scheduleConfig.timezone})\n\n` +
             `The agent will execute "${prompt}" according to this schedule.` +
-            (spaceId !== null ? " Its runs will land in this Pod." : "") +
+            (spaceId !== null ? " Its runs will land in the Pod." : "") +
             `\n\n` +
             renderSchedule(trigger),
         },
       ]);
     },
 
-    list_schedules: async () => {
+    list_schedules: async ({ podId }) => {
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"
@@ -175,14 +172,11 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration, conversation } = toolContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
-      // Inside a Pod, list all of the user's schedules scoped to that Pod
-      // (across agents). Otherwise, fall back to this agent's schedules.
-      const spaceIdRes = await resolveTriggerSpaceId(
-        auth,
-        conversation.spaceId
-      );
+      // When a podId is provided, list all of the user's schedules scoped to
+      // that Pod (across agents). Otherwise, list this agent's schedules.
+      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
       if (spaceIdRes.isErr()) {
         return new Err(new MCPError(spaceIdRes.error));
       }
@@ -239,7 +233,7 @@ export function createSchedulesManagementTools(
       ]);
     },
 
-    disable_schedule: async ({ scheduleId }) => {
+    disable_schedule: async ({ scheduleId, podId }) => {
       assert(
         isAgentLoopRunContext(toolContext?.runContext),
         "AgentLoopRunContext expected"
@@ -248,14 +242,11 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const { agentConfiguration, conversation } = toolContext.runContext;
+      const { agentConfiguration } = toolContext.runContext;
 
       // Match the scope used by list_schedules so any schedule the user can see
-      // in this context can also be disabled.
-      const spaceIdRes = await resolveTriggerSpaceId(
-        auth,
-        conversation.spaceId
-      );
+      // there can also be disabled: pass the same podId.
+      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
       if (spaceIdRes.isErr()) {
         return new Err(new MCPError(spaceIdRes.error));
       }

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -212,7 +212,7 @@ export function createSchedulesManagementTools(
       }
 
       // Resolve Pod names for schedules attached to a Pod (single batch query).
-      const podSIds = [
+      const podIds = [
         ...new Set(
           schedules
             .map((s) => s.spaceId)
@@ -220,14 +220,14 @@ export function createSchedulesManagementTools(
         ),
       ];
       const pods =
-        podSIds.length > 0 ? await SpaceResource.fetchByIds(auth, podSIds) : [];
-      const podNameBySId = new Map(pods.map((p) => [p.sId, p.name]));
+        podIds.length > 0 ? await SpaceResource.fetchByIds(auth, podIds) : [];
+      const podNameById = new Map(pods.map((p) => [p.sId, p.name]));
 
       const scheduleList = schedules
         .map((schedule) =>
           renderSchedule(
             schedule,
-            schedule.spaceId ? podNameBySId.get(schedule.spaceId) : null
+            schedule.spaceId ? podNameById.get(schedule.spaceId) : null
           )
         )
         .join("\n\n");

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -179,16 +179,23 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      const schedulesResult = await TriggerResource.listByEditors(auth, {
-        editorIds: [userId],
-      });
+      const { agentConfiguration } = toolContext.runContext;
+
+      const schedulesResult =
+        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+          agentConfigurationId: agentConfiguration.sId,
+          editorIds: [userId],
+        });
 
       if (schedulesResult.isErr()) {
-        return new Err(new MCPError("Error while fetching schedules"));
+        return new Err(
+          new MCPError("Error while fetching schedules for this agent")
+        );
       }
 
       getStatsDClient().increment("tools.schedules_management.listed", 1, [
         `workspace_id:${owner.sId}`,
+        `agent_id:${agentConfiguration.sId}`,
       ]);
 
       const schedules = schedulesResult.value
@@ -199,7 +206,7 @@ export function createSchedulesManagementTools(
         return new Ok([
           {
             type: "text" as const,
-            text: "You have no schedules.",
+            text: "No schedules configured for this agent.",
           },
         ]);
       }
@@ -228,7 +235,7 @@ export function createSchedulesManagementTools(
       return new Ok([
         {
           type: "text" as const,
-          text: `Your schedules:\n\n${scheduleList}`,
+          text: `Schedules for this agent:\n\n${scheduleList}`,
         },
       ]);
     },
@@ -242,13 +249,20 @@ export function createSchedulesManagementTools(
       const owner = auth.getNonNullableWorkspace();
       const userId = auth.getNonNullableUser().id;
 
-      // Disable by id; only the schedule's own editor may disable it.
-      const schedule = await TriggerResource.fetchById(auth, scheduleId);
-      if (
-        !schedule ||
-        schedule.kind !== "schedule" ||
-        schedule.editor !== userId
-      ) {
+      const { agentConfiguration } = toolContext.runContext;
+
+      const triggersResult =
+        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+          agentConfigurationId: agentConfiguration.sId,
+          editorIds: [userId],
+        });
+      if (triggersResult.isErr()) {
+        return new Err(new MCPError("Error fetching schedules"));
+      }
+      const schedule = triggersResult.value.find(
+        (t) => t.kind === "schedule" && t.sId === scheduleId
+      );
+      if (!schedule) {
         return new Err(new MCPError("Schedule not found"));
       }
 
@@ -263,6 +277,7 @@ export function createSchedulesManagementTools(
 
       getStatsDClient().increment("tools.schedules_management.disabled", 1, [
         `workspace_id:${owner.sId}`,
+        `agent_id:${agentConfiguration.sId}`,
       ]);
 
       return new Ok([

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -207,6 +207,28 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
+  static async listBySpaceAndEditors(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      editorIds,
+    }: {
+      spaceModelId: ModelId;
+      editorIds: ModelId[];
+    }
+  ): Promise<Result<TriggerResource[], Error>> {
+    if (editorIds.length === 0) {
+      return new Ok([]);
+    }
+    const triggers = await this.baseFetch(auth, {
+      where: {
+        spaceId: spaceModelId,
+        editor: { [Op.in]: editorIds },
+      },
+    });
+    return new Ok(triggers);
+  }
+
   static listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
   }

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -207,14 +207,16 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
-  static async listBySpaceAndEditors(
+  // Lists triggers owned by the given editors, optionally narrowed to a single
+  // Pod (space). Passing spaceModelId = null lists across all Pods.
+  static async listByEditors(
     auth: Authenticator,
     {
-      spaceModelId,
       editorIds,
+      spaceModelId = null,
     }: {
-      spaceModelId: ModelId;
       editorIds: ModelId[];
+      spaceModelId?: ModelId | null;
     }
   ): Promise<Result<TriggerResource[], Error>> {
     if (editorIds.length === 0) {
@@ -222,8 +224,8 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     }
     const triggers = await this.baseFetch(auth, {
       where: {
-        spaceId: spaceModelId,
         editor: { [Op.in]: editorIds },
+        ...(spaceModelId !== null ? { spaceId: spaceModelId } : {}),
       },
     });
     return new Ok(triggers);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -207,17 +207,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
-  // Lists triggers owned by the given editors, optionally narrowed to a single
-  // Pod (space). Passing spaceModelId = null lists across all Pods.
+  // Lists all triggers owned by the given editors, across all Pods.
   static async listByEditors(
     auth: Authenticator,
-    {
-      editorIds,
-      spaceModelId = null,
-    }: {
-      editorIds: ModelId[];
-      spaceModelId?: ModelId | null;
-    }
+    { editorIds }: { editorIds: ModelId[] }
   ): Promise<Result<TriggerResource[], Error>> {
     if (editorIds.length === 0) {
       return new Ok([]);
@@ -225,7 +218,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const triggers = await this.baseFetch(auth, {
       where: {
         editor: { [Op.in]: editorIds },
-        ...(spaceModelId !== null ? { spaceId: spaceModelId } : {}),
       },
     });
     return new Ok(triggers);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -207,22 +207,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
-  // Lists all triggers owned by the given editors, across all Pods.
-  static async listByEditors(
-    auth: Authenticator,
-    { editorIds }: { editorIds: ModelId[] }
-  ): Promise<Result<TriggerResource[], Error>> {
-    if (editorIds.length === 0) {
-      return new Ok([]);
-    }
-    const triggers = await this.baseFetch(auth, {
-      where: {
-        editor: { [Op.in]: editorIds },
-      },
-    });
-    return new Ok(triggers);
-  }
-
   static listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
   }


### PR DESCRIPTION
## Summary

Makes the `schedules_management` MCP tool Pod-aware, so schedules created inside a Pod are attached to it

## Risk

Low

## Testing
<img width="397" height="142" alt="Screenshot 2026-07-15 at 3 04 47 PM" src="https://github.com/user-attachments/assets/8a22e63e-60c8-4521-965c-c926c02b10e9" />

## Deployment
1. Deploy front

