### PR TITLE
[Admin Gov] Reshape group_permissions registry to role definitions

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -175,13 +175,11 @@ describe("assertValidGrant", () => {
 });
 
 describe("ROLE_REGISTRY invariants", () => {
-  const resourceTypes = Object.keys(ROLE_REGISTRY) as Array<
-    keyof typeof ROLE_REGISTRY
-  >;
+  const roleMaps = Object.values(ROLE_REGISTRY);
 
   it("has no two roles with an identical verb set within a resource type", () => {
-    for (const resourceType of resourceTypes) {
-      const verbSets = Object.values(ROLE_REGISTRY[resourceType]).map((role) =>
+    for (const roles of roleMaps) {
+      const verbSets = Object.values(roles).map((role) =>
         [...role.verbs].sort().join(",")
       );
       expect(new Set(verbSets).size).toBe(verbSets.length);
@@ -190,8 +188,8 @@ describe("ROLE_REGISTRY invariants", () => {
 
   it("makes every grant verb reachable via at least one role", () => {
     const reachable = new Set<string>();
-    for (const resourceType of resourceTypes) {
-      for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+    for (const roles of roleMaps) {
+      for (const role of Object.values(roles)) {
         for (const verb of role.verbs) {
           reachable.add(verb);
         }
@@ -205,11 +203,12 @@ describe("ROLE_REGISTRY invariants", () => {
     }
   });
 
-  it("keeps every type-level role a singleton", () => {
-    for (const resourceType of resourceTypes) {
-      for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+  it("keeps every type-level role a singleton whose name is its verb", () => {
+    for (const roles of roleMaps) {
+      for (const [name, role] of Object.entries(roles)) {
         if (role.levels.includes("type")) {
           expect(role.verbs).toHaveLength(1);
+          expect(name).toBe(role.verbs[0]);
         }
       }
     }

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -1,5 +1,11 @@
-import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
-import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import {
+  assertValidGrant,
+  ROLE_REGISTRY,
+} from "@app/lib/resources/group_permission_registry";
+import {
+  GRANT_TYPES,
+  WHOLE_TYPE_RESOURCE_ID,
+} from "@app/types/group_permissions";
 import { describe, expect, it } from "vitest";
 
 describe("assertValidGrant", () => {
@@ -14,10 +20,20 @@ describe("assertValidGrant", () => {
       ).not.toThrow();
     });
 
-    it("instance-level verb with -1 (all resources of the type)", () => {
+    it("instance-level write on an agent (editor role)", () => {
       expect(() =>
         assertValidGrant({
           grantType: "write",
+          resourceType: "agent",
+          resourceId: 7,
+        })
+      ).not.toThrow();
+    });
+
+    it("type-level capability (publish) with -1", () => {
+      expect(() =>
+        assertValidGrant({
+          grantType: "publish",
           resourceType: "agent",
           resourceId: WHOLE_TYPE_RESOURCE_ID,
         })
@@ -125,5 +141,77 @@ describe("assertValidGrant", () => {
         })
       ).toThrow(/cannot be granted type-wide/);
     });
+
+    it("instance-level publish on an agent (publish is type-level)", () => {
+      expect(() =>
+        assertValidGrant({
+          grantType: "publish",
+          resourceType: "agent",
+          resourceId: 5,
+        })
+      ).toThrow(/type-level/);
+    });
+
+    it("type-wide write on an agent (editor is instance-only)", () => {
+      expect(() =>
+        assertValidGrant({
+          grantType: "write",
+          resourceType: "agent",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).toThrow(/cannot be granted type-wide/);
+    });
+
+    it("type-wide grant on a space (space roles are instance-only)", () => {
+      expect(() =>
+        assertValidGrant({
+          grantType: "read",
+          resourceType: "space",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        })
+      ).toThrow(/cannot be granted type-wide/);
+    });
+  });
+});
+
+describe("ROLE_REGISTRY invariants", () => {
+  const resourceTypes = Object.keys(ROLE_REGISTRY) as Array<
+    keyof typeof ROLE_REGISTRY
+  >;
+
+  it("has no two roles with an identical verb set within a resource type", () => {
+    for (const resourceType of resourceTypes) {
+      const verbSets = Object.values(ROLE_REGISTRY[resourceType]).map((role) =>
+        [...role.verbs].sort().join(",")
+      );
+      expect(new Set(verbSets).size).toBe(verbSets.length);
+    }
+  });
+
+  it("makes every grant verb reachable via at least one role", () => {
+    const reachable = new Set<string>();
+    for (const resourceType of resourceTypes) {
+      for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+        for (const verb of role.verbs) {
+          reachable.add(verb);
+        }
+      }
+    }
+    // Every concrete verb in the vocabulary ("*" excluded) must be granted by some role.
+    for (const verb of GRANT_TYPES) {
+      if (verb !== "*") {
+        expect(reachable.has(verb)).toBe(true);
+      }
+    }
+  });
+
+  it("keeps every type-level role a singleton", () => {
+    for (const resourceType of resourceTypes) {
+      for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+        if (role.levels.includes("type")) {
+          expect(role.verbs).toHaveLength(1);
+        }
+      }
+    }
   });
 });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -6,66 +6,88 @@ import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import assert from "assert";
 
 /**
- * Static source of truth for `group_permissions` validity.
+ * Static source of truth for `group_permissions` validity, expressed as roles.
  *
- * The table is polymorphic, so its representable space is larger than its valid space. Every write
- * path in `GroupPermissionResource` validates against this registry and throws on violation — invalid
- * writes are programmer errors, so we fail fast rather than returning a `Result`. The DB CHECK only
- * covers the coarse instance-less-domain rule; finer per-verb rules (e.g. `create` ⇒ `-1` only) live
- * here.
+ * A role is a named bundle of verbs, valid at one or more levels. Instance-level roles bundle the
+ * verbs the product grants and revokes as a unit (e.g. a space `member` is `read` + `write`).
+ * Type-level capability roles are singletons — their name equals their single verb — because the
+ * Governance page toggles capabilities one verb at a time; a multi-verb type-level role would make
+ * a single toggle revoke verbs it did not touch.
  *
- * The `"*"` wildcards in the vocabulary are intentionally not part of the per-type table: a wildcard
+ * The stored grant value is still a plain verb today (see `@app/types/group_permissions`); this
+ * registry therefore currently serves to derive the set of valid verbs per (resourceType, level).
+ * When grants move to storing the role name, the same definitions drive verb→role expansion.
+ *
+ * The `"*"` wildcards in the vocabulary are intentionally not part of this registry: a wildcard
  * grant applies to the whole type (or all types) and is only ever a type-level (`-1`) grant.
  */
 
 // Concrete (non-wildcard) vocabulary — the registry describes these.
 type ConcreteResourceType = Exclude<GroupPermissionResourceType, "*">;
-type ConcreteGrantType = Exclude<GrantType, "*">;
+type GrantVerb = Exclude<GrantType, "*">;
 
-interface ResourceTypeRule {
-  // Verbs grantable on a specific instance (resourceId > 0).
-  instanceLevelPermissions: ConcreteGrantType[];
-  // Verbs grantable type-wide (resourceId = -1). For types with instances this includes the
-  // instance verbs (a -1 grant covers all resources) plus type-only verbs like "create"; the two
-  // lists therefore overlap. Instance-less domains have an empty instanceLevelPermissions and list
-  // their verbs here only.
-  typeLevelPermissions: ConcreteGrantType[];
+// A grant applies either to a specific resource instance (resourceId > 0) or to the whole type
+// (resourceId = -1). A role declares the levels at which it can be granted.
+type GrantLevel = "instance" | "type";
+
+interface RoleDefinition {
+  verbs: GrantVerb[];
+  levels: GrantLevel[];
 }
 
-const REGISTRY: Record<ConcreteResourceType, ResourceTypeRule> = {
+export const ROLE_REGISTRY: Record<
+  ConcreteResourceType,
+  Record<string, RoleDefinition>
+> = {
   space: {
-    instanceLevelPermissions: ["read", "write", "admin"],
-    typeLevelPermissions: ["read", "write", "admin"],
+    reader: { verbs: ["read"], levels: ["instance"] },
+    member: { verbs: ["read", "write"], levels: ["instance"] },
+    admin: { verbs: ["read", "write", "admin"], levels: ["instance"] },
   },
   agent: {
-    instanceLevelPermissions: ["read", "write", "publish"],
-    typeLevelPermissions: ["read", "write", "publish", "create"],
+    editor: { verbs: ["read", "write"], levels: ["instance"] },
+    create: { verbs: ["create"], levels: ["type"] },
+    publish: { verbs: ["publish"], levels: ["type"] },
   },
   skill: {
-    instanceLevelPermissions: ["read", "write", "publish"],
-    typeLevelPermissions: ["read", "write", "publish", "create"],
+    editor: { verbs: ["read", "write"], levels: ["instance"] },
+    create: { verbs: ["create"], levels: ["type"] },
+    publish: { verbs: ["publish"], levels: ["type"] },
   },
   frame: {
-    instanceLevelPermissions: [],
-    typeLevelPermissions: ["invite", "publish"],
+    invite: { verbs: ["invite"], levels: ["type"] },
+    publish: { verbs: ["publish"], levels: ["type"] },
   },
   billing: {
-    instanceLevelPermissions: [],
-    typeLevelPermissions: ["admin"],
+    admin: { verbs: ["admin"], levels: ["type"] },
   },
   identity: {
-    instanceLevelPermissions: [],
-    typeLevelPermissions: ["admin"],
+    admin: { verbs: ["admin"], levels: ["type"] },
   },
   audit_log: {
-    instanceLevelPermissions: [],
-    typeLevelPermissions: ["read"],
+    read: { verbs: ["read"], levels: ["type"] },
   },
   models_tier: {
-    instanceLevelPermissions: ["use"],
-    typeLevelPermissions: [],
+    use: { verbs: ["use"], levels: ["instance"] },
   },
 };
+
+// Verbs grantable at a level on a resource type = the union of the verbs of the roles valid at that
+// level. Derived (never stored) so the roles stay the single source of truth.
+function verbsForLevel(
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
+): GrantVerb[] {
+  const verbs = new Set<GrantVerb>();
+  for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+    if (role.levels.includes(level)) {
+      for (const verb of role.verbs) {
+        verbs.add(verb);
+      }
+    }
+  }
+  return [...verbs];
+}
 
 interface GrantSpec {
   grantType: GrantType;
@@ -89,9 +111,12 @@ export function assertValidGrant({
     return;
   }
 
-  const rule = REGISTRY[resourceType];
-  const allowedOnInstance = rule.instanceLevelPermissions.includes(grantType);
-  const allowedTypeWide = rule.typeLevelPermissions.includes(grantType);
+  const allowedOnInstance = verbsForLevel(resourceType, "instance").some(
+    (verb) => verb === grantType
+  );
+  const allowedTypeWide = verbsForLevel(resourceType, "type").some(
+    (verb) => verb === grantType
+  );
   assert(
     allowedOnInstance || allowedTypeWide,
     `Permission "${grantType}" is not allowed on resource type "${resourceType}".`


### PR DESCRIPTION
## Description

Reshapes the `group_permissions` registry from flat per-type verb lists to **role definitions** — a
role is a named bundle of verbs valid at one or more levels (`instance` / `type`). The set of valid
verbs for a `(resourceType, level)` is now *derived* as the union of the roles' verb sets, so the
roles are the single source of truth.

Follows #29011 (the `grantType` rename). Grants still store and validate a plain verb; switching the
stored value to the role name (and expanding verb→roles at check time) is the next PR. This PR only
changes the registry's shape and tightens validity to the intended role model:

- **Instance-level roles** (multi-verb bundles the product grants/revokes as a unit): `space`
  reader/member/admin, `agent`+`skill` editor.
- **Type-level capability roles** are singletons (name = verb): create/publish (agent+skill),
  invite/publish (frame), admin (billing+identity), read (audit_log), use (models_tier).
- Drops combos that were representable but unused anywhere: instance `publish` on agent/skill,
  type-wide `read`/`write` on agent/skill, and type-wide `space` grants.

Adds registry-invariant tests: no two roles in a type share a verb set, every vocabulary verb is
reachable via some role, and every type-level role is a singleton.

No behavior change for any live caller — the only current writers use singleton grant types
(`models_tier` → `use`; governance capabilities → create/publish/invite/admin), all still valid.

## Risks

Blast radius: `group_permissions` grant validation (`assertValidGrant`). No schema change, no query
change; the dropped combos have no writer in the codebase.
Risk: low

## Deploy Plan

- deploy front + front-sse (no migration)