### PR TITLE
feat(temporal): fire activation trigger for pods on scheduled run

### DIFF
--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,16 +1,49 @@
+import { emitActivationEvent } from "@app/lib/api/activation/trigger";
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
+const ACTIVATION_PODS_CONCURRENCY = 4;
+
 /**
- * Skeleton activity for the workspace-level activation run. Business logic
- * (what the short-lived run actually does) is not implemented yet.
+ * Re-fires the activation trigger for every Activation Pod in the workspace,
+ * nudging users back into the pod's activation conversation.
  */
 export async function runActivationForWorkspaceActivity({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<void> {
-  logger.info(
-    { workspaceId },
-    "[ActivationScheduler] Skeleton activation activity invoked."
+  // Activation conversations live in Pods, which are restricted spaces: request
+  // all groups so admin auth can read/write them.
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
+
+  const activationPodsMetadata =
+    await ProjectMetadataResource.fetchActivationPods(auth);
+  if (activationPodsMetadata.length === 0) {
+    return;
+  }
+
+  const pods = await SpaceResource.fetchByModelIds(
+    auth,
+    activationPodsMetadata.map((metadata) => metadata.spaceId)
+  );
+
+  await concurrentExecutor(
+    pods,
+    async (pod) => {
+      const result = await emitActivationEvent(auth, pod);
+      if (result.isErr()) {
+        logger.error(
+          { workspaceId, spaceId: pod.sId, error: result.error },
+          "[ActivationScheduler] Failed to emit activation event for pod."
+        );
+      }
+    },
+    { concurrency: ACTIVATION_PODS_CONCURRENCY }
   );
 }


### PR DESCRIPTION
## Description

Plugs the existing Activation Pod nudge mechanism into the `activation_scheduler` workflow scaffolded in #29031, replacing the logging placeholder.

`runActivationForWorkspaceActivity` now, for each workspace run: looks up the workspace's Activation Pods (`ProjectMetadataResource.fetchActivationPods`), resolves their spaces, and re-fires each pod's activation trigger via the existing `emitActivationEvent` helper — the same one used today only once, at pod-creation time. This turns that one-shot nudge into a recurring daily one, with no new business logic introduced. Failures for an individual pod are logged and don't block the others (bounded concurrency of 4).

Since Activation Pods are restricted spaces, the activity requests an admin `Authenticator` with `dangerouslyRequestAllGroups: true`, matching the same justification already used in `temporal/reinforcement` for accessing project conversations.

## Tests

Verified with `npx tsgo --noEmit` and `biome check`. No new automated coverage — the feature flag is off by default and this only runs from the scheduled workflow.

## Risk

Low — gated behind the `activation_scheduler` flag (off by default), and per-pod failures are isolated and logged rather than failing the whole run.
