### PR TITLE
Fix test invocations.test.ts

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -715,7 +715,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       });
     const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
       adminAuth,
-      { sandboxFunction }
+      { sandboxFunction, input: undefined }
     );
 
     const response = await postResolveAuthentication({


### PR DESCRIPTION
## Description

front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts:718 was calling makeNew(adminAuth, { sandboxFunction }) without the now-required input. This is a classic two-greens-collide: #28983 (resolve-authentication, added that test) and the PR that made makeNew's input required each passed CI alone, but combine to break tsgo once both land. Added input: undefined (matching the pattern used elsewhere). Also fixed my untracked dev script (sandbox_create_blocked_action.ts:93) the same way. 

## Tests

CI

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge.