### PR TITLE
feat(temporal): scaffold per-workspace activation scheduler workflow

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "base64",

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,7 +1,7 @@
 import { seedWorkspaceCapabilities } from "@app/lib/api/permissions/governance_seeding";
 import { activateCreditPricedFreePlanForWorkspace } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -18,6 +18,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { UTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 
 export async function createWorkspace(
   session: SessionWithUser,
@@ -102,6 +103,18 @@ export async function createWorkspaceInternal({
 
   // Ensure all auto MCP server views are created for the workspace
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+  if (await hasFeatureFlag(auth, "activation_scheduler")) {
+    const scheduleRes = await startActivationWorkspaceSchedule({
+      workspaceId: workspace.sId,
+    });
+    if (scheduleRes.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: scheduleRes.error },
+        "Failed to start activation schedule for new workspace"
+      );
+    }
+  }
 
   if (planCode) {
     if (isCreditPricedFreePlan(planCode)) {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -83,6 +83,7 @@ import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspa
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { deleteActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 import { deleteAllConversations } from "@app/temporal/scrub_workspace/activities";
 import { CoreAPI } from "@app/types/core/core_api";
 import assert from "assert";
@@ -771,6 +772,7 @@ export async function deleteWorkspaceActivity({
     },
   });
   await TriggerResource.deleteAllForWorkspace(auth);
+  await deleteActivationWorkspaceSchedule({ workspaceId });
   await FileResource.deleteAllForWorkspace(auth);
   await RunResource.deleteAllForWorkspace(auth);
   await MembershipResource.deleteAllForWorkspace(auth);

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -32,6 +32,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
   const baseDir = path.join(__dirname, "../../");
 
   switch (workerName) {
+    case "activation_scheduler":
+      return path.join(baseDir, "temporal/activation_scheduler");
     case "agent_loop":
       return path.join(baseDir, "temporal/agent_loop");
     case "agent_schedule":

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,0 +1,16 @@
+import logger from "@app/logger/logger";
+
+/**
+ * Skeleton activity for the workspace-level activation run. Business logic
+ * (what the short-lived run actually does) is not implemented yet.
+ */
+export async function runActivationForWorkspaceActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  logger.info(
+    { workspaceId },
+    "[ActivationScheduler] Skeleton activation activity invoked."
+  );
+}

--- a/front/temporal/activation_scheduler/client.ts
+++ b/front/temporal/activation_scheduler/client.ts
@@ -1,0 +1,132 @@
+import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import {
+  ScheduleAlreadyRunning,
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
+} from "@temporalio/client";
+
+import { QUEUE_NAME } from "./config";
+import { activationWorkspaceWorkflow } from "./workflows";
+
+const WORKSPACE_WORKFLOW_ID_PREFIX = "activation-workspace-";
+
+export function makeWorkspaceWorkflowId(workspaceId: string): string {
+  return `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-workspace cron lifecycle
+// ---------------------------------------------------------------------------
+
+const ACTIVATION_WORKDAY_START_HOUR = 9;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Launch a schedule for a single workspace.
+ * Fires at the start of the regional workday with a 1-hour jitter to spread
+ * load.
+ */
+export async function startActivationWorkspaceSchedule({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const region = config.getCurrentRegion();
+  const timezone = REGION_TIMEZONES[region];
+  const scheduleId = makeWorkspaceWorkflowId(workspaceId);
+
+  try {
+    await client.schedule.create({
+      action: {
+        type: "startWorkflow",
+        workflowType: activationWorkspaceWorkflow,
+        args: [{ workspaceId }],
+        taskQueue: QUEUE_NAME,
+      },
+      scheduleId,
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+      },
+      spec: {
+        calendars: [{ hour: ACTIVATION_WORKDAY_START_HOUR, minute: 0 }],
+        timezone,
+        jitter: ONE_HOUR_MS,
+      },
+    });
+
+    logger.info(
+      { region, timezone, scheduleId, workspaceId },
+      "[ActivationScheduler] Created workspace schedule."
+    );
+  } catch (e) {
+    if (e instanceof ScheduleAlreadyRunning) {
+      logger.info(
+        { scheduleId, workspaceId },
+        "[ActivationScheduler] Workspace schedule already exists, skipping."
+      );
+    } else {
+      throw e;
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Stop (delete) the schedule for a single workspace.
+ */
+export async function deleteActivationWorkspaceSchedule({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const client = await getTemporalClientForFrontNamespace();
+  const scheduleId = makeWorkspaceWorkflowId(workspaceId);
+
+  try {
+    const handle = client.schedule.getHandle(scheduleId);
+    await handle.delete();
+  } catch (e) {
+    if (e instanceof ScheduleNotFoundError) {
+      logger.info(
+        { scheduleId, workspaceId },
+        "[ActivationScheduler] Workspace schedule not found, skipping."
+      );
+    } else {
+      logger.error(
+        { error: e, scheduleId, workspaceId },
+        "[ActivationScheduler] Failed deleting workspace schedule."
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manual one-off runs
+// ---------------------------------------------------------------------------
+
+export async function startActivationWorkspaceWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<string, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}-manual-${Date.now()}`;
+
+  await client.workflow.start(activationWorkspaceWorkflow, {
+    args: [{ workspaceId }],
+    taskQueue: QUEUE_NAME,
+    workflowId,
+  });
+
+  logger.info(
+    { workflowId, workspaceId },
+    "[ActivationScheduler] Started workspace workflow."
+  );
+  return new Ok(workflowId);
+}

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -1,0 +1,2 @@
+const QUEUE_VERSION = 1;
+export const QUEUE_NAME = `activation-scheduler-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/activation_scheduler/worker.ts
+++ b/front/temporal/activation_scheduler/worker.ts
@@ -1,0 +1,44 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/activation_scheduler/activities";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { QUEUE_NAME } from "./config";
+
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
+export async function runActivationSchedulerWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "activation_scheduler",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/activation_scheduler/workflows.ts
+++ b/front/temporal/activation_scheduler/workflows.ts
@@ -1,0 +1,21 @@
+import type * as activities from "@app/temporal/activation_scheduler/activities";
+import { proxyActivities } from "@temporalio/workflow";
+
+const { runActivationForWorkspaceActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+});
+
+/**
+ * Workspace-level workflow (one per workspace, schedule-triggered).
+ * The Temporal schedule applies jitter to spread load across the region's
+ * workday start.
+ */
+export async function activationWorkspaceWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  await runActivationForWorkspaceActivity({ workspaceId });
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -1,4 +1,5 @@
 import { runPokeWorker } from "@app/poke/temporal/worker";
+import { runActivationSchedulerWorker } from "@app/temporal/activation_scheduler/worker";
 import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
 import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
 import { runConversationForkQueueWorker } from "@app/temporal/conversation_fork_queue/worker";
@@ -27,6 +28,7 @@ import { runUpdateWorkspaceUsageWorker } from "@app/temporal/usage_queue/worker"
 import { runWorkOSEventsWorker } from "@app/temporal/workos_events_queue/worker";
 
 export type WorkerName =
+  | "activation_scheduler"
   | "agent_loop"
   | "agent_schedule"
   | "agent_trigger_webhook"
@@ -56,6 +58,7 @@ export type WorkerName =
   | "workos_events_queue";
 
 export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
+  activation_scheduler: runActivationSchedulerWorker,
   agent_loop: runAgentLoopWorker,
   agent_schedule: runAgentTriggerWorker,
   agent_trigger_webhook: runAgentTriggerWebhookWorker,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -324,6 +324,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the Activation skill for agentic user activation pods",
     stage: "dust_only",
   },
+  activation_scheduler: {
+    description: "Enable the per-workspace Activation scheduler workflow",
+    stage: "dust_only",
+  },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -700,6 +700,7 @@ export type RetrievalDocumentPublicType = z.infer<
 >;
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
+  | "activation_scheduler"
   | "activation_skill"
   | "advanced_notion_management"
   | "allow_sso"


### PR DESCRIPTION
## Description

Scaffolds a per-workspace Temporal scheduler for the upcoming Activation feature, following the same pattern as `temporal/reinforcement`: one schedule per workspace, firing at the start of the regional workday (9am local, 1h jitter) with `ScheduleOverlapPolicy.SKIP`, running a short-lived per-workspace workflow.

Gated behind a new `activation_scheduler` feature flag (off by default). This is intentionally just the skeleton — `runActivationForWorkspaceActivity` is a logging placeholder; business logic will be plugged in separately. No cross-workspace reconciliation loop is included: schedules are started/stopped explicitly rather than reconciled against the flag on a cron.

Lifecycle is wired at both ends:
- `startActivationWorkspaceSchedule` is called from `createWorkspaceInternal` when the flag is already enabled for the workspace (workspace-level flag or global rollout) at creation time.
- `deleteActivationWorkspaceSchedule` is called from workspace hard-deletion (`deleteWorkspaceActivity`) so a deleted workspace's schedule doesn't keep firing indefinitely.

## Tests


## Risk

Low — new code behind a flag that defaults to off, and the worker isn't wired to run anything by default.
