### PR TITLE
[sparkle] Polish form control interactions

### DIFF
--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from "./Tooltip";
 
 export const checkboxStyles = cva(
   cn(
-    "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-200 ease-in-out motion-reduce:transition-none",
+    "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
     "active:scale-95",
     "border-border-dark bg-background",
     "text-foreground",
@@ -19,8 +19,15 @@ export const checkboxStyles = cva(
 
 // The checked state renders a dark rounded square that fills the box's inner
 // content area; the light "ring" is the box's own border showing through.
+// Concentric corners: inner radius = outer radius (rounded-md, 6px) minus the
+// 1px border the fill sits inside.
 export const checkboxIndicatorStyles = cva(
-  "absolute inset-0 flex items-center justify-center rounded-[3px]",
+  cn(
+    "absolute inset-0 flex items-center justify-center rounded-[5px]",
+    // Quick pop-in on check; unchecking unmounts instantly, which is fine —
+    // exits may be faster than entrances, and this is a high-frequency control.
+    "animate-in fade-in-0 zoom-in-90 duration-150 ease-enter motion-reduce:animate-none"
+  ),
   {
     variants: {
       isMutedAfterCheck: {

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 
 export const radioStyles = cva(
   cn(
-    "h-5 w-5 aspect-square rounded-full border transition duration-200 ease-in-out motion-reduce:transition-none active:scale-95",
+    "h-5 w-5 aspect-square rounded-full border transition duration-100 ease-out motion-reduce:transition-none active:scale-95",
     "border-border-dark",
     "bg-background",
     "text-foreground",
@@ -18,7 +18,12 @@ export const radioStyles = cva(
 );
 
 export const radioIndicatorStyles = cva(
-  "h-3 w-3 bg-primary flex items-center justify-center rounded-full"
+  cn(
+    "h-3 w-3 bg-primary flex items-center justify-center rounded-full",
+    // Quick pop-in on select; deselecting unmounts instantly, which is fine —
+    // exits may be faster than entrances, and this is a high-frequency control.
+    "animate-in fade-in-0 zoom-in-90 duration-150 ease-enter motion-reduce:animate-none"
+  )
 );
 
 const RadioGroup = React.forwardRef<

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -9,18 +9,29 @@ type SliderToggleProps = {
 };
 
 const baseClasses = cn(
-  "shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
+  "relative shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
   // Track color and knob slide share timing so they animate as one unit.
   "transition-colors duration-200 ease-in-out motion-reduce:transition-none",
   "shadow-[inset_0px_-3px_3px_0px_rgba(255,255,255,0.25),inset_0px_0.5px_2px_0px_rgba(0,0,0,0.14)]"
 );
 
+// Hover darkens the track by the same amount in both states: a translucent
+// overlay under the knob (::before paints below child content), like Button's
+// hover tint. Dark mode lightens instead, matching the hover token direction.
+const hoverDarkenClasses = cn(
+  "before:pointer-events-none before:absolute before:inset-0 before:rounded-full",
+  "before:bg-black/[0.06] dark:before:bg-white/[0.08]",
+  "before:opacity-0 hover:before:opacity-100",
+  "before:transition-opacity before:duration-200 before:ease-in-out motion-reduce:before:transition-none"
+);
+
 const stateClasses = {
-  idle: cn("bg-slider-toggle-bg-idle", "hover:bg-highlight-300"),
-  selected: cn("bg-highlight-400"),
+  idle: cn("bg-slider-toggle-bg-idle", hoverDarkenClasses),
+  selected: cn("bg-highlight-400", hoverDarkenClasses),
   disabled: cn(
     "bg-primary-200",
     "hover:bg-primary-200",
+    "before:hidden",
     "cursor-not-allowed hover:cursor-not-allowed"
   ),
 };
@@ -43,15 +54,34 @@ export function SliderToggle({
           onClick?.(e); // Run passed onClick event
         }
       }}
-      className={cn(className, baseClasses, combinedStateClasses)}
+      className={cn(
+        "group/slider",
+        className,
+        baseClasses,
+        combinedStateClasses
+      )}
     >
       <div
         id="cursor"
         className={cn(
           "h-4 w-4 transform rounded-full bg-white drop-shadow",
-          "transition-transform duration-200 ease-in-out motion-reduce:transition-none",
+          // Width shares the translate's timing: the hover stretch and the
+          // slide must animate together so the knob stays edge-anchored.
+          // (v4 translate-x-* sets the standalone `translate` property, so it
+          // must be listed explicitly — `transform` alone won't transition it.)
+          "transition-[transform,translate,width] duration-200 ease-in-out motion-reduce:transition-none",
           disabled && "opacity-50",
-          selected ? "translate-x-[14px]" : "translate-x-[2px]"
+          selected ? "translate-x-[14px]" : "translate-x-[2px]",
+          // On hover the knob stretches 2px toward the opposite side, anchored
+          // to its resting edge — hinting the direction it will travel. When
+          // selected, translate compensates so the right edge stays put.
+          // Pressing reverts to resting geometry so the toggle travel runs the
+          // full distance and lands exactly — otherwise the hover compensation
+          // makes the knob stop 2px short until the pointer leaves.
+          !disabled &&
+            (selected
+              ? "group-hover/slider:w-[18px] group-hover/slider:translate-x-[12px] group-active/slider:w-4 group-active/slider:translate-x-[14px]"
+              : "group-hover/slider:w-[18px] group-active/slider:w-4")
         )}
       />
     </div>

--- a/sparkle/src/stories/SliderToggle.stories.tsx
+++ b/sparkle/src/stories/SliderToggle.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { useArgs } from "storybook/preview-api";
 
 import { Button, SliderToggle } from "../index_with_tw_base";
 
@@ -30,14 +31,43 @@ export const SliderToggleBasic: Story = {
   args: {
     selected: false,
   },
+  // The component is fully controlled; wire clicks back into the `selected`
+  // arg so the story is interactive and stays in sync with the controls panel.
+  render: function Render(args) {
+    const [{ selected }, updateArgs] = useArgs<{ selected: boolean }>();
+    return (
+      <SliderToggle
+        {...args}
+        selected={selected}
+        onClick={() => updateArgs({ selected: !selected })}
+      />
+    );
+  },
+};
+
+const InteractiveSliderToggle = ({
+  selected: initialSelected = false,
+  disabled,
+}: {
+  selected?: boolean;
+  disabled?: boolean;
+}) => {
+  const [selected, setSelected] = React.useState(initialSelected);
+  return (
+    <SliderToggle
+      selected={selected}
+      disabled={disabled}
+      onClick={() => setSelected((prev) => !prev)}
+    />
+  );
 };
 
 export const SliderExample = () => (
   <div className="flex items-center gap-2">
     <Button variant="outline" size="sm" label="Settings" />
-    <SliderToggle />
-    <SliderToggle selected />
-    <SliderToggle disabled />
-    <SliderToggle selected disabled />
+    <InteractiveSliderToggle />
+    <InteractiveSliderToggle selected />
+    <InteractiveSliderToggle disabled />
+    <InteractiveSliderToggle selected disabled />
   </div>
 );


### PR DESCRIPTION
## Description

Polish pass on Sparkle form control interactions across three components:

- **Checkbox**: fixes the checked-fill corner radius to `5px` (outer `rounded-md` = 6px minus 1px border, keeping concentric corners); speeds up the press transition to 100ms `ease-out`; adds a quick `zoom-in` / `fade-in` pop-in animation on the check indicator.
- **RadioGroup**: same press timing (100ms `ease-out`) and indicator pop-in animation, also affecting dropdown radio items that share these styles.
- **SliderToggle**: replaces the blue hover tint on the idle track with a uniform translucent darken overlay (via a `::before` pseudo-element) applied consistently in both idle and selected states, lightening in dark mode; disabled state suppresses the overlay. Also wires up `SliderToggle.stories.tsx` with `useArgs` / local state so the Storybook stories are actually interactive.

## Tests

Manual visual check in Storybook — stories are now interactive for `SliderToggle`. Verify checkbox, radio, and toggle interactions look correct in light and dark mode.

## Risk

Low — purely cosmetic/animation changes in Sparkle. No logic or API changes.

## Deploy Plan

Deploy sparkle.