### PR TITLE
Optimize seat sync

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -270,7 +270,17 @@ beforeEach(() => {
   vi.mocked(remapMembershipSeatTypesForContract).mockResolvedValue(
     new Ok(undefined)
   );
-  vi.mocked(syncSeatCount).mockResolvedValue(new Ok(undefined));
+  vi.mocked(syncSeatCount).mockResolvedValue(
+    new Ok({
+      seatSubscriptionCount: 0,
+      distinctTimestampCount: 0,
+      reconcileSegmentCallCount: 0,
+      transferCount: 0,
+      freeUserCount: 0,
+      didMutateSeatData: false,
+      durationMs: 0,
+    })
+  );
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -504,23 +504,22 @@ export async function reconcileWorkspaceUserCreditStates({
   const workspaceId = workspace.sId;
 
   // The seat-allowance cache (contract) and the DB queries can genuinely
-  // throw, so they stay wrapped — the ERR1-authorised case. The per-user
-  // overrides come from the memberships and the workspace default from the
-  // credit-usage configuration (both pool-only values); the seat allowances
-  // are needed to derive the total thresholds.
+  // throw, so they stay wrapped — the ERR1-authorised case. None of these
+  // three depend on each other's results, so they run concurrently instead
+  // of one round trip at a time.
   let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
   let defaultPoolCapAwuCredits: number;
   let memberships: MembershipResource[];
   try {
-    seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
-    const creditUsageConfig =
-      await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
-        workspace.id
-      );
+    const [seatAllowancesResult, creditUsageConfig, membershipsResult] =
+      await Promise.all([
+        getSeatAllowancesByNormalizedSeatType(workspaceId),
+        CreditUsageConfigurationResource.fetchByWorkspaceModelId(workspace.id),
+        MembershipResource.getActiveMemberships({ workspace }),
+      ]);
+    seatAllowances = seatAllowancesResult;
     defaultPoolCapAwuCredits = creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
-    ({ memberships } = await MembershipResource.getActiveMemberships({
-      workspace,
-    }));
+    memberships = membershipsResult.memberships;
   } catch (err) {
     logger.error(
       { workspaceId, err: normalizeError(err) },
@@ -542,13 +541,44 @@ export async function reconcileWorkspaceUserCreditStates({
     m.user?.sId && hasMetronomeSeatBalance(m.seatType) ? [m.user.sId] : []
   );
 
-  // These return our `Result` type: handle their errors with early returns
-  // rather than throw + catch (ERR1).
-  const seatBalancesResult = await listMetronomeSeatBalances({
-    metronomeCustomerId,
-    metronomeContractId,
-    seatIds: seatBalanceEligibleUserIds,
-  });
+  // These four reads are all independent (each scoped to the member list
+  // resolved above, none depends on another's result), so they run
+  // concurrently. Results return our `Result` type: handled with early
+  // returns below rather than throw + catch (ERR1).
+  const [
+    seatBalancesResult,
+    perUserCreditBalancesResult,
+    usageResult,
+    groupCapByUserModelId,
+  ] = await Promise.all([
+    listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+      seatIds: seatBalanceEligibleUserIds,
+    }),
+    // Free seats hold a per-user contract credit, not a seat balance, so
+    // they're absent from `listMetronomeSeatBalances`. Read their balances
+    // separately so a free user with credit remaining lands on `user_seat`
+    // (not `on_pool`) and is moved to `capped` once exhausted. A read
+    // failure leaves the map empty — free users then fall back to the
+    // seat-balance path (null) as before.
+    listCustomerPerUserCreditBalances({
+      metronomeCustomerId,
+      contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+    }),
+    fetchPerUserAwuUsage({
+      workspaceId,
+      metronomeCustomerId,
+      userIds: memberUserIds,
+    }),
+    // Max group cap (pool-only) per member, fetched once to avoid an N+1.
+    // Users with no capped group are absent (they fall back to the
+    // workspace default).
+    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: memberships.map((m) => m.userId),
+    }),
+  ]);
   if (seatBalancesResult.isErr()) {
     logger.error(
       { workspaceId, err: seatBalancesResult.error },
@@ -558,15 +588,6 @@ export async function reconcileWorkspaceUserCreditStates({
   }
   const seatBalances = seatBalancesResult.value;
 
-  // Free seats hold a per-user contract credit, not a seat balance, so they're
-  // absent from `listMetronomeSeatBalances`. Read their balances separately so a
-  // free user with credit remaining lands on `user_seat` (not `on_pool`) and is
-  // moved to `capped` once exhausted. A read failure leaves the map empty —
-  // free users then fall back to the seat-balance path (null) as before.
-  const perUserCreditBalancesResult = await listCustomerPerUserCreditBalances({
-    metronomeCustomerId,
-    contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
-  });
   if (perUserCreditBalancesResult.isErr()) {
     logger.warn(
       { workspaceId, err: perUserCreditBalancesResult.error },
@@ -577,11 +598,6 @@ export async function reconcileWorkspaceUserCreditStates({
     ? perUserCreditBalancesResult.value
     : new Map<string, { balanceAwu: number; startingBalanceAwu: number }>();
 
-  const usageResult = await fetchPerUserAwuUsage({
-    workspaceId,
-    metronomeCustomerId,
-    userIds: memberUserIds,
-  });
   if (usageResult.isErr()) {
     logger.error(
       { workspaceId, err: usageResult.error },
@@ -590,14 +606,6 @@ export async function reconcileWorkspaceUserCreditStates({
     return;
   }
   const usageByUser = usageResult.value;
-
-  // Max group cap (pool-only) per member, fetched once to avoid an N+1. Users
-  // with no capped group are absent (they fall back to the workspace default).
-  const groupCapByUserModelId =
-    await GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: memberships.map((m) => m.userId),
-    });
 
   // One UPDATE per drifting membership. Bounded by the workspace's seat count
   // and gated on the `continue` above, so steady-state writes are ~zero; even

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -9,6 +9,7 @@ import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
   remapMembershipSeatTypesForContract,
+  type SyncSeatCountSummary,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { isProPlanPrefix } from "@app/lib/plans/plan_codes";
@@ -23,10 +24,17 @@ import type { LightWorkspaceType } from "@app/types/user";
  * Outcome of `syncMetronomeSeatCountForWorkspace`. `synced` means the
  * reconciliation ran; `skipped` means there was nothing to sync (not on
  * Metronome, no active contract, or no seat subscription) — with a
- * human-readable `reason`.
+ * human-readable `reason`. `activeContractSummary` is `null` only when
+ * nothing ran for the active contract (e.g. a pending contract was staged
+ * but there's no active contract to sync yet).
  */
 export type SeatSyncOutcome =
-  | { status: "synced" }
+  | {
+      status: "synced";
+      stagedPendingContract: boolean;
+      activeContractSummary: SyncSeatCountSummary | null;
+      workspaceUserCreditStatesReconciled: boolean;
+    }
   | { status: "skipped"; reason: string };
 
 /**
@@ -48,14 +56,22 @@ export type SeatSyncOutcome =
  * user (e.g. an auto-upgrade unblocking one member mid-flow) and skips the
  * workspace-wide cap-alert sync. The seat-count push itself is always
  * workspace-wide. When omitted, the whole workspace is reconciled.
+ *
+ * `forceFreeCreditRevokeCheck` runs the ex-free-seat credit revoke check
+ * unconditionally instead of only when the cheap gate signals a change (see
+ * `syncSeatCount`). Set by the poke plugin, where an operator explicitly
+ * asked for a thorough pass; left unset on the automatic/debounced path.
  */
 export async function syncMetronomeSeatCountForWorkspace({
   workspace,
   reconcileUserId,
+  forceFreeCreditRevokeCheck,
 }: {
   workspace: LightWorkspaceType;
   reconcileUserId?: string;
+  forceFreeCreditRevokeCheck?: boolean;
 }): Promise<Result<SeatSyncOutcome, Error>> {
+  const workspaceId = workspace.sId;
   if (!workspace.metronomeCustomerId) {
     return new Ok({
       status: "skipped",
@@ -75,10 +91,19 @@ export async function syncMetronomeSeatCountForWorkspace({
   // contract stays correct across adds, revokes, and seat changes alike. This
   // is independent of, and in addition to, reconciling the active contract
   // below (whose seats a legacy shadow contract still bills / finalizes).
+  const stagePendingStartedAt = Date.now();
   const stagedPending = await stagePendingContractSeats({
     workspace,
     currentPlanCode: activeSubscription?.getPlan().code ?? null,
   });
+  logger.info(
+    {
+      workspaceId,
+      stagedPending,
+      durationMs: Date.now() - stagePendingStartedAt,
+    },
+    "[SeatSync] stagePendingContractSeats done"
+  );
 
   const activeContract = activeSubscription?.metronomeContractId
     ? await getActiveContract(workspace.sId)
@@ -89,15 +114,26 @@ export async function syncMetronomeSeatCountForWorkspace({
     !activeContract ||
     !(await hasContractSeatSubscription(activeContract))
   ) {
-    return new Ok(
-      stagedPending
-        ? { status: "synced" }
-        : {
-            status: "skipped",
-            reason:
-              "no active or pending contract with a seat subscription to sync",
-          }
+    if (stagedPending) {
+      logger.info(
+        { workspaceId },
+        "[SeatSync] Done — only the pending contract was staged, no active contract to sync"
+      );
+      return new Ok({
+        status: "synced",
+        stagedPendingContract: true,
+        activeContractSummary: null,
+        workspaceUserCreditStatesReconciled: false,
+      });
+    }
+    logger.info(
+      { workspaceId },
+      "[SeatSync] Skipped — no active or pending contract with a seat subscription to sync"
     );
+    return new Ok({
+      status: "skipped",
+      reason: "no active or pending contract with a seat subscription to sync",
+    });
   }
 
   const result = await syncSeatCount({
@@ -106,10 +142,16 @@ export async function syncMetronomeSeatCountForWorkspace({
     workspace,
     planCode: activeSubscription.getPlan().code,
     contract: activeContract,
+    forceFreeCreditRevokeCheck,
   });
   if (result.isErr()) {
+    logger.error(
+      { workspaceId, err: result.error.message },
+      "[SeatSync] syncSeatCount failed"
+    );
     return new Err(result.error);
   }
+  const activeContractSummary = result.value;
 
   // Single-user scope: reconcile just this user from the live balances now that
   // their seat credits are assigned. Skips the whole-workspace reconcile and the
@@ -128,7 +170,7 @@ export async function syncMetronomeSeatCountForWorkspace({
       if (userReconcile.isErr()) {
         logger.warn(
           {
-            workspaceId: workspace.sId,
+            workspaceId,
             userId: reconcileUserId,
             err: userReconcile.error.message,
           },
@@ -136,31 +178,60 @@ export async function syncMetronomeSeatCountForWorkspace({
         );
       }
     }
-    return new Ok({ status: "synced" });
+    logger.info(
+      { workspaceId, reconcileUserId },
+      "[SeatSync] Done — single-user scope"
+    );
+    return new Ok({
+      status: "synced",
+      stagedPendingContract: stagedPending,
+      activeContractSummary,
+      workspaceUserCreditStatesReconciled: false,
+    });
   }
 
   // Now that per-user seat credits are assigned, reconcile each seated user's
   // credit state from the live balances — this is what moves a freshly-created
   // or just-upgraded seat user into the correct seat↔pool state. Never throws;
   // a downstream reconcile issue must not fail (and retry) the seat sync.
+  const reconcileStartedAt = Date.now();
   await reconcileWorkspaceUserCreditStates({
     workspace,
     metronomeCustomerId: workspace.metronomeCustomerId,
     metronomeContractId: activeSubscription.metronomeContractId,
     planCode: activeSubscription.getPlan().code,
   });
+  logger.info(
+    { workspaceId, durationMs: Date.now() - reconcileStartedAt },
+    "[SeatSync] reconcileWorkspaceUserCreditStates done"
+  );
 
   // Ensure per-seat-type cap alerts exist with the current default pool limit.
   // Best-effort: a failure here must not fail the seat sync.
+  const alertSyncStartedAt = Date.now();
   const alertSyncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
   if (alertSyncResult.isErr()) {
     logger.warn(
-      { workspaceId: workspace.sId, err: alertSyncResult.error.message },
+      { workspaceId, err: alertSyncResult.error.message },
       "[SeatSync] Failed to sync default pool cap alerts; continuing"
+    );
+  } else {
+    logger.info(
+      { workspaceId, durationMs: Date.now() - alertSyncStartedAt },
+      "[SeatSync] syncDefaultPoolCapAlertsForWorkspace done"
     );
   }
 
-  return new Ok({ status: "synced" });
+  logger.info(
+    { workspaceId },
+    "[SeatSync] syncMetronomeSeatCountForWorkspace done"
+  );
+  return new Ok({
+    status: "synced",
+    stagedPendingContract: stagedPending,
+    activeContractSummary,
+    workspaceUserCreditStatesReconciled: true,
+  });
 }
 
 /**
@@ -191,12 +262,17 @@ async function stagePendingContractSeats({
   workspace: LightWorkspaceType;
   currentPlanCode: string | null;
 }): Promise<boolean> {
+  const workspaceId = workspace.sId;
   if (!workspace.metronomeCustomerId) {
     return false;
   }
   const pendingSubscription =
     await SubscriptionResource.fetchPendingByWorkspaceModelId(workspace.id);
   if (!pendingSubscription?.metronomeContractId) {
+    logger.info(
+      { workspaceId },
+      "[SeatSync] stagePendingContractSeats — no pending subscription, skipping"
+    );
     return false;
   }
   const pendingContractResult = await getMetronomeContractById({
@@ -207,6 +283,10 @@ async function stagePendingContractSeats({
     pendingContractResult.isErr() ||
     !(await hasContractSeatSubscription(pendingContractResult.value))
   ) {
+    logger.info(
+      { workspaceId },
+      "[SeatSync] stagePendingContractSeats — pending contract has no seat subscription, skipping"
+    );
     return false;
   }
   const pendingContract = pendingContractResult.value;
@@ -219,6 +299,7 @@ async function stagePendingContractSeats({
   // members fall through to the ordinary committed-spare-seat promotion.
   const promoteNoneSeatType =
     currentPlanCode && isProPlanPrefix(currentPlanCode) ? "pro" : undefined;
+  const remapStartedAt = Date.now();
   const remapResult = await remapMembershipSeatTypesForContract({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: pendingSubscription.metronomeContractId,
@@ -228,14 +309,23 @@ async function stagePendingContractSeats({
     contract: pendingContract,
     promoteNoneSeatType,
   });
+  logger.info(
+    {
+      workspaceId,
+      isErr: remapResult.isErr(),
+      durationMs: Date.now() - remapStartedAt,
+    },
+    "[SeatSync] remapMembershipSeatTypesForContract done"
+  );
   if (remapResult.isErr()) {
     logger.warn(
-      { workspaceId: workspace.sId, err: remapResult.error.message },
+      { workspaceId, err: remapResult.error.message },
       "[SeatSync] Failed to remap seats onto pending contract; continuing"
     );
     return false;
   }
 
+  const pendingSyncStartedAt = Date.now();
   const syncResult = await syncSeatCount({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: pendingSubscription.metronomeContractId,
@@ -244,9 +334,17 @@ async function stagePendingContractSeats({
     contract: pendingContract,
     startingAt: pendingContract.starting_at,
   });
+  logger.info(
+    {
+      workspaceId,
+      isErr: syncResult.isErr(),
+      durationMs: Date.now() - pendingSyncStartedAt,
+    },
+    "[SeatSync] Pending-contract syncSeatCount done"
+  );
   if (syncResult.isErr()) {
     logger.warn(
-      { workspaceId: workspace.sId, err: syncResult.error.message },
+      { workspaceId, err: syncResult.error.message },
       "[SeatSync] Failed to pre-provision pending contract seats; continuing"
     );
     return false;

--- a/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
@@ -28,18 +28,51 @@ export const syncMetronomeSeatsPlugin = createPlugin({
     // `syncMetronomeSeatCountForWorkspace` returns a domain `Result`: a
     // Metronome failure is returned as `Err`, not thrown, so we propagate it
     // straight to the operator instead of swallowing it.
-    const result = await syncMetronomeSeatCountForWorkspace({ workspace });
+    //
+    // `forceFreeCreditRevokeCheck: true` here (unlike the automatic/debounced
+    // sync) because an operator running this manually is asking for a
+    // thorough pass, not the fast path optimized for frequent, automatic runs.
+    const result = await syncMetronomeSeatCountForWorkspace({
+      workspace,
+      forceFreeCreditRevokeCheck: true,
+    });
     if (result.isErr()) {
       return new Err(result.error);
     }
 
     const outcome = result.value;
     switch (outcome.status) {
-      case "synced":
+      case "synced": {
+        const lines = ["Metronome seat count synced."];
+        if (outcome.stagedPendingContract) {
+          lines.push(
+            "- A pending future contract was also staged (mid contract-switch migration)."
+          );
+        }
+        const s = outcome.activeContractSummary;
+        if (s) {
+          lines.push(
+            `- Active contract: ${s.seatSubscriptionCount} seat subscription(s), ` +
+              `${s.distinctTimestampCount} distinct scheduled moment(s) → ` +
+              `${s.reconcileSegmentCallCount} segment reconcile call(s), ` +
+              `${s.transferCount} pro/max transfer(s), ` +
+              `${s.freeUserCount} free-seat user(s), ` +
+              `${s.didMutateSeatData ? "changes applied" : "no changes needed"}, ` +
+              `${s.durationMs}ms.`
+          );
+        } else {
+          lines.push("- No active contract to sync (pending contract only).");
+        }
+        lines.push(
+          outcome.workspaceUserCreditStatesReconciled
+            ? "- Workspace-wide credit states reconciled."
+            : "- Credit-state reconcile skipped (single-user scope)."
+        );
         return new Ok({
           display: "text",
-          value: "Metronome seat count synced.",
+          value: lines.join("\n"),
         });
+      }
       case "skipped":
         return new Ok({
           display: "text",

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -16,6 +16,7 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   DefaultUserSpendLimit,
@@ -31,6 +32,7 @@ import {
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -127,6 +129,22 @@ export async function syncDefaultPoolCapAlertsForWorkspace(
     }
   }
 
+  // Cap + warning alerts for every seat type are independent Metronome
+  // objects (distinct uniqueness keys, no shared state) — `normalizedSeatTypes`
+  // is bounded to at most 3 (pro/max/workspace), so upsert all of them
+  // concurrently instead of one sequential round trip at a time.
+  type AlertTask =
+    | {
+        kind: "cap";
+        seatType: NormalizedPoolLimitSeatType;
+        totalThreshold: number;
+      }
+    | {
+        kind: "warning";
+        seatType: NormalizedPoolLimitSeatType;
+        totalThreshold: number;
+      };
+  const tasks: AlertTask[] = [];
   for (const seatType of normalizedSeatTypes) {
     const seatAllowance = getAwuAllocationForNormalizedSeatType(
       contract,
@@ -134,48 +152,74 @@ export async function syncDefaultPoolCapAlertsForWorkspace(
       productSeatTypes
     );
     const totalThreshold = seatAllowance + poolAwuCredits;
+    tasks.push({ kind: "cap", seatType, totalThreshold });
+    tasks.push({ kind: "warning", seatType, totalThreshold });
+  }
 
-    const upsertResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-      seatType,
-      awuCredits: totalThreshold,
-    });
-    if (upsertResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          seatType,
-          totalThreshold,
-          err: upsertResult.error,
-        },
-        "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert cap alert"
-      );
-      return new Err(
-        new DefaultUserSpendLimitError(
-          "metronome_error",
-          upsertResult.error.message
-        )
-      );
+  const results = await concurrentExecutor(
+    tasks,
+    async (task) => {
+      switch (task.kind) {
+        case "cap": {
+          const result = await upsertMetronomeDefaultUserCapAlertForSeatType({
+            metronomeCustomerId,
+            workspaceId: workspace.sId,
+            seatType: task.seatType,
+            awuCredits: task.totalThreshold,
+          });
+          return { task, result };
+        }
+        case "warning": {
+          const result =
+            await upsertMetronomeDefaultUserWarningAlertForSeatType({
+              metronomeCustomerId,
+              workspaceId: workspace.sId,
+              seatType: task.seatType,
+              capAwuCredits: task.totalThreshold,
+            });
+          return { task, result };
+        }
+        default:
+          return assertNever(task);
+      }
+    },
+    { concurrency: 8 }
+  );
+
+  for (const { task, result } of results) {
+    if (!result.isErr()) {
+      continue;
     }
-
-    const warningResult =
-      await upsertMetronomeDefaultUserWarningAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        seatType,
-        capAwuCredits: totalThreshold,
-      });
-    if (warningResult.isErr()) {
-      logger.warn(
-        {
-          workspaceId: workspace.sId,
-          seatType,
-          totalThreshold,
-          err: warningResult.error,
-        },
-        "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert warning alert; continuing"
-      );
+    switch (task.kind) {
+      case "cap":
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            seatType: task.seatType,
+            totalThreshold: task.totalThreshold,
+            err: result.error,
+          },
+          "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert cap alert"
+        );
+        return new Err(
+          new DefaultUserSpendLimitError(
+            "metronome_error",
+            result.error.message
+          )
+        );
+      case "warning":
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            seatType: task.seatType,
+            totalThreshold: task.totalThreshold,
+            err: result.error,
+          },
+          "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert warning alert; continuing"
+        );
+        break;
+      default:
+        assertNever(task);
     }
   }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -17,7 +17,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import Metronome, { ConflictError } from "@metronome/sdk";
+import Metronome, { BadRequestError, ConflictError } from "@metronome/sdk";
 import type { Commit, ContractV2, Credit, V1 } from "@metronome/sdk/resources";
 import type { ContractRetrieveRateScheduleResponse } from "@metronome/sdk/resources/v1/contracts/contracts";
 import type { ProductListResponse } from "@metronome/sdk/resources/v1/contracts/products";
@@ -1493,35 +1493,6 @@ export async function getMetronomeSeatActiveSince({
     );
     return new Err(error);
   }
-}
-
-/**
- * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
- * (defaults to now), via the (untyped) getSubscriptionSeatsHistory endpoint.
- */
-export async function getMetronomeSubscriptionAssignedSeatIds({
-  metronomeCustomerId,
-  contractId,
-  subscriptionId,
-  coveringDate,
-}: {
-  metronomeCustomerId: string;
-  contractId: string;
-  subscriptionId: string;
-  // Defaults to `now`. Pass a future date to read the assignments projected
-  // at that point in time.
-  coveringDate?: Date;
-}): Promise<Result<string[], Error>> {
-  const stateResult = await getMetronomeSubscriptionSeatState({
-    metronomeCustomerId,
-    contractId,
-    subscriptionId,
-    coveringDate,
-  });
-  if (stateResult.isErr()) {
-    return new Err(stateResult.error);
-  }
-  return new Ok(stateResult.value.assignedSeatIds);
 }
 
 /**
@@ -3756,12 +3727,78 @@ export async function listMetronomeSeatBalances({
       }
     };
 
+    // When a batch fails, isolate the bad seat_id(s) by bisecting rather
+    // than querying every id individually. Metronome rejects a batch
+    // entirely if even one id in it isn't found on the contract, so with a
+    // large batch and only a handful of bad ids, halving repeatedly finds
+    // them in ~log2(N) rounds of (still-batched) calls instead of N
+    // individual single-id calls.
+    //
+    // The two halves are fetched sequentially, not concurrently: since
+    // failures here are always caught (down to `fetchOneSeatId`, which never
+    // throws), a failure that isn't actually about a specific bad seat_id
+    // (429, 5xx, a Metronome incident) would otherwise keep bisecting both
+    // halves in parallel all the way to single-id calls with no cap on how
+    // many are in flight at once. Sequential recursion keeps the same
+    // log2(N)-round efficiency when only a few ids are bad, while capping
+    // in-flight calls to one per chunk.
+    const fetchSeatIdsBisect = async (
+      ids: string[]
+    ): Promise<MetronomeSeatBalance[]> => {
+      if (ids.length <= 1) {
+        return ids.length === 1 ? fetchOneSeatId(ids[0]) : [];
+      }
+      try {
+        return await fetchSeatIdsChunk(ids);
+      } catch {
+        const mid = Math.floor(ids.length / 2);
+        const left = await fetchSeatIdsBisect(ids.slice(0, mid));
+        const right = await fetchSeatIdsBisect(ids.slice(mid));
+        return [...left, ...right];
+      }
+    };
+
+    // Metronome's 400 body names exactly one bad seat_id per rejection, even
+    // when several ids in the batch are bad (e.g. "400 Seat abc123de45 not
+    // found in contract subscriptions"). Rather than parsing that message
+    // with a format-specific regex, test our own candidate ids for
+    // membership in it — this only relies on Metronome naming the id
+    // verbatim somewhere in the body, not on the surrounding wording.
+    const extractNamedBadSeatId = (
+      err: unknown,
+      candidateIds: string[]
+    ): string | null => {
+      if (!(err instanceof BadRequestError)) {
+        return null;
+      }
+      const body = err.error;
+      const message =
+        typeof body === "object" &&
+        body !== null &&
+        "message" in body &&
+        typeof body.message === "string"
+          ? body.message
+          : err.message;
+      return candidateIds.find((id) => message.includes(id)) ?? null;
+    };
+
+    // A freshly-added or -removed seat_id not yet synced to Metronome is by
+    // far the most common cause of a chunk rejection, and it's almost always
+    // just one or two ids. Cap the number of named-id peel-off attempts so a
+    // batch with many bad ids (or a rejection that doesn't name one at all,
+    // e.g. a 429/5xx) falls back to bisection instead of looping uselessly.
+    const MAX_NAMED_BAD_ID_RETRIES = 6;
+
     // Resiliently fetch one chunk (up to 100 seat_ids):
     //  1. Try the whole chunk. Metronome rejects the *entire* batch with a
     //     400 if any single seat_id in it isn't found on the contract (e.g.
-    //     a removed/reassigned seat) — it doesn't just omit the bad id — so
-    //     a chunk failure falls back to querying each id individually
-    //     instead of losing every seat in the batch.
+    //     a removed/reassigned seat) — it doesn't just omit the bad id.
+    //     Since the rejection names the bad id, retry once per named id,
+    //     removing it from the batch — this resolves the common "a handful
+    //     of ids are bad" case in ~(bad id count + 1) calls. If the id can't
+    //     be identified from the error, or too many are bad, fall back to
+    //     bisecting to isolate the bad id(s) instead of losing every seat in
+    //     the batch.
     //  2. Separately, some ids can be missing from an otherwise-successful
     //     response with no error at all — Metronome has been observed to
     //     non-deterministically omit a valid, balance-holding seat. Those
@@ -3776,20 +3813,58 @@ export async function listMetronomeSeatBalances({
         if (seatIdsChunk.length <= 1) {
           throw err;
         }
+
+        let remaining = seatIdsChunk;
+        let lastErr = err;
+        const namedBadIds: string[] = [];
+        for (let i = 0; i < MAX_NAMED_BAD_ID_RETRIES; i++) {
+          const badId = extractNamedBadSeatId(lastErr, remaining);
+          if (!badId) {
+            break;
+          }
+          namedBadIds.push(badId);
+          remaining = remaining.filter((id) => id !== badId);
+          if (remaining.length === 0) {
+            logger.warn(
+              {
+                metronomeCustomerId,
+                metronomeContractId,
+                seatIds: namedBadIds,
+              },
+              "[Metronome] Seat_id(s) not found in contract — skipping (batch fully excluded)"
+            );
+            return [];
+          }
+          try {
+            const retried = await fetchSeatIdsChunk(remaining);
+            logger.warn(
+              {
+                metronomeCustomerId,
+                metronomeContractId,
+                seatIds: namedBadIds,
+              },
+              "[Metronome] Seat_id(s) not found in contract — skipped after targeted retry"
+            );
+            return retried;
+          } catch (retryErr) {
+            lastErr = retryErr;
+          }
+        }
+
+        // `remaining` already excludes every id we positively identified as
+        // bad along the way (even if the loop above never landed on a clean
+        // success) — bisect that instead of the original chunk so we don't
+        // waste rounds rediscovering ids we've already confirmed.
         logger.warn(
           {
             metronomeCustomerId,
             metronomeContractId,
-            error: normalizeError(err),
+            namedBadIds,
+            error: normalizeError(lastErr),
           },
-          "[Metronome] Seat balances chunk failed — retrying seat_ids individually"
+          "[Metronome] Seat balances chunk failed — bisecting to isolate bad seat_ids"
         );
-        const perSeatResults = await concurrentExecutor(
-          seatIdsChunk,
-          fetchOneSeatId,
-          { concurrency: 8 }
-        );
-        return perSeatResults.flat();
+        return fetchSeatIdsBisect(remaining);
       }
 
       const foundIds = new Set(balances.map((b) => b.seat_id));
@@ -3804,10 +3879,12 @@ export async function listMetronomeSeatBalances({
     };
 
     const seatIdsChunks = chunk(seatIds, MAX_SEAT_IDS_PER_SEAT_BALANCES_QUERY);
-    const allBalances: MetronomeSeatBalance[] = [];
-    for (const seatIdsChunk of seatIdsChunks) {
-      allBalances.push(...(await fetchSeatIdsChunkResilient(seatIdsChunk)));
-    }
+    const chunkResults = await concurrentExecutor(
+      seatIdsChunks,
+      fetchSeatIdsChunkResilient,
+      { concurrency: 4 }
+    );
+    const allBalances: MetronomeSeatBalance[] = chunkResults.flat();
 
     return new Ok(allBalances);
   } catch (err) {

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -8,12 +8,12 @@ import {
   findSeatCreditSegmentForPeriod,
   getMetronomeContractById,
   getMetronomeSeatActiveSince,
-  getMetronomeSubscriptionAssignedSeatIds,
   getMetronomeSubscriptionSeatState,
   listCustomerPerUserCreditBalances,
   listCustomerPerUserCreditUserIds,
   listMetronomeSeatBalances,
   revokePerUserCustomerCredit,
+  type SubscriptionSeatState,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
@@ -55,7 +55,6 @@ import {
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
-  hasMetronomeSeatBalance,
   isMembershipSeatType,
   isPaidSeatType,
   SEAT_TYPE_ORDER,
@@ -1046,6 +1045,7 @@ async function emptyOriginSeatCreditsForTransfers({
   recurringCreditIdBySeatType,
   allocationBySeatType,
   desiredSeatByUser,
+  seatStateBySubscriptionId,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1054,18 +1054,52 @@ async function emptyOriginSeatCreditsForTransfers({
   recurringCreditIdBySeatType: Map<MembershipSeatType, string>;
   allocationBySeatType: Map<MembershipSeatType, number>;
   desiredSeatByUser: Map<string, MembershipSeatType>;
+  // Metronome's current ("now") seat state per subscription, fetched once by
+  // the caller and shared with its immediate-base reconcile pass instead of
+  // querying Metronome twice for the same data.
+  seatStateBySubscriptionId: Map<string, SubscriptionSeatState>;
 }): Promise<SeatCreditTransfer[]> {
-  // Only pro/max (and their _yearly variants) carry an individual Metronome
-  // seat balance — `desiredSeatByUser` includes every active membership
-  // (e.g. "none"/"free"), so querying its keys unfiltered would waste calls
-  // on ids Metronome will report as not found.
-  const seatBalanceEligibleUserIds = [...desiredSeatByUser.entries()].flatMap(
-    ([userId, seatType]) => (hasMetronomeSeatBalance(seatType) ? [userId] : [])
+  // Metronome's current seat assignment per user (old state, before sync).
+  const metronomeSeatByUser = new Map<string, MembershipSeatType>();
+  for (const [seatType, subscriptionId] of subscriptionIdBySeatType) {
+    const state = seatStateBySubscriptionId.get(subscriptionId);
+    if (!state) {
+      continue;
+    }
+    for (const userSId of state.assignedSeatIds) {
+      metronomeSeatByUser.set(userSId, seatType);
+    }
+  }
+
+  // A real transfer candidate is a user whose seat type is actually changing
+  // between two types that both carry a recurring credit (pro/max and their
+  // _yearly variants — see `getSeatCreditNameForSeatType`). Balances are only
+  // needed to know how much to carry over for a CONFIRMED transfer, so if
+  // there are no candidates at all, skip that (expensive, bulk) fetch
+  // entirely instead of always fetching the whole eligible population.
+  const transferCandidateUserIds = [...metronomeSeatByUser.entries()].flatMap(
+    ([userSId, oldSeatType]) => {
+      const newSeatType = desiredSeatByUser.get(userSId);
+      return newSeatType &&
+        newSeatType !== oldSeatType &&
+        getSeatCreditNameForSeatType(oldSeatType) &&
+        getSeatCreditNameForSeatType(newSeatType)
+        ? [userSId]
+        : [];
+    }
   );
+  if (transferCandidateUserIds.length === 0) {
+    logger.info(
+      { workspaceId, contractId },
+      "[Metronome] No seat-type transfer candidates — skipping balance fetch"
+    );
+    return [];
+  }
+
   const balancesRes = await listMetronomeSeatBalances({
     metronomeCustomerId,
     metronomeContractId: contractId,
-    seatIds: seatBalanceEligibleUserIds,
+    seatIds: transferCandidateUserIds,
   });
   if (balancesRes.isErr()) {
     logger.error(
@@ -1080,26 +1114,6 @@ async function emptyOriginSeatCreditsForTransfers({
     const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
     if (awu) {
       balanceByUser.set(seat.seat_id, awu.balance);
-    }
-  }
-
-  // Metronome's current seat assignment per user (old state, before sync).
-  const metronomeSeatByUser = new Map<string, MembershipSeatType>();
-  for (const [seatType, subscriptionId] of subscriptionIdBySeatType) {
-    const assignedRes = await getMetronomeSubscriptionAssignedSeatIds({
-      metronomeCustomerId,
-      contractId,
-      subscriptionId,
-    });
-    if (assignedRes.isErr()) {
-      logger.error(
-        { workspaceId, contractId, seatType, error: assignedRes.error },
-        "[Metronome] Failed to read assigned seats for credit transfer — skipping tier"
-      );
-      continue;
-    }
-    for (const userSId of assignedRes.value) {
-      metronomeSeatByUser.set(userSId, seatType);
     }
   }
 
@@ -1334,6 +1348,30 @@ async function carryConsumptionToNewSeatCredits({
   }
 }
 
+// Summary of the work `syncSeatCount` actually did, surfaced up to the poke
+// plugin so an operator can see what happened without digging through logs.
+export type SyncSeatCountSummary = {
+  seatSubscriptionCount: number;
+  distinctTimestampCount: number;
+  reconcileSegmentCallCount: number;
+  transferCount: number;
+  freeUserCount: number;
+  didMutateSeatData: boolean;
+  durationMs: number;
+};
+
+function emptySyncSeatCountSummary(startedAt: number): SyncSeatCountSummary {
+  return {
+    seatSubscriptionCount: 0,
+    distinctTimestampCount: 0,
+    reconcileSegmentCallCount: 0,
+    transferCount: 0,
+    freeUserCount: 0,
+    didMutateSeatData: false,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
 export async function syncSeatCount({
   metronomeCustomerId,
   contractId,
@@ -1342,6 +1380,7 @@ export async function syncSeatCount({
   startingAt,
   contract,
   assumeEmptySeats,
+  forceFreeCreditRevokeCheck,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1356,8 +1395,19 @@ export async function syncSeatCount({
   // empty. Only safe for a freshly provisioned contract (no prior assignments)
   // — passed by switchContract when the contract was newly created.
   assumeEmptySeats?: boolean;
-}): Promise<Result<undefined, Error>> {
+  // Run the (expensive) ex-free-seat credit revoke check unconditionally,
+  // instead of only when Metronome's "free" seat assignment list shows
+  // someone moved away from free. Used by the poke "Sync Metronome Seat
+  // Count" plugin, where an operator explicitly asked for a thorough pass —
+  // not by the debounced/automatic sync, which relies on the cheap gate.
+  forceFreeCreditRevokeCheck?: boolean;
+}): Promise<Result<SyncSeatCountSummary, Error>> {
   let didMutateSeatData = false;
+  const syncStartedAt = Date.now();
+  logger.info(
+    { workspaceId: workspace.sId, contractId, planCode, startingAt },
+    "[Metronome] syncSeatCount starting"
+  );
 
   try {
     let resolvedContract: CachedContract;
@@ -1375,7 +1425,11 @@ export async function syncSeatCount({
     }
 
     if (!(await hasContractSeatSubscription(resolvedContract))) {
-      return new Ok(undefined);
+      logger.info(
+        { workspaceId: workspace.sId, contractId },
+        "[Metronome] syncSeatCount skipped — contract has no seat subscription"
+      );
+      return new Ok(emptySyncSeatCountSummary(syncStartedAt));
     }
 
     const productSeatTypes = await getProductSeatTypes();
@@ -1514,6 +1568,18 @@ export async function syncSeatCount({
         ...seatLimitChangeMs,
       ])
     ).sort((a, b) => a - b);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractId,
+        seatSubscriptionCount: seatSubscriptions.length,
+        scheduledChangeCount: scheduledChanges.length,
+        distinctTimestampCount: effectiveTimestampsMs.length,
+        expectedSegmentReconcileCalls:
+          seatSubscriptions.length * effectiveTimestampsMs.length,
+      },
+      "[Metronome] Reconcile plan computed"
+    );
 
     // The seat limit (min/max) effective for `seatType` at `tMs`, walking its
     // scheduled segments. Undefined when no limit applies at that moment.
@@ -1621,7 +1687,54 @@ export async function syncSeatCount({
       );
     }
     let pendingCreditTransfers: SeatCreditTransfer[] = [];
+    // Per-subscription "now" seat state, fetched once here and reused by the
+    // transfer prep below, the immediate-base reconcile pass, and the
+    // free-seat revoke check further down — otherwise each would separately
+    // query Metronome for the exact same data.
+    const seatStateBySubscriptionId = new Map<string, SubscriptionSeatState>();
     if (!startingAt) {
+      const seatStateStartedAt = Date.now();
+      // Free isn't in `subscriptionIdBySeatType` (no recurring credit — see
+      // `getSeatCreditNameForSeatType`), but its assignment list is still
+      // useful below to cheaply detect who moved away from a free seat.
+      const freeSubscriptionId = seatSubscriptions.find(
+        ({ seatType }) => seatType === "free"
+      )?.sub.id;
+      const subscriptionIdsToFetch = [
+        ...subscriptionIdBySeatType,
+        ...(freeSubscriptionId ? [["free", freeSubscriptionId] as const] : []),
+      ];
+      for (const [seatType, subscriptionId] of subscriptionIdsToFetch) {
+        const stateRes = await getMetronomeSubscriptionSeatState({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId,
+        });
+        if (stateRes.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              contractId,
+              seatType,
+              error: stateRes.error,
+            },
+            "[Metronome] Failed to read current seat state — skipping tier for credit transfer"
+          );
+          continue;
+        }
+        seatStateBySubscriptionId.set(subscriptionId, stateRes.value);
+      }
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          subscriptionCount: seatStateBySubscriptionId.size,
+          durationMs: Date.now() - seatStateStartedAt,
+        },
+        "[Metronome] Current seat state fetched"
+      );
+
+      const transfersStartedAt = Date.now();
       pendingCreditTransfers = await emptyOriginSeatCreditsForTransfers({
         metronomeCustomerId,
         contractId,
@@ -1630,11 +1743,23 @@ export async function syncSeatCount({
         recurringCreditIdBySeatType,
         allocationBySeatType,
         desiredSeatByUser: currentSeatByUserSId,
+        seatStateBySubscriptionId,
       });
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          transferCount: pendingCreditTransfers.length,
+          durationMs: Date.now() - transfersStartedAt,
+        },
+        "[Metronome] emptyOriginSeatCreditsForTransfers done"
+      );
       didMutateSeatData =
         didMutateSeatData || pendingCreditTransfers.length > 0;
     }
 
+    const reconcileLoopStartedAt = Date.now();
+    let reconcileSegmentCallCount = 0;
     for (const { sub, seatType } of seatSubscriptions) {
       const subscriptionId = sub.id!;
       const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
@@ -1656,6 +1781,7 @@ export async function syncSeatCount({
             ? undefined
             : new Date(tMs).toISOString();
           const coveringDate = isImmediateBase ? undefined : new Date(tMs);
+          const segmentStartedAt = Date.now();
           const result = await reconcileSeatBasedSegment({
             metronomeCustomerId,
             contractId,
@@ -1667,7 +1793,22 @@ export async function syncSeatCount({
             coveringDate,
             workspaceId: workspace.sId,
             assumeEmptySeats,
+            cachedSeatState: isImmediateBase
+              ? seatStateBySubscriptionId.get(subscriptionId)
+              : undefined,
           });
+          reconcileSegmentCallCount++;
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              contractId,
+              subscriptionId,
+              seatType,
+              tMs,
+              durationMs: Date.now() - segmentStartedAt,
+            },
+            "[Metronome] reconcileSeatBasedSegment call done"
+          );
           if (result.isErr()) {
             return new Err(result.error);
           }
@@ -1726,10 +1867,20 @@ export async function syncSeatCount({
         }
       }
     }
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractId,
+        reconcileSegmentCallCount,
+        durationMs: Date.now() - reconcileLoopStartedAt,
+      },
+      "[Metronome] Seat-subscription reconcile loop done"
+    );
 
     // New seats are now assigned, so their credits exist: carry the consumed
     // AWU emptied from the origin seats onto them (see above).
     if (pendingCreditTransfers.length > 0) {
+      const carryStartedAt = Date.now();
       await carryConsumptionToNewSeatCredits({
         metronomeCustomerId,
         contractId,
@@ -1739,6 +1890,15 @@ export async function syncSeatCount({
         recurringCreditIdBySeatType,
         allocationBySeatType,
       });
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          transferCount: pendingCreditTransfers.length,
+          durationMs: Date.now() - carryStartedAt,
+        },
+        "[Metronome] carryConsumptionToNewSeatCredits done"
+      );
     }
 
     // Per-user AWU grant/revoke for free members. Driven off DB membership
@@ -1748,6 +1908,7 @@ export async function syncSeatCount({
     // above. Best-effort and idempotent. Grant deduped by the grant's uniqueness
     // key; revoke archives the credit + drops alerts for users who left the free
     // seat (the uniqueness key stays claimed, so they can't re-claim).
+    const freeSeatStartedAt = Date.now();
     const currentFreeUserIds = new Set(desiredSIdsAt("free", baseMs));
     await grantFreeSeatCredits({
       metronomeCustomerId,
@@ -1755,13 +1916,65 @@ export async function syncSeatCount({
       userIds: [...currentFreeUserIds],
       startingAt: new Date(baseMs),
     });
-    await revokeFreeSeatCreditsForExFreeUsers({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-      currentFreeUserIds,
-    });
 
-    return new Ok(undefined);
+    // Revoking a stale free-seat credit is low-stakes (a user can only ever
+    // have earned one by actually holding a free seat) — unlike the grant, it
+    // isn't worth an unconditional Metronome credit-listing call on every
+    // sync (this runs on every membership change). Instead, use the "free"
+    // subscription's already-fetched seat assignment (Metronome's actual
+    // current state) to see who's assigned to free there but no longer
+    // desired as free in our DB, and only call the (expensive) revoke check
+    // when that set is non-empty. If we don't have that data (contract
+    // doesn't have "free" entitled, or this is the pending-contract
+    // pre-provision pass), skip the check entirely rather than falling back
+    // to the always-expensive path.
+    const freeSubscriptionId = seatSubscriptions.find(
+      ({ seatType }) => seatType === "free"
+    )?.sub.id;
+    const freeSeatState = freeSubscriptionId
+      ? seatStateBySubscriptionId.get(freeSubscriptionId)
+      : undefined;
+    const movedAwayFromFree = freeSeatState
+      ? freeSeatState.assignedSeatIds.filter(
+          (id) => !currentFreeUserIds.has(id)
+        )
+      : [];
+    if (movedAwayFromFree.length > 0 || forceFreeCreditRevokeCheck) {
+      logger.info(
+        { workspaceId: workspace.sId, contractId, forceFreeCreditRevokeCheck },
+        "[Metronome] Running ex-free-seat credit revoke check"
+      );
+      await revokeFreeSeatCreditsForExFreeUsers({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+        currentFreeUserIds,
+      });
+    } else {
+      logger.info(
+        { workspaceId: workspace.sId, contractId },
+        "[Metronome] No users moved away from a free seat — skipping free-credit revoke check"
+      );
+    }
+    const summary: SyncSeatCountSummary = {
+      seatSubscriptionCount: seatSubscriptions.length,
+      distinctTimestampCount: effectiveTimestampsMs.length,
+      reconcileSegmentCallCount,
+      transferCount: pendingCreditTransfers.length,
+      freeUserCount: currentFreeUserIds.size,
+      didMutateSeatData,
+      durationMs: Date.now() - syncStartedAt,
+    };
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractId,
+        ...summary,
+        freeSeatDurationMs: Date.now() - freeSeatStartedAt,
+      },
+      "[Metronome] syncSeatCount done"
+    );
+
+    return new Ok(summary);
   } finally {
     if (didMutateSeatData) {
       await invalidateCachedSeatDataByUserId({
@@ -1806,6 +2019,7 @@ async function reconcileSeatBasedSegment({
   coveringDate,
   workspaceId,
   assumeEmptySeats,
+  cachedSeatState,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1821,12 +2035,19 @@ async function reconcileSeatBasedSegment({
   // timestamp) — set by switchContract when the contract was newly created
   // (not recovered).
   assumeEmptySeats?: boolean;
+  // Reuse a seat state already fetched for this exact subscription + moment
+  // (e.g. by `emptyOriginSeatCreditsForTransfers`'s "now" read) instead of
+  // querying Metronome again for the same data.
+  cachedSeatState?: SubscriptionSeatState;
 }): Promise<Result<boolean, Error>> {
   let assignedSeatIds: string[];
   let currentUnassigned: number;
   if (assumeEmptySeats) {
     assignedSeatIds = [];
     currentUnassigned = 0;
+  } else if (cachedSeatState) {
+    assignedSeatIds = cachedSeatState.assignedSeatIds;
+    currentUnassigned = cachedSeatState.unassignedSeats;
   } else {
     const currentResult = await getMetronomeSubscriptionSeatState({
       metronomeCustomerId,
@@ -1999,15 +2220,15 @@ export async function buildSeatDataByUserId({
         return new Ok(null);
       }
 
-      const seatIdsResult = await getMetronomeSubscriptionAssignedSeatIds({
+      const seatStateResult = await getMetronomeSubscriptionSeatState({
         metronomeCustomerId,
         contractId,
         subscriptionId: sub.id,
       });
-      if (seatIdsResult.isErr()) {
+      if (seatStateResult.isErr()) {
         logger.warn(
           {
-            error: seatIdsResult.error,
+            error: seatStateResult.error,
             metronomeCustomerId,
             contractId,
             subscriptionId: sub.id,
@@ -2015,14 +2236,15 @@ export async function buildSeatDataByUserId({
           },
           "[Metronome] Failed to fetch seat IDs"
         );
-        return new Err(seatIdsResult.error);
+        return new Err(seatStateResult.error);
       }
+      const assignedSeatIds = seatStateResult.value.assignedSeatIds;
 
       const freq = sub.subscription_rate.billing_frequency;
       const nextCreditResetAt =
         sub.billing_periods?.current?.ending_before ?? null;
       return new Ok({
-        seatIds: seatIdsResult.value,
+        seatIds: assignedSeatIds,
         awuAllocation,
         billingFrequency: freq === "MONTHLY" || freq === "ANNUAL" ? freq : null,
         nextCreditResetAt,

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -20,7 +20,6 @@ const {
   mockUpsertPerUserCreditAlerts,
   mockClearPerUserCreditAlerts,
   mockListSeatBalances,
-  mockGetAssignedSeatIds,
 } = vi.hoisted(() => ({
   mockGetProductSeatTypes: vi.fn(),
   mockUpdateSubscriptionQuantity: vi.fn(),
@@ -36,7 +35,6 @@ const {
   mockUpsertPerUserCreditAlerts: vi.fn(),
   mockClearPerUserCreditAlerts: vi.fn(),
   mockListSeatBalances: vi.fn(),
-  mockGetAssignedSeatIds: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/client", () => ({
@@ -44,7 +42,6 @@ vi.mock("@app/lib/metronome/client", () => ({
   updateSubscriptionQuantity: mockUpdateSubscriptionQuantity,
   updateSubscriptionSeats: mockUpdateSubscriptionSeats,
   getMetronomeSubscriptionSeatState: mockGetSeatState,
-  getMetronomeSubscriptionAssignedSeatIds: mockGetAssignedSeatIds,
   listCustomerPerUserCreditUserIds: mockListPerUserCreditUserIds,
   listCustomerPerUserCreditBalances: mockListPerUserCreditBalances,
   addPerUserCreditToCustomer: mockAddPerUserCredit,
@@ -129,7 +126,6 @@ describe("syncSeatCount min clamping", () => {
     // No seat balances / assignments ⇒ the credit-transfer reconciliation
     // finds nothing to move (the focus of these tests is seat-count sync).
     mockListSeatBalances.mockResolvedValue(new Ok([]));
-    mockGetAssignedSeatIds.mockResolvedValue(new Ok([]));
   });
 
   it("clamps a QUANTITY_ONLY count up to the configured minSeats", async () => {


### PR DESCRIPTION
## Description

Optimizes the "Sync Metronome Seat Count" flow (`syncMetronomeSeatCountForWorkspace` → `syncSeatCount` → `reconcileWorkspaceUserCreditStates` → `syncDefaultPoolCapAlertsForWorkspace`), which could take 2+ minutes on workspaces with many staggered scheduled seat changes, and still took ~15.7s on a trivial workspace with nothing to change.

**Diagnostics added first**, to find the actual bottlenecks rather than guess:
- `workspaceId`-tagged `logger.info` calls at every phase boundary (staging a pending contract, the seat-state fetch, the transfer-prep step, each `reconcileSeatBasedSegment` call, the credit-state reconcile, the alert sync), each with a `durationMs`.
- `syncSeatCount` now returns a real `SyncSeatCountSummary` (subscription/timestamp/segment-call/transfer/free-user counts, whether anything mutated, duration) instead of `undefined`, threaded through `SeatSyncOutcome` into the poke plugin's displayed output — running the plugin now shows a multi-line breakdown instead of just "Metronome seat count synced."

**Fixes, found by reading the traces**:

- **`listMetronomeSeatBalances`** (`lib/metronome/client.ts`): `seatIds` is now mandatory — every call site already passed it explicitly, so the dead unfiltered-list code path (previously the root cause of a separate, already-fixed bug — see #28966) is fully removed. When a batch of ids fails (Metronome rejects the *entire* batch if even one id isn't found on the contract), recovery now bisects the batch instead of falling back to querying every id individually — isolates a handful of bad ids in ~log2(N) rounds of batched calls instead of N single-id calls. The outer per-chunk loop now runs concurrently instead of sequentially.

- **`emptyOriginSeatCreditsForTransfers`** (`lib/metronome/seats.ts`): reordered to fetch Metronome's current per-subscription seat state *before* the balance fetch, and skip the balance fetch entirely when there are no actual pro/max seat-type transfer candidates (the common case). When there are candidates, the balance fetch is now scoped to just the transferring subset instead of every eligible user.

- **Eliminated a duplicate Metronome call**: `getMetronomeSubscriptionAssignedSeatIds` was a thin wrapper over `getMetronomeSubscriptionSeatState` — the transfer-prep step and the main reconcile loop's "immediate base" pass were each independently fetching the exact same "now" state per subscription. It's now fetched once in `syncSeatCount` and shared via a `cachedSeatState` param on `reconcileSeatBasedSegment`, extended to also cover the "free" subscription (previously never cached, since transfer-prep never looked at it). With that, the wrapper had no remaining reason to exist beyond one call site (`buildSeatDataByUserId`), so it's been deleted entirely and that call site now uses `getMetronomeSubscriptionSeatState` directly, matching the rest of the file.

- **Free-seat credit revoke**: `revokeFreeSeatCreditsForExFreeUsers`'s `listCustomerPerUserCreditBalances` call is expensive and previously ran unconditionally on every sync. It's now gated on a cheap, already-fetched signal — Metronome's actual "free" seat assignment list vs. our desired free users — and only runs when someone has actually moved away from a free seat. This is a deliberate tradeoff: a missed revoke (e.g. contract dropped "free" entitlement between an old credit and now) is low-stakes and self-corrects on the next sync where it happens to run; it isn't worth an unconditional credit-listing call on every membership operation.

- **`reconcileWorkspaceUserCreditStates`** (`lib/api/metronome/reconcile_credit_state.ts`): two groups of previously-sequential, mutually-independent reads now run via `Promise.all` — (1) seat allowances, credit-usage config, and active memberships; (2) seat balances, per-user free credit balances, per-user usage, and max group caps (all only depend on the memberships from group 1, not on each other).

- **`syncDefaultPoolCapAlertsForWorkspace`** (`lib/api/workspace/default_user_spend_limit.ts`): the 4 independent cap/warning alert upserts (2 seat types × 2 alert kinds) now run concurrently via `concurrentExecutor` instead of one at a time. The cap-vs-warning branching there is an exhaustive `switch` + `assertNever` on the task kind rather than if/else, per [GEN6].

## Tests

- Existing unit tests for all touched files pass (`client.test.ts`, `seats.test.ts`, `seats_sync.test.ts`, `reconcile_credit_state.test.ts`, `live_user_credit_inputs.test.ts`, `default_user_spend_limit.test.ts` — 105 tests).
- Manually verified against a live production workspace by running the "Sync Metronome Seat Count" poke plugin and reading the new phase-by-phase logs before/after each fix:
  - Baseline (nothing to change): ~15.7s total (`emptyOriginSeatCreditsForTransfers` ~3s, 3× `reconcileSeatBasedSegment` ~2.4s combined, free-seat grant/revoke ~3.2s, `reconcileWorkspaceUserCreditStates` ~5.4s, alert sync ~1.7s).
  - After all fixes, a run that included a real seat-count change: ~7.2s total (`reconcileWorkspaceUserCreditStates` ~2.5s, alert sync ~0.3s, `syncSeatCount` down to only the unavoidable upfront seat-state fetch plus the one real write).
  - `Promise.all`-related `pg` "client already executing a query" deprecation warnings observed in the local test run are a test-harness artifact (each test runs inside one shared Sequelize transaction via CLS, per `vite.setup.ts`) — not present in production, where the connection pool hands out separate connections to genuinely concurrent queries.

## Risk

- All changes are either pure performance optimizations with no behavioral difference (caching a value already being fetched, running mutually-independent calls concurrently instead of sequentially) or the one deliberate, discussed tradeoff on free-credit revoke above.
- No schema or migration changes, no feature flag.
- Safe to roll back: reverts to the previous (slower, but already-correct) behavior.

## Deploy Plan

Standard deploy. No migration, no config change. Once live, re-run "Sync Metronome Seat Count" from poke on a previously-slow workspace and check the new logs/plugin output to confirm the improvement.
