### PR TITLE
fix(conversation): make Pod breadcrumb a real link so Cmd+click opens a new tab

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -9,7 +9,6 @@ import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversation } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
@@ -44,7 +43,6 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     workspaceId: owner.sId,
     spaceId: conversation?.spaceId ?? null,
   });
-  const router = useAppRouter();
   const isMobile = useIsMobile();
 
   const [showRenameDialog, setShowRenameDialog] = useState(false);
@@ -76,11 +74,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     breadcrumbItems.push({
       icon: isMobile ? undefined : ArrowLeft,
       label: spaceInfo.name,
-      onClick: () => {
-        void router.push(getPodRoute(owner.sId, spaceId), undefined, {
-          shallow: true,
-        });
-      },
+      href: getPodRoute(owner.sId, spaceId),
     });
   }
 


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/9622
## Description

Cmd+clicking the Pod breadcrumb title in the conversation header navigated the current tab to the Pod instead of opening it in a new tab.

The breadcrumb item was wired as an `onClick` + `router.push(...)`, which renders a plain `<button>` — the browser has no URL to open in a new tab, so modified clicks just fired the handler.

This switches the item to Sparkle's existing `LinkBreadcrumbItem` variant (`href: getPodRoute(...)`), which renders the exact same button styles onto a real anchor via the app link component (react-router `Link`). React Router only intercepts plain left-clicks, so Cmd/Ctrl/middle-click open a new tab natively while plain clicks keep client-side navigation.

Notes:
- No visual change: `LinkBreadcrumbItem` renders the same `Button` (variant, size, icon, truncation, tooltip) with styles slotted onto the anchor.
- The dropped `shallow: true` is a no-op: the SPA `useAppRouter().push` ignores the options argument.
- Matches existing patterns: the sidebar Pod item and `SpaceBreadcrumb` already navigate via `href`.

## Risk

Low — one breadcrumb item changed from button to link, same rendered styles, same client-side navigation path.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)