### PR TITLE
feat(front-api): expose model and reasoning effort selection in public message API

### DIFF
--- a/front-api/lib/api/assistant/conversation/model_selection.ts
+++ b/front-api/lib/api/assistant/conversation/model_selection.ts
@@ -1,0 +1,65 @@
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { getEnabledModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import { ModelSelectionSchema } from "@app/types/assistant/models/types";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { fromError } from "zod-validation-error";
+
+export async function validatePublicModelSelection(
+  auth: Authenticator,
+  rawModelSelection: unknown
+): Promise<
+  Result<ModelSelectionType | undefined, APIErrorWithContentfulStatusCode>
+> {
+  if (!rawModelSelection) {
+    return new Ok(undefined);
+  }
+
+  const parsed = ModelSelectionSchema.safeParse(rawModelSelection);
+  if (!parsed.success) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid modelSelection: ${fromError(parsed.error).toString()}`,
+      },
+    });
+  }
+  const modelSelection = parsed.data;
+
+  if (!(await hasFeatureFlag(auth, "models_picker"))) {
+    return new Err({
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message:
+          "Per-message model selection requires the 'models_picker' feature, " +
+          "which is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const enabledModels = await getEnabledModelsForAuth(auth);
+  const isAuthorized = enabledModels.some(
+    (model) =>
+      model.isSelectable &&
+      model.providerId === modelSelection.providerId &&
+      model.modelId === modelSelection.modelId
+  );
+  if (!isAuthorized) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "model_disabled",
+        message:
+          `The selected model (${modelSelection.providerId}/${modelSelection.modelId}) ` +
+          "is not authorized for this workspace.",
+      },
+    });
+  }
+
+  return new Ok(modelSelection);
+}

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -13660,6 +13660,40 @@
           },
           "context": {
             "$ref": "#/components/schemas/Context"
+          },
+          "modelSelection": {
+            "$ref": "#/components/schemas/ModelSelection"
+          }
+        }
+      },
+      "ModelSelection": {
+        "type": "object",
+        "description": "Optional per-message model and reasoning-effort override applied to the\nmentioned agent(s). When omitted, each agent runs its configured model.\nIf the requested model is not available to the workspace, the agent's\nconfigured model is used instead. An unknown provider, model, or\nreasoning effort results in a 400.\n",
+        "required": [
+          "providerId",
+          "modelId"
+        ],
+        "properties": {
+          "providerId": {
+            "type": "string",
+            "description": "The model provider id (e.g. \"anthropic\", \"openai\", \"google_ai_studio\").",
+            "example": "anthropic"
+          },
+          "modelId": {
+            "type": "string",
+            "description": "The model id to run (e.g. \"claude-sonnet-4-20250514\").",
+            "example": "claude-sonnet-4-20250514"
+          },
+          "reasoningEffort": {
+            "type": "string",
+            "enum": [
+              "none",
+              "light",
+              "medium",
+              "high"
+            ],
+            "description": "Optional reasoning effort. Honored only if the resolved model supports it.",
+            "example": "medium"
           }
         }
       },

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -176,6 +177,7 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
       user.sId,
       workspace.sId
     );
+    await FeatureFlagFactory.basic(userAuth, "models_picker");
     const conversation = await ConversationFactory.create(userAuth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
       messagesCreatedAt: [new Date()],

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -4,6 +4,7 @@ import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
@@ -91,5 +92,114 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when modelSelection references an unknown model", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "tester",
+        timezone: "Europe/Paris",
+        origin: "api",
+      },
+      modelSelection: {
+        providerId: "anthropic",
+        modelId: "not-a-real-model",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("Invalid modelSelection");
+  });
+
+  it("returns 400 when modelSelection has an invalid reasoning effort", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "tester",
+        timezone: "Europe/Paris",
+        origin: "api",
+      },
+      modelSelection: {
+        providerId: "anthropic",
+        modelId: CLAUDE_OPUS_4_8_MODEL_ID,
+        reasoningEffort: "extreme",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("persists a valid modelSelection as the user message requestedModel", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const modelSelection = {
+      providerId: "anthropic" as const,
+      modelId: CLAUDE_OPUS_4_8_MODEL_ID,
+      reasoningEffort: "medium" as const,
+    };
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "tester",
+        timezone: "Europe/Paris",
+        origin: "api",
+      },
+      modelSelection,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.message.requestedModel).toEqual(modelSelection);
   });
 });

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -11,20 +11,18 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { UserMessageContext } from "@app/types/assistant/conversation";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
   type PostMessagesResponseBody,
   PublicPostMessagesRequestBodySchema,
 } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
+import { validatePublicModelSelection } from "@front-api/lib/api/assistant/conversation/model_selection";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 import message from "./[mId]";
 
@@ -110,25 +108,14 @@ app.post(
 
     const origin = context.origin ?? "api";
 
-    // The public schema accepts model selections loosely (flexible enums); we
-    // re-validate against the concrete internal schema so unknown providers,
-    // models, or reasoning efforts are rejected with a clear 400 rather than
-    // silently ignored. A valid-but-not-enabled model still falls back to the
-    // agent's configured model server-side (see resolveModel).
-    let modelSelection: ModelSelectionType | undefined;
-    if (rawModelSelection) {
-      const parsed = ModelSelectionSchema.safeParse(rawModelSelection);
-      if (!parsed.success) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid modelSelection: ${fromError(parsed.error).toString()}`,
-          },
-        });
-      }
-      modelSelection = parsed.data;
+    const modelSelectionRes = await validatePublicModelSelection(
+      auth,
+      rawModelSelection
+    );
+    if (modelSelectionRes.isErr()) {
+      return apiError(ctx, modelSelectionRes.error);
     }
+    const modelSelection = modelSelectionRes.value;
 
     if (isEmptyString(context.username)) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -11,6 +11,8 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { UserMessageContext } from "@app/types/assistant/conversation";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
   type PostMessagesResponseBody,
@@ -22,6 +24,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import message from "./[mId]";
 
@@ -102,9 +105,30 @@ app.post(
       blocking,
       skipToolsValidation,
       agenticMessageData,
+      modelSelection: rawModelSelection,
     } = ctx.req.valid("json");
 
     const origin = context.origin ?? "api";
+
+    // The public schema accepts model selections loosely (flexible enums); we
+    // re-validate against the concrete internal schema so unknown providers,
+    // models, or reasoning efforts are rejected with a clear 400 rather than
+    // silently ignored. A valid-but-not-enabled model still falls back to the
+    // agent's configured model server-side (see resolveModel).
+    let modelSelection: ModelSelectionType | undefined;
+    if (rawModelSelection) {
+      const parsed = ModelSelectionSchema.safeParse(rawModelSelection);
+      if (!parsed.success) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid modelSelection: ${fromError(parsed.error).toString()}`,
+          },
+        });
+      }
+      modelSelection = parsed.data;
+    }
 
     if (isEmptyString(context.username)) {
       return apiError(ctx, {
@@ -231,6 +255,7 @@ app.post(
             agenticMessageData,
             conversation,
             mentions,
+            modelSelection,
             skipToolsValidation: skipToolsValidation ?? false,
           })
         : await postUserMessage(auth, {
@@ -239,6 +264,7 @@ app.post(
             agenticMessageData,
             conversation,
             mentions,
+            modelSelection,
             skipToolsValidation: skipToolsValidation ?? false,
           });
     if (messageRes.isErr()) {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -40,8 +40,6 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
@@ -55,11 +53,11 @@ import {
   PublicPostConversationsRequestBodySchema,
 } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
+import { validatePublicModelSelection } from "@front-api/lib/api/assistant/conversation/model_selection";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { fromError } from "zod-validation-error";
 import conversation from "./[cId]";
 
 // Mounted at /api/v1/w/:wId/assistant/conversations.
@@ -436,25 +434,14 @@ app.post(
       const agenticMessageData: AgenticMessageData | undefined =
         message.agenticMessageData ?? undefined;
 
-      // The public schema accepts model selections loosely (flexible enums); we
-      // re-validate against the concrete internal schema so unknown providers,
-      // models, or reasoning efforts are rejected with a clear 400 rather than
-      // silently ignored. A valid-but-not-enabled model still falls back to the
-      // agent's configured model server-side (see resolveModel).
-      let modelSelection: ModelSelectionType | undefined;
-      if (message.modelSelection) {
-        const parsed = ModelSelectionSchema.safeParse(message.modelSelection);
-        if (!parsed.success) {
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: `Invalid modelSelection: ${fromError(parsed.error).toString()}`,
-            },
-          });
-        }
-        modelSelection = parsed.data;
+      const modelSelectionRes = await validatePublicModelSelection(
+        auth,
+        message.modelSelection
+      );
+      if (modelSelectionRes.isErr()) {
+        return apiError(ctx, modelSelectionRes.error);
       }
+      const modelSelection = modelSelectionRes.value;
 
       // If tools are enabled, we need to add the MCP server views to the conversation before posting the message.
       if (message.context.selectedMCPServerViewIds) {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -40,6 +40,8 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
@@ -57,6 +59,7 @@ import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { fromError } from "zod-validation-error";
 import conversation from "./[cId]";
 
 // Mounted at /api/v1/w/:wId/assistant/conversations.
@@ -433,6 +436,26 @@ app.post(
       const agenticMessageData: AgenticMessageData | undefined =
         message.agenticMessageData ?? undefined;
 
+      // The public schema accepts model selections loosely (flexible enums); we
+      // re-validate against the concrete internal schema so unknown providers,
+      // models, or reasoning efforts are rejected with a clear 400 rather than
+      // silently ignored. A valid-but-not-enabled model still falls back to the
+      // agent's configured model server-side (see resolveModel).
+      let modelSelection: ModelSelectionType | undefined;
+      if (message.modelSelection) {
+        const parsed = ModelSelectionSchema.safeParse(message.modelSelection);
+        if (!parsed.success) {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid modelSelection: ${fromError(parsed.error).toString()}`,
+            },
+          });
+        }
+        modelSelection = parsed.data;
+      }
+
       // If tools are enabled, we need to add the MCP server views to the conversation before posting the message.
       if (message.context.selectedMCPServerViewIds) {
         if (!auth.user()) {
@@ -497,6 +520,7 @@ app.post(
               agenticMessageData,
               conversation,
               mentions: message.mentions,
+              modelSelection,
               skipToolsValidation: skipToolsValidation ?? false,
             })
           : await postUserMessage(auth, {
@@ -505,6 +529,7 @@ app.post(
               agenticMessageData,
               conversation,
               mentions: message.mentions,
+              modelSelection,
               skipToolsValidation: skipToolsValidation ?? false,
             });
 

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -406,6 +406,33 @@
  *             $ref: '#/components/schemas/Mention'
  *         context:
  *           $ref: '#/components/schemas/Context'
+ *         modelSelection:
+ *           $ref: '#/components/schemas/ModelSelection'
+ *     ModelSelection:
+ *       type: object
+ *       description: |
+ *         Optional per-message model and reasoning-effort override applied to the
+ *         mentioned agent(s). When omitted, each agent runs its configured model.
+ *         If the requested model is not available to the workspace, the agent's
+ *         configured model is used instead. An unknown provider, model, or
+ *         reasoning effort results in a 400.
+ *       required:
+ *         - providerId
+ *         - modelId
+ *       properties:
+ *         providerId:
+ *           type: string
+ *           description: The model provider id (e.g. "anthropic", "openai", "google_ai_studio").
+ *           example: "anthropic"
+ *         modelId:
+ *           type: string
+ *           description: The model id to run (e.g. "claude-sonnet-4-20250514").
+ *           example: "claude-sonnet-4-20250514"
+ *         reasoningEffort:
+ *           type: string
+ *           enum: [none, light, medium, high]
+ *           description: Optional reasoning effort. Honored only if the resolved model supports it.
+ *           example: "medium"
  *     ContentFragment:
  *       type: object
  *       required:

--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -14,6 +14,7 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { PubSubError } from "@app/types/assistant/pubsub";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -151,6 +152,7 @@ export async function postUserMessageAndWaitForCompletion(
     agenticMessageData,
     conversation,
     mentions,
+    modelSelection,
     skipToolsValidation,
   }: {
     content: string;
@@ -158,6 +160,7 @@ export async function postUserMessageAndWaitForCompletion(
     agenticMessageData?: AgenticMessageData;
     conversation: ConversationType;
     mentions: MentionType[];
+    modelSelection?: ModelSelectionType;
     skipToolsValidation: boolean;
   }
 ): Promise<
@@ -177,6 +180,7 @@ export async function postUserMessageAndWaitForCompletion(
         agenticMessageData,
         conversation,
         mentions,
+        modelSelection,
         skipToolsValidation,
       });
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -9,7 +9,14 @@ import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import { beforeEach, describe, expect, it } from "vitest";
+
+const CUSTOM_MODEL_CONFIG = {
+  ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  // unsafe "as", because those are generated at runtime.
+  modelId: "my-custom-model-from-eap" as ModelIdType,
+};
 
 describe("withModelSelectability", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
@@ -127,5 +134,18 @@ describe("withModelSelectability", () => {
       medium: false,
       high: false,
     });
+  });
+
+  it("keeps custom (non-tiered) models selectable when models_picker is enabled and the user is tier-capped", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("cost_efficient");
+
+    const [model] = await withModelSelectability(auth, {
+      models: [CUSTOM_MODEL_CONFIG],
+    });
+    expect(model.isSelectable).toBe(true);
+    expect(model.supportedReasoningEfforts).toEqual(
+      CUSTOM_MODEL_CONFIG.supportedReasoningEfforts
+    );
   });
 });

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -16,7 +16,7 @@ import type {
 } from "@app/types/assistant/models/types";
 import { getMaximumReasoningEffort } from "@app/types/assistant/models/types";
 
-function isTieredModelId(
+function isStaticModel(
   modelId: string
 ): modelId is keyof typeof STATIC_MODEL_TIERS {
   return modelId in STATIC_MODEL_TIERS;
@@ -26,10 +26,12 @@ function restrictModelConfigToAllowedTiers(
   model: ModelConfigurationType,
   allowedTierNamesSet: Set<ModelsTierName>
 ): EnabledModelConfigurationType {
-  if (!isTieredModelId(model.modelId)) {
+  if (!isStaticModel(model.modelId)) {
+    // Models outside the tier table are models added dynamically (as we
+    // have a type guard for all models), so it is expected that we allow them.
     return {
       ...model,
-      isSelectable: false,
+      isSelectable: true,
     };
   }
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -107,6 +107,25 @@ const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<
   KnownModelLLMId | (string & {})
 >;
 
+// Flexible so the SDK does not need updating when new efforts are added; the
+// server re-validates against the concrete set and rejects unknown values.
+const ReasoningEffortSchema = FlexibleEnumSchema<
+  "none" | "light" | "medium" | "high"
+>();
+
+// Explicit per-message model + reasoning-effort selection. Providing it makes
+// the mentioned agent(s) run this model instead of their configured one, when
+// it is available to the workspace (otherwise the server falls back). Uses the
+// flexible enums above so unknown-but-syntactically-valid values reach the
+// server, which validates them and returns a 400 on truly unknown ids.
+export const PublicModelSelectionSchema = z.object({
+  providerId: ModelProviderIdSchema,
+  modelId: ModelLLMIdSchema,
+  reasoningEffort: ReasoningEffortSchema.optional(),
+});
+
+export type PublicModelSelection = z.infer<typeof PublicModelSelectionSchema>;
+
 const EmbeddingProviderIdSchema = FlexibleEnumSchema<"openai" | "mistral">();
 
 const ConnectorsAPIErrorTypeSchema = FlexibleEnumSchema<
@@ -2319,6 +2338,9 @@ export const PublicPostMessagesRequestBodySchema = z.intersection(
       clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
     }),
     agenticMessageData: AgenticMessageDataSchema.optional(),
+    // Optional per-message model + reasoning-effort override applied to the
+    // mentioned agent(s). Omitted means each agent runs its configured model.
+    modelSelection: PublicModelSelectionSchema.optional(),
   }),
   z
     .object({
@@ -2419,6 +2441,10 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
           mentions: z.array(MentionSchema),
           context: UserMessageContextSchema,
           agenticMessageData: AgenticMessageDataSchema.optional(),
+          // Optional per-message model + reasoning-effort override applied to
+          // the mentioned agent(s). Omitted means each agent runs its
+          // configured model.
+          modelSelection: PublicModelSelectionSchema.optional(),
         }),
         z
           .object({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -109,6 +109,7 @@ const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<
 
 // Flexible so the SDK does not need updating when new efforts are added; the
 // server re-validates against the concrete set and rejects unknown values.
+// copied from reasoning.ts to avoid circular dependency
 const ReasoningEffortSchema = FlexibleEnumSchema<
   "none" | "light" | "medium" | "high"
 >();


### PR DESCRIPTION
## Description

Exposes the existing per-message model + reasoning-effort override on the public API. Until now, only the internal API (and the input-bar model picker) could request a specific model when running an agent; the machinery to persist and resolve that selection already existed end-to-end (`postUserMessage` → `requestedModel` columns → `resolveModel` → agent run), but the public v1 endpoints neither accepted nor forwarded it.

Callers can now pass an optional `modelSelection` when creating a message or a conversation-with-message:

```jsonc
{
  "content": "…",
  "mentions": [{ "configurationId": "…" }],
  "context": { … },
  "modelSelection": {
    "providerId": "anthropic",
    "modelId": "claude-opus-4-8",
    "reasoningEffort": "medium"   // optional: none | light | medium | high
  }
}
```

Behavior:
- Omitting `modelSelection` runs the agent's configured model, exactly as before.
- An unknown provider / model / reasoning effort returns a `400` (`Invalid modelSelection: …`).
- A syntactically valid but not-enabled model returns an error 
- A workspace without model_picker returns an error if adding this param

Changes:
- `sdks/js`: new optional `PublicModelSelectionSchema` on `PublicPostMessagesRequestBodySchema` and the conversations `message` (flexible enums so the SDK does not need updating when models change; optional so the schema stays append-only). Flows automatically into the SDK's `postUserMessage` / `createConversation` client methods.
- `front-api` message + conversation routes re-validate the loosely-typed public input against the strict internal `ModelSelectionSchema` and forward it to `postUserMessage` / `postUserMessageAndWaitForCompletion`.
- `postUserMessageAndWaitForCompletion` now accepts and forwards `modelSelection` (the blocking path previously dropped it).
- Swagger shared schemas + regenerated `public/swagger.json`.

## Tests

Added functional tests on the public messages endpoint: `400` on an unknown model, `400` on an invalid reasoning effort, and `200` with the selection persisted as the user message `requestedModel`.
