### PR TITLE
[front] enh: wrap readable.fromWeb to have better error msg

### DIFF
--- a/front/lib/api/file_system/upload_from_url.test.ts
+++ b/front/lib/api/file_system/upload_from_url.test.ts
@@ -3,6 +3,7 @@ import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { uploadFileFromUrlToFileSystem } from "@app/lib/api/file_system/upload_from_url";
 import { untrustedFetch } from "@app/lib/egress/server";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { isString } from "@app/types/shared/utils/general";
 import { Readable } from "stream";
 import { describe, expect, it, vi } from "vitest";
 
@@ -36,7 +37,7 @@ function mockFetchResponse({
   statusText?: string;
   contentType?: string;
   contentLength?: string;
-  body?: string;
+  body?: string | Readable;
 }) {
   const headers = new Headers({ "content-type": contentType });
   if (contentLength !== undefined) {
@@ -49,7 +50,10 @@ function mockFetchResponse({
       status,
       statusText,
       headers,
-      body: body === undefined ? null : Readable.toWeb(Readable.from([body])),
+      body:
+        body === undefined
+          ? null
+          : Readable.toWeb(isString(body) ? Readable.from([body]) : body),
     })
   );
 }
@@ -168,6 +172,44 @@ describe("uploadFileFromUrlToFileSystem", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.message).toContain("maximum supported size");
+    }
+  });
+
+  it("returns an error when the download aborts mid-stream", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    async function* abortedBodyChunks() {
+      yield "partial content";
+      throw new DOMException(
+        "The operation was aborted due to timeout",
+        "TimeoutError"
+      );
+    }
+
+    mockFetchResponse({
+      contentType: "text/plain",
+      body: Readable.from(abortedBodyChunks()),
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path: `conversation-${conversation.sId}/aborted.txt`,
+      url: "https://example.com/aborted.txt",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Failed to fetch URL");
     }
   });
 

--- a/front/lib/api/file_system/upload_from_url.ts
+++ b/front/lib/api/file_system/upload_from_url.ts
@@ -62,6 +62,9 @@ function limitReadableStream(
   });
 
   limited.on("error", () => stream.destroy());
+  // pipe() does not forward source errors (e.g. a fetch abort mid-stream);
+  // left unforwarded they throw as uncaught exceptions.
+  stream.on("error", (err) => limited.destroy(err));
 
   return {
     stream: stream.pipe(limited),
@@ -177,14 +180,24 @@ export async function uploadFileFromUrlToFileSystem(
     }
   }
 
-  const sourceStream = Readable.fromWeb(response.body);
-  const { stream: limitedStream, getBytesRead } = limitReadableStream(
-    sourceStream,
-    maxBytes
-  );
+  let sourceStream: Readable;
+  let getBytesRead: () => number;
+  let writeResult: Awaited<ReturnType<typeof dustFs.write>>;
+  try {
+    sourceStream = Readable.fromWeb(response.body);
+    const limited = limitReadableStream(sourceStream, maxBytes);
+    getBytesRead = limited.getBytesRead;
+    writeResult = await dustFs.write(path, limited.stream, finalContentType);
+  } catch {
+    return new Err({ message: `Failed to fetch URL: ${sanitizedUrl}` });
+  }
 
-  const writeResult = await dustFs.write(path, limitedStream, finalContentType);
   if (writeResult.isErr()) {
+    // A source failure (abort, network reset) surfaces through the write
+    // pipeline; report it as a fetch failure rather than a write one.
+    if (sourceStream.errored) {
+      return new Err({ message: `Failed to fetch URL: ${sanitizedUrl}` });
+    }
     const err = writeResult.error;
     switch (err.code) {
       case "legacy_path":


### PR DESCRIPTION
## Description

When AbortSignal.timeout fires while the response body of an upload-from-URL is being streamed to GCS, the resulting DOMException (TimeoutError) was emitted as an 'error' event on the Readable.fromWeb source stream. 

pipe() does not forward source errors to the destination, so nothing routed the error into the write pipeline: the write hung and the exception surfaced as an uncaught exception in the agent loop instead of a tool error.

**Fix: we will no longer log an uncaught exception when a transient upload error happens.**

- limitReadableStream now forwards source-stream errors into the transform (limited.destroy(err)), so an abort mid-stream rejects dustFs.write's internal pipeline and resolves to a normal Err.
- The Readable.fromWeb → limitReadableStream → dustFs.write sequence is wrapped in a try/catch returning Err({ message: "Failed to fetch URL: ..." }) as a double protection for anything else overflowing from node's internals.



## Tests

Added some tests

## Risk

Low
Blast radius: some file uploads codepaths around dust filesystem's upload from url. Mostly agent loop


## Deploy Plan

Deploy front