### PR TITLE
[Admin Gov] Store role names as group_permissions grant types

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1099,7 +1099,7 @@ export class Authenticator {
    * Whether the caller holds a workspace-level capability. A capability is a
    * (grantType, resourceType) pair whose grants live on the type-wide (-1) group_permissions
    * rows. Admins bypass unconditionally (billing/security are admin-by-default). Otherwise we look
-   * for a -1 grant on any of the caller's groups; "*" grants match any verb / type.
+   * for a -1 grant on any of the caller's groups; "*" grants match any grant type / resource type.
    *
    * Cold path: a query per check is fine — no caching yet (pending auth-resolution decision).
    */

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -111,9 +111,9 @@ describe("Authenticator.hasWorkspacePermission", () => {
   });
 
   it("rejects an invalid capability query, even for admins", async () => {
-    // `write` is not a valid verb on `billing`; a wildcard grant must not satisfy it.
+    // `create` is not a valid grant type on `billing`; a wildcard grant must not satisfy it.
     await expect(
-      adminAuth.hasWorkspacePermission("write", "billing")
+      adminAuth.hasWorkspacePermission("create", "billing")
     ).rejects.toThrow(/not allowed/);
   });
 });

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -4,26 +4,27 @@ import {
 } from "@app/lib/resources/group_permission_registry";
 import {
   GRANT_TYPES,
+  GRANT_VERBS,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
 import { describe, expect, it } from "vitest";
 
 describe("assertValidGrant", () => {
   describe("accepts valid combinations", () => {
-    it("instance-level grant with a real resourceId", () => {
+    it("instance-level role (reader) with a real resourceId", () => {
       expect(() =>
         assertValidGrant({
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: 5,
         })
       ).not.toThrow();
     });
 
-    it("instance-level write on an agent (editor role)", () => {
+    it("instance-level role (editor) on an agent", () => {
       expect(() =>
         assertValidGrant({
-          grantType: "write",
+          grantType: "editor",
           resourceType: "agent",
           resourceId: 7,
         })
@@ -40,7 +41,7 @@ describe("assertValidGrant", () => {
       ).not.toThrow();
     });
 
-    it("type-level verb (create) with -1", () => {
+    it("type-level capability (create) with -1", () => {
       expect(() =>
         assertValidGrant({
           grantType: "create",
@@ -82,7 +83,7 @@ describe("assertValidGrant", () => {
   });
 
   describe("rejects invalid combinations", () => {
-    it("verb not allowed on the resource type", () => {
+    it("grant type not a role on the resource type", () => {
       expect(() =>
         assertValidGrant({
           grantType: "invite",
@@ -102,7 +103,7 @@ describe("assertValidGrant", () => {
       ).toThrow(/type-level/);
     });
 
-    it("real resourceId on a type-level verb (create)", () => {
+    it("real resourceId on a type-level capability (create)", () => {
       expect(() =>
         assertValidGrant({
           grantType: "create",
@@ -125,7 +126,7 @@ describe("assertValidGrant", () => {
     it("zero resourceId (neither a real id nor the sentinel)", () => {
       expect(() =>
         assertValidGrant({
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: 0,
         })
@@ -152,10 +153,10 @@ describe("assertValidGrant", () => {
       ).toThrow(/type-level/);
     });
 
-    it("type-wide write on an agent (editor is instance-only)", () => {
+    it("type-wide editor on an agent (editor is instance-only)", () => {
       expect(() =>
         assertValidGrant({
-          grantType: "write",
+          grantType: "editor",
           resourceType: "agent",
           resourceId: WHOLE_TYPE_RESOURCE_ID,
         })
@@ -165,7 +166,7 @@ describe("assertValidGrant", () => {
     it("type-wide grant on a space (space roles are instance-only)", () => {
       expect(() =>
         assertValidGrant({
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: WHOLE_TYPE_RESOURCE_ID,
         })
@@ -195,11 +196,8 @@ describe("ROLE_REGISTRY invariants", () => {
         }
       }
     }
-    // Every concrete verb in the vocabulary ("*" excluded) must be granted by some role.
-    for (const verb of GRANT_TYPES) {
-      if (verb !== "*") {
-        expect(reachable.has(verb)).toBe(true);
-      }
+    for (const verb of GRANT_VERBS) {
+      expect(reachable.has(verb)).toBe(true);
     }
   });
 
@@ -210,6 +208,24 @@ describe("ROLE_REGISTRY invariants", () => {
           expect(role.verbs).toHaveLength(1);
           expect(name).toBe(role.verbs[0]);
         }
+      }
+    }
+  });
+
+  it("keeps the flat GRANT_TYPES vocabulary in sync with the role names", () => {
+    const roleNames = new Set<string>();
+    for (const roles of roleMaps) {
+      for (const name of Object.keys(roles)) {
+        roleNames.add(name);
+      }
+    }
+    // Every role name is a declared grant type, and every grant type ("*" aside) is a real role.
+    for (const name of roleNames) {
+      expect(GRANT_TYPES).toContain(name);
+    }
+    for (const grantType of GRANT_TYPES) {
+      if (grantType !== "*") {
+        expect(roleNames.has(grantType)).toBe(true);
       }
     }
   });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -1,5 +1,6 @@
 import type {
   GrantType,
+  GrantVerb,
   GroupPermissionResourceType,
 } from "@app/types/group_permissions";
 import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
@@ -24,7 +25,6 @@ import assert from "assert";
 
 // Concrete (non-wildcard) vocabulary — the registry describes these.
 type ConcreteResourceType = Exclude<GroupPermissionResourceType, "*">;
-type GrantVerb = Exclude<GrantType, "*">;
 
 // A grant applies either to a specific resource instance (resourceId > 0) or to the whole type
 // (resourceId = -1). A role declares the levels at which it can be granted.
@@ -72,23 +72,6 @@ export const ROLE_REGISTRY: Record<
   },
 };
 
-// Verbs grantable at a level on a resource type = the union of the verbs of the roles valid at that
-// level. Derived (never stored) so the roles stay the single source of truth.
-function verbsForLevel(
-  resourceType: ConcreteResourceType,
-  level: GrantLevel
-): GrantVerb[] {
-  const verbs = new Set<GrantVerb>();
-  for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
-    if (role.levels.includes(level)) {
-      for (const verb of role.verbs) {
-        verbs.add(verb);
-      }
-    }
-  }
-  return [...verbs];
-}
-
 interface GrantSpec {
   grantType: GrantType;
   resourceType: GroupPermissionResourceType;
@@ -111,22 +94,17 @@ export function assertValidGrant({
     return;
   }
 
-  const allowedOnInstance = verbsForLevel(resourceType, "instance").some(
-    (verb) => verb === grantType
-  );
-  const allowedTypeWide = verbsForLevel(resourceType, "type").some(
-    (verb) => verb === grantType
-  );
+  const role = ROLE_REGISTRY[resourceType][grantType];
   assert(
-    allowedOnInstance || allowedTypeWide,
-    `Permission "${grantType}" is not allowed on resource type "${resourceType}".`
+    role,
+    `Grant type "${grantType}" is not allowed on resource type "${resourceType}".`
   );
 
   // Type-wide grant (all resources of the type / an instance-less domain).
   if (resourceId === WHOLE_TYPE_RESOURCE_ID) {
     assert(
-      allowedTypeWide,
-      `Permission "${grantType}" cannot be granted type-wide on "${resourceType}".`
+      role.levels.includes("type"),
+      `Grant type "${grantType}" cannot be granted type-wide on "${resourceType}".`
     );
     return;
   }
@@ -137,7 +115,7 @@ export function assertValidGrant({
     `Instance-level grant on "${resourceType}" requires a positive resourceId or ${WHOLE_TYPE_RESOURCE_ID}, got ${resourceId}.`
   );
   assert(
-    allowedOnInstance,
-    `Permission "${grantType}" on "${resourceType}" is type-level and requires resourceId = ${WHOLE_TYPE_RESOURCE_ID}.`
+    role.levels.includes("instance"),
+    `Grant type "${grantType}" on "${resourceType}" is type-level and requires resourceId = ${WHOLE_TYPE_RESOURCE_ID}.`
   );
 }

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -15,9 +15,10 @@ import assert from "assert";
  * Governance page toggles capabilities one verb at a time; a multi-verb type-level role would make
  * a single toggle revoke verbs it did not touch.
  *
- * The stored grant value is still a plain verb today (see `@app/types/group_permissions`); this
- * registry therefore currently serves to derive the set of valid verbs per (resourceType, level).
- * When grants move to storing the role name, the same definitions drive verb→role expansion.
+ * A grant row stores the role name (see `@app/types/group_permissions`); `assertValidGrant` checks
+ * a grant type is a role defined for its resource type at the required level. Translating a
+ * capability question (a verb) into the roles that grant it — verb→role expansion — is deferred
+ * until an instance-level, multi-verb capability check needs it.
  *
  * The `"*"` wildcards in the vocabulary are intentionally not part of this registry: a wildcard
  * grant applies to the whole type (or all types) and is only ever a type-level (`-1`) grant.

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -25,7 +25,7 @@ describe("GroupPermissionResource", () => {
     it("creates an instance-level grant that is readable", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
@@ -34,7 +34,7 @@ describe("GroupPermissionResource", () => {
         groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
-      expect(grants[0].grantType).toBe("read");
+      expect(grants[0].grantType).toBe("reader");
       expect(grants[0].resourceType).toBe("space");
       expect(grants[0].resourceId).toBe(42);
     });
@@ -42,7 +42,7 @@ describe("GroupPermissionResource", () => {
     it("is idempotent (unique index dedupes)", async () => {
       const spec = {
         group: groupA,
-        grantType: "write" as const,
+        grantType: "editor" as const,
         resourceType: "agent" as const,
         resourceId: 7,
       };
@@ -59,7 +59,7 @@ describe("GroupPermissionResource", () => {
       await expect(
         GroupPermissionResource.grant(auth, {
           group: groupA,
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: -1,
         })
@@ -88,7 +88,7 @@ describe("GroupPermissionResource", () => {
       await expect(
         GroupPermissionResource.grant(auth, {
           group: otherGroup,
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: 5,
         })
@@ -100,13 +100,13 @@ describe("GroupPermissionResource", () => {
     it("returns grants from every requested group", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 1,
       });
       await GroupPermissionResource.grant(auth, {
         group: groupB,
-        grantType: "write",
+        grantType: "member",
         resourceType: "space",
         resourceId: 1,
       });
@@ -134,20 +134,20 @@ describe("GroupPermissionResource", () => {
     it("removes a specific grant only", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 1,
       });
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "write",
+        grantType: "member",
         resourceType: "space",
         resourceId: 1,
       });
 
       await GroupPermissionResource.revoke(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 1,
       });
@@ -156,7 +156,39 @@ describe("GroupPermissionResource", () => {
         groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(1);
-      expect(grants[0].grantType).toBe("write");
+      expect(grants[0].grantType).toBe("member");
+    });
+
+    it("keeps overlapping roles independent on revoke (revoke-collision regression)", async () => {
+      // `member` (read, write) and `admin` (read, write, admin) share verbs. Storing the role name
+      // keeps them as two distinct rows, so revoking `member` cannot destroy the read/write the
+      // group still holds via `admin`. (Under verb storage both roles would collapse onto shared
+      // read/write rows and revoking `member` would delete them.)
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "member",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "admin",
+        resourceType: "space",
+        resourceId: 1,
+      });
+
+      await GroupPermissionResource.revoke(auth, {
+        group: groupA,
+        grantType: "member",
+        resourceType: "space",
+        resourceId: 1,
+      });
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: [groupA.id],
+      });
+      expect(grants).toHaveLength(1);
+      expect(grants[0].grantType).toBe("admin");
     });
   });
 
@@ -164,20 +196,20 @@ describe("GroupPermissionResource", () => {
     it("drops every group's grants for one resource", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 99,
       });
       await GroupPermissionResource.grant(auth, {
         group: groupB,
-        grantType: "write",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 99,
       });
       // A grant on a different resource must survive.
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 100,
       });
@@ -209,13 +241,13 @@ describe("GroupPermissionResource", () => {
     it("drops every grant for the workspace (scrub hook)", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 1,
       });
       await GroupPermissionResource.grant(auth, {
         group: groupB,
-        grantType: "write",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 2,
       });
@@ -249,7 +281,7 @@ describe("GroupPermissionResource", () => {
       expect(grants[0].resourceId).toBe(-1);
     });
 
-    it("rejects a verb the registry does not allow", async () => {
+    it("rejects a grant type the registry does not allow", async () => {
       await expect(
         GroupPermissionResource.grantTypeWide(auth, {
           group: groupA,
@@ -298,19 +330,19 @@ describe("GroupPermissionResource", () => {
         grants: [
           {
             group: groupA,
-            grantType: "read",
+            grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
             group: groupA,
-            grantType: "read",
+            grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
             group: groupA,
-            grantType: "read",
+            grantType: "reader",
             resourceType: "space",
             resourceId: 2,
           },
@@ -329,7 +361,7 @@ describe("GroupPermissionResource", () => {
           grants: [
             {
               group: groupA,
-              grantType: "read",
+              grantType: "reader",
               resourceType: "space",
               resourceId: -1,
             },
@@ -346,7 +378,7 @@ describe("GroupPermissionResource", () => {
 
       const result = await GroupPermissionResource.grantToUser(auth, {
         user: user.toJSON(),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
@@ -358,7 +390,7 @@ describe("GroupPermissionResource", () => {
             groupKinds: ["regular_auto"],
           })
         ).map((group) => group.id),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
@@ -379,13 +411,13 @@ describe("GroupPermissionResource", () => {
 
       await GroupPermissionResource.grantToUser(auth, {
         user: user1.toJSON(),
-        grantType: "write",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 7,
       });
       await GroupPermissionResource.grantToUser(auth, {
         user: user2.toJSON(),
-        grantType: "write",
+        grantType: "editor",
         resourceType: "agent",
         resourceId: 7,
       });
@@ -397,7 +429,7 @@ describe("GroupPermissionResource", () => {
       for (const group of autoGroups) {
         const grants = await GroupPermissionResource.listForGroups(auth, {
           groupModelIds: [group.id],
-          grantType: "write",
+          grantType: "editor",
           resourceType: "agent",
           resourceId: 7,
         });
@@ -416,14 +448,14 @@ describe("GroupPermissionResource", () => {
 
       await GroupPermissionResource.grantToUser(auth, {
         user: user.toJSON(),
-        grantType: "read",
+        grantType: "editor",
         resourceType: "skill",
         resourceId: 99,
       });
 
       const result = await GroupPermissionResource.revokeFromUser(auth, {
         user: user.toJSON(),
-        grantType: "read",
+        grantType: "editor",
         resourceType: "skill",
         resourceId: 99,
       });
@@ -434,7 +466,7 @@ describe("GroupPermissionResource", () => {
       });
       const grants = await GroupPermissionResource.listForGroups(auth, {
         groupModelIds: autoGroups.map((group) => group.id),
-        grantType: "read",
+        grantType: "editor",
         resourceType: "skill",
         resourceId: 99,
       });
@@ -449,20 +481,20 @@ describe("GroupPermissionResource", () => {
 
       await GroupPermissionResource.grantToUser(auth, {
         user: user1.toJSON(),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 5,
       });
       await GroupPermissionResource.grantToUser(auth, {
         user: user2.toJSON(),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 5,
       });
 
       const result = await GroupPermissionResource.revokeFromUser(auth, {
         user: user1.toJSON(),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 5,
       });
@@ -474,7 +506,7 @@ describe("GroupPermissionResource", () => {
             groupKinds: ["regular_auto"],
           })
         ).map((group) => group.id),
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 5,
       });
@@ -498,28 +530,28 @@ describe("GroupPermissionResource", () => {
       }
 
       await GroupPermissionResource.grantToEverybody(auth, {
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
         groupModelIds: [globalGroup.id],
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
       expect(grants).toHaveLength(1);
 
       await GroupPermissionResource.revokeFromEverybody(auth, {
-        grantType: "read",
+        grantType: "reader",
         resourceType: "space",
         resourceId: 42,
       });
       expect(
         await GroupPermissionResource.listForGroups(auth, {
           groupModelIds: [globalGroup.id],
-          grantType: "read",
+          grantType: "reader",
           resourceType: "space",
           resourceId: 42,
         })

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -1,22 +1,37 @@
 /**
  * Vocabulary for the `group_permissions` table (Admin Governance §1A).
  *
- * All permission grants — resource-level access (spaces, agents, skills) and workspace-level
- * capabilities (billing, identity, …) — live in a single table keyed by a plain-verb
- * `grantType`, a `resourceType`, and a numeric `resourceId`. The validity of a given
- * (grantType, resourceType, resourceId) combination is enforced by the registry in
- * `@app/lib/resources/group_permission_registry`; this file only defines the raw vocabulary and
- * the "whole type" sentinel.
+ * A grant row stores a registry-defined *grant type* — a role such as `member`/`editor`, or a
+ * singleton capability such as `create`/`use` — for a `resourceType` and a numeric `resourceId`.
+ * Which roles are valid for a (grantType, resourceType, resourceId) combination, and the verbs each
+ * role grants, are defined by the registry in `@app/lib/resources/group_permission_registry`. This
+ * file defines the raw vocabulary and the "whole type" sentinel.
  */
 
-// Plain verbs. "*" means "all verbs".
-export const GRANT_TYPES = [
+// Verbs are the granular capabilities a role grants. They are never stored — roles map to them in
+// the registry, and capability questions are expressed in verbs.
+export const GRANT_VERBS = [
   "read",
   "write",
   "admin",
   "create",
   "publish",
   "invite",
+  "use",
+] as const;
+export type GrantVerb = (typeof GRANT_VERBS)[number];
+
+// Grant types are the registry-defined role names stored in a grant row. "*" means "all grant
+// types". Each role's verbs and levels live in the registry.
+export const GRANT_TYPES = [
+  "reader",
+  "member",
+  "admin",
+  "editor",
+  "create",
+  "publish",
+  "invite",
+  "read",
   "use",
   "*",
 ] as const;
@@ -37,9 +52,10 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
 export type GroupPermissionResourceType =
   (typeof GROUP_PERMISSION_RESOURCE_TYPES)[number];
 
-// `resourceId = -1` means "the type as a whole": for instance-level verbs, all resources of the
-// type; for type-level verbs (e.g. "create"), the only sensible value. There is deliberately no
-// NULL anywhere — one meaning, one representation — and the unique index dedupes wildcard rows.
+// `resourceId = -1` means "the type as a whole": for instance-level roles, all resources of the
+// type; for type-level roles (e.g. the `create` capability), the only sensible value. There is
+// deliberately no NULL anywhere — one meaning, one representation — and the unique index dedupes
+// wildcard rows.
 export const WHOLE_TYPE_RESOURCE_ID = -1;
 
 export function isGrantType(value: unknown): value is GrantType {


### PR DESCRIPTION
## Description

Switches what a `group_permissions` grant row stores from a plain **verb** to a registry-defined
**role name**. Follows #29047 (which reshaped the registry into role definitions).

- **Vocabulary** (`types/group_permissions.ts`): split into two sets.
  - `GRANT_VERBS` — the granular capabilities (`read`/`write`/`admin`/`create`/`publish`/`invite`/`use`).
    Never stored; used only to describe what a role grants and to ask capability questions.
  - `GRANT_TYPES` — the role names actually stored: `reader`/`member`/`admin` (space), `editor`
    (agent+skill), and the singleton capabilities `create`/`publish`/`invite`/`admin`/`read`/`use`
    (+ `"*"`).
- **Validation** (`group_permission_registry.ts`): `assertValidGrant` now checks the grant type is a
  role defined for the resource type at the required level (instance vs type-wide), instead of
  deriving a verb set.

**No schema change and no live-writer change.** The only grant types stored today are singletons —
`models_tier` writes `use`; the governance capabilities are `create`/`publish`/`invite`/`admin` —
whose role name equals the verb, so their stored values are unchanged.

### Why this matters (revoke-collision)

Additive multi-grant is a design invariant: a group can hold more than one role on the same
resource. Storing the role name keeps overlapping roles as distinct rows, so revoking one never
destroys verbs the group still holds via another (e.g. revoking `member` leaves an `admin` grant —
and its `read`/`write` — intact). Under verb storage those roles would collapse onto shared
`read`/`write` rows and revoking `member` would delete them. Adds a regression test for exactly this.

### Deferred

Verb→role expansion at check time is intentionally **not** in this PR. The only check today,
`auth.hasWorkspacePermission`, is type-wide, and every type-level role is a singleton (name == verb),
so it matches the stored value directly with no expansion. Expansion arrives with the first
instance-level, multi-verb capability check that needs it.

## Risks

Blast radius: `group_permissions` grant validation and the stored grant-type vocabulary. No schema
change; no change to any live writer's stored values.
Risk: low

## Deploy Plan

- deploy front + front-sse (no migration)