### PR TITLE
[Sessions] Keep conversation forks at root depth

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -481,12 +481,13 @@ function mockContentNodeAttachments(nodeDataSourceViewId: number) {
 }
 
 describe("createConversationFork", () => {
-  it("creates the child conversation, sole participant, and lineage row", async () => {
+  it("creates the child at root depth with sole participant and lineage row", async () => {
     const { auth, globalSpace, user } = await createPrivateApiMockRequest();
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
+      depth: 1,
       spaceId: globalSpace.id,
     });
 

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -519,7 +519,7 @@ describe("createConversationFork", () => {
 
     expect(childConversation.title).toBeNull();
     expect(childConversation.spaceId).toBe(globalSpace.sId);
-    expect(childConversation.depth).toBe(parentConversation.depth + 1);
+    expect(childConversation.depth).toBe(0);
     expect(childConversation.forkingData).toEqual({
       forkedFrom: {
         parentConversationId: parentConversation.sId,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -628,7 +628,7 @@ export async function createConversationFork(
         sId: generateRandomModelSId(),
         title: null,
         visibility: parentConversation.visibility,
-        depth: parentConversation.depth + 1,
+        depth: 0,
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,
         requestedSpaceIds: [...parentConversation.requestedSpaceIds],


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/9586

Conversation depth is the run-agent recursion level: it controls recursion limits and other sub-agent behavior. Fork lineage is stored separately in `conversation_forks`, so user-created forks now always start at depth 0, including forks created from nested run-agent conversations.

This PR only fixes new fork creation. A follow-up PR will backfill existing forks. Related broader approach: https://github.com/dust-tt/dust/pull/28931.

## Risks
Blast radius: new conversation fork creation
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test npm test -- lib/api/assistant/conversation/forks.test.ts`