### PR TITLE
fix(front): keep category in knowledge picker breadcrumb during search

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -264,13 +264,14 @@ export const DataSourceBuilderSelector = ({
 
   const breadcrumbItems: BreadcrumbsItem[] = useMemo(() => {
     if (shouldShowSearch && currentSpace) {
-      // When searching in space scope, show only up to space level
+      // Space-scope search still filters by currentCategory, so keep it in the breadcrumb.
       if (searchScope === "space") {
         const spaceIndex = navigationHistory.findIndex(
           (entry) => entry.type === "space"
         );
+        const lastIndex = currentCategory ? spaceIndex + 1 : spaceIndex;
         const spaceNavigation =
-          spaceIndex >= 0 ? navigationHistory.slice(0, spaceIndex + 1) : [];
+          spaceIndex >= 0 ? navigationHistory.slice(0, lastIndex + 1) : [];
 
         return spaceNavigation.map((entry, index) => ({
           ...getBreadcrumbConfig(entry),
@@ -299,6 +300,7 @@ export const DataSourceBuilderSelector = ({
     shouldShowSearch,
     currentSpace,
     searchScope,
+    currentCategory,
   ]);
 
   if (filteredSpaces.length === 0) {


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/9610

## Description

Since #28912, searching while browsing a category (e.g. Company Data > Websites) scopes results to that category correctly, but the breadcrumb was dropping the category and collapsing to "All > Company Data". Now it stays put while searching.

## Tests

Manual repro in agent builder: Knowledge > Add Knowledge > Select Data Sources > Company Data > Websites > type a query. Breadcrumb now keeps "Websites".

## Risk

Low, breadcrumb display only, no change to search filtering.

## Deploy Plan

None.