### PR TITLE
[front] perf: skip loading unrequested skill instructions

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -64,6 +64,28 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("listByWorkspace", () => {
+    it("omits custom skill instructions when they are not requested", async () => {
+      await SkillFactory.create(testContext.authenticator, {
+        instructions: "Large instructions",
+        instructionsHtml: "<p>Large instructions</p>",
+      });
+
+      const [skill] = await SkillResource.listByWorkspace(
+        testContext.authenticator,
+        {
+          onlyCustom: true,
+          withInstructions: false,
+          withTools: false,
+          withFileAttachments: false,
+        }
+      );
+
+      expect(skill.instructions).toBe("");
+      expect(skill.instructionsHtml).toBeNull();
+    });
+  });
+
   // Helper function to create real SkillDataSourceConfigurationModel instances
   async function createDataSourceConfiguration({
     dataSourceView,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -566,14 +566,32 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withInstructions = true,
       withTools = true,
       withFileAttachments = true,
+      attributes,
       ...otherOptions
     } = options;
 
+    const instructionAttributes = ["instructions", "instructionsHtml"];
+    const isInstructionAttribute = (attribute: unknown) =>
+      instructionAttributes.some(
+        (instructionAttribute) => instructionAttribute === attribute
+      );
+    const attributesWithoutInstructions = Array.isArray(attributes)
+      ? attributes.filter((attribute) => !isInstructionAttribute(attribute))
+      : {
+          ...attributes,
+          exclude: [...(attributes?.exclude ?? []), ...instructionAttributes],
+          ...(attributes?.include
+            ? {
+                include: attributes.include.filter(
+                  (attribute) => !isInstructionAttribute(attribute)
+                ),
+              }
+            : {}),
+        };
+
     const customSkills = await this.model.findAll({
       ...otherOptions,
-      ...(withInstructions
-        ? {}
-        : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
+      attributes: withInstructions ? attributes : attributesWithoutInstructions,
       where: {
         // Fetch active by default, unless explicitly overridden by the caller.
         status: "active",

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -571,6 +571,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const customSkills = await this.model.findAll({
       ...otherOptions,
+      ...(withInstructions
+        ? {}
+        : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
       where: {
         // Fetch active by default, unless explicitly overridden by the caller.
         status: "active",
@@ -725,6 +728,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       }
 
       allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
+        const customSkillAttributes = {
+          ...customSkill.get(),
+          ...(withInstructions
+            ? {}
+            : { instructions: "", instructionsHtml: null }),
+        };
         const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[
           customSkill.id
         ]?.map((skillConfig) => skillConfig.mcpServerViewId);
@@ -738,7 +747,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           )
         );
 
-        return new this(this.model, customSkill.get(), {
+        return new this(this.model, customSkillAttributes, {
           mcpServerConfigurations: skillMCPServerViews.map((view) => ({
             view,
           })),

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -566,32 +566,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withInstructions = true,
       withTools = true,
       withFileAttachments = true,
-      attributes,
       ...otherOptions
     } = options;
 
-    const instructionAttributes = ["instructions", "instructionsHtml"];
-    const isInstructionAttribute = (attribute: unknown) =>
-      instructionAttributes.some(
-        (instructionAttribute) => instructionAttribute === attribute
-      );
-    const attributesWithoutInstructions = Array.isArray(attributes)
-      ? attributes.filter((attribute) => !isInstructionAttribute(attribute))
-      : {
-          ...attributes,
-          exclude: [...(attributes?.exclude ?? []), ...instructionAttributes],
-          ...(attributes?.include
-            ? {
-                include: attributes.include.filter(
-                  (attribute) => !isInstructionAttribute(attribute)
-                ),
-              }
-            : {}),
-        };
-
     const customSkills = await this.model.findAll({
       ...otherOptions,
-      attributes: withInstructions ? attributes : attributesWithoutInstructions,
+      ...(withInstructions
+        ? {}
+        : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
       where: {
         // Fetch active by default, unless explicitly overridden by the caller.
         status: "active",

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -15,22 +15,21 @@ export type AllSkillConfigurationFindOptions = Omit<
     isDefault?: boolean;
   };
   onlyCustom?: false; // Default: include global skills.
-  withTools?: boolean;
-  withInstructions?: boolean;
-  withFileAttachments?: boolean;
 };
 
 // Full find options only custom skills from database.
 type CustomSkillConfigurationFindOptions =
   ResourceFindOptions<SkillConfigurationModel> & {
     onlyCustom: true; // Explicit: only custom skills.
-    withTools?: boolean;
-    withInstructions?: boolean;
-    withFileAttachments?: boolean;
   };
 
 // baseFetch controls the selected model attributes based on hydration options
 // such as withInstructions.
-export type SkillConfigurationFindOptions =
+export type SkillConfigurationFindOptions = (
   | Omit<AllSkillConfigurationFindOptions, "attributes">
-  | Omit<CustomSkillConfigurationFindOptions, "attributes">;
+  | Omit<CustomSkillConfigurationFindOptions, "attributes">
+) & {
+  withTools?: boolean;
+  withInstructions?: boolean;
+  withFileAttachments?: boolean;
+};

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -2,9 +2,14 @@ import type { SkillConfigurationModel } from "@app/lib/models/skill";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 
+type SkillResourceFindOptions = Omit<
+  ResourceFindOptions<SkillConfigurationModel>,
+  "attributes"
+>;
+
 // Constrained find options include both global and custom skills.
 export type AllSkillConfigurationFindOptions = Omit<
-  ResourceFindOptions<SkillConfigurationModel>,
+  SkillResourceFindOptions,
   "limit" | "offset" | "where"
 > & {
   where?: {
@@ -21,13 +26,12 @@ export type AllSkillConfigurationFindOptions = Omit<
 };
 
 // Full find options only custom skills from database.
-type CustomSkillConfigurationFindOptions =
-  ResourceFindOptions<SkillConfigurationModel> & {
-    onlyCustom: true; // Explicit: only custom skills.
-    withTools?: boolean;
-    withInstructions?: boolean;
-    withFileAttachments?: boolean;
-  };
+type CustomSkillConfigurationFindOptions = SkillResourceFindOptions & {
+  onlyCustom: true; // Explicit: only custom skills.
+  withTools?: boolean;
+  withInstructions?: boolean;
+  withFileAttachments?: boolean;
+};
 
 export type SkillConfigurationFindOptions =
   | AllSkillConfigurationFindOptions

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -2,15 +2,10 @@ import type { SkillConfigurationModel } from "@app/lib/models/skill";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 
-type SkillResourceFindOptions = Omit<
-  ResourceFindOptions<SkillConfigurationModel>,
-  "attributes"
->;
-
 // Constrained find options include both global and custom skills.
 export type AllSkillConfigurationFindOptions = Omit<
-  SkillResourceFindOptions,
-  "limit" | "offset" | "where"
+  ResourceFindOptions<SkillConfigurationModel>,
+  "attributes" | "limit" | "offset" | "where"
 > & {
   where?: {
     name?: string | string[];
@@ -26,7 +21,10 @@ export type AllSkillConfigurationFindOptions = Omit<
 };
 
 // Full find options only custom skills from database.
-type CustomSkillConfigurationFindOptions = SkillResourceFindOptions & {
+type CustomSkillConfigurationFindOptions = Omit<
+  ResourceFindOptions<SkillConfigurationModel>,
+  "attributes"
+> & {
   onlyCustom: true; // Explicit: only custom skills.
   withTools?: boolean;
   withInstructions?: boolean;

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -5,7 +5,7 @@ import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 // Constrained find options include both global and custom skills.
 export type AllSkillConfigurationFindOptions = Omit<
   ResourceFindOptions<SkillConfigurationModel>,
-  "attributes" | "limit" | "offset" | "where"
+  "limit" | "offset" | "where"
 > & {
   where?: {
     name?: string | string[];
@@ -21,16 +21,16 @@ export type AllSkillConfigurationFindOptions = Omit<
 };
 
 // Full find options only custom skills from database.
-type CustomSkillConfigurationFindOptions = Omit<
-  ResourceFindOptions<SkillConfigurationModel>,
-  "attributes"
-> & {
-  onlyCustom: true; // Explicit: only custom skills.
-  withTools?: boolean;
-  withInstructions?: boolean;
-  withFileAttachments?: boolean;
-};
+type CustomSkillConfigurationFindOptions =
+  ResourceFindOptions<SkillConfigurationModel> & {
+    onlyCustom: true; // Explicit: only custom skills.
+    withTools?: boolean;
+    withInstructions?: boolean;
+    withFileAttachments?: boolean;
+  };
 
+// baseFetch controls the selected model attributes based on hydration options
+// such as withInstructions.
 export type SkillConfigurationFindOptions =
-  | AllSkillConfigurationFindOptions
-  | CustomSkillConfigurationFindOptions;
+  | Omit<AllSkillConfigurationFindOptions, "attributes">
+  | Omit<CustomSkillConfigurationFindOptions, "attributes">;


### PR DESCRIPTION
## Description

When `SkillResource` callers set `withInstructions: false`, code-defined skill instructions are skipped, but custom skills still `SELECT` `instructions` and `instructionsHtml` from the db. These fields can be large, and the callers do not consume them.

This PR excludes both columns from the `SELECT` when instructions are not requested.

Strongly suspect these text values are stored in TOAST storage. Not selecting these columns should avoid fetching and decompressing their external TOAST values, and it also removes a bit of I/O + memory usage in the node process. 

Should not change anything for single-skill fetches, targets more specifically large lists of skills.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
