### PR TITLE
add myself as author

### DIFF
--- a/.authors
+++ b/.authors
@@ -51,3 +51,4 @@ xebeohp: phoebe@dust.tt
 TimotheeCrouzet: tim@dust.tt
 Inesvvv: ines.v@dust.tt
 sfriquet: sylvain@dust.tt
+A-Marc: marc@dust.tt


### PR DESCRIPTION
## Description

Adds `A-Marc` (marc@dust.tt) to the `.authors` file to associate the GitHub handle with the corresponding email address.

## Tests

No testing needed.

## Risk

None.

## Deploy Plan

Deploy front.