### PR TITLE
feat(front): attach files to code-defined skills; ship activation pod Frame template

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -8,7 +8,7 @@ const {
   mockBatchFetchUsedBySkills,
   mockFetchByName,
   mockFetchByIds,
-  mockGetFileAttachments,
+  mockHasFiles,
   mockListForAgentLoop,
   mockLoadSkillFilesToConversation,
 } = vi.hoisted(() => ({
@@ -16,7 +16,7 @@ const {
   mockBatchFetchUsedBySkills: vi.fn(),
   mockFetchByName: vi.fn(),
   mockFetchByIds: vi.fn(),
-  mockGetFileAttachments: vi.fn(),
+  mockHasFiles: vi.fn(),
   mockListForAgentLoop: vi.fn(),
   mockLoadSkillFilesToConversation: vi.fn(),
 }));
@@ -69,7 +69,7 @@ describe("skill_management enable_skill tool", () => {
   } = { content: [], sId: "conversation-id" };
   const skill = {
     enableForAgent: mockEnableForAgent,
-    getFileAttachments: mockGetFileAttachments,
+    hasFiles: mockHasFiles,
     name: "commit",
     sId: "skill-id",
   };
@@ -91,7 +91,7 @@ describe("skill_management enable_skill tool", () => {
     mockFetchByName.mockResolvedValue(null);
     mockFetchByIds.mockResolvedValue([]);
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: false });
-    mockGetFileAttachments.mockReturnValue([{ fileName: "SKILL.md" }]);
+    mockHasFiles.mockReturnValue(true);
     mockLoadSkillFilesToConversation.mockResolvedValue(
       new Ok({
         loadedPaths: ["conversation-conversation-id/skills/commit/SKILL.md"],
@@ -156,7 +156,7 @@ describe("skill_management enable_skill tool", () => {
   });
 
   it("skips file loading when the skill has no attachments", async () => {
-    mockGetFileAttachments.mockReturnValue([]);
+    mockHasFiles.mockReturnValue(false);
 
     const result = await getTool().handler(
       { skillName: "commit" },

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -144,10 +144,11 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       ]);
     }
 
-    // Copy the skill's file attachments into the conversation file system so they are visible to
-    // both the files tools and the sandbox (when one exists).
+    // Copy the skill's files into the conversation file system so they are visible to both the
+    // files tools and the sandbox (when one exists). Covers both custom-skill attachments and
+    // code-defined skill files.
     let fileMessage: string | null = null;
-    if (skill.getFileAttachments().length > 0) {
+    if (skill.hasFiles()) {
       const fileLoadResult = await loadSkillFilesToConversation(auth, {
         skill,
         conversation,

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -3,10 +3,25 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { Ok, type Result } from "@app/types/shared/result";
+import type { Readable } from "stream";
+
+// A skill file ready to be written into a conversation, regardless of whether it
+// came from a database-backed `FileResource` (custom skills) or was declared
+// inline by a code-defined skill.
+type WritableSkillFile = {
+  fileName: string;
+  contentType: string;
+  content: Readable | string;
+};
 
 /**
- * Copy a skill's file attachments into the conversation's file system under
+ * Copy a skill's files into the conversation's file system under
  * `skills/{skillName}/{fileName}` (skill names are unique per workspace).
+ *
+ * This handles both file sources uniformly: database-backed `FileResource`
+ * attachments (custom skills) and inline files declared by code-defined skills.
+ * From the model's, the `files__*` tools', and the sandbox's point of view they
+ * are indistinguishable once written.
  *
  * Writing through DustFileSystem (rather than the sandbox filesystem) makes the files visible
  * everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
@@ -26,8 +41,20 @@ export async function loadSkillFilesToConversation(
     conversation: ConversationWithoutContentType;
   }
 ): Promise<Result<{ loadedPaths: string[] }, Error>> {
-  const fileAttachments = skill.getFileAttachments();
-  if (fileAttachments.length === 0) {
+  const files: WritableSkillFile[] = [
+    ...skill.getFileAttachments().map((file) => ({
+      fileName: file.fileName,
+      contentType: file.contentType,
+      content: file.getReadStream({ auth, version: "original" }),
+    })),
+    ...skill.getCodeDefinedFiles().map((file) => ({
+      fileName: file.fileName,
+      contentType: file.contentType,
+      content: file.content,
+    })),
+  ];
+
+  if (files.length === 0) {
     return new Ok({ loadedPaths: [] });
   }
 
@@ -47,12 +74,12 @@ export async function loadSkillFilesToConversation(
 
   const loadedPaths: string[] = [];
 
-  for (const file of fileAttachments) {
+  for (const file of files) {
     const scopedPath = `${conversationMount.scopedPrefix}/skills/${skill.name}/${file.fileName}`;
 
     const writeResult = await fileSystem.write(
       scopedPath,
-      file.getReadStream({ auth, version: "original" }),
+      file.content,
       file.contentType
     );
     if (writeResult.isErr()) {

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -88,15 +88,17 @@ For data to use:
 
 ### First Ever Pod Message
 
-If this is not the case, move to Stage 1 prior to giving a customer response.
+Sent only on the first session in a new Pod. If this is not the case, move to Stage 1 prior to giving a customer response.
+It is possible the user has existing recommendations from other Pods, but you should still start fresh.
 
-Sent only on the first session in a new Pod. It is possible the user has existing recommendations from other Pods, but you should still start fresh.
 The turn arrives with zero context on the user's side — they did not ask for this, and a recommendation dropped in cold is disorienting. This one message MUST be extremely friendly and welcoming, and flow in this order:
-1. A warm welcome — greet the user by name, in plain human language, zero jargon and zero pressure: this space works for them, you looked at how they and their workspace use Dust, and you're here to help them get more out of it. Nothing is required of them.
-2. Explain what a Dust "Frame" is in plain words
-3. ALWAYS end the message with 3 \`:quickReply\` directives (not \`askQuestion\`):
-   - 2 quickReply options that represent real recommendations. Both generated with the same logic define in the Stage 1 section below.
-   - 1 quickReply option asking if the user wants the agent to Scan their personal data. Leads into the Scan path. Make this friendly and avoid making this sound jarring from a security perspective.
+1. Greet the user with the mention directive :mention_user[name]{sId=xxx}.
+2. Explain all the related Dust concepts, especially the Pod and Frame, in a way that is easy to understand and not jargon-heavy. Use the Dust Support skill to generate the content.
+3. Tell the user in a clear way that you are here to help them get more value from Dust. You don't know their day-to-day work or working habits yet, but you are excited to learn them. To start, you've taken a first guess at a use case relevant to their role (explain where that guess came from). If it's relevant accept the action card. Otherwise, select the option below to go through a quick Q/A session to help you understand their work better. If you would like, we can scan your connected sources (typically Slack, Gmail, Calendar) to find their real repetitive automatically.
+4. Generate one action card with the recommendation from the Stage 1 section below.
+5. Use the quick reply format (":quickReply[Label]{message="message to send"}") to provide the following options: 
+   - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
+   - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
 
 ## Stage 1 — Recommend
 

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -3,11 +3,13 @@ import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/confi
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ACTIVATION_POD_FRAME_TEMPLATE } from "@app/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
+import { frameContentType } from "@app/types/files";
 import { isJobType, JOB_TYPE_LABELS } from "@app/types/job_type";
 import { isStringArray } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
@@ -70,53 +72,18 @@ ALWAYS check the sources below to get an understanding of the workspace and user
 3. If a Pod ID is present, call \`list_conversations\` with \`includeMessages=false\` to scan recent Pod conversations. The conversation titles will help indicate what the user is currently working on. Avoid calling with \`includeMessages=true\` unless there is a specific reason to do so as this will bloat the context window.
 4. Only if you are creating the new Frame, use \`/Exa People And Company\` look up the user by name + company to source the public profile facts. This will allow to get a broader understanding of the user experience and job. 
 
-### Pod Frame
+### Pod Overview Frame
 
-#### Design
-- One Frame
-- Two swipeable slides (prev/next arrows + dot indicators + touch swipe + keyboard left/right arrow keys, with the frame focusable so arrows work on click or tab focus)
-- Hard height budget: 300px is the absolute maximum. Never rely on vertical scrolling.
-- Fill the space: content stretches to 100% of the frame width and uses the full height budget; large blank regions are a rendering defect.
-- Title it something non-technical, i.e. "Your Dust Use Cases".
-- Sleek, restrained, small type (7–12px)
-- Structural neutrals plus one accent color per audience tab
-- A second accent reserved for recommendations.
-- Real data only
+You have access to a template at \`skills/Activation/pod_frame_template.tsx\`. ALWAYS build the pod overview Frame from this template — never write Frame code from scratch.
+This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case.
 
-##### Slide 1
-- Two-line header: Description of the Pod/Frame, what data was used to build it.
-- Directly under the header, a slim identity strip: name, role/user type, one source pill
-- What we noticed section on the left: 2–3 most relevant work patterns as plain sentences in the user's own vocabulary ("you rebuild a pipeline summary from HubSpot most Mondays"), each with a source pill (your usage / workspace activity / public profile). This is the evidence layer that makes the recommendations credible.
-- Next steps section on the right: the 2–3 evidence-backed recommendations with a one-line payoff naming the concrete outcome ("→ your Monday summary, ready before you sit down")
-
-##### Slide 2 (The Use-Case Map)
-
-One dense grid answering "what is Dust used for — by me, by people like me, by my company?". Everything relevant is visible at once: no click-to-reveal, no hidden content, no scrolling. Two levels of data:
-- Areas — 3-10 most relevant/impactful areas of work (e.g. "Pipeline & forecasting", "Hiring"), each a group in the grid.
-- Use cases — the concrete recurring jobs inside each area (e.g. "Weekly pipeline digest"), each a chip inside its group. Merge near-duplicate use cases into one chip rather than listing variants.
-
-Whose usage the map shows is controlled by the audience tab. Each tab has its own accent color and its own data source:
-
-- You — from get_personal_usage: cluster the user's ranked skills and tools into areas and use cases.
-- People like you — the standard use cases for the user's job type, from the provided templates and search_agent_templates, enriched with workspace trending skills that match. This tab must NEVER be empty or a placeholder: when no personal or workspace signal exists, build the full grid from the agent template results alone.
-- Your company — from get_workspace_activity: real use cases carrying their 30-day message counts, grouped into areas inferred from their names; label the grouping as inferred.
-
-Layout blueprint — follow exactly, do not improvise:
-- Header line: the slide's one-line explainer on the left (12px, muted); the audience tab on the right as a compact segmented control (11px, three options, no full-width track). Switching tabs re-renders the grid and rewrites the explainer ("What you use Dust for" / "What people in your role use Dust for" / "What your company uses Dust for").
-- The map is a responsive CSS grid of area groups: \`grid-template-columns: repeat(auto-fill, minmax(220px, 1fr))\`, 12px gap, filling 100% of the frame width. Area groups flow into as many columns as fit. Large empty regions and full-width single-column rows are rendering defects.
-- An area group = a label row + wrapping chips. Label row: area name in 10px uppercase 600-weight muted text with a 2px left tick in the active tab's accent, followed by the use-case count in a 9px neutral badge. Chips wrap below with 4px gaps.
-- A use-case chip = one compact pill: 11px text, 3px 8px padding, 6px radius, 1px neutral border, white background, inline-flex. Truncate with ellipsis past ~30 characters; put the full text in the title attribute.
-- What powers a use case renders inside the chip as a muted 9px suffix after the name — "· @agentname" (agent), "· skill" (saved Skill), "· Mon 9am" with a tiny clock glyph (scheduled), "· 214 msgs" (company tab counts). Plain words only, never abbreviations or jargon like "AUTO". No separate badge elements.
-- Color: chips stay neutral; the active tab's accent appears only on the area ticks and the tab itself. At most two accents on screen.
-- Interaction is minimal by design: tabs switch audience; chips and labels have no click behavior (a subtle hover emphasis is enough). A static grid that always renders correctly beats a clever one.
-
-Density rules — the map must show everything relevant inside the height budget:
-- Fit by tightening, in this order: more grid columns → smaller gaps (12→8px, 4→3px) → 10px chip text.
-- Only when a tab's content physically cannot fit, keep the most relevant chips per area and end the group with a "+N more" chip. Never silently drop anything, and never drop the user's own skills or anything scheduled.
+For data to use:
+* Pick 2-5 agents and or skills from the user job type and the larger workspace. ALWAYS include one-line descriptions of what each does. Do not necessarily just show the most used, but rather the most relevant to the user. Never show Dust default agents. 
+* The recommendations are generated from the logic described in the Stage 1 section below.
 
 #### Frame Management
-- If no Frame is pinned yet, ALWAYS create the frame and pin it to the pod.
-- If the Frame exists, ALWAYS refresh the existing frame with the data acquired during research.
+- If no Frame is pinned yet, ALWAYS create it from the template (above) and pin it to the pod.
+- If the Frame exists, ALWAYS refresh its data block with what you learned during research, using targeted edits — never rebuild it.
 - At the start of any conversation, ALWAYS open the pinned frame in the side panel by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
 
 ### First Ever Pod Message
@@ -385,7 +352,14 @@ export const activationSkill = {
     { name: "pod_manager" },
     { name: "exa_people_and_company" },
   ],
-  version: 2,
+  files: [
+    {
+      fileName: "pod_frame_template.tsx",
+      contentType: frameContentType,
+      content: ACTIVATION_POD_FRAME_TEMPLATE,
+    },
+  ],
+  version: 3,
   icon: "ActionRocketIcon",
   isRestricted: async (auth) => {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -1,0 +1,367 @@
+export const ACTIVATION_POD_FRAME_TEMPLATE = `import { useEffect, useState } from "react";
+import {
+  Sparkles,
+  ArrowRight,
+  Search,
+  MessageCircleQuestion,
+  Gift,
+  Users,
+  Building2,
+  Lightbulb,
+  Bot,
+  Wrench,
+} from "lucide-react";
+
+/* ============================================================
+   ACTIVATION POD FRAME v7
+   Design sources: beautiful-frames-design skill (icons not
+   emojis, perfect spacing, premium minimalist), Henry's
+   failure-mode analysis (committed visual identity: one accent
+   [violet], one neutral base, one strong anchor [dark masthead];
+   no default-admin-panel), Frame design playbook.
+   Content rules from this thread:
+   - Enumeration intro kept (top left).
+   - Analytics are the hero: agents & skills shown DIRECTLY,
+     each with a proper plain-language description. Replaces
+     the process map.
+   - No gamification. No pulsing badges, streaks, or locks.
+   - No presumed artifacts: recommendations are clearly labeled
+     curated ideas. The real next step is getting more intel,
+     and the single CTA says so.
+   - Calm: masthead + 3 regions + 1 CTA. Nothing else.
+   Two renderings, auto-selected by surface.
+   ============================================================ */
+
+/* ----------------- surface detection ----------------- */
+
+function useSurface(): "dashboard" | "full" {
+  const [surface, setSurface] = useState<"dashboard" | "full">(() => detect());
+  function detect(): "dashboard" | "full" {
+    try {
+      const id =
+        new URLSearchParams(window.location.search).get("identifier") ?? "";
+      if (id.startsWith("viz-banner-")) return "dashboard";
+    } catch {
+      /* fall through */
+    }
+    return window.innerHeight < 400 ? "dashboard" : "full";
+  }
+  useEffect(() => {
+    const onResize = () => setSurface(detect());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return surface;
+}
+
+/* ----------------- TEMPLATE DATA (from allowed calls only) -----------------
+   get_personal_usage / get_personal_usage(job_type) /
+   get_workspace_activity / skills list / Exa public profile.
+   RULE: agents and skills are shown directly, by name, each with
+   a real one-line description of what it does. Counts are real.
+   No claims about schedules or automations we cannot see. */
+
+/* ==== TEMPLATE DATA — EDIT ONLY THIS BLOCK ==== */
+const USER = { name: "Alex", role: "Customer Success", company: "Acme" };
+
+const YOUR_USAGE = { messages: 6 };
+
+// get_personal_usage(job_type) — agents & skills peers actually use
+const PEER_TOOLS = [
+  {
+    kind: "agent",
+    name: "@account-recap",
+    desc: "Pulls a customer's recent tickets, calls, and docs into one recap before a check-in.",
+    who: "7 of 11 CSMs",
+  },
+  {
+    kind: "skill",
+    name: "QBR builder",
+    desc: "Turns account notes and shared usage stats into a quarterly review draft.",
+    who: "5 CSMs",
+  },
+  {
+    kind: "agent",
+    name: "@renewal-radar",
+    desc: "Summarizes open risks and blockers on accounts approaching renewal, on request.",
+    who: "3 CSMs",
+  },
+];
+
+// get_workspace_activity — most used across the whole workspace
+const WORKSPACE_TOOLS = [
+  {
+    kind: "agent",
+    name: "@ticket-triage",
+    desc: "Sorts incoming support tickets and drafts first responses.",
+    who: "420 runs last month",
+  },
+  {
+    kind: "agent",
+    name: "@sales-assistant",
+    desc: "Answers reps' product and pricing questions mid-deal.",
+    who: "310 runs last month",
+  },
+];
+
+// skills/templates list — curated for the role, labeled honestly
+const IDEAS = [
+  {
+    name: "Escalation tracker",
+    desc: "Collect open escalations across accounts, with status and owner, in one view.",
+  },
+  {
+    name: "Health-check digest",
+    desc: "A recurring summary of account health signals from shared sources.",
+  },
+];
+
+/* ==== END TEMPLATE DATA — RENDER CODE BELOW IS FROZEN ==== */
+
+/* ----------------- shared: tool row ----------------- */
+
+function ToolRow({
+  kind,
+  name,
+  desc,
+  who,
+}: {
+  kind: string;
+  name: string;
+  desc: string;
+  who: string;
+}) {
+  const Icon = kind === "skill" ? Wrench : Bot;
+  return (
+    <div className="flex items-start gap-3 py-3">
+      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-50 dark:bg-violet-950">
+        <Icon className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <p className="truncate text-sm font-semibold text-foreground">{name}</p>
+          <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2.5 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+            {who}
+          </span>
+        </div>
+        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{desc}</p>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------- FULL VIEW (conversation) ----------------- */
+
+function FullView() {
+  return (
+    <main className="flex h-screen w-screen flex-col overflow-hidden bg-background">
+      {/* masthead — the one strong visual anchor */}
+      <div className="shrink-0 bg-slate-900 px-8 py-5">
+        <div className="mx-auto flex w-full max-w-4xl items-center gap-3">
+          <Sparkles className="h-5 w-5 shrink-0 text-violet-400" />
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold text-white">
+              {USER.name}, welcome to your pod
+            </h1>
+            <p className="text-sm text-slate-400">
+              One job: get Dust quietly working for you — without you building
+              anything.
+            </p>
+          </div>
+          <span className="ml-auto hidden shrink-0 text-xs text-slate-500 sm:block">
+            {USER.role} · {USER.company}
+          </span>
+        </div>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-y-auto px-8 py-6">
+        <div
+          className="grid flex-1 gap-8"
+          style={{ gridTemplateColumns: "minmax(220px, 2fr) 3fr" }}
+        >
+          {/* LEFT — how this works (the enumeration) */}
+          <div className="flex min-w-0 flex-col">
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              How this works
+            </p>
+            <div className="mt-4 space-y-5">
+              {[
+                {
+                  icon: Search,
+                  t: "I read the signals",
+                  d: \`how \${USER.role.toLowerCase()} peers and \${USER.company} use Dust, plus your public role — never your email, calendar, or files\`,
+                },
+                {
+                  icon: MessageCircleQuestion,
+                  t: "You point me",
+                  d: "a couple of quick questions in the conversation — that's what turns generic ideas into your ideas",
+                },
+                {
+                  icon: Gift,
+                  t: "Things arrive finished",
+                  d: "keep or toss, one click — kept things run on their own, and this panel keeps score",
+                },
+              ].map((s, i) => (
+                <div key={s.t} className="flex items-start gap-3">
+                  <span
+                    className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-violet-600 font-semibold text-white"
+                    style={{ fontSize: 11 }}
+                  >
+                    {i + 1}
+                  </span>
+                  <div className="min-w-0">
+                    <p className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                      <s.icon className="h-4 w-4 text-violet-600" />
+                      {s.t}
+                    </p>
+                    <p className="mt-1 text-sm leading-snug text-muted-foreground">
+                      {s.d}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-auto pt-6">
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  You, so far:
+                </span>{" "}
+                {YOUR_USAGE.messages} messages in 30 days, nothing running.
+                That's exactly who this pod is for.
+              </p>
+            </div>
+          </div>
+
+          {/* RIGHT — the analytics, front and center */}
+          <div className="flex min-w-0 flex-col">
+            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <Users className="h-3.5 w-3.5 text-violet-600" />
+              What {USER.role.toLowerCase()} peers here already use
+            </p>
+            <div className="mt-1 divide-y divide-border">
+              {PEER_TOOLS.map((t) => (
+                <ToolRow key={t.name} {...t} />
+              ))}
+            </div>
+
+            <p className="mt-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <Building2 className="h-3.5 w-3.5 text-violet-600" />
+              Busiest across {USER.company}
+            </p>
+            <div className="mt-1 divide-y divide-border">
+              {WORKSPACE_TOOLS.map((t) => (
+                <ToolRow key={t.name} {...t} />
+              ))}
+            </div>
+
+            <div className="mt-4 rounded-xl border border-dashed border-border px-4 py-3">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <Lightbulb className="h-3.5 w-3.5 text-violet-600" />
+                Ideas for your role — curated, not personalized yet
+              </p>
+              <div className="mt-2 space-y-1.5">
+                {IDEAS.map((i) => (
+                  <p key={i.name} className="text-sm text-muted-foreground">
+                    <span className="font-medium text-foreground">{i.name}</span>
+                    {" — "}
+                    {i.desc}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* the single CTA — intel, not a presumed artifact */}
+        <div className="mt-6 flex shrink-0 items-center gap-4 rounded-xl bg-violet-600 px-6 py-4">
+          <MessageCircleQuestion className="h-6 w-6 shrink-0 text-violet-200" />
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-white">
+              I took a first guess at a use case relevant to your role.
+            </p>
+            <p className="text-sm text-violet-200">
+              To curate further and understand your workflows, I need to learn
+              more about you — a couple of quick questions when you're ready.
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-3 shrink-0 text-xs text-muted-foreground opacity-70">
+          Built from workspace usage stats and your public profile.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+/* ----------------- DASHBOARD VIEW (pinned banner) ----------------- */
+
+function DashboardView() {
+  return (
+    <main className="flex h-screen w-screen flex-col overflow-hidden bg-background">
+      {/* condensed masthead — same anchor as the full view */}
+      <div className="flex shrink-0 items-center gap-2 bg-slate-900 px-4 py-2.5">
+        <Sparkles className="h-4 w-4 shrink-0 text-violet-400" />
+        <span className="truncate text-sm font-semibold text-white">
+          {USER.name}'s activation pod
+        </span>
+        <span className="ml-auto shrink-0 rounded-full bg-slate-800 px-2.5 py-0.5 text-xs font-medium text-slate-300">
+          nothing running yet
+        </span>
+      </div>
+
+      {/* condensed ledger — peers only, the highest-value section */}
+      <div className="flex min-h-0 flex-1 flex-col justify-center px-4">
+        <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <Users className="h-3 w-3 text-violet-600" />
+          What {USER.role.toLowerCase()} peers here already use
+        </p>
+        <div className="mt-0.5 divide-y divide-border">
+          {PEER_TOOLS.slice(0, 2).map((t) => (
+            <div key={t.name} className="flex items-baseline gap-2 py-1.5">
+              <span className="shrink-0 text-sm font-semibold text-foreground">
+                {t.name}
+              </span>
+              <span className="truncate text-xs text-muted-foreground">
+                {t.desc}
+              </span>
+              <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+                {t.who}
+              </span>
+            </div>
+          ))}
+          <div className="flex items-baseline gap-2 py-1.5">
+            <span className="shrink-0 text-sm font-semibold text-foreground">
+              {IDEAS[0].name}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {IDEAS[0].desc}
+            </span>
+            <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+              curated
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* condensed CTA — same message as the full view, one line */}
+      <div className="mx-4 mb-3 flex shrink-0 items-center gap-2.5 rounded-lg bg-violet-600 px-3 py-2">
+        <MessageCircleQuestion className="h-4 w-4 shrink-0 text-violet-200" />
+        <p className="truncate text-xs font-medium text-white">
+          I took a first guess for your role — help me sharpen it in the
+          conversation
+        </p>
+        <ArrowRight className="ml-auto h-3.5 w-3.5 shrink-0 text-violet-200" />
+      </div>
+    </main>
+  );
+}
+
+/* ----------------- ROOT ----------------- */
+
+export default function ActivationPodFrame() {
+  const surface = useSurface();
+  return surface === "dashboard" ? <DashboardView /> : <FullView />;
+}
+`;

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -1,35 +1,23 @@
-export const ACTIVATION_POD_FRAME_TEMPLATE = `import { useEffect, useState } from "react";
+export const ACTIVATION_POD_FRAME_TEMPLATE = `
+import { useEffect, useState } from "react";
 import {
   Sparkles,
-  ArrowRight,
+  Wrench,
+  Bot,
+  CheckCircle2,
+  Circle,
+  Radar,
   Search,
   MessageCircleQuestion,
   Gift,
-  Users,
-  Building2,
-  Lightbulb,
-  Bot,
-  Wrench,
 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "shadcn";
 
 /* ============================================================
-   ACTIVATION POD FRAME v7
-   Design sources: beautiful-frames-design skill (icons not
-   emojis, perfect spacing, premium minimalist), Henry's
-   failure-mode analysis (committed visual identity: one accent
-   [violet], one neutral base, one strong anchor [dark masthead];
-   no default-admin-panel), Frame design playbook.
-   Content rules from this thread:
-   - Enumeration intro kept (top left).
-   - Analytics are the hero: agents & skills shown DIRECTLY,
-     each with a proper plain-language description. Replaces
-     the process map.
-   - No gamification. No pulsing badges, streaks, or locks.
-   - No presumed artifacts: recommendations are clearly labeled
-     curated ideas. The real next step is getting more intel,
-     and the single CTA says so.
-   - Calm: masthead + 3 regions + 1 CTA. Nothing else.
-   Two renderings, auto-selected by surface.
+   ACTIVATION POD FRAME — v2 experiment
+   Card-based, single scrolling column formatting (from the
+   "recreate from scratch" iteration), applied on top of the
+   current template's placeholder data.
    ============================================================ */
 
 /* ----------------- surface detection ----------------- */
@@ -54,97 +42,93 @@ function useSurface(): "dashboard" | "full" {
   return surface;
 }
 
-/* ----------------- TEMPLATE DATA (from allowed calls only) -----------------
-   get_personal_usage / get_personal_usage(job_type) /
-   get_workspace_activity / skills list / Exa public profile.
-   RULE: agents and skills are shown directly, by name, each with
-   a real one-line description of what it does. Counts are real.
-   No claims about schedules or automations we cannot see. */
-
 /* ==== TEMPLATE DATA — EDIT ONLY THIS BLOCK ==== */
 const USER = { name: "Alex", role: "Customer Success", company: "Acme" };
 
 const YOUR_USAGE = { messages: 6 };
 
-// get_personal_usage(job_type) — agents & skills peers actually use
 const PEER_TOOLS = [
   {
     kind: "agent",
     name: "@account-recap",
     desc: "Pulls a customer's recent tickets, calls, and docs into one recap before a check-in.",
-    who: "7 of 11 CSMs",
   },
   {
     kind: "skill",
     name: "QBR builder",
     desc: "Turns account notes and shared usage stats into a quarterly review draft.",
-    who: "5 CSMs",
   },
   {
     kind: "agent",
     name: "@renewal-radar",
     desc: "Summarizes open risks and blockers on accounts approaching renewal, on request.",
-    who: "3 CSMs",
   },
 ];
 
-// get_workspace_activity — most used across the whole workspace
 const WORKSPACE_TOOLS = [
   {
     kind: "agent",
     name: "@ticket-triage",
     desc: "Sorts incoming support tickets and drafts first responses.",
-    who: "420 runs last month",
   },
   {
     kind: "agent",
     name: "@sales-assistant",
     desc: "Answers reps' product and pricing questions mid-deal.",
-    who: "310 runs last month",
   },
 ];
 
-// skills/templates list — curated for the role, labeled honestly
-const IDEAS = [
+type IdeaStatus = "shown" | "accepted";
+
+const IDEAS: { name: string; desc: string; status: IdeaStatus }[] = [
   {
     name: "Escalation tracker",
     desc: "Collect open escalations across accounts, with status and owner, in one view.",
+    status: "shown",
   },
   {
     name: "Health-check digest",
     desc: "A recurring summary of account health signals from shared sources.",
+    status: "shown",
   },
 ];
 
 /* ==== END TEMPLATE DATA — RENDER CODE BELOW IS FROZEN ==== */
 
-/* ----------------- shared: tool row ----------------- */
-
-function ToolRow({
-  kind,
-  name,
-  desc,
-  who,
-}: {
-  kind: string;
-  name: string;
-  desc: string;
-  who: string;
-}) {
+function KindIcon({ kind }: { kind: string }) {
   const Icon = kind === "skill" ? Wrench : Bot;
   return (
-    <div className="flex items-start gap-3 py-3">
-      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-50 dark:bg-violet-950">
-        <Icon className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-violet-50 dark:bg-violet-950">
+      <Icon className="h-3.5 w-3.5 text-violet-600 dark:text-violet-400" />
+    </div>
+  );
+}
+
+function ToolItem({ name, desc, kind }: { name: string; desc: string; kind: string }) {
+  return (
+    <div className="flex items-start gap-2.5 py-1.5">
+      <KindIcon kind={kind} />
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-foreground">{name}</p>
+        <p className="text-xs leading-snug text-muted-foreground">{desc}</p>
       </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <p className="truncate text-sm font-semibold text-foreground">{name}</p>
-          <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2.5 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-            {who}
-          </span>
-        </div>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{desc}</p>
+    </div>
+  );
+}
+
+function IdeaItem({ name, desc, status }: { name: string; desc: string; status: IdeaStatus }) {
+  const StatusIcon = status === "accepted" ? CheckCircle2 : Circle;
+  return (
+    <div className="flex items-start gap-2.5 py-1.5">
+      <StatusIcon
+        className={
+          "mt-0.5 h-3.5 w-3.5 shrink-0 " +
+          (status === "accepted" ? "text-violet-600" : "text-muted-foreground")
+        }
+      />
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-foreground">{name}</p>
+        <p className="text-xs leading-snug text-muted-foreground">{desc}</p>
       </div>
     </div>
   );
@@ -155,141 +139,137 @@ function ToolRow({
 function FullView() {
   return (
     <main className="flex h-screen w-screen flex-col overflow-hidden bg-background">
-      {/* masthead — the one strong visual anchor */}
-      <div className="shrink-0 bg-slate-900 px-8 py-5">
-        <div className="mx-auto flex w-full max-w-4xl items-center gap-3">
-          <Sparkles className="h-5 w-5 shrink-0 text-violet-400" />
+      <div className="shrink-0 bg-slate-900 px-6 py-3">
+        <div className="mx-auto flex max-w-4xl items-center gap-3">
+          <Sparkles className="h-4 w-4 shrink-0 text-violet-400" />
           <div className="min-w-0">
-            <h1 className="text-lg font-semibold text-white">
+            <h1 className="text-sm font-semibold text-white">
               {USER.name}, welcome to your pod
             </h1>
-            <p className="text-sm text-slate-400">
-              One job: get Dust quietly working for you — without you building
-              anything.
+            <p className="text-xs text-slate-400">
+              One job: get Dust working for you.
             </p>
           </div>
-          <span className="ml-auto hidden shrink-0 text-xs text-slate-500 sm:block">
+          <span className="ml-auto shrink-0 rounded-full bg-slate-800 px-2.5 py-0.5 text-xs font-medium text-slate-300">
             {USER.role} · {USER.company}
           </span>
         </div>
       </div>
 
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-y-auto px-8 py-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden px-4 py-3">
         <div
-          className="grid flex-1 gap-8"
-          style={{ gridTemplateColumns: "minmax(220px, 2fr) 3fr" }}
+          className="grid flex-1 gap-4 overflow-hidden"
+          style={{ gridTemplateColumns: "minmax(200px, 1fr) minmax(0, 1.4fr)" }}
         >
-          {/* LEFT — how this works (the enumeration) */}
-          <div className="flex min-w-0 flex-col">
-            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              How this works
-            </p>
-            <div className="mt-4 space-y-5">
-              {[
-                {
-                  icon: Search,
-                  t: "I read the signals",
-                  d: \`how \${USER.role.toLowerCase()} peers and \${USER.company} use Dust, plus your public role — never your email, calendar, or files\`,
-                },
-                {
-                  icon: MessageCircleQuestion,
-                  t: "You point me",
-                  d: "a couple of quick questions in the conversation — that's what turns generic ideas into your ideas",
-                },
-                {
-                  icon: Gift,
-                  t: "Things arrive finished",
-                  d: "keep or toss, one click — kept things run on their own, and this panel keeps score",
-                },
-              ].map((s, i) => (
-                <div key={s.t} className="flex items-start gap-3">
-                  <span
-                    className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-violet-600 font-semibold text-white"
-                    style={{ fontSize: 11 }}
-                  >
-                    {i + 1}
-                  </span>
-                  <div className="min-w-0">
-                    <p className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
-                      <s.icon className="h-4 w-4 text-violet-600" />
-                      {s.t}
-                    </p>
-                    <p className="mt-1 text-sm leading-snug text-muted-foreground">
-                      {s.d}
-                    </p>
+          {/* LEFT — how this works */}
+          <Card className="flex min-h-0 flex-col overflow-hidden">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-violet-700">
+                How this works
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex min-h-0 flex-1 flex-col justify-between space-y-3 overflow-hidden pt-0">
+              <div className="space-y-3">
+                {[
+                  {
+                    icon: Search,
+                    t: "I read the signals",
+                    d:
+                      "how " +
+                      USER.role.toLowerCase() +
+                      " peers and " +
+                      USER.company +
+                      " use Dust, plus your public role",
+                  },
+                  {
+                    icon: MessageCircleQuestion,
+                    t: "You point me",
+                    d: "a couple of quick questions turn generic ideas into your ideas",
+                  },
+                  {
+                    icon: Gift,
+                    t: "Things arrive finished",
+                    d: "keep or toss, one click — kept things run on their own",
+                  },
+                ].map((s, i) => (
+                  <div key={s.t} className="flex items-start gap-2.5">
+                    <span
+                      className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-violet-600 font-semibold text-white"
+                      style={{ fontSize: 10 }}
+                    >
+                      {i + 1}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                        <s.icon className="h-3.5 w-3.5 text-violet-600" />
+                        {s.t}
+                      </p>
+                      <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                        {s.d}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-
-            <div className="mt-auto pt-6">
-              <p className="text-sm text-muted-foreground">
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
                 <span className="font-medium text-foreground">
                   You, so far:
                 </span>{" "}
                 {YOUR_USAGE.messages} messages in 30 days, nothing running.
-                That's exactly who this pod is for.
               </p>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
-          {/* RIGHT — the analytics, front and center */}
-          <div className="flex min-w-0 flex-col">
-            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              <Users className="h-3.5 w-3.5 text-violet-600" />
-              What {USER.role.toLowerCase()} peers here already use
-            </p>
-            <div className="mt-1 divide-y divide-border">
-              {PEER_TOOLS.map((t) => (
-                <ToolRow key={t.name} {...t} />
-              ))}
-            </div>
-
-            <p className="mt-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              <Building2 className="h-3.5 w-3.5 text-violet-600" />
-              Busiest across {USER.company}
-            </p>
-            <div className="mt-1 divide-y divide-border">
-              {WORKSPACE_TOOLS.map((t) => (
-                <ToolRow key={t.name} {...t} />
-              ))}
-            </div>
-
-            <div className="mt-4 rounded-xl border border-dashed border-border px-4 py-3">
-              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                <Lightbulb className="h-3.5 w-3.5 text-violet-600" />
-                Ideas for your role — curated, not personalized yet
-              </p>
-              <div className="mt-2 space-y-1.5">
-                {IDEAS.map((i) => (
-                  <p key={i.name} className="text-sm text-muted-foreground">
-                    <span className="font-medium text-foreground">{i.name}</span>
-                    {" — "}
-                    {i.desc}
-                  </p>
+          {/* RIGHT — tools & ideas */}
+          <div className="flex min-h-0 flex-col gap-3 overflow-hidden">
+            <Card className="min-h-0 flex-1 overflow-hidden">
+              <CardHeader className="pb-1 pt-3">
+                <CardTitle className="text-sm text-violet-700">
+                  What {USER.role.toLowerCase()} peers here already use
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y divide-border overflow-y-auto pt-0">
+                {PEER_TOOLS.map((t) => (
+                  <ToolItem key={t.name} {...t} />
                 ))}
-              </div>
-            </div>
+              </CardContent>
+            </Card>
+
+            <Card className="min-h-0 flex-1 overflow-hidden">
+              <CardHeader className="pb-1 pt-3">
+                <CardTitle className="text-sm text-violet-700">
+                  Busiest across {USER.company}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y divide-border overflow-y-auto pt-0">
+                {WORKSPACE_TOOLS.map((t) => (
+                  <ToolItem key={t.name} {...t} />
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="min-h-0 flex-1 overflow-hidden border-dashed">
+              <CardHeader className="pb-1 pt-3">
+                <CardTitle className="text-sm text-violet-700">
+                  Ideas, curated not personalized yet
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y divide-border overflow-y-auto pt-0">
+                {IDEAS.map((i) => (
+                  <IdeaItem key={i.name} {...i} />
+                ))}
+              </CardContent>
+            </Card>
           </div>
         </div>
 
-        {/* the single CTA — intel, not a presumed artifact */}
-        <div className="mt-6 flex shrink-0 items-center gap-4 rounded-xl bg-violet-600 px-6 py-4">
-          <MessageCircleQuestion className="h-6 w-6 shrink-0 text-violet-200" />
-          <div className="min-w-0">
-            <p className="text-sm font-semibold text-white">
-              I took a first guess at a use case relevant to your role.
-            </p>
-            <p className="text-sm text-violet-200">
-              To curate further and understand your workflows, I need to learn
-              more about you — a couple of quick questions when you're ready.
-            </p>
-          </div>
+        <div className="mt-3 flex shrink-0 items-center gap-3 rounded-xl bg-violet-600 px-4 py-2.5">
+          <Radar className="h-4 w-4 shrink-0 text-violet-200" />
+          <p className="text-xs text-white">
+            I took a first guess at a use case relevant to your role, a
+            couple of quick questions sharpens it further.
+          </p>
         </div>
-
-        <p className="mt-3 shrink-0 text-xs text-muted-foreground opacity-70">
-          Built from workspace usage stats and your public profile.
-        </p>
       </div>
     </main>
   );
@@ -300,59 +280,76 @@ function FullView() {
 function DashboardView() {
   return (
     <main className="flex h-screen w-screen flex-col overflow-hidden bg-background">
-      {/* condensed masthead — same anchor as the full view */}
-      <div className="flex shrink-0 items-center gap-2 bg-slate-900 px-4 py-2.5">
+      <div className="flex shrink-0 items-center gap-3 bg-slate-900 px-5 py-2.5">
         <Sparkles className="h-4 w-4 shrink-0 text-violet-400" />
-        <span className="truncate text-sm font-semibold text-white">
-          {USER.name}'s activation pod
-        </span>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-white">
+            {USER.name}, welcome to your pod
+          </p>
+          <p className="truncate text-xs text-slate-400">
+            One job: get Dust working for you.
+          </p>
+        </div>
         <span className="ml-auto shrink-0 rounded-full bg-slate-800 px-2.5 py-0.5 text-xs font-medium text-slate-300">
-          nothing running yet
+          {USER.role} · {USER.company}
         </span>
       </div>
 
-      {/* condensed ledger — peers only, the highest-value section */}
-      <div className="flex min-h-0 flex-1 flex-col justify-center px-4">
-        <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          <Users className="h-3 w-3 text-violet-600" />
-          What {USER.role.toLowerCase()} peers here already use
+      <div className="flex min-h-0 flex-1 flex-col justify-center overflow-hidden px-5 py-2">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-violet-700">
+          How this works
         </p>
-        <div className="mt-0.5 divide-y divide-border">
-          {PEER_TOOLS.slice(0, 2).map((t) => (
-            <div key={t.name} className="flex items-baseline gap-2 py-1.5">
-              <span className="shrink-0 text-sm font-semibold text-foreground">
-                {t.name}
+        <div className="space-y-2.5">
+          {[
+            {
+              icon: Search,
+              t: "I read the signals",
+              d:
+                "how " +
+                USER.role.toLowerCase() +
+                " peers and " +
+                USER.company +
+                " use Dust, plus your public role — never your email, calendar, or files",
+            },
+            {
+              icon: MessageCircleQuestion,
+              t: "You point me",
+              d: "a couple of quick questions in the conversation — that's what turns generic ideas into your ideas",
+            },
+            {
+              icon: Gift,
+              t: "Things arrive finished",
+              d: "keep or toss, one click — kept things run on their own, and this panel keeps score",
+            },
+          ].map((s, i) => (
+            <div key={s.t} className="flex items-start gap-2.5">
+              <span
+                className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-violet-600 font-semibold text-white"
+                style={{ fontSize: 10 }}
+              >
+                {i + 1}
               </span>
-              <span className="truncate text-xs text-muted-foreground">
-                {t.desc}
-              </span>
-              <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-                {t.who}
-              </span>
+              <div className="min-w-0">
+                <p className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                  <s.icon className="h-3.5 w-3.5 text-violet-600" />
+                  {s.t}
+                </p>
+                <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                  {s.d}
+                </p>
+              </div>
             </div>
           ))}
-          <div className="flex items-baseline gap-2 py-1.5">
-            <span className="shrink-0 text-sm font-semibold text-foreground">
-              {IDEAS[0].name}
-            </span>
-            <span className="truncate text-xs text-muted-foreground">
-              {IDEAS[0].desc}
-            </span>
-            <span className="ml-auto shrink-0 rounded-full bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
-              curated
-            </span>
-          </div>
         </div>
       </div>
 
-      {/* condensed CTA — same message as the full view, one line */}
-      <div className="mx-4 mb-3 flex shrink-0 items-center gap-2.5 rounded-lg bg-violet-600 px-3 py-2">
-        <MessageCircleQuestion className="h-4 w-4 shrink-0 text-violet-200" />
-        <p className="truncate text-xs font-medium text-white">
-          I took a first guess for your role — help me sharpen it in the
-          conversation
+      <div className="mx-5 mb-2.5 flex shrink-0 items-center gap-2.5 rounded-lg bg-violet-600 px-3 py-2">
+        <Radar className="h-4 w-4 shrink-0 text-violet-200" />
+        <p className="text-xs text-white">
+          I took a first guess at a use case relevant to your role. To curate
+          further, I need to learn more about you, a couple of quick
+          questions when you're ready.
         </p>
-        <ArrowRight className="ml-auto h-3.5 w-3.5 shrink-0 text-violet-200" />
       </div>
     </main>
   );

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -28,6 +28,9 @@ interface BaseSkillDefinition<
   readonly version: number;
   readonly icon: string;
   readonly mcpServers?: MCPServerDefinition[];
+  // Files that ship with the skill and are loaded into the conversation file
+  // system when the skill is enabled, exactly like custom-skill attachments.
+  readonly files?: readonly CodeDefinedSkillFile[];
   readonly inheritAgentConfigurationDataSources?: boolean;
   // When true, the skill's instructions are exposed to the front-end so builders
   // can read them in the skill details panel and build on top of the skill.
@@ -47,6 +50,13 @@ interface BaseSkillDefinition<
     agentLoopData: AgentLoopExecutionData
   ) => boolean;
 }
+
+export type CodeDefinedSkillFile = {
+  // Unique within the skill; becomes the file name under `skills/<skillName>/`.
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly content: string;
+};
 
 type WithStaticInstructions<T extends BaseSkillDefinition> = T & {
   readonly instructions: string;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -37,7 +37,10 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
-import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type {
+  CodeDefinedSkillFile,
+  SkillDefinition,
+} from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -127,6 +130,8 @@ type SkillResourceConstructorOptions =
       // When true, the global skill's instructions are exposed to the front-end.
       exposeInstructions?: boolean;
       fileAttachments: FileResource[];
+      // Files that ship with a code-defined skill (addressable, not embedded).
+      files?: readonly CodeDefinedSkillFile[];
       globalSId: string;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -137,6 +142,7 @@ type SkillResourceConstructorOptions =
       // Custom skills always expose their own instructions; this flag is unused.
       exposeInstructions?: undefined;
       fileAttachments: FileResource[];
+      files?: readonly CodeDefinedSkillFile[];
       globalSId?: undefined;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -230,6 +236,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   readonly dataSourceConfigurations: SkillDataSourceConfigurationModel[];
   private fileAttachments: FileResource[];
+  private readonly codeDefinedFiles: readonly CodeDefinedSkillFile[];
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
@@ -247,6 +254,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       dataSourceConfigurations,
       exposeInstructions,
       fileAttachments,
+      files,
       globalSId,
       mcpServerConfigurations,
       editorGroup,
@@ -259,6 +267,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     this.editorGroup = editorGroup ?? null;
     this.exposeInstructions = exposeInstructions ?? false;
     this.fileAttachments = fileAttachments ?? [];
+    this.codeDefinedFiles = files ?? [];
     this.globalSId = globalSId ?? null;
     this._mcpServerConfigurations = mcpServerConfigurations;
     this.version = version ?? null;
@@ -281,6 +290,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   getFileAttachments(): readonly FileResource[] {
     return this.fileAttachments;
+  }
+
+  getCodeDefinedFiles(): readonly CodeDefinedSkillFile[] {
+    return this.codeDefinedFiles;
+  }
+
+  hasFiles(): boolean {
+    return this.fileAttachments.length > 0 || this.codeDefinedFiles.length > 0;
   }
 
   get mcpServerConfigurations(): SkillMCPServerConfiguration[] {
@@ -1812,6 +1829,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         globalSId: def.sId,
         mcpServerConfigurations,
         fileAttachments: [],
+        files: def.files ?? [],
       }
     );
   }


### PR DESCRIPTION
## Summary

Adds the ability for **code-defined (global/system) skills** to ship files, and uses it to attach the day-zero **pod overview Frame template** to the Activation skill.

- A global skill definition can now declare `files: [{ fileName, contentType, content }]` (`CodeDefinedSkillFile`).
- On enable, these files are materialized into the conversation file system under `skills/<skillName>/<fileName>` — through the **same** `loadSkillFilesToConversation` path that custom-skill `FileResource` attachments already use.
- The loader now normalizes **both** sources into one `WritableSkillFile` list and writes them in a single loop, so any future global skill can attach files with no extra wiring:
- **Activation skill**: attaches `pod_frame_template.tsx` (bundled in `static_files/`) and instructs the skill to build the pinned pod overview Frame from that template rather than authoring Frame code from scratch.
- This template tsx file is just downloaded from a real Frame i created

Not too concerned on exact frame content yet, we can iterate as we go

## Risk

* Intended to be low and additive

## Testing
<img width="1321" height="913" alt="Screenshot 2026-07-16 at 6 23 34 PM" src="https://github.com/user-attachments/assets/84471d62-56bb-4141-9d95-a0be328b1315" />

## Deplyoment
1. Deploy front