### PR TITLE
Stabilize conversation window pruning

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -215,10 +215,7 @@ describe("renderConversationForModel", () => {
     expect(res.value.prunedContext).toBe(false);
   });
 
-  it("prunes old tool outputs beyond TOOL_RESULTS_TO_PRESERVE but keeps the most recent ones, across separate interactions", async () => {
-    // 12 interactions (TOOL_RESULTS_TO_PRESERVE is 10), each with one tool call: the first 2 are
-    // outside the preserved window and must be pruned. The last 10 are the protected floor and
-    // must survive untouched, regardless of budget-driven checkpoint search.
+  it("prunes old tool outputs globally across separate interactions", async () => {
     const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
       userMessage(`u_${i}`),
       assistantMessage(`a_${i}`),
@@ -241,9 +238,8 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Total unpruned: 12 * 5020 = 60_240. Pruning the 2 eligible tool results (outside the
-      // floor of 10) saves 2 * (5000 - 24) = 9_952, bringing it to 50_288, comfortably under
-      // this budget. Nothing else needs to be touched.
+      // The hard limit is 51k. Chronological replay prunes old results in stable batches while
+      // preserving the latest result of whichever interaction is current at each prefix.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
@@ -264,9 +260,13 @@ describe("renderConversationForModel", () => {
       res.value.modelConversation.messages,
       "tool_2"
     );
-    const tool3 = getFunctionMessage(
+    const tool4 = getFunctionMessage(
       res.value.modelConversation.messages,
-      "tool_3"
+      "tool_4"
+    );
+    const tool5 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "tool_5"
     );
     const tool12 = getFunctionMessage(
       res.value.modelConversation.messages,
@@ -274,15 +274,13 @@ describe("renderConversationForModel", () => {
     );
     expect(tool1.content).toContain("This tool result is no longer available");
     expect(tool2.content).toContain("This tool result is no longer available");
-    expect(tool3.content).toBe("result_3");
+    expect(tool4.content).toContain("This tool result is no longer available");
+    expect(tool5.content).toContain("This tool result is no longer available");
     expect(tool12.content).toBe("result_12");
     expect(res.value.prunedContext).toBe(true);
   });
 
-  it("prunes a single turn's OWN earlier tool-call steps once it makes many tool calls, since the current turn gets no special exemption", async () => {
-    // ONE continuous interaction: a single user question answered via 12 tool-call steps before
-    // the final reply. Nothing here is a "previous interaction", it's all the current turn, yet
-    // its own earliest steps (beyond TOOL_RESULTS_TO_PRESERVE=10) still get pruned.
+  it("prunes a long current turn in a checkpoint and preserves its latest result", async () => {
     const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     const steps = indices.flatMap((i) => [
       assistantMessage(`thinking_${i}`),
@@ -310,8 +308,8 @@ describe("renderConversationForModel", () => {
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Total unpruned: 10 (question) + 12*(10+5000) + 10 (answer) = 60_140. Pruning the 2
-      // steps outside the floor of 10 saves 2 * (5000-24) = 9_952 -> 50_188, under this budget.
+      // Total unpruned is 60_140. Crossing the 51k soft limit targets 31k, so pruning advances
+      // through the 40k prefix checkpoint while the latest result remains intact.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
@@ -332,9 +330,13 @@ describe("renderConversationForModel", () => {
       res.value.modelConversation.messages,
       "step_2"
     );
-    const step3 = getFunctionMessage(
+    const step8 = getFunctionMessage(
       res.value.modelConversation.messages,
-      "step_3"
+      "step_8"
+    );
+    const step9 = getFunctionMessage(
+      res.value.modelConversation.messages,
+      "step_9"
     );
     const step12 = getFunctionMessage(
       res.value.modelConversation.messages,
@@ -342,17 +344,16 @@ describe("renderConversationForModel", () => {
     );
     expect(step1.content).toContain("This tool result is no longer available");
     expect(step2.content).toContain("This tool result is no longer available");
-    expect(step3.content).toBe("step_3_result_big");
+    expect(step8.content).toContain("This tool result is no longer available");
+    expect(step9.content).toBe("step_9_result_big");
     expect(step12.content).toBe("step_12_result_big");
     expect(res.value.prunedContext).toBe(true);
   });
 
   it("proactively prunes once the conversation crosses PRUNING_TARGET_CONTEXT_UTILIZATION of contextSize, even though allowedTokenCount alone would comfortably fit it", async () => {
-    // 12 small interactions (TOOL_RESULTS_TO_PRESERVE=10, so 2 fall outside the floor). contextSize
-    // 4_000 gives a proactive target of 1_359 tokens (baseTokens=1041, so 4_000*0.6 - 1041):
-    // comfortably above the 1_288 tokens left after pruning the 2 eligible tool results, but
-    // well below the 1_440 unpruned total, so the proactive target is what forces the
-    // pruning, not the real ceiling, which is set far higher below.
+    // The old interaction prefix contains more than one 20k checkpoint of prunable payload.
+    // contextSize 55_000 gives a proactive target of 31_959 tokens after base tokens, below the
+    // 36_240-token full history but well below the hard ceiling configured below.
     const messages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
       userMessage(`u_${i}`),
       assistantMessage(`a_${i}`),
@@ -364,23 +365,23 @@ describe("renderConversationForModel", () => {
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => [
           [`u_${i}`, 10],
           [`a_${i}`, 10],
-          [`result_${i}`, 100],
+          [`result_${i}`, 3_000],
         ])
       ),
     });
 
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
-      model: { ...model, contextSize: 4_000 },
+      model: { ...model, contextSize: 55_000 },
       prompt: "PROMPT",
       enabledSkills: [],
       tools: "TOOLS",
-      // Real ceiling comfortably fits everything (1_440) in full: proves pruning is driven by
-      // the proactive target, not by running out of the real budget.
+      // The real ceiling comfortably fits everything in full, proving that the soft target is
+      // what triggers pruning.
       allowedTokenCount: computeAllowedTokenCount({
         promptTokens: 10,
         toolsTokens: 10,
-        interactionTokens: 20_000,
+        interactionTokens: 50_000,
       }),
     });
 
@@ -745,17 +746,8 @@ describe("renderConversationForModel", () => {
       },
     });
 
-    // Each interaction is 90 tokens (30 + 30 + 30), well within TOOL_RESULTS_TO_PRESERVE (10 tool
-    // results total here), so Layer 1 (pruning) can't touch any of them at all, this is meant
-    // to exercise Layer 2 (drop-entirely) in isolation, not cascade into Layer 3's force-pruning.
-    //
-    // Hand-verified: total unpruned = 8 * 90 = 720. Layer 2's target for the 7 previous
-    // interactions is budgetForInteractions(400) - current's cost(90) = 310. With
-    // PREVIOUS_INTERACTIONS_TO_PRESERVE=3, i1-i4 (4 * 90 = 360) can be dropped, leaving the
-    // protected floor i5-i7 (3 * 90 = 270) plus current i8 (90) = 360 <= 400: Layer 2 alone gets
-    // under budget, so Layer 3/4 never fire and i5-i8 survive WITH THEIR REAL, UNPRUNED CONTENT.
-    // An earlier version of this test only checked message names, which stay the same whether
-    // a tool result is pruned or not, and so couldn't actually tell the difference.
+    // The latest three interactions are protected from soft dropping, not from tool-result
+    // pruning. Older interactions are removed whole. Only the latest current result stays full.
     const res = await renderConversationForModel(auth, {
       conversation: createConversation(),
       model,
@@ -783,11 +775,10 @@ describe("renderConversationForModel", () => {
     expect(names).not.toContain("tool_03");
     expect(names).not.toContain("tool_04");
 
-    // The surviving tool results carry their REAL content, not a pruning placeholder,
-    // confirming Layer 2 (drop) alone was enough, and Layer 3 (force-prune) never fired.
-    for (const [i, name] of ["f_05", "f_06", "f_07", "f_08"].entries()) {
-      expect(functionMessages[i].content).toBe(name);
+    for (const message of functionMessages.slice(0, -1)) {
+      expect(message.content).toContain("no longer available");
     }
+    expect(functionMessages.at(-1)?.content).toBe("f_08");
   });
 
   it("prepends leading messages", async () => {
@@ -829,5 +820,88 @@ describe("renderConversationForModel", () => {
       leadingMessage,
       userMessage("rendered"),
     ]);
+  });
+
+  it("never restores interactions dropped for an earlier conversation prefix", async () => {
+    const nonPrunableHistory = Array.from(
+      { length: 4 },
+      (_, index) => index + 1
+    ).flatMap((i) => [
+      userMessage(`old_user_${i}`),
+      assistantMessage(`old_assistant_${i}`),
+    ]);
+    const initiallyProtectedHistory = Array.from(
+      { length: 3 },
+      (_, index) => index + 5
+    ).flatMap((i) => [
+      userMessage(`old_user_${i}`),
+      assistantMessage(`old_assistant_${i}`),
+      functionMessage(`old_tool_${i}`, `old_result_${i}`),
+    ]);
+    const history = [...nonPrunableHistory, ...initiallyProtectedHistory];
+    const extendedHistory = [
+      ...history,
+      ...Array.from({ length: 3 }, (_, index) => index + 1).flatMap((i) => [
+        userMessage(`new_user_${i}`),
+        assistantMessage(`new_assistant_${i}`),
+        functionMessage(`new_tool_${i}`, `new_result_${i}`),
+      ]),
+    ];
+
+    vi.mocked(renderAllMessages)
+      .mockResolvedValueOnce(history)
+      .mockResolvedValueOnce(extendedHistory);
+    mockTokenCounter({
+      byContains: Object.fromEntries([
+        ...Array.from({ length: 4 }, (_, index) => index + 1).flatMap((i) => [
+          [`old_user_${i}`, 5_000],
+          [`old_assistant_${i}`, 5_000],
+        ]),
+        ...Array.from({ length: 3 }, (_, index) => index + 5).flatMap((i) => [
+          [`old_user_${i}`, 5],
+          [`old_assistant_${i}`, 5],
+          [`old_result_${i}`, 5_000],
+        ]),
+        ...Array.from({ length: 3 }, (_, index) => index + 1).flatMap((i) => [
+          [`new_user_${i}`, 5],
+          [`new_assistant_${i}`, 5],
+          [`new_result_${i}`, 100],
+        ]),
+      ]),
+    });
+
+    const render = () =>
+      renderConversationForModel(auth, {
+        conversation: createConversation(),
+        model,
+        prompt: "PROMPT",
+        enabledSkills: [],
+        tools: "TOOLS",
+        allowedTokenCount: computeAllowedTokenCount({
+          promptTokens: 10,
+          toolsTokens: 10,
+          interactionTokens: 15_500,
+        }),
+      });
+
+    const first = await render();
+    const second = await render();
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isErr() || second.isErr()) {
+      return;
+    }
+
+    const firstUserTexts = first.value.modelConversation.messages
+      .filter(isUserMessage)
+      .map((message) => textOf(message.content[0]));
+    const secondUserTexts = second.value.modelConversation.messages
+      .filter(isUserMessage)
+      .map((message) => textOf(message.content[0]));
+
+    expect(firstUserTexts).not.toContain("old_user_1");
+    expect(secondUserTexts).not.toContain("old_user_1");
+    expect(secondUserTexts).toContain("new_user_3");
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -8,6 +8,12 @@ import {
   emitConversationRenderingMetrics,
 } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
 import { renderAllMessages } from "@app/lib/api/assistant/conversation_rendering/message_rendering";
+import type {
+  InteractionWithTokens,
+  MessageWithTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+import { sumInteractionTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import { ConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/window_state";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -31,11 +37,8 @@ import type { CredentialsType } from "@app/types/provider";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { InteractionWithTokens, MessageWithTokens } from "./pruning";
-import { sumInteractionTokens } from "./pruning";
-import { ConversationWindowState } from "./window_state";
 
-export { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "./window_state";
+export { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering/window_state";
 
 // Fixed number of tokens assumed for image contents
 const IMAGE_CONTENT_TOKEN_COUNT = 3100;
@@ -49,17 +52,11 @@ export const TOKENS_MARGIN = 1024;
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
 /**
- * Escalates through pruning and dropping until the conversation fits budgetForInteractions, or
- * returns an error if even the last resort isn't enough. Four layers, each tried only if the
- * previous one left the conversation over budget: prune tool results proactively (up to
- * pruningBudget), drop old interactions entirely (never the current one), force pruning into the
- * protected floor, then force dropping past the protected floor.
- *
- * pruneToolResults and dropInteractionsToFit each run twice, first with their normal floor and
- * then with a floor of 0. The second call never conflicts with the first. An already-pruned
- * message sits at placeholder size, so re-pruning it saves nothing and the eligibility check
- * skips it. An already-dropped interaction is gone from the array, so there is nothing left to
- * reconsider. The second call can only ever reach further than the first.
+ * Replays the conversation chronologically so cleanup decisions are deterministic for every
+ * interaction prefix. Old tool results are pruned before interactions are dropped. Soft drops
+ * preserve the latest three interactions. Hard-budget pressure can drop every previous
+ * interaction. The current interaction is never dropped and its latest tool result is never
+ * pruned.
  */
 function pruneConversationToBudget(
   interactions: InteractionWithTokens[],
@@ -80,11 +77,17 @@ function pruneConversationToBudget(
   },
   Error
 > {
-  return ConversationWindowState.fromSnapshot(interactions, {
+  const state = ConversationWindowState.empty({
     pruningBudget,
     budgetForInteractions,
     logDetails,
-  }).fit();
+  });
+
+  for (const interaction of interactions) {
+    state.append(interaction);
+  }
+
+  return state.fit();
 }
 
 export async function renderConversationForModel(

--- a/front/lib/api/assistant/conversation_rendering/pruning.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.test.ts
@@ -117,8 +117,9 @@ describe("pruneToolResults", () => {
     const messages = [1, 2, 3, 4].flatMap((i) => turn(i));
     const wrapped = asInteractions(messages);
     const pruned = pruneToolResults(wrapped, {
+      batchToCheckpoint: true,
       maxTokens: HUGE_BUDGET,
-      toolResultsToPreserve: 10,
+      eligibleToolResultCount: 4,
     });
 
     expect(pruned).toBe(wrapped); // same reference: nothing needed pruning.
@@ -127,13 +128,14 @@ describe("pruneToolResults", () => {
     }
   });
 
-  it("prunes the oldest eligible tool results first, preserving the last toolResultsToPreserve", () => {
+  it("prunes the explicitly eligible oldest tool results first", () => {
     // 6 turns, one tool result each (all big enough that pruning several is required).
     const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
     // Budget forces pruning of everything except the last 2 tool results.
     const pruned = pruneToolResults(asInteractions(messages), {
+      batchToCheckpoint: true,
       maxTokens: 12_000,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 4,
     });
 
     const fns = functionMessagesOf(flatMessages(pruned));
@@ -147,13 +149,14 @@ describe("pruneToolResults", () => {
     ]);
   });
 
-  it("makes a single turn's OWN early tool calls eligible for pruning once they exceed the preserved window, since there is no exemption for the current turn", () => {
+  it("can prune an explicitly eligible prefix within one interaction", () => {
     // ONE interaction (one continuous turn) making 6 tool calls in a row, e.g. a single agent
     // response that does 6 tool-call steps before its final answer. Preserve only the last 2.
     const oneLongTurn = [1, 2, 3, 4, 5, 6].flatMap((i) => toolStep(i, 5000));
     const pruned = pruneToolResults(asInteractions(oneLongTurn), {
+      batchToCheckpoint: true,
       maxTokens: 12_000,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 4,
     });
 
     const fns = functionMessagesOf(flatMessages(pruned));
@@ -170,18 +173,17 @@ describe("pruneToolResults", () => {
     ]);
   });
 
-  it("calling it twice with a wider floor only ever reaches further, never reconsiders what the first call already pruned", () => {
-    // This is the pattern index.ts's escalation uses: call once with the normal floor, then again
-    // with a smaller floor (0) and a tighter budget if that wasn't enough. Verifies the two calls
-    // don't conflict: the first call's prunings are untouched, and the second call reaches
-    // exactly the previously-protected tool results, nothing more, nothing less.
+  it("calling it twice with wider eligibility only reaches further", () => {
+    // A later cleanup can widen eligibility without conflicting with an earlier one: the first
+    // call's prunings remain untouched and the second only reaches further.
     const messages = [1, 2, 3, 4, 5, 6].flatMap((i) => turn(i, 5000));
 
     // First call: same as the test above. Prunes turns 1-4, protects the floor of the last 2
     // (turns 5 and 6, each still at their full 5000 tokens).
     const afterFirstCall = pruneToolResults(asInteractions(messages), {
+      batchToCheckpoint: true,
       maxTokens: 12_000,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 4,
     });
     const prunedAfterFirstCall = functionMessagesOf(
       flatMessages(afterFirstCall)
@@ -200,8 +202,9 @@ describe("pruneToolResults", () => {
     // pruning too: pruning turn 5 alone only brings it to 5_240, still over 300, so turn 6
     // gets pruned as well, landing at 264.
     const afterSecondCall = pruneToolResults(afterFirstCall, {
+      batchToCheckpoint: true,
       maxTokens: 300,
-      toolResultsToPreserve: 0,
+      eligibleToolResultCount: 6,
     });
     const flatAfterSecondCall = flatMessages(afterSecondCall);
 
@@ -231,8 +234,9 @@ describe("pruneToolResults", () => {
     const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
     const pruned = flatMessages(
       pruneToolResults(asInteractions(messages), {
+        batchToCheckpoint: true,
         maxTokens: 100,
-        toolResultsToPreserve: 0,
+        eligibleToolResultCount: 3,
       })
     );
 
@@ -245,14 +249,15 @@ describe("pruneToolResults", () => {
     }
   });
 
-  it("respects the floor even when the budget cannot be met: never prunes the last toolResultsToPreserve tool results", () => {
+  it("never prunes outside the explicitly eligible result prefix", () => {
     const messages = [1, 2, 3].flatMap((i) => turn(i, 5000));
     // Budget impossibly small: even pruning everything eligible won't fit. The floor (last 2
     // tool results) must still survive untouched, since that's this function's contract. Fitting
     // the impossible case is the caller's job (dropInteractionsToFit or a smaller floor).
     const pruned = pruneToolResults(asInteractions(messages), {
+      batchToCheckpoint: true,
       maxTokens: 1,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 1,
     });
 
     const fns = functionMessagesOf(flatMessages(pruned));
@@ -312,8 +317,9 @@ describe("pruneToolResults", () => {
     // total to 1_596, over the 1_530 budget.
     const pruned = flatMessages(
       pruneToolResults(asInteractions(messages), {
+        batchToCheckpoint: true,
         maxTokens: 1530,
-        toolResultsToPreserve: 1,
+        eligibleToolResultCount: 1,
       })
     );
     const totalTokens = pruned.reduce((sum, m) => sum + m.tokenCount, 0);
@@ -325,7 +331,7 @@ describe("pruneToolResults", () => {
       false, // tiny1: left alone, pruning it wouldn't help
       false, // tiny2: left alone
       false, // tiny3: left alone
-      false, // floor: protected (toolResultsToPreserve=1)
+      false, // outside the explicitly eligible prefix
     ]);
   });
 
@@ -344,14 +350,14 @@ describe("pruneToolResults", () => {
       );
     }
 
-    const toolResultsToPreserve = 0;
     const maxTokens = 6_000;
 
     const historyA = [0, 1, 2, 3, 4, 5].map((i) => toolResult(i, 4000));
     const prunedA = flatMessages(
       pruneToolResults(asInteractions(historyA), {
+        batchToCheckpoint: true,
         maxTokens,
-        toolResultsToPreserve,
+        eligibleToolResultCount: 6,
       })
     );
     // Hand-verified: pruning indices 0-4 (saving 3976 tokens each) brings the 24_000-token
@@ -368,8 +374,9 @@ describe("pruneToolResults", () => {
     const historyB = [...historyA, toolResult(6, 500)];
     const prunedB = flatMessages(
       pruneToolResults(asInteractions(historyB), {
+        batchToCheckpoint: true,
         maxTokens,
-        toolResultsToPreserve,
+        eligibleToolResultCount: 7,
       })
     );
     expect(
@@ -390,8 +397,9 @@ describe("pruneToolResults", () => {
     const historyC = [...historyA, toolResult(6, 4000)];
     const prunedC = flatMessages(
       pruneToolResults(asInteractions(historyC), {
+        batchToCheckpoint: true,
         maxTokens,
-        toolResultsToPreserve,
+        eligibleToolResultCount: 7,
       })
     );
     const prunedFlagsC = functionMessagesOf(prunedC).map((f) =>
@@ -403,26 +411,28 @@ describe("pruneToolResults", () => {
   it("is a pure function of history: the same input always yields the same pruning decision", () => {
     const messages = [1, 2, 3, 4, 5].flatMap((i) => turn(i, 3000));
     const first = pruneToolResults(asInteractions(messages), {
+      batchToCheckpoint: true,
       maxTokens: 10_000,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 3,
     });
     const second = pruneToolResults(asInteractions(messages), {
+      batchToCheckpoint: true,
       maxTokens: 10_000,
-      toolResultsToPreserve: 2,
+      eligibleToolResultCount: 3,
     });
     expect(first).toEqual(second);
   });
 
   it("prunes SOME messages while dropping OTHER whole interactions in a realistic multi-interaction conversation, preserving interaction boundaries throughout", () => {
-    // 12 separate interactions (TOOL_RESULTS_TO_PRESERVE-scale), each a real [user, assistant,
-    // function] turn, exercises pruneToolResults' interaction-boundary bookkeeping (flatten,
-    // prune, re-slice) against real turn structure, not a single synthetic interaction.
+    // 12 separate interactions exercise pruneToolResults' interaction-boundary bookkeeping
+    // (flatten, prune, re-slice) against real turn structure, not a single synthetic interaction.
     const interactions = groupMessagesIntoInteractions(
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].flatMap((i) => turn(i, 5000))
     );
     const pruned = pruneToolResults(interactions, {
+      batchToCheckpoint: true,
       maxTokens: 51_000,
-      toolResultsToPreserve: 10,
+      eligibleToolResultCount: 2,
     });
 
     // Interaction boundaries survive exactly: still 12 interactions, each still 3 messages.
@@ -433,8 +443,8 @@ describe("pruneToolResults", () => {
 
     const fns = functionMessagesOf(flatMessages(pruned));
     expect(fns.map((f) => isPruned(f.content))).toEqual([
-      true, // tool_1: outside the floor of 10, pruned
-      true, // tool_2: outside the floor of 10, pruned
+      true,
+      true,
       false,
       false,
       false,
@@ -444,7 +454,7 @@ describe("pruneToolResults", () => {
       false,
       false,
       false,
-      false, // tool_3..tool_12: the protected floor
+      false,
     ]);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -6,7 +6,8 @@
  *   message stays in place, so tool_use/tool_result pairing is never broken.
  * - "drop" (dropInteractionsToFit): remove whole interactions entirely, oldest first.
  *
- * index.ts owns the policy of when to apply which. This module owns the mechanisms.
+ * ConversationWindowState owns the policy of when to apply which. This module owns the
+ * mechanisms.
  */
 import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
@@ -29,12 +30,6 @@ export const PRUNING_CHECKPOINT_TOKENS = 20_000;
 // A drop invalidates the cache from the very first message, pruning only from its frontier, so
 // a drop miss costs more and may deserve a larger batch. Tune independently.
 export const DROP_CHECKPOINT_TOKENS = 20_000;
-
-// How many of the most recent tool results pruneToolResults never prunes, regardless of budget.
-// Counted in tool results, not turns: a single turn's own long tool-call chain is eligible for
-// pruning past this window exactly like an older turn's would be. Starting point, tune against
-// production metrics.
-export const TOOL_RESULTS_TO_PRESERVE = 10;
 
 export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
@@ -70,6 +65,13 @@ export function sumInteractionTokens(
   );
 }
 
+/** Tokens removed by replacing a tool result with the pruning placeholder. */
+export function getToolResultTokenSavings(message: MessageWithTokens): number {
+  return message.role === "function"
+    ? Math.max(message.tokenCount - PRUNED_TOOL_RESULT_TOKENS, 0)
+    : 0;
+}
+
 /**
  * Re-slices a flat message array back into template's interaction boundaries. Safe because
  * pruneToolResultsFlat never adds, removes, or reorders messages. Throws if that's ever violated.
@@ -102,11 +104,13 @@ function sliceIntoInteractions(
 function pruneToolResultsFlat(
   messages: MessageWithTokens[],
   {
+    batchToCheckpoint,
     maxTokens,
-    toolResultsToPreserve,
+    eligibleToolResultCount,
   }: {
+    batchToCheckpoint: boolean;
     maxTokens: number;
-    toolResultsToPreserve: number;
+    eligibleToolResultCount: number;
   }
 ): MessageWithTokens[] {
   const n = messages.length;
@@ -145,18 +149,11 @@ function pruneToolResultsFlat(
     }
   }
 
-  // Last toolResultsToPreserve tool results: never pruned, regardless of budget.
-  const floorStart = Math.max(
-    functionIndices.length - toolResultsToPreserve,
-    0
-  );
-  // Excludes results already smaller than the placeholder (e.g. "ok"). Pruning one would grow
-  // it, not shrink it, breaking the budget guarantee below.
-  //
-  // eligible holds indices into messages. The frontier variables below are indices into eligible
-  // itself (its k-th entry), not into messages.
+  // Eligibility is policy supplied by ConversationWindowState. This mechanism only transforms
+  // the explicitly eligible oldest tool results. Results smaller than the placeholder are
+  // excluded because replacing them would increase the token count.
   const eligible = functionIndices
-    .slice(0, floorStart)
+    .slice(0, eligibleToolResultCount)
     .filter((idx) => prunedTokens[idx] < originalTokens[idx]);
 
   // Minimal pruning needed: walk oldest-to-newest until the running total fits.
@@ -172,23 +169,25 @@ function pruneToolResultsFlat(
     return messages;
   }
 
-  // Round forward to the next checkpoint (a prefix-sum multiple of PRUNING_CHECKPOINT_TOKENS) so
-  // the same boundary keeps holding for several turns instead of creeping forward on every one.
-  // If no checkpoint exists in the remaining eligible range, the frontier runs to the end of it:
-  // over-pruning is acceptable, undershooting the budget is not.
   let effectiveFrontier = neededFrontier;
-  for (let k = neededFrontier; k < eligible.length; k++) {
-    effectiveFrontier = k;
-    const idx = eligible[k];
-    if (idx === 0) {
-      break; // Start of conversation is trivially a checkpoint.
-    }
-    const bucketAtIdx = Math.floor(prefixSum[idx] / PRUNING_CHECKPOINT_TOKENS);
-    const bucketBefore = Math.floor(
-      prefixSum[idx - 1] / PRUNING_CHECKPOINT_TOKENS
-    );
-    if (bucketAtIdx !== bucketBefore) {
-      break;
+  if (batchToCheckpoint) {
+    // Round forward to the next checkpoint so the same boundary keeps holding across turns. If
+    // none exists in the eligible range, prune through the end of that range.
+    for (let k = neededFrontier; k < eligible.length; k++) {
+      effectiveFrontier = k;
+      const idx = eligible[k];
+      if (idx === 0) {
+        break;
+      }
+      const bucketAtIdx = Math.floor(
+        prefixSum[idx] / PRUNING_CHECKPOINT_TOKENS
+      );
+      const bucketBefore = Math.floor(
+        prefixSum[idx - 1] / PRUNING_CHECKPOINT_TOKENS
+      );
+      if (bucketAtIdx !== bucketBefore) {
+        break;
+      }
     }
   }
 
@@ -200,10 +199,8 @@ function pruneToolResultsFlat(
 }
 
 /**
- * Prunes tool results across the whole conversation, previous interactions and the current,
- * in-progress one combined, as one flat sequence, oldest eligible first. No exemption for the
- * current turn: a long tool-call chain within it becomes eligible past toolResultsToPreserve
- * exactly like an older turn's would.
+ * Prunes the explicitly eligible oldest tool results, oldest first. The caller owns the policy
+ * that determines eligibleToolResultCount.
  *
  * Takes and returns `InteractionWithTokens[]`, flattening and re-slicing internally so callers
  * never juggle a flat view and an interaction view themselves. Only ever replaces a function
@@ -223,8 +220,9 @@ function pruneToolResultsFlat(
 export function pruneToolResults(
   interactions: InteractionWithTokens[],
   opts: {
+    batchToCheckpoint: boolean;
+    eligibleToolResultCount: number;
     maxTokens: number;
-    toolResultsToPreserve: number;
   }
 ): InteractionWithTokens[] {
   const messages = interactions.flatMap((interaction) => interaction.messages);
@@ -232,6 +230,7 @@ export function pruneToolResults(
   if (pruned === messages) {
     return interactions; // No-op: same reference, same as dropInteractionsToFit below.
   }
+
   return sliceIntoInteractions(interactions, pruned);
 }
 

--- a/front/lib/api/assistant/conversation_rendering/window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_state.test.ts
@@ -1,0 +1,163 @@
+import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import { ConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/window_state";
+import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import { describe, expect, it } from "vitest";
+
+function withTokens<T extends ModelMessageTypeMultiActions>(
+  message: T,
+  tokenCount: number
+): T & { tokenCount: number } {
+  return { ...message, tokenCount };
+}
+
+function interaction(
+  name: string,
+  toolResultTokenCounts: number[],
+  userTokenCount = 10
+): InteractionWithTokens {
+  return {
+    messages: [
+      withTokens(
+        {
+          role: "user" as const,
+          name: "user",
+          content: [{ type: "text" as const, text: name }],
+        },
+        userTokenCount
+      ),
+      ...toolResultTokenCounts.map((tokenCount, index) =>
+        withTokens(
+          {
+            role: "function" as const,
+            name: `${name}_tool_${index}`,
+            function_call_id: `${name}_tool_${index}_call`,
+            content: `${name}_result_${index}`,
+          },
+          tokenCount
+        )
+      ),
+    ],
+  };
+}
+
+function interactionNames(interactions: InteractionWithTokens[]): string[] {
+  return interactions.map((item) => {
+    const firstMessage = item.messages[0];
+    const firstContent =
+      firstMessage.role === "user" ? firstMessage.content[0] : undefined;
+    if (!firstContent || firstContent.type !== "text") {
+      throw new Error("Expected each test interaction to start with text");
+    }
+
+    return firstContent.text;
+  });
+}
+
+function toolResults(interactions: InteractionWithTokens[]) {
+  return interactions
+    .flatMap((item) => item.messages)
+    .filter((message) => message.role === "function");
+}
+
+function isPruned(content: unknown): boolean {
+  return typeof content === "string" && content.includes("no longer available");
+}
+
+describe("ConversationWindowState", () => {
+  it("prunes a long current interaction in one checkpoint while preserving its latest result", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 30_000,
+      budgetForInteractions: 100_000,
+      logDetails: {},
+    });
+
+    state.append(interaction("current", [10_000, 10_000, 10_000, 10_000]));
+
+    const results = toolResults(state.renderedInteractions());
+    expect(
+      results.slice(0, 3).every((message) => isPruned(message.content))
+    ).toBe(true);
+    expect(results[3].content).toBe("current_result_3");
+  });
+
+  it("does not move the pruning frontier again before the reclaimed headroom is consumed", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 30_000,
+      budgetForInteractions: 100_000,
+      logDetails: {},
+    });
+
+    state.append(interaction("first", [10_000, 10_000, 10_000, 10_000]));
+    state.append(interaction("second", [10_000]));
+
+    const results = toolResults(state.renderedInteractions());
+    expect(
+      results.slice(0, 3).every((message) => isPruned(message.content))
+    ).toBe(true);
+    expect(results[3].content).toBe("first_result_3");
+    expect(results[4].content).toBe("second_result_0");
+  });
+
+  it("drops old interactions at the soft limit in a checkpoint-sized batch", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 50_000,
+      budgetForInteractions: 100_000,
+      logDetails: {},
+    });
+
+    for (let i = 1; i <= 6; i++) {
+      state.append(interaction(`turn_${i}`, [], 10_000));
+    }
+
+    expect(interactionNames(state.renderedInteractions())).toEqual([
+      "turn_4",
+      "turn_5",
+      "turn_6",
+    ]);
+    expect(state.fit().isOk()).toBe(true);
+  });
+
+  it("ignores the checkpoint minimum at the hard limit", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 50_000,
+      budgetForInteractions: 55_000,
+      logDetails: {},
+    });
+
+    state.append(interaction("current", [10_000, 45_000]));
+
+    expect(state.fit().isOk()).toBe(true);
+    const results = toolResults(state.renderedInteractions());
+    expect(isPruned(results[0].content)).toBe(true);
+    expect(results[1].content).toBe("current_result_1");
+  });
+
+  it("drops protected previous interactions at the hard limit", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 50_000,
+      budgetForInteractions: 55_000,
+      logDetails: {},
+    });
+
+    state.append(interaction("turn_1", [], 20_000));
+    state.append(interaction("turn_2", [], 20_000));
+    state.append(interaction("turn_3", [], 20_000));
+
+    expect(interactionNames(state.renderedInteractions())).toEqual(["turn_3"]);
+    expect(state.fit().isOk()).toBe(true);
+  });
+
+  it("returns overflow rather than pruning the latest current result", () => {
+    const state = ConversationWindowState.empty({
+      pruningBudget: 50_000,
+      budgetForInteractions: 55_000,
+      logDetails: {},
+    });
+
+    state.append(interaction("current", [60_000]));
+
+    expect(state.fit().isErr()).toBe(true);
+    const results = toolResults(state.renderedInteractions());
+    expect(results[0].content).toBe("current_result_0");
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_state.ts
@@ -1,21 +1,24 @@
 import type { ConversationPruningStats } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
+import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import {
+  DROP_CHECKPOINT_TOKENS,
+  dropInteractionsToFit,
+  getInteractionTokenCount,
+  getToolResultTokenSavings,
+  PRUNING_CHECKPOINT_TOKENS,
+  pruneToolResults,
+  sumInteractionTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { InteractionWithTokens } from "./pruning";
-import {
-  dropInteractionsToFit,
-  getInteractionTokenCount,
-  pruneToolResults,
-  sumInteractionTokens,
-  TOOL_RESULTS_TO_PRESERVE,
-} from "./pruning";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
-// How many of the most recent interactions dropInteractionsToFit never drops entirely, even if
-// their own tool results were already pruned. A different floor from TOOL_RESULTS_TO_PRESERVE
-// (pruning.ts). That one protects tool result content regardless of turn. This one protects whole
-// recent turns from being erased regardless of how many tool calls they made.
+// Existing consumers use this to decide when compaction is available. Keep that behavior
+// independent from the window's soft-drop policy.
 export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
+
+const INTERACTIONS_TO_PRESERVE_AT_SOFT_LIMIT = 3;
 
 type ConversationWindowResult = {
   interactions: InteractionWithTokens[];
@@ -24,14 +27,32 @@ type ConversationWindowResult = {
 };
 
 /**
- * Applies the conversation-window fitting policy to one complete interaction snapshot.
+ * Deterministically replays an append-only sequence of interactions into a bounded model context.
  *
- * This class intentionally preserves the existing one-shot behavior. It does not retain state
- * across renders or apply interactions incrementally.
+ * An instance is local to one render. Replaying additional interactions first reproduces every
+ * decision for the previous interaction prefix, so tool results can only move from intact to
+ * pruned and interactions can only move from retained to dropped at those boundaries.
+ *
+ * Above the soft limit, cleanup first prunes old tool results, then drops old interactions while
+ * preserving the latest three. Each operation must reclaim a full checkpoint and targets one
+ * checkpoint below the soft limit. At the hard limit those thresholds and interaction
+ * protections are lifted. The current interaction is never dropped and its latest tool result is
+ * never pruned. If that irreducible context cannot fit, the window returns an overflow.
  */
 export class ConversationWindowState {
+  private interactions: InteractionWithTokens[] = [];
+  private retainedTokens = 0;
+  private totalTokensBefore = 0;
+  private interactionsBefore = 0;
+  private prunedContext = false;
+  private softPrunedTokens = 0;
+  private softDroppedTokens = 0;
+  private hardPrunedTokens = 0;
+  private hardDroppedTokens = 0;
+  private softDroppedInteractions = 0;
+  private hardDroppedInteractions = 0;
+
   private constructor(
-    private readonly interactions: InteractionWithTokens[],
     private readonly options: {
       pruningBudget: number;
       budgetForInteractions: number;
@@ -39,27 +60,39 @@ export class ConversationWindowState {
     }
   ) {}
 
-  static fromSnapshot(
-    interactions: InteractionWithTokens[],
-    options: {
-      pruningBudget: number;
-      budgetForInteractions: number;
-      logDetails: Record<string, unknown>;
-    }
-  ): ConversationWindowState {
-    return new ConversationWindowState(interactions, options);
+  static empty(options: {
+    pruningBudget: number;
+    budgetForInteractions: number;
+    logDetails: Record<string, unknown>;
+  }): ConversationWindowState {
+    return new ConversationWindowState(options);
   }
 
-  /**
-   * Escalates through the existing four cleanup layers until the snapshot fits.
-   */
+  append(interaction: InteractionWithTokens): void {
+    const interactionTokens = getInteractionTokenCount(interaction);
+    this.totalTokensBefore += interactionTokens;
+    this.retainedTokens += interactionTokens;
+    this.interactionsBefore += 1;
+    this.interactions.push(interaction);
+
+    this.pruneAtSoftLimit();
+    this.dropAtSoftLimit();
+    this.pruneAtHardLimit();
+    this.dropAtHardLimit();
+  }
+
+  renderedInteractions(): InteractionWithTokens[] {
+    return this.interactions;
+  }
+
   fit(): Result<ConversationWindowResult, Error> {
     const { pruningBudget, budgetForInteractions, logDetails } = this.options;
+    const totalTokens = this.totalTokens();
 
-    // An empty conversation trivially fits, and the layers below assume at least one interaction.
-    if (this.interactions.length === 0) {
+    // The caller reports the distinct no-messages error after windowing.
+    if (this.interactionsBefore === 0) {
       return new Ok({
-        interactions: this.interactions,
+        interactions: [],
         prunedContext: false,
         stats: {
           totalTokensBefore: 0,
@@ -76,82 +109,6 @@ export class ConversationWindowState {
       });
     }
 
-    const totalTokensBefore = sumInteractionTokens(this.interactions);
-
-    // Layer 1: proactive pruning, within the protected floor, up to pruningBudget.
-    let pruned = pruneToolResults(this.interactions, {
-      maxTokens: pruningBudget,
-      toolResultsToPreserve: TOOL_RESULTS_TO_PRESERVE,
-    });
-    let prunedContext = pruned !== this.interactions;
-    let totalTokens = sumInteractionTokens(pruned);
-    const totalTokensAfterPruning = totalTokens;
-
-    // Layer 2: drop whole previous interactions, oldest first. The last
-    // PREVIOUS_INTERACTIONS_TO_PRESERVE of them are protected, and the current one always survives.
-    if (totalTokens > budgetForInteractions) {
-      const currentInteraction = pruned[pruned.length - 1];
-      const previousBefore = pruned.slice(0, -1);
-      const previousAfter = dropInteractionsToFit(previousBefore, {
-        maxTokens:
-          budgetForInteractions - getInteractionTokenCount(currentInteraction),
-        interactionsToPreserve: PREVIOUS_INTERACTIONS_TO_PRESERVE,
-        batchToCheckpoint: true,
-      });
-      if (previousAfter !== previousBefore) {
-        prunedContext = true;
-        pruned = [...previousAfter, currentInteraction];
-        totalTokens = sumInteractionTokens(pruned);
-      }
-    }
-    const totalTokensAfterDropping = totalTokens;
-    const interactionsAfterDropping = pruned.length;
-
-    // Layer 3: reaching here means layer 2 dropped every previous interaction it was allowed to,
-    // and what remains (the last PREVIOUS_INTERACTIONS_TO_PRESERVE plus the current interaction)
-    // still doesn't fit. Force pruning past TOOL_RESULTS_TO_PRESERVE into the protected floor.
-    if (totalTokens > budgetForInteractions) {
-      logger.warn(
-        { ...logDetails, totalTokens, budgetForInteractions },
-        "Dropped every eligible previous interaction; still over budget, forcing floor pruning."
-      );
-      const beforeFloorPruning = pruned;
-      pruned = pruneToolResults(pruned, {
-        maxTokens: budgetForInteractions,
-        toolResultsToPreserve: 0,
-      });
-      if (pruned !== beforeFloorPruning) {
-        prunedContext = true;
-      }
-      totalTokens = sumInteractionTokens(pruned);
-    }
-    const totalTokensAfterFloorPruning = totalTokens;
-
-    // Layer 4: still over budget with every tool result already at placeholder size. Drop previous
-    // interactions past PREVIOUS_INTERACTIONS_TO_PRESERVE, down to the current interaction alone
-    // if needed. Minimal drops here, not batched: the head moves on this call regardless, and the
-    // interactions a batched over-drop would additionally erase are the most recent ones.
-    if (totalTokens > budgetForInteractions) {
-      logger.warn(
-        { ...logDetails, totalTokens, budgetForInteractions },
-        "Floor pruning still not enough; dropping previous interactions past the normal floor."
-      );
-      const currentInteraction = pruned[pruned.length - 1];
-      const previousBefore = pruned.slice(0, -1);
-      const previousAfter = dropInteractionsToFit(previousBefore, {
-        maxTokens:
-          budgetForInteractions - getInteractionTokenCount(currentInteraction),
-        interactionsToPreserve: 0,
-        batchToCheckpoint: false,
-      });
-      if (previousAfter !== previousBefore) {
-        prunedContext = true;
-        pruned = [...previousAfter, currentInteraction];
-        totalTokens = sumInteractionTokens(pruned);
-      }
-    }
-
-    // Last resort exhausted: even the current interaction alone doesn't fit.
     if (totalTokens > budgetForInteractions) {
       logger.error(
         {
@@ -162,26 +119,259 @@ export class ConversationWindowState {
         },
         "Render Conversation V2: No interactions fit in context window."
       );
+
       return new Err(
         new Error("Context window exceeded: at least one message is required")
       );
     }
 
+    const totalTokensAfterPruning =
+      this.totalTokensBefore - this.softPrunedTokens;
+    const totalTokensAfterDropping =
+      totalTokensAfterPruning - this.softDroppedTokens;
+    const totalTokensAfterFloorPruning =
+      totalTokensAfterDropping - this.hardPrunedTokens;
+
     return new Ok({
-      interactions: pruned,
-      prunedContext,
+      interactions: this.interactions,
+      prunedContext: this.prunedContext,
       stats: {
-        totalTokensBefore,
+        totalTokensBefore: this.totalTokensBefore,
         totalTokensAfterPruning,
         totalTokensAfterDropping,
         totalTokensAfterFloorPruning,
-        totalTokensAfterFloorDropping: totalTokens,
-        interactionsBefore: this.interactions.length,
-        interactionsAfterDropping,
-        interactionsAfterFloorDropping: pruned.length,
+        totalTokensAfterFloorDropping:
+          totalTokensAfterFloorPruning - this.hardDroppedTokens,
+        interactionsBefore: this.interactionsBefore,
+        interactionsAfterDropping:
+          this.interactionsBefore - this.softDroppedInteractions,
+        interactionsAfterFloorDropping:
+          this.interactionsBefore -
+          this.softDroppedInteractions -
+          this.hardDroppedInteractions,
         pruningBudget,
         budgetForInteractions,
       },
     });
+  }
+
+  private pruneAtSoftLimit(): void {
+    if (!this.exceedsSoftLimit()) {
+      return;
+    }
+
+    const eligibleToolResultCount = this.prunableToolResultCount();
+    if (
+      this.toolResultTokenSavings(eligibleToolResultCount) <
+      PRUNING_CHECKPOINT_TOKENS
+    ) {
+      return;
+    }
+
+    this.pruneEligibleToolResults({
+      eligibleToolResultCount,
+      maxTokens: this.softCleanupTarget(),
+      tier: "soft",
+    });
+  }
+
+  private dropAtSoftLimit(): void {
+    if (!this.exceedsSoftLimit()) {
+      return;
+    }
+
+    const droppableInteractionCount = Math.max(
+      this.interactions.length - INTERACTIONS_TO_PRESERVE_AT_SOFT_LIMIT,
+      0
+    );
+    const droppableTokens = sumInteractionTokens(
+      this.interactions.slice(0, droppableInteractionCount)
+    );
+    if (droppableTokens < DROP_CHECKPOINT_TOKENS) {
+      return;
+    }
+
+    const before = this.interactions;
+    const after = dropInteractionsToFit(before, {
+      maxTokens: this.softCleanupTarget(),
+      interactionsToPreserve: INTERACTIONS_TO_PRESERVE_AT_SOFT_LIMIT,
+      batchToCheckpoint: true,
+    });
+    if (after === before) {
+      return;
+    }
+
+    const tokensAfter = sumInteractionTokens(after);
+    this.softDroppedTokens += this.retainedTokens - tokensAfter;
+    this.softDroppedInteractions += before.length - after.length;
+    this.prunedContext = true;
+    this.interactions = after;
+    this.retainedTokens = tokensAfter;
+  }
+
+  private pruneAtHardLimit(): void {
+    if (!this.exceedsHardBudget()) {
+      return;
+    }
+
+    this.pruneEligibleToolResults({
+      eligibleToolResultCount: this.prunableToolResultCount(),
+      maxTokens: this.softCleanupTarget(),
+      tier: "hard",
+    });
+  }
+
+  private dropAtHardLimit(): void {
+    if (!this.exceedsHardBudget()) {
+      return;
+    }
+
+    const currentInteraction = this.interactions[this.interactions.length - 1];
+    const previousBefore = this.interactions.slice(0, -1);
+    const previousAfter = dropInteractionsToFit(previousBefore, {
+      maxTokens:
+        this.softCleanupTarget() - getInteractionTokenCount(currentInteraction),
+      interactionsToPreserve: 0,
+      batchToCheckpoint: true,
+    });
+    if (previousAfter === previousBefore) {
+      return;
+    }
+
+    logger.warn(
+      {
+        ...this.options.logDetails,
+        totalTokens: sumInteractionTokens(this.interactions),
+        budgetForInteractions: this.options.budgetForInteractions,
+      },
+      "Soft cleanup was insufficient; dropping previous interactions at the hard limit."
+    );
+    const tokensAfter =
+      sumInteractionTokens(previousAfter) +
+      getInteractionTokenCount(currentInteraction);
+    this.hardDroppedTokens += this.retainedTokens - tokensAfter;
+    this.hardDroppedInteractions +=
+      previousBefore.length - previousAfter.length;
+    this.prunedContext = true;
+    this.interactions = [...previousAfter, currentInteraction];
+    this.retainedTokens = tokensAfter;
+  }
+
+  private pruneEligibleToolResults({
+    eligibleToolResultCount,
+    maxTokens,
+    tier,
+  }: {
+    eligibleToolResultCount: number;
+    maxTokens: number;
+    tier: "soft" | "hard";
+  }): void {
+    if (eligibleToolResultCount === 0) {
+      return;
+    }
+
+    const before = this.interactions;
+    const after = pruneToolResults(before, {
+      batchToCheckpoint: true,
+      maxTokens,
+      eligibleToolResultCount,
+    });
+    if (after === before) {
+      return;
+    }
+
+    const tokensAfter = sumInteractionTokens(after);
+    const prunedTokens = this.retainedTokens - tokensAfter;
+    switch (tier) {
+      case "soft":
+        this.softPrunedTokens += prunedTokens;
+        break;
+      case "hard":
+        logger.warn(
+          {
+            ...this.options.logDetails,
+            totalTokens: sumInteractionTokens(before),
+            budgetForInteractions: this.options.budgetForInteractions,
+          },
+          "Soft cleanup was insufficient; pruning tool results at the hard limit."
+        );
+        this.hardPrunedTokens += prunedTokens;
+        break;
+      default:
+        assertNever(tier);
+    }
+    this.prunedContext = true;
+    this.interactions = after;
+    this.retainedTokens = tokensAfter;
+  }
+
+  private prunableToolResultCount(): number {
+    const currentInteraction = this.interactions[this.interactions.length - 1];
+    const currentHasToolResult = currentInteraction.messages.some(
+      (message) => message.role === "function"
+    );
+
+    return (
+      this.countToolResults(this.interactions) - (currentHasToolResult ? 1 : 0)
+    );
+  }
+
+  /**
+   * This scan is O(retained messages). Since stateless replay calls it once per appended
+   * interaction above the soft limit, the pathological replay cost can approach O(n²).
+   *
+   * Checkpoint cleanup normally leaves the latest three interactions plus fewer than 20k tokens
+   * of droppable history. The expected scan is therefore hundreds to low thousands of messages
+   * and low single-digit milliseconds. Histories made of unusually tiny messages remain bounded
+   * by the hard context limit. This tradeoff avoids persisted state in this version. A stateful
+   * window can maintain the savings incrementally and remove the repeated scan.
+   */
+  private toolResultTokenSavings(eligibleToolResultCount: number): number {
+    let remaining = eligibleToolResultCount;
+    let savings = 0;
+
+    for (const interaction of this.interactions) {
+      for (const message of interaction.messages) {
+        if (message.role === "function" && remaining > 0) {
+          savings += getToolResultTokenSavings(message);
+          remaining -= 1;
+        }
+      }
+    }
+
+    return savings;
+  }
+
+  private countToolResults(interactions: InteractionWithTokens[]): number {
+    return interactions.reduce(
+      (count, interaction) =>
+        count +
+        interaction.messages.filter((message) => message.role === "function")
+          .length,
+      0
+    );
+  }
+
+  private exceedsHardBudget(): boolean {
+    return this.totalTokens() > this.options.budgetForInteractions;
+  }
+
+  private exceedsSoftLimit(): boolean {
+    return this.totalTokens() > this.options.pruningBudget;
+  }
+
+  private softCleanupTarget(): number {
+    const headroomTokens = Math.max(
+      PRUNING_CHECKPOINT_TOKENS,
+      DROP_CHECKPOINT_TOKENS
+    );
+
+    return this.options.pruningBudget > headroomTokens
+      ? this.options.pruningBudget - headroomTokens
+      : this.options.pruningBudget;
+  }
+
+  private totalTokens(): number {
+    return this.retainedTokens;
   }
 }

--- a/front/lib/api/assistant/conversation_rendering/window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_state.ts
@@ -232,7 +232,7 @@ export class ConversationWindowState {
       maxTokens:
         this.softCleanupTarget() - getInteractionTokenCount(currentInteraction),
       interactionsToPreserve: 0,
-      batchToCheckpoint: true,
+      batchToCheckpoint: false,
     });
     if (previousAfter === previousBefore) {
       return;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The existing policy protects a fixed number of recent tool results. Those results can span many interactions,
causing the pruning frontier to advance repeatedly as new tool calls arrive. Whole-interaction dropping also
happens close to the hard context limit, which can produce frequent cache rewrites without creating meaningful
headroom.

This change separates tool-result pruning from whole-interaction dropping. Old tool results are eligible for
pruning across the retained conversation, including long-running current interactions, **while the latest current
tool result remains protected**.

Normal cleanup starts at the soft context limit only when it can reclaim at least 20k tokens. It targets 20k below
that limit. If pruning is insufficient, old complete interactions are dropped in checkpoint-sized batches while the
latest three interactions remain protected from soft dropping. This creates enough headroom to avoid moving the
pruning or dropping frontier on every ordinary interaction.

At the hard limit, checkpoint requirements and previous-interaction protection are lifted. Remaining eligible tool
results are pruned and previous interactions can be dropped until the request fits. The current interaction is
never dropped. Rendering returns a context overflow when its irreducible content cannot fit.

**The conversation is replayed chronologically because the service remains stateless.** Replaying previous interaction
prefixes reproduces earlier cleanup decisions and prevents dropped history from returning as new interactions are
appended (preventing reversals).

This replay introduces an explicit performance tradeoff. Appending interactions adds a loop, and cleanup above the
soft limit may scan retained history to calculate pruning savings and droppable context. The worst case can
therefore approach O(n²), compared with the previous one-shot pass. Retained token totals are tracked
incrementally, so the common path below the soft limit remains linear. Cleanup also reduces the retained window and
normal mutations are separated by 20k checkpoints. A future persisted window state can remove the replay cost and
maintain pruning and dropping frontiers directly.

Monotonicity is currently guaranteed at interaction boundaries. A growing open interaction is still processed
atomically. Moving interaction construction into the window state is intentionally deferred so the class can later
own the open interaction without reconstructing message-level checkpoints in this change.

Existing compaction thresholds and leading-message behavior remain unchanged. The full conversation-rendering and
downstream agent-loop test suites pass.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
