### PR TITLE
[front] Time-bound workspace seat limits (schedulable commitments)

### DIFF
--- a/front/lib/resources/storage/models/workspace_seat_limit.ts
+++ b/front/lib/resources/storage/models/workspace_seat_limit.ts
@@ -10,6 +10,18 @@ import type { CreationOptional } from "sequelize";
  * - `minSeats`: billing floor for that seat type — the minimum count billed to
  *   Metronome even when the actual headcount on the seat type is lower.
  * - `maxSeats`: hard assignment cap — null means no cap.
+ *
+ * Configurations are time-bounded like memberships so that changes can be
+ * scheduled ahead of time:
+ *
+ * - `startAt`: when the configuration becomes effective.
+ * - `endAt`: when it stops being effective; `null` means open-ended.
+ *
+ * A configuration is "active" at time `t` when `startAt <= t` and
+ * (`endAt` is null or `endAt > t`). Scheduling a change end-dates the current
+ * open-ended row at the effective date and inserts a new open-ended row that
+ * starts on that date. The partial unique index below guarantees at most one
+ * open-ended row per (workspace, seat type).
  */
 export class WorkspaceSeatLimitModel extends WorkspaceAwareModel<WorkspaceSeatLimitModel> {
   declare createdAt: CreationOptional<Date>;
@@ -18,6 +30,8 @@ export class WorkspaceSeatLimitModel extends WorkspaceAwareModel<WorkspaceSeatLi
   declare seatType: MembershipSeatType;
   declare minSeats: CreationOptional<number>;
   declare maxSeats: CreationOptional<number | null>;
+  declare startAt: CreationOptional<Date>;
+  declare endAt: CreationOptional<Date | null>;
 }
 
 WorkspaceSeatLimitModel.init(
@@ -45,15 +59,28 @@ WorkspaceSeatLimitModel.init(
       type: DataTypes.INTEGER,
       allowNull: true,
     },
+    startAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    endAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     modelName: "workspace_seat_limit",
     sequelize: frontSequelize,
     indexes: [
+      // At most one open-ended (current/future) configuration per
+      // (workspace, seat type). Historical and scheduled rows carry a non-null
+      // `endAt` and are therefore excluded from this constraint.
       {
         fields: ["workspaceId", "seatType"],
         unique: true,
-        name: "workspace_seat_limits_workspace_seat_type_idx",
+        where: { endAt: null },
+        name: "workspace_seat_limits_workspace_seat_type_active_idx",
       },
     ],
   }

--- a/front/lib/resources/workspace_seat_limit_resource.test.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.test.ts
@@ -1,12 +1,18 @@
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("WorkspaceSeatLimitResource", () => {
   let workspace: LightWorkspaceType;
+  // Captured so scheduleChange can nest under the test-isolation transaction as
+  // a SAVEPOINT; without it, scheduleChange opens a second DB connection that
+  // cannot see the workspace created inside the (uncommitted) test transaction.
+  let outerTransaction: Transaction;
 
-  beforeEach(async () => {
+  beforeEach(async (ctx) => {
+    outerTransaction = (ctx as any)["transaction"] as Transaction;
     workspace = await WorkspaceFactory.basic();
   });
 
@@ -160,5 +166,333 @@ describe("WorkspaceSeatLimitResource", () => {
       workspace,
     });
     expect(limits.size).toBe(0);
+  });
+
+  it("schedules a change: current value now, new value from the start date", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+      maxSeats: 10,
+    });
+
+    const startAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 8,
+      maxSeats: 20,
+      startAt,
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // Now: still the current value.
+    const nowLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(nowLimits.get("pro")).toEqual({ minSeats: 5, maxSeats: 10 });
+
+    // Just before the start date: still the current value.
+    const beforeLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(startAt.getTime() - 1000),
+    });
+    expect(beforeLimits.get("pro")).toEqual({ minSeats: 5, maxSeats: 10 });
+
+    // From the start date onwards: the scheduled value.
+    const afterLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(startAt.getTime() + 1000),
+    });
+    expect(afterLimits.get("pro")).toEqual({ minSeats: 8, maxSeats: 20 });
+  });
+
+  it("schedules a first-ever change with no current configuration", async () => {
+    const startAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 4,
+      startAt,
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // No floor applies before the start date.
+    const nowLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(nowLimits.has("pro")).toBe(false);
+
+    const afterLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(startAt.getTime() + 1000),
+    });
+    expect(afterLimits.get("pro")).toEqual({ minSeats: 4, maxSeats: null });
+  });
+
+  it("applies a bounded window: limit active only between start and end", async () => {
+    const startAt = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const endAt = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 7,
+      startAt,
+      endAt,
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // Before the window: no limit.
+    const before = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(before.has("pro")).toBe(false);
+
+    // Inside the window: the configured limit.
+    const during = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(startAt.getTime() + 1000),
+    });
+    expect(during.get("pro")).toEqual({ minSeats: 7, maxSeats: null });
+
+    // After the window: no limit again.
+    const after = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(endAt.getTime() + 1000),
+    });
+    expect(after.has("pro")).toBe(false);
+  });
+
+  it("rejects a window whose endAt is not after startAt", async () => {
+    const startAt = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 4,
+      startAt,
+      endAt: startAt,
+      transaction: outerTransaction,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/endAt.*startAt/);
+    }
+  });
+
+  it("rejects a scheduled limit with maxSeats < minSeats", async () => {
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 10,
+      maxSeats: 5,
+      startAt: new Date(Date.now() + 1000),
+      transaction: outerTransaction,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/maxSeats.*minSeats/);
+    }
+  });
+
+  it("supersedes a later scheduled change when a new one is set earlier", async () => {
+    const laterStart = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000);
+    await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 8,
+      startAt: laterStart,
+      transaction: outerTransaction,
+    });
+
+    const earlierStart = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000);
+    await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 6,
+      startAt: earlierStart,
+      transaction: outerTransaction,
+    });
+
+    // The later (superseded) schedule no longer applies; the earlier one holds
+    // open-ended.
+    const afterLater = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(laterStart.getTime() + 1000),
+    });
+    expect(afterLater.get("pro")).toEqual({ minSeats: 6, maxSeats: null });
+  });
+
+  it("upsert after a scheduled change updates the open-ended (future) row", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+    const startAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 8,
+      startAt,
+      transaction: outerTransaction,
+    });
+
+    // Upsert targets the open-ended (scheduled) row, not the currently active one.
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 9,
+    });
+
+    const nowLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(nowLimits.get("pro")).toEqual({ minSeats: 5, maxSeats: null });
+
+    const afterLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(startAt.getTime() + 1000),
+    });
+    expect(afterLimits.get("pro")).toEqual({ minSeats: 9, maxSeats: null });
+  });
+
+  it("replaces the full schedule for a seat type", async () => {
+    // Seed a limit that the replace must wipe.
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 99,
+    });
+
+    const phase1Start = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const phase2Start = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    // Only starts are provided; the resource derives phase 1's end from phase 2.
+    const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
+      workspace,
+      seatType: "pro",
+      phases: [
+        { minSeats: 3, maxSeats: 10, startAt: phase1Start },
+        { minSeats: 6, maxSeats: null, startAt: phase2Start },
+      ],
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // Now falls in phase 1.
+    const nowLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(nowLimits.get("pro")).toEqual({ minSeats: 3, maxSeats: 10 });
+
+    // Just before phase 2 starts, phase 1 still applies (derived end).
+    const beforeLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(phase2Start.getTime() - 1000),
+    });
+    expect(beforeLimits.get("pro")).toEqual({ minSeats: 3, maxSeats: 10 });
+
+    // From phase 2 start, phase 2 applies open-ended.
+    const afterLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(phase2Start.getTime() + 1000),
+    });
+    expect(afterLimits.get("pro")).toEqual({ minSeats: 6, maxSeats: null });
+  });
+
+  it("clears a seat type when replacing with an empty schedule", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+
+    const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
+      workspace,
+      seatType: "pro",
+      phases: [],
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.has("pro")).toBe(false);
+  });
+
+  it("derives contiguous windows and an open-ended last phase from starts", async () => {
+    const start1 = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const start2 = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
+      workspace,
+      seatType: "pro",
+      // Deliberately out of order to check the resource sorts by start.
+      phases: [
+        { minSeats: 6, maxSeats: null, startAt: start2 },
+        { minSeats: 3, maxSeats: null, startAt: start1 },
+      ],
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const schedule = await WorkspaceSeatLimitResource.fetchScheduleByWorkspace({
+      workspace,
+      // Read from before the first phase so both phases are returned.
+      at: new Date(Date.now() + 1000),
+    });
+    const proPhases = schedule.get("pro") ?? [];
+    expect(proPhases).toHaveLength(2);
+    // Phase 1 ends exactly when phase 2 starts (derived); phase 2 is open-ended.
+    expect(proPhases[0].minSeats).toBe(3);
+    expect(proPhases[0].endAt?.getTime()).toBe(start2.getTime());
+    expect(proPhases[1].minSeats).toBe(6);
+    expect(proPhases[1].endAt).toBeNull();
+  });
+
+  it("rejects a schedule with two phases sharing a start", async () => {
+    const start = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
+      workspace,
+      seatType: "pro",
+      phases: [
+        { minSeats: 3, maxSeats: null, startAt: start },
+        { minSeats: 6, maxSeats: null, startAt: new Date(start.getTime()) },
+      ],
+      transaction: outerTransaction,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/distinct start/);
+    }
+  });
+
+  it("removes all rows (current and scheduled) for a seat type", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+    await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 8,
+      startAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      transaction: outerTransaction,
+    });
+
+    const removed = await WorkspaceSeatLimitResource.remove({
+      workspace,
+      seatType: "pro",
+    });
+    expect(removed).toBe(true);
+
+    const futureLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+      at: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+    });
+    expect(futureLimits.has("pro")).toBe(false);
   });
 });

--- a/front/lib/resources/workspace_seat_limit_resource.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.ts
@@ -1,5 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceSeatLimitModel } from "@app/lib/resources/storage/models/workspace_seat_limit";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -22,6 +24,34 @@ export type SeatLimit = {
   maxSeats: number | null;
 };
 
+/**
+ * A {@link SeatLimit} together with the `[startAt, endAt)` window over which it
+ * applies (`endAt` null means open-ended). Returned by
+ * {@link WorkspaceSeatLimitResource.fetchScheduleByWorkspace} so callers can
+ * reason about scheduled future changes, not just the value effective now.
+ */
+export type SeatLimitSegment = SeatLimit & {
+  startAt: Date;
+  endAt: Date | null;
+};
+
+function validateMaxSeats({
+  minSeats,
+  maxSeats,
+}: {
+  minSeats: number;
+  maxSeats?: number | null;
+}): Result<void, Error> {
+  if (maxSeats !== null && maxSeats !== undefined && maxSeats < minSeats) {
+    return new Err(
+      new Error(
+        `maxSeats (${maxSeats}) must be greater than or equal to minSeats (${minSeats}).`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WorkspaceSeatLimitResource
   extends ReadonlyAttributesType<WorkspaceSeatLimitModel> {}
@@ -38,33 +68,100 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
   }
 
   /**
-   * Returns the configured per-seat-type limits for a workspace, keyed by seat
-   * type. Seat types without a row are simply absent from the map (callers
-   * treat that as "no floor / no cap").
+   * Returns the per-seat-type limits that are active for a workspace at a given
+   * point in time (defaults to now), keyed by seat type. A row is active when
+   * `startAt <= at` and (`endAt` is null or `endAt > at`). Scheduled (future)
+   * and historical (already ended) rows are ignored. Seat types without an
+   * active row are simply absent from the map (callers treat that as "no floor
+   * / no cap").
    */
   static async fetchByWorkspace({
     workspace,
+    at = new Date(),
   }: {
     workspace: LightWorkspaceType;
+    at?: Date;
   }): Promise<Map<MembershipSeatType, SeatLimit>> {
     const rows = await this.model.findAll({
       where: { workspaceId: workspace.id },
     });
-    const result = new Map<MembershipSeatType, SeatLimit>();
+    // The number of rows per workspace is small (a handful of seat types, each
+    // with at most a few scheduled/historical rows), so we filter and pick the
+    // active row in memory rather than pushing a time predicate into SQL.
+    const activeByType = new Map<MembershipSeatType, WorkspaceSeatLimitModel>();
     for (const row of rows) {
-      if (isMembershipSeatType(row.seatType)) {
-        result.set(row.seatType, {
-          minSeats: row.minSeats,
-          maxSeats: row.maxSeats ?? null,
-        });
+      if (!isMembershipSeatType(row.seatType)) {
+        continue;
       }
+      if (row.startAt > at || (row.endAt !== null && row.endAt <= at)) {
+        continue;
+      }
+      // Defensive: if several rows are active at once (should not happen), keep
+      // the one that started most recently.
+      const current = activeByType.get(row.seatType);
+      if (!current || row.startAt > current.startAt) {
+        activeByType.set(row.seatType, row);
+      }
+    }
+    const result = new Map<MembershipSeatType, SeatLimit>();
+    for (const [seatType, row] of activeByType) {
+      result.set(seatType, {
+        minSeats: row.minSeats,
+        maxSeats: row.maxSeats ?? null,
+      });
     }
     return result;
   }
 
   /**
-   * Create or update the configured limit for a (workspace, seat type).
-   * Rejects when `maxSeats` is set and less than `minSeats`.
+   * Returns the currently-active and scheduled-future limits for a workspace,
+   * keyed by seat type. Each seat type maps to its segments ordered by
+   * `startAt` ascending: the active one (`startAt <= at`) followed by any
+   * scheduled changes. Historical rows (already ended at `at`) are excluded.
+   *
+   * Use this when scheduled future changes matter (e.g. the Metronome seat sync
+   * programs future-dated quantities); callers that only need the value
+   * effective now should use {@link fetchByWorkspace}.
+   */
+  static async fetchScheduleByWorkspace({
+    workspace,
+    at = new Date(),
+  }: {
+    workspace: LightWorkspaceType;
+    at?: Date;
+  }): Promise<Map<MembershipSeatType, SeatLimitSegment[]>> {
+    const rows = await this.model.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    const result = new Map<MembershipSeatType, SeatLimitSegment[]>();
+    for (const row of rows) {
+      if (!isMembershipSeatType(row.seatType)) {
+        continue;
+      }
+      // Skip historical rows (already ended at `at`).
+      if (row.endAt !== null && row.endAt <= at) {
+        continue;
+      }
+      const bucket = result.get(row.seatType) ?? [];
+      bucket.push({
+        minSeats: row.minSeats,
+        maxSeats: row.maxSeats ?? null,
+        startAt: row.startAt,
+        endAt: row.endAt ?? null,
+      });
+      result.set(row.seatType, bucket);
+    }
+    for (const bucket of result.values()) {
+      bucket.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+    }
+    return result;
+  }
+
+  /**
+   * Create or update the currently effective (open-ended) limit for a
+   * (workspace, seat type). This is the "apply now" path: it targets the row
+   * with `endAt === null` and leaves any scheduled or historical rows
+   * untouched. Rejects when `maxSeats` is set and less than `minSeats`.
    */
   static async upsert({
     workspace,
@@ -79,12 +176,9 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
     maxSeats?: number | null;
     transaction?: Transaction;
   }): Promise<Result<void, Error>> {
-    if (maxSeats !== null && maxSeats !== undefined && maxSeats < minSeats) {
-      return new Err(
-        new Error(
-          `maxSeats (${maxSeats}) must be greater than or equal to minSeats (${minSeats}).`
-        )
-      );
+    const validation = validateMaxSeats({ minSeats, maxSeats });
+    if (validation.isErr()) {
+      return validation;
     }
     const fields: {
       minSeats: number;
@@ -94,7 +188,7 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
       fields.maxSeats = maxSeats;
     }
     const existing = await this.model.findOne({
-      where: { workspaceId: workspace.id, seatType },
+      where: { workspaceId: workspace.id, seatType, endAt: null },
       transaction,
     });
     if (existing) {
@@ -106,6 +200,163 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
       { transaction }
     );
     return new Ok(undefined);
+  }
+
+  /**
+   * Set the seat limit for a (workspace, seat type) over the window
+   * `[startAt, endAt)`. This is the general scheduling primitive behind the poke
+   * "manage seat limits" tool:
+   *
+   * - Any existing rows that start at or after `startAt` are removed, so
+   *   re-applying the same window is idempotent and a new schedule supersedes
+   *   later ones.
+   * - The currently open-ended row (if it starts before `startAt`) is end-dated
+   *   at `startAt`, so the new row takes over cleanly and the single-open-ended
+   *   invariant is preserved.
+   * - A new row `[startAt, endAt)` is inserted. `endAt` null means open-ended;
+   *   after a non-null `endAt` no floor/cap applies unless another row covers
+   *   that time.
+   *
+   * Reading limits before `startAt` still returns the previous values; from
+   * `startAt` (until `endAt`) the new values apply. Rejects when `maxSeats` is
+   * set and less than `minSeats`, or when `endAt` is not after `startAt`.
+   */
+  static async setScheduledLimit({
+    workspace,
+    seatType,
+    minSeats,
+    maxSeats,
+    startAt,
+    endAt = null,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    seatType: MembershipSeatType;
+    minSeats: number;
+    maxSeats?: number | null;
+    startAt: Date;
+    endAt?: Date | null;
+    transaction?: Transaction;
+  }): Promise<Result<void, Error>> {
+    const validation = validateMaxSeats({ minSeats, maxSeats });
+    if (validation.isErr()) {
+      return validation;
+    }
+    if (endAt !== null && endAt <= startAt) {
+      return new Err(new Error("endAt must be after startAt."));
+    }
+    // Nest under the caller's transaction when provided (SAVEPOINT) so the
+    // supersede/end-date/insert steps are atomic; otherwise open a standalone
+    // transaction.
+    const txOptions = transaction ? { transaction } : {};
+    return frontSequelize.transaction(txOptions, async (t) => {
+      // Supersede any row that starts at or after the new window start.
+      await this.model.destroy({
+        where: {
+          workspaceId: workspace.id,
+          seatType,
+          startAt: { [Op.gte]: startAt },
+        },
+        transaction: t,
+      });
+      // End-date the open-ended row that predates the new window so it stops at
+      // `startAt` and becomes historical.
+      const current = await this.model.findOne({
+        where: { workspaceId: workspace.id, seatType, endAt: null },
+        transaction: t,
+      });
+      if (current && current.startAt < startAt) {
+        await current.update({ endAt: startAt }, { transaction: t });
+      }
+      await this.model.create(
+        {
+          workspaceId: workspace.id,
+          seatType,
+          minSeats,
+          maxSeats: maxSeats ?? null,
+          startAt,
+          endAt,
+        },
+        { transaction: t }
+      );
+      return new Ok(undefined);
+    });
+  }
+
+  /**
+   * Replace the entire schedule of phases for a single (workspace, seat type)
+   * in one shot. This is the primitive behind the poke "edit seat-limit
+   * schedule" dialog, which submits the phases (each defined only by its start
+   * date) for the selected seat type. An empty `phases` array clears the seat
+   * type.
+   *
+   * Phases are treated as a contiguous timeline: end dates are DERIVED here —
+   * each phase runs until the next phase's start, and the last (latest) phase
+   * is always open-ended. This guarantees no gaps, no overlaps and no bounded
+   * trailing phase by construction; callers cannot pass an inconsistent set of
+   * windows. Each phase's `maxSeats` must be `>= minSeats`, `minSeats` a
+   * non-negative integer, and no two phases may share the same start.
+   */
+  static async setScheduleForSeatType({
+    workspace,
+    seatType,
+    phases,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    seatType: MembershipSeatType;
+    phases: Array<{
+      minSeats: number;
+      maxSeats: number | null;
+      startAt: Date;
+    }>;
+    transaction?: Transaction;
+  }): Promise<Result<void, Error>> {
+    const sorted = [...phases].sort(
+      (a, b) => a.startAt.getTime() - b.startAt.getTime()
+    );
+    for (let i = 0; i < sorted.length; i++) {
+      const phase = sorted[i];
+      const validation = validateMaxSeats({
+        minSeats: phase.minSeats,
+        maxSeats: phase.maxSeats,
+      });
+      if (validation.isErr()) {
+        return validation;
+      }
+      if (!Number.isInteger(phase.minSeats) || phase.minSeats < 0) {
+        return new Err(new Error("minSeats must be a non-negative integer."));
+      }
+      if (
+        i > 0 &&
+        sorted[i - 1].startAt.getTime() === phase.startAt.getTime()
+      ) {
+        return new Err(new Error("Phases must have distinct start dates."));
+      }
+    }
+    const txOptions = transaction ? { transaction } : {};
+    return frontSequelize.transaction(txOptions, async (t) => {
+      await this.model.destroy({
+        where: { workspaceId: workspace.id, seatType },
+        transaction: t,
+      });
+      if (sorted.length > 0) {
+        await this.model.bulkCreate(
+          sorted.map((phase, i) => ({
+            workspaceId: workspace.id,
+            seatType,
+            minSeats: phase.minSeats,
+            maxSeats: phase.maxSeats,
+            startAt: phase.startAt,
+            // Derived: a phase runs until the next one starts; the last phase
+            // is open-ended.
+            endAt: i < sorted.length - 1 ? sorted[i + 1].startAt : null,
+          })),
+          { transaction: t }
+        );
+      }
+      return new Ok(undefined);
+    });
   }
 
   /**
@@ -128,8 +379,9 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
   }
 
   /**
-   * Remove the configured limit for a (workspace, seat type). Returns whether
-   * a row was actually deleted.
+   * Remove all configured limits for a (workspace, seat type) — the current
+   * one as well as any scheduled or historical rows. Returns whether at least
+   * one row was actually deleted.
    */
   static async remove({
     workspace,

--- a/front/migrations/pre-deploy/20260715120000_add_time_bounds_to_workspace_seat_limit.sql
+++ b/front/migrations/pre-deploy/20260715120000_add_time_bounds_to_workspace_seat_limit.sql
@@ -1,0 +1,24 @@
+SET SESSION statement_timeout = 3000;
+
+SET SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."workspace_seat_limits"
+ADD COLUMN "startAt" timestamp with time zone NOT NULL DEFAULT NOW();
+
+ALTER TABLE "public"."workspace_seat_limits"
+ADD COLUMN "endAt" timestamp with time zone DEFAULT NULL;
+
+-- Seat-limit windows are whole-hour aligned (Metronome effective dates are
+-- whole hours), so floor the backfilled startAt to the top of the hour.
+UPDATE "public"."workspace_seat_limits"
+SET
+  "startAt" = date_trunc('hour', "startAt");
+
+-- Relax the old one-row-per-(workspace, seat type) unique constraint and replace
+-- it with a partial unique index scoped to open-ended rows, so that scheduled
+-- and historical rows (endAt IS NOT NULL) can coexist for the same seat type.
+DROP INDEX CONCURRENTLY IF EXISTS "workspace_seat_limits_workspace_seat_type_idx";
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "workspace_seat_limits_workspace_seat_type_active_idx" ON "public"."workspace_seat_limits" ("workspaceId", "seatType")
+WHERE
+  "endAt" IS NULL;


### PR DESCRIPTION
Give `workspace_seat_limit` a `startAt`/`endAt` window (like memberships) so
seat commitments can be scheduled ahead of time, and add the resource methods
to read/write them.

- Model: add startAt (NOT NULL default NOW) + endAt (nullable); replace the
  (workspaceId, seatType) unique index with a partial unique index scoped to
  open-ended rows so scheduled/historical rows coexist.
- Pre-deploy migration adds the columns (backfilled startAt floored to the
  hour) and swaps the index.
- Resource: fetchByWorkspace reads the active value only; fetchScheduleByWorkspace
  returns current + scheduled-future phases; setScheduledLimit (windowed) and
  setScheduleForSeatType (replace a seat type's whole timeline, deriving
  contiguous windows from start-only phases).
- Resource tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run `./scripts/run-migrations.sh pre-deploy front`