### PR TITLE
feat(activation): require the pinned Frame to be a rendered Frame

### DIFF
--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -65,6 +65,8 @@ Workspaces vary wildly — some have many skills and agents, some have only tool
 
 ### The Frame Specification
 
+The pinned Frame must be a rendered Frame (\`application/vnd.dust.frame\`), created via \`create_interactive_content_file\` and moved into the Pod file system.
+
 - One Frame
 - Two swipeable slides (prev/next arrows + dot indicators + touch swipe + keyboard left/right arrow keys, with the frame focusable so arrows work on click or tab focus)
 - Hard height budget: 300px is the absolute maximum. Never rely on vertical scrolling.


### PR DESCRIPTION
## Summary

Adds one line to the Activation skill's Frame spec: the pinned Overview Frame must be a rendered Frame (`application/vnd.dust.frame`), created via `create_interactive_content_file` and moved into the Pod file system. Prompt-only change; no code paths touched.

## Risk

Minimal — single-line addition inside the `ACTIVATION_BEHAVIOR` template literal.

## Testing

- `npx tsgo --noEmit`: clean for `activation.ts`.
- `npx @biomejs/biome check`: clean (no fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)