### PR TITLE
feat: create regular_manual groups from ui

### DIFF
--- a/front/components/groups/CreateGroupDialog.tsx
+++ b/front/components/groups/CreateGroupDialog.tsx
@@ -1,4 +1,5 @@
 import { MemberSelectionTable } from "@app/components/members/MemberSelectionTable";
+import { useCreateGroup } from "@app/lib/swr/groups";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -27,6 +28,8 @@ export function CreateGroupDialog({
     () => new Set()
   );
 
+  const { doCreateGroup, isCreating } = useCreateGroup({ owner });
+
   useEffect(() => {
     if (isOpen) {
       setName("");
@@ -34,13 +37,18 @@ export function CreateGroupDialog({
     }
   }, [isOpen]);
 
-  const handleCreate = () => {
-    // TODO: wire backend
-    onOpenChange(false);
+  const handleCreate = async () => {
+    const result = await doCreateGroup({
+      name: name.trim(),
+      memberIds: Array.from(selectedMemberIds),
+    });
+    if (result) {
+      onOpenChange(false);
+    }
   };
 
   const shouldDisableButton =
-    name.trim().length === 0 || selectedMemberIds.size === 0;
+    isCreating || name.trim().length === 0 || selectedMemberIds.size === 0;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -72,6 +80,7 @@ export function CreateGroupDialog({
             variant: "primary",
             onClick: handleCreate,
             disabled: shouldDisableButton,
+            isLoading: isCreating,
           }}
         />
       </DialogContent>

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -3,11 +3,12 @@ import { clientFetch } from "@app/lib/egress/client";
 import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetGroupsResponseBody } from "@app/types/api/groups";
+import type { PostGroupResponseBody } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { type Fetcher, mutate } from "swr";
 import { z } from "zod";
 
@@ -67,6 +68,58 @@ async function invalidateWorkspaceGroups(workspaceId: string): Promise<void> {
     (key) =>
       typeof key === "string" && key.startsWith(`/api/w/${workspaceId}/groups`)
   );
+}
+
+export function useCreateGroup({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+  const [isCreating, setIsCreating] = useState(false);
+
+  const doCreateGroup = useCallback(
+    async ({
+      name,
+      memberIds,
+    }: {
+      name: string;
+      memberIds: string[];
+    }): Promise<PostGroupResponseBody | null> => {
+      setIsCreating(true);
+      try {
+        const res = await clientFetch(`/api/w/${owner.sId}/groups`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, memberIds }),
+        });
+
+        if (!res.ok) {
+          const error = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to create group",
+            description:
+              error?.error?.message ?? "An unexpected error occurred.",
+          });
+          return null;
+        }
+
+        const body: PostGroupResponseBody = await res.json();
+
+        sendNotification({
+          type: "success",
+          title: "Group created",
+          description: `${name} has been created.`,
+        });
+
+        await invalidateWorkspaceGroups(owner.sId);
+
+        return body;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return { doCreateGroup, isCreating };
 }
 
 export function useUpdateGroupSpendLimit({

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -59,7 +59,10 @@ export function isCapEligibleGroupKind(kind: GroupKind): boolean {
 // Group kinds that represent user-managed membership collections and are
 // surfaced in workspace admin UIs (Groups tab, governance). Excludes internal
 // system/permission groups.
-export const MANAGEABLE_GROUP_KINDS = ["provisioned"] as const;
+export const MANAGEABLE_GROUP_KINDS = [
+  "provisioned",
+  "regular_manual",
+] as const;
 
 export function isManageableGroupKind(kind: GroupKind): boolean {
   return MANAGEABLE_GROUP_KINDS.some((k) => k === kind);


### PR DESCRIPTION
## Description

This PR wires up the `CreateGroupDialog` UI to actually call the backend API for creating `regular_manual` groups.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.