### PR TITLE
feat(analytics): display message count and avg cost in dashboard

### DIFF
--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -1,11 +1,11 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import type { AnalyticsEntityFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
   AvatarNameCell,
   CreditsCell,
-  EmptyCell,
   EntityList,
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useDebounce } from "@app/hooks/useDebounce";
@@ -15,13 +15,16 @@ import type {
   AgentCreditSkill,
   AgentCreditUser,
 } from "@app/lib/api/assistant/observability/agent_credits";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useWorkspaceAgentCredits } from "@app/lib/swr/workspaces";
-import { DataTable, Tooltip } from "@dust-tt/sparkle";
+import { DataTable, Hoverable, Tooltip } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
 
 interface AgentCreditRowData extends AgentCreditRow {
   onClick?: () => void;
   onDoubleClick?: () => void;
+  onNameClick?: () => void;
 }
 
 type AgentCreditInfo = CellContext<AgentCreditRowData, unknown>;
@@ -69,64 +72,70 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
     id: "name",
     accessorKey: "name",
     header: "Agent",
-    meta: { sizeRatio: 16 },
-    cell: (info: AgentCreditInfo) => (
-      <DataTable.CellContent>
-        <AvatarNameCell
-          name={info.row.original.name}
-          imageUrl={info.row.original.pictureUrl}
-        />
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "modelDisplayName",
-    accessorKey: "modelDisplayName",
-    header: "Model",
-    meta: { sizeRatio: 11 },
-    cell: (info: AgentCreditInfo) => (
-      <DataTable.BasicCellContent label={info.row.original.modelDisplayName} />
-    ),
-  },
-  {
-    id: "description",
-    header: "Description",
-    meta: { sizeRatio: 20 },
+    meta: { sizeRatio: 18 },
     cell: (info: AgentCreditInfo) => {
-      const { description } = info.row.original;
-      if (!description) {
-        return <EmptyCell />;
-      }
+      const { name, pictureUrl, onNameClick } = info.row.original;
+      const content = <AvatarNameCell name={name} imageUrl={pictureUrl} />;
       return (
         <DataTable.CellContent>
-          <Tooltip
-            label={description}
-            tooltipTriggerAsChild
-            trigger={
-              <span className="line-clamp-2 text-sm text-muted-foreground">
-                {description}
-              </span>
-            }
-          />
+          {onNameClick ? (
+            <Hoverable
+              variant="primary"
+              className="flex min-w-0 items-center text-left"
+              onClick={(e) => {
+                // Open the agent details sheet without also triggering the
+                // row-level chart-scope toggle.
+                e.stopPropagation();
+                onNameClick();
+              }}
+            >
+              {content}
+            </Hoverable>
+          ) : (
+            content
+          )}
         </DataTable.CellContent>
       );
     },
   },
   {
+    id: "modelDisplayName",
+    accessorKey: "modelDisplayName",
+    header: "Model",
+    meta: { sizeRatio: 12 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.BasicCellContent label={info.row.original.modelDisplayName} />
+    ),
+  },
+  {
+    id: "messageCount",
+    accessorKey: "messageCount",
+    header: "Messages",
+    meta: { sizeRatio: 10 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.BasicCellContent
+        label={info.row.original.messageCount.toLocaleString()}
+      />
+    ),
+  },
+  {
     id: "credits",
     accessorKey: "credits",
     header: "Credits",
-    meta: { sizeRatio: 8 },
+    meta: { sizeRatio: 10 },
     cell: (info: AgentCreditInfo) => (
       <DataTable.CellContent>
-        <CreditsCell credits={info.row.original.credits} />
+        <CreditsCell
+          credits={info.row.original.credits}
+          messageCount={info.row.original.messageCount}
+        />
       </DataTable.CellContent>
     ),
   },
   {
     id: "topUsers",
     header: "Top users",
-    meta: { sizeRatio: 23 },
+    meta: { sizeRatio: 26 },
     cell: (info: AgentCreditInfo) => (
       <DataTable.CellContent>
         <TopUsersCell users={info.row.original.topUsers} />
@@ -136,7 +145,7 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
   {
     id: "topSkills",
     header: "Top skills",
-    meta: { sizeRatio: 22 },
+    meta: { sizeRatio: 24 },
     cell: (info: AgentCreditInfo) => (
       <DataTable.CellContent>
         <TopSkillsCell skills={info.row.original.topSkills} />
@@ -156,6 +165,9 @@ export function WorkspaceAgentCreditsTable({
   period,
   onSelectAgent,
 }: WorkspaceAgentCreditsTableProps) {
+  const { user, workspace } = useAuth();
+  const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
+
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: 300,
   });
@@ -169,12 +181,13 @@ export function WorkspaceAgentCreditsTable({
       disabled: !workspaceId,
     });
 
-  const rows: AgentCreditRowData[] = onSelectAgent
-    ? agentCredits.map((row) => ({
-        ...row,
-        onClick: () => onSelectAgent({ id: row.agentId, name: row.name }),
-      }))
-    : agentCredits;
+  const rows: AgentCreditRowData[] = agentCredits.map((row) => ({
+    ...row,
+    onNameClick: () => setDetailedAgentId(row.agentId),
+    ...(onSelectAgent
+      ? { onClick: () => onSelectAgent({ id: row.agentId, name: row.name }) }
+      : {}),
+  }));
 
   const exportParams = new URLSearchParams({
     days: period.toString(),
@@ -194,24 +207,32 @@ export function WorkspaceAgentCreditsTable({
   });
 
   return (
-    <CreditsTableCard<AgentCreditRowData>
-      actions={<CsvDownloadButton {...csvDownload} />}
-      title="Agents by credits"
-      description={`Top 100 agents by credits over the last ${period} days, with their top users and skills.`}
-      searchName="agent-credits-search"
-      searchPlaceholder="Search an agent…"
-      searchValue={inputValue}
-      onSearchChange={setValue}
-      isLoading={isAgentCreditsLoading}
-      isError={Boolean(isAgentCreditsError)}
-      errorMessage="Failed to load agent credits."
-      emptyMessage={
-        debouncedValue
-          ? `No agent matches "${inputValue}".`
-          : "No agent activity for this selection."
-      }
-      columns={columns}
-      data={rows}
-    />
+    <>
+      <AgentDetailsSheet
+        owner={workspace}
+        user={user}
+        agentId={detailedAgentId}
+        onClose={() => setDetailedAgentId(null)}
+      />
+      <CreditsTableCard<AgentCreditRowData>
+        actions={<CsvDownloadButton {...csvDownload} />}
+        title="Agents by credits"
+        description={`Top 100 agents by credits over the last ${period} days, with their top users and skills.`}
+        searchName="agent-credits-search"
+        searchPlaceholder="Search an agent…"
+        searchValue={inputValue}
+        onSearchChange={setValue}
+        isLoading={isAgentCreditsLoading}
+        isError={Boolean(isAgentCreditsError)}
+        errorMessage="Failed to load agent credits."
+        emptyMessage={
+          debouncedValue
+            ? `No agent matches "${inputValue}".`
+            : "No agent activity for this selection."
+        }
+        columns={columns}
+        data={rows}
+      />
+    </>
   );
 }

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -93,7 +93,10 @@ const columns: ColumnDef<UserCreditRowData>[] = [
     meta: { sizeRatio: 13 },
     cell: (info: UserCreditInfo) => (
       <DataTable.CellContent>
-        <CreditsCell credits={info.row.original.credits} />
+        <CreditsCell
+          credits={info.row.original.credits}
+          messageCount={info.row.original.messageCount}
+        />
       </DataTable.CellContent>
     ),
   },

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -21,10 +21,28 @@ export function AvatarNameCell({
   );
 }
 
-export function CreditsCell({ credits }: { credits: number }) {
+export function CreditsCell({
+  credits,
+  messageCount,
+}: {
+  credits: number;
+  // When provided (and > 0), the tooltip also shows the average cost per
+  // message (credits / messageCount).
+  messageCount?: number;
+}) {
+  const showAvg = messageCount !== undefined && messageCount > 0;
   return (
     <Tooltip
-      label={`${formatCredits(credits)} credits`}
+      label={
+        <div className="flex flex-col">
+          <span>{formatCredits(credits)} credits</span>
+          {showAvg && (
+            <span>
+              {formatCredits(credits / messageCount)} credits / message
+            </span>
+          )}
+        </div>
+      }
       tooltipTriggerAsChild
       trigger={<span className="text-sm">{formatCreditsCompact(credits)}</span>}
     />

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -37,6 +37,7 @@ export type AgentCreditRow = {
   pictureUrl: string | null;
   modelDisplayName: string;
   description: string;
+  messageCount: number;
   credits: number;
   topUsers: AgentCreditUser[];
   topSkills: AgentCreditSkill[];
@@ -53,6 +54,7 @@ type SkillBucket = {
 
 type AgentBucket = {
   key: string;
+  doc_count: number;
   credits?: estypes.AggregationsSumAggregate;
   top_users?: estypes.AggregationsMultiBucketAggregateBase<SubBucket>;
   top_skills?: {
@@ -65,8 +67,9 @@ type AgentCreditAggs = {
 };
 
 // Per-agent AWU credits (cost.full_awu) over the last `days`: the agent's
-// current model and description, its top 3 users (by cost) and top 3 skills (by
-// execution count — skills carry no per-skill cost). Ranked by credits desc.
+// current model and description, its message count, its top 3 users (by cost)
+// and top 3 skills (by execution count — skills carry no per-skill cost).
+// Ranked by credits desc.
 // Non-free scope; the programmatic "unknown" user is excluded from the top
 // users (but its usage still counts toward the agent's credits). When `search`
 // is set, the ranking is scoped to the matching agents so matches outside the
@@ -217,6 +220,7 @@ export async function fetchAgentCreditBreakdown(
       pictureUrl: label.pictureUrl,
       modelDisplayName: label.modelDisplayName,
       description: label.description,
+      messageCount: bucket.doc_count,
       credits: Math.round(bucket.credits?.value ?? 0),
       topUsers,
       topSkills,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9362

- align both `Users by credits` and `Agents by credits` to display a message and credits column
- removed the description column from the `Agents by credits` table to make way for the message column
- on hover, display avg credit / message
- agent name is now clickable and opens the drawer (similar to the agent builder list)

## Tests

locally tested:

<img width="1126" height="565" alt="Screenshot 2026-07-16 at 15 00 30" src="https://github.com/user-attachments/assets/1775fa42-4fda-4296-b0ea-531b0519f9f8" />
<img width="1127" height="297" alt="Screenshot 2026-07-16 at 15 00 39" src="https://github.com/user-attachments/assets/58b4caf5-157c-4e5e-86cf-e7886391758a" />
https://github.com/user-attachments/assets/11375845-8258-4cd2-9e10-d44a4e0e7b92

