### PR TITLE
[sparkle][front] Align option card hover/selected with menu tokens

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -292,13 +292,13 @@ describe("UserAnswerRequired", () => {
     const betaOption = screen.getByRole("button", { name: /Beta/i });
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
-    expect(alphaOption).toHaveClass("bg-primary-100");
-    expect(betaOption).not.toHaveClass("bg-primary-100");
+    expect(alphaOption).toHaveClass("bg-hover");
+    expect(betaOption).not.toHaveClass("bg-hover");
 
     fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
 
-    expect(betaOption).toHaveClass("bg-primary-100");
-    expect(alphaOption).not.toHaveClass("bg-primary-100");
+    expect(betaOption).toHaveClass("bg-hover");
+    expect(alphaOption).not.toHaveClass("bg-hover");
   });
 
   it("hides the cursor during keyboard navigation and restores it on mouse movement", async () => {
@@ -526,13 +526,13 @@ describe("UserAnswerRequired", () => {
     const customInput = screen.getByPlaceholderText("Type something else");
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
-    expect(alphaOption).toHaveClass("bg-primary-100");
+    expect(alphaOption).toHaveClass("bg-hover");
 
     await user.keyboard("h");
 
     expect(customInput).toHaveFocus();
     expect(customInput).toHaveValue("h");
-    expect(alphaOption).not.toHaveClass("bg-primary-100");
+    expect(alphaOption).not.toHaveClass("bg-hover");
 
     await user.type(customInput, "ello");
     fireEvent.keyDown(customInput, { key: "Enter", metaKey: true });
@@ -594,8 +594,8 @@ describe("UserAnswerRequired", () => {
     fireEvent.keyDown(customInput, { key: "Backspace" });
 
     expect(keyboardContainer).toHaveFocus();
-    expect(betaOption).toHaveClass("bg-primary-100");
-    expect(alphaOption).not.toHaveClass("bg-primary-100");
+    expect(betaOption).toHaveClass("bg-hover");
+    expect(alphaOption).not.toHaveClass("bg-hover");
   });
 
   it("submits the current multi-select choices when Cmd+Enter is pressed on a focused option", async () => {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -321,10 +321,12 @@ export function UserAnswerRequired({
               onFocusCapture={() => activateOption(index)}
               onMouseEnter={() => activateOption(index)}
               className={cn(
+                // Keyboard-active highlight uses the same hover token as the
+                // pointer hover, so both navigation modes read identically.
                 activeOptionIndex === index &&
                   !isCustomResponseActive &&
                   !answerDraft.selectedOptions.includes(index) &&
-                  "bg-primary-100",
+                  "bg-hover",
                 isKeyboardNavigating && "cursor-none"
               )}
               onClick={() => handleOptionClick(index)}

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -85,10 +85,11 @@ export function OptionCard(props: OptionCardProps) {
         isInteractive && "cursor-pointer",
         // In input mode `disabled` targets the field, not the card chrome.
         !isInput && disabled && "pointer-events-none opacity-60",
-        // Selected state is a flat "transparency-selected" overlay (6% of the
-        // foreground); the token is dark-mode aware on its own.
-        selected && "bg-foreground/[0.06] hover:bg-foreground/[0.06]",
-        !selected && !disableHover && "hover:bg-muted-background/60",
+        // Same hover/selected tints as sidebar and menu items: the translucent
+        // hover/selected tokens composite over any surface and flip with the
+        // theme. A selected card gets no extra tint on hover.
+        selected && "bg-selected hover:bg-selected",
+        !selected && !disableHover && "hover:bg-hover",
         className
       )}
       onClick={disabled ? undefined : onClick}


### PR DESCRIPTION
## Description

Aligns `OptionCard` hover and selected state colors with the design system tokens already used by sidebar and menu items (`bg-hover`, `bg-selected`), replacing the previous ad-hoc `bg-foreground/[0.06]` and `bg-muted-background/60` values. As a follow-on, the keyboard-active highlight in `AskUserQuestion` (`UserAnswerRequired`) is switched from `bg-primary-100` to `bg-hover` so pointer and keyboard navigation modes are visually identical.

## Tests

Manual visual check: hover/select option cards in light and dark mode, and verify keyboard navigation highlight in `AskUserQuestion` matches pointer hover.

## Risk

Low — cosmetic token swap only. No logic or API changes.

## Deploy Plan

Deploy sparkle, front.