### PR TITLE
feat: delete regular manual groups

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -76,7 +76,7 @@ app.get(
     const members = await group.getActiveMembers(auth);
 
     return ctx.json({
-      group: group.toJSON(),
+      group: { ...group.toJSON(), memberCount: members.length },
       members: members.map((member) => member.toJSON()),
     });
   }
@@ -194,7 +194,7 @@ app.patch(
     const members = await group.getActiveMembers(auth);
 
     return ctx.json({
-      group: group.toJSON(),
+      group: { ...group.toJSON(), memberCount: members.length },
       members: members.map((member) => member.toJSON()),
     });
   }

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -112,8 +112,9 @@ app.post(
           assertNever(groupRes.error.code);
       }
     }
+    const group = await groupRes.value.toJSONWithMemberCount(auth);
 
-    return ctx.json({ group: groupRes.value.toJSON() });
+    return ctx.json({ group });
   }
 );
 

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -41,7 +41,7 @@ function getGroupKindChip(kind: GroupKind): {
     case "provisioned":
       return { label: "Provisioned", color: "success" };
     default:
-      return { label: kind, color: "primary" };
+      return { label: "Manual", color: "info" };
   }
 }
 

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -1,8 +1,9 @@
+import { ConfirmContext } from "@app/components/Confirm";
 import { GroupDialog } from "@app/components/groups/GroupDialog";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { useGroups } from "@app/lib/swr/groups";
+import { useDeleteGroup, useGroups } from "@app/lib/swr/groups";
 import {
   type GroupKind,
   isRegularManualGroupKind,
@@ -14,14 +15,21 @@ import {
   Button,
   Chip,
   DataTable,
+  DotsHorizontal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
   EmptyCTA,
   Plus,
   SearchInput,
   Spinner,
+  Trash01,
   Users01,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 type ChipColor = NonNullable<React.ComponentProps<typeof Chip>["color"]>;
 
@@ -43,9 +51,8 @@ type GroupRowData = {
   memberCount: number;
   kind: GroupKind;
   onClick?: () => void;
+  onDelete?: () => void;
 };
-
-type GroupInfo = CellContext<GroupRowData, unknown>;
 
 interface WorkspaceGroupsListProps {
   owner: WorkspaceType;
@@ -57,8 +64,8 @@ const columns: ColumnDef<GroupRowData>[] = [
     accessorKey: "name",
     header: "Name",
     meta: { className: "w-full" },
-    cell: (info: GroupInfo) => {
-      const { name, memberCount } = info.row.original;
+    cell: ({ row }) => {
+      const { name, memberCount } = row.original;
       return (
         <DataTable.CellContent
           icon={Users01}
@@ -73,11 +80,49 @@ const columns: ColumnDef<GroupRowData>[] = [
     id: "kind",
     header: "",
     meta: { className: "w-[160px]" },
-    cell: (info: GroupInfo) => {
-      const { label, color } = getGroupKindChip(info.row.original.kind);
+    cell: ({ row }) => {
+      const { label, color } = getGroupKindChip(row.original.kind);
       return (
         <DataTable.CellContent>
           <Chip size="xs" color={color} label={label} />
+        </DataTable.CellContent>
+      );
+    },
+  },
+  {
+    id: "actions",
+    header: "",
+    meta: { className: "w-12" },
+    cell: ({ row }) => {
+      const { onDelete } = row.original;
+      if (!onDelete) {
+        return null;
+      }
+      return (
+        <DataTable.CellContent>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                icon={DotsHorizontal}
+                size="mini"
+                variant="ghost-secondary"
+                onClick={(e) => e.stopPropagation()}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuContent
+                align="end"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <DropdownMenuItem
+                  label="Delete"
+                  icon={Trash01}
+                  variant="warning"
+                  onClick={onDelete}
+                />
+              </DropdownMenuContent>
+            </DropdownMenuPortal>
+          </DropdownMenu>
         </DataTable.CellContent>
       );
     },
@@ -97,25 +142,50 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editedGroupId, setEditedGroupId] = useState<string | null>(null);
 
+  const confirm = useContext(ConfirmContext);
+  const { doDeleteGroup } = useDeleteGroup({ owner });
+
   const openCreateDialog = () => {
     setEditedGroupId(null);
     setIsDialogOpen(true);
   };
 
+  const handleDeleteGroup = useCallback(
+    async (groupId: string, groupName: string) => {
+      const confirmed = await confirm({
+        title: "Delete group",
+        message: `Are you sure you want to delete ${groupName}? This action cannot be undone.`,
+        validateLabel: "Delete",
+        validateVariant: "warning",
+      });
+      if (confirmed) {
+        await doDeleteGroup({ groupId, groupName });
+      }
+    },
+    [confirm, doDeleteGroup]
+  );
+
   const rows = useMemo<GroupRowData[]>(() => {
-    return groups.map((group) => ({
-      groupId: group.sId,
-      name: group.name,
-      memberCount: group.memberCount,
-      kind: group.kind,
-      onClick: isRegularManualGroupKind(group.kind)
-        ? () => {
-            setEditedGroupId(group.sId);
-            setIsDialogOpen(true);
-          }
-        : undefined,
-    }));
-  }, [groups]);
+    return groups.map((group) => {
+      // Only manually-managed groups can be edited or deleted.
+      const isManual = isRegularManualGroupKind(group.kind);
+      return {
+        groupId: group.sId,
+        name: group.name,
+        memberCount: group.memberCount,
+        kind: group.kind,
+        onClick: isManual
+          ? () => {
+              setEditedGroupId(group.sId);
+              setIsDialogOpen(true);
+            }
+          : undefined,
+        onDelete: isManual
+          ? () => handleDeleteGroup(group.sId, group.name)
+          : undefined,
+      };
+    });
+  }, [groups, handleDeleteGroup]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -9,7 +9,7 @@ import type {
   PostGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
-import type { GroupKind, GroupType } from "@app/types/groups";
+import { type GroupKind, MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { useCallback, useMemo, useState } from "react";
@@ -46,8 +46,14 @@ export function useGroups({
     disabled,
   });
 
+  const groups = useMemo(
+    () =>
+      data ? [...data.groups].sort((a, b) => a.name.localeCompare(b.name)) : [],
+    [data]
+  );
+
   return {
-    groups: data ? data.groups : emptyArray<GroupType>(),
+    groups,
     isGroupsLoading: !error && !data && !disabled,
     isGroupsError: !!error,
     mutateGroups: mutate,
@@ -106,6 +112,11 @@ async function invalidateWorkspaceGroups(workspaceId: string): Promise<void> {
 export function useCreateGroup({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const [isCreating, setIsCreating] = useState(false);
+  const { mutateGroups } = useGroups({
+    owner,
+    kinds: MANAGEABLE_GROUP_KINDS,
+    disabled: true,
+  });
 
   const doCreateGroup = useCallback(
     async ({
@@ -142,14 +153,20 @@ export function useCreateGroup({ owner }: { owner: LightWorkspaceType }) {
           description: `${name} has been created.`,
         });
 
-        await invalidateWorkspaceGroups(owner.sId);
+        await mutateGroups(
+          (previous) =>
+            previous
+              ? { ...previous, groups: [body.group, ...previous.groups] }
+              : previous,
+          { revalidate: false }
+        );
 
         return body;
       } finally {
         setIsCreating(false);
       }
     },
-    [owner.sId, sendNotification]
+    [owner.sId, mutateGroups, sendNotification]
   );
 
   return { doCreateGroup, isCreating };
@@ -165,6 +182,11 @@ export function useUpdateGroup({
   const sendNotification = useSendNotification();
   const [isUpdating, setIsUpdating] = useState(false);
   const { mutateGroup } = useGroup({ owner, groupId, disabled: true });
+  const { mutateGroups } = useGroups({
+    owner,
+    kinds: MANAGEABLE_GROUP_KINDS,
+    disabled: true,
+  });
 
   const doUpdateGroup = useCallback(
     async ({
@@ -205,14 +227,25 @@ export function useUpdateGroup({
         });
 
         await mutateGroup(body, { revalidate: false });
-        await invalidateWorkspaceGroups(owner.sId);
+        await mutateGroups(
+          (previous) =>
+            previous
+              ? {
+                  ...previous,
+                  groups: previous.groups.map((g) =>
+                    g.sId === body.group.sId ? body.group : g
+                  ),
+                }
+              : previous,
+          { revalidate: false }
+        );
 
         return body;
       } finally {
         setIsUpdating(false);
       }
     },
-    [owner.sId, groupId, mutateGroup, sendNotification]
+    [owner.sId, groupId, mutateGroup, mutateGroups, sendNotification]
   );
 
   return { doUpdateGroup, isUpdating };
@@ -221,6 +254,11 @@ export function useUpdateGroup({
 export function useDeleteGroup({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const [isDeleting, setIsDeleting] = useState(false);
+  const { mutateGroups } = useGroups({
+    owner,
+    kinds: MANAGEABLE_GROUP_KINDS,
+    disabled: true,
+  });
 
   const doDeleteGroup = useCallback(
     async ({
@@ -253,14 +291,23 @@ export function useDeleteGroup({ owner }: { owner: LightWorkspaceType }) {
           description: `${groupName} has been deleted.`,
         });
 
-        await invalidateWorkspaceGroups(owner.sId);
+        await mutateGroups(
+          (previous) =>
+            previous
+              ? {
+                  ...previous,
+                  groups: previous.groups.filter((g) => g.sId !== groupId),
+                }
+              : previous,
+          { revalidate: false }
+        );
 
         return true;
       } finally {
         setIsDeleting(false);
       }
     },
-    [owner.sId, sendNotification]
+    [owner.sId, mutateGroups, sendNotification]
   );
 
   return { doDeleteGroup, isDeleting };

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -218,6 +218,54 @@ export function useUpdateGroup({
   return { doUpdateGroup, isUpdating };
 }
 
+export function useDeleteGroup({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const doDeleteGroup = useCallback(
+    async ({
+      groupId,
+      groupName,
+    }: {
+      groupId: string;
+      groupName: string;
+    }): Promise<boolean> => {
+      setIsDeleting(true);
+      try {
+        const res = await clientFetch(`/api/w/${owner.sId}/groups/${groupId}`, {
+          method: "DELETE",
+        });
+
+        if (!res.ok) {
+          const error = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to delete group",
+            description:
+              error?.error?.message ?? "An unexpected error occurred.",
+          });
+          return false;
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Group deleted",
+          description: `${groupName} has been deleted.`,
+        });
+
+        await invalidateWorkspaceGroups(owner.sId);
+
+        return true;
+      } finally {
+        setIsDeleting(false);
+      }
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return { doDeleteGroup, isDeleting };
+}
+
 export function useUpdateGroupSpendLimit({
   workspaceId,
 }: {


### PR DESCRIPTION
## Description

This PR adds the ability to delete regular manual groups from the workspace groups list UI.

## Tests

Manually.

## Risks

Low.
## Deploy Plan

Standard deployment