### PR TITLE
[front] Remove sandbox invocation context

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -218,7 +218,6 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       functionIdOrSlug: sandboxFunction.sId,
       body: {
         input: { message: "hello" },
-        context: { frameFileId: sandboxFunction.file.sId },
       },
     });
 
@@ -237,7 +236,6 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       SandboxFunctionInvocationResource.prototype.execute
     ).toHaveBeenCalledWith(expect.anything(), {
       input: { message: "hello" },
-      context: { frameFileId: sandboxFunction.file.sId },
     });
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -31,12 +31,6 @@ const ValidateActionBodySchema = z
 const PostSandboxFunctionInvocationBodySchema = z
   .object({
     input: z.unknown().optional(),
-    context: z
-      .object({
-        frameFileId: z.string().optional(),
-      })
-      .strict()
-      .optional(),
   })
   .strict();
 

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -481,7 +481,6 @@ export function CodeDrawer({
 interface VisualizationActionIframeProps {
   agentConfigurationId: string | null;
   conversationId: string | null;
-  frameFileId?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   isPublic?: boolean;
@@ -565,7 +564,6 @@ export const VisualizationActionIframe = forwardRef<
   const {
     agentConfigurationId,
     conversationId,
-    frameFileId,
     isEditable = false,
     isInDrawer = false,
     isPublic = false,
@@ -631,7 +629,6 @@ export const VisualizationActionIframe = forwardRef<
 
         const body: PostSandboxFunctionInvocationRequestBody = {
           input,
-          context: frameFileId ? { frameFileId } : undefined,
         };
 
         const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);
@@ -659,7 +656,7 @@ export const VisualizationActionIframe = forwardRef<
         return new Err(normalizeError(error));
       }
     },
-    [frameFileId, isPublic, workspaceId]
+    [isPublic, workspaceId]
   );
 
   useVisualizationDataHandler({

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -442,7 +442,6 @@ export function FrameRenderer({
                 identifier: `viz-${fileId}`,
               }}
               key={`viz-${fileId}`}
-              frameFileId={fileId}
               conversationId={conversation?.sId ?? null}
               isEditable={true}
               spaceId={frameSpaceId ?? undefined}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -55,7 +55,6 @@ function PodPinnedBannerFrame({
         identifier: `viz-banner-${fileId}`,
       }}
       conversationId={null}
-      frameFileId={fileId}
       spaceId={podId}
       isInDrawer={true}
       ref={iframeRef}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -112,7 +112,6 @@ export function PodFrameSheet({
                 }}
                 key={`viz-${fileId}`}
                 conversationId={null}
-                frameFileId={fileId}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 isInDrawer={true}
                 ref={iframeRef}

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -102,7 +102,6 @@ async function setupExecutionTest() {
   return {
     authenticator,
     space,
-    file,
     sandboxFunction,
     sandbox,
     invocation,
@@ -199,7 +198,7 @@ describe("SandboxFunctionInvocationResource", () => {
   });
 
   it("executes an invocation on the pod sandbox", async () => {
-    const { authenticator, space, file, sandboxFunction, sandbox, invocation } =
+    const { authenticator, space, sandboxFunction, sandbox, invocation } =
       await setupExecutionTest();
     const updateLastActivityAtSpy = vi.spyOn(sandbox, "updateLastActivityAt");
     const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
@@ -219,7 +218,6 @@ describe("SandboxFunctionInvocationResource", () => {
 
     const executionResult = await invocation.execute(authenticator, {
       input: { message: "hello" },
-      context: { frameFileId: file.sId },
     });
     if (executionResult.isErr()) {
       throw executionResult.error;
@@ -270,7 +268,6 @@ describe("SandboxFunctionInvocationResource", () => {
       url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${invocation.sId}`,
       headers: {
         "content-type": "application/json",
-        "x-dust-frame-file-id": file.sId,
         "x-dust-sandbox-function-id": sandboxFunction.sId,
         "x-dust-sandbox-function-invocation-id": invocation.sId,
       },

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -222,9 +222,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           "content-type": "application/json",
           "x-dust-sandbox-function-id": sandboxFunction.sId,
           "x-dust-sandbox-function-invocation-id": this.sId,
-          ...(body.context?.frameFileId
-            ? { "x-dust-frame-file-id": body.context.frameFileId }
-            : {}),
         },
         ...(body.input === undefined
           ? {}

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -87,9 +87,6 @@ export function isSandboxFunctionInvocationTerminalEvent(
 
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
-  context?: {
-    frameFileId?: string;
-  };
 };
 
 export type PostSandboxFunctionInvocationResponseBody = {


### PR DESCRIPTION
## Description

Remove the unused sandbox function invocation context and its `frameFileId` plumbing.

The context was only forwarded to user function code as an HTTP header and had no Dust-side consumer.

## Tests

- `NODE_ENV=test npm test -- lib/resources/sandbox_function_invocation_resource.test.ts`
- `NODE_ENV=test npm test -- routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts`
- Tested locally

## Risk

Low. This removes an unused internal request field and header.

## Deploy Plan

- deploy `front`
- deploy `front-api`
