### PR TITLE
[sparkle] Center spinner and preserve size in button loading state

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -344,13 +344,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       return <Icon visual={visual} size={iconSize} className={extraClass} />;
     };
 
-    const content = (
+    const restingContent = (
       <>
-        {isLoading ? (
-          <Spinner size="xs" variant={spinnerVariantMap[normalizedVariant]} />
-        ) : (
-          icon && renderIcon(icon, iconShadow)
-        )}
+        {icon && renderIcon(icon, iconShadow)}
         {label && (
           <span className={cn(hasTextShadow && TEXT_SHADOW)}>{label}</span>
         )}
@@ -362,7 +358,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             isInButton={true}
           />
         )}
-        {!isLoading && iconRight && renderIcon(iconRight, iconShadow)}
+        {iconRight && renderIcon(iconRight, iconShadow)}
         {isSelect && (
           <Icon
             visual={ChevronDown}
@@ -373,6 +369,24 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           />
         )}
       </>
+    );
+
+    // Loading keeps the button at its resting size: the normal content stays
+    // in the layout but invisible, and a centered spinner overlays it.
+    const content = isLoading ? (
+      <>
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Spinner size="xs" variant={spinnerVariantMap[normalizedVariant]} />
+        </span>
+        <span
+          aria-hidden="true"
+          className="invisible flex items-center gap-[inherit]"
+        >
+          {restingContent}
+        </span>
+      </>
+    ) : (
+      restingContent
     );
 
     const pointerEventProps = React.useMemo(() => {
@@ -405,6 +419,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           }),
           isPulsing && "animate-ring-pulse-soft",
           isRounded && "rounded-full",
+          isLoading && "relative",
           className
         )}
         aria-label={ariaLabel || tooltip || label}


### PR DESCRIPTION
## Description

Previously, the `Button` loading state replaced the icon with a spinner and hid other content, causing the button to change size depending on the label/icon widths. This PR fixes that by keeping the resting content (icon, label, chevron, `iconRight`) in the layout but invisible during loading, and overlaying an absolutely-centered spinner on top. The button wrapper gets `position: relative` only when `isLoading` is true to support the overlay positioning.

## Tests

Visual check: toggle `isLoading` on buttons of various sizes/variants and confirm the button does not resize and the spinner is centered.

## Risk

Low — cosmetic-only change to `Button.tsx` in Sparkle. No logic or API surface changes.

## Deploy Plan

Deploy sparkle.