### PR TITLE
[front] remove background color from date indicator

### DIFF
--- a/front/components/assistant/conversation/MessageDateIndicator.tsx
+++ b/front/components/assistant/conversation/MessageDateIndicator.tsx
@@ -9,7 +9,7 @@ export const MessageDateIndicator = ({
 }) => {
   return (
     <div className="mb-3 mt-1 select-none text-center">
-      <span className="rounded bg-background px-4 text-xs text-faint">
+      <span className="rounded px-4 text-xs text-faint">
         {formatCalendarDate(getMessageDate(message))}
       </span>
     </div>


### PR DESCRIPTION
## Description
This PR is to remove the background color from date indicator in conversation view:

before:
<img width="276" height="78" alt="CleanShot 2026-07-16 at 09 17 24@2x" src="https://github.com/user-attachments/assets/005c778c-1d0f-49e8-a420-640990edda69" />

after: 
<img width="206" height="62" alt="CleanShot 2026-07-16 at 09 17 49@2x" src="https://github.com/user-attachments/assets/50eda1a2-49a7-41b3-b927-f5a45ec1a10f" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
