### PR TITLE
feat: endpoint to get governance permissions

### DIFF
--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -1,0 +1,126 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { GetGovernancePermissionsResponseBody } from "@app/types/api/governance";
+import { honoApp } from "@front-api/app";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+function getGovernancePermissions(workspace: { sId: string }) {
+  return honoApp.request(`/api/w/${workspace.sId}/governance-permissions`);
+}
+
+// A capability with no grants yet, so its default configuration is admins_only.
+function adminsOnly(
+  grantType: string,
+  resourceType: string
+): {
+  grantType: string;
+  resourceType: string;
+  configuration: { scope: string };
+} {
+  return { grantType, resourceType, configuration: { scope: "admins_only" } };
+}
+
+describe("GET /api/w/:wId/governance-permissions", () => {
+  it("returns every capability for an admin, defaulting to admins_only", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await getGovernancePermissions(workspace);
+
+    expect(response.status).toBe(200);
+    const { governancePermissions }: GetGovernancePermissionsResponseBody =
+      await response.json();
+
+    // Admin sees every domain: agent/skill/frame plus the admin-only billing/identity.
+    expect(governancePermissions).toEqual({
+      "create:agent": adminsOnly("create", "agent"),
+      "publish:agent": adminsOnly("publish", "agent"),
+      "create:skill": adminsOnly("create", "skill"),
+      "publish:skill": adminsOnly("publish", "skill"),
+      "invite:frame": adminsOnly("invite", "frame"),
+      "publish:frame": adminsOnly("publish", "frame"),
+      "admin:billing": adminsOnly("admin", "billing"),
+      "admin:identity": adminsOnly("admin", "identity"),
+    });
+  });
+
+  it("returns every capability except billing and identity for a business admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+    });
+
+    const response = await getGovernancePermissions(workspace);
+
+    expect(response.status).toBe(200);
+    const { governancePermissions }: GetGovernancePermissionsResponseBody =
+      await response.json();
+
+    // Business admin sees agent/skill/frame but never the admin-only billing/identity.
+    expect(governancePermissions).toEqual({
+      "create:agent": adminsOnly("create", "agent"),
+      "publish:agent": adminsOnly("publish", "agent"),
+      "create:skill": adminsOnly("create", "skill"),
+      "publish:skill": adminsOnly("publish", "skill"),
+      "invite:frame": adminsOnly("invite", "frame"),
+      "publish:frame": adminsOnly("publish", "frame"),
+    });
+  });
+
+  it("reflects the everyone and groups scopes", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Set up grant state with an internal admin auth, independent of the request user.
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(
+      workspace.id
+    );
+    assert(globalGroup, "global group should exist");
+
+    await GroupPermissionResource.setForEverybody(auth, {
+      grantType: "create",
+      resourceType: "agent",
+    });
+
+    const groupA = await GroupFactory.regularAuto(workspace, "A");
+    await GroupPermissionResource.setGroups(
+      auth,
+      { grantType: "publish", resourceType: "agent" },
+      [groupA]
+    );
+
+    const response = await getGovernancePermissions(workspace);
+
+    expect(response.status).toBe(200);
+    const { governancePermissions }: GetGovernancePermissionsResponseBody =
+      await response.json();
+
+    expect(governancePermissions["create:agent"]?.configuration).toEqual({
+      scope: "everyone",
+    });
+    expect(governancePermissions["publish:agent"]?.configuration).toEqual({
+      scope: "groups",
+      groupIds: [groupA.sId],
+    });
+  });
+
+  it("returns 403 for a non-business-admin user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await getGovernancePermissions(workspace);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/governance-permissions.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.ts
@@ -1,0 +1,23 @@
+import { getWorkspaceGovernancePermissions } from "@app/lib/api/permissions/governance";
+import type { GetGovernancePermissionsResponseBody } from "@app/types/api/governance";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/governance-permissions.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsBusinessAdmin(),
+  async (ctx): HandlerResult<GetGovernancePermissionsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const governancePermissions = await getWorkspaceGovernancePermissions(auth);
+
+    return ctx.json({ governancePermissions });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -47,6 +47,7 @@ import featureFlags from "./feature-flags";
 import files from "./files";
 import googleDrivePickerToken from "./google_drive/picker_token";
 import googleDriveSearchForAuthorization from "./google_drive/search_for_authorization";
+import governancePermissions from "./governance-permissions";
 import groups from "./groups";
 import invitations from "./invitations";
 import keys from "./keys";
@@ -795,6 +796,7 @@ app.route(
   "/google_drive/search_for_authorization",
   googleDriveSearchForAuthorization
 );
+app.route("/governance-permissions", governancePermissions);
 app.route("/groups", groups);
 app.route("/invitations", invitations);
 app.route("/keys", keys);

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -1,3 +1,4 @@
+import { GovernancePageLayout } from "@app/components/pages/workspace/governance/GovernancePageLayout";
 import { GovernancePageSkeleton } from "@app/components/pages/workspace/governance/GovernancePageSkeleton";
 import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
@@ -31,11 +32,8 @@ import type {
   GrantType,
 } from "@app/types/group_permissions";
 import {
-  AGENT_GOVERNANCE_CAPABILITIES,
-  BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
   capabilityKey,
-  FRAME_GOVERNANCE_CAPABILITIES,
-  SKILL_GOVERNANCE_CAPABILITIES,
+  GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -48,12 +46,11 @@ import {
   CloudArrowLeftRight,
   ContentMessage,
   Cube01,
+  InfoCircle,
   Lock01,
-  Page,
   PuzzlePiece01,
   Robot,
   ShapesPlus,
-  Toggle01Left,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
@@ -101,10 +98,10 @@ function groupGovernancePermissionsBySection(
     );
 
   return {
-    agents: resolve(AGENT_GOVERNANCE_CAPABILITIES),
-    skills: resolve(SKILL_GOVERNANCE_CAPABILITIES),
-    frames: resolve(FRAME_GOVERNANCE_CAPABILITIES),
-    billingAndSecurity: resolve(BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES),
+    agents: resolve(GOVERNANCE_CAPABILITIES.agent),
+    skills: resolve(GOVERNANCE_CAPABILITIES.skill),
+    frames: resolve(GOVERNANCE_CAPABILITIES.frame),
+    billingAndSecurity: resolve(GOVERNANCE_CAPABILITIES.billingAndSecurity),
   };
 }
 
@@ -114,18 +111,22 @@ export const GovernancePage = () => {
 
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const { groups, isGroupsLoading } = useGroups({
+  const { groups, isGroupsLoading, isGroupsError } = useGroups({
     owner,
     kinds: MANAGEABLE_GROUP_KINDS,
   });
-  const { governancePermissions, isLoading: isGovernancePermissionsLoading } =
-    useGovernancePermissions(owner);
+  const {
+    governancePermissions,
+    isLoading: isGovernancePermissionsLoading,
+    isGovernancePermissionsError,
+  } = useGovernancePermissions(owner);
   const onPermissionChange = useUpdateGovernancePermission(owner);
 
   const { sharingPolicy, doUpdateSharingPolicy, isChanging } =
     useFrameSharingToggle({ owner });
 
   const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
+  const isError = isGroupsError || isGovernancePermissionsError;
 
   const { agents, skills, frames, billingAndSecurity } =
     groupGovernancePermissionsBySection(governancePermissions);
@@ -187,13 +188,23 @@ export const GovernancePage = () => {
     return <GovernancePageSkeleton />;
   }
 
+  if (isError) {
+    return (
+      <GovernancePageLayout>
+        <ContentMessage
+          variant="warning"
+          icon={InfoCircle}
+          size="lg"
+          title="Failed to load"
+        >
+          Governance settings could not be loaded.
+        </ContentMessage>
+      </GovernancePageLayout>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-6">
-      <Page.Header
-        title="Workspace & Governance"
-        description="Manage what members can do in your workspace."
-        icon={Toggle01Left}
-      />
+    <GovernancePageLayout>
       <ContentMessage>
         This page is WIP. Do not change unless you know what you are doing.
       </ContentMessage>
@@ -258,6 +269,6 @@ export const GovernancePage = () => {
           </>
         )}
       </div>
-    </div>
+    </GovernancePageLayout>
   );
 };

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -24,12 +24,21 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import { useGovernancePermissions } from "@app/lib/swr/governance";
 import { useGroups } from "@app/lib/swr/groups";
+import type { GovernancePermissionsByKey } from "@app/types/api/governance";
 import type {
+  CapabilitySpec,
   GovernancePermission,
   GrantType,
-  GroupPermissionResourceType,
+} from "@app/types/group_permissions";
+import {
+  AGENT_GOVERNANCE_CAPABILITIES,
+  BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
+  capabilityKey,
+  FRAME_GOVERNANCE_CAPABILITIES,
+  SKILL_GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type {
   LightWorkspaceType,
   WorkspaceSharingPolicy,
@@ -46,7 +55,6 @@ import {
   ShapesPlus,
   Toggle01Left,
 } from "@dust-tt/sparkle";
-import groupBy from "lodash/groupBy";
 import type { ComponentType } from "react";
 
 function useUpdateGovernancePermission(owner: LightWorkspaceType) {
@@ -75,6 +83,31 @@ function isFrameCapabilityEnabled(
   }
 }
 
+// Split the keyed permission map into the page's four sections. Each section pulls its capabilities
+// from the map in catalog (display) order, dropping any the current user's role isn't allowed to
+// see (absent from the map). Frame filtering by sharing policy is applied by the caller, which has
+// the runtime policy.
+function groupGovernancePermissionsBySection(
+  governancePermissions: GovernancePermissionsByKey
+): {
+  agents: GovernancePermission[];
+  skills: GovernancePermission[];
+  frames: GovernancePermission[];
+  billingAndSecurity: GovernancePermission[];
+} {
+  const resolve = (specs: CapabilitySpec[]): GovernancePermission[] =>
+    removeNulls(
+      specs.map((spec) => governancePermissions[capabilityKey(spec)])
+    );
+
+  return {
+    agents: resolve(AGENT_GOVERNANCE_CAPABILITIES),
+    skills: resolve(SKILL_GOVERNANCE_CAPABILITIES),
+    frames: resolve(FRAME_GOVERNANCE_CAPABILITIES),
+    billingAndSecurity: resolve(BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES),
+  };
+}
+
 export const GovernancePage = () => {
   const { hasFeature } = useFeatureFlags();
   const hasAdminGovernanceFeature = hasFeature("admin_governance");
@@ -94,16 +127,11 @@ export const GovernancePage = () => {
 
   const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
 
-  const governancePermissionsMap: Partial<
-    Record<GroupPermissionResourceType, GovernancePermission[]>
-  > = groupBy(governancePermissions, "resourceType");
+  const { agents, skills, frames, billingAndSecurity } =
+    groupGovernancePermissionsBySection(governancePermissions);
 
-  const billingPermissions = governancePermissionsMap.billing ?? [];
-  const identityPermissions = governancePermissionsMap.identity ?? [];
-
-  const framePermissions = (governancePermissionsMap.frame ?? []).filter(
-    (permission) =>
-      isFrameCapabilityEnabled(permission.grantType, sharingPolicy)
+  const framePermissions = frames.filter((permission) =>
+    isFrameCapabilityEnabled(permission.grantType, sharingPolicy)
   );
 
   const router = useAppRouter();
@@ -121,13 +149,13 @@ export const GovernancePage = () => {
       id: "agents",
       label: "Agents",
       icon: Robot,
-      governancePermissions: governancePermissionsMap.agent ?? [],
+      governancePermissions: agents,
     },
     {
       id: "skills",
       label: "Skills",
       icon: PuzzlePiece01,
-      governancePermissions: governancePermissionsMap.skill ?? [],
+      governancePermissions: skills,
     },
     ...(framePermissions.length > 0 || isAdmin
       ? [
@@ -145,10 +173,7 @@ export const GovernancePage = () => {
             id: "billing" as const,
             label: "Billing and security",
             icon: Lock01,
-            governancePermissions: [
-              ...billingPermissions,
-              ...identityPermissions,
-            ],
+            governancePermissions: billingAndSecurity,
           },
         ]
       : []),
@@ -163,7 +188,7 @@ export const GovernancePage = () => {
   }
 
   return (
-    <Page>
+    <div className="flex flex-col gap-6">
       <Page.Header
         title="Workspace & Governance"
         description="Manage what members can do in your workspace."
@@ -190,11 +215,7 @@ export const GovernancePage = () => {
             )}
             {governancePermissions.map((governancePermission) => (
               <GovernanceSettingRow
-                key={
-                  governancePermission.grantType +
-                  ":" +
-                  governancePermission.resourceType
-                }
+                key={capabilityKey(governancePermission)}
                 governancePermission={governancePermission}
                 groups={groups}
                 onChange={(newConfiguration) =>
@@ -237,6 +258,6 @@ export const GovernancePage = () => {
           </>
         )}
       </div>
-    </Page>
+    </div>
   );
 };

--- a/front/components/pages/workspace/governance/GovernancePageLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageLayout.tsx
@@ -1,0 +1,19 @@
+import { Page, Toggle01Left } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+interface GovernancePageLayoutProps {
+  children: ReactNode;
+}
+
+export function GovernancePageLayout({ children }: GovernancePageLayoutProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <Page.Header
+        title="Workspace & Governance"
+        description="Manage what members can do in your workspace."
+        icon={Toggle01Left}
+      />
+      {children}
+    </div>
+  );
+}

--- a/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
@@ -35,7 +35,7 @@ function SkeletonSection({ labelWidth, rows }: SkeletonSectionProps) {
 
 export function GovernancePageSkeleton() {
   return (
-    <Page>
+    <div className="flex flex-col gap-6">
       <Page.Header
         title="Workspace & Governance"
         description="Manage what members can do in your workspace."
@@ -57,6 +57,6 @@ export function GovernancePageSkeleton() {
         <SkeletonSection labelWidth="w-32" rows={2} />
         <SkeletonSection labelWidth="w-44" rows={2} />
       </div>
-    </Page>
+    </div>
   );
 }

--- a/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageSkeleton.tsx
@@ -1,4 +1,5 @@
-import { cn, LoadingBlock, Page, Toggle01Left } from "@dust-tt/sparkle";
+import { GovernancePageLayout } from "@app/components/pages/workspace/governance/GovernancePageLayout";
+import { cn, LoadingBlock } from "@dust-tt/sparkle";
 
 function SkeletonRow() {
   return (
@@ -35,12 +36,7 @@ function SkeletonSection({ labelWidth, rows }: SkeletonSectionProps) {
 
 export function GovernancePageSkeleton() {
   return (
-    <div className="flex flex-col gap-6">
-      <Page.Header
-        title="Workspace & Governance"
-        description="Manage what members can do in your workspace."
-        icon={Toggle01Left}
-      />
+    <GovernancePageLayout>
       <div className="flex items-center justify-between">
         <div className="flex flex-1 flex-col gap-2">
           <LoadingBlock className="h-6 w-40" />
@@ -57,6 +53,6 @@ export function GovernancePageSkeleton() {
         <SkeletonSection labelWidth="w-32" rows={2} />
         <SkeletonSection labelWidth="w-44" rows={2} />
       </div>
-    </div>
+    </GovernancePageLayout>
   );
 }

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -1,0 +1,75 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { CapabilityState } from "@app/lib/resources/group_permission_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import type { GovernancePermissionsByKey } from "@app/types/api/governance";
+import type {
+  CapabilitySpec,
+  GovernancePermissionConfiguration,
+} from "@app/types/group_permissions";
+import {
+  AGENT_GOVERNANCE_CAPABILITIES,
+  BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
+  capabilityKey,
+  FRAME_GOVERNANCE_CAPABILITIES,
+  SKILL_GOVERNANCE_CAPABILITIES,
+} from "@app/types/group_permissions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
+
+// Capabilities every business admin (and admin) can manage.
+const BUSINESS_ADMIN_CAPABILITIES: CapabilitySpec[] = [
+  ...AGENT_GOVERNANCE_CAPABILITIES,
+  ...SKILL_GOVERNANCE_CAPABILITIES,
+  ...FRAME_GOVERNANCE_CAPABILITIES,
+];
+
+// Capabilities every admin can manage.
+const ADMIN_CAPABILITIES: CapabilitySpec[] = [
+  ...BUSINESS_ADMIN_CAPABILITIES,
+  ...BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
+];
+
+function toConfiguration(
+  state: CapabilityState
+): GovernancePermissionConfiguration {
+  switch (state.scope) {
+    case "disabled":
+      return { scope: "admins_only" };
+    case "everyone":
+      return { scope: "everyone" };
+    case "groups":
+      return { scope: "groups", groupIds: state.groups.map((g) => g.sId) };
+    default:
+      return assertNever(state);
+  }
+}
+
+// Governance capabilities shown on the page, keyed by `${grantType}:${resourceType}`
+// Business admins receive every domain except billing/identity; admins receive all.
+export async function getWorkspaceGovernancePermissions(
+  auth: Authenticator
+): Promise<GovernancePermissionsByKey> {
+  const capabilities = auth.isAdmin()
+    ? ADMIN_CAPABILITIES
+    : BUSINESS_ADMIN_CAPABILITIES;
+
+  const stateByKey = await GroupPermissionResource.getCapabilitiesState(
+    auth,
+    capabilities
+  );
+
+  const permissionsByKey: GovernancePermissionsByKey = {};
+  for (const { grantType, resourceType } of capabilities) {
+    const key = capabilityKey({ grantType, resourceType });
+    const state = stateByKey.get(key);
+    assert(state, `Missing capability state for ${key}.`);
+
+    permissionsByKey[key] = {
+      grantType,
+      resourceType,
+      configuration: toConfiguration(state),
+    };
+  }
+
+  return permissionsByKey;
+}

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -7,33 +7,30 @@ import type {
   GovernancePermissionConfiguration,
 } from "@app/types/group_permissions";
 import {
-  AGENT_GOVERNANCE_CAPABILITIES,
-  BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
   capabilityKey,
-  FRAME_GOVERNANCE_CAPABILITIES,
-  SKILL_GOVERNANCE_CAPABILITIES,
+  GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 
 // Capabilities every business admin (and admin) can manage.
 const BUSINESS_ADMIN_CAPABILITIES: CapabilitySpec[] = [
-  ...AGENT_GOVERNANCE_CAPABILITIES,
-  ...SKILL_GOVERNANCE_CAPABILITIES,
-  ...FRAME_GOVERNANCE_CAPABILITIES,
+  ...GOVERNANCE_CAPABILITIES.agent,
+  ...GOVERNANCE_CAPABILITIES.skill,
+  ...GOVERNANCE_CAPABILITIES.frame,
 ];
 
 // Capabilities every admin can manage.
 const ADMIN_CAPABILITIES: CapabilitySpec[] = [
   ...BUSINESS_ADMIN_CAPABILITIES,
-  ...BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES,
+  ...GOVERNANCE_CAPABILITIES.billingAndSecurity,
 ];
 
 function toConfiguration(
   state: CapabilityState
 ): GovernancePermissionConfiguration {
   switch (state.scope) {
-    case "disabled":
+    case "admins_only":
       return { scope: "admins_only" };
     case "everyone":
       return { scope: "everyone" };

--- a/front/lib/resources/group_permission_governance.test.ts
+++ b/front/lib/resources/group_permission_governance.test.ts
@@ -38,7 +38,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
     ).get(`${capability.grantType}:${capability.resourceType}`);
 
   it("reports disabled when there is no -1 row", async () => {
-    expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
+    expect(await stateOf(CAPABILITY)).toEqual({ scope: "admins_only" });
   });
 
   it("reports everyone when the global group holds the -1 row", async () => {
@@ -91,7 +91,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
       disabledCap,
     ]);
     expect(states.get("publish:agent")).toEqual({ scope: "everyone" });
-    expect(states.get("admin:billing")).toEqual({ scope: "disabled" });
+    expect(states.get("admin:billing")).toEqual({ scope: "admins_only" });
     const groupsState = states.get("create:skill");
     assert(groupsState?.scope === "groups", "expected groups scope");
     expect(groupsState.groups.map((g) => g.id)).toEqual([groupA.id]);
@@ -157,7 +157,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
       });
       await GroupPermissionResource.disable(auth, CAPABILITY, { transaction });
 
-      expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
+      expect(await stateOf(CAPABILITY)).toEqual({ scope: "admins_only" });
     });
 
     it("setGroups([]) disables the capability", async () => {
@@ -168,7 +168,7 @@ describe("GroupPermissionResource — governance state (reads)", () => {
         transaction,
       });
 
-      expect(await stateOf(CAPABILITY)).toEqual({ scope: "disabled" });
+      expect(await stateOf(CAPABILITY)).toEqual({ scope: "admins_only" });
     });
 
     it("setGroups rejects the system group", async () => {

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -8,10 +8,14 @@ import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_pe
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
+  CapabilitySpec,
   GrantType,
   GroupPermissionResourceType,
 } from "@app/types/group_permissions";
-import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import {
+  capabilityKey,
+  WHOLE_TYPE_RESOURCE_ID,
+} from "@app/types/group_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -43,11 +47,6 @@ interface TypeWideGrantSpec {
   transaction?: Transaction;
 }
 
-interface CapabilitySpec {
-  grantType: GrantType;
-  resourceType: GroupPermissionResourceType;
-}
-
 // The state of a governance capability. "everyone" and "disabled" carry no groups; "groups" lists
 // the specific (non-global) groups it is granted to. Scope values match the governance page's
 // PermissionConfigurationScope.
@@ -55,10 +54,6 @@ export type CapabilityState =
   | { scope: "disabled" }
   | { scope: "everyone" }
   | { scope: "groups"; groups: GroupResource[] };
-
-function capabilityKey({ grantType, resourceType }: CapabilitySpec): string {
-  return `${grantType}:${resourceType}`;
-}
 
 interface ListForGroupsSpec {
   groupModelIds: ModelId[];

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -47,11 +47,11 @@ interface TypeWideGrantSpec {
   transaction?: Transaction;
 }
 
-// The state of a governance capability. "everyone" and "disabled" carry no groups; "groups" lists
-// the specific (non-global) groups it is granted to. Scope values match the governance page's
-// PermissionConfigurationScope.
+// The state of a governance capability. "everyone" and "admins_only" carry no groups; "groups"
+// lists the specific (non-global) groups it is granted to. Scope values match the governance
+// page's PermissionConfigurationScope.
 export type CapabilityState =
-  | { scope: "disabled" }
+  | { scope: "admins_only" }
   | { scope: "everyone" }
   | { scope: "groups"; groups: GroupResource[] };
 
@@ -605,7 +605,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       const key = capabilityKey(capability);
 
       if (capabilityRows.length === 0) {
-        result.set(key, { scope: "disabled" });
+        result.set(key, { scope: "admins_only" });
       } else if (capabilityRows.some((row) => row.groupId === globalGroup.id)) {
         result.set(key, { scope: "everyone" });
       } else {

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -1,57 +1,33 @@
-import type { GovernancePermission } from "@app/types/group_permissions";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  GetGovernancePermissionsResponseBody,
+  GovernancePermissionsByKey,
+} from "@app/types/api/governance";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
 
-const TEST_GOVERNANCE_PERMISSIONS: GovernancePermission[] = [
-  {
-    grantType: "create",
-    resourceType: "agent",
-    configuration: { scope: "everyone" },
-  },
-  {
-    grantType: "publish",
-    resourceType: "agent",
-    configuration: { scope: "everyone" },
-  },
-  {
-    grantType: "create",
-    resourceType: "skill",
-    configuration: { scope: "everyone" },
-  },
-  {
-    grantType: "publish",
-    resourceType: "skill",
-    configuration: { scope: "everyone" },
-  },
-  {
-    grantType: "invite",
-    resourceType: "frame",
-    configuration: { scope: "admins_only" },
-  },
-  {
-    grantType: "publish",
-    resourceType: "frame",
-    configuration: { scope: "admins_only" },
-  },
-  {
-    grantType: "admin",
-    resourceType: "billing",
-    configuration: { scope: "admins_only" },
-  },
-  {
-    grantType: "admin",
-    resourceType: "identity",
-    configuration: { scope: "admins_only" },
-  },
-];
+// Stable empty reference so the default doesn't create a new object on every render.
+const EMPTY_GOVERNANCE_PERMISSIONS: GovernancePermissionsByKey = {};
 
-export function useGovernancePermissions(owner: LightWorkspaceType): {
-  governancePermissions: GovernancePermission[];
-  isLoading: boolean;
-} {
-  const governancePermissions = TEST_GOVERNANCE_PERMISSIONS;
+export function useGovernancePermissions(
+  owner: LightWorkspaceType,
+  { disabled }: { disabled?: boolean } = {}
+) {
+  const { fetcher } = useFetcher();
+  const url = `/api/w/${owner.sId}/governance-permissions`;
+
+  const governanceFetcher: Fetcher<GetGovernancePermissionsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(url, governanceFetcher, {
+    disabled,
+  });
 
   return {
-    governancePermissions,
-    isLoading: false,
+    governancePermissions:
+      data?.governancePermissions ?? EMPTY_GOVERNANCE_PERMISSIONS,
+    isLoading: !error && !data && !disabled,
+    isGovernancePermissionsError: !!error,
+    mutateGovernancePermissions: mutate,
   };
 }

--- a/front/types/api/governance.ts
+++ b/front/types/api/governance.ts
@@ -1,0 +1,12 @@
+import type {
+  CapabilityKey,
+  GovernancePermission,
+} from "@app/types/group_permissions";
+
+export type GovernancePermissionsByKey = Partial<
+  Record<CapabilityKey, GovernancePermission>
+>;
+
+export type GetGovernancePermissionsResponseBody = {
+  governancePermissions: GovernancePermissionsByKey;
+};

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -123,19 +123,21 @@ export function capabilityKey({
  * Catalog of the governance capabilities the Workspace & Governance page manages, grouped by the
  * section they belong to.
  */
-export const AGENT_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
-  { grantType: "create", resourceType: "agent" },
-  { grantType: "publish", resourceType: "agent" },
-];
-export const SKILL_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
-  { grantType: "create", resourceType: "skill" },
-  { grantType: "publish", resourceType: "skill" },
-];
-export const FRAME_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
-  { grantType: "invite", resourceType: "frame" },
-  { grantType: "publish", resourceType: "frame" },
-];
-export const BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
-  { grantType: "admin", resourceType: "billing" },
-  { grantType: "admin", resourceType: "identity" },
-];
+export const GOVERNANCE_CAPABILITIES = {
+  agent: [
+    { grantType: "create", resourceType: "agent" },
+    { grantType: "publish", resourceType: "agent" },
+  ],
+  skill: [
+    { grantType: "create", resourceType: "skill" },
+    { grantType: "publish", resourceType: "skill" },
+  ],
+  frame: [
+    { grantType: "invite", resourceType: "frame" },
+    { grantType: "publish", resourceType: "frame" },
+  ],
+  billingAndSecurity: [
+    { grantType: "admin", resourceType: "billing" },
+    { grantType: "admin", resourceType: "identity" },
+  ],
+} satisfies Record<string, CapabilitySpec[]>;

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -101,3 +101,41 @@ export type GovernancePermission = {
   resourceType: GroupPermissionResourceType;
   configuration: GovernancePermissionConfiguration;
 };
+
+// A governance capability: a (grantType, resourceType) pair, without its configuration.
+export type CapabilitySpec = Pick<
+  GovernancePermission,
+  "grantType" | "resourceType"
+>;
+
+// Stable string key for a governance capability.
+export type CapabilityKey = `${GrantType}:${GroupPermissionResourceType}`;
+
+// The single source of truth for the capability-key format; used to key capability-state maps.
+export function capabilityKey({
+  grantType,
+  resourceType,
+}: CapabilitySpec): CapabilityKey {
+  return `${grantType}:${resourceType}`;
+}
+
+/**
+ * Catalog of the governance capabilities the Workspace & Governance page manages, grouped by the
+ * section they belong to.
+ */
+export const AGENT_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
+  { grantType: "create", resourceType: "agent" },
+  { grantType: "publish", resourceType: "agent" },
+];
+export const SKILL_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
+  { grantType: "create", resourceType: "skill" },
+  { grantType: "publish", resourceType: "skill" },
+];
+export const FRAME_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
+  { grantType: "invite", resourceType: "frame" },
+  { grantType: "publish", resourceType: "frame" },
+];
+export const BILLING_AND_SECURITY_GOVERNANCE_CAPABILITIES: CapabilitySpec[] = [
+  { grantType: "admin", resourceType: "billing" },
+  { grantType: "admin", resourceType: "identity" },
+];


### PR DESCRIPTION
## Description

This PR introduces a `GET /api/w/:wId/governance-permissions` endpoint to serve workspace governance permissions, replacing the hardcoded test data that was previously used on the frontend.

- Adds a new Hono route handler (`front-api/routes/w/[wId]/governance-permissions.ts`) restricted to business admins and above, calling a new `getWorkspaceGovernancePermissions` service function.
- Admins receive all capabilities (agents, skills, frames, billing/identity); business admins receive the same minus billing/identity.

## Tests

Added tests covering: admin (all capabilities, defaulting to `admins_only`), business admin (no billing/identity), scope reflection (`everyone` and `groups`), and 403 for non-business-admin users.

## Risks

Low.

## Deploy Plan

Standard deployment.