### PR TITLE
[sparkle] ButtonsSwitch: white container background

### DIFF
--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -31,7 +31,7 @@ const useButtonsSwitch = () => {
 const listStyles = cva(
   cn(
     "inline-flex items-center gap-1",
-    "box-border bg-muted border border-border"
+    "box-border bg-background border border-border"
   ),
   {
     variants: {


### PR DESCRIPTION
## Summary

- Changes `ButtonsSwitchList` container background from `bg-muted` (stone-50) to `bg-background` (white) for a cleaner, lighter look.

## Test plan

- [ ] Check `ButtonsSwitch` in Storybook (light + dark theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)