### PR TITLE
Sandbox functions: record the initiating user on invocations

### DIFF
--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -2,6 +2,7 @@ import { formatSandboxFunctionInvocations } from "@app/lib/api/actions/servers/s
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -210,6 +211,35 @@ describe("SandboxFunctionInvocationResource", () => {
       { sandboxFunction, invocationId: invocation.sId }
     );
     expect(refetched?.input).toEqual({ message: "hello" });
+  });
+
+  it("records the initiating user", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    expect(invocation.userId).toBe(authenticator.user()?.id);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.userId).toBe(authenticator.user()?.id);
+  });
+
+  it("stores a null user for userless origins", async () => {
+    const { authenticator, sandboxFunction } = await setupExecutionTest();
+
+    // A userless workspace auth (e.g. public API key run) has no user to attribute.
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      authenticator.getNonNullableWorkspace().sId
+    );
+    expect(userlessAuth.user()).toBeNull();
+
+    const invocation = await SandboxFunctionInvocationResource.makeNew(
+      userlessAuth,
+      { sandboxFunction, input: undefined }
+    );
+    expect(invocation.userId).toBeNull();
   });
 
   it("rejects unsupported stored data versions", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -349,6 +349,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         {
           workspaceId: auth.getNonNullableWorkspace().id,
           sandboxFunctionId: sandboxFunction.id,
+          // Null when the invocation has no human origin (e.g. public API key runs, slack/email
+          // bot messages). Scheduled triggers carry their editor's user, so they are not null.
+          userId: auth.user()?.id ?? null,
           status: "created",
           // The final path contains the database-generated invocation sId. This placeholder is
           // replaced in the same transaction before the row becomes visible.


### PR DESCRIPTION
## Description

Second of 3 PRs adding the initiating user to sandbox function invocations (follow-up to the PR1 column add), so PR3 can enforce that only the invoker resolves their own tool auth/approval (fixes the confused-deputy gap flagged on #28983).

- PR1: add nullable `userId` FK + migration (unused).
- **PR2 (this):** populate `userId` at invocation creation.
- PR3: enforce resolver == invoker in `resolve-authentication` and `validate-action`.

`makeNew` now writes `userId: auth.user()?.id ?? null` on the created invocation. Human-initiated runs (UI, session `POST /invocations`) capture the invoker. It's null when there's no human origin — notably public API-key agent runs (which execute tools with a null user) and slack/email bot messages. Scheduled triggers carry their editor's user, so they're not null. Stays nullable forever.

No read path added yet: the resource already surfaces model columns via `ReadonlyAttributesType`, so `invocation.userId` is readable for PR3 without a getter.

## Tests

- New resource test asserting `userId` matches the invoker and survives a refetch
- New resource test asserting a userless origin (public API-key style auth) stores a null `userId`
- Full `sandbox_function_invocation_resource` test file green (9/9)
- Front TypeScript check

## Risk

Worst case, invocations get a `userId` written but nothing reads it yet. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front` (PR1 migration already applied)