### PR TITLE
[Skills] Remove 'globalSpaceOnly: true' to fix restricted skills bug

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -334,7 +334,7 @@ app.post(
       const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 
       const r = await SkillResource.upsertConversationSkills(auth, {
-        conversationId: conversation.id,
+        conversation,
         skills,
         enabled: true,
       });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -82,7 +82,7 @@ app.post(
     }
 
     const r = await SkillResource.upsertConversationSkills(auth, {
-      conversationId: conversationWithoutContent.id,
+      conversation: conversationWithoutContent,
       skills: [skillRes],
       enabled: action === "add",
     });

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -360,7 +360,7 @@ app.post(
         const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 
         const r = await SkillResource.upsertConversationSkills(auth, {
-          conversationId: newConversation.id,
+          conversation: newConversation,
           skills,
           enabled: true,
         });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -235,6 +235,32 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).toContain("Skill In Restricted Space");
   });
 
+  it("includes accessible restricted skills by default but excludes them when globalSpaceOnly=true", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [user.sId] });
+
+    await SkillFactory.create(auth, {
+      name: "Member Restricted Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const defaultRes = await getSkills(workspace);
+    const defaultNames = (await defaultRes.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(defaultNames).toContain("Member Restricted Skill");
+
+    const globalRes = await getSkills(workspace, { globalSpaceOnly: "true" });
+    const globalNames = (await globalRes.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(globalNames).not.toContain("Member Restricted Skill");
+  });
+
   it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 
@@ -767,6 +793,29 @@ describe("POST /api/w/:wId/skills", () => {
         message: `User does not have access to the following spaces: ${restrictedSpace.sId}`,
       },
     });
+  });
+
+  it("allows restricting a skill to an open Pod the user can access", async () => {
+    const { workspace, globalGroup } = await setupTest("builder");
+
+    const openPod = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(openPod, globalGroup);
+
+    const response = await postSkill(workspace, {
+      name: "Skill Restricted To Open Pod",
+      agentFacingDescription: "To use with an open Pod",
+      userFacingDescription: "A skill with a selected Pod",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [openPod.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.skill.requestedSpaceIds).toContain(openPod.sId);
   });
 
   it("creates a skill configuration with 2 tools", async () => {

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -271,7 +271,6 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !shouldFetchToolsData,
   });
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -72,7 +72,6 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
   });
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(owner, globalSpaces);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -180,7 +180,6 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -854,7 +854,7 @@ describe("createConversationFork", () => {
     });
 
     const upsertResult = await SkillResource.upsertConversationSkills(auth, {
-      conversationId: parentConversation.id,
+      conversation: parentConversation,
       skills: [enabledSkill],
       enabled: true,
     });

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -203,7 +203,7 @@ async function copyConversationSkills(
   const upsertResult = await SkillResource.upsertConversationSkills(
     auth,
     {
-      conversationId: childConversation.id,
+      conversation: childConversation,
       skills: parentSkills,
       enabled: true,
     },

--- a/front/lib/api/assistant/conversation/skill_permissions.test.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.test.ts
@@ -1,0 +1,170 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { updateConversationRequirementsForSkills } from "@app/lib/api/assistant/conversation/skill_permissions";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("updateConversationRequirementsForSkills", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
+  let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    projectSpace = await SpaceFactory.project(workspace);
+    anotherProjectSpace = await SpaceFactory.project(workspace);
+
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userJson = auth.getNonNullableUser().toJSON();
+
+    for (const space of [projectSpace, anotherProjectSpace]) {
+      const group = space.groups.find((g) => g.isRegularAuto());
+      if (group) {
+        const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
+          user: userJson,
+        });
+        if (addRes.isErr()) {
+          throw new Error(addRes.error.message);
+        }
+      }
+    }
+
+    await auth.refresh();
+  });
+
+  const fetchConversationWithoutContent = async (
+    conversationSId: string
+  ): Promise<ConversationWithoutContentType> => {
+    const result = await getConversation(auth, conversationSId);
+    if (result.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+    return result.value;
+  };
+
+  const createRegularConversation =
+    async (): Promise<ConversationWithoutContentType> => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+      return fetchConversationWithoutContent(conversation.sId);
+    };
+
+  const createSkill = (requestedSpaceIds: number[]): Promise<SkillResource> =>
+    SkillFactory.create(auth, {
+      name: `Skill ${requestedSpaceIds.join("-")}-${Math.random()}`,
+      requestedSpaceIds,
+    });
+
+  describe("regular conversations", () => {
+    it("appends the skills' space requirements", async () => {
+      const conversation = await createRegularConversation();
+      const skill = await createSkill([projectSpace.id]);
+
+      await updateConversationRequirementsForSkills(auth, {
+        skills: [skill],
+        conversation,
+      });
+
+      const updated = await fetchConversationWithoutContent(conversation.sId);
+      expect(updated.requestedSpaceIds).toContain(projectSpace.sId);
+    });
+
+    it("merges requirements from multiple skills", async () => {
+      const conversation = await createRegularConversation();
+      const skillA = await createSkill([projectSpace.id]);
+      const skillB = await createSkill([anotherProjectSpace.id]);
+
+      await updateConversationRequirementsForSkills(auth, {
+        skills: [skillA, skillB],
+        conversation,
+      });
+
+      const updated = await fetchConversationWithoutContent(conversation.sId);
+      expect(updated.requestedSpaceIds).toContain(projectSpace.sId);
+      expect(updated.requestedSpaceIds).toContain(anotherProjectSpace.sId);
+    });
+
+    it("preserves existing requirements and does not duplicate", async () => {
+      const conversation = await createRegularConversation();
+      await ConversationResource.updateRequirements(auth, conversation.sId, [
+        projectSpace.id,
+      ]);
+      const withInitial = await fetchConversationWithoutContent(
+        conversation.sId
+      );
+
+      const skill = await createSkill([
+        projectSpace.id,
+        anotherProjectSpace.id,
+      ]);
+
+      await updateConversationRequirementsForSkills(auth, {
+        skills: [skill],
+        conversation: withInitial,
+      });
+
+      const updated = await fetchConversationWithoutContent(conversation.sId);
+      expect(updated.requestedSpaceIds).toContain(projectSpace.sId);
+      expect(updated.requestedSpaceIds).toContain(anotherProjectSpace.sId);
+      expect(
+        updated.requestedSpaceIds.filter((id) => id === projectSpace.sId)
+      ).toHaveLength(1);
+    });
+
+    it("does nothing for skills without space requirements", async () => {
+      const conversation = await createRegularConversation();
+      const initialCount = conversation.requestedSpaceIds.length;
+      const skill = await createSkill([]);
+
+      await updateConversationRequirementsForSkills(auth, {
+        skills: [skill],
+        conversation,
+      });
+
+      const updated = await fetchConversationWithoutContent(conversation.sId);
+      expect(updated.requestedSpaceIds).toHaveLength(initialCount);
+    });
+  });
+
+  describe("project conversations", () => {
+    it("does not append skill space requirements (requirements stay pinned to the project)", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        spaceId: projectSpace.id,
+      });
+      await ConversationResource.updateRequirements(auth, conversation.sId, [
+        projectSpace.id,
+      ]);
+      const projectConversation = await fetchConversationWithoutContent(
+        conversation.sId
+      );
+
+      const skill = await createSkill([anotherProjectSpace.id]);
+
+      await updateConversationRequirementsForSkills(auth, {
+        skills: [skill],
+        conversation: projectConversation,
+      });
+
+      const updated = await fetchConversationWithoutContent(conversation.sId);
+      expect(updated.requestedSpaceIds).toEqual([projectSpace.sId]);
+    });
+  });
+});

--- a/front/lib/api/assistant/conversation/skill_permissions.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.ts
@@ -1,0 +1,67 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isPodConversation } from "@app/types/assistant/conversation";
+import { removeNulls } from "@app/types/shared/utils/general";
+import uniq from "lodash/uniq";
+import type { Transaction } from "sequelize";
+
+/**
+ * Update the conversation requestedSpaceIds based on the skills added to it. This function is
+ * purely additive - requirements are never removed.
+ *
+ * Each skill's requestedSpaceIds represents the set of spaces the skill needs access to.
+ * When a skill is added to a conversation (slash command, input bar dropdown, conversation fork,
+ * agent runtime enable, ...), its spaces are appended to the conversation's requirements so that
+ * conversation access is gated on those spaces.
+ */
+export async function updateConversationRequirementsForSkills(
+  auth: Authenticator,
+  {
+    skills,
+    conversation,
+    t,
+  }: {
+    skills: SkillResource[];
+    conversation: ConversationWithoutContentType;
+    t?: Transaction;
+  }
+): Promise<void> {
+  // By design, pod conversations are always visible to everyone with READ permission to the
+  // project, so their requirements stay pinned to [projectSpaceId]. As with agents, we do not
+  // append per-skill space requirements for pod conversations.
+  if (isPodConversation(conversation)) {
+    return;
+  }
+
+  const newSpaceRequirements = uniq(skills.flatMap((s) => s.requestedSpaceIds));
+  if (newSpaceRequirements.length === 0) {
+    return;
+  }
+
+  // conversation.requestedSpaceIds are space sIds; convert back to ModelIds to merge with the
+  // skill requirements (which are already ModelIds).
+  const currentSpaceRequirements = removeNulls(
+    conversation.requestedSpaceIds.map(getResourceIdFromSId)
+  );
+  const currentSet = new Set(currentSpaceRequirements);
+
+  // Early return if all new requirements are already present.
+  if (newSpaceRequirements.every((id) => currentSet.has(id))) {
+    return;
+  }
+
+  const allSpaceRequirements = uniq([
+    ...currentSpaceRequirements,
+    ...newSpaceRequirements,
+  ]);
+
+  await ConversationResource.updateRequirements(
+    auth,
+    conversation.sId,
+    allSpaceRequirements,
+    t
+  );
+}

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2,6 +2,7 @@ import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configurati
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
+import { updateConversationRequirementsForSkills } from "@app/lib/api/assistant/conversation/skill_permissions";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import {
   filterUsersWithSharedMembership,
@@ -1677,11 +1678,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async upsertConversationSkills(
     auth: Authenticator,
     {
-      conversationId,
+      conversation,
       skills,
       enabled,
     }: {
-      conversationId: ModelId;
+      conversation: ConversationWithoutContentType;
       skills: SkillResource[];
       enabled: boolean;
     },
@@ -1691,7 +1692,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const result = await skill.upsertToConversation(
         auth,
         {
-          conversationId,
+          conversationId: conversation.id,
           enabled,
         },
         { transaction }
@@ -1700,6 +1701,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       if (result.isErr()) {
         return result;
       }
+    }
+
+    // When enabling skills, append their space requirements to the conversation so access is
+    // gated on those spaces (no-op for project conversations).
+    if (enabled) {
+      await updateConversationRequirementsForSkills(auth, {
+        skills,
+        conversation,
+        t: transaction,
+      });
     }
 
     return new Ok(undefined);
@@ -3372,6 +3383,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     await ConversationSkillModel.create(conversationSkillBlob);
+
+    // Append the skill's space requirements to the conversation so access is gated on those
+    // spaces (no-op for project conversations).
+    await updateConversationRequirementsForSkills(auth, {
+      skills: [this],
+      conversation,
+    });
 
     return { wasAlreadyEnabled: false };
   }

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1114,7 +1114,6 @@ export function usePodDefaultSkills({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    globalSpaceOnly: true,
     disabled: !enabled,
   });
 


### PR DESCRIPTION
## Description
Fix the bug with restricted skills becoming unsearchable for all after being restricted to pods/spaces. The fix involves removing the 'globalSpaceOnly: true' flag from the capabilities picker, slash command, and default skills.

## Tests
Added tests to skills/test. Tested locally.

## Risk

## Deploy Plan