### PR TITLE
Move invocation GCS write outside transaction

### DIFF
--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -344,7 +344,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
-    return withTransaction(async (t) => {
+    const resource = await withTransaction(async (t) => {
       const invocation = await this.model.create(
         {
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -367,10 +367,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       });
       const gcsPath = resource.buildGcsPath(auth);
       await resource.update({ gcsPath }, t);
-      await resource.writeDataToGcs();
 
       return resource;
     }, transaction);
+
+    await resource.writeDataToGcs();
+    return resource;
   }
 
   static async createAndStartExecution(


### PR DESCRIPTION
## Description

Move sandbox function invocation data writes to GCS outside the database transaction callback. The transaction now only creates the invocation and persists its generated GCS path.

## Tests

- `NODE_ENV=test npm test -- lib/resources/sandbox_function_invocation_resource.test.ts`

## Risk

Low. This only changes when the initial invocation payload is written to GCS.

## Deploy Plan

- Deploy `front`