### PR TITLE
[front] chore: render semantic search results as markdown globally

### DIFF
--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -101,10 +101,7 @@ export function hideFileFromActionOutput({
 }
 
 export function rewriteContentForModel(
-  content: CallToolResult["content"][number],
-  {
-    renderSearchResultsAsMarkdown = false,
-  }: { renderSearchResultsAsMarkdown?: boolean } = {}
+  content: CallToolResult["content"][number]
 ): CallToolResult["content"][number] | null {
   // Only render tool generated files that are supported.
   if (
@@ -147,7 +144,7 @@ export function rewriteContentForModel(
     return null;
   }
 
-  if (renderSearchResultsAsMarkdown && isSearchResultResourceType(content)) {
+  if (isSearchResultResourceType(content)) {
     let text = `Search result: ${content.resource.text}\n`;
     text += `id: ${content.resource.id}\n`;
     text += `url: ${content.resource.uri}\n`;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -15,7 +15,7 @@ import {
 } from "@app/lib/api/assistant/skills_rendering";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { getConversationFileMountSignedUrl } from "@app/lib/api/files/gcs_mount/files";
-import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS } from "@app/lib/file_storage/signed_url_cache";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
@@ -129,13 +129,7 @@ async function renderActionForMultiActionsModel(
   auth: Authenticator,
   action: AgentMCPActionWithOutputType,
   model: ModelConfigurationType,
-  {
-    conversationId,
-    renderSearchResultsAsMarkdown,
-  }: {
-    conversationId: string;
-    renderSearchResultsAsMarkdown: boolean;
-  }
+  { conversationId }: { conversationId: string }
 ): Promise<FunctionMessageTypeModel> {
   if (action.status === "denied") {
     return {
@@ -171,11 +165,7 @@ async function renderActionForMultiActionsModel(
   }
 
   const outputItems = removeNulls(
-    action.output?.map((content) =>
-      rewriteContentForModel(content, {
-        renderSearchResultsAsMarkdown,
-      })
-    ) ?? []
+    action.output?.map(rewriteContentForModel) ?? []
   );
 
   let output: string | Content[];
@@ -259,10 +249,6 @@ export async function getSteps(
     return [];
   }
   const actions = removeNulls(message.actions);
-  const renderSearchResultsAsMarkdown = await hasFeatureFlag(
-    auth,
-    "render_search_results_as_markdown"
-  );
 
   // We store for each step (identified by its index) the "contents" array (raw model outputs, including
   // text content, reasoning and function calls) and "actions", i.e the function results.
@@ -280,7 +266,6 @@ export async function getSteps(
       action,
       result: await renderActionForMultiActionsModel(auth, action, model, {
         conversationId,
-        renderSearchResultsAsMarkdown,
       }),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -286,11 +286,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",
     stage: "dust_only",
   },
-  render_search_results_as_markdown: {
-    description:
-      "Render semantic search results as Markdown instead of serialized JSON",
-    stage: "dust_only",
-  },
   admin_governance: {
     description:
       "Access to admin governance features, including assigning the business_admin role from the UI",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -764,7 +764,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_usage_mcp"
   | "power_bi_mcp"
   | "reinforced_agents"
-  | "render_search_results_as_markdown"
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"


### PR DESCRIPTION
## Description

This PR drops the `render_search_results_as_markdown` feature flag and the plumbing that goes with it.
The feature flag gated a different way of rendering semantic search results, where we show a rendered Markdown instead of a verbose JSON. This has been progressively released since.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
