### PR TITLE
[LLM] Add global Gemini stream endpoints + fix Gemini pricing/regions

### DIFF
--- a/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite";
+
+export class DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream extends WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
@@ -8,4 +8,6 @@ export class DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream extends Wit
   static readonly endpointFilter = {};
 }
 
-defineDustStreamEndpoint(DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream);
+defineDustStreamEndpoint(
+  DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream
+);

--- a/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_pro.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_pro.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro";
+
+export class DustAgentPlatformGlobalGeminiThreeDotOneProStream extends WithDustGoogleAiStudioGeminiThreeDotOneProConfig(
+  AgentPlatformGlobalGeminiThreeDotOneProStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAgentPlatformGlobalGeminiThreeDotOneProStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_5_flash.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_global_gemini_3_5_flash.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash";
+
+export class DustAgentPlatformGlobalGeminiThreeDotFiveFlashStream extends WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  AgentPlatformGlobalGeminiThreeDotFiveFlashStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAgentPlatformGlobalGeminiThreeDotFiveFlashStream);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,13 @@
+import { WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+
+export class DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream extends WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(
+  DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream
+);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+
+export class DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream extends WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -18,7 +18,9 @@ import { DustFireworksGlobalDeepSeekV4ProStream } from "@app/lib/llms/stream/end
 import { DustFireworksGlobalGlmFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { DustFireworksGlobalKimiK2Dot5Stream } from "@app/lib/llms/stream/endpoints/fireworks_global_kimi_k2_dot_five";
 import { DustFireworksGlobalKimiK2Dot6Stream } from "@app/lib/llms/stream/endpoints/fireworks_global_kimi_k2_dot_six";
+import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustMistralEuropeCodestralStream } from "@app/lib/llms/stream/endpoints/mistral_eu_codestral";
 import { DustMistralEuropeMistralLargeStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_large";
 import { DustMistralEuropeMistralMedium35Stream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5";
@@ -87,8 +89,12 @@ export const DUST_STREAM_ENDPOINTS = {
     DustFireworksGlobalGlmFiveDotTwoStream,
   [DustFireworksGlobalKimiK2Dot5Stream.id]: DustFireworksGlobalKimiK2Dot5Stream,
   [DustFireworksGlobalKimiK2Dot6Stream.id]: DustFireworksGlobalKimiK2Dot6Stream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
   [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     DustGoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
   [DustMistralEuropeCodestralStream.id]: DustMistralEuropeCodestralStream,
   [DustMistralEuropeMistralLargeStream.id]: DustMistralEuropeMistralLargeStream,
   [DustMistralEuropeMistralMedium35Stream.id]:

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -7,6 +7,9 @@ import { DustAgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/llms/str
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite";
+import { DustAgentPlatformGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/agent_platform_global_gemini_3_1_pro";
+import { DustAgentPlatformGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_global_gemini_3_5_flash";
 import { DustAnthropicGlobalClaudeFableFiveStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_fable_five";
 import { DustAnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
@@ -69,6 +72,12 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream,
   [DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
     DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
+  [DustAgentPlatformGlobalGeminiThreeDotFiveFlashStream.id]:
+    DustAgentPlatformGlobalGeminiThreeDotFiveFlashStream,
+  [DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    DustAgentPlatformGlobalGeminiThreeDotOneFlashLiteStream,
+  [DustAgentPlatformGlobalGeminiThreeDotOneProStream.id]:
+    DustAgentPlatformGlobalGeminiThreeDotOneProStream,
   [DustAnthropicGlobalClaudeFableFiveStream.id]:
     DustAnthropicGlobalClaudeFableFiveStream,
   [DustAnthropicGlobalClaudeHaikuFourDotFiveStream.id]:

--- a/front/lib/model_constructors/stream/clients/google_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/google_agent_platform.ts
@@ -24,7 +24,7 @@ import { GoogleGenAI } from "@google/genai";
 // the same place — it passes no location, so `@google/genai` defaults to
 // `global`. Extend with a specific region (e.g. `europe-west1`) once these
 // models become available there.
-export type GoogleAgentPlatformLocation = "global";
+export type GoogleAgentPlatformLocation = "global" | "eu";
 
 // Gemini-on-Vertex transport. Same @google/genai SDK and converters as the AI
 // Studio client; only the client construction differs (Vertex project +

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
@@ -6,15 +6,17 @@ import { EUROPE } from "@app/lib/model_constructors/types/regions";
 export class AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
   GoogleAgentPlatformStream
 ) {
+  // Agent platform bills 10% more in multi-region.
   static readonly tokenPricing = {
-    cacheCreated: 1.0,
-    cacheHit: 0.025,
-    standardInput: 0.25,
-    standardOutput: 1.5,
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.0275,
+    standardInput: 0.275,
+    standardOutput: 1.65,
   };
 
   static readonly region = EUROPE;
-  static readonly regionalEndpoint = "global";
+  static readonly regionalEndpoint = "eu";
 
   static readonly id = this.buildId();
 }

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
@@ -6,15 +6,17 @@ import { EUROPE } from "@app/lib/model_constructors/types/regions";
 export class AgentPlatformEuropeGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
   GoogleAgentPlatformStream
 ) {
+  // Agent platform bills 10% more in multi-region.
   static readonly tokenPricing = {
-    cacheCreated: 1.0,
-    cacheHit: 0.15,
-    standardInput: 1.5,
-    standardOutput: 9.0,
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.165,
+    standardInput: 1.65,
+    standardOutput: 9.9,
   };
 
   static readonly region = EUROPE;
-  static readonly regionalEndpoint = "global";
+  static readonly regionalEndpoint = "eu";
 
   static readonly id = this.buildId();
 }

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,24 @@
+import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/google_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  GoogleAgentPlatformStream
+) {
+  // Global endpoint bills at base rate (non-global adds 10%).
+  static readonly tokenPricing = {
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.025,
+    standardInput: 0.25,
+    standardOutput: 1.5,
+  };
+
+  static readonly region = GLOBAL;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro.ts
@@ -1,0 +1,24 @@
+import { WithGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
+import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/google_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformGlobalGeminiThreeDotOneProStream extends WithGoogleAiStudioGeminiThreeDotOneProConfig(
+  GoogleAgentPlatformStream
+) {
+  // Global endpoint bills at base rate (non-global adds 10%).
+  static readonly tokenPricing = {
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.4,
+    standardInput: 4.0,
+    standardOutput: 18.0,
+  };
+
+  static readonly region = GLOBAL;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformGlobalGeminiThreeDotOneProStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash.ts
@@ -1,0 +1,24 @@
+import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { GoogleAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/google_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformGlobalGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  GoogleAgentPlatformStream
+) {
+  // Global endpoint bills at base rate (non-global adds 10%).
+  static readonly tokenPricing = {
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.15,
+    standardInput: 1.5,
+    standardOutput: 9.0,
+  };
+
+  static readonly region = GLOBAL;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformGlobalGeminiThreeDotFiveFlashStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,23 @@
+import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  GoogleAiStudioStream
+) {
+  //TODO(new-llm): implement progressive token billing
+  static readonly tokenPricing = {
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.025,
+    standardInput: 0.25,
+    standardOutput: 1.5,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -8,7 +8,8 @@ export class GoogleAiStudioGlobalGeminiThreeDotOneProStream extends WithGoogleAi
 ) {
   //TODO(new-llm): implement progressive token billing
   static readonly tokenPricing = {
-    cacheCreated: 4.5,
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
     cacheHit: 0.4,
     standardInput: 4.0,
     standardOutput: 18.0,

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,23 @@
+import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  GoogleAiStudioStream
+) {
+  //TODO(new-llm): implement progressive token billing
+  static readonly tokenPricing = {
+    // Gemini uses implicit caching; cache creation is not charged.
+    cacheCreated: 0,
+    cacheHit: 0.15,
+    standardInput: 1.5,
+    standardOutput: 9.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -7,6 +7,9 @@ import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constr
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite";
+import { AgentPlatformGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro";
+import { AgentPlatformGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash";
 import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
@@ -18,7 +21,9 @@ import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/
 import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
 import { FireworksGlobalKimiK2Dot6Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_six";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
@@ -60,6 +65,12 @@ export const STREAM_ENDPOINTS = {
     AgentPlatformEuropeGeminiThreeDotFiveFlashStream,
   [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
     AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
+  [AgentPlatformGlobalGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformGlobalGeminiThreeDotFiveFlashStream,
+  [AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream,
+  [AgentPlatformGlobalGeminiThreeDotOneProStream.id]:
+    AgentPlatformGlobalGeminiThreeDotOneProStream,
   [AnthropicGlobalClaudeFableFiveStream.id]:
     AnthropicGlobalClaudeFableFiveStream,
   [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
@@ -78,8 +89,12 @@ export const STREAM_ENDPOINTS = {
   [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
   [FireworksGlobalKimiK2Dot6Stream.id]: FireworksGlobalKimiK2Dot6Stream,
+  [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
   [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
   [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStream,
   [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
   [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35Stream,

--- a/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_flash_lite.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+
+import { AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformGlobalGeminiThreeDotOneFlashLiteStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
+      // unsupported and rejected by the config schema. `none` maps to the minimum
+      // thinking budget with thoughts hidden (legacy parity).
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-1/r-none": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-none": null,
+
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-1/r-minimal": null,
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+
+      // Even with low effort, Flash-Lite does not always emit a reasoning item,
+      // so this case can be flaky.
+      "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_flash_lite.test.ts
+runStreamEndpointTests(
+  AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream,
+  AgentPlatformGlobalGeminiThreeDotOneFlashLiteStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_pro.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+
+import { AgentPlatformGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformGlobalGeminiThreeDotOneProStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformGlobalGeminiThreeDotOneProStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Pro supports none/low/medium/high; `minimal` and `maximal` are rejected.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_pro.test.ts
+runStreamEndpointTests(
+  AgentPlatformGlobalGeminiThreeDotOneProStream,
+  AgentPlatformGlobalGeminiThreeDotOneProStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_5_flash.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+import { AgentPlatformGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AgentPlatformGlobalGeminiThreeDotFiveFlashStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AgentPlatformGlobalGeminiThreeDotFiveFlashStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash supports minimal/low/medium/high. `none` and `maximal` are
+      // unsupported and rejected by the config schema.
+      "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+      "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-minimal": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_5_flash.test.ts
+runStreamEndpointTests(
+  AgentPlatformGlobalGeminiThreeDotFiveFlashStream,
+  AgentPlatformGlobalGeminiThreeDotFiveFlashStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream({
+        GOOGLE_AI_STUDIO_API_KEY:
+          process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+      }),
+    debug: true,
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
+      // unsupported and rejected by the config schema. `none` maps to the minimum
+      // thinking budget with thoughts hidden (legacy parity).
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-1/r-none": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+      "reasoning/no-tools/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-none": null,
+
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-1/r-minimal": null,
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+
+      // Even with low effort, Flash-Lite does not always emit a reasoning item,
+      // so this case can be flaky.
+      "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+runStreamEndpointTests(
+  GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
+  GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const GoogleAiStudioGlobalGeminiThreeDotFiveFlashStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream({
+        GOOGLE_AI_STUDIO_API_KEY:
+          process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Flash supports minimal/low/medium/high. `none` and `maximal` are
+      // unsupported and rejected by the config schema.
+      "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+      "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+      "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-minimal": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-minimal": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-minimal": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-minimal": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+
+      // Gemini ignores the Anthropic-style cache markers (it uses implicit
+      // caching), so this behaves like a plain "say Hi" prompt.
+      "cache/no-tools/t-default/r-default": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
+runStreamEndpointTests(
+  GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
+  GoogleAiStudioGlobalGeminiThreeDotFiveFlashStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -11,6 +11,9 @@ import { AgentPlatformEuropeClaudeSonnetFiveStream } from "@app/lib/model_constr
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_flash_lite";
+import { AgentPlatformGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_1_pro";
+import { AgentPlatformGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_global_gemini_3_5_flash";
 import { AnthropicGlobalClaudeFableFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_fable_five";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
@@ -22,7 +25,9 @@ import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/
 import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
 import { FireworksGlobalKimiK2Dot6Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_six";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
 import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
@@ -54,6 +59,9 @@ import { AgentPlatformEuropeClaudeSonnetFiveStreamSetup } from "@app/lib/model_c
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test";
 import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test";
 import { AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test";
+import { AgentPlatformGlobalGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_flash_lite.test";
+import { AgentPlatformGlobalGeminiThreeDotOneProStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_1_pro.test";
+import { AgentPlatformGlobalGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/agent_platform_global_gemini_3_5_flash.test";
 import { AnthropicGlobalClaudeFableFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five.test";
 import { AnthropicGlobalClaudeHaikuFourDotFiveStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test";
 import { AnthropicGlobalClaudeOpusFourDotEightStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test";
@@ -65,7 +73,9 @@ import { FireworksGlobalDeepSeekV4ProStreamSetup } from "@app/lib/model_construc
 import { FireworksGlobalGlmFiveDotTwoStreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test";
 import { FireworksGlobalKimiK2Dot5StreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test";
 import { FireworksGlobalKimiK2Dot6StreamSetup } from "@app/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_six.test";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStreamSetup } from "@app/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test";
 import { MistralEuropeCodestralStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_codestral.test";
 import { MistralEuropeMistralLargeStreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test";
 import { MistralEuropeMistralMedium35StreamSetup } from "@app/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test";
@@ -108,6 +118,12 @@ export const STREAM_ENDPOINT_SETUPS = {
     AgentPlatformEuropeGeminiThreeDotFiveFlashStreamSetup,
   [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
     AgentPlatformEuropeGeminiThreeDotOneFlashLiteStreamSetup,
+  [AgentPlatformGlobalGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformGlobalGeminiThreeDotFiveFlashStreamSetup,
+  [AgentPlatformGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformGlobalGeminiThreeDotOneFlashLiteStreamSetup,
+  [AgentPlatformGlobalGeminiThreeDotOneProStream.id]:
+    AgentPlatformGlobalGeminiThreeDotOneProStreamSetup,
   [AnthropicGlobalClaudeFableFiveStream.id]:
     AnthropicGlobalClaudeFableFiveStreamSetup,
   [AnthropicGlobalClaudeHaikuFourDotFiveStream.id]:
@@ -128,8 +144,12 @@ export const STREAM_ENDPOINT_SETUPS = {
     FireworksGlobalGlmFiveDotTwoStreamSetup,
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5StreamSetup,
   [FireworksGlobalKimiK2Dot6Stream.id]: FireworksGlobalKimiK2Dot6StreamSetup,
+  [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStreamSetup,
   [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneProStreamSetup,
+  [GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotFiveFlashStreamSetup,
   [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStreamSetup,
   [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStreamSetup,
   [MistralEuropeMistralMedium35Stream.id]:


### PR DESCRIPTION
## Description

Add global-region Gemini stream endpoints (3.1 Pro, 3.1 Flash Lite, 3.5 Flash) across the inference and dust layers, and correct Gemini pricing (implicit caching → no cache-creation charge, EU multi-region markup) while routing EU endpoints to the `eu` region.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`