### PR TITLE
feat(analytics): expose tags to analytics mcp

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2506,15 +2506,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "basic",
     },
+    "get_top_agent_tags": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
     "get_top_agents": {
       "freeUsage": false,
       "toolCostCategory": "basic",
     },
     "get_top_skills": {
-      "freeUsage": false,
-      "toolCostCategory": "basic",
-    },
-    "get_top_tags": {
       "freeUsage": false,
       "toolCostCategory": "basic",
     },
@@ -3305,9 +3305,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_credit_timeseries": "never_ask",
     "get_credit_usage": "never_ask",
     "get_source_breakdown": "never_ask",
+    "get_top_agent_tags": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",
-    "get_top_tags": "never_ask",
     "get_top_tools": "never_ask",
     "get_top_users": "never_ask",
     "get_usage_timeseries": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2514,6 +2514,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "basic",
     },
+    "get_top_tags": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
     "get_top_tools": {
       "freeUsage": false,
       "toolCostCategory": "basic",
@@ -3303,6 +3307,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_source_breakdown": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",
+    "get_top_tags": "never_ask",
     "get_top_tools": "never_ask",
     "get_top_users": "never_ask",
     "get_usage_timeseries": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1058,7 +1058,7 @@ const QUERIES: LabeledQuery[] = [
   },
   {
     query: "list the agent tags",
-    expected: "workspace_analytics.get_top_tags",
+    expected: "workspace_analytics.get_top_agent_tags",
   },
   {
     query:

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1057,6 +1057,10 @@ const QUERIES: LabeledQuery[] = [
     expected: "workspace_analytics.get_top_users",
   },
   {
+    query: "list the agent tags",
+    expected: "workspace_analytics.get_top_tags",
+  },
+  {
     query:
       "what does the support agent actually do - show its configuration and prompt",
     expected: "workspace_analytics.get_agent_details",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -31,13 +31,13 @@ const getTopAgentsSchema = topListSchema("agents");
 const getTopUsersSchema = topListSchema("users");
 const getTopSkillsSchema = topListSchema("skills");
 const getTopToolsSchema = topListSchema("tools");
-const getTopTagsSchema = topListSchema("tags");
+const getTopAgentTagsSchema = topListSchema("agent tags");
 
 const getSourceBreakdownSchema = {
   ...timeWindowSchemaShape,
   agentIds: usageFilterSchema.agentIds,
   userIds: usageFilterSchema.userIds,
-  tagIds: usageFilterSchema.tagIds,
+  agentTagIds: usageFilterSchema.agentTagIds,
 };
 
 const getAgentDetailsSchema = {
@@ -149,20 +149,20 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_top_tags: {
+  get_top_agent_tags: {
     description:
       "List the agent tags applied across the workspace over a time window " +
       "(defaults to the current calendar month), ranked by message volume, " +
       "with the number of distinct agents bearing each tag. Each row includes " +
-      "the tag's id. Use this to enumerate which tags exist and obtain their " +
-      "ids, then supply those ids as the tag filter on the other analytics " +
-      "tools. Because an agent can bear several tags, per-tag counts overlap " +
-      "and may exceed the workspace total. Admin-only.",
-    schema: getTopTagsSchema,
+      "the tag's id. Use this to enumerate which agent tags exist and obtain " +
+      "their ids, then supply those ids as the agentTagIds filter on the " +
+      "other analytics tools. Because an agent can bear several tags, per-tag " +
+      "counts overlap and may exceed the workspace total. Admin-only.",
+    schema: getTopAgentTagsSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving top tags",
-      done: "Retrieved top tags",
+      running: "Retrieving top agent tags",
+      done: "Retrieved top agent tags",
     },
     toolCostCategory: "basic",
     freeUsage: false,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -157,7 +157,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "the tag's id. Use this to enumerate which agent tags exist and obtain " +
       "their ids, then supply those ids as the agentTagIds filter on the " +
       "other analytics tools. Because an agent can bear several tags, per-tag " +
-      "counts overlap and may exceed the workspace total. Admin-only.",
+      "counts overlap and may exceed the workspace total. Tags are fetched " +
+      "based on historical message data and may not reflect current agent tags. Admin-only.",
     schema: getTopAgentTagsSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -31,11 +31,13 @@ const getTopAgentsSchema = topListSchema("agents");
 const getTopUsersSchema = topListSchema("users");
 const getTopSkillsSchema = topListSchema("skills");
 const getTopToolsSchema = topListSchema("tools");
+const getTopTagsSchema = topListSchema("tags");
 
 const getSourceBreakdownSchema = {
   ...timeWindowSchemaShape,
   agentIds: usageFilterSchema.agentIds,
   userIds: usageFilterSchema.userIds,
+  tagIds: usageFilterSchema.tagIds,
 };
 
 const getAgentDetailsSchema = {
@@ -147,6 +149,24 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
+  get_top_tags: {
+    description:
+      "List the agent tags applied across the workspace over a time window " +
+      "(defaults to the current calendar month), ranked by message volume, " +
+      "with the number of distinct agents bearing each tag. Each row includes " +
+      "the tag's id. Use this to enumerate which tags exist and obtain their " +
+      "ids, then supply those ids as the tag filter on the other analytics " +
+      "tools. Because an agent can bear several tags, per-tag counts overlap " +
+      "and may exceed the workspace total. Admin-only.",
+    schema: getTopTagsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top tags",
+      done: "Retrieved top tags",
+    },
+    toolCostCategory: "basic",
+    freeUsage: false,
+  },
   get_agent_details: {
     description:
       "Return an agent's full configuration: name, description, scope, model, " +
@@ -166,8 +186,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     description:
       "Return the workspace's most-used skills over a time window (defaults " +
       "to the current calendar month), ranked by execution count. Optionally " +
-      "filter by source (context_origin), agent, or user. Use this to answer " +
-      "which skills are used most. Admin-only.",
+      "filter by source (context_origin), agent, user, or tag. Use this to " +
+      "answer which skills are used most. Admin-only.",
     schema: getTopSkillsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -182,8 +202,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "Return the workspace's most-used MCP tools and integrations over a " +
       "time window (defaults to the current calendar month), ranked by " +
       "execution count. Shows which MCP server tools are called most. Optionally " +
-      "filter by source (context_origin), agent, or user. Use this to answer " +
-      "which tools are used most or which integrations agents " +
+      "filter by source (context_origin), agent, user, or tag. Use this to " +
+      "answer which tools are used most or which integrations agents " +
       "rely on. Admin-only.",
     schema: getTopToolsSchema,
     stake: "never_ask",
@@ -204,8 +224,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "dashboard. Use this to discover and compare which channels or " +
       "integrations drive usage (including programmatic ones like API and " +
       "triggers) — the source filter on the other tools only narrows to one " +
-      "source, this enumerates them all. Optionally filter by agent or user. " +
-      "Admin-only.",
+      "source, this enumerates them all. Optionally filter by agent, user, or " +
+      "tag. Admin-only.",
     schema: getSourceBreakdownSchema,
     stake: "never_ask",
     displayLabels: {
@@ -223,8 +243,9 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "billing computes them. IMPORTANT: these figures are ESTIMATES derived " +
       "from usage logs — always tell the user they are approximate and point " +
       "them to the workspace Usage page for exact, billed credit amounts. " +
-      "Optionally filter by source (context_origin), agent, or user. " +
-      "Admin-only.",
+      "Optionally filter by source (context_origin), agent, user, or tag — " +
+      "e.g. filter by tag to attribute credits to all agents with a given " +
+      "tag. Admin-only.",
     schema: getCreditUsageSchema,
     stake: "never_ask",
     displayLabels: {
@@ -245,7 +266,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "these figures are ESTIMATES — always tell the user they are approximate " +
       "and point them to the workspace Usage page for exact, billed credit " +
       "amounts. Chart the result. Optionally filter by source (context_origin), " +
-      "agent, or user. Admin-only.",
+      "agent, user, or tag. Admin-only.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -79,11 +79,12 @@ export const usageFilterSchema = {
     .array(z.string())
     .optional()
     .describe("Restrict to messages from these user sIds."),
-  tagIds: z
+  agentTagIds: z
     .array(z.string())
     .optional()
     .describe(
-      "Restrict to messages from agents carrying any of these tag sIds."
+      "Restrict to messages from agents carrying any of these agent tag " +
+        "sIds, as returned by get_top_agent_tags."
     ),
 };
 

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -79,6 +79,12 @@ export const usageFilterSchema = {
     .array(z.string())
     .optional()
     .describe("Restrict to messages from these user sIds."),
+  tagIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to messages from agents carrying any of these tag sIds."
+    ),
 };
 
 export type TimeWindowInput = z.input<typeof timeWindowInputSchema>;

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -26,6 +26,7 @@ describe("workspace_analytics tools", () => {
   it.each([
     "get_top_agents",
     "get_top_users",
+    "get_top_tags",
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -26,7 +26,7 @@ describe("workspace_analytics tools", () => {
   it.each([
     "get_top_agents",
     "get_top_users",
-    "get_top_tags",
+    "get_top_agent_tags",
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -33,6 +33,7 @@ import {
   resolveServerDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
+import { fetchTopTags } from "@app/lib/api/assistant/observability/top_tags";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -48,7 +49,13 @@ function scopedBaseQuery(
     source,
     agentIds,
     userIds,
-  }: { source?: string; agentIds?: string[]; userIds?: string[] }
+    tagIds,
+  }: {
+    source?: string;
+    agentIds?: string[];
+    userIds?: string[];
+    tagIds?: string[];
+  }
 ) {
   return buildAgentAnalyticsBaseQuery({
     workspaceId: auth.getNonNullableWorkspace().sId,
@@ -57,6 +64,7 @@ function scopedBaseQuery(
     contextOrigin: source,
     agentIds,
     userIds,
+    agentTagIds: tagIds,
   });
 }
 
@@ -100,7 +108,17 @@ function renderExecutionSeries<
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   get_top_agents: async (
-    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      tagIds,
+    },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -120,6 +138,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
+      agentTagIds: tagIds,
     });
 
     if (result.isErr()) {
@@ -156,7 +175,17 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_top_users: async (
-    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      tagIds,
+    },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -176,6 +205,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
+      agentTagIds: tagIds,
     });
 
     if (result.isErr()) {
@@ -206,6 +236,73 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Top users for ${label} (${tz}), most active first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_top_tags: async (
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      tagIds,
+    },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const result = await fetchTopTags(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      limit: limit ?? DEFAULT_RESULTS,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+      agentTagIds: tagIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve top tags: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+
+    if (result.value.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No agent tag activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = result.value.map(
+      (tag, index) =>
+        `${index + 1}. ${tag.name} [${tag.tagId}] — ` +
+        `${tag.messageCount} messages, ${tag.agentCount} agents`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Top agent tags for ${label} (${tz}), most used first:\n` +
           lines.join("\n"),
       },
     ]);
@@ -269,7 +366,17 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_top_skills: async (
-    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      tagIds,
+    },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -286,6 +393,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     });
 
     const result = await fetchAvailableSkills(baseQuery);
@@ -323,7 +431,17 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_top_tools: async (
-    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      tagIds,
+    },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -340,6 +458,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     });
 
     const result = await fetchAvailableTools(baseQuery);
@@ -386,7 +505,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_source_breakdown: async (
-    { period, startDate, endDate, timezone, agentIds, userIds },
+    { period, startDate, endDate, timezone, agentIds, userIds, tagIds },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -402,6 +521,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const baseQuery = scopedBaseQuery(auth, window.value, {
       agentIds,
       userIds,
+      tagIds,
     });
 
     const result = await fetchContextOriginBreakdown(baseQuery);
@@ -452,6 +572,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     },
     { auth }
   ) => {
@@ -474,6 +595,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
+      agentTagIds: tagIds,
     });
 
     if (result.isErr()) {
@@ -531,6 +653,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     },
     { auth }
   ) => {
@@ -564,6 +687,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         contextOrigin: source,
         agentIds,
         userIds,
+        agentTagIds: tagIds,
       });
 
       if (result.isErr()) {
@@ -616,6 +740,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
+      agentTagIds: tagIds,
     });
 
     if (result.isErr()) {
@@ -661,6 +786,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     },
     { auth }
   ) => {
@@ -681,6 +807,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
+      tagIds,
     });
     const { label, timezone: tz } = window.value;
     const selectedMetric = metric ?? "messages";

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -32,8 +32,8 @@ import {
   fetchToolUsageMetrics,
   resolveServerDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
+import { fetchTopAgentTags } from "@app/lib/api/assistant/observability/top_agent_tags";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
-import { fetchTopTags } from "@app/lib/api/assistant/observability/top_tags";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -49,12 +49,12 @@ function scopedBaseQuery(
     source,
     agentIds,
     userIds,
-    tagIds,
+    agentTagIds,
   }: {
     source?: string;
     agentIds?: string[];
     userIds?: string[];
-    tagIds?: string[];
+    agentTagIds?: string[];
   }
 ) {
   return buildAgentAnalyticsBaseQuery({
@@ -64,7 +64,7 @@ function scopedBaseQuery(
     contextOrigin: source,
     agentIds,
     userIds,
-    agentTagIds: tagIds,
+    agentTagIds,
   });
 }
 
@@ -117,7 +117,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -138,7 +138,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
-      agentTagIds: tagIds,
+      agentTagIds,
     });
 
     if (result.isErr()) {
@@ -184,7 +184,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -205,7 +205,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
-      agentTagIds: tagIds,
+      agentTagIds,
     });
 
     if (result.isErr()) {
@@ -241,7 +241,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     ]);
   },
 
-  get_top_tags: async (
+  get_top_agent_tags: async (
     {
       limit,
       period,
@@ -251,7 +251,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -265,14 +265,14 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
 
-    const result = await fetchTopTags(auth, {
+    const result = await fetchTopAgentTags(auth, {
       startDate: window.value.startDate,
       endDate: window.value.endDate,
       limit: limit ?? DEFAULT_RESULTS,
       contextOrigin: source,
       agentIds,
       userIds,
-      agentTagIds: tagIds,
+      agentTagIds,
     });
 
     if (result.isErr()) {
@@ -375,7 +375,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -393,7 +393,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     });
 
     const result = await fetchAvailableSkills(baseQuery);
@@ -440,7 +440,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -458,7 +458,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     });
 
     const result = await fetchAvailableTools(baseQuery);
@@ -505,7 +505,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_source_breakdown: async (
-    { period, startDate, endDate, timezone, agentIds, userIds, tagIds },
+    { period, startDate, endDate, timezone, agentIds, userIds, agentTagIds },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -521,7 +521,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const baseQuery = scopedBaseQuery(auth, window.value, {
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     });
 
     const result = await fetchContextOriginBreakdown(baseQuery);
@@ -572,7 +572,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -595,7 +595,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
-      agentTagIds: tagIds,
+      agentTagIds,
     });
 
     if (result.isErr()) {
@@ -653,7 +653,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -687,7 +687,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         contextOrigin: source,
         agentIds,
         userIds,
-        agentTagIds: tagIds,
+        agentTagIds,
       });
 
       if (result.isErr()) {
@@ -740,7 +740,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       contextOrigin: source,
       agentIds,
       userIds,
-      agentTagIds: tagIds,
+      agentTagIds,
     });
 
     if (result.isErr()) {
@@ -786,7 +786,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     },
     { auth }
   ) => {
@@ -807,7 +807,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       source,
       agentIds,
       userIds,
-      tagIds,
+      agentTagIds,
     });
     const { label, timezone: tz } = window.value;
     const selectedMetric = metric ?? "messages";

--- a/front/lib/api/assistant/observability/top_agent_tags.ts
+++ b/front/lib/api/assistant/observability/top_agent_tags.ts
@@ -7,31 +7,31 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
-export type TopTagRow = {
+export type TopAgentTagRow = {
   tagId: string;
   name: string;
   messageCount: number;
   agentCount: number;
 };
 
-type TopTagBucket = {
+type TopAgentTagBucket = {
   key: string;
   doc_count: number;
   unique_agents?: estypes.AggregationsCardinalityAggregate;
 };
 
-type TopTagsAggs = {
-  by_tag?: estypes.AggregationsMultiBucketAggregateBase<TopTagBucket>;
+type TopAgentTagsAggs = {
+  by_agent_tag?: estypes.AggregationsMultiBucketAggregateBase<TopAgentTagBucket>;
 };
 
 // Ranks agent tags by message count over a time window, with the count of
 // distinct agents carrying each tag.
-// Backs the top-tags analytics endpoint.
+// Backs the top-agent-tags analytics endpoint.
 // Either `days` or `startDate`/`endDate` bounds the window; source/agent/user
 // filters are optional.
 // Since agents can have multiple tags, counts overlap and can sum to more than
 // the total message volume.
-export async function fetchTopTags(
+export async function fetchTopAgentTags(
   auth: Authenticator,
   {
     days,
@@ -52,7 +52,7 @@ export async function fetchTopTags(
     userIds?: string[];
     agentTagIds?: string[];
   }
-): Promise<Result<TopTagRow[], ElasticsearchError>> {
+): Promise<Result<TopAgentTagRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
 
   const baseQuery = buildAgentAnalyticsBaseQuery({
@@ -66,7 +66,7 @@ export async function fetchTopTags(
     agentTagIds,
   });
 
-  const result = await searchAnalytics<never, TopTagsAggs>(
+  const result = await searchAnalytics<never, TopAgentTagsAggs>(
     {
       bool: {
         filter: [baseQuery, { exists: { field: "agent_tag_ids" } }],
@@ -74,7 +74,7 @@ export async function fetchTopTags(
     },
     {
       aggregations: {
-        by_tag: {
+        by_agent_tag: {
           terms: { field: "agent_tag_ids", size: limit },
           aggs: {
             unique_agents: { cardinality: { field: "agent_id" } },
@@ -89,8 +89,8 @@ export async function fetchTopTags(
     return result;
   }
 
-  const buckets = bucketsToArray<TopTagBucket>(
-    result.value.aggregations?.by_tag?.buckets
+  const buckets = bucketsToArray<TopAgentTagBucket>(
+    result.value.aggregations?.by_agent_tag?.buckets
   );
 
   const tagIds = buckets.map((bucket) => String(bucket.key));

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -39,6 +39,7 @@ export async function fetchTopAgents(
     contextOrigin,
     agentIds,
     userIds,
+    agentTagIds,
   }: {
     days?: number;
     startDate?: string;
@@ -47,6 +48,7 @@ export async function fetchTopAgents(
     contextOrigin?: string | string[];
     agentIds?: string[];
     userIds?: string[];
+    agentTagIds?: string[];
   }
 ): Promise<Result<WorkspaceTopAgentRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -59,6 +61,7 @@ export async function fetchTopAgents(
     contextOrigin,
     agentIds,
     userIds,
+    agentTagIds,
   });
 
   const result = await searchAnalytics<never, TopAgentsAggs>(

--- a/front/lib/api/assistant/observability/top_tags.ts
+++ b/front/lib/api/assistant/observability/top_tags.ts
@@ -1,38 +1,37 @@
-import type { WorkspaceTopUserRow } from "@app/lib/api/analytics/workspace_analytics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import { UserResource } from "@app/lib/resources/user_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
-type TopUserBucket = {
+export type TopTagRow = {
+  tagId: string;
+  name: string;
+  messageCount: number;
+  agentCount: number;
+};
+
+type TopTagBucket = {
   key: string;
   doc_count: number;
   unique_agents?: estypes.AggregationsCardinalityAggregate;
 };
 
-type TopUsersAggs = {
-  by_user?: estypes.AggregationsMultiBucketAggregateBase<TopUserBucket>;
+type TopTagsAggs = {
+  by_tag?: estypes.AggregationsMultiBucketAggregateBase<TopTagBucket>;
 };
 
-function getUserDisplayName(user: UserResource | undefined): string {
-  if (!user) {
-    return "Programmatic usage";
-  }
-  const fullName = user.fullName();
-  if (fullName) {
-    return fullName;
-  }
-  if (user.username) {
-    return user.username;
-  }
-  return user.email || "Programmatic usage";
-}
-
-export async function fetchTopUsers(
+// Ranks agent tags by message count over a time window, with the count of
+// distinct agents carrying each tag.
+// Backs the top-tags analytics endpoint.
+// Either `days` or `startDate`/`endDate` bounds the window; source/agent/user
+// filters are optional.
+// Since agents can have multiple tags, counts overlap and can sum to more than
+// the total message volume.
+export async function fetchTopTags(
   auth: Authenticator,
   {
     days,
@@ -53,7 +52,7 @@ export async function fetchTopUsers(
     userIds?: string[];
     agentTagIds?: string[];
   }
-): Promise<Result<WorkspaceTopUserRow[], ElasticsearchError>> {
+): Promise<Result<TopTagRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
 
   const baseQuery = buildAgentAnalyticsBaseQuery({
@@ -67,16 +66,16 @@ export async function fetchTopUsers(
     agentTagIds,
   });
 
-  const result = await searchAnalytics<never, TopUsersAggs>(
+  const result = await searchAnalytics<never, TopTagsAggs>(
     {
       bool: {
-        filter: [baseQuery, { exists: { field: "user_id" } }],
+        filter: [baseQuery, { exists: { field: "agent_tag_ids" } }],
       },
     },
     {
       aggregations: {
-        by_user: {
-          terms: { field: "user_id", size: limit },
+        by_tag: {
+          terms: { field: "agent_tag_ids", size: limit },
           aggs: {
             unique_agents: { cardinality: { field: "agent_id" } },
           },
@@ -90,24 +89,25 @@ export async function fetchTopUsers(
     return result;
   }
 
-  const buckets = bucketsToArray<TopUserBucket>(
-    result.value.aggregations?.by_user?.buckets
+  const buckets = bucketsToArray<TopTagBucket>(
+    result.value.aggregations?.by_tag?.buckets
   );
 
-  const bucketUserIds = buckets.map((bucket) => String(bucket.key));
-  const users =
-    bucketUserIds.length > 0
-      ? await UserResource.fetchByIds(bucketUserIds)
-      : [];
-  const usersById = new Map(users.map((user) => [user.sId, user]));
+  const tagIds = buckets.map((bucket) => String(bucket.key));
+  if (tagIds.length === 0) {
+    return new Ok([]);
+  }
+
+  const tags = await TagResource.fetchByIds(auth, tagIds);
+  const nameById = new Map(tags.map((tag) => [tag.sId, tag.name]));
 
   const rows = buckets.map((bucket) => {
-    const userId = String(bucket.key);
-    const user = usersById.get(userId);
+    const tagId = String(bucket.key);
     return {
-      userId,
-      name: getUserDisplayName(user),
-      imageUrl: user?.imageUrl ?? null,
+      tagId,
+      // A tag may have been deleted after messages were indexed; fall back to
+      // the raw id so the row is still actionable.
+      name: nameById.get(tagId) ?? tagId,
       messageCount: bucket.doc_count ?? 0,
       agentCount: Math.round(bucket.unique_agents?.value ?? 0),
     };


### PR DESCRIPTION
## Description

Expose tags to workspace analytics mcp. Goal is to have the analyst agent be able to leverage tags, e.g: "how many credits are used by agents tagged finance ?"

- creates a new call `get_top_tags`: returns tags by message count (gets the name and the sid)
- adds tagsId to other functions like `get_credit_usage`

refs https://github.com/dust-tt/tasks/issues/8167

## Tests

<img width="862" height="588" alt="Screenshot 2026-07-15 at 18 41 42" src="https://github.com/user-attachments/assets/286f2758-e475-4aaf-837d-558c314b9722" />
<img width="847" height="523" alt="Screenshot 2026-07-15 at 18 42 27" src="https://github.com/user-attachments/assets/ac8af891-4025-4591-8384-6b80c51747d8" />

