### PR TITLE
feat(activation): record and gate pod nudges with a frequency cap

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -1,0 +1,77 @@
+import {
+  getActivationNudgeFrequencyCapDays,
+  isEligibleForNudge,
+} from "@app/lib/api/activation/nudge";
+import { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS } from "@app/temporal/activation_scheduler/config";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { describe, expect, it } from "vitest";
+
+describe("getActivationNudgeFrequencyCapDays", () => {
+  it("falls back to the default when the workspace has no override", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    expect(getActivationNudgeFrequencyCapDays(authenticator)).toBe(
+      DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS
+    );
+  });
+
+  it("uses the workspace-configured override when valid", async () => {
+    const { workspace } = await createResourceTest({
+      role: "admin",
+    });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeFrequencyCapDays: 30,
+    });
+    const refreshedAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    expect(getActivationNudgeFrequencyCapDays(refreshedAuth)).toBe(30);
+  });
+
+  it("falls back to the default when the override is not a number", async () => {
+    const { workspace } = await createResourceTest({
+      role: "admin",
+    });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeFrequencyCapDays: "not-a-number",
+    });
+    const refreshedAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    expect(getActivationNudgeFrequencyCapDays(refreshedAuth)).toBe(
+      DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS
+    );
+  });
+});
+
+describe("isEligibleForNudge", () => {
+  it("is eligible when the pod has never been nudged", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+
+    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(true);
+  });
+
+  it("is not eligible right after a nudge, within the cap window", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const trigger = await TriggerFactory.webhook(authenticator, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    });
+    await ActivationNudgeResource.makeNew(authenticator, {
+      pod: globalSpace,
+      trigger,
+    });
+
+    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+  });
+});

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,0 +1,37 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS } from "@app/temporal/activation_scheduler/config";
+import isNumber from "lodash/isNumber";
+
+export function getActivationNudgeFrequencyCapDays(
+  auth: Authenticator
+): number {
+  const workspace = auth.getNonNullableWorkspace();
+  const customFrequencyCapDays =
+    workspace.metadata?.activationNudgeFrequencyCapDays;
+
+  if (isNumber(customFrequencyCapDays)) {
+    return customFrequencyCapDays;
+  }
+  return DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS;
+}
+
+// Frequency cap: gates re-nudging a pod that was already nudged within the
+// workspace's configured cap window.
+export async function isEligibleForNudge(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<boolean> {
+  const latestNudge = await ActivationNudgeResource.fetchLatestForSpace(auth, {
+    pod,
+  });
+  if (!latestNudge) {
+    return true;
+  }
+
+  const frequencyCapDays = getActivationNudgeFrequencyCapDays(auth);
+  const frequencyCapMs = frequencyCapDays * 24 * 60 * 60 * 1000;
+
+  return Date.now() - latestNudge.createdAt.getTime() >= frequencyCapMs;
+}

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -57,6 +57,22 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
     return new this(this.model, nudge.get());
   }
 
+  // Fetches the most recent nudge recorded for a pod, if any.
+  static async fetchLatestForSpace(
+    auth: Authenticator,
+    { pod }: { pod: SpaceResource }
+  ): Promise<ActivationNudgeResource | null> {
+    const nudge = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: pod.id,
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return nudge ? new this(this.model, nudge.get()) : null;
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -1,0 +1,77 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ActivationNudgeResource
+  extends ReadonlyAttributesType<ActivationNudgeModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> {
+  static model: ModelStatic<ActivationNudgeModel> = ActivationNudgeModel;
+
+  constructor(
+    _: ModelStatic<ActivationNudgeModel>,
+    blob: Attributes<ActivationNudgeModel>
+  ) {
+    super(ActivationNudgeModel, blob);
+  }
+
+  get sId(): string {
+    return ActivationNudgeResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("activation_nudge", { id, workspaceId });
+  }
+
+  // Records that the pod's activation trigger fired.
+  static async makeNew(
+    auth: Authenticator,
+    { pod, trigger }: { pod: SpaceResource; trigger: TriggerResource }
+  ): Promise<ActivationNudgeResource> {
+    const nudge = await this.model.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: pod.id,
+      triggerId: trigger.id,
+      userId: trigger.editor,
+    });
+
+    return new this(this.model, nudge.get());
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+}

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -47,14 +47,29 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
     auth: Authenticator,
     { pod, trigger }: { pod: SpaceResource; trigger: TriggerResource }
   ): Promise<ActivationNudgeResource> {
-    const nudge = await this.model.create({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      spaceId: pod.id,
-      triggerId: trigger.id,
-      userId: trigger.editor,
-    });
+    const [nudge] = await this.bulkCreate(auth, [{ pod, trigger }]);
+    return nudge;
+  }
 
-    return new this(this.model, nudge.get());
+  // Records that a batch of pods' activation triggers fired, in a single
+  // insert (avoids one query per pod when the scheduler processes many pods).
+  static async bulkCreate(
+    auth: Authenticator,
+    nudges: { pod: SpaceResource; trigger: TriggerResource }[]
+  ): Promise<ActivationNudgeResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const created = await this.model.bulkCreate(
+      nudges.map(({ pod, trigger }) => ({
+        workspaceId,
+        spaceId: pod.id,
+        triggerId: trigger.id,
+        userId: trigger.editor,
+      })),
+      { returning: true }
+    );
+
+    return created.map((nudge) => new this(this.model, nudge.get()));
   }
 
   // Fetches the most recent nudge recorded for a pod, if any.

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -108,6 +108,9 @@ export const RESOURCES_PREFIX = {
 
   // Activation recommendations.
   activation_recommendation: "arc",
+
+  // Activation nudges.
+  activation_nudge: "anu",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,7 +1,9 @@
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
@@ -42,7 +44,28 @@ export async function runActivationForWorkspaceActivity({
           { workspaceId, spaceId: pod.sId, error: result.error },
           "[ActivationScheduler] Failed to emit activation event for pod."
         );
+        return;
       }
+
+      const { triggerId } = result.value;
+      if (!triggerId) {
+        logger.warn(
+          { workspaceId, spaceId: pod.sId },
+          "[ActivationScheduler] Activation event did not match the pod's trigger."
+        );
+        return;
+      }
+
+      const trigger = await TriggerResource.fetchById(auth, triggerId);
+      if (!trigger) {
+        logger.error(
+          { workspaceId, spaceId: pod.sId, triggerId },
+          "[ActivationScheduler] Activation trigger not found after firing."
+        );
+        return;
+      }
+
+      await ActivationNudgeResource.makeNew(auth, { pod, trigger });
     },
     { concurrency: ACTIVATION_PODS_CONCURRENCY }
   );

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,3 +1,4 @@
+import { isEligibleForNudge } from "@app/lib/api/activation/nudge";
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
@@ -38,6 +39,10 @@ export async function runActivationForWorkspaceActivity({
   await concurrentExecutor(
     pods,
     async (pod) => {
+      if (!(await isEligibleForNudge(auth, pod))) {
+        return;
+      }
+
       const result = await emitActivationEvent(auth, pod);
       if (result.isErr()) {
         logger.error(

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -36,10 +36,18 @@ export async function runActivationForWorkspaceActivity({
     activationPodsMetadata.map((metadata) => metadata.spaceId)
   );
 
+  // Collected across pods so the trigger lookup and the nudge inserts below
+  // can each run as a single batched query instead of one per pod.
+  const firedTriggersByPod: { pod: SpaceResource; triggerId: string }[] = [];
+
   await concurrentExecutor(
     pods,
     async (pod) => {
       if (!(await isEligibleForNudge(auth, pod))) {
+        logger.info(
+          { workspaceId, spaceId: pod.sId },
+          "[ActivationScheduler] Pod is within the nudge frequency cap, skipping."
+        );
         return;
       }
 
@@ -56,22 +64,40 @@ export async function runActivationForWorkspaceActivity({
       if (!triggerId) {
         logger.warn(
           { workspaceId, spaceId: pod.sId },
-          "[ActivationScheduler] Activation event did not match the pod's trigger."
+          "[ActivationScheduler] Activation event did not fire the pod's trigger."
         );
         return;
       }
 
-      const trigger = await TriggerResource.fetchById(auth, triggerId);
-      if (!trigger) {
-        logger.error(
-          { workspaceId, spaceId: pod.sId, triggerId },
-          "[ActivationScheduler] Activation trigger not found after firing."
-        );
-        return;
-      }
-
-      await ActivationNudgeResource.makeNew(auth, { pod, trigger });
+      firedTriggersByPod.push({ pod, triggerId });
     },
     { concurrency: ACTIVATION_PODS_CONCURRENCY }
   );
+
+  if (firedTriggersByPod.length === 0) {
+    return;
+  }
+
+  const triggers = await TriggerResource.fetchByIds(
+    auth,
+    firedTriggersByPod.map(({ triggerId }) => triggerId)
+  );
+  const triggerById = new Map(
+    triggers.map((trigger) => [trigger.sId, trigger])
+  );
+
+  const nudges: { pod: SpaceResource; trigger: TriggerResource }[] = [];
+  for (const { pod, triggerId } of firedTriggersByPod) {
+    const trigger = triggerById.get(triggerId);
+    if (!trigger) {
+      logger.error(
+        { workspaceId, spaceId: pod.sId, triggerId },
+        "[ActivationScheduler] Activation trigger not found after firing."
+      );
+      continue;
+    }
+    nudges.push({ pod, trigger });
+  }
+
+  await ActivationNudgeResource.bulkCreate(auth, nudges);
 }

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -1,2 +1,6 @@
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `activation-scheduler-queue-v${QUEUE_VERSION}`;
+
+// Default number of days to wait before nudging the same pod again. Workspaces
+// can override this via the `activationNudgeFrequencyCapDays` metadata key.
+export const DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS = 2;


### PR DESCRIPTION
## Description

Builds on the activation scheduler by recording every nudge that's sent and using that history to avoid over-nudging.

- Adds `ActivationNudgeResource`/`ActivationNudgeModel`, and records one each time the scheduler fires a pod's activation trigger.
- Adds `isEligibleForNudge`, called before firing a pod's trigger: skips the pod if it was already nudged within the last `activationNudgeFrequencyCapDays` (workspace `metadata`, defaults to 2 days when unset).

## Tests

Added unit tests for `getActivationNudgeFrequencyCapDays` (default, workspace override, invalid override) and `isEligibleForNudge` (never nudged vs. nudged within the cap window).
