### PR TITLE
mcp file utils: fall back to FileResource when a canonical scoped path is missing from GCS

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -42,6 +42,8 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
     DustFileSystem: {
       ...actual.DustFileSystem,
       fromScopedPath: mockFromScopedPath,
+      // Class statics are non-enumerable, so the spread above does not carry them over.
+      normalizeScopedPath: actual.DustFileSystem.normalizeScopedPath,
     },
   };
 });
@@ -110,7 +112,7 @@ describe("getFileFromConversationAttachment", () => {
     });
 
     it("returns Err when the file is not found", async () => {
-      const { authenticator: auth } = await createResourceTest({
+      const { authenticator: auth, workspace } = await createResourceTest({
         role: "admin",
       });
 
@@ -127,7 +129,7 @@ describe("getFileFromConversationAttachment", () => {
           toMountFilePath: vi
             .fn()
             .mockReturnValue(
-              `w/unknown/conversations/${conversation.sId}/files/missing.pdf`
+              `w/${workspace.sId}/conversations/${conversation.sId}/files/missing.pdf`
             ),
         })
       );
@@ -462,7 +464,7 @@ describe("resolveConversationFileRef", () => {
     });
 
     it("returns Err when the file is not found", async () => {
-      const { authenticator: auth } = await createResourceTest({
+      const { authenticator: auth, workspace } = await createResourceTest({
         role: "admin",
       });
 
@@ -478,7 +480,7 @@ describe("resolveConversationFileRef", () => {
           toMountFilePath: vi
             .fn()
             .mockReturnValue(
-              `w/unknown/conversations/${conversation.sId}/files/missing.png`
+              `w/${workspace.sId}/conversations/${conversation.sId}/files/missing.png`
             ),
         })
       );
@@ -539,6 +541,41 @@ describe("resolveConversationFileRef", () => {
       expect(result.value.fileName).toBe("photo.png");
       expect(typeof result.value.getSignedUrl).toBe("function");
       expect(typeof result.value.createReadStream).toBe("function");
+    });
+
+    it("normalizes the scoped path before mapping it to a mount file path", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const toMountFilePath = vi
+        .fn()
+        .mockReturnValue(
+          `w/${workspace.sId}/conversations/${conversation.sId}/files/missing.png`
+        );
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi.fn().mockResolvedValue(new Ok(null)),
+          toMountFilePath,
+        })
+      );
+
+      const result = await resolveConversationFileRef(
+        auth,
+        `conversation-${conversation.sId}/dir/../missing.png`,
+        undefined
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(toMountFilePath).toHaveBeenCalledWith(
+        `conversation-${conversation.sId}/missing.png`
+      );
     });
   });
 

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -124,6 +124,11 @@ describe("getFileFromConversationAttachment", () => {
         new Ok({
           stat: vi.fn().mockResolvedValue(new Ok(null)),
           read: vi.fn(),
+          toMountFilePath: vi
+            .fn()
+            .mockReturnValue(
+              `w/unknown/conversations/${conversation.sId}/files/missing.pdf`
+            ),
         })
       );
 
@@ -138,6 +143,57 @@ describe("getFileFromConversationAttachment", () => {
         return;
       }
       expect(result.error).toContain("not found");
+    });
+
+    it("falls back to the FileResource when the GCS mount object is missing", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      // A ready conversation file claims its mount path on creation, but the GCS object at
+      // that path may be missing (user uploads are stored at the FileResource canonical key).
+      const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+        contentType: "application/pdf",
+        fileName: "report.pdf",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+      expect(file.mountFilePath).not.toBeNull();
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi.fn().mockResolvedValue(new Ok(null)),
+          read: vi.fn(),
+          toMountFilePath: vi.fn().mockReturnValue(file.mountFilePath),
+        })
+      );
+
+      const expectedContent = "pdf bytes";
+      vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
+        makeReadableStream(expectedContent)
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        `conversation-${conversation.sId}/report.pdf`,
+        makeToolContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.buffer.toString()).toBe(expectedContent);
+      expect(result.value.contentType).toBe("application/pdf");
+      expect(result.value.filename).toBe("report.pdf");
     });
 
     it("returns Err when fromScopedPath fails", async () => {
@@ -419,6 +475,11 @@ describe("resolveConversationFileRef", () => {
       mockFromScopedPath.mockResolvedValue(
         new Ok({
           stat: vi.fn().mockResolvedValue(new Ok(null)),
+          toMountFilePath: vi
+            .fn()
+            .mockReturnValue(
+              `w/unknown/conversations/${conversation.sId}/files/missing.png`
+            ),
         })
       );
 
@@ -433,6 +494,51 @@ describe("resolveConversationFileRef", () => {
         return;
       }
       expect(result.error).toContain("not found");
+    });
+
+    it("falls back to the FileResource when the GCS mount object is missing", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+        contentType: "image/png",
+        fileName: "photo.png",
+        fileSize: 512,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+      expect(file.mountFilePath).not.toBeNull();
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi.fn().mockResolvedValue(new Ok(null)),
+          toMountFilePath: vi.fn().mockReturnValue(file.mountFilePath),
+        })
+      );
+
+      const result = await resolveConversationFileRef(
+        auth,
+        `conversation-${conversation.sId}/photo.png`,
+        undefined // canonical paths do not need toolContext
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.contentType).toBe("image/png");
+      expect(result.value.sizeBytes).toBe(512);
+      expect(result.value.fileName).toBe("photo.png");
+      expect(typeof result.value.getSignedUrl).toBe("function");
+      expect(typeof result.value.createReadStream).toBe("function");
     });
   });
 

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -10,6 +10,7 @@ import {
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { DustFileSystem } from "@app/lib/api/file_system";
+import { fetchLinkedFileResource } from "@app/lib/api/files/file_system_ops";
 import {
   isCanonicalScopedPath,
   parseScopedFilePath,
@@ -24,7 +25,6 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import assert from "assert";
-import minBy from "lodash/minBy";
 import { PassThrough } from "stream";
 
 export function sanitizeFilename(filename: string): string {
@@ -50,52 +50,27 @@ export type ConversationFileRef = {
  * User-uploaded conversation files are stored at their FileResource canonical key
  * (files/w/{wId}/{fileId}/...) and may never have been copied to the deterministic mount path
  * DustFileSystem reads from, even though the model was shown the canonical scoped path (it is
- * rendered from `FileResource.mountFilePath`). Map the scoped path back to the FileResource
- * through its claimed mount path so content can be served from the original version.
+ * rendered from `FileResource.mountFilePath`). Serve such files from the linked FileResource's
+ * original version.
  *
- * A mount copy deleted via the files tool also resolves here (the FileResource row keeps its
- * mount path), matching how legacy fileId references behave after such a deletion.
+ * A file whose mount copy was deleted also resolves here — it is still a live conversation
+ * attachment, referenced and servable through its legacy fileId.
  */
-// TODO(FILE SYSTEM MIGRATION): Revisit once FileResource is decoupled from mount paths (this
-// relies on toMountFilePath, which is slated for removal).
 async function findFileForCanonicalScopedPath(
   auth: Authenticator,
   fs: DustFileSystem,
   scopedPath: string
 ): Promise<FileResource | null> {
-  // stat() resolves the normalized path; translate the same shape so both lookups agree on
-  // inputs containing `.` or `..` segments.
+  // stat() resolves the normalized path; look up the same shape so inputs containing `.` or
+  // `..` segments cannot diverge between the two lookups.
   const normalizedPath =
     DustFileSystem.normalizeScopedPath(scopedPath) ?? scopedPath;
 
-  const mountFilePath = fs.toMountFilePath(normalizedPath);
-  if (!mountFilePath) {
-    return null;
-  }
-
-  // Stored mount paths may differ in Unicode normalization from what the model echoes back
-  // (see resolveFile). Try the path as-is, then NFC, then NFD.
-  const candidates = [
-    ...new Set([
-      mountFilePath,
-      mountFilePath.normalize("NFC"),
-      mountFilePath.normalize("NFD"),
-    ]),
-  ];
+  const linkedFile = await fetchLinkedFileResource(auth, fs, normalizedPath);
 
   // A file that never finished uploading may have claimed a mount path without its original
   // version being written; only ready files are servable.
-  const files = (
-    await FileResource.fetchByMountFilePaths(auth, candidates)
-  ).filter((f) => f.isReady);
-
-  const exactMatch = files.find((f) => f.mountFilePath === mountFilePath);
-  if (exactMatch) {
-    return exactMatch;
-  }
-
-  // Only a normalization variant matched; pick deterministically.
-  return minBy(files, (f) => f.id) ?? null;
+  return linkedFile?.isReady ? linkedFile : null;
 }
 
 function makeFileRefFromResource(

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -44,6 +44,55 @@ export type ConversationFileRef = {
 };
 
 /**
+ * Fallback resolution for canonical scoped paths whose GCS mount object is missing.
+ *
+ * User-uploaded conversation files are stored at their FileResource canonical key
+ * (files/w/{wId}/{fileId}/...) and may never have been copied to the deterministic mount path
+ * DustFileSystem reads from, even though the model was shown the canonical scoped path (it is
+ * rendered from `FileResource.mountFilePath`). Map the scoped path back to the FileResource
+ * through its claimed mount path so content can be served from the original version.
+ */
+async function findFileForCanonicalScopedPath(
+  auth: Authenticator,
+  fs: DustFileSystem,
+  scopedPath: string
+): Promise<FileResource | null> {
+  const mountFilePath = fs.toMountFilePath(scopedPath);
+  if (!mountFilePath) {
+    return null;
+  }
+
+  // Stored mount paths may differ in Unicode normalization from what the model echoes back
+  // (see resolveFile). Try the path as-is, then NFC, then NFD.
+  const candidates = [
+    ...new Set([
+      mountFilePath,
+      mountFilePath.normalize("NFC"),
+      mountFilePath.normalize("NFD"),
+    ]),
+  ];
+
+  const files = await FileResource.fetchByMountFilePaths(auth, candidates);
+  return (
+    files.find((f) => f.mountFilePath === mountFilePath) ?? files[0] ?? null
+  );
+}
+
+function makeFileRefFromResource(
+  auth: Authenticator,
+  fileResource: FileResource
+): ConversationFileRef {
+  return {
+    contentType: fileResource.contentType,
+    sizeBytes: fileResource.fileSize,
+    fileName: sanitizeFilename(fileResource.fileName),
+    getSignedUrl: () => fileResource.getSignedUrlForDownload(auth, "original"),
+    createReadStream: () =>
+      fileResource.getReadStream({ auth, version: "original" }),
+  };
+}
+
+/**
  * Resolve a conversation file (scoped path or legacy fileId) to its metadata
  * and lazy GCS accessors, without reading its content.
  *
@@ -69,7 +118,16 @@ export async function resolveConversationFileRef(
       return new Err(statResult.error.message);
     }
     if (!statResult.value) {
-      return new Err(`File not found: \`${fileId}\`.`);
+      const fileResource = await findFileForCanonicalScopedPath(
+        auth,
+        fs,
+        fileId
+      );
+      if (!fileResource) {
+        return new Err(`File not found: \`${fileId}\`.`);
+      }
+
+      return new Ok(makeFileRefFromResource(auth, fileResource));
     }
 
     const { contentType, sizeBytes } = statResult.value;
@@ -137,14 +195,7 @@ export async function resolveConversationFileRef(
     return new Err(`File ${fileId} does not belong to this conversation`);
   }
 
-  return new Ok({
-    contentType: fileResource.contentType,
-    sizeBytes: fileResource.fileSize,
-    fileName: sanitizeFilename(fileResource.fileName),
-    getSignedUrl: () => fileResource.getSignedUrlForDownload(auth, "original"),
-    createReadStream: () =>
-      fileResource.getReadStream({ auth, version: "original" }),
-  });
+  return new Ok(makeFileRefFromResource(auth, fileResource));
 }
 
 /**
@@ -190,7 +241,27 @@ export async function getFileFromConversationAttachment(
       return new Err(statResult.error.message);
     }
     if (!statResult.value) {
-      return new Err(`File not found: \`${fileId}\`.`);
+      const fileResource = await findFileForCanonicalScopedPath(
+        auth,
+        fs,
+        fileId
+      );
+      if (!fileResource) {
+        return new Err(`File not found: \`${fileId}\`.`);
+      }
+
+      const bufferResult = await streamToBuffer(
+        fileResource.getReadStream({ auth, version: "original" })
+      );
+      if (bufferResult.isErr()) {
+        return new Err(bufferResult.error);
+      }
+
+      return new Ok({
+        buffer: bufferResult.value,
+        filename: sanitizeFilename(fileResource.fileName),
+        contentType: fileResource.contentType,
+      });
     }
 
     const readResult = await fs.read(fileId);

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -24,6 +24,7 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import assert from "assert";
+import minBy from "lodash/minBy";
 import { PassThrough } from "stream";
 
 export function sanitizeFilename(filename: string): string {
@@ -51,13 +52,23 @@ export type ConversationFileRef = {
  * DustFileSystem reads from, even though the model was shown the canonical scoped path (it is
  * rendered from `FileResource.mountFilePath`). Map the scoped path back to the FileResource
  * through its claimed mount path so content can be served from the original version.
+ *
+ * A mount copy deleted via the files tool also resolves here (the FileResource row keeps its
+ * mount path), matching how legacy fileId references behave after such a deletion.
  */
+// TODO(FILE SYSTEM MIGRATION): Revisit once FileResource is decoupled from mount paths (this
+// relies on toMountFilePath, which is slated for removal).
 async function findFileForCanonicalScopedPath(
   auth: Authenticator,
   fs: DustFileSystem,
   scopedPath: string
 ): Promise<FileResource | null> {
-  const mountFilePath = fs.toMountFilePath(scopedPath);
+  // stat() resolves the normalized path; translate the same shape so both lookups agree on
+  // inputs containing `.` or `..` segments.
+  const normalizedPath =
+    DustFileSystem.normalizeScopedPath(scopedPath) ?? scopedPath;
+
+  const mountFilePath = fs.toMountFilePath(normalizedPath);
   if (!mountFilePath) {
     return null;
   }
@@ -72,10 +83,19 @@ async function findFileForCanonicalScopedPath(
     ]),
   ];
 
-  const files = await FileResource.fetchByMountFilePaths(auth, candidates);
-  return (
-    files.find((f) => f.mountFilePath === mountFilePath) ?? files[0] ?? null
-  );
+  // A file that never finished uploading may have claimed a mount path without its original
+  // version being written; only ready files are servable.
+  const files = (
+    await FileResource.fetchByMountFilePaths(auth, candidates)
+  ).filter((f) => f.isReady);
+
+  const exactMatch = files.find((f) => f.mountFilePath === mountFilePath);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  // Only a normalization variant matched; pick deterministically.
+  return minBy(files, (f) => f.id) ?? null;
 }
 
 function makeFileRefFromResource(


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9648.

MCP tools (gmail, google_drive, jira, microsoft_drive, outlook, slack, file_generation, image_generation) fail with `File not found` when the model references a **user-uploaded** conversation file by its **canonical scoped path** (`conversation-{id}/report.pptx`).

**Root cause:** the model sees canonical scoped paths because content fragments render `path` from `FileResource.mountFilePath` — but user uploads are stored at the FileResource canonical key (`files/w/{wId}/{fileId}/...`) and may never have been copied to the deterministic mount path `DustFileSystem` reads from. `resolveConversationFileRef` and `getFileFromConversationAttachment` resolved canonical paths exclusively through the `DustFileSystem` stat, so the miss returned `File not found` without ever trying the pre-existing `FileResource`-based resolution (regression from `#26375`, which added the canonical-path branch without a fallback).

**What this PR does:**

1. On a canonical-path stat miss, resolve the linked `FileResource` via the existing `fetchLinkedFileResource` helper (`lib/api/files/file_system_ops.ts`, same bridge the files move tool uses) and serve the original version from there. Only ready files are served; a genuine miss keeps the original `File not found` error.
2. Normalize the scoped path before the lookup, so the fallback resolves the same key `stat()` just missed on inputs with `.`/`..` segments.
3. Drive-by 🚗: extract `makeFileRefFromResource` so the fallback and the legacy fileId branch share the ref shape.

> [!NOTE]
> The native `files` tool and the `/files/path/[...canonicalPath]` route read through `DustFileSystem` directly and have the same gap — intentionally out of scope here, follow-up to be filed.

Confirmed in prod logs (workspace `35WFegvIrd`, conversation `wRRqT5Izdf`): `microsoft_drive__upload_file` and the native `files` tool both fail on the same canonical path.

## Tests

- New functional tests for the fallback in both functions (real factory-created files whose mount path is claimed in the DB but absent from GCS), plus a test that the path is normalized before translation.
- Existing genuine-miss tests still assert `File not found`.
- `npx tsgo --noEmit` + `npx biome check` clean.

## Risk

Worst case, a canonical path whose GCS mount copy was deleted via `files__delete` resolves to the original version instead of `File not found`. This is consistent with existing behavior, not a resurrection: `files__delete` only removes the GCS object (the `FileResource` row and the content fragment remain), so the file is still a live conversation attachment and legacy `fil_xxx` references already serve it. The coherent fix for delete semantics is wiring the existing-but-uncalled `deleteCanonicalFile` (which deletes the linked `FileResource`) into the delete tool — follow-up, out of scope here. Safe to rollback.

## Deploy Plan

- [ ] Deploy front
