### PR TITLE
Surface space-restricted skills in capability pickers

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -235,6 +235,32 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).toContain("Skill In Restricted Space");
   });
 
+  it("includes accessible restricted skills by default but excludes them when globalSpaceOnly=true", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [user.sId] });
+
+    await SkillFactory.create(auth, {
+      name: "Member Restricted Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const defaultRes = await getSkills(workspace);
+    const defaultNames = (await defaultRes.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(defaultNames).toContain("Member Restricted Skill");
+
+    const globalRes = await getSkills(workspace, { globalSpaceOnly: "true" });
+    const globalNames = (await globalRes.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(globalNames).not.toContain("Member Restricted Skill");
+  });
+
   it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 
@@ -767,6 +793,29 @@ describe("POST /api/w/:wId/skills", () => {
         message: `User does not have access to the following spaces: ${restrictedSpace.sId}`,
       },
     });
+  });
+
+  it("allows restricting a skill to an open Pod the user can access", async () => {
+    const { workspace, globalGroup } = await setupTest("builder");
+
+    const openPod = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(openPod, globalGroup);
+
+    const response = await postSkill(workspace, {
+      name: "Skill Restricted To Open Pod",
+      agentFacingDescription: "To use with an open Pod",
+      userFacingDescription: "A skill with a selected Pod",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [openPod.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.skill.requestedSpaceIds).toContain(openPod.sId);
   });
 
   it("creates a skill configuration with 2 tools", async () => {

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -271,7 +271,6 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !shouldFetchToolsData,
   });
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -72,7 +72,6 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
   });
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(owner, globalSpaces);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -180,7 +180,6 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1114,7 +1114,6 @@ export function usePodDefaultSkills({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !enabled,
   });
 


### PR DESCRIPTION
Removes the globalSpaceOnly filter from useSkills in the capabilities
picker, pod settings, slash-command capabilities, and usePodDefaultSkills
so skills restricted to spaces/Pods the user can access appear in the
pickers. Adds an endpoint test for the default vs globalSpaceOnly listing
behavior.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
