### PR TITLE
feat(front): notify on model tier changes and show picker loading state

### DIFF
--- a/front/components/workspace/ModelTierPickerDropdown.tsx
+++ b/front/components/workspace/ModelTierPickerDropdown.tsx
@@ -42,6 +42,7 @@ export function ModelTierPickerDropdown({
           size="sm"
           isSelect
           label={label}
+          isLoading={isMutating}
           disabled={readOnly || isMutating}
           className={className ?? "min-w-48 justify-between"}
         />

--- a/front/lib/swr/model_tiers.ts
+++ b/front/lib/swr/model_tiers.ts
@@ -171,6 +171,11 @@ export function useUserAllowedModelTierMutations({
         }
 
         await mutateUserAllowedModelTiers();
+        sendNotification({
+          type: "success",
+          title: "Model tier updated",
+          description: "The model tier for the user has been updated.",
+        });
         return true;
       } catch (e) {
         sendNotification({
@@ -210,6 +215,11 @@ export function useUserAllowedModelTierMutations({
         }
 
         await mutateUserAllowedModelTiers();
+        sendNotification({
+          type: "success",
+          title: "Model tier override cleared",
+          description: "The user now inherits the model tier.",
+        });
         return true;
       } catch (e) {
         sendNotification({
@@ -268,6 +278,11 @@ export function useGroupAllowedModelTierMutations({
         }
 
         await mutateGroupAllowedModelTiers();
+        sendNotification({
+          type: "success",
+          title: "Model tier updated",
+          description: "The model tier for the group has been updated.",
+        });
         return true;
       } catch (e) {
         sendNotification({
@@ -307,6 +322,11 @@ export function useGroupAllowedModelTierMutations({
         }
 
         await mutateGroupAllowedModelTiers();
+        sendNotification({
+          type: "success",
+          title: "Model tier cleared",
+          description: "The group now inherits the model tier.",
+        });
         return true;
       } catch (e) {
         sendNotification({
@@ -365,6 +385,11 @@ export function useWorkspaceAllowedModelTierMutations({
         }
 
         await mutateWorkspaceAllowedModelTiers();
+        sendNotification({
+          type: "success",
+          title: "Model tier updated",
+          description: "The model tier for the workspace has been updated.",
+        });
         return true;
       } catch (e) {
         sendNotification({


### PR DESCRIPTION
## Description

Improves feedback when changing allowed model tiers from the Usage page. Previously the mutation hooks in `lib/swr/model_tiers.ts` only surfaced a notification on failure, so a successful change was silent.

- Add a success notification after every model tier mutation succeeds — for the user, group, and workspace levels (both set and clear paths).
- Show a visible loading state on the tier picker button while a mutation is in flight: the `ModelTierPickerDropdown` button now renders Sparkle's built-in `isLoading` spinner in addition to being disabled.

## Tests

Manual: on the workspace Usage page (with the `models_picker` flag enabled, as an admin), change the workspace, a group, and a user model tier. Verify the picker shows a spinner while saving and a success toast on completion, and that clearing an override notifies as expected.
