### PR TITLE
Fix workspace isolation violation in revoke_frame_share.ts

### DIFF
--- a/front/scripts/revoke_frame_share.ts
+++ b/front/scripts/revoke_frame_share.ts
@@ -1,3 +1,4 @@
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { ShareableFileModel } from "@app/lib/resources/storage/models/files";
 import { makeScript } from "@app/scripts/helpers";
 import type { FileShareScope } from "@app/types/files";
@@ -9,6 +10,12 @@ const DEFAULT_SCOPE: FileShareScope = "emails_only";
 
 makeScript(
   {
+    workspaceId: {
+      type: "string",
+      alias: "w",
+      demandOption: true,
+      describe: "Workspace sId that owns the Frame share to update",
+    },
     tokenId: {
       type: "string",
       demandOption: true,
@@ -24,15 +31,24 @@ makeScript(
         "restrictive scope (emails_only).",
     },
   },
-  async ({ tokenId, scope, execute }, logger) => {
+  async ({ workspaceId, tokenId, scope, execute }, logger) => {
     const targetScope = fileShareScopeSchema.parse(scope);
 
+    const workspace = await getWorkspaceInfos(workspaceId);
+    if (!workspace) {
+      logger.error(`Workspace ${workspaceId} not found`);
+      return;
+    }
+
     const share = await ShareableFileModel.findOne({
-      where: { token: tokenId },
+      where: { token: tokenId, workspaceId: workspace.id },
     });
 
     if (!share) {
-      logger.error(`No shareable_files row found for token ${tokenId}`);
+      logger.error(
+        `No shareable_files row found for token ${tokenId} in workspace ` +
+          `${workspaceId}`
+      );
       return;
     }
 


### PR DESCRIPTION
## Description

Follow-up to #29013. Running `revoke_frame_share.ts` on prodbox logged a `workspace_isolation_violation` warning:

```
"model":"shareable_files","query_type":"find", ... "msg":"workspace_isolation_violation"
```

`ShareableFileModel` is a `WorkspaceAwareModel`, and the script's original lookup (`ShareableFileModel.findOne({ where: { token: tokenId } })`) queried it without a `workspaceId`, tripping the tenant isolation guardrail in `checkWorkspaceIsolation` (`front/lib/resources/storage/wrappers/workspace_models.ts`). It still worked in production (that check only throws outside prod, and warns on a 1% sample in prod), but it's the wrong pattern to ship.

Rather than reach for `dangerouslyBypassWorkspaceIsolationSecurity`, this PR requires the caller to pass `--workspaceId` (the workspace sId), resolves it to the numeric `workspaceId` via `getWorkspaceInfos` (same pattern as `front/scripts/unrevoke_membership.ts`), and scopes the `shareable_files` query by both `token` and `workspaceId`. This satisfies the isolation check properly instead of bypassing it.

## Tests

Not run in CI locally. Manually verified against the running script's actual prodbox output for token `ff743b97-eaeb-43db-b4ec-4871a418addd`: the `shareableFileId`/`fileId`/`workspaceId` returned by the original (unscoped) query match what this scoped query will return, since `workspaceId=274877908216` for that row. Local validation was not run in the Computer; relying on PR CI (typecheck/lint) for verification.

## Risk

Low risk: adds a required parameter and an extra `where` clause key. No schema changes. Existing invocations from earlier today (without `--workspaceId`) will now fail argument validation and need to be re-run with the flag, that's intentional.

## Deploy Plan

1. Merge this PR.
2. On prodbox, pull `main`.
3. Re-run dry-run with the new required flag:
   `npx tsx front/scripts/revoke_frame_share.ts --workspaceId <lokalise-sId> --tokenId ff743b97-eaeb-43db-b4ec-4871a418addd --scope workspace_and_emails`
4. Confirm no `workspace_isolation_violation` warning this time, then re-run with `--execute`.
5. Post the command and outcome to `#engineering_papertrail`.