### PR TITLE
feat: add messaging app policies to governance page and remove workspace settings

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -270,6 +270,7 @@ export const subNavigationAdmin = ({
 
   const hasAdminRole = isAdmin(owner);
   const hasBusinessAdminRole = isBusinessAdmin(owner);
+  const isAdminGovernanceEnabled = featureFlags.includes("admin_governance");
 
   nav.push({
     id: "workspace",
@@ -285,7 +286,7 @@ export const subNavigationAdmin = ({
       },
       {
         id: "identity_and_provisioning",
-        label: featureFlags.includes("admin_governance")
+        label: isAdminGovernanceEnabled
           ? "IT & Security"
           : "Identity & Provisioning",
         icon: Fingerprint04,
@@ -293,15 +294,7 @@ export const subNavigationAdmin = ({
         current: isCurrent("identity_and_provisioning"),
         disabled: !hasAdminRole,
       },
-      {
-        id: "workspace",
-        label: "Workspace Settings",
-        icon: Building04,
-        href: `/w/${owner.sId}/workspace`,
-        current: isCurrent("workspace"),
-        disabled: !hasAdminRole,
-      },
-      ...(featureFlags.includes("admin_governance")
+      ...(isAdminGovernanceEnabled
         ? [
             {
               id: "governance" as const,
@@ -312,7 +305,16 @@ export const subNavigationAdmin = ({
               disabled: !hasBusinessAdminRole,
             },
           ]
-        : []),
+        : [
+            {
+              id: "workspace" as const,
+              label: "Workspace Settings",
+              icon: Building04,
+              href: `/w/${owner.sId}/workspace`,
+              current: isCurrent("workspace"),
+              disabled: !hasAdminRole,
+            },
+          ]),
       ...(featureFlags.includes("whitelabel_frames")
         ? [
             {

--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -4,33 +4,14 @@ import { PreferencesSection } from "@app/components/workspace/settings/Preferenc
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
 import { getPublishingRestrictionMessage } from "@app/lib/api/assistant/publishing_restrictions";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
-import { useBotDataSources } from "@app/lib/swr/data_sources";
-import { useSystemSpace } from "@app/lib/swr/spaces";
-import { Building04, Page, Spinner } from "@dust-tt/sparkle";
+import { Building04, Page } from "@dust-tt/sparkle";
 
 export function WorkspaceSettingsPage() {
   const owner = useWorkspace();
-  const { featureFlags } = useFeatureFlags();
-  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
-    workspaceId: owner.sId,
-  });
-  const {
-    slackBotDataSource,
-    microsoftBotDataSource,
-    discordBotDataSource,
-    isBotDataSourcesLoading,
-  } = useBotDataSources({ workspaceId: owner.sId });
+  const { featureFlags, hasFeature } = useFeatureFlags();
 
-  const isDiscordBotAvailable = featureFlags.includes("discord_bot");
-
-  const isLoading = isSystemSpaceLoading || isBotDataSourcesLoading;
-
-  if (isLoading || !systemSpace) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+  if (hasFeature("admin_governance")) {
+    return null;
   }
 
   return (
@@ -46,14 +27,7 @@ export function WorkspaceSettingsPage() {
           featureFlags
         )}
       />
-      <IntegrationsSection
-        owner={owner}
-        systemSpace={systemSpace}
-        slackBotDataSource={slackBotDataSource}
-        microsoftBotDataSource={microsoftBotDataSource}
-        discordBotDataSource={discordBotDataSource}
-        isDiscordBotAvailable={isDiscordBotAvailable}
-      />
+      <IntegrationsSection owner={owner} />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -2,10 +2,11 @@ import { GovernanceSettingRow } from "@app/components/pages/workspace/governance
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
 import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
-import { AuditLogsToggle } from "@app/components/workspace/settings/AuditLogsToggle";
+import { AuditLogsGovernanceSection } from "@app/components/workspace/settings/AuditLogsToggle";
 import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharing } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
+import { MessagingAppToggles } from "@app/components/workspace/settings/MessagingAppToggles";
 import { OpenPodPolicy } from "@app/components/workspace/settings/OpenProjectsPolicy";
 import { PodKnowledgePolicy } from "@app/components/workspace/settings/PodKnowledgePolicy";
 import { PrivateConversationUrlsToggle } from "@app/components/workspace/settings/PrivateConversationUrlsToggle";
@@ -34,9 +35,9 @@ import type {
 } from "@app/types/user";
 import {
   ActionFrame,
+  CloudArrowLeftRight,
   ContentMessage,
-  File04,
-  IntersectDust,
+  Cube01,
   Lock01,
   Page,
   PuzzlePiece01,
@@ -213,11 +214,14 @@ export const GovernancePage = () => {
 
         {isAdmin && (
           <>
-            <GovernanceSettingSection label="Pods" icon={IntersectDust}>
+            <GovernanceSettingSection label="Pods" icon={Cube01}>
               <OpenPodPolicy owner={owner} />
               <PodKnowledgePolicy owner={owner} />
             </GovernanceSettingSection>
-            <GovernanceSettingSection label="Capabilities" icon={ShapesPlus}>
+            <GovernanceSettingSection
+              label="Feature policies"
+              icon={ShapesPlus}
+            >
               <VoiceTranscriptionToggle owner={owner} />
               <EmailAgentsToggle owner={owner} />
               <PrivateConversationUrlsToggle owner={owner} />
@@ -226,9 +230,13 @@ export const GovernancePage = () => {
               <SlackPersonalFooterRemovalToggle owner={owner} />
               <WorkspaceAnalyticsToggle owner={owner} />
             </GovernanceSettingSection>
-            <GovernanceSettingSection label="Audit" icon={File04}>
-              <AuditLogsToggle owner={owner} />
+            <GovernanceSettingSection
+              label="Messaging app policies"
+              icon={CloudArrowLeftRight}
+            >
+              <MessagingAppToggles owner={owner} />
             </GovernanceSettingSection>
+            <AuditLogsGovernanceSection owner={owner} />
           </>
         )}
       </div>

--- a/front/components/pages/workspace/governance/GovernanceSettingRowLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRowLayout.tsx
@@ -1,4 +1,4 @@
-import { Page } from "@dust-tt/sparkle";
+import { BookOpen01, Page } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 interface GovernanceSettingRowLayoutProps {
@@ -6,6 +6,7 @@ interface GovernanceSettingRowLayoutProps {
   description: string;
   action?: ReactNode;
   children?: ReactNode;
+  documentationUrl?: string;
 }
 
 export const GovernanceSettingRowLayout = ({
@@ -13,15 +14,28 @@ export const GovernanceSettingRowLayout = ({
   description,
   action,
   children,
+  documentationUrl,
 }: GovernanceSettingRowLayoutProps) => {
   return (
     <div className="flex w-full flex-col gap-3 p-4">
       <div className="flex w-full items-center justify-between gap-4">
         <Page.Vertical gap="xs" sizing="grow">
           <Page.H variant="h6">{label}</Page.H>
-          <Page.P variant="secondary" size="sm">
-            {description}
-          </Page.P>
+          <div className="flex flex-row items-center gap-2">
+            <Page.P variant="secondary" size="sm">
+              {description}
+            </Page.P>
+            {documentationUrl && (
+              <a
+                href={documentationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-action-400 hover:text-action-500 text-sm"
+              >
+                <BookOpen01 className="h-4 w-4" />
+              </a>
+            )}
+          </div>
         </Page.Vertical>
         {action}
       </div>

--- a/front/components/workspace/settings/AuditLogsToggle.tsx
+++ b/front/components/workspace/settings/AuditLogsToggle.tsx
@@ -1,8 +1,14 @@
 import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
+import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
 import { useAuditLogsToggle } from "@app/hooks/useAuditLogsToggle";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
-import { ContextItem, File04, SliderToggle } from "@dust-tt/sparkle";
+import {
+  ContextItem,
+  File04,
+  LayerSingle,
+  SliderToggle,
+} from "@dust-tt/sparkle";
 
 interface AuditLogsToggleProps {
   owner: WorkspaceType;
@@ -22,22 +28,6 @@ export function AuditLogsToggle({ owner }: AuditLogsToggleProps) {
     return null;
   }
 
-  if (hasFeature("admin_governance")) {
-    return (
-      <GovernanceSettingRowLayout
-        label="Audit logs"
-        description="Emit audit events to WorkOS and expose the audit logs section in IT & Security."
-        action={
-          <SliderToggle
-            selected={isEnabled}
-            disabled={isChanging}
-            onClick={doToggleAuditLogs}
-          />
-        }
-      />
-    );
-  }
-
   return (
     <ContextItem
       title="Audit Logs"
@@ -52,5 +42,36 @@ export function AuditLogsToggle({ owner }: AuditLogsToggleProps) {
         />
       }
     />
+  );
+}
+
+export function AuditLogsGovernanceSection({ owner }: AuditLogsToggleProps) {
+  const { subscription } = useAuth();
+  const { isEnabled, isChanging, doToggleAuditLogs } = useAuditLogsToggle({
+    owner,
+  });
+  const { hasFeature } = useFeatureFlags();
+
+  const hasAuditLogsAccess =
+    subscription.plan.isAuditLogsAllowed || hasFeature("audit_logs");
+
+  if (!hasAuditLogsAccess) {
+    return null;
+  }
+
+  return (
+    <GovernanceSettingSection label="Audit" icon={LayerSingle}>
+      <GovernanceSettingRowLayout
+        label="Audit logs"
+        description="Emit audit events to WorkOS and expose the audit logs section in IT & Security."
+        action={
+          <SliderToggle
+            selected={isEnabled}
+            disabled={isChanging}
+            onClick={doToggleAuditLogs}
+          />
+        }
+      />
+    </GovernanceSettingSection>
   );
 }

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -125,73 +125,76 @@ export function BotToggle({
     setIsChangingBot(false);
   };
 
-  const actionNode = (
-    <div className="flex flex-row items-center gap-2">
-      {isBotEnabled && botDataSource && (
-        <Button
-          variant="outline"
-          label="Reconnect"
-          size="xs"
-          icon={RefreshCw02}
-          onClick={async () => {
-            const cRes = await setupOAuthConnection({
-              owner,
-              provider: oauth.provider,
-              useCase: oauth.useCase ?? "connection",
-              extraConfig: oauth.extraConfig,
-              regionInfo: regionContext.regionInfo,
-            });
-            if (!cRes.isOk()) {
-              sendNotification({
-                type: "error",
-                title: `Failed to reconnect ${name}.`,
-                description: `Could not reconnect the Dust ${name}.`,
-              });
-            } else {
-              const updateRes = await updateConnectorConnectionId(
-                cRes.value.connection_id,
-                oauth.extraConfig,
-                connectorProvider,
-                botDataSource,
-                owner
-              );
+  const handleReconnect = async () => {
+    if (!botDataSource) {
+      return;
+    }
+    const cRes = await setupOAuthConnection({
+      owner,
+      provider: oauth.provider,
+      useCase: oauth.useCase ?? "connection",
+      extraConfig: oauth.extraConfig,
+      regionInfo: regionContext.regionInfo,
+    });
+    if (!cRes.isOk()) {
+      sendNotification({
+        type: "error",
+        title: `Failed to reconnect ${name}.`,
+        description: `Could not reconnect the Dust ${name}.`,
+      });
+    } else {
+      const updateRes = await updateConnectorConnectionId(
+        cRes.value.connection_id,
+        oauth.extraConfig,
+        connectorProvider,
+        botDataSource,
+        owner
+      );
 
-              if (updateRes.error) {
-                sendNotification({
-                  type: "error",
-                  title: `Failed to update the ${name} connection`,
-                  description: updateRes.error,
-                });
-              } else {
-                sendNotification({
-                  type: "success",
-                  title: `Successfully updated ${name} connection`,
-                  description: "The connection was successfully updated.",
-                });
-              }
-            }
-          }}
-        />
-      )}
-      <SliderToggle
-        selected={
-          // When changing and initially enabled, show disabled, and vice versa.
-          isBotEnabled !== isChangingBot
-        }
-        disabled={isChangingBot}
-        onClick={() => {
-          void toggleBot();
-        }}
-      />
-    </div>
-  );
+      if (updateRes.error) {
+        sendNotification({
+          type: "error",
+          title: `Failed to update the ${name} connection`,
+          description: updateRes.error,
+        });
+      } else {
+        sendNotification({
+          type: "success",
+          title: `Successfully updated ${name} connection`,
+          description: "The connection was successfully updated.",
+        });
+      }
+    }
+  };
 
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
         label={name}
         description={description}
-        action={actionNode}
+        action={
+          <div className="flex flex-row items-center gap-2">
+            {isBotEnabled && botDataSource && (
+              <Button
+                variant="outline"
+                label="Reconnect"
+                size="xs"
+                icon={RefreshCw02}
+                onClick={handleReconnect}
+              />
+            )}
+            <SliderToggle
+              selected={
+                // When changing and initially enabled, show disabled, and vice versa.
+                isBotEnabled !== isChangingBot
+              }
+              disabled={isChangingBot}
+              onClick={() => {
+                void toggleBot();
+              }}
+            />
+          </div>
+        }
         documentationUrl={documentationUrl}
       />
     );
@@ -218,7 +221,29 @@ export function BotToggle({
       visual={visual}
       truncateSubElement={true}
       hasSeparatorIfLast={true}
-      action={actionNode}
+      action={
+        <div className="flex flex-row items-center gap-2">
+          {isBotEnabled && botDataSource && (
+            <Button
+              variant="outline"
+              label="Reconnect"
+              size="xs"
+              icon={RefreshCw02}
+              onClick={handleReconnect}
+            />
+          )}
+          <SliderToggle
+            selected={
+              // When changing and initially enabled, show disabled, and vice versa.
+              isBotEnabled !== isChangingBot
+            }
+            disabled={isChangingBot}
+            onClick={() => {
+              void toggleBot();
+            }}
+          />
+        </div>
+      }
     />
   );
 }

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -1,5 +1,7 @@
 import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
+import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig, useToggleChatBot } from "@app/lib/swr/connectors";
@@ -41,9 +43,11 @@ export function BotToggle({
   connectorProvider: ConnectorProvider;
   name: string;
   description: string;
-  visual: React.ReactNode;
+  visual?: React.ReactNode;
   documentationUrl?: string;
 }) {
+  const { hasFeature } = useFeatureFlags();
+
   const { configValue } = useConnectorConfig({
     configKey: "botEnabled",
     dataSource: botDataSource ?? null,
@@ -121,6 +125,78 @@ export function BotToggle({
     setIsChangingBot(false);
   };
 
+  const actionNode = (
+    <div className="flex flex-row items-center gap-2">
+      {isBotEnabled && botDataSource && (
+        <Button
+          variant="outline"
+          label="Reconnect"
+          size="xs"
+          icon={RefreshCw02}
+          onClick={async () => {
+            const cRes = await setupOAuthConnection({
+              owner,
+              provider: oauth.provider,
+              useCase: oauth.useCase ?? "connection",
+              extraConfig: oauth.extraConfig,
+              regionInfo: regionContext.regionInfo,
+            });
+            if (!cRes.isOk()) {
+              sendNotification({
+                type: "error",
+                title: `Failed to reconnect ${name}.`,
+                description: `Could not reconnect the Dust ${name}.`,
+              });
+            } else {
+              const updateRes = await updateConnectorConnectionId(
+                cRes.value.connection_id,
+                oauth.extraConfig,
+                connectorProvider,
+                botDataSource,
+                owner
+              );
+
+              if (updateRes.error) {
+                sendNotification({
+                  type: "error",
+                  title: `Failed to update the ${name} connection`,
+                  description: updateRes.error,
+                });
+              } else {
+                sendNotification({
+                  type: "success",
+                  title: `Successfully updated ${name} connection`,
+                  description: "The connection was successfully updated.",
+                });
+              }
+            }
+          }}
+        />
+      )}
+      <SliderToggle
+        selected={
+          // When changing and initially enabled, show disabled, and vice versa.
+          isBotEnabled !== isChangingBot
+        }
+        disabled={isChangingBot}
+        onClick={() => {
+          void toggleBot();
+        }}
+      />
+    </div>
+  );
+
+  if (hasFeature("admin_governance")) {
+    return (
+      <GovernanceSettingRowLayout
+        label={name}
+        description={description}
+        action={actionNode}
+        documentationUrl={documentationUrl}
+      />
+    );
+  }
+
   return (
     <ContextItem
       title={name}
@@ -142,66 +218,7 @@ export function BotToggle({
       visual={visual}
       truncateSubElement={true}
       hasSeparatorIfLast={true}
-      action={
-        <div className="flex flex-row items-center gap-2">
-          {isBotEnabled && botDataSource && (
-            <Button
-              variant="outline"
-              label="Reconnect"
-              size="xs"
-              icon={RefreshCw02}
-              onClick={async () => {
-                const cRes = await setupOAuthConnection({
-                  owner,
-                  provider: oauth.provider,
-                  useCase: oauth.useCase ?? "connection",
-                  extraConfig: oauth.extraConfig,
-                  regionInfo: regionContext.regionInfo,
-                });
-                if (!cRes.isOk()) {
-                  sendNotification({
-                    type: "error",
-                    title: `Failed to reconnect ${name}.`,
-                    description: `Could not reconnect the Dust ${name}.`,
-                  });
-                } else {
-                  const updateRes = await updateConnectorConnectionId(
-                    cRes.value.connection_id,
-                    oauth.extraConfig,
-                    connectorProvider,
-                    botDataSource,
-                    owner
-                  );
-
-                  if (updateRes.error) {
-                    sendNotification({
-                      type: "error",
-                      title: `Failed to update the ${name} connection`,
-                      description: updateRes.error,
-                    });
-                  } else {
-                    sendNotification({
-                      type: "success",
-                      title: `Successfully updated ${name} connection`,
-                      description: "The connection was successfully updated.",
-                    });
-                  }
-                }
-              }}
-            />
-          )}
-          <SliderToggle
-            selected={
-              // When changing and initially enabled, show disabled, and vice versa.
-              isBotEnabled !== isChangingBot
-            }
-            disabled={isChangingBot}
-            onClick={() => {
-              void toggleBot();
-            }}
-          />
-        </div>
-      }
+      action={actionNode}
     />
   );
 }

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -9,7 +9,6 @@ import { RestrictAgentsPublishingCapability } from "@app/components/workspace/se
 import { SlackPersonalFooterRemovalToggle } from "@app/components/workspace/settings/SlackPersonalFooterRemovalToggle";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
 import { WorkspaceAnalyticsToggle } from "@app/components/workspace/settings/WorkspaceAnalyticsToggle";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
 
@@ -22,13 +21,6 @@ export function CapabilitiesSection({
   owner,
   publishingRestrictionMessage,
 }: CapabilitiesSectionProps) {
-  const { hasFeature } = useFeatureFlags();
-  const isAdminGovernanceEnabled = hasFeature("admin_governance");
-
-  if (isAdminGovernanceEnabled) {
-    return null;
-  }
-
   return (
     <Page.Vertical align="stretch" gap="md">
       <Page.H variant="h4">Capabilities</Page.H>

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -47,6 +47,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
 
   const label = "Email agents";
   const description = `Allow workspace members to email agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}`;
+  const documentationUrl = "https://docs.dust.tt/docs/email-agents";
 
   return (
     <>
@@ -54,6 +55,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
         <GovernanceSettingRowLayout
           label={label}
           description={description}
+          documentationUrl={documentationUrl}
           action={
             <SliderToggle
               selected={isEnabled}
@@ -74,7 +76,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
                 <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
               </span>
               <a
-                href="https://docs.dust.tt/docs/email-agents"
+                href={documentationUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-action-400 hover:text-action-500 text-sm"

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -24,6 +24,10 @@ const ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE =
   "from untrusted sources, since those are exposed to security risks such as " +
   "prompt injection.";
 
+const LABEL = "Email agents";
+const DESCRIPTION = `Allow workspace members to email agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}`;
+const DOCUMENTATION_URL = "https://docs.dust.tt/docs/email-agents";
+
 interface EmailAgentsToggleProps {
   owner: WorkspaceType;
 }
@@ -45,17 +49,13 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
     ? "Disable email agents"
     : "Enable email agents";
 
-  const label = "Email agents";
-  const description = `Allow workspace members to email agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}`;
-  const documentationUrl = "https://docs.dust.tt/docs/email-agents";
-
   return (
     <>
       {hasFeature("admin_governance") ? (
         <GovernanceSettingRowLayout
-          label={label}
-          description={description}
-          documentationUrl={documentationUrl}
+          label={LABEL}
+          description={DESCRIPTION}
+          documentationUrl={DOCUMENTATION_URL}
           action={
             <SliderToggle
               selected={isEnabled}
@@ -68,7 +68,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
         />
       ) : (
         <ContextItem
-          title={label}
+          title={LABEL}
           subElement={
             <div className="flex flex-row items-center gap-2">
               <span>
@@ -76,7 +76,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
                 <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
               </span>
               <a
-                href={documentationUrl}
+                href={DOCUMENTATION_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-action-400 hover:text-action-500 text-sm"

--- a/front/components/workspace/settings/IntegrationsSection.tsx
+++ b/front/components/workspace/settings/IntegrationsSection.tsx
@@ -1,77 +1,18 @@
-import { BotToggle } from "@app/components/workspace/settings/BotToggle";
-import type { DataSourceType } from "@app/types/data_source";
-import type { SpaceType } from "@app/types/space";
+import { MessagingAppToggles } from "@app/components/workspace/settings/MessagingAppToggles";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  ContextItem,
-  DiscordLogo,
-  MicrosoftLogo,
-  Page,
-  SlackLogo,
-} from "@dust-tt/sparkle";
+import { ContextItem, Page } from "@dust-tt/sparkle";
 
-export function IntegrationsSection({
-  owner,
-  systemSpace,
-  slackBotDataSource,
-  microsoftBotDataSource,
-  discordBotDataSource,
-  isDiscordBotAvailable,
-}: {
+interface IntegrationsSectionProps {
   owner: WorkspaceType;
-  systemSpace: SpaceType;
-  slackBotDataSource: DataSourceType | null;
-  microsoftBotDataSource: DataSourceType | null;
-  discordBotDataSource: DataSourceType | null;
-  isDiscordBotAvailable: boolean;
-}) {
+}
+
+export function IntegrationsSection({ owner }: IntegrationsSectionProps) {
   return (
     <Page.Vertical align="stretch" gap="md">
       <Page.H variant="h4">Integrations</Page.H>
       <ContextItem.List>
         <div className="h-full border-b border-border" />
-        <BotToggle
-          owner={owner}
-          botDataSource={slackBotDataSource}
-          systemSpace={systemSpace}
-          oauth={{ provider: "slack", useCase: "bot", extraConfig: {} }}
-          connectorProvider="slack_bot"
-          name="Slack Bot"
-          description="Use Dust Agents in Slack with the Dust Slack app"
-          visual={<SlackLogo className="h-6 w-6" />}
-          documentationUrl="https://docs.dust.tt/docs/slack"
-        />
-        <BotToggle
-          owner={owner}
-          botDataSource={microsoftBotDataSource}
-          systemSpace={systemSpace}
-          oauth={{
-            provider: "microsoft_tools",
-            useCase: "bot",
-            extraConfig: {},
-          }}
-          connectorProvider="microsoft_bot"
-          name="Microsoft Teams Bot"
-          description="Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
-          visual={<MicrosoftLogo className="h-6 w-6" />}
-          documentationUrl="https://docs.dust.tt/docs/dust-in-teams"
-        />
-        {isDiscordBotAvailable && (
-          <BotToggle
-            owner={owner}
-            botDataSource={discordBotDataSource}
-            systemSpace={systemSpace}
-            oauth={{
-              provider: "discord",
-              useCase: "bot",
-              extraConfig: {},
-            }}
-            connectorProvider="discord_bot"
-            name="Discord Bot"
-            description="Use Dust Agents in Discord with the Dust Discord app"
-            visual={<DiscordLogo className="h-6 w-6" />}
-          />
-        )}
+        <MessagingAppToggles owner={owner} />
       </ContextItem.List>
     </Page.Vertical>
   );

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -17,33 +17,26 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
-  Globe01,
-  Lock01,
-  Users01,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const SHARING_POLICY_OPTIONS: {
   description: string;
-  icon: typeof Lock01;
   label: string;
   value: WorkspaceSharingPolicy;
 }[] = [
   {
-    icon: Lock01,
     label: "Workspace members only",
     description: "Frames can only be viewed by workspace members",
     value: "workspace_only",
   },
   {
-    icon: Users01,
     label: "Members + email invites",
     description:
       "Frames can be shared with workspace members or via email invite",
     value: "workspace_and_emails",
   },
   {
-    icon: Globe01,
     label: "No restrictions",
     description:
       "Members can share Frames publicly, with the workspace, or via email invite",
@@ -198,7 +191,6 @@ export function InteractiveContentSharing({
 
 interface InteractiveContentSharingDropdownProps {
   selectedOption?: {
-    icon: typeof Lock01;
     label: string;
   };
   isChanging: boolean;
@@ -220,7 +212,6 @@ const InteractiveContentSharingDropdown = ({
           size="sm"
           isSelect
           label={selectedOption?.label}
-          icon={selectedOption?.icon}
           disabled={isChanging}
           className="grid grid-cols-[auto_1fr_auto] truncate"
         />
@@ -233,7 +224,6 @@ const InteractiveContentSharingDropdown = ({
               value={option.value}
               label={option.label}
               description={option.description}
-              icon={option.icon}
               onClick={() => onPolicyChange(option.value)}
             />
           ))}

--- a/front/components/workspace/settings/MessagingAppToggles.tsx
+++ b/front/components/workspace/settings/MessagingAppToggles.tsx
@@ -1,0 +1,85 @@
+import { BotToggle } from "@app/components/workspace/settings/BotToggle";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useBotDataSources } from "@app/lib/swr/data_sources";
+import { useSystemSpace } from "@app/lib/swr/spaces";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  DiscordLogo,
+  MicrosoftLogo,
+  SlackLogo,
+  Spinner,
+} from "@dust-tt/sparkle";
+
+interface MessagingAppTogglesProps {
+  owner: WorkspaceType;
+}
+
+export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
+  const { hasFeature } = useFeatureFlags();
+  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
+    workspaceId: owner.sId,
+  });
+  const {
+    slackBotDataSource,
+    microsoftBotDataSource,
+    discordBotDataSource,
+    isBotDataSourcesLoading,
+  } = useBotDataSources({ workspaceId: owner.sId });
+
+  const isDiscordBotAvailable = hasFeature("discord_bot");
+
+  if (isSystemSpaceLoading || isBotDataSourcesLoading || !systemSpace) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <BotToggle
+        owner={owner}
+        botDataSource={slackBotDataSource}
+        systemSpace={systemSpace}
+        oauth={{ provider: "slack", useCase: "bot", extraConfig: {} }}
+        connectorProvider="slack_bot"
+        name="Slack Bot"
+        description="Use Dust Agents in Slack with the Dust Slack app"
+        visual={<SlackLogo className="h-6 w-6" />}
+        documentationUrl="https://docs.dust.tt/docs/slack"
+      />
+      <BotToggle
+        owner={owner}
+        botDataSource={microsoftBotDataSource}
+        systemSpace={systemSpace}
+        oauth={{
+          provider: "microsoft_tools",
+          useCase: "bot",
+          extraConfig: {},
+        }}
+        connectorProvider="microsoft_bot"
+        name="Microsoft Teams Bot"
+        description="Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
+        visual={<MicrosoftLogo className="h-6 w-6" />}
+        documentationUrl="https://docs.dust.tt/docs/dust-in-teams"
+      />
+      {isDiscordBotAvailable && (
+        <BotToggle
+          owner={owner}
+          botDataSource={discordBotDataSource}
+          systemSpace={systemSpace}
+          oauth={{
+            provider: "discord",
+            useCase: "bot",
+            extraConfig: {},
+          }}
+          connectorProvider="discord_bot"
+          name="Discord Bot"
+          description="Use Dust Agents in Discord with the Dust Discord app"
+          visual={<DiscordLogo className="h-6 w-6" />}
+        />
+      )}
+    </>
+  );
+}

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -5,7 +5,6 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
   ContextItem,
-  Cube01,
   CubeOutline,
   DropdownMenu,
   DropdownMenuContent,
@@ -19,14 +18,12 @@ const OPEN_PODS_POLICIES = [
     value: "private_and_open",
     label: "Restricted and open Pods",
     description: "Members can create either restricted or open Pods.",
-    icon: Cube01,
     allowOpenProjects: true,
   },
   {
     value: "private_only",
     label: "Restricted Pods only",
     description: "Members can only create restricted Pods.",
-    icon: CubeOutline,
     allowOpenProjects: false,
   },
 ] as const;
@@ -98,7 +95,6 @@ const OpenPodPolicyDropdown = ({
           size="sm"
           isSelect
           label={selectedPolicy?.label}
-          icon={selectedPolicy?.icon}
           disabled={isChanging}
           className="grid grid-cols-[auto_1fr_auto] truncate"
         />
@@ -111,7 +107,6 @@ const OpenPodPolicyDropdown = ({
               value={policy.value}
               label={policy.label}
               description={policy.description}
-              icon={policy.icon}
               onClick={() =>
                 void doUpdateOpenPodsPolicy(policy.allowOpenProjects)
               }

--- a/front/components/workspace/settings/PodKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/PodKnowledgePolicy.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
-  Lock01,
 } from "@dust-tt/sparkle";
 
 const POD_KNOWLEDGE_POLICIES = [
@@ -19,14 +18,12 @@ const POD_KNOWLEDGE_POLICIES = [
     value: "enabled",
     label: "Manual updates allowed",
     description: "Members can manually add files to Pod.",
-    icon: BookOpen01,
     allowManualProjectKnowledgeManagement: true,
   },
   {
     value: "disabled",
     label: "Manual updates disabled",
     description: "Members cannot manually add files to Pod.",
-    icon: Lock01,
     allowManualProjectKnowledgeManagement: false,
   },
 ] as const;
@@ -104,7 +101,6 @@ const PodKnowledgePolicyDropdown = ({
           size="sm"
           isSelect
           label={selectedPolicy?.label}
-          icon={selectedPolicy?.icon}
           disabled={isChanging}
           className="grid grid-cols-[auto_1fr_auto] truncate"
         />
@@ -117,7 +113,6 @@ const PodKnowledgePolicyDropdown = ({
               value={policy.value}
               label={policy.label}
               description={policy.description}
-              icon={policy.icon}
               onClick={() =>
                 void doUpdatePodKnowledgePolicy(
                   policy.allowManualProjectKnowledgeManagement


### PR DESCRIPTION
## Description

This PR moves messaging app policies (Slack Bot, Microsoft Teams Bot, Discord Bot) to the governance page and hides the workspace settings page when the `admin_governance` feature flag is enabled.
Moreover it adds `documentationUrl` support to `GovernanceSettingRowLayout` to render an inline documentation icon link and it updates copy and icons.

## Tests

Manually.

## Risks

Low. Only UI changes, no functionalities.

## Deploy Plan

Standard deployment.