### PR TITLE
[connectors] enh: stream gdrive spreadsheets to reduce heap footprint

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.test.ts
@@ -1,0 +1,393 @@
+import type {
+  Sheet,
+  SheetContentEvent,
+  StreamSheetRows,
+} from "@connectors/connectors/google_drive/temporal/spreadsheets";
+import {
+  fetchSheetContentsAsCsv,
+  sheetValuesRange,
+  streamRowsFromValuesJson,
+} from "@connectors/connectors/google_drive/temporal/spreadsheets";
+import logger from "@connectors/logger/logger";
+import { stringify } from "csv-stringify/sync";
+import { Readable } from "stream";
+import { describe, expect, it } from "vitest";
+
+function makeSheet(overrides: Partial<Sheet> = {}): Sheet {
+  return {
+    id: 1,
+    spreadsheet: { id: "spreadsheet-id", title: "My Spreadsheet" },
+    title: "Sheet1",
+    gridRowCount: 10,
+    ...overrides,
+  };
+}
+
+// Serves per-sheet fixtures as chunked row streams the way the streamed values.get produces
+// them, recording the chunks pulled per sheet and whether each sheet's stream was torn down
+// (its finally ran) — the observable proof that an aborted consumer closes the stream.
+function makeRowStreamer(
+  rowsBySheetTitle: Record<string, string[][]>,
+  { chunkRows = 1000 }: { chunkRows?: number } = {}
+) {
+  const pulledChunks: Record<string, number> = {};
+  const closedSheets: string[] = [];
+  const streamSheetRows: StreamSheetRows = async function* (sheet) {
+    try {
+      const allRows = rowsBySheetTitle[sheet.title];
+      if (!allRows) {
+        throw new Error(`Unknown sheet: ${sheet.title}`);
+      }
+      for (let i = 0; i < allRows.length; i += chunkRows) {
+        pulledChunks[sheet.title] = (pulledChunks[sheet.title] ?? 0) + 1;
+        yield { kind: "rows", rows: allRows.slice(i, i + chunkRows) };
+      }
+    } finally {
+      closedSheets.push(sheet.title);
+    }
+  };
+  return { streamSheetRows, pulledChunks, closedSheets };
+}
+
+async function collectEvents(
+  events: AsyncGenerator<SheetContentEvent, void>
+): Promise<SheetContentEvent[]> {
+  const collected: SheetContentEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+describe("fetchSheetContentsAsCsv", () => {
+  it("builds the CSV from the sheet values", async () => {
+    const sheet = makeSheet();
+    const { streamSheetRows } = makeRowStreamer({
+      Sheet1: [
+        ["h1", "h2"],
+        ["a", "b"],
+        ["c", "d"],
+      ],
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([sheet], streamSheetRows, logger)
+    );
+
+    expect(events).toEqual([
+      {
+        type: "sheet",
+        sheet,
+        content: { outcome: "csv", csv: "h1,h2\na,b\nc,d\n", rowCount: 3 },
+      },
+    ]);
+  });
+
+  it("pads every row to the widest row with empty cells", async () => {
+    const { streamSheetRows } = makeRowStreamer({
+      Sheet1: [["h1"], ["a", "b", "c"], ["d", "e"]],
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([makeSheet()], streamSheetRows, logger)
+    );
+
+    expect(events).toMatchObject([
+      {
+        type: "sheet",
+        content: { outcome: "csv", csv: "h1,,\na,b,c\nd,e,\n", rowCount: 3 },
+      },
+    ]);
+  });
+
+  it("produces the same CSV as stringifying the padded rows at once", async () => {
+    const rows = [
+      ["header 1", "header,2", "header\n3"],
+      ["plain", 'quo"ted', ""],
+      ["wide", "row", "with", "extra", "cells"],
+      ["", " ", "kept: has a whitespace cell"],
+    ];
+    const { streamSheetRows } = makeRowStreamer({ Sheet1: rows });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([makeSheet()], streamSheetRows, logger)
+    );
+
+    // Replicates the previous implementation: pad all rows to the widest row, stringify at once.
+    const maxCols = Math.max(...rows.map((row) => row.length));
+    const paddedRows = rows.map((row) => [
+      ...row,
+      ...Array(maxCols - row.length).fill(""),
+    ]);
+    const expectedCsv = stringify(paddedRows);
+
+    expect(events).toMatchObject([
+      { type: "sheet", content: { outcome: "csv", csv: expectedCsv } },
+    ]);
+  });
+
+  it("filters out rows with no data", async () => {
+    const { streamSheetRows } = makeRowStreamer({
+      Sheet1: [["", ""], ["h1", "h2"], [], [" ", "  "], ["a", "b"]],
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([makeSheet()], streamSheetRows, logger)
+    );
+
+    expect(events).toMatchObject([
+      {
+        type: "sheet",
+        content: { outcome: "csv", csv: "h1,h2\na,b\n", rowCount: 2 },
+      },
+    ]);
+  });
+
+  it("consumes each sheet's chunks fully and routes rows to their own sheet", async () => {
+    const sheets = [
+      makeSheet({ id: 1, title: "A", gridRowCount: 2500 }),
+      makeSheet({ id: 2, title: "B", gridRowCount: 100 }),
+    ];
+    const { streamSheetRows, pulledChunks } = makeRowStreamer({
+      A: Array.from({ length: 2500 }, (_, i) => [`a${i}`]),
+      B: Array.from({ length: 100 }, (_, i) => [`b${i}`]),
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(sheets, streamSheetRows, logger)
+    );
+
+    expect(pulledChunks).toEqual({ A: 3, B: 1 });
+    expect(events).toMatchObject([
+      { type: "sheet", sheet: { id: 1 }, content: { rowCount: 2500 } },
+      { type: "sheet", sheet: { id: 2 }, content: { rowCount: 100 } },
+    ]);
+    for (const [event, letter] of [
+      [events[0], "a"],
+      [events[1], "b"],
+    ] as const) {
+      if (event?.type !== "sheet" || event.content.outcome !== "csv") {
+        throw new Error("Expected a csv sheet event");
+      }
+      expect(event.content.csv.startsWith(`${letter}0\n`)).toBe(true);
+    }
+  });
+
+  it("stops pulling and closes the stream once the sheet exceeds the maximum number of rows", async () => {
+    const allRows = Array.from({ length: 60000 }, (_, i) => [`a${i}`]);
+    const { streamSheetRows, pulledChunks, closedSheets } = makeRowStreamer({
+      Sheet1: allRows,
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(
+        [makeSheet({ gridRowCount: 60000 })],
+        streamSheetRows,
+        logger
+      )
+    );
+
+    expect(events).toMatchObject([
+      { type: "sheet", content: { outcome: "no_content" } },
+    ]);
+    // The cap trips on the chunk containing the 50001st row; the remaining chunks are never
+    // pulled and the stream is torn down.
+    expect(pulledChunks.Sheet1).toBe(51);
+    expect(closedSheets).toEqual(["Sheet1"]);
+  });
+
+  it("stops pulling and closes the stream once the CSV exceeds the maximum size", async () => {
+    // 4 rows of 20MB cross the 50MB cap on the 3rd big cell.
+    const bigCell = "x".repeat(20 * 1024 * 1024);
+    const { streamSheetRows, pulledChunks, closedSheets } = makeRowStreamer(
+      { Sheet1: [["h1"], [bigCell], [bigCell], [bigCell], [bigCell]] },
+      { chunkRows: 1 }
+    );
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([makeSheet()], streamSheetRows, logger)
+    );
+
+    expect(events).toMatchObject([
+      { type: "sheet", content: { outcome: "too_large" } },
+    ]);
+    // The cap trips on the 4th row (3rd big cell); the 5th row is never pulled.
+    expect(pulledChunks.Sheet1).toBe(4);
+    expect(closedSheets).toEqual(["Sheet1"]);
+  });
+
+  it("detects a too-large CSV when a late wide row inflates the padding", async () => {
+    // 5000 one-cell rows weigh ~10KB unpadded, but padded to the 11000 columns of the late wide
+    // row every line weighs ~11KB — over 50MB in total. The following sheet still syncs.
+    const wideRow = ["y", ...Array(10999).fill("")];
+    const sheets = [
+      makeSheet({ id: 1, title: "Wide", gridRowCount: 5001 }),
+      makeSheet({ id: 2, title: "Small", gridRowCount: 10 }),
+    ];
+    const { streamSheetRows } = makeRowStreamer({
+      Wide: [...Array.from({ length: 5000 }, () => ["x"]), wideRow],
+      Small: [["h1"], ["a"]],
+    });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(sheets, streamSheetRows, logger)
+    );
+
+    expect(events).toMatchObject([
+      { type: "sheet", sheet: { id: 1 }, content: { outcome: "too_large" } },
+      {
+        type: "sheet",
+        sheet: { id: 2 },
+        content: { outcome: "csv", rowCount: 2 },
+      },
+    ]);
+  });
+
+  it("skips only a sheet whose values cannot be read", async () => {
+    const sheets = [
+      makeSheet({ id: 1, title: "A" }),
+      makeSheet({ id: 2, title: "B" }),
+      makeSheet({ id: 3, title: "C" }),
+    ];
+    const { streamSheetRows } = makeRowStreamer({
+      B: [["h1"], ["b"]],
+      C: [["h1"], ["c"]],
+    });
+    const notReadableFirst: StreamSheetRows = async function* (sheet) {
+      if (sheet.title === "A") {
+        yield { kind: "sheet_not_readable" };
+        return;
+      }
+      yield* streamSheetRows(sheet);
+    };
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(sheets, notReadableFirst, logger)
+    );
+
+    expect(events).toMatchObject([
+      { type: "sheet", sheet: { id: 1 }, content: { outcome: "no_content" } },
+      { type: "sheet", sheet: { id: 2 }, content: { outcome: "csv" } },
+      { type: "sheet", sheet: { id: 3 }, content: { outcome: "csv" } },
+    ]);
+  });
+
+  it("returns no_content when the sheet has no data", async () => {
+    const { streamSheetRows } = makeRowStreamer({ Sheet1: [] });
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv([makeSheet()], streamSheetRows, logger)
+    );
+
+    expect(events).toMatchObject([
+      { type: "sheet", content: { outcome: "no_content" } },
+    ]);
+  });
+
+  it("returns no_content without opening a stream for an empty grid", async () => {
+    const { streamSheetRows, closedSheets } = makeRowStreamer({});
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(
+        [makeSheet({ gridRowCount: 0 })],
+        streamSheetRows,
+        logger
+      )
+    );
+
+    expect(closedSheets).toEqual([]);
+    expect(events).toMatchObject([
+      { type: "sheet", content: { outcome: "no_content" } },
+    ]);
+  });
+
+  it("propagates a file-level skip and stops fetching", async () => {
+    const sheets = [
+      makeSheet({ id: 1, title: "A" }),
+      makeSheet({ id: 2, title: "B" }),
+    ];
+    let callCount = 0;
+    const skippingStreamer: StreamSheetRows = async function* () {
+      callCount += 1;
+      yield {
+        kind: "skip_file",
+        skipReason: "google_internal_server_error",
+      };
+    };
+
+    const events = await collectEvents(
+      fetchSheetContentsAsCsv(sheets, skippingStreamer, logger)
+    );
+
+    expect(events).toEqual([
+      { type: "skip_file", skipReason: "google_internal_server_error" },
+    ]);
+    expect(callCount).toBe(1);
+  });
+});
+
+describe("sheetValuesRange", () => {
+  it("escapes single quotes in sheet titles", () => {
+    expect(sheetValuesRange("Sheet1")).toBe("'Sheet1'");
+    expect(sheetValuesRange("It's a sheet")).toBe("'It''s a sheet'");
+  });
+});
+
+describe("streamRowsFromValuesJson", () => {
+  function valuesResponse(values: unknown): string {
+    return JSON.stringify({
+      range: "'Sheet1'!A1:Z10",
+      majorDimension: "ROWS",
+      values,
+    });
+  }
+
+  async function collectChunks(
+    source: Readable,
+    chunkRows: number
+  ): Promise<string[][][]> {
+    const chunks: string[][][] = [];
+    for await (const chunk of streamRowsFromValuesJson(source, chunkRows)) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
+  it("yields the rows of the values array in chunks", async () => {
+    const source = Readable.from([
+      valuesResponse([["a", "b"], ["c"], [], ["d"]]),
+    ]);
+
+    const chunks = await collectChunks(source, 3);
+
+    expect(chunks).toEqual([[["a", "b"], ["c"], []], [["d"]]]);
+  });
+
+  it("yields nothing when the values field is absent", async () => {
+    const source = Readable.from([
+      JSON.stringify({ range: "'Sheet1'!A1", majorDimension: "ROWS" }),
+    ]);
+
+    expect(await collectChunks(source, 3)).toEqual([]);
+  });
+
+  it("rejects on malformed JSON", async () => {
+    const source = Readable.from(['{"values": [["a"']);
+
+    await expect(collectChunks(source, 3)).rejects.toThrow();
+  });
+
+  it("destroys the source stream on early exit", async () => {
+    const source = Readable.from([
+      valuesResponse(Array.from({ length: 10 }, (_, i) => [`r${i}`])),
+    ]);
+
+    const rowChunks = streamRowsFromValuesJson(source, 2);
+    const first = await rowChunks.next();
+    expect(first.value).toEqual([["r0"], ["r1"]]);
+
+    await rowChunks.return(undefined);
+
+    expect(source.destroyed).toBe(true);
+  });
+});

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -11,6 +11,7 @@ import {
   deleteDataSourceFolder,
   deleteDataSourceTable,
   ignoreTablesError,
+  MAX_CSV_SIZE,
   MAX_FILE_SIZE_TO_DOWNLOAD,
   upsertDataSourceFolder,
   upsertDataSourceTableFromCsv,
@@ -18,6 +19,7 @@ import {
 import { ProviderWorkflowError, TablesError } from "@connectors/lib/error";
 import type { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheetModel } from "@connectors/lib/models/google_drive";
+import { heartbeat } from "@connectors/lib/temporal";
 import type { Logger } from "@connectors/logger/logger";
 import { getActivityLogger, getLoggerArgs } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -25,28 +27,61 @@ import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import {
   getGoogleSheetTableId,
   INTERNAL_MIME_TYPES,
-  InvalidStructuredDataHeaderError,
   slugify,
 } from "@connectors/types";
+import { assertNever } from "@dust-tt/client";
 import { Context } from "@temporalio/activity";
 import { stringify } from "csv-stringify/sync";
 import tracer from "dd-trace";
 import type { sheets_v4 } from "googleapis";
 import { google } from "googleapis";
-import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
+import type { OAuth2Client } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
+import type { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import { parser } from "stream-json";
+import { pick } from "stream-json/filters/Pick";
+import { streamArray } from "stream-json/streamers/StreamArray";
 
 const MAXIMUM_NUMBER_OF_GSHEET_ROWS = 50000;
 const MAXIMUM_NUMBER_OF_SHEETS_PER_SPREADSHEET = 50;
+// Rows per "rows" event handed to the consumer: amortizes heartbeats and CSV-builder calls while
+// keeping the largest buffered unit small.
+const STREAM_ROWS_PER_CHUNK = 1000;
 
-export type Sheet = sheets_v4.Schema$ValueRange & {
+export type Sheet = {
   id: number;
   spreadsheet: {
     id: string;
     title: string;
   };
   title: string;
+  gridRowCount: number;
 };
+
+export type SheetRowsEvent =
+  // One chunk of parsed rows (at most STREAM_ROWS_PER_CHUNK), in sheet order, each row in
+  // column order with trailing empty cells trimmed by the API.
+  | { kind: "rows"; rows: string[][] }
+  // The sheet's values could not be read (e.g. the sheet was renamed mid-sync and the range no
+  // longer parses); the sheet is skipped and deleted if previously synced.
+  | { kind: "sheet_not_readable" }
+  // Google consistently returns 500s on an activity that already retried 20+ times; the whole
+  // file is skipped.
+  | { kind: "skip_file"; skipReason: string };
+
+export type StreamSheetRows = (
+  sheet: Sheet
+) => AsyncGenerator<SheetRowsEvent, void>;
+
+type SheetContent =
+  | { outcome: "csv"; csv: string; rowCount: number }
+  | { outcome: "no_content" }
+  | { outcome: "too_large" };
+
+export type SheetContentEvent =
+  | { type: "sheet"; sheet: Sheet; content: SheetContent }
+  | { type: "skip_file"; skipReason: string };
 
 function getSpreadsheetLoggerArgs(fileId: string) {
   return {
@@ -74,7 +109,7 @@ async function upsertGdriveTable(
   connector: ConnectorResource,
   sheet: Sheet,
   parents: string[],
-  rows: string[][],
+  csv: string,
   tags: string[]
 ): Promise<TablesError | null> {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
@@ -87,8 +122,6 @@ async function upsertGdriveTable(
   );
 
   const tableDescription = `Structured data from the Google Spreadsheet (${spreadsheet.title}) and sheet (${title}`;
-
-  const csv = stringify(rows);
 
   // Upserting is safe: Core truncates any previous table with the same Id before
   // the operation. Note: Renaming a sheet in Google Drive retains its original Id.
@@ -115,75 +148,223 @@ async function upsertGdriveTable(
   );
 }
 
-function findDataRangeAndSelectRows(allRows: string[][]): string[][] {
-  // Find the first row with data to determine the range.
-  const nonEmptyRow = allRows.filter((row) =>
-    row.some((cell) => cell.trim() !== "")
-  );
+type AppendRowsOutcome = "ok" | "no_content" | "too_large";
 
-  return nonEmptyRow;
-}
+// Incrementally builds one sheet's CSV: each non-empty row is stringified as soon as it arrives
+// and the row arrays are released, so the full sheet contents are never buffered. Padding every
+// row to the widest row of the sheet is only possible once all rows have been seen, so each CSV
+// line is kept with its column count and the missing empty cells (bare commas) are appended in
+// finalize().
+class SheetCsvBuilder {
+  private csvLines: { line: string; columnCount: number }[] = [];
+  private maxColumnCount = 0;
+  // Unpadded size: stringified lines plus one newline byte each.
+  private csvSizeBytes = 0;
+  // Sum of the column counts of all appended lines, to derive the padding size.
+  private sumColumnCounts = 0;
 
-function getValidRows(allRows: string[][], localLogger: Logger): string[][] {
-  const filteredRows = findDataRangeAndSelectRows(allRows);
+  constructor(private readonly localLogger: Logger) {}
 
-  const maxCols = filteredRows.reduce(
-    (acc, row) => (row.length > acc ? row.length : acc),
-    0
-  );
-
-  // We assume that the first row is always the headers.
-  // Headers are used to assert the number of cells per row.
-  const [rawHeaders] = filteredRows;
-  if (!rawHeaders || rawHeaders.length === 0) {
-    localLogger.info("[Spreadsheet] Skipping due to empty initial rows.");
-    return [];
+  // Exact byte size of the final CSV once every line is padded to maxColumnCount columns with
+  // one-byte commas.
+  private paddedCsvSizeBytes(): number {
+    return (
+      this.csvSizeBytes +
+      this.maxColumnCount * this.csvLines.length -
+      this.sumColumnCounts
+    );
   }
 
-  try {
-    const validRows: string[][] = filteredRows.map((row) => {
-      // If a row has less cells than headers, we fill the gap with empty strings.
-      if (row.length < maxCols) {
-        const shortfall = maxCols - row.length;
-        return [...row, ...Array(shortfall).fill("")];
+  appendRows(rows: string[][]): AppendRowsOutcome {
+    for (const row of rows) {
+      // Skip rows with no data.
+      if (!row.some((cell) => cell.trim() !== "")) {
+        continue;
       }
 
-      return row;
-    });
+      if (this.csvLines.length >= MAXIMUM_NUMBER_OF_GSHEET_ROWS) {
+        this.localLogger.info(
+          { rowCount: this.csvLines.length },
+          `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}, skipping further processing.`
+        );
+        return "no_content";
+      }
 
-    if (validRows.length > MAXIMUM_NUMBER_OF_GSHEET_ROWS) {
-      localLogger.info(
-        { rowCount: validRows.length },
-        `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}, skipping further processing.`
+      const line = stringify([row]).slice(0, -1);
+      this.csvLines.push({ line, columnCount: row.length });
+      this.maxColumnCount = Math.max(this.maxColumnCount, row.length);
+      this.csvSizeBytes += Buffer.byteLength(line, "utf8") + 1;
+      this.sumColumnCounts += row.length;
+
+      // Check the padded size on every row: a new widest row retroactively inflates the padding
+      // of every previous line, so a late wide row can blow the cap even when the unpadded
+      // content is tiny.
+      const paddedCsvSizeBytes = this.paddedCsvSizeBytes();
+      if (paddedCsvSizeBytes > MAX_CSV_SIZE) {
+        this.localLogger.info(
+          { paddedCsvSizeBytes, rowCount: this.csvLines.length },
+          "[Spreadsheet] Sheet CSV exceeds the maximum size, skipping further processing."
+        );
+        return "too_large";
+      }
+    }
+
+    return "ok";
+  }
+
+  finalize(): SheetContent {
+    // We assume that the first row is always the headers.
+    if (this.csvLines.length === 0) {
+      this.localLogger.info(
+        "[Spreadsheet] Skipping due to empty initial rows."
       );
-
-      // If the sheet has too many rows, return an empty array to ignore it.
-      return [];
+      return { outcome: "no_content" };
     }
 
-    return validRows;
-  } catch (err) {
-    localLogger.info({ err }, `[Spreadsheet] Failed to retrieve valid rows.`);
+    this.localLogger.info(
+      {
+        paddedCsvSizeBytes: this.paddedCsvSizeBytes(),
+        rowCount: this.csvLines.length,
+      },
+      "[Spreadsheet] Fetched sheet content."
+    );
 
-    // If the headers are invalid, return an empty array to ignore it.
-    if (err instanceof InvalidStructuredDataHeaderError) {
-      return [];
-    }
+    // If a row has less cells than the widest row, fill the gap with empty cells.
+    const csv = `${this.csvLines
+      .map(
+        ({ line, columnCount }) =>
+          line + ",".repeat(this.maxColumnCount - columnCount)
+      )
+      .join("\n")}\n`;
 
-    throw err;
+    return { outcome: "csv", csv, rowCount: this.csvLines.length };
   }
 }
 
-async function processSheet(
+// Single quotes in sheet titles are escaped by doubling them in A1 notation. A title-only range
+// covers the whole sheet; the API trims trailing empty rows from the response.
+// Exported for tests.
+export function sheetValuesRange(title: string): string {
+  return `'${title.replace(/'/g, "''")}'`;
+}
+
+// Incrementally parses a values.get JSON response ({ range, majorDimension, values: [...] }),
+// yielding the rows of `values` in chunks of at most chunkRows without ever materializing the
+// full array — the reason we stream: a sheet's values can exceed both the heap and Node's
+// maximum string length. An absent `values` field (empty sheet) yields nothing. The source
+// stream is destroyed on early exit so an aborted consumer closes the underlying socket.
+// Exported for tests.
+export async function* streamRowsFromValuesJson(
+  source: Readable,
+  chunkRows: number
+): AsyncGenerator<string[][], void> {
+  const rows = streamArray();
+  const done = pipeline(source, parser(), pick({ filter: "values" }), rows);
+  // Any pipeline error also surfaces through the iteration below; this handler only prevents an
+  // unhandled rejection when the consumer exits the loop early and the pipeline is torn down.
+  done.catch(() => {});
+
+  try {
+    let chunk: string[][] = [];
+    for await (const entry of rows) {
+      // StreamArray emits { key, value } pairs, one per element of `values`.
+      const row: unknown = entry.value;
+      if (!Array.isArray(row)) {
+        throw new Error("Unexpected non-array row in sheet values response");
+      }
+      chunk.push(row);
+      if (chunk.length >= chunkRows) {
+        yield chunk;
+        chunk = [];
+      }
+    }
+    if (chunk.length > 0) {
+      yield chunk;
+    }
+    await done;
+  } finally {
+    source.destroy();
+    rows.destroy();
+  }
+}
+
+// Streams the CSV content of every sheet, one sheet at a time: row chunks are folded into the
+// CSV builder as they arrive on the wire, so live memory is bounded by one chunk, the CSV being
+// built (<= MAX_CSV_SIZE) and the one yielded CSV being upserted. Breaking out of a sheet's
+// stream (row cap, size cap) tears down the producer and its HTTP stream.
+// Exported for tests.
+export async function* fetchSheetContentsAsCsv(
+  sheets: Sheet[],
+  streamSheetRows: StreamSheetRows,
+  spreadsheetLogger: Logger
+): AsyncGenerator<SheetContentEvent, void> {
+  for (const sheet of sheets) {
+    const localLogger = spreadsheetLogger.child({
+      sheet: {
+        id: sheet.id,
+        spreadsheet: sheet.spreadsheet,
+        title: sheet.title,
+      },
+    });
+
+    // A sheet with an empty grid has no values to fetch.
+    if (sheet.gridRowCount === 0) {
+      yield {
+        type: "sheet",
+        sheet,
+        content: { outcome: "no_content" },
+      };
+      continue;
+    }
+
+    localLogger.info("[Spreadsheet] Processing sheet in Google Spreadsheet.");
+    const builder = new SheetCsvBuilder(localLogger);
+    let earlyContent: SheetContent | null = null;
+
+    streamLoop: for await (const event of streamSheetRows(sheet)) {
+      switch (event.kind) {
+        case "rows": {
+          const appendOutcome = builder.appendRows(event.rows);
+          if (appendOutcome !== "ok") {
+            // Stop pulling: exiting the loop closes the sheet's HTTP stream.
+            earlyContent = { outcome: appendOutcome };
+            break streamLoop;
+          }
+          break;
+        }
+
+        case "sheet_not_readable":
+          localLogger.info(
+            "[Spreadsheet] Could not read sheet values, skipping further processing."
+          );
+          earlyContent = { outcome: "no_content" };
+          break streamLoop;
+
+        case "skip_file":
+          yield { type: "skip_file", skipReason: event.skipReason };
+          return;
+
+        default:
+          assertNever(event);
+      }
+    }
+
+    yield {
+      type: "sheet",
+      sheet,
+      content: earlyContent ?? builder.finalize(),
+    };
+  }
+}
+
+async function processSheetContent(
   connector: ConnectorResource,
   sheet: Sheet,
   parents: string[],
   tags: string[],
+  content: SheetContent,
   spreadsheetLogger: Logger
 ): Promise<boolean> {
-  if (!sheet.values) {
-    return false;
-  }
   const { id, spreadsheet, title } = sheet;
   const localLogger = spreadsheetLogger.child({
     sheet: {
@@ -193,121 +374,75 @@ async function processSheet(
     },
   });
 
-  localLogger.info("[Spreadsheet] Processing sheet in Google Spreadsheet.");
+  switch (content.outcome) {
+    case "no_content":
+      localLogger.info(
+        "[Spreadsheet] Failed to import sheet. Will be deleted if already synced."
+      );
+      return false;
 
-  const rows = getValidRows(sheet.values, localLogger);
-  // Assuming the first line as headers, at least one additional data line is required.
-  if (rows.length > 1) {
-    let upsertError = null;
-    try {
-      upsertError = await upsertGdriveTable(
+    case "too_large":
+      // Record the sheet as not upserted, like an upsert attempt rejected by the API, so it is
+      // kept in the DB and not deleted.
+      await upsertSheetInDb(
         connector,
         sheet,
-        parents,
-        rows,
-        tags
+        new TablesError(
+          "file_too_large",
+          "The file is too large to be processed."
+        )
       );
-    } catch (err) {
-      if (err instanceof TablesError) {
-        localLogger.warn(
-          { error: err },
-          "[Spreadsheet] Tables error - skipping (but not failing)."
-        );
-        upsertError = err;
-      } else {
-        localLogger.error(
-          { error: err },
-          "[Spreadsheet] Failed to upsert table."
-        );
-        throw err;
-      }
-    }
+      return true;
 
-    await upsertSheetInDb(connector, sheet, upsertError);
+    case "csv":
+      break;
 
-    return true;
+    default:
+      assertNever(content);
   }
 
-  localLogger.info(
-    "[Spreadsheet] Failed to import sheet. Will be deleted if already synced."
-  );
+  // Assuming the first line as headers, at least one additional data line is required.
+  if (content.rowCount <= 1) {
+    localLogger.info(
+      "[Spreadsheet] Failed to import sheet. Will be deleted if already synced."
+    );
+    return false;
+  }
 
-  return false;
-}
-
-async function batchGetSheets(
-  sheetsAPI: sheets_v4.Sheets,
-  spreadsheetId: string,
-  sheetRanges: Map<string, Sheet>,
-  localLogger: Logger
-) {
-  const maxCharacters = 1500;
-  const sheetRangeKeys = [...sheetRanges.keys()].map((k) => `'${k}'`);
-  const allRanges: sheets_v4.Schema$ValueRange[] = [];
-
-  // Chunk sheet ranges into groups such that the concatenated length of each group doesn't exceed the maxCharacters limit (1500).
-  const chunks = sheetRangeKeys.reduce<string[][]>((acc, key) => {
-    const lastChunk = acc.at(-1);
-
-    if (!lastChunk || lastChunk.join("").length + key.length > maxCharacters) {
-      acc.push([key]);
+  let upsertError = null;
+  try {
+    upsertError = await upsertGdriveTable(
+      connector,
+      sheet,
+      parents,
+      content.csv,
+      tags
+    );
+  } catch (err) {
+    if (err instanceof TablesError) {
+      localLogger.warn(
+        { error: err },
+        "[Spreadsheet] Tables error - skipping (but not failing)."
+      );
+      upsertError = err;
     } else {
-      lastChunk.push(key);
-    }
-
-    return acc;
-  }, []);
-
-  localLogger.info(
-    {
-      chunkCount: chunks.length,
-      sheetCount: sheetRangeKeys.length,
-    },
-    "[Spreadsheet] Chunked sheet ranges into groups to respect URL character limit."
-  );
-
-  for (const chunk of chunks) {
-    // Query the API using the previously constructed sheet ranges to fetch
-    // the desired data from each corresponding sheet range.
-
-    let sheetRanges: GaxiosResponse<sheets_v4.Schema$BatchGetValuesResponse>;
-    try {
-      sheetRanges = await sheetsAPI.spreadsheets.values.batchGet({
-        ranges: chunk,
-        spreadsheetId,
-        valueRenderOption: "FORMATTED_VALUE",
-      });
-    } catch (err) {
-      if (isStringTooLongError(err)) {
-        // Ignore when the string is too long.
-        continue;
-      } else if (isUnableToParseError(err)) {
-        // Ignore when unable to parse the range.
-        continue;
-      } else {
-        throw err;
-      }
-    }
-
-    const { valueRanges } = sheetRanges.data;
-    if (!valueRanges) {
-      localLogger.info(
-        "[Spreadsheet] No data ranges found in the spreadsheet, skipping further processing."
+      localLogger.error(
+        { error: err },
+        "[Spreadsheet] Failed to upsert table."
       );
-      continue;
+      throw err;
     }
-
-    allRanges.push(...valueRanges);
   }
 
-  return allRanges;
+  await upsertSheetInDb(connector, sheet, upsertError);
+
+  return true;
 }
 
-async function getAllSheetsFromSpreadSheet(
-  sheetsAPI: sheets_v4.Sheets,
+function getSheetsFromSpreadsheet(
   spreadsheet: sheets_v4.Schema$Spreadsheet,
   logger: Logger
-): Promise<Sheet[]> {
+): Sheet[] {
   const { spreadsheetId, properties } = spreadsheet;
   if (!spreadsheetId || !properties) {
     return [];
@@ -317,24 +452,21 @@ async function getAllSheetsFromSpreadSheet(
 
   const localLogger = logger.child({
     spreadsheet: {
-      id: spreadsheet.spreadsheetId,
+      id: spreadsheetId,
     },
     sheetCount: spreadsheet.sheets?.length,
   });
 
   localLogger.info("[Spreadsheet] List sheets in spreadsheet.");
 
-  // Construct the sheet ranges using the sheet name. If we do not provide any
-  // specific A1 notation, the API will capture the maximum range available on
-  // the sheet.
-  const sheetRanges = new Map<string, Sheet>();
+  const sheets: Sheet[] = [];
   for (const sheet of spreadsheet.sheets ?? []) {
     const { properties } = sheet;
     if (!properties) {
       continue;
     }
 
-    const { sheetId, sheetType, title } = properties;
+    const { gridProperties, sheetId, sheetType, title } = properties;
     // We only support "GRID" sheet.
     // For spreadsheet with one unique sheet, sheetId will be zero.
     if (
@@ -346,53 +478,14 @@ async function getAllSheetsFromSpreadSheet(
       continue;
     }
 
-    sheetRanges.set(title, {
+    sheets.push({
       id: sheetId,
       spreadsheet: {
         id: spreadsheetId,
         title: spreadsheetTitle ?? "Untitled Spreadsheet",
       },
       title,
-    });
-  }
-
-  const valueRanges = await batchGetSheets(
-    sheetsAPI,
-    spreadsheetId,
-    sheetRanges,
-    localLogger
-  );
-
-  if (valueRanges.length === 0) {
-    localLogger.info(
-      "[Spreadsheet] No data ranges found in the spreadsheet, skipping further processing."
-    );
-    return [];
-  }
-
-  const sheets: Sheet[] = [];
-  for (const [sheetName, sheet] of sheetRanges) {
-    // To locate the value range for the current sheet within the batch get response,
-    // we use the sheet name in the format Sheet1!<range> or 'Details-View'!<range>. This notation helps us
-    // match and extract the appropriate range from the response for the current sheet.
-    const valueRangeForSheet = valueRanges.find(
-      (s) =>
-        s.range?.startsWith(`'${sheetName}'`) || s.range?.startsWith(sheetName)
-    );
-    if (!valueRangeForSheet) {
-      localLogger.info(
-        {
-          sheetId: sheet.id,
-        },
-        "[Spreadsheet] Could not find value range for sheet, skipping further processing."
-      );
-
-      continue;
-    }
-
-    sheets.push({
-      ...valueRangeForSheet,
-      ...sheet,
+      gridRowCount: gridProperties?.rowCount ?? 0,
     });
   }
 
@@ -511,47 +604,7 @@ export async function syncSpreadSheet(
         }
       }
 
-      let sheets: Sheet[];
-      // We do 3 local retries for 500 Internal Server Error on batchGet too.
-      // If we still get 500 after 3 retries and the activity has been retried
-      // 20+ times, we skip the file (same logic as getSpreadsheet above).
-      internalErrorsCount = 0;
-      for (;;) {
-        try {
-          sheets = await getAllSheetsFromSpreadSheet(
-            sheetsAPI,
-            spreadsheet.data,
-            localLogger
-          );
-          break;
-        } catch (err) {
-          if (isGAxiosServiceUnavailableError(err)) {
-            throw new ProviderWorkflowError(
-              "google_drive",
-              "503 - Service Unavailable from Google Sheets (batchGet)",
-              "transient_upstream_activity_error",
-              err
-            );
-          } else if (isGAxiosInternalServerError(err)) {
-            internalErrorsCount++;
-            if (internalErrorsCount > maxInternalErrors) {
-              if (Context.current().info.attempt > 20) {
-                localLogger.info(
-                  "[Spreadsheet] Consistently getting 500 Internal Server Error from Google Sheets on batchGet, skipping further processing."
-                );
-                return {
-                  isSupported: true,
-                  skipReason: "google_internal_server_error",
-                };
-              }
-            } else {
-              // Allow locally retrying the API call.
-              continue;
-            }
-          }
-          throw err;
-        }
-      }
+      const sheets = getSheetsFromSpreadsheet(spreadsheet.data, localLogger);
 
       if (sheets.length > MAXIMUM_NUMBER_OF_SHEETS_PER_SPREADSHEET) {
         localLogger.info(
@@ -588,19 +641,109 @@ export async function syncSpreadSheet(
         sourceUrl: getSourceUrlForGoogleDriveFiles(file),
       });
 
+      // Sheet values are streamed with one values.get call per sheet, sharing the same local
+      // retry budget on 500 Internal Server Error as getSpreadsheet above: 3 local retries
+      // across the file, then skip the file if the activity already has been retried 20+ times.
+      internalErrorsCount = 0;
+      let valuesGetCallCount = 0;
+      const streamSheetRows: StreamSheetRows = async function* (sheet) {
+        let stream: Readable;
+        for (;;) {
+          try {
+            // Heartbeat once per Sheets API call (retries included): streamed fetches of large
+            // spreadsheets can outlast the activity's heartbeat timeout otherwise.
+            await heartbeat();
+            valuesGetCallCount++;
+            const res = await sheetsAPI.spreadsheets.values.get(
+              {
+                spreadsheetId: file.id,
+                range: sheetValuesRange(sheet.title),
+                valueRenderOption: "FORMATTED_VALUE",
+              },
+              { responseType: "stream" }
+            );
+            stream = res.data;
+            break;
+          } catch (err) {
+            if (isUnableToParseError(err)) {
+              // The range no longer parses (e.g. the sheet was renamed mid-sync).
+              yield { kind: "sheet_not_readable" };
+              return;
+            } else if (isGAxiosServiceUnavailableError(err)) {
+              throw new ProviderWorkflowError(
+                "google_drive",
+                "503 - Service Unavailable from Google Sheets",
+                "transient_upstream_activity_error",
+                err
+              );
+            } else if (isGAxiosInternalServerError(err)) {
+              internalErrorsCount++;
+              if (internalErrorsCount > maxInternalErrors) {
+                if (Context.current().info.attempt > 20) {
+                  localLogger.info(
+                    "[Spreadsheet] Consistently getting 500 Internal Server Error from Google Sheets, skipping further processing."
+                  );
+                  yield {
+                    kind: "skip_file",
+                    skipReason: "google_internal_server_error",
+                  };
+                  return;
+                }
+              } else {
+                // Allow locally retrying the API call.
+                continue;
+              }
+            }
+            throw err;
+          }
+        }
+
+        // Mid-body failures (socket resets, malformed JSON) are not retried locally: the
+        // sheet's partially-built CSV cannot be safely resumed, so they fail the activity and
+        // Temporal retries it.
+        for await (const rows of streamRowsFromValuesJson(
+          stream,
+          STREAM_ROWS_PER_CHUNK
+        )) {
+          await heartbeat();
+          yield { kind: "rows", rows };
+        }
+      };
+
       const successfulSheetIdImports: number[] = [];
-      for (const sheet of sheets) {
-        const isImported = await processSheet(
-          connector,
-          sheet,
-          parents,
-          file.labels,
-          localLogger
-        );
-        if (isImported) {
-          successfulSheetIdImports.push(sheet.id);
+      for await (const event of fetchSheetContentsAsCsv(
+        sheets,
+        streamSheetRows,
+        localLogger
+      )) {
+        switch (event.type) {
+          case "skip_file":
+            return { isSupported: true, skipReason: event.skipReason };
+
+          case "sheet": {
+            const isImported = await processSheetContent(
+              connector,
+              event.sheet,
+              parents,
+              file.labels,
+              event.content,
+              localLogger
+            );
+            if (isImported) {
+              successfulSheetIdImports.push(event.sheet.id);
+            }
+            break;
+          }
+
+          default:
+            assertNever(event);
         }
       }
+
+      localLogger.info(
+        { sheetCount: sheets.length, valuesGetCallCount },
+        "[Spreadsheet] Fetched sheet values."
+      );
 
       // Delete any previously synced sheets that no longer exist in the current spreadsheet
       // or have exceeded the maximum number of rows.
@@ -726,23 +869,32 @@ function isGAxiosBadRequestError(err: unknown): err is Error {
   return err instanceof Error && "code" in err && err.code === 400;
 }
 
-function isStringTooLongError(
-  err: unknown
-): err is Error & { code: "ERR_STRING_TOO_LONG" } {
-  return (
-    err instanceof Error && "code" in err && err.code === "ERR_STRING_TOO_LONG"
-  );
+// With responseType "stream", gaxios drains a non-2xx body and attaches it as a raw string
+// instead of parsed JSON; normalize before inspecting the payload.
+function gaxiosResponseData(data: unknown): unknown {
+  if (typeof data !== "string") {
+    return data;
+  }
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
 }
 
 function isUnableToParseError(err: unknown): err is GaxiosError {
+  if (!(err instanceof GaxiosError) || err.response?.status !== 400) {
+    return false;
+  }
+  const data = gaxiosResponseData(err.response.data);
   return (
-    err instanceof GaxiosError &&
-    err.response?.status === 400 &&
-    err.response?.data &&
-    typeof err.response.data === "object" &&
-    "error" in err.response.data &&
-    "message" in err.response.data.error &&
-    typeof err.response.data.error.message === "string" &&
-    err.response.data.error.message.includes("Unable to parse range")
+    data !== null &&
+    typeof data === "object" &&
+    "error" in data &&
+    data.error !== null &&
+    typeof data.error === "object" &&
+    "message" in data.error &&
+    typeof data.error.message === "string" &&
+    data.error.message.includes("Unable to parse range")
   );
 }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -32,7 +32,7 @@ import { gfmFromMarkdown, gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
 import { gfm } from "micromark-extension-gfm";
 
-const MAX_CSV_SIZE = 50 * 1024 * 1024;
+export const MAX_CSV_SIZE = 50 * 1024 * 1024;
 
 function isTimeoutError(e: unknown): boolean {
   return (


### PR DESCRIPTION
## Description

Concurrent google spreadsheet processing on connectors has always been putting pressure on heap memory. Previous mitigations: concurrency down to 8 per activity, cut processing at 50k rows. But we were still buffering each whole sheet three times over (JSON response, rows, CSV) before sending it to core.

This PR streams sheet values instead: one `values.get` call per sheet with `responseType: "stream"`, parsed incrementally with `stream-json` (already a connectors dependency — the Microsoft connector uses it for GCS delta files). Rows are folded into the CSV builder in 1000-row chunks as they arrive on the wire, so live memory is bounded by one chunk + the CSV being built (≤ 50MB cap) + the one CSV being upserted. When a cap trips (50k non-empty rows / 50MB padded CSV), we stop pulling and close the socket — bytes we never download.

Behavior deltas vs main:

- `ERR_STRING_TOO_LONG` can no longer occur — the response body is never buffered into a string; dropped that handling.
- "Unable to parse range" 400s (sheet renamed mid-sync) now skip only that sheet instead of every sheet in the same batched call.
- gaxios attaches non-2xx bodies as raw strings when `responseType: "stream"`; `isUnableToParseError` handles both shapes.
- Heartbeat before each API call and per 1000-row chunk; one log per file with `valuesGetCallCount`.

## Tests

17 unit tests: CSV building/padding byte-identical to the previous pad-then-`stringify` implementation, both caps closing the stream early (the fixture asserts teardown ran and no further chunks were pulled), per-sheet not-readable, file-level skip, plus real-stream tests of the JSON parser (absent `values`, malformed JSON rejects, early exit destroys the source).

## Risk

Low
Blast radius: spreadsheet file processing activity in gdrive sync.
Worst case, gsheet sync misbehaves on some spreadsheet shape. Safe to rollback (deploy-only, no schema change).

## Deploy Plan

- [ ] Deploy connectors
- [ ] Watch connectors heap + Sheets API 429 rate in DD