### PR TITLE
feat: add governance page skeleton

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,3 +1,4 @@
+import { GovernancePageSkeleton } from "@app/components/pages/workspace/governance/GovernancePageSkeleton";
 import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
 import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
@@ -158,11 +159,7 @@ export const GovernancePage = () => {
   }
 
   if (isLoading) {
-    return (
-      <Page>
-        <Page.Header title="Workspace & Governance" description="Loading..." />
-      </Page>
-    );
+    return <GovernancePageSkeleton />;
   }
 
   return (

--- a/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
@@ -1,36 +1,39 @@
 import { cn, LoadingBlock, Page, Toggle01Left } from "@dust-tt/sparkle";
 
-const SkeletonRow = () => (
-  <div className="flex w-full items-center justify-between gap-4 p-4">
-    <div className="flex flex-col gap-2">
-      <LoadingBlock className="h-5 w-44" />
-      <LoadingBlock className="h-4 w-80" />
+function SkeletonRow() {
+  return (
+    <div className="flex w-full items-center justify-between gap-4 p-4">
+      <div className="flex flex-col gap-2">
+        <LoadingBlock className="h-5 w-44" />
+        <LoadingBlock className="h-4 w-80" />
+      </div>
+      <LoadingBlock className="h-8 w-52 rounded-lg" />
     </div>
-    <LoadingBlock className="h-8 w-52 rounded-lg" />
-  </div>
-);
+  );
+}
 
-const SkeletonSection = ({
-  labelWidth,
-  rows,
-}: {
+interface SkeletonSectionProps {
   labelWidth: string;
   rows: number;
-}) => (
-  <div className="flex w-full flex-col gap-4">
-    <div className="flex items-center gap-2">
-      <LoadingBlock className="h-5 w-5 rounded-md" />
-      <LoadingBlock className={cn("h-6", labelWidth)} />
-    </div>
-    <div className="w-full divide-y divide-border rounded-xl border border-border">
-      {Array.from({ length: rows }).map((_, i) => (
-        <SkeletonRow key={i} />
-      ))}
-    </div>
-  </div>
-);
+}
 
-export const GovernancePageSkeleton = () => {
+function SkeletonSection({ labelWidth, rows }: SkeletonSectionProps) {
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <LoadingBlock className="h-5 w-5 rounded-md" />
+        <LoadingBlock className={cn("h-6", labelWidth)} />
+      </div>
+      <div className="w-full divide-y divide-border rounded-xl border border-border">
+        {Array.from({ length: rows }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function GovernancePageSkeleton() {
   return (
     <Page>
       <Page.Header
@@ -56,4 +59,4 @@ export const GovernancePageSkeleton = () => {
       </div>
     </Page>
   );
-};
+}

--- a/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
@@ -1,0 +1,59 @@
+import { cn, LoadingBlock, Page, Toggle01Left } from "@dust-tt/sparkle";
+
+const SkeletonRow = () => (
+  <div className="flex w-full items-center justify-between gap-4 p-4">
+    <div className="flex flex-col gap-2">
+      <LoadingBlock className="h-5 w-44" />
+      <LoadingBlock className="h-4 w-80" />
+    </div>
+    <LoadingBlock className="h-8 w-52 rounded-lg" />
+  </div>
+);
+
+const SkeletonSection = ({
+  labelWidth,
+  rows,
+}: {
+  labelWidth: string;
+  rows: number;
+}) => (
+  <div className="flex w-full flex-col gap-4">
+    <div className="flex items-center gap-2">
+      <LoadingBlock className="h-5 w-5 rounded-md" />
+      <LoadingBlock className={cn("h-6", labelWidth)} />
+    </div>
+    <div className="w-full divide-y divide-border rounded-xl border border-border">
+      {Array.from({ length: rows }).map((_, i) => (
+        <SkeletonRow key={i} />
+      ))}
+    </div>
+  </div>
+);
+
+export const GovernancePageSkeleton = () => {
+  return (
+    <Page>
+      <Page.Header
+        title="Workspace & Governance"
+        description="Manage what members can do in your workspace."
+        icon={Toggle01Left}
+      />
+      <div className="flex items-center justify-between">
+        <div className="flex flex-1 flex-col gap-2">
+          <LoadingBlock className="h-6 w-40" />
+          <LoadingBlock className="h-5 w-56" />
+        </div>
+        <LoadingBlock className="h-9 w-20 rounded-lg" />
+      </div>
+      <div className="w-full rounded-xl bg-muted-background px-4 py-3">
+        <LoadingBlock className="h-4 w-96" />
+      </div>
+      <div className="flex w-full flex-col gap-8">
+        <SkeletonSection labelWidth="w-20" rows={2} />
+        <SkeletonSection labelWidth="w-16" rows={2} />
+        <SkeletonSection labelWidth="w-32" rows={2} />
+        <SkeletonSection labelWidth="w-44" rows={2} />
+      </div>
+    </Page>
+  );
+};


### PR DESCRIPTION
## Description

This PR adds a dedicated skeleton loading component for the Governance page.


https://github.com/user-attachments/assets/6bb4b291-e4f6-4607-b96a-d458c04e4834



## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.