### PR TITLE
fix(front): reorder Auto toggle above search bar in model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -47,16 +47,6 @@ export function ModelPickerContent({
 
   return (
     <DropdownMenuContent className="w-72" align="start" side={side}>
-      <div className="sticky top-0 z-10 bg-overlay-background pb-1">
-        <DropdownMenuSearchbar
-          autoFocus={!isMobile}
-          name="search-models"
-          placeholder="Search models"
-          value={search}
-          onChange={onSearchChange}
-        />
-      </div>
-
       {auto && (
         <ModelPickerRowTooltip description={AUTO_TOOLTIP} isMobile={isMobile}>
           <DropdownMenuItem
@@ -66,6 +56,18 @@ export function ModelPickerContent({
             onSelect={(e) => e.preventDefault()}
           />
         </ModelPickerRowTooltip>
+      )}
+
+      {!auto?.isOn && (
+        <div className="sticky top-0 z-10 bg-overlay-background pt-2">
+          <DropdownMenuSearchbar
+            autoFocus={!isMobile}
+            name="search-models"
+            placeholder="Search models"
+            value={search}
+            onChange={onSearchChange}
+          />
+        </div>
       )}
 
       <ModelPickerList


### PR DESCRIPTION
## Description

Reorders the model picker content in the input bar so the **Auto** toggle sits at the top, above the search bar. The search bar is now hidden while Auto is on, since there is no model to pick in that state (it still shows during the searching state, when the Auto row is hidden).

## Tests

Manual: open the model picker from the input bar, toggle Auto on/off, and confirm the Auto row renders above the search bar and the search bar disappears when Auto is enabled.

## Risk

Low — presentation-only change to `ModelPickerContent`.

## Deploy Plan

Standard deploy, no special steps.
