### PR TITLE
google_drive: stop personal-auth loops when the user lacks file or folder permissions

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -12,6 +12,9 @@ export const MAX_FILE_SIZE = 64 * 1024 * 1024; // 64 MB max original file size
 
 export const GOOGLE_DRIVE_TOOL_NAME = "google_drive" as const;
 
+export const GOOGLE_DRIVE_SCOPES =
+  "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly";
+
 const capabilitiesSchema = z
   .object({
     canEdit: z.boolean().optional(),
@@ -672,8 +675,7 @@ export function getGoogleDriveServerMetadata() {
       authorization: {
         provider: "google_drive",
         supported_use_cases: ["personal_actions", "platform_actions"],
-        scope:
-          "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly",
+        scope: GOOGLE_DRIVE_SCOPES,
       },
       icon: "DriveLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-drive",

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -28,20 +28,28 @@ vi.mock(
 function createGaxiosError(
   code: number,
   message: string,
-  reason?: string
+  reason?: string | string[]
 ): Common.GaxiosError {
   const mockConfig = {
     url: "https://test.example.com",
     method: "GET",
   };
 
+  const reasons = reason === undefined ? [] : [reason].flat();
   const mockResponse = {
     status: code,
     statusText: message,
     config: mockConfig,
-    data: reason
-      ? { error: { code, message, errors: [{ reason, message }] } }
-      : {},
+    data:
+      reasons.length > 0
+        ? {
+            error: {
+              code,
+              message,
+              errors: reasons.map((r) => ({ reason: r, message })),
+            },
+          }
+        : {},
     headers: {},
     request: { responseURL: "https://test.example.com" },
   };
@@ -287,6 +295,25 @@ describe("handleFileAccessError", () => {
         "The user has not granted the app access to the file",
         "appNotAuthorizedToFile"
       ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(item.resource.type).toBe("tool_file_auth_required");
+    }
+  });
+
+  it("should prefer the file picker when appNotAuthorizedToFile appears alongside a permission reason", async () => {
+    // An explicit missing app grant is fixable by the picker even if Google
+    // also reports a user-level permission reason in the same error body.
+    const result = await handleFileAccessError(
+      createGaxiosError(403, "The user has not granted the app access", [
+        "insufficientFilePermissions",
+        "appNotAuthorizedToFile",
+      ]),
       "test-file-id",
       createMockExtra("my-connection")
     );

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -25,7 +25,11 @@ vi.mock(
 );
 
 // Helper to create a mock GaxiosError
-function createGaxiosError(code: number, message: string): Common.GaxiosError {
+function createGaxiosError(
+  code: number,
+  message: string,
+  reason?: string
+): Common.GaxiosError {
   const mockConfig = {
     url: "https://test.example.com",
     method: "GET",
@@ -35,7 +39,9 @@ function createGaxiosError(code: number, message: string): Common.GaxiosError {
     status: code,
     statusText: message,
     config: mockConfig,
-    data: {},
+    data: reason
+      ? { error: { code, message, errors: [{ reason, message }] } }
+      : {},
     headers: {},
     request: { responseURL: "https://test.example.com" },
   };
@@ -61,6 +67,11 @@ describe("handleFileAccessError", () => {
         },
       },
     }) as ToolHandlerExtra;
+
+  beforeEach(() => {
+    // Default: no drive client, so the token-validity probe reports invalid.
+    vi.mocked(getDriveClient).mockReset();
+  });
 
   it("should return file authorization error for 403 with 'has not granted' message", async () => {
     const result = await handleFileAccessError(
@@ -136,7 +147,8 @@ describe("handleFileAccessError", () => {
     }
   });
 
-  it("should return OAuth re-auth for general 403 errors without permission keywords", async () => {
+  it("should return OAuth re-auth for general 403 errors when the token is invalid", async () => {
+    // getDriveClient resolves to undefined, so the token-validity probe fails.
     const result = await handleFileAccessError(
       createGaxiosError(403, "Forbidden"),
       "test-file-id",
@@ -150,6 +162,139 @@ describe("handleFileAccessError", () => {
       const item = content[0] as any;
       expect(item.type).toBe("resource");
       expect(item.resource.type).toBe("tool_personal_auth_required");
+    }
+  });
+
+  it("should return a permission error for general 403 errors when the token is valid", async () => {
+    const aboutGet = vi.fn().mockResolvedValue({ data: { user: {} } });
+    vi.mocked(getDriveClient).mockResolvedValue({
+      about: { get: aboutGet },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await handleFileAccessError(
+      createGaxiosError(403, "Forbidden"),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(aboutGet).toHaveBeenCalled();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("does not have permission");
+    }
+  });
+
+  it("should return a rate-limit error for 403 with a rate-limit reason", async () => {
+    const result = await handleFileAccessError(
+      createGaxiosError(
+        403,
+        "User rate limit exceeded.",
+        "userRateLimitExceeded"
+      ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("rate limiting");
+    }
+  });
+
+  it("should return a permission error for 403 with a permission reason without probing the token", async () => {
+    const aboutGet = vi.fn().mockResolvedValue({ data: { user: {} } });
+    vi.mocked(getDriveClient).mockResolvedValue({
+      about: { get: aboutGet },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await handleFileAccessError(
+      createGaxiosError(
+        403,
+        "Insufficient permissions for the specified parent",
+        "insufficientParentPermissions"
+      ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(aboutGet).not.toHaveBeenCalled();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("does not have permission");
+    }
+  });
+
+  it("should return OAuth re-auth for 403 with an insufficient-scope reason even when the token is valid", async () => {
+    vi.mocked(getDriveClient).mockResolvedValue({
+      about: { get: vi.fn().mockResolvedValue({ data: { user: {} } }) },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await handleFileAccessError(
+      createGaxiosError(
+        403,
+        "Insufficient Permission: Request had insufficient authentication scopes.",
+        "insufficientPermissions"
+      ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(item.resource.type).toBe("tool_personal_auth_required");
+    }
+  });
+
+  it("should return OAuth re-auth for 401 errors", async () => {
+    const result = await handleFileAccessError(
+      createGaxiosError(401, "Invalid Credentials", "authError"),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(item.type).toBe("resource");
+      expect(item.resource.type).toBe("tool_personal_auth_required");
+    }
+  });
+
+  it("should skip the file picker and return a permission error when Google reports a user-level permission denial", async () => {
+    // Message matches the picker keywords, but the structured reason says the
+    // user lacks rights on the file: re-picking cannot help.
+    const result = await handleFileAccessError(
+      createGaxiosError(
+        403,
+        "The caller does not have permission",
+        "insufficientFilePermissions"
+      ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("does not have permission");
+    }
+  });
+
+  it("should return file authorization error for 403 with the appNotAuthorizedToFile reason", async () => {
+    const result = await handleFileAccessError(
+      createGaxiosError(
+        403,
+        "The user has not granted the app access to the file",
+        "appNotAuthorizedToFile"
+      ),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(item.resource.type).toBe("tool_file_auth_required");
     }
   });
 
@@ -195,6 +340,150 @@ describe("handleFileAccessError", () => {
     if (result.isErr()) {
       expect(result.error.message).toBe("Failed to access file");
     }
+  });
+});
+
+describe("parent folder permission checks", () => {
+  const extra = {
+    authInfo: undefined,
+    runContext: undefined,
+  } as unknown as ToolHandlerExtra;
+
+  function getTool(name: string) {
+    const tool = TOOLS.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`${name} tool not found`);
+    }
+    return tool;
+  }
+
+  function expectPermissionError(
+    result: Awaited<ReturnType<ReturnType<typeof getTool>["handler"]>>
+  ) {
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(item.type).toBe("text");
+      expect(JSON.parse(item.text).error).toContain(
+        "permission to add files to this folder"
+      );
+    }
+  }
+
+  beforeEach(() => {
+    vi.mocked(getDriveClient).mockReset();
+  });
+
+  it("copy_file returns a permission error when the destination folder is not writable", async () => {
+    const filesGet = vi.fn().mockResolvedValue({
+      data: { capabilities: { canAddChildren: false } },
+    });
+    const filesCopy = vi.fn();
+    vi.mocked(getDriveClient).mockResolvedValue({
+      files: { get: filesGet, copy: filesCopy },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await getTool("copy_file").handler(
+      {
+        fileId: "src-file",
+        parentId: "restricted-folder",
+        capabilities: { canCopy: true },
+      },
+      extra
+    );
+
+    expect(filesGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: "restricted-folder",
+        fields: "capabilities/canAddChildren",
+      })
+    );
+    expect(filesCopy).not.toHaveBeenCalled();
+    expectPermissionError(result);
+  });
+
+  it("copy_file returns a permission error when the source file cannot be copied", async () => {
+    const filesGet = vi.fn().mockResolvedValue({
+      data: { capabilities: { canCopy: false } },
+    });
+    const filesCopy = vi.fn();
+    vi.mocked(getDriveClient).mockResolvedValue({
+      files: { get: filesGet, copy: filesCopy },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await getTool("copy_file").handler(
+      { fileId: "src-file" },
+      extra
+    );
+
+    expect(filesCopy).not.toHaveBeenCalled();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(JSON.parse(item.text).error).toContain(
+        "permission to copy this file"
+      );
+    }
+  });
+
+  it("create_document returns a permission error when the parent folder is not writable", async () => {
+    const filesGet = vi.fn().mockResolvedValue({
+      data: { capabilities: { canAddChildren: false } },
+    });
+    const filesCreate = vi.fn();
+    vi.mocked(getDriveClient).mockResolvedValue({
+      files: { get: filesGet, create: filesCreate },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await getTool("create_document").handler(
+      { title: "Doc", parentId: "restricted-folder" },
+      extra
+    );
+
+    expect(filesCreate).not.toHaveBeenCalled();
+    expectPermissionError(result);
+  });
+
+  it("create_document proceeds when the parent folder is writable", async () => {
+    const filesGet = vi.fn().mockResolvedValue({
+      data: { capabilities: { canAddChildren: true } },
+    });
+    const filesCreate = vi.fn().mockResolvedValue({
+      data: { id: "new-doc", name: "Doc", webViewLink: "https://link" },
+    });
+    vi.mocked(getDriveClient).mockResolvedValue({
+      files: { get: filesGet, create: filesCreate },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await getTool("create_document").handler(
+      { title: "Doc", parentId: "writable-folder" },
+      extra
+    );
+
+    expect(filesCreate).toHaveBeenCalled();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const item = result.value[0] as any;
+      expect(JSON.parse(item.text).documentId).toBe("new-doc");
+    }
+  });
+
+  it("create_document skips the folder check when no parent is given", async () => {
+    const filesGet = vi.fn();
+    const filesCreate = vi.fn().mockResolvedValue({
+      data: { id: "new-doc", name: "Doc", webViewLink: "https://link" },
+    });
+    vi.mocked(getDriveClient).mockResolvedValue({
+      files: { get: filesGet, create: filesCreate },
+    } as unknown as Awaited<ReturnType<typeof getDriveClient>>);
+
+    const result = await getTool("create_document").handler(
+      { title: "Doc" },
+      extra
+    );
+
+    expect(filesGet).not.toHaveBeenCalled();
+    expect(result.isOk()).toBe(true);
   });
 });
 

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -65,6 +65,17 @@ function createGaxiosError(
   return error;
 }
 
+function isTextBlock(block: unknown): block is { type: "text"; text: string } {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    "type" in block &&
+    block.type === "text" &&
+    "text" in block &&
+    typeof block.text === "string"
+  );
+}
+
 describe("handleFileAccessError", () => {
   const createMockExtra = (toolServerId: string): ToolHandlerExtra =>
     ({
@@ -91,16 +102,16 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const content = result.value;
-      expect(content).toHaveLength(1);
-      const item = content[0] as any;
-      expect(item.type).toBe("resource");
-      expect(item.resource).toMatchObject({
-        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
-        type: "tool_file_auth_required",
-        fileId: "test-file-id",
-        fileName: "test-file.txt",
-        connectionId: "my-connection",
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+          type: "tool_file_auth_required",
+          fileId: "test-file-id",
+          fileName: "test-file.txt",
+          connectionId: "my-connection",
+        },
       });
     }
   });
@@ -114,12 +125,12 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const content = result.value;
-      const item = content[0] as any;
-      expect(item.type).toBe("resource");
-      expect(item.resource).toMatchObject({
-        fileName: "test-file-id",
-        fileId: "test-file-id",
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: {
+          fileName: "test-file-id",
+          fileId: "test-file-id",
+        },
       });
     }
   });
@@ -133,11 +144,11 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const content = result.value;
-      const item = content[0] as any;
-      expect(item.type).toBe("resource");
-      expect(item.resource).toMatchObject({
-        connectionId: "my-connection",
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: {
+          connectionId: "my-connection",
+        },
       });
     }
   });
@@ -165,11 +176,11 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const content = result.value;
-      expect(content).toHaveLength(1);
-      const item = content[0] as any;
-      expect(item.type).toBe("resource");
-      expect(item.resource.type).toBe("tool_personal_auth_required");
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: { type: "tool_personal_auth_required" },
+      });
     }
   });
 
@@ -249,8 +260,10 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
-      expect(item.resource.type).toBe("tool_personal_auth_required");
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: { type: "tool_personal_auth_required" },
+      });
     }
   });
 
@@ -263,9 +276,10 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
-      expect(item.type).toBe("resource");
-      expect(item.resource.type).toBe("tool_personal_auth_required");
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: { type: "tool_personal_auth_required" },
+      });
     }
   });
 
@@ -301,8 +315,10 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
-      expect(item.resource.type).toBe("tool_file_auth_required");
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: { type: "tool_file_auth_required" },
+      });
     }
   });
 
@@ -320,8 +336,10 @@ describe("handleFileAccessError", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
-      expect(item.resource.type).toBe("tool_file_auth_required");
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: { type: "tool_file_auth_required" },
+      });
     }
   });
 
@@ -389,8 +407,10 @@ describe("parent folder permission checks", () => {
   ) {
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
-      expect(item.type).toBe("text");
+      const item = result.value[0];
+      if (!isTextBlock(item)) {
+        throw new Error("Expected the first block to be a text block");
+      }
       expect(JSON.parse(item.text).error).toContain(
         "permission to add files to this folder"
       );
@@ -446,7 +466,10 @@ describe("parent folder permission checks", () => {
     expect(filesCopy).not.toHaveBeenCalled();
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
+      const item = result.value[0];
+      if (!isTextBlock(item)) {
+        throw new Error("Expected the first block to be a text block");
+      }
       expect(JSON.parse(item.text).error).toContain(
         "permission to copy this file"
       );
@@ -490,7 +513,10 @@ describe("parent folder permission checks", () => {
     expect(filesCreate).toHaveBeenCalled();
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      const item = result.value[0] as any;
+      const item = result.value[0];
+      if (!isTextBlock(item)) {
+        throw new Error("Expected the first block to be a text block");
+      }
       expect(JSON.parse(item.text).documentId).toBe("new-doc");
     }
   });
@@ -567,19 +593,6 @@ describe("get_file_content", () => {
     authInfo: undefined,
     runContext: undefined,
   } as unknown as ToolHandlerExtra;
-
-  function isTextBlock(
-    block: unknown
-  ): block is { type: "text"; text: string } {
-    return (
-      typeof block === "object" &&
-      block !== null &&
-      "type" in block &&
-      block.type === "text" &&
-      "text" in block &&
-      typeof block.text === "string"
-    );
-  }
 
   function isBinaryFileResourceBlock(
     block: unknown

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -314,17 +314,18 @@ export async function handleFileAccessError(
     }
 
     // The file picker only helps when the app is missing a drive.file grant
-    // on the file. When Google explicitly reports a user-level permission
-    // denial, re-picking the file cannot help: skip the picker and let the
-    // 403 classification below report the permission error.
+    // on the file, which Google reports as appNotAuthorizedToFile. When
+    // Google instead reports a user-level permission denial, re-picking the
+    // file cannot help: veto the message-keyword heuristic and let the 403
+    // classification below report the permission error.
     const reasons = extractGoogleErrorReasons(err);
     if (
       (status === "403" || status === "404") &&
-      !reasons.some((reason) => PERMISSION_403_REASONS.has(reason)) &&
       (reasons.includes("appNotAuthorizedToFile") ||
-        message.includes("caller does not have permission") ||
-        message.includes("has not granted") ||
-        message.includes("write access"))
+        (!reasons.some((reason) => PERMISSION_403_REASONS.has(reason)) &&
+          (message.includes("caller does not have permission") ||
+            message.includes("has not granted") ||
+            message.includes("write access"))))
     ) {
       const connectionId = runContext.toolConfiguration.toolServerId;
 

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -24,6 +24,7 @@ import {
   getSlidesClient,
 } from "@app/lib/api/actions/servers/google_drive/helpers";
 import {
+  GOOGLE_DRIVE_SCOPES,
   GOOGLE_DRIVE_TOOLS_METADATA,
   GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
   MAX_CONTENT_SIZE,
@@ -136,11 +137,158 @@ function normalizeCode(code: string | number | undefined): string | undefined {
   return code !== undefined ? String(code) : undefined;
 }
 
+// 403 reasons that are authentication problems: the token lacks the required
+// OAuth scopes, so re-consenting does fix them.
+const REAUTH_403_REASONS = new Set([
+  "insufficientPermissions",
+  "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
+]);
+
+// 403 reasons that are plain permission denials on the file or folder:
+// re-authenticating cannot fix them.
+const PERMISSION_403_REASONS = new Set([
+  "insufficientFilePermissions",
+  "insufficientParentPermissions",
+  "domainPolicy",
+]);
+
+// 403 reasons that are transient quota/rate limits: neither re-auth nor
+// different permissions help; the caller should retry later.
+const RATE_LIMIT_403_REASONS = new Set([
+  "userRateLimitExceeded",
+  "rateLimitExceeded",
+  "dailyLimitExceeded",
+  "sharingRateLimitExceeded",
+]);
+
+/**
+ * Extracts the structured Google API error reasons from a GaxiosError.
+ * Handles both the legacy error body shape (error.errors[].reason) and the
+ * google.rpc.ErrorInfo shape (error.details[].reason).
+ */
+function extractGoogleErrorReasons(err: Common.GaxiosError): string[] {
+  const data: unknown = err.response?.data;
+  if (typeof data !== "object" || data === null || !("error" in data)) {
+    return [];
+  }
+  const { error } = data;
+  if (typeof error !== "object" || error === null) {
+    return [];
+  }
+
+  const entryLists: unknown[] = [
+    "errors" in error ? error.errors : undefined,
+    "details" in error ? error.details : undefined,
+  ];
+
+  const reasons: string[] = [];
+  for (const entries of entryLists) {
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        "reason" in entry &&
+        typeof entry.reason === "string"
+      ) {
+        reasons.push(entry.reason);
+      }
+    }
+  }
+  return reasons;
+}
+
+/**
+ * Verifies that the OAuth token is still valid by making a cheap
+ * authenticated call. Google returns 403 both for auth-level problems and
+ * for plain permission denials on a file or folder; prompting an
+ * authenticated user to re-authenticate on the latter creates a re-auth
+ * loop that never resolves. Returns false when the check itself cannot run.
+ */
+async function isAuthTokenValid(
+  authInfo: ToolHandlerExtra["authInfo"]
+): Promise<boolean> {
+  const drive = await getDriveClient(authInfo);
+  if (!drive) {
+    return false;
+  }
+  try {
+    await drive.about.get({ fields: "user" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Builds the re-authentication response: an admin-facing error for
+ * workspace connections, or the OAuth re-auth prompt for personal ones.
+ */
+function makeReauthenticationResult(
+  authInfo: ToolHandlerExtra["authInfo"]
+): ToolHandlerResult {
+  if (authInfo?.extra?.connectionType === "workspace") {
+    return new Err(
+      new MCPError(
+        "The workspace Google Drive credentials are invalid or expired. A workspace admin needs to re-authenticate the Google Drive connection.",
+        { tracked: false }
+      )
+    );
+  }
+  return new Ok(
+    makePersonalAuthenticationError("google_drive", GOOGLE_DRIVE_SCOPES).content
+  );
+}
+
+/**
+ * Maps a 403 to either the re-auth flow (missing OAuth scopes or invalid
+ * token) or a permission error (valid token: re-auth would not help and
+ * would loop).
+ */
+async function handleForbiddenError(
+  err: Common.GaxiosError,
+  authInfo: ToolHandlerExtra["authInfo"]
+): Promise<ToolHandlerResult> {
+  const reasons = extractGoogleErrorReasons(err);
+  logger.info(
+    { reasons, connectionType: authInfo?.extra?.connectionType },
+    "Google Drive tool call returned 403"
+  );
+
+  if (reasons.some((reason) => REAUTH_403_REASONS.has(reason))) {
+    return makeReauthenticationResult(authInfo);
+  }
+  if (reasons.some((reason) => RATE_LIMIT_403_REASONS.has(reason))) {
+    return new Err(
+      new MCPError(
+        `Google Drive is rate limiting requests; wait before retrying. Google Drive error: ${err.message ?? "rate limit exceeded"}`,
+        { tracked: false }
+      )
+    );
+  }
+  if (
+    reasons.some((reason) => PERMISSION_403_REASONS.has(reason)) ||
+    (await isAuthTokenValid(authInfo))
+  ) {
+    return new Err(
+      new MCPError(
+        `The user is authenticated but does not have permission to perform this action. Google Drive error: ${err.message ?? "permission denied"}`,
+        { tracked: false }
+      )
+    );
+  }
+  return makeReauthenticationResult(authInfo);
+}
+
 /**
  * Handles errors for operations that require per-file permissions.
  * Uses GAxios error typing for cleaner error handling.
  * - For file-specific 403/404 permission errors: triggers file picker flow
- * - For general 403 errors: triggers OAuth re-auth flow
+ * - For 401 errors: triggers OAuth re-auth flow
+ * - For general 403 errors: re-auth only if the token is invalid, otherwise
+ *   reports a permission error (re-auth cannot fix a permission denial)
  * - For 404 errors: fetches metadata to provide context about the file type
  * - For other errors: returns generic error message
  */
@@ -154,7 +302,6 @@ export async function handleFileAccessError(
     const status = normalizeCode(err.code);
     const message = err.message?.toLowerCase() ?? "";
 
-    // Check for file-specific permission issues that should trigger file picker
     // Export size limit errors are 403s but are not auth issues: Google caps
     // file exports at 10MB.
     if (status === "403" && message.includes("too large")) {
@@ -166,9 +313,16 @@ export async function handleFileAccessError(
       );
     }
 
+    // The file picker only helps when the app is missing a drive.file grant
+    // on the file. When Google explicitly reports a user-level permission
+    // denial, re-picking the file cannot help: skip the picker and let the
+    // 403 classification below report the permission error.
+    const reasons = extractGoogleErrorReasons(err);
     if (
       (status === "403" || status === "404") &&
-      (message.includes("caller does not have permission") ||
+      !reasons.some((reason) => PERMISSION_403_REASONS.has(reason)) &&
+      (reasons.includes("appNotAuthorizedToFile") ||
+        message.includes("caller does not have permission") ||
         message.includes("has not granted") ||
         message.includes("write access"))
     ) {
@@ -184,22 +338,14 @@ export async function handleFileAccessError(
       );
     }
 
-    // Handle general 403 errors with OAuth re-auth
+    // 401 means the token itself is invalid or expired: re-auth is the fix.
+    if (status === "401") {
+      return makeReauthenticationResult(authInfo);
+    }
+
+    // General 403: only re-auth when the token is actually invalid.
     if (status === "403") {
-      if (authInfo?.extra?.connectionType === "workspace") {
-        return new Err(
-          new MCPError(
-            "The workspace Google Drive credentials are invalid or expired. A workspace admin needs to re-authenticate the Google Drive connection.",
-            { tracked: false }
-          )
-        );
-      }
-      return new Ok(
-        makePersonalAuthenticationError(
-          "google_drive",
-          "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly"
-        ).content
-      );
+      return handleForbiddenError(err, authInfo);
     }
 
     // Handle 404 errors - try to fetch metadata for better error message
@@ -249,31 +395,24 @@ export async function handleFileAccessError(
 /**
  * Handles errors for operations that only require Drive-level OAuth (read and create tools).
  * Uses GAxios error typing for cleaner error handling.
- * Returns OAuth re-auth prompt for 403 errors, or generic error for others.
+ * Returns the OAuth re-auth prompt for 401 errors and for 403 errors with an
+ * invalid token; 403 with a valid token reports a permission error instead.
  */
-function handleDriveAccessError(
+async function handleDriveAccessError(
   err: unknown,
   authInfo?: Pick<ToolHandlerExtra, "authInfo">["authInfo"]
-): ToolHandlerResult {
+): Promise<ToolHandlerResult> {
   if (err instanceof Common.GaxiosError) {
     const status = normalizeCode(err.code);
 
-    // Handle 403 errors with OAuth re-auth
+    // 401 means the token itself is invalid or expired: re-auth is the fix.
+    if (status === "401") {
+      return makeReauthenticationResult(authInfo);
+    }
+
+    // General 403: only re-auth when the token is actually invalid.
     if (status === "403") {
-      if (authInfo?.extra?.connectionType === "workspace") {
-        return new Err(
-          new MCPError(
-            "The workspace Google Drive credentials are invalid or expired. A workspace admin needs to re-authenticate the Google Drive connection.",
-            { tracked: false }
-          )
-        );
-      }
-      return new Ok(
-        makePersonalAuthenticationError(
-          "google_drive",
-          "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly"
-        ).content
-      );
+      return handleForbiddenError(err, authInfo);
     }
 
     return new Err(
@@ -311,7 +450,12 @@ function addAgentAttribution(
  * If the capability is true or confirmed via API, returns null to proceed.
  */
 async function ensureCapability(
-  capabilityName: "canEdit" | "canComment" | "canShare" | "canCopy",
+  capabilityName:
+    | "canEdit"
+    | "canComment"
+    | "canShare"
+    | "canCopy"
+    | "canAddChildren",
   capabilityValue: boolean | undefined,
   fileId: string,
   authInfo: ToolHandlerExtra["authInfo"]
@@ -347,6 +491,8 @@ async function ensureCapability(
         "You don't have permission to manage sharing for this file. The file owner may have restricted sharing to owners only.",
       canCopy:
         "You don't have permission to copy this file. The file owner may have restricted copying.",
+      canAddChildren:
+        "You don't have permission to add files to this folder. You need editor access on the folder, or you can create the file in a different location.",
     };
     return new Ok([
       {
@@ -357,6 +503,22 @@ async function ensureCapability(
   }
 
   return null;
+}
+
+/**
+ * Checks that the user can add files to the target folder before a create,
+ * upload, or copy that places a file into it. Without this check, Google's
+ * 403 would surface as a re-authentication prompt even though the user is
+ * authenticated and simply lacks write access to the folder.
+ */
+async function ensureParentFolderWritable(
+  parentId: string | undefined,
+  authInfo: ToolHandlerExtra["authInfo"]
+): Promise<ToolHandlerResult | null> {
+  if (!parentId) {
+    return null;
+  }
+  return ensureCapability("canAddChildren", undefined, parentId, authInfo);
 }
 
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
@@ -830,6 +992,10 @@ const readOnlyTools = buildTools(GOOGLE_DRIVE_TOOLS_METADATA, handlers);
 
 const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   create_document: async ({ title, parentId }, { authInfo }) => {
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -864,6 +1030,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   create_spreadsheet: async ({ title, parentId }, { authInfo }) => {
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -898,6 +1068,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   create_presentation: async ({ title, parentId }, { authInfo }) => {
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -932,6 +1106,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   create_folder: async ({ name, parentId }, { authInfo }) => {
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -977,6 +1155,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     );
     if (accessError) {
       return accessError;
+    }
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
     }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
@@ -1587,6 +1769,10 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { fileId, parentId, fileName },
     { auth, authInfo, runContext }
   ) => {
+    const folderError = await ensureParentFolderWritable(parentId, authInfo);
+    if (folderError) {
+      return folderError;
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/8263
## Context

`dust-tt/tasks#8263` (google_drive `copy_file`/`create_document`) and `dust-tt/dust#28875` (same shape on Slack) report the personal-auth "Connect your account" prompt looping indefinitely even though the OAuth reconnect completes successfully every time (`outcome: completed` in Datadog).

Hard to verify 100% that this is the issue but I'm assuming its the same shape as previous similar bugs where we assume too many error types are auth errors. This PR is parsing out every error possible to stop these looping flows

## What this PR does

1. **Classify 403s by structured error reason** (`error.errors[].reason` / `error.details[].reason`) instead of treating them all as auth failures:
   - insufficient-scope reasons (`insufficientPermissions`, `ACCESS_TOKEN_SCOPE_INSUFFICIENT`) → re-auth (re-consent does fix these)
   - rate-limit reasons → "wait before retrying" error
   - permission reasons (`insufficientFilePermissions`, `insufficientParentPermissions`, `domainPolicy`) → clear permission error, no re-auth
   - anything else → cheap `about.get` token probe: token valid ⇒ permission error, token invalid ⇒ re-auth. This breaks the loop even for 403 shapes not enumerated above (including the create-in-My-Drive-root case with no `parentId` to check upfront).
2. **Handle 401 as the actual invalid-token signal** → re-auth (previously fell through to a generic error, so genuinely expired tokens never triggered reconnect).
3. **Check the parent folder upfront**: `copy_file`, `create_document`/`create_spreadsheet`/`create_presentation`/`create_folder`, and `upload_file` now verify the destination folder's `capabilities.canAddChildren` (the Drive capability for "can add items to this folder") before the call, via the existing `ensureCapability` pattern, returning an actionable message.
4. **Skip the file-picker flow when Google explicitly reports a user-level permission denial** — re-picking the file can't grant rights the user doesn't have. The picker still triggers for `appNotAuthorizedToFile` and keyword matches without a structured reason (its legitimate `drive.file`-grant use case).
5. **Log the extracted reasons + connection type** on every 403 so Datadog shows which branch fires when the next report lands.

## Tests

29 unit tests in `tools/index.test.ts`: 403 classification (scope / permission / rate-limit / probe-valid / probe-invalid), 401 re-auth, picker-skip regression, and the folder checks on `copy_file`/`create_document` (blocked, allowed, skipped-when-no-parent).

## Risk

Worst case, a genuine auth failure with an unusual shape gets reported as a permission error instead of prompting reconnect — the user can still reconnect from tool settings, and the error message includes Google's original text. Safe to rollback.
