### PR TITLE
fix(scripts): surface spawn errors in run-migrate, install devDeps in prodbox

### DIFF
--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -14,8 +14,9 @@ RUN npm install -g npm@11.11.0
 
 COPY . .
 
-# Install dependencies
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci
+# Install dependencies, including devDependencies (e.g. tsx, needed to run
+# scripts/db/run-migrate.cjs against uncompiled TypeScript).
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci --include=dev
 
 RUN cd sdks/js && npm run build
 

--- a/scripts/db/run-migrate.cjs
+++ b/scripts/db/run-migrate.cjs
@@ -5,8 +5,27 @@ const { spawnSync } = require('child_process');
 const args = process.argv.slice(2);
 const compiled = 'dist/migrate.js';
 
-const result = existsSync(compiled)
-  ? spawnSync('node', [compiled, ...args], { stdio: 'inherit' })
-  : spawnSync('tsx', ['scripts/migrate.ts', ...args], { stdio: 'inherit' });
+const command = existsSync(compiled)
+  ? { bin: 'node', binArgs: [compiled, ...args] }
+  : { bin: 'tsx', binArgs: ['scripts/migrate.ts', ...args] };
+
+const result = spawnSync(command.bin, command.binArgs, { stdio: 'inherit' });
+
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    console.error(
+      `run-migrate: could not find "${command.bin}" on PATH.
+      Make sure ${command.bin} is installed and on PATH.`
+    );
+  } else {
+    console.error(`run-migrate: failed to run "${command.bin}": ${result.error.message}`);
+  }
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(`run-migrate: "${command.bin}" was killed by signal ${result.signal}.`);
+  process.exit(1);
+}
 
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## Description

`scripts/db/run-migrate.cjs` swallowed `spawnSync` failures silently (e.g. when
`tsx` isn't on `PATH`, `result.error` was set but never checked, so the script
just exited with an unhelpful status code). This surfaces `ENOENT` and other
spawn errors, plus signal termination, with an actionable message.

Since `tsx` is a devDependency, this also updates the prodbox image to install
devDependencies (`npm ci --include=dev`) so the migration script can actually
find `tsx` when running against uncompiled TypeScript.

## Tests

Verified locally: running the script with `tsx` removed from `PATH` now prints
a clear error and exits 1, instead of failing without explanation.
