### PR TITLE
feat(activation): return trigger id from emitActivationEvent

### DIFF
--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -158,11 +158,13 @@ export async function createActivationTrigger(
   return new Ok({ triggerId: triggerRes.value.sId });
 }
 
-// Fires the activation trigger for a single pod by emitting an internal webhook event.
+// Fires the activation trigger for a single pod by emitting an internal webhook
+// event. Returns the sId of the pod's activation trigger, if the event matched
+// it (a pod has at most one activation trigger, via `activationTriggerFilter`).
 export async function emitActivationEvent(
   auth: Authenticator,
   pod: SpaceResource
-): Promise<Result<void, Error>> {
+): Promise<Result<{ triggerId: string | null }, Error>> {
   const source = await WebhookSourceResource.fetchByName(
     auth,
     ACTIVATION_WEBHOOK_SOURCE_NAME
@@ -199,5 +201,5 @@ export async function emitActivationEvent(
     return result;
   }
 
-  return new Ok(undefined);
+  return new Ok({ triggerId: result.value.triggerIds[0] ?? null });
 }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -674,7 +674,7 @@ export async function processWebhookRequest(
     body: Record<string, unknown>;
     rawBody: string;
   }
-): Promise<Result<void, Error>> {
+): Promise<Result<{ triggerIds: string[] }, Error>> {
   const localLogger = logger.child({
     webhookRequestId: webhookRequest.id,
     webhookSourceId: webhookSource.id,
@@ -710,12 +710,12 @@ export async function processWebhookRequest(
   if (eventValidationResult.isErr()) {
     await webhookRequest.markAsFailed(eventValidationResult.error.message);
     localLogger.error(eventValidationResult.error.message);
-    return new Ok(undefined); // We consider event validation errors as non-retryable.
+    return new Ok({ triggerIds: [] }); // We consider event validation errors as non-retryable.
   }
 
   const { skipReason, receivedEventValue } = eventValidationResult.value;
   if (skipReason) {
-    return new Ok(undefined);
+    return new Ok({ triggerIds: [] });
   }
 
   const filteredTriggersResult = await filterTriggers({
@@ -729,14 +729,14 @@ export async function processWebhookRequest(
   if (filteredTriggersResult.isErr()) {
     await webhookRequest.markAsFailed(filteredTriggersResult.error.message);
     localLogger.error(filteredTriggersResult.error.message);
-    return new Ok(undefined); // We consider filtering errors as non-retryable.
+    return new Ok({ triggerIds: [] }); // We consider filtering errors as non-retryable.
   }
 
   const filteredTriggers = filteredTriggersResult.value;
   if (filteredTriggers.length === 0) {
     localLogger.info("No triggers matched the webhook request.");
     await webhookRequest.markAsProcessed();
-    return new Ok(undefined);
+    return new Ok({ triggerIds: [] });
   }
 
   if (filteredTriggers.some((t) => t.configuration.includePayload)) {
@@ -757,12 +757,12 @@ export async function processWebhookRequest(
   if (launchResult.isErr()) {
     await webhookRequest.markAsFailed(launchResult.error.message);
     localLogger.error(launchResult.error.message);
-    return new Ok(undefined); // We consider launch errors as non-retryable.
+    return new Ok({ triggerIds: [] }); // We consider launch errors as non-retryable.
   }
 
   await webhookRequest.markAsProcessed();
 
-  return new Ok(undefined);
+  return new Ok({ triggerIds: filteredTriggers.map((t) => t.sId) });
 }
 
 export async function fetchRecentWebhookRequestTriggersWithPayload(


### PR DESCRIPTION
## Description

`emitActivationEvent` currently returns `void` on success. To link an `ActivationNudge` row (added in #29059) to the trigger that fired it, we need that trigger's sId at the call site.

`processWebhookRequest` already computes the matched trigger(s) internally via `filterTriggers` when it processes the activation webhook event, so this just surfaces that id through the return value instead of the caller having to look it up again. `emitActivationEvent` now returns `{ triggerId: string | null }` (a pod has at most one activation trigger, via `activationTriggerFilter`), and `processWebhookRequest` returns `{ triggerIds: string[] }` for the shared webhook-processing path.

No existing call sites needed changes since they only checked `.isErr()`.

## Tests

Pure return-type plumbing; verified with `npx tsgo --noEmit` and `biome check` on the touched files. No new tests needed — behavior is unchanged, only the return value is now populated.