### PR TITLE
feat(front): add allowed models section to model providers page

### DIFF
--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -4,6 +4,7 @@ import { ProvidersConfigurationList } from "@app/components/pages/workspace/mode
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
 import { RegionalModelsOnlyToggle } from "@app/components/pages/workspace/model_providers/RegionalModelsOnlyToggle";
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import { AllowedModelsSection } from "@app/components/workspace/AllowedModelsSection";
 import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
@@ -14,6 +15,7 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import type { WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import groupBy from "lodash/groupBy";
 import mapValues from "lodash/mapValues";
 import uniqBy from "lodash/uniqBy";
@@ -35,8 +37,10 @@ export function ModelProvidersPageContent({
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
-  const { featureFlags } = useFeatureFlags();
+  const { featureFlags, hasFeature } = useFeatureFlags();
   const { regionInfo } = useRegionContext();
+
+  const modelsPickerEnabled = hasFeature("models_picker") && isAdmin(workspace);
 
   // Filter models based on feature flags and build modelProviders dynamically
   const filteredModels = uniqBy(USED_MODEL_CONFIGS, (m) => m.modelId).filter(
@@ -82,6 +86,7 @@ export function ModelProvidersPageContent({
         </>
       )}
       <EmbeddingModelSelect workspace={workspace} />
+      {modelsPickerEnabled && <AllowedModelsSection owner={workspace} />}
     </div>
   );
 }

--- a/front/components/workspace/AllowedModelsMembersTable.tsx
+++ b/front/components/workspace/AllowedModelsMembersTable.tsx
@@ -1,0 +1,242 @@
+import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
+import {
+  getUserModelTierMenuItemsWithSelection,
+  INHERIT_MODEL_TIER,
+  toUserModelTierSelection,
+} from "@app/lib/client/model_tier_options";
+import {
+  formatModelTiersSummary,
+  formatUserModelTierInheritLabel,
+  resolveModelTiersForUser,
+} from "@app/lib/client/model_tiers";
+import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
+import {
+  DataTable,
+  LoadingBlock,
+  type MenuItem,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+} from "@tanstack/react-table";
+import { useMemo } from "react";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  groups: string[];
+  modelTiersSummary: string;
+  hasUserLevelModelTiersOverride: boolean;
+  menuItems: MenuItem[];
+};
+
+type Info = CellContext<RowData, string>;
+
+const nameColumn = buildMemberNameColumn<RowData>();
+
+const groupsColumn: ColumnDef<RowData, string> = {
+  id: "groups" as const,
+  header: "Groups",
+  enableSorting: false,
+  accessorFn: (row) => row.groups.join(", "),
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground">
+        {info.row.original.groups.length > 0
+          ? info.row.original.groups.join(", ")
+          : "--"}
+      </span>
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "w-48",
+  },
+};
+
+const modelTiersColumn: ColumnDef<RowData, string> = {
+  id: "modelTiers" as const,
+  header: "Models tier",
+  enableSorting: false,
+  accessorFn: (row) => row.modelTiersSummary,
+  cell: (info: Info) => {
+    const customSuffix = info.row.original.hasUserLevelModelTiersOverride
+      ? " (custom)"
+      : "";
+
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {info.row.original.modelTiersSummary}
+          {customSuffix}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-48",
+  },
+};
+
+const actionsColumn: ColumnDef<RowData, string> = {
+  id: "actions" as const,
+  header: "",
+  enableSorting: false,
+  accessorKey: "actions",
+  cell: (info: Info) => (
+    <div
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      <DataTable.MoreButton menuItems={info.row.original.menuItems} />
+    </div>
+  ),
+  meta: {
+    className: "w-14",
+  },
+};
+
+const columns: ColumnDef<RowData, string>[] = [
+  nameColumn,
+  groupsColumn,
+  modelTiersColumn,
+  actionsColumn,
+];
+
+interface AllowedModelsMembersTableProps {
+  members: MemberUsageType[];
+  isLoading: boolean;
+  isRefreshing?: boolean;
+  readOnly: boolean;
+  userModelTierSelectionByUserId: Record<string, UserModelTierSelection>;
+  userAllowedModelTiersByUserId: Record<string, ModelsTierName[]>;
+  groupModelTiersByGroupId: Record<string, ModelsTierName[]>;
+  workspaceAllowedModelTiers: ModelsTierName[];
+  groupNameToId: Map<string, string>;
+  onSetUserModelTier: (
+    member: MemberUsageType,
+    selection: UserModelTierSelection
+  ) => void;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
+  totalRowCount: number;
+}
+
+export function AllowedModelsMembersTable({
+  members,
+  isLoading,
+  isRefreshing = false,
+  readOnly,
+  userModelTierSelectionByUserId,
+  userAllowedModelTiersByUserId,
+  groupModelTiersByGroupId,
+  workspaceAllowedModelTiers,
+  groupNameToId,
+  onSetUserModelTier,
+  pagination,
+  setPagination,
+  totalRowCount,
+}: AllowedModelsMembersTableProps) {
+  const rows: RowData[] = useMemo(
+    () =>
+      members.map((m) => {
+        const resolvedModelTiers = resolveModelTiersForUser({
+          userId: m.sId,
+          groupNames: m.groups,
+          groupNameToId,
+          userAllowedTierNamesByUserId: userAllowedModelTiersByUserId,
+          groupTierNamesByGroupId: groupModelTiersByGroupId,
+          workspaceAllowedTierNames: workspaceAllowedModelTiers,
+        });
+
+        return {
+          sId: m.sId,
+          name: m.name,
+          email: m.email,
+          image: m.image,
+          groups: m.groups,
+          modelTiersSummary: formatModelTiersSummary(
+            getMaxTierName(resolvedModelTiers.tiers)
+          ),
+          hasUserLevelModelTiersOverride: resolvedModelTiers.source === "user",
+          menuItems: [
+            {
+              kind: "submenu" as const,
+              label: "Models tier",
+              disabled: readOnly,
+              selectionMode: "checkbox" as const,
+              items: getUserModelTierMenuItemsWithSelection({
+                selectedValue:
+                  userModelTierSelectionByUserId[m.sId] ?? INHERIT_MODEL_TIER,
+                inheritLabel: formatUserModelTierInheritLabel({
+                  groupNames: m.groups,
+                  groupNameToId,
+                  groupTierNamesByGroupId: groupModelTiersByGroupId,
+                  workspaceAllowedTierNames: workspaceAllowedModelTiers,
+                }),
+              }).map((tierItem) => ({
+                id: tierItem.id,
+                name: tierItem.name,
+                description: tierItem.description,
+                checked: tierItem.checked,
+              })),
+              onSelect: (itemId: string) =>
+                onSetUserModelTier(m, toUserModelTierSelection(itemId)),
+            },
+          ],
+        };
+      }),
+    [
+      members,
+      readOnly,
+      userModelTierSelectionByUserId,
+      userAllowedModelTiersByUserId,
+      groupModelTiersByGroupId,
+      workspaceAllowedModelTiers,
+      groupNameToId,
+      onSetUserModelTier,
+    ]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div
+        className={
+          isRefreshing
+            ? "pointer-events-none opacity-50 transition-opacity"
+            : "transition-opacity"
+        }
+      >
+        <DataTable
+          data={rows}
+          columns={columns}
+          pagination={pagination}
+          setPagination={setPagination}
+          totalRowCount={totalRowCount}
+          getRowId={(row) => row.sId}
+        />
+      </div>
+      {isRefreshing && (
+        <div className="absolute inset-x-0 top-16 flex justify-center">
+          <Spinner size="sm" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/workspace/AllowedModelsSection.tsx
+++ b/front/components/workspace/AllowedModelsSection.tsx
@@ -1,0 +1,163 @@
+import { AllowedModelsMembersTable } from "@app/components/workspace/AllowedModelsMembersTable";
+import { GroupsUsageTable } from "@app/components/workspace/GroupsUsageTable";
+import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTiersSettingsCard";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
+import { INHERIT_MODEL_TIER } from "@app/lib/client/model_tier_options";
+import { expandMaxTierName } from "@app/lib/client/model_tiers";
+import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
+import { useGroups } from "@app/lib/swr/groups";
+import { useMembersUsage } from "@app/lib/swr/memberships";
+import {
+  useGroupAllowedModelTiers,
+  useUserAllowedModelTierMutations,
+  useUserAllowedModelTiers,
+  useWorkspaceAllowedModelTiers,
+} from "@app/lib/swr/model_tiers";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@dust-tt/sparkle";
+import type { PaginationState } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+interface AllowedModelsSectionProps {
+  owner: LightWorkspaceType;
+  readOnly?: boolean;
+}
+
+export function AllowedModelsSection({
+  owner,
+  readOnly = false,
+}: AllowedModelsSectionProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+
+  const {
+    membersUsage,
+    isMembersUsageLoading,
+    isMembersUsageRefreshing,
+    totalMembersUsage,
+  } = useMembersUsage({
+    workspaceId: owner.sId,
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+  });
+
+  const { groups } = useGroups({
+    owner,
+    kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+  });
+
+  const { users: userAllowedModelTiers } = useUserAllowedModelTiers({ owner });
+  const { groups: groupAllowedModelTiers } = useGroupAllowedModelTiers({
+    owner,
+  });
+  const { maxTierName: workspaceMaxTierName } = useWorkspaceAllowedModelTiers({
+    owner,
+  });
+
+  const workspaceAllowedModelTiers = useMemo(
+    () => expandMaxTierName(workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER),
+    [workspaceMaxTierName]
+  );
+  const userModelTierSelectionByUserId = useMemo(() => {
+    const map: Record<string, UserModelTierSelection> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = entry.maxTierName;
+    }
+    return map;
+  }, [userAllowedModelTiers]);
+  const userAllowedModelTiersByUserId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of userAllowedModelTiers) {
+      map[entry.userId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [userAllowedModelTiers]);
+  const groupModelTiersByGroupId = useMemo(() => {
+    const map: Record<string, ModelsTierName[]> = {};
+    for (const entry of groupAllowedModelTiers) {
+      map[entry.groupId] = expandMaxTierName(entry.maxTierName);
+    }
+    return map;
+  }, [groupAllowedModelTiers]);
+  const groupNameToId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const group of groups) {
+      map.set(group.name, group.sId);
+    }
+    return map;
+  }, [groups]);
+
+  const { setUserAllowedModelTier, clearUserAllowedModelTier } =
+    useUserAllowedModelTierMutations({ owner });
+  const handleSetUserModelTier = useCallback(
+    (member: MemberUsageType, selection: UserModelTierSelection) => {
+      if (selection === INHERIT_MODEL_TIER) {
+        void clearUserAllowedModelTier({ userId: member.sId });
+        return;
+      }
+
+      void setUserAllowedModelTier({
+        userId: member.sId,
+        tierName: selection,
+      });
+    },
+    [clearUserAllowedModelTier, setUserAllowedModelTier]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="heading-base text-foreground dark:text-foreground-night">
+        Allowed models
+      </span>
+      <Tabs defaultValue="members">
+        <TabsList className="mb-4">
+          <TabsTrigger value="members" label="Members" />
+          <TabsTrigger value="groups" label="Groups" />
+          <TabsTrigger value="settings" label="Workspace settings" />
+        </TabsList>
+
+        <TabsContent value="members">
+          <AllowedModelsMembersTable
+            members={membersUsage}
+            isLoading={isMembersUsageLoading}
+            isRefreshing={isMembersUsageRefreshing}
+            readOnly={readOnly}
+            userModelTierSelectionByUserId={userModelTierSelectionByUserId}
+            userAllowedModelTiersByUserId={userAllowedModelTiersByUserId}
+            groupModelTiersByGroupId={groupModelTiersByGroupId}
+            workspaceAllowedModelTiers={workspaceAllowedModelTiers}
+            groupNameToId={groupNameToId}
+            onSetUserModelTier={handleSetUserModelTier}
+            pagination={pagination}
+            setPagination={setPagination}
+            totalRowCount={totalMembersUsage}
+          />
+        </TabsContent>
+
+        <TabsContent value="groups">
+          <GroupsUsageTable
+            owner={owner}
+            readOnly={readOnly}
+            showModelTiersColumn
+            showSpendLimitColumn={false}
+          />
+        </TabsContent>
+
+        <TabsContent value="settings">
+          <ModelTiersSettingsCard
+            owner={owner}
+            readOnly={readOnly}
+            showHeader={false}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -11,6 +11,7 @@ interface GroupsUsageTableProps {
   owner: LightWorkspaceType;
   readOnly: boolean;
   showModelTiersColumn?: boolean;
+  showSpendLimitColumn?: boolean;
 }
 
 type GroupRowData = {
@@ -77,6 +78,7 @@ export function GroupsUsageTable({
   owner,
   readOnly,
   showModelTiersColumn = false,
+  showSpendLimitColumn = true,
 }: GroupsUsageTableProps) {
   const { groups, isGroupsLoading } = useGroups({
     owner,
@@ -122,25 +124,29 @@ export function GroupsUsageTable({
         ),
         enableSorting: false,
       },
-      {
-        id: "cap",
-        header: "Spend limit",
-        meta: { className: "w-64" },
-        cell: (info: GroupInfo) => (
-          <GroupCapCell
-            group={info.row.original}
-            readOnly={readOnly}
-            onSave={async (group, limit) => {
-              await doUpdateGroupSpendLimit({
-                groupId: group.groupId,
-                groupName: group.name,
-                limit,
-              });
-            }}
-          />
-        ),
-        enableSorting: false,
-      },
+      ...(showSpendLimitColumn
+        ? [
+            {
+              id: "cap",
+              header: "Spend limit",
+              meta: { className: "w-64" },
+              cell: (info: GroupInfo) => (
+                <GroupCapCell
+                  group={info.row.original}
+                  readOnly={readOnly}
+                  onSave={async (group, limit) => {
+                    await doUpdateGroupSpendLimit({
+                      groupId: group.groupId,
+                      groupName: group.name,
+                      limit,
+                    });
+                  }}
+                />
+              ),
+              enableSorting: false,
+            } satisfies ColumnDef<GroupRowData, string>,
+          ]
+        : []),
       ...(showModelTiersColumn
         ? [
             {
@@ -159,7 +165,13 @@ export function GroupsUsageTable({
           ]
         : []),
     ],
-    [owner, readOnly, showModelTiersColumn, doUpdateGroupSpendLimit]
+    [
+      owner,
+      readOnly,
+      showModelTiersColumn,
+      showSpendLimitColumn,
+      doUpdateGroupSpendLimit,
+    ]
   );
 
   if (isGroupsLoading) {
@@ -172,10 +184,12 @@ export function GroupsUsageTable({
 
   return (
     <div className="flex flex-col gap-3">
-      <span className="copy-sm text-muted-foreground">
-        A group's monthly spend limit applies to each of its members. When a
-        member belongs to several groups, the highest limit is used.
-      </span>
+      {showSpendLimitColumn && (
+        <span className="copy-sm text-muted-foreground">
+          A group's monthly spend limit applies to each of its members. When a
+          member belongs to several groups, the highest limit is used.
+        </span>
+      )}
       <DataTable
         filterColumn="name"
         data={rows}

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -12,11 +12,13 @@ import { Page, SettingsList } from "@dust-tt/sparkle";
 interface ModelTiersSettingsCardProps {
   owner: LightWorkspaceType;
   readOnly: boolean;
+  showHeader?: boolean;
 }
 
 export function ModelTiersSettingsCard({
   owner,
   readOnly,
+  showHeader = true,
 }: ModelTiersSettingsCardProps) {
   const {
     maxTierName: workspaceMaxTierName,
@@ -29,9 +31,11 @@ export function ModelTiersSettingsCard({
 
   return (
     <Page.Vertical gap="sm" align="stretch">
-      <span className="heading-base text-foreground dark:text-foreground-night">
-        Models tier
-      </span>
+      {showHeader && (
+        <span className="heading-base text-foreground dark:text-foreground-night">
+          Models tier
+        </span>
+      )}
       <SettingsList>
         <SettingsList.Row
           title="Workspace access"


### PR DESCRIPTION
## Description

Adds an **"Allowed models"** section to the Model Providers page, mirroring the model-tier management feature already available on the Usage page. The section is gated behind the `models_picker` feature flag and is admin-only.

It exposes three tabs (matching the Usage page):

- **Members** — a table listing each member with **Name / Groups / Models tier**, plus a three-dots menu with a **"Models tier ›"** submenu to override a member's allowed tier.
- **Groups** — reuses `GroupsUsageTable` showing **Group / Members / Models tier** (spend-limit column hidden here).
- **Workspace settings** — the workspace-wide model-tier toggle.

Shared logic (tier resolution, tier picker, submenu builder, SWR hooks) is reused across both pages; only the presentational tables differ.

Changes:
- New `AllowedModelsSection` (tabbed section + data fetching) and `AllowedModelsMembersTable` (lightweight members table composing the existing tier helpers).
- `GroupsUsageTable` gains a `showSpendLimitColumn` prop (default `true`) so the section can render Group/Members/Models tier only.
- `ModelTiersSettingsCard` gains a `showHeader` prop (default `true`) so the settings tab shows just the toggle.
- Wired into `ModelProvidersPageContent`, gated by `hasFeature("models_picker") && isAdmin(workspace)` — the same gate used on the Usage page.

## Tests

Manual verification behind the `models_picker` flag on the Model Providers page: each tab renders, the members three-dots "Models tier" submenu sets/clears a per-user override, the groups picker updates per-group tiers, and the workspace toggle updates the workspace-wide tier. Usage page behavior is unchanged (both extended components default to their previous rendering).
