### PR TITLE
fix(mcp-freshervice) update ui placeholder wording

### DIFF
--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -230,7 +230,7 @@ export function getProviderRequiredOAuthCredentialInputs({
             label: "Freshworks Organization URL",
             value: undefined,
             helpMessage:
-              "Your Freshworks organization URL (e.g., yourcompany.myfreshworks.com).",
+              "Your Freshworks organization URL (e.g., yourcompany.myfreshservice.com).",
           },
           freshservice_domain: {
             label: "Freshservice Domain URL",


### PR DESCRIPTION
## Description

Fixes an incorrect example URL in the Freshservice OAuth credential input help message. The placeholder was showing `yourcompany.myfreshworks.com` (the generic Freshworks domain) instead of the correct `yourcompany.myfreshservice.com` (the Freshservice-specific domain).

## Tests

Verified visually in the OAuth configuration UI for the Freshservice connector.

## Risk

None — copy-only change.

## Deploy Plan

Deploy front.