### PR TITLE
feat(subscriptions): gate business-activation status endpoint on metronome billing

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
@@ -1,0 +1,81 @@
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function get(workspace: { sId: string }, query: Record<string, string> = {}) {
+  const qs = new URLSearchParams(query).toString();
+  const suffix = qs ? `?${qs}` : "";
+  return honoApp.request(
+    `/api/w/${workspace.sId}/subscriptions/checkout/business-activation${suffix}`,
+    { method: "GET" }
+  );
+}
+
+describe("GET /api/w/:wId/subscriptions/checkout/business-activation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await KillSwitchResource.disableKillSwitch(
+      "global_disable_metronome_billing"
+    );
+  });
+
+  it("returns 403 when metronome billing is killed", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await KillSwitchResource.enableKillSwitch(
+      "global_disable_metronome_billing"
+    );
+
+    const response = await get(workspace, { setup_session_id: "cs_test" });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 403 when the legacy_billing flag is set", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "legacy_billing");
+
+    const response = await get(workspace, { setup_session_id: "cs_test" });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("passes the metronome gate when billing is enabled (400 on missing identifier)", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // No contract_id / setup_session_id: the request clears the metronome gate
+    // and fails on identifier validation instead of the 403 gate.
+    const response = await get(workspace);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await get(workspace, { setup_session_id: "cs_test" });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -6,6 +6,7 @@ import {
   type PostBusinessActivationResponseBody,
   processBusinessActivation,
 } from "@app/lib/api/checkout/business_activation";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { wakeLock } from "@app/lib/wake_lock";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -22,6 +23,19 @@ app.get(
   ensureIsAdmin(),
   async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
     const auth = ctx.get("auth");
+
+    // Business activation is a credit-priced (Metronome) checkout flow: gate it
+    // on Metronome billing being enabled, consistently with the POST handler.
+    const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
+    if (!metronomeBillingEnabled) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    }
 
     // The record can be looked up by contract id or by Stripe setup session id.
     // The polling UI uses the session id so it can poll from the first step,


### PR DESCRIPTION
## Context

Follow-up to [dust-tt/tasks#8897](https://github.com/dust-tt/tasks/issues/8897) — *"Make sure checkout endpoint and pages are only available for the right plans"*.

Checkout flows that register a credit-priced (`CP_*`) plan should only be usable when Metronome billing is enabled, i.e. the `legacy_billing` feature flag is **off** and the `global_disable_metronome_billing` kill switch is **off** (`isMetronomeBillingEnabled()`).

Auditing the checkout endpoints showed every write-path is already gated (the `POST /subscriptions` dispatch, `prepare-payment`, `business-activation` POST, `awu-purchase`). The one exception was the **`GET` business-activation status** endpoint, which polled status without any Metronome check.

## Change

- Add the `isMetronomeBillingEnabled()` gate to the `GET .../checkout/business-activation` handler, returning `403 workspace_auth_error` when Metronome billing is disabled — consistent with the `POST` handler.
- Add functional tests covering the kill-switch 403, the `legacy_billing` flag 403, the non-admin 403, and the enabled pass-through.

## Test

```
NODE_ENV=test npm test -- business-activation
✓ 4 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)