### PR TITLE
Add user id to invocation model

### DIFF
--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/resources/storage/data_types";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type { SandboxFunctionInvocationStatus } from "@app/types/api/sandbox_functions";
@@ -54,10 +55,13 @@ export class SandboxFunctionInvocationModel extends WorkspaceAwareModel<SandboxF
   declare updatedAt: CreationOptional<Date>;
 
   declare sandboxFunctionId: ForeignKey<SandboxFunctionModel["id"]>;
+  // Human who triggered the invocation. Null for non-human origins (API key, scheduled/bot runs).
+  declare userId: ForeignKey<UserModel["id"]> | null;
   declare status: SandboxFunctionInvocationStatus;
   declare gcsPath: string;
 
   declare sandboxFunction: NonAttribute<SandboxFunctionModel>;
+  declare user: NonAttribute<UserModel> | null;
 }
 
 SandboxFunctionModel.init(
@@ -171,6 +175,10 @@ SandboxFunctionInvocationModel.init(
       type: DataTypes.BIGINT,
       allowNull: false,
     },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
     status: {
       type: DataTypes.STRING(64),
       allowNull: false,
@@ -191,6 +199,10 @@ SandboxFunctionInvocationModel.init(
         fields: ["sandboxFunctionId"],
         concurrently: true,
       },
+      {
+        fields: ["userId"],
+        concurrently: true,
+      },
     ],
   }
 );
@@ -204,4 +216,14 @@ SandboxFunctionInvocationModel.belongsTo(SandboxFunctionModel, {
 SandboxFunctionModel.hasMany(SandboxFunctionInvocationModel, {
   foreignKey: { name: "sandboxFunctionId", allowNull: false },
   as: "invocations",
+});
+
+SandboxFunctionInvocationModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "user",
+});
+
+UserModel.hasMany(SandboxFunctionInvocationModel, {
+  foreignKey: { name: "userId", allowNull: true },
 });

--- a/front/migrations/pre-deploy/20260716203813_add_user_id_to_sandbox_function_invocations.sql
+++ b/front/migrations/pre-deploy/20260716203813_add_user_id_to_sandbox_function_invocations.sql
@@ -1,0 +1,28 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ADD COLUMN "userId" bigint;
+
+/*
+Statement 1
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY sandbox_function_invocations_user_id ON public.sandbox_function_invocations USING btree ("userId");
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ADD CONSTRAINT "sandbox_function_invocations_userId_fkey" FOREIGN KEY ("userId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" VALIDATE CONSTRAINT "sandbox_function_invocations_userId_fkey";


### PR DESCRIPTION
## Description

First of 3 PRs adding the initiating user to sandbox function invocations, so we can enforce that only the invoker resolves their own tool auth/approval (fixes the confused-deputy gap flagged on #28983).

- **PR1 (this):** add nullable `userId` FK on `SandboxFunctionInvocationModel` + migration. **Unused** for now, purely additive and deployable on its own.
- **PR2:** populate `userId` at `makeNew` from `auth.user()`.
- **PR3:** enforce resolver == invoker in `resolve-authentication` and `validate-action` via `canCurrentUserRespondToParentUserMessage`.

**Notes:**
- Nullable forever: API-key / scheduled / bot invocations have no human, so it stays nullable (no future non-null backfill).
- `ON DELETE SET NULL`: an invocation is a workspace operation record that should outlive its triggerer. Also required because the action -> invocation FK is `RESTRICT`, so a `CASCADE` from the user would be blocked / bypass GCS cleanup. Same pattern as `resolvedByUserId` / `generatedByUserId`.
- Index on `userId` (single column, not `workspaceId`-first) because it serves the `ON DELETE SET NULL` scan on user deletion, which is not workspace-scoped.

## Tests

- Front TypeScript check
- Migration applied locally, verified column (nullable), index, and FK (`SET NULL`, validated)

## Risk

Worst case, an unused nullable column + index. Safe to rollback.

## Deploy Plan

- [ ] Apply pre-deploy migration
- [ ] Deploy `front`