### PR TITLE
feat(front): show per-message credit cost on all plans

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -319,14 +319,14 @@ export function AgentMessage({
   });
   const refreshedAgentMessage =
     refreshedMessage?.type === "agent_message" ? refreshedMessage : null;
-  const { creditCostItem, isCreditPriced } = useCreditCostMenuItem({
+  const creditCostItem = useCreditCostMenuItem({
     credits: refreshedAgentMessage?.costCredits ?? agentMessage.costCredits,
     subAgentCredits:
       refreshedAgentMessage?.subAgentCostCredits ??
       agentMessage.subAgentCostCredits,
   });
-  // On a credit-priced plan, keep the cost section visible while the fetch is
-  // in flight (showing a loader) rather than popping it in once it resolves.
+  // Keep the cost section visible while the fetch is in flight (showing a
+  // loader) rather than popping it in once it resolves.
   const isCreditCostLoading = needsCostFetch && isMessageLoading;
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
@@ -963,7 +963,7 @@ export function AgentMessage({
               // post-event). Revalidate the authoritative value once per
               // completion so the total (e.g. summed across an `ask_user`
               // resume) is correct without a page refresh.
-              if (isCreditPriced && pendingCostRevalidationRef.current) {
+              if (pendingCostRevalidationRef.current) {
                 pendingCostRevalidationRef.current = false;
                 void mutateMessage();
               }
@@ -979,7 +979,7 @@ export function AgentMessage({
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {isCreditPriced && (creditCostItem || isCreditCostLoading) && (
+            {(creditCostItem || isCreditCostLoading) && (
               <>
                 {creditCostItem ? (
                   <DropdownMenuItem {...creditCostItem} />

--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -12,8 +12,6 @@ interface UseCreditCostMenuItemProps {
   subAgentCredits: number | null | undefined;
 }
 
-// Returns the credit-cost dropdown item, or null when there is no cost to show
-// yet (e.g. total is zero or the authoritative value is still being fetched).
 export function useCreditCostMenuItem({
   credits,
   subAgentCredits,

--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -1,6 +1,4 @@
-import { useAuth } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
-import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 
 const BEGINNING_AGENT_TOOLTIP =
@@ -14,30 +12,18 @@ interface UseCreditCostMenuItemProps {
   subAgentCredits: number | null | undefined;
 }
 
-interface UseCreditCostMenuItemResult {
-  creditCostItem: DropdownMenuItemProps | null;
-  // Whether the current plan bills with credits. Gates whether the menu
-  // section should be shown at all: on a credit-priced plan we keep it visible
-  // (with a loader) while the cost is still being fetched.
-  isCreditPriced: boolean;
-}
-
+// Returns the credit-cost dropdown item, or null when there is no cost to show
+// yet (e.g. total is zero or the authoritative value is still being fetched).
 export function useCreditCostMenuItem({
   credits,
   subAgentCredits,
-}: UseCreditCostMenuItemProps): UseCreditCostMenuItemResult {
-  const { subscription } = useAuth();
-
-  if (!isCreditPricedPlan(subscription.plan)) {
-    return { creditCostItem: null, isCreditPriced: false };
-  }
-
+}: UseCreditCostMenuItemProps): DropdownMenuItemProps | null {
   const ownCredits = credits ?? 0;
   const subCredits = subAgentCredits ?? 0;
   const totalCredits = ownCredits + subCredits;
 
   if (totalCredits <= 0) {
-    return { creditCostItem: null, isCreditPriced: true };
+    return null;
   }
 
   const tooltip =
@@ -47,13 +33,10 @@ export function useCreditCostMenuItem({
       : "");
 
   return {
-    creditCostItem: {
-      label: "Credit cost",
-      endComponent: formatCredits(totalCredits),
-      tooltip,
-      className: CREDIT_COST_ITEM_CLASS_NAME,
-      onSelect: (e) => e.preventDefault(),
-    },
-    isCreditPriced: true,
+    label: "Credit cost",
+    endComponent: formatCredits(totalCredits),
+    tooltip,
+    className: CREDIT_COST_ITEM_CLASS_NAME,
+    onSelect: (e) => e.preventDefault(),
   };
 }


### PR DESCRIPTION
## Description

Show the per-message "Credit cost" row in the agent message action dropdown for all
workspaces, not just those on a credit-priced (`CP_`) plan.

Previously `useCreditCostMenuItem` gated the item behind `isCreditPricedPlan(subscription.plan)`,
so only credit-priced workspaces saw the cost. That plan check is removed, so the row now
appears on every plan whenever a message has a computed credit cost.

Also cleans up the now-redundant `isCreditPriced` flag that was always `true` after removing
the gate: the hook now returns `DropdownMenuItemProps | null` directly, and the two call sites
in `AgentMessage.tsx` (open-revalidation guard and the render condition) are simplified
accordingly.

## Tests

Manual: open an agent message's "..." action menu and confirm the "Credit cost" row shows
with the correct total (and sub-agent breakdown tooltip) on a non-credit-priced workspace,
including the loading placeholder while the authoritative cost is being fetched.
