### PR TITLE
[front] Program scheduled seat-commitment changes to Metronome

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
@@ -7,9 +7,31 @@ import {
 } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { mapToEnumValues } from "@app/types/poke/plugins";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+// Poke date args arrive as strings (empty when unset). Parse to a Date or
+// null, surfacing a readable error for an unparseable value.
+function parseOptionalDate(
+  value: unknown,
+  label: string
+): Result<Date | null, Error> {
+  if (!isString(value) || value.trim() === "") {
+    return new Ok(null);
+  }
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return new Err(new Error(`Invalid ${label}.`));
+  }
+  return new Ok(date);
+}
+
+function toDateLabel(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
 
 const SeatLimitArgsSchema = z.object({
   minSeats: z
@@ -70,6 +92,23 @@ export const manageSeatLimitsPlugin = createPlugin({
           "Hard cap — maximum seats assignable for this type. Leave blank for no cap.",
         dependsOn: { field: "enabled", value: true },
       },
+      startDate: {
+        type: "date",
+        label: "Start date (optional)",
+        description:
+          "When these limits take effect. Leave blank to apply immediately. " +
+          "A future date schedules the change (it is programmed into Metronome " +
+          "ahead of time and supersedes any later scheduled change).",
+        dependsOn: { field: "enabled", value: true },
+      },
+      endDate: {
+        type: "date",
+        label: "End date (optional)",
+        description:
+          "When these limits stop applying (no floor/cap afterwards). Leave " +
+          "blank for open-ended.",
+        dependsOn: { field: "enabled", value: true },
+      },
     },
     requiredRoles: ["billing"],
   },
@@ -106,17 +145,48 @@ export const manageSeatLimitsPlugin = createPlugin({
       }
 
       const { minSeats, maxSeats } = parseResult.data;
-      const upsertResult = await WorkspaceSeatLimitResource.upsert({
-        workspace,
-        seatType,
-        minSeats,
-        maxSeats: maxSeats ?? null,
-      });
-      if (upsertResult.isErr()) {
-        return new Err(upsertResult.error);
+
+      const startAtResult = parseOptionalDate(args.startDate, "start date");
+      if (startAtResult.isErr()) {
+        return new Err(startAtResult.error);
+      }
+      const endAtResult = parseOptionalDate(args.endDate, "end date");
+      if (endAtResult.isErr()) {
+        return new Err(endAtResult.error);
+      }
+      const startAt = startAtResult.value;
+      const endAt = endAtResult.value;
+
+      // No dates: keep the simple "apply now" upsert (in place, leaving any
+      // pending scheduled change untouched). Any date given routes through the
+      // windowed scheduling primitive.
+      const saveResult =
+        startAt === null && endAt === null
+          ? await WorkspaceSeatLimitResource.upsert({
+              workspace,
+              seatType,
+              minSeats,
+              maxSeats: maxSeats ?? null,
+            })
+          : await WorkspaceSeatLimitResource.setScheduledLimit({
+              workspace,
+              seatType,
+              minSeats,
+              maxSeats: maxSeats ?? null,
+              startAt: startAt ?? new Date(),
+              endAt,
+            });
+      if (saveResult.isErr()) {
+        return new Err(saveResult.error);
       }
       const maxDesc = maxSeats !== undefined ? `, max ${maxSeats}` : ", no cap";
-      message = `Seat limits for '${seatType}' saved: min ${minSeats}${maxDesc}.`;
+      const windowDesc =
+        startAt || endAt
+          ? ` (effective ${startAt ? toDateLabel(startAt) : "now"}${
+              endAt ? ` until ${toDateLabel(endAt)}` : ""
+            })`
+          : "";
+      message = `Seat limits for '${seatType}' saved: min ${minSeats}${maxDesc}${windowDesc}.`;
     }
 
     // Re-sync seats to Metronome so the new limits are reflected immediately.

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1402,14 +1402,18 @@ export async function syncSeatCount({
     // transitions: each row has `startAt > now` and represents the seat
     // type the user will be on from `startAt` forward. The companion "current"
     // row (with `endAt = startAt`) still appears in `getActiveMemberships`.
-    const [{ memberships: activeMemberships }, futureMemberships, seatLimits] =
-      await Promise.all([
-        MembershipResource.getActiveMemberships({ workspace }),
-        MembershipResource.getScheduledFutureMemberships({ workspace }),
-        // Per-seat-type min/max configuration (only `minSeats` today). Used to
-        // clamp the count sent to Metronome up to the configured floor.
-        WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
-      ]);
+    const [
+      { memberships: activeMemberships },
+      futureMemberships,
+      seatLimitSchedule,
+    ] = await Promise.all([
+      MembershipResource.getActiveMemberships({ workspace }),
+      MembershipResource.getScheduledFutureMemberships({ workspace }),
+      // Per-seat-type min/max configuration over time: the active segment plus
+      // any scheduled-future changes. Used to clamp the count sent to Metronome
+      // up to the configured floor at each effective moment.
+      WorkspaceSeatLimitResource.fetchScheduleByWorkspace({ workspace }),
+    ]);
 
     // TODO(pricing): Remove this + planCode param once we have no more shadow legacy contracts
     const legacy = !isCreditPricedPlanPrefix(planCode);
@@ -1490,9 +1494,47 @@ export async function syncSeatCount({
     // remap at the contract start); deduping prevents reconciling that segment
     // twice, which would double-apply the unassigned-seat floor.
     const baseMs = startingAt ? Date.parse(startingAt) : Date.now();
+    const nowMs = Date.now();
+    // Scheduled seat-limit (commitment) change moments: every future segment
+    // start is an effective date where the committed floor changes, so Metronome
+    // must be programmed with the new quantity from that instant — even if no
+    // membership changes at the same moment.
+    const seatLimitChangeMs: number[] = [];
+    for (const segments of seatLimitSchedule.values()) {
+      for (const seg of segments) {
+        if (seg.startAt.getTime() > nowMs) {
+          seatLimitChangeMs.push(seg.startAt.getTime());
+        }
+      }
+    }
     const effectiveTimestampsMs = Array.from(
-      new Set([baseMs, ...scheduledChanges.map((c) => c.at.getTime())])
+      new Set([
+        baseMs,
+        ...scheduledChanges.map((c) => c.at.getTime()),
+        ...seatLimitChangeMs,
+      ])
     ).sort((a, b) => a - b);
+
+    // The seat limit (min/max) effective for `seatType` at `tMs`, walking its
+    // scheduled segments. Undefined when no limit applies at that moment.
+    const seatLimitAt = (
+      seatType: MembershipSeatType,
+      tMs: number
+    ): SeatLimit | undefined => {
+      const segments = seatLimitSchedule.get(seatType);
+      if (!segments) {
+        return undefined;
+      }
+      for (const seg of segments) {
+        if (
+          seg.startAt.getTime() <= tMs &&
+          (seg.endAt === null || seg.endAt.getTime() > tMs)
+        ) {
+          return { minSeats: seg.minSeats, maxSeats: seg.maxSeats };
+        }
+      }
+      return undefined;
+    };
 
     // Compute the desired seat type per user at a given timestamp, by walking
     // scheduled changes from earliest up to (and including) `tMs`.
@@ -1596,13 +1638,15 @@ export async function syncSeatCount({
     for (const { sub, seatType } of seatSubscriptions) {
       const subscriptionId = sub.id!;
       const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
-      const seatLimit = seatLimits.get(seatType);
 
       if (quantityMode === "SEAT_BASED") {
-        // One reconcile per distinct effective moment. `desiredSIds` is
-        // evaluated at the SAME moment the segment is written to — so a future
-        // contract start reflects the membership state at the start (post-remap)
-        // rather than "now".
+        // One reconcile per distinct effective moment. `desiredSIds` and the
+        // seat limit are BOTH evaluated at the SAME moment the segment is
+        // written to — so a future contract start reflects the membership state
+        // at the start (post-remap), and a scheduled commitment change reflects
+        // the floor active from that instant. A commitment change that leaves
+        // membership unchanged therefore only moves the *unassigned* seats (the
+        // floor top-up), since the assigned real users stay the same.
         for (const tMs of effectiveTimestampsMs) {
           const isImmediateBase = tMs === baseMs && !startingAt;
           // Immediate base sync: let Metronome default to "now" for both the
@@ -1618,7 +1662,7 @@ export async function syncSeatCount({
             subscriptionId,
             seatType,
             desiredSIds: desiredSIdsAt(seatType, tMs),
-            seatLimit,
+            seatLimit: seatLimitAt(seatType, tMs),
             startingAt: segmentStartingAt,
             coveringDate,
             workspaceId: workspace.sId,
@@ -1630,40 +1674,56 @@ export async function syncSeatCount({
           didMutateSeatData = didMutateSeatData || result.value;
         }
       } else {
-        // QUANTITY_ONLY: only sync the "now" total. Scheduled changes within
-        // a quantity-only seat tier are not modeled — they're rare in practice
-        // (free / unlimited tiers) and Metronome doesn't bill them per-seat.
-        const actualQuantity = desiredSIdsAt(seatType, Date.now()).length;
-        // Clamp up to the configured billing floor: below `minSeats` we still
-        // bill the floor. `maxSeats` is deliberately NOT applied here — it is
-        // an assignment-time cap, and billing must always reflect the actual
-        // assigned count so members holding a seat are never unbilled.
-        const quantity = clampSeatCountToMin(actualQuantity, seatLimit);
-        logger.info(
-          {
-            workspaceId: workspace.sId,
+        // QUANTITY_ONLY: send the total for "now" plus a future-dated total at
+        // every effective moment where it changes (a scheduled commitment or
+        // membership change). Consecutive equal quantities are skipped so we
+        // only write real transitions. `maxSeats` is deliberately NOT applied
+        // here — it is an assignment-time cap, and billing must always reflect
+        // the actual assigned count so members holding a seat are never
+        // unbilled.
+        let lastQuantity: number | undefined;
+        for (const tMs of effectiveTimestampsMs) {
+          const isImmediateBase = tMs === baseMs && !startingAt;
+          const segmentStartingAt = isImmediateBase
+            ? startingAt
+            : new Date(tMs).toISOString();
+          const actualQuantity = desiredSIdsAt(seatType, tMs).length;
+          // Clamp up to the configured billing floor: below `minSeats` we still
+          // bill the floor.
+          const quantity = clampSeatCountToMin(
+            actualQuantity,
+            seatLimitAt(seatType, tMs)
+          );
+          if (quantity === lastQuantity) {
+            continue;
+          }
+          lastQuantity = quantity;
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              contractId,
+              subscriptionId,
+              seatType,
+              actualQuantity,
+              quantity,
+              startingAt: segmentStartingAt,
+            },
+            quantity !== actualQuantity
+              ? "[Metronome] Updating seat quantity (clamped up to configured min)"
+              : "[Metronome] Updating seat quantity"
+          );
+          const updateResult = await updateSubscriptionQuantity({
+            metronomeCustomerId,
             contractId,
             subscriptionId,
-            seatType,
-            actualQuantity,
             quantity,
-            minSeats: seatLimit?.minSeats,
-          },
-          quantity !== actualQuantity
-            ? "[Metronome] Updating seat quantity (clamped up to configured min)"
-            : "[Metronome] Updating seat quantity"
-        );
-        const updateResult = await updateSubscriptionQuantity({
-          metronomeCustomerId,
-          contractId,
-          subscriptionId,
-          quantity,
-          startingAt,
-        });
-        if (updateResult.isErr()) {
-          return new Err(updateResult.error);
+            startingAt: segmentStartingAt,
+          });
+          if (updateResult.isErr()) {
+            return new Err(updateResult.error);
+          }
+          didMutateSeatData = true;
         }
-        didMutateSeatData = true;
       }
     }
 

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -77,8 +77,14 @@ vi.mock("@app/lib/resources/membership_resource", () => ({
 }));
 
 vi.mock("@app/lib/resources/workspace_seat_limit_resource", () => ({
-  WorkspaceSeatLimitResource: { fetchByWorkspace: mockFetchSeatLimits },
+  WorkspaceSeatLimitResource: { fetchScheduleByWorkspace: mockFetchSeatLimits },
 }));
+
+// Build the schedule map value for a single always-active limit (no scheduled
+// changes): one open-ended segment starting in the distant past.
+function activeSchedule(minSeats: number, maxSeats: number | null = null) {
+  return [{ minSeats, maxSeats, startAt: new Date(0), endAt: null }];
+}
 
 // Cache wrappers run at import time and (for invalidate) in `syncSeatCount`'s
 // finally block — stub them so the test never touches Redis.
@@ -135,7 +141,7 @@ describe("syncSeatCount min clamping", () => {
       total: 1,
     });
     mockFetchSeatLimits.mockResolvedValue(
-      new Map([["workspace", { minSeats: 5 }]])
+      new Map([["workspace", activeSchedule(5)]])
     );
 
     const result = await syncSeatCount({
@@ -168,7 +174,7 @@ describe("syncSeatCount min clamping", () => {
       total: 3,
     });
     mockFetchSeatLimits.mockResolvedValue(
-      new Map([["workspace", { minSeats: 2 }]])
+      new Map([["workspace", activeSchedule(2)]])
     );
 
     await syncSeatCount({
@@ -194,7 +200,9 @@ describe("syncSeatCount min clamping", () => {
       memberships: [membership("u1", "pro")],
       total: 1,
     });
-    mockFetchSeatLimits.mockResolvedValue(new Map([["pro", { minSeats: 3 }]]));
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["pro", activeSchedule(3)]])
+    );
     // No seats currently assigned in Metronome.
     mockGetSeatState.mockResolvedValue(
       new Ok({ assignedSeatIds: [], unassignedSeats: 0 })
@@ -234,7 +242,9 @@ describe("syncSeatCount min clamping", () => {
       ],
       total: 4,
     });
-    mockFetchSeatLimits.mockResolvedValue(new Map([["pro", { minSeats: 3 }]]));
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["pro", activeSchedule(3)]])
+    );
     // Previously: 1 assigned + 2 unassigned (floor padding). Now 4 real users.
     mockGetSeatState.mockResolvedValue(
       new Ok({ assignedSeatIds: ["u1"], unassignedSeats: 2 })
@@ -275,7 +285,7 @@ describe("syncSeatCount min clamping", () => {
       total: 1,
     });
     mockFetchSeatLimits.mockResolvedValue(
-      new Map([["pro", { minSeats: 200 }]])
+      new Map([["pro", activeSchedule(200)]])
     );
     // 200 floor already provisioned as unassigned; user not yet assigned.
     mockGetSeatState.mockResolvedValue(
@@ -314,7 +324,7 @@ describe("syncSeatCount min clamping", () => {
       total: 1,
     });
     mockFetchSeatLimits.mockResolvedValue(
-      new Map([["pro", { minSeats: 200 }]])
+      new Map([["pro", activeSchedule(200)]])
     );
     mockGetSeatState.mockResolvedValue(
       new Ok({ assignedSeatIds: ["u1"], unassignedSeats: 598 })
@@ -338,6 +348,126 @@ describe("syncSeatCount min clamping", () => {
         removeSeatIds: [],
         addUnassignedSeats: 0,
         removeUnassignedSeats: 399,
+      })
+    );
+  });
+
+  it("sends now and future-dated quantities for a scheduled QUANTITY_ONLY commitment change", async () => {
+    const scheduledAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["ws-product", "workspace"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "workspace")],
+      total: 1,
+    });
+    // Committed floor rises from 2 to 5 at `scheduledAt`.
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([
+        [
+          "workspace",
+          [
+            {
+              minSeats: 2,
+              maxSeats: null,
+              startAt: new Date(0),
+              endAt: scheduledAt,
+            },
+            { minSeats: 5, maxSeats: null, startAt: scheduledAt, endAt: null },
+          ],
+        ],
+      ])
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
+      contract: makeContract([
+        { id: "sub_ws", productId: "ws-product", mode: "QUANTITY_ONLY" },
+      ]),
+    });
+
+    // Now: floor 2 billed (1 real user).
+    expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ subscriptionId: "sub_ws", quantity: 2 })
+    );
+    // At the effective date: floor 5 billed, pinned to `scheduledAt`.
+    expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionId: "sub_ws",
+        quantity: 5,
+        startingAt: scheduledAt.toISOString(),
+      })
+    );
+  });
+
+  it("updates only unassigned seats at the effective date for a scheduled SEAT_BASED commitment change", async () => {
+    const scheduledAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["pro-product", "pro"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "pro")],
+      total: 1,
+    });
+    // Committed floor rises from 3 to 5 at `scheduledAt`; membership unchanged.
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([
+        [
+          "pro",
+          [
+            {
+              minSeats: 3,
+              maxSeats: null,
+              startAt: new Date(0),
+              endAt: scheduledAt,
+            },
+            { minSeats: 5, maxSeats: null, startAt: scheduledAt, endAt: null },
+          ],
+        ],
+      ])
+    );
+    // "now" read: nothing assigned yet. Future read (covering `scheduledAt`)
+    // reflects the state after the "now" reconcile: u1 assigned + 2 unassigned.
+    mockGetSeatState
+      .mockResolvedValueOnce(
+        new Ok({ assignedSeatIds: [], unassignedSeats: 0 })
+      )
+      .mockResolvedValueOnce(
+        new Ok({ assignedSeatIds: ["u1"], unassignedSeats: 2 })
+      );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
+      contract: makeContract([
+        { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
+      ]),
+    });
+
+    // Now: assign u1 and pad to floor 3 (2 unassigned).
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: ["u1"],
+        addUnassignedSeats: 2,
+        removeUnassignedSeats: 0,
+      })
+    );
+    // At the effective date: membership unchanged — only unassigned seats grow to
+    // reach the new floor 5 (2 → 4), pinned to `scheduledAt`.
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: [],
+        removeSeatIds: [],
+        addUnassignedSeats: 2,
+        removeUnassignedSeats: 0,
+        startingAt: scheduledAt.toISOString(),
       })
     );
   });

--- a/front/lib/resources/workspace_seat_limit_resource.test.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.test.ts
@@ -4,6 +4,13 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
 
+// Seat-limit windows are floored to the whole UTC hour, so tests that assert on
+// exact boundaries use hour-aligned dates (flooring is then a no-op).
+const HOUR_MS = 60 * 60 * 1000;
+function hourAligned(ms: number): Date {
+  return new Date(Math.floor(ms / HOUR_MS) * HOUR_MS);
+}
+
 describe("WorkspaceSeatLimitResource", () => {
   let workspace: LightWorkspaceType;
   // Captured so scheduleChange can nest under the test-isolation transaction as
@@ -176,7 +183,7 @@ describe("WorkspaceSeatLimitResource", () => {
       maxSeats: 10,
     });
 
-    const startAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const startAt = hourAligned(Date.now() + 30 * 24 * 60 * 60 * 1000);
     const result = await WorkspaceSeatLimitResource.setScheduledLimit({
       workspace,
       seatType: "pro",
@@ -367,8 +374,8 @@ describe("WorkspaceSeatLimitResource", () => {
       minSeats: 99,
     });
 
-    const phase1Start = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    const phase2Start = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const phase1Start = hourAligned(Date.now() - 24 * 60 * 60 * 1000);
+    const phase2Start = hourAligned(Date.now() + 30 * 24 * 60 * 60 * 1000);
     // Only starts are provided; the resource derives phase 1's end from phase 2.
     const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
       workspace,
@@ -424,8 +431,8 @@ describe("WorkspaceSeatLimitResource", () => {
   });
 
   it("derives contiguous windows and an open-ended last phase from starts", async () => {
-    const start1 = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
-    const start2 = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000);
+    const start1 = hourAligned(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const start2 = hourAligned(Date.now() + 20 * 24 * 60 * 60 * 1000);
     const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
       workspace,
       seatType: "pro",
@@ -494,5 +501,61 @@ describe("WorkspaceSeatLimitResource", () => {
       at: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
     });
     expect(futureLimits.has("pro")).toBe(false);
+  });
+
+  it("floors setScheduledLimit dates to the whole UTC hour", async () => {
+    const startAt = new Date("2026-08-01T14:37:42.000Z");
+    const endAt = new Date("2026-09-01T09:15:00.000Z");
+    const result = await WorkspaceSeatLimitResource.setScheduledLimit({
+      workspace,
+      seatType: "pro",
+      minSeats: 4,
+      startAt,
+      endAt,
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const schedule = await WorkspaceSeatLimitResource.fetchScheduleByWorkspace({
+      workspace,
+      at: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    const proPhases = schedule.get("pro") ?? [];
+    expect(proPhases).toHaveLength(1);
+    expect(proPhases[0].startAt.toISOString()).toBe("2026-08-01T14:00:00.000Z");
+    expect(proPhases[0].endAt?.toISOString()).toBe("2026-09-01T09:00:00.000Z");
+  });
+
+  it("floors setScheduleForSeatType phase starts to the whole UTC hour", async () => {
+    const result = await WorkspaceSeatLimitResource.setScheduleForSeatType({
+      workspace,
+      seatType: "pro",
+      phases: [
+        {
+          minSeats: 3,
+          maxSeats: null,
+          startAt: new Date("2026-08-01T10:59:59.000Z"),
+        },
+        {
+          minSeats: 6,
+          maxSeats: null,
+          startAt: new Date("2026-09-01T00:30:00.000Z"),
+        },
+      ],
+      transaction: outerTransaction,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const schedule = await WorkspaceSeatLimitResource.fetchScheduleByWorkspace({
+      workspace,
+      at: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    const proPhases = schedule.get("pro") ?? [];
+    expect(proPhases).toHaveLength(2);
+    expect(proPhases[0].startAt.toISOString()).toBe("2026-08-01T10:00:00.000Z");
+    // Derived end of phase 1 equals the floored start of phase 2.
+    expect(proPhases[0].endAt?.toISOString()).toBe("2026-09-01T00:00:00.000Z");
+    expect(proPhases[1].startAt.toISOString()).toBe("2026-09-01T00:00:00.000Z");
+    expect(proPhases[1].endAt).toBeNull();
   });
 });

--- a/front/lib/resources/workspace_seat_limit_resource.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.ts
@@ -35,6 +35,14 @@ export type SeatLimitSegment = SeatLimit & {
   endAt: Date | null;
 };
 
+// Metronome effective dates must land on a whole UTC hour, so every scheduled
+// seat-limit window is floored to the top of the hour here — regardless of what
+// callers pass. Flooring epoch ms to an hour boundary yields a whole UTC hour.
+const HOUR_MS = 3_600_000;
+function floorToHourUTC(date: Date): Date {
+  return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS);
+}
+
 function validateMaxSeats({
   minSeats,
   maxSeats,
@@ -242,7 +250,10 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
     if (validation.isErr()) {
       return validation;
     }
-    if (endAt !== null && endAt <= startAt) {
+    // Whole-hour UTC alignment for Metronome effective dates.
+    const flooredStartAt = floorToHourUTC(startAt);
+    const flooredEndAt = endAt === null ? null : floorToHourUTC(endAt);
+    if (flooredEndAt !== null && flooredEndAt <= flooredStartAt) {
       return new Err(new Error("endAt must be after startAt."));
     }
     // Nest under the caller's transaction when provided (SAVEPOINT) so the
@@ -255,7 +266,7 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
         where: {
           workspaceId: workspace.id,
           seatType,
-          startAt: { [Op.gte]: startAt },
+          startAt: { [Op.gte]: flooredStartAt },
         },
         transaction: t,
       });
@@ -265,8 +276,8 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
         where: { workspaceId: workspace.id, seatType, endAt: null },
         transaction: t,
       });
-      if (current && current.startAt < startAt) {
-        await current.update({ endAt: startAt }, { transaction: t });
+      if (current && current.startAt < flooredStartAt) {
+        await current.update({ endAt: flooredStartAt }, { transaction: t });
       }
       await this.model.create(
         {
@@ -274,8 +285,8 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
           seatType,
           minSeats,
           maxSeats: maxSeats ?? null,
-          startAt,
-          endAt,
+          startAt: flooredStartAt,
+          endAt: flooredEndAt,
         },
         { transaction: t }
       );
@@ -312,9 +323,11 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
     }>;
     transaction?: Transaction;
   }): Promise<Result<void, Error>> {
-    const sorted = [...phases].sort(
-      (a, b) => a.startAt.getTime() - b.startAt.getTime()
-    );
+    // Floor every start to the top of the UTC hour (Metronome parity), then
+    // order by start.
+    const sorted = phases
+      .map((phase) => ({ ...phase, startAt: floorToHourUTC(phase.startAt) }))
+      .sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
     for (let i = 0; i < sorted.length; i++) {
       const phase = sorted[i];
       const validation = validateMaxSeats({


### PR DESCRIPTION
## Description

Read the seat-limit schedule in the Metronome seat sync and program each
scheduled change with an effective date, and let the poke plugin schedule them.

- syncSeatCount adds each scheduled seat-limit change to the set of effective
  timestamps and resolves the limit active at each timestamp. SEAT_BASED only
  moves the unassigned (committed-floor) seats at the effective date;
  QUANTITY_ONLY sends the quantity for now plus future-dated quantities
  (consecutive equal quantities skipped). Because the sync reads the full
  schedule, launching it after an edit programs Metronome ahead of time.
- manage-seat-limits plugin gains optional start/end dates (routes through
  setScheduledLimit).
- Sync tests.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

deploy front
