### PR TITLE
feat: update governance page ui

### DIFF
--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -1,4 +1,7 @@
 import { CreateGroupDialog } from "@app/components/groups/CreateGroupDialog";
+import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
 import { type GroupKind, MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -83,6 +86,9 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
     kinds: MANAGEABLE_GROUP_KINDS,
   });
 
+  const router = useAppRouter();
+  const { subscription } = useAuth();
+  const isScimAllowed = subscription.plan.limits.users.isSCIMAllowed;
   const [searchTerm, setSearchTerm] = useState("");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
@@ -97,6 +103,15 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
 
   return (
     <div className="flex flex-col gap-4">
+      {isScimAllowed && (
+        <LinkedSectionNotice
+          description="User provisioning is configured in"
+          linkLabel="IT & Security → User provisioning"
+          onLinkClick={() =>
+            void router.push(`/w/${owner.sId}/identity-and-provisioning`)
+          }
+        />
+      )}
       {isGroupsLoading && (
         <div className="flex items-center justify-center py-8">
           <Spinner size="lg" />

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -305,7 +305,7 @@ export const subNavigationAdmin = ({
         ? [
             {
               id: "governance" as const,
-              label: "Governance",
+              label: "Workspace & Governance",
               icon: Toggle01Left,
               href: `/w/${owner.sId}/governance`,
               current: isCurrent("governance"),

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -1,5 +1,6 @@
 import { WorkspaceGroupsList } from "@app/components/groups/WorkspaceGroupsList";
 import { WorkspaceMembersSection } from "@app/components/members/WorkspaceMembersSection";
+import { useQueryParams } from "@app/hooks/useQueryParams";
 import {
   useAuth,
   useFeatureFlags,
@@ -28,6 +29,9 @@ export function MembersPage() {
   const owner = useWorkspace();
   const { subscription, user } = useAuth();
   const plan = subscription.plan;
+
+  const { tab } = useQueryParams(["tab"]);
+  const activeTab = tab.value === "groups" ? "groups" : "members";
 
   const { verifiedDomains, isVerifiedDomainsLoading } =
     useWorkspaceVerifiedDomains({ workspaceId: owner.sId });
@@ -77,7 +81,10 @@ export function MembersPage() {
           description="Manage team members and their roles."
         />
         {isAdminGovernanceEnabled ? (
-          <Tabs defaultValue="members">
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => tab.setParam(value)}
+          >
             <TabsList className="mb-6">
               <TabsTrigger value="members" label="Members" />
               <TabsTrigger value="groups" label="Groups" />

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,5 +1,7 @@
 import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
+import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
+import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { AuditLogsToggle } from "@app/components/workspace/settings/AuditLogsToggle";
 import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
@@ -10,12 +12,14 @@ import { PrivateConversationUrlsToggle } from "@app/components/workspace/setting
 import { SlackPersonalFooterRemovalToggle } from "@app/components/workspace/settings/SlackPersonalFooterRemovalToggle";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
 import { WorkspaceAnalyticsToggle } from "@app/components/workspace/settings/WorkspaceAnalyticsToggle";
+import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
 import { useFrameSharingToggle } from "@app/hooks/useFrameSharingToggle";
 import {
   useAuth,
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
 import { useGovernancePermissions } from "@app/lib/swr/governance";
 import { useGroups } from "@app/lib/swr/groups";
 import type {
@@ -23,6 +27,7 @@ import type {
   GroupPermissionResourceType,
   PermissionType,
 } from "@app/types/group_permissions";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   LightWorkspaceType,
   WorkspaceSharingPolicy,
@@ -73,10 +78,10 @@ export const GovernancePage = () => {
   const hasAdminGovernanceFeature = hasFeature("admin_governance");
 
   const owner = useWorkspace();
-  const { isAdmin, subscription } = useAuth();
+  const { isAdmin } = useAuth();
   const { groups, isGroupsLoading } = useGroups({
     owner,
-    kinds: ["provisioned"],
+    kinds: MANAGEABLE_GROUP_KINDS,
   });
   const { governancePermissions, isLoading: isGovernancePermissionsLoading } =
     useGovernancePermissions(owner);
@@ -98,6 +103,11 @@ export const GovernancePage = () => {
     (permission) =>
       isFrameCapabilityEnabled(permission.permissionType, sharingPolicy)
   );
+
+  const router = useAppRouter();
+  const handleNavigateToGroups = () => {
+    void router.push(`/w/${owner.sId}/members?tab=groups`);
+  };
 
   const sections: {
     id: "agents" | "skills" | "frame" | "billing";
@@ -149,7 +159,7 @@ export const GovernancePage = () => {
   if (isLoading) {
     return (
       <Page>
-        <Page.Header title="Governance" description="Loading..." />
+        <Page.Header title="Workspace & Governance" description="Loading..." />
       </Page>
     );
   }
@@ -157,13 +167,19 @@ export const GovernancePage = () => {
   return (
     <Page>
       <Page.Header
-        title="Governance"
+        title="Workspace & Governance"
         description="Manage what members can do in your workspace."
         icon={Toggle01Left}
       />
       <ContentMessage>
         This page is WIP. Do not change unless you know what you are doing.
       </ContentMessage>
+      <WorkspaceNameEditor owner={owner} />
+      <LinkedSectionNotice
+        description="Groups assigned here are managed in"
+        linkLabel="People → Groups"
+        onLinkClick={handleNavigateToGroups}
+      />
       <div className="flex w-full flex-col gap-8">
         {sections.map(({ id, label, icon, governancePermissions }) => (
           <GovernanceSettingSection key={id} label={label} icon={icon}>
@@ -202,12 +218,11 @@ export const GovernancePage = () => {
               <PodKnowledgePolicy owner={owner} />
             </GovernanceSettingSection>
             <GovernanceSettingSection label="Capabilities" icon={ShapesPlus}>
-              {!subscription.plan.isByok && (
-                <VoiceTranscriptionToggle owner={owner} />
-              )}
+              <VoiceTranscriptionToggle owner={owner} />
               <EmailAgentsToggle owner={owner} />
               <PrivateConversationUrlsToggle owner={owner} />
               <DustMcpServerSettingsItem owner={owner} />
+              <ExtensionMcpToolsSection owner={owner} />
               <SlackPersonalFooterRemovalToggle owner={owner} />
               <WorkspaceAnalyticsToggle owner={owner} />
             </GovernanceSettingSection>

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -57,7 +57,7 @@ export const GroupSelector = ({
                   label={
                     group.kind === "provisioned" ? "Provisioned" : "Manual"
                   }
-                  color={group.kind === "provisioned" ? "primary" : "highlight"}
+                  color={group.kind === "provisioned" ? "success" : "info"}
                   size="xs"
                 />
               }

--- a/front/components/workspace/ExtensionMcpToolsSection.tsx
+++ b/front/components/workspace/ExtensionMcpToolsSection.tsx
@@ -1,4 +1,6 @@
+import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
 import { useExtensionMcpToolsToggle } from "@app/hooks/useExtensionMcpToolsToggle";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Page, PuzzlePiece01, SliderToggle } from "@dust-tt/sparkle";
 
@@ -13,9 +15,35 @@ export function ExtensionMcpToolsSection({
 }: ExtensionMcpToolsSectionProps) {
   const { isEnabled, isChanging, doToggleExtensionMcpTools } =
     useExtensionMcpToolsToggle({ owner });
+  const { hasFeature } = useFeatureFlags();
+
+  const label = "Browser Extension Tools";
+  const description =
+    "Allow the Dust browser extension to use MCP tools such as listing and " +
+    "reading browser tabs.";
+
+  if (!hasFeature("browser_extension_mcp_tools")) {
+    return null;
+  }
+
+  if (hasFeature("admin_governance")) {
+    return (
+      <GovernanceSettingRowLayout
+        label={label}
+        description={description}
+        action={
+          <SliderToggle
+            selected={isEnabled}
+            disabled={isChanging}
+            onClick={() => void doToggleExtensionMcpTools()}
+          />
+        }
+      />
+    );
+  }
 
   return (
-    <WorkspaceSection title="Browser Extension Tools" icon={PuzzlePiece01}>
+    <WorkspaceSection title={label} icon={PuzzlePiece01}>
       <div className="flex w-full flex-row items-center gap-2">
         <div className="flex-1">
           <Page.P variant="secondary">

--- a/front/components/workspace/LinkedSectionNotice.tsx
+++ b/front/components/workspace/LinkedSectionNotice.tsx
@@ -1,0 +1,24 @@
+import { Hoverable, Page } from "@dust-tt/sparkle";
+
+interface LinkedSectionNoticeProps {
+  description: string;
+  linkLabel: string;
+  onLinkClick: () => void;
+}
+
+export function LinkedSectionNotice({
+  description,
+  linkLabel,
+  onLinkClick,
+}: LinkedSectionNoticeProps) {
+  return (
+    <div className="w-full rounded-xl bg-muted-background px-4 py-3">
+      <Page.P variant="secondary" size="sm">
+        {description}{" "}
+        <Hoverable variant="primary" onClick={onLinkClick}>
+          {linkLabel}
+        </Hoverable>
+      </Page.P>
+    </div>
+  );
+}

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -51,7 +51,9 @@ export default function WorkspaceAccessPanel({
     plan.isAuditLogsAllowed || hasFeature("audit_logs");
   const showAuditLogs =
     hasAuditLogsAccess && workspace.metadata?.disableAuditLogs !== true;
-  const showExtensionMcpTools = hasFeature("browser_extension_mcp_tools");
+  const showExtensionMcpTools =
+    !hasFeature("admin_governance") &&
+    hasFeature("browser_extension_mcp_tools");
 
   return (
     <div className="flex flex-col gap-6">

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -9,7 +9,7 @@ import { RestrictAgentsPublishingCapability } from "@app/components/workspace/se
 import { SlackPersonalFooterRemovalToggle } from "@app/components/workspace/settings/SlackPersonalFooterRemovalToggle";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
 import { WorkspaceAnalyticsToggle } from "@app/components/workspace/settings/WorkspaceAnalyticsToggle";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
 
@@ -22,7 +22,6 @@ export function CapabilitiesSection({
   owner,
   publishingRestrictionMessage,
 }: CapabilitiesSectionProps) {
-  const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
   const isAdminGovernanceEnabled = hasFeature("admin_governance");
 
@@ -36,9 +35,7 @@ export function CapabilitiesSection({
       <ContextItem.List>
         <div className="h-full border-b border-border" />
         <InteractiveContentSharingToggle owner={owner} />
-        {!subscription.plan.isByok && (
-          <VoiceTranscriptionToggle owner={owner} />
-        )}
+        <VoiceTranscriptionToggle owner={owner} />
         <OpenPodPolicy owner={owner} />
         <PodKnowledgePolicy owner={owner} />
         <EmailAgentsToggle owner={owner} />

--- a/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
+++ b/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
@@ -1,16 +1,21 @@
 import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
 import { useVoiceTranscriptionToggle } from "@app/hooks/useVoiceTranscriptionToggle";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Microphone01, SliderToggle } from "@dust-tt/sparkle";
 
 export function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
   const { isEnabled, isChanging, doToggleVoiceTranscription } =
     useVoiceTranscriptionToggle({ owner });
+  const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
 
   const label = "Voice transcription";
   const description = "Allow voice transcription in Dust conversations";
+
+  if (subscription.plan.isByok) {
+    return null;
+  }
 
   if (hasFeature("admin_governance")) {
     return (

--- a/front/components/workspace/settings/WorkspaceNameEditor.tsx
+++ b/front/components/workspace/settings/WorkspaceNameEditor.tsx
@@ -79,7 +79,7 @@ export function WorkspaceNameEditor({ owner }: { owner: WorkspaceType }) {
   return (
     <div className="flex items-center justify-between">
       <div className="flex-1">
-        <Page.H variant="h4">Workspace Name</Page.H>
+        <Page.H variant="h5">Workspace Name</Page.H>
         <Page.P variant="secondary">{owner.name}</Page.P>
       </div>
       <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>


### PR DESCRIPTION
## Description
This PR makes some UI updates to the governance page
- adds the section to change the workspace name
- adds the hint on top of the page to manage groups in the group page
- adds a missing capabilities toggle
- updates the name of the page to "Workspace & Governance"
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low. No change in functionality.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
