### PR TITLE
fix(front): surface triggered conversations blocked on user input in the inbox

### DIFF
--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -38,8 +38,7 @@ type GroupLabel =
   | "Last 12 Months"
   | "Older";
 
-// We treat the conversations as unread if they are unread or have an action required
-// (note that action required conversations are never marked as unread).
+// We treat the conversations as unread if they are unread or have an action required.
 // Unread reinforced-skill-notification conversations are split out into their own bucket so
 // the sidebar can show them in a dedicated "Skill suggestions" section above the Inbox; once
 // read they fall back into the date-grouped Conversations list like any other read conversation.

--- a/front/lib/api/assistant/conversation/triggered_blocked_inbox.test.ts
+++ b/front/lib/api/assistant/conversation/triggered_blocked_inbox.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Redis hybrid manager (same as blocked_actions.test.ts) so cleanup paths don't hit Redis.
+const { removeEventMock } = vi.hoisted(() => ({
+  removeEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: removeEventMock,
+  }),
+}));
+
+import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+
+/**
+ * Repro for: triggered conversations with a blocking action (tool approval) never show up in
+ * the inbox.
+ *
+ * Inbox condition (client-side, see
+ * front/components/assistant/conversation/utils.ts filterTriggeredConversations /
+ * getGroupConversationsByUnreadAndActionRequired): a triggered conversation is surfaced iff
+ * `unread || actionRequired` on the list item returned by
+ * GET /api/w/{wId}/assistant/conversations (listPrivateConversationsForUserPaginated).
+ */
+describe("triggered conversation with blocked action → inbox visibility", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    // Mimic the trigger flow (front/temporal/triggers/activities.ts):
+    // createConversation + postUserMessage with the trigger owner's auth.
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const trigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: "test-agent",
+      configuration: {
+        cron: "0 9 * * *",
+        timezone: "UTC",
+      },
+    });
+    await ConversationFactory.setTriggerIdForTest(
+      conversation.id,
+      workspace.id,
+      trigger.id
+    );
+
+    // postUserMessage upserts participation with default lastReadAt = new Date(),
+    // so the conversation starts "read" for the trigger owner.
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+    });
+  });
+
+  async function getListItem() {
+    const { conversations } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        auth,
+        { limit: 100 }
+      );
+    return conversations.find((c) => c.sId === conversation.sId);
+  }
+
+  it("appears in inbox after a tool blocks on validation (run_tool path)", async () => {
+    // Agent message stays status "created" with a blocked_validation_required action.
+    await AgentMCPActionFactory.createWithAgentMessage(auth, {
+      workspace,
+      conversation,
+    });
+
+    // What run_tool.ts does when it sees tool_approve_execution:
+    await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    const item = await getListItem();
+    expect(item).toBeDefined();
+    expect(item?.actionRequired).toBe(true);
+    // Blocking bumps `updatedAt` past the owner's post-time `lastReadAt`.
+    expect(item?.unread).toBe(true);
+    // Inbox condition:
+    expect(item!.unread || item!.actionRequired).toBe(true);
+  });
+
+  it("keeps actionRequired when the stale-flag cleanup runs (GET conversation path)", async () => {
+    // Production-faithful linkage: agent message has a parent user message
+    // (postUserMessage always sets parentId).
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Trigger message",
+    });
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Blocked Test Agent",
+    });
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+    await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessageRow.agentMessageId!,
+    });
+    await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    // GET /conversations/[cId] runs this to clear stale flags; it must NOT clear the flag
+    // while a blocked action is still pending.
+    await clearActionRequiredIfNoBlockedActions(auth, {
+      conversationId: conversation.sId,
+    });
+
+    const item = await getListItem();
+    expect(item?.actionRequired).toBe(true);
+  });
+
+  it("resurfaces to the top of the paginated list when a tool blocks", async () => {
+    // The conversation was triggered a while ago and other conversations have
+    // been updated since: pin its updatedAt in the past and add a newer one.
+    await ConversationFactory.setUpdatedAtForTest(
+      auth,
+      conversation.id,
+      new Date(Date.now() - 60 * 60 * 1000)
+    );
+    const newerConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    await ConversationResource.upsertParticipation(auth, {
+      conversation: newerConversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+    });
+
+    // Sidebar fetches pages of N most-recently-updated conversations. With a page
+    // of 1 (stand-in for 100 in prod), the triggered conversation is not in the
+    // page while it runs.
+    const { conversations: beforeBlock } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        auth,
+        { limit: 1 }
+      );
+    expect(beforeBlock.map((c) => c.sId)).not.toContain(conversation.sId);
+
+    // A tool blocks on validation: like the completed-run path, this must bump
+    // updatedAt so the conversation re-enters the fetched window and the inbox.
+    await AgentMCPActionFactory.createWithAgentMessage(auth, {
+      workspace,
+      conversation,
+    });
+    await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    const { conversations: afterBlock } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        auth,
+        { limit: 1 }
+      );
+    expect(afterBlock.map((c) => c.sId)).toContain(conversation.sId);
+    expect(afterBlock[0].unread).toBe(true);
+    expect(afterBlock[0].actionRequired).toBe(true);
+  });
+});

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2487,6 +2487,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     );
 
+    // Bump `updatedAt` like the completed-run path does: the sidebar list is paginated by
+    // `updatedAt` and a blocked conversation would otherwise keep its creation-time position
+    // (and stay read), so it would never surface in the inbox while waiting on user input.
+    await this.markAsUpdated(auth, { conversation });
+
     return new Ok(updated);
   }
 


### PR DESCRIPTION
## Description

Triggered conversations that pause on a blocking action (tool approval, personal auth, ask-user-question) never surface in the inbox, so unattended runs block forever and nothing is delivered.

A triggered conversation is marked **read** for its owner at creation (`postUserMessage` bumps `updatedAt`, then writes the owner's `lastReadAt`). Only the terminal success path bumps `updatedAt` again — that's what makes a completed triggered conversation unread and re-sorts it to the top of the sidebar. When the loop blocked instead, `markAsActionRequired` only set the per-user participant flag: `unread` stayed false forever, and the conversation kept its creation-time position in the `updatedAt DESC`-paginated conversations list (pages of 100), falling out of the fetched window — its `actionRequired: true` never reached the client. With the "Hide triggered" sidebar filter on, it disappeared from the sidebar entirely.

Fix: bump `conversation.updatedAt` in `ConversationResource.markAsActionRequired`, mirroring the completed-run path. All three blocking call sites go through it. A blocked conversation now re-enters the first page, becomes unread, and shows in the Inbox section until the block is resolved. Interactive runs were never visibly affected (the user's own message already bumped `updatedAt` and they see the approval card live), which is why only trigger-initiated runs exhibited the symptom.

## Tests

- New `front/lib/api/assistant/conversation/triggered_blocked_inbox.test.ts`:
  - blocked triggered conversation appears in the paginated list with `actionRequired: true` and `unread: true`;
  - the stale-flag self-heal (`clearActionRequiredIfNoBlockedActions`) keeps the flag while a blocked action is pending;
  - a triggered conversation buried below newer conversations resurfaces to the top of the page when a tool blocks (regression for the pagination mechanism).
- Existing `markAsActionRequired` suite in `conversation_resource.test.ts` passes. Two failures elsewhere in that file ("missing step content link", "hydrates nextWakeupAt") reproduce identically on unmodified `main` — pre-existing, unrelated.
- `tsgo --noEmit` and biome clean.

## Risk

Low. One additional `UPDATE` on `conversations` per blocking event, behind the existing participant-flag write. Behavior change is intentional and applies to all origins: any conversation blocking on user input now becomes unread and re-sorts to the top of the sidebar (previously only visible via `actionRequired` when within the fetched page). No schema change; safe to roll back.

## Deploy Plan

Standard front deploy, no ordering constraints. Conversations already stuck before the deploy keep their stale `updatedAt` and will not resurface on their own — resolving the existing backlog needs a one-off backfill (bump `updatedAt` on conversations with pending blocked actions) or manual triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)