### PR TITLE
feat: endpoint to edit governance permissions

### DIFF
--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -3,13 +3,27 @@ import { GroupPermissionResource } from "@app/lib/resources/group_permission_res
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import type { GetGovernancePermissionsResponseBody } from "@app/types/api/governance";
+import type {
+  GetGovernancePermissionsResponseBody,
+  PatchGovernancePermissionResponseBody,
+} from "@app/types/api/governance";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
 
 function getGovernancePermissions(workspace: { sId: string }) {
   return honoApp.request(`/api/w/${workspace.sId}/governance-permissions`);
+}
+
+function patchGovernancePermission(
+  workspace: { sId: string },
+  body: Record<string, unknown>
+) {
+  return honoApp.request(`/api/w/${workspace.sId}/governance-permissions`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 // A capability with no grants yet, so its default configuration is admins_only.
@@ -120,6 +134,178 @@ describe("GET /api/w/:wId/governance-permissions", () => {
     });
 
     const response = await getGovernancePermissions(workspace);
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("PATCH /api/w/:wId/governance-permissions", () => {
+  it("grants a capability to everyone", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    });
+
+    expect(response.status).toBe(200);
+    const { governancePermission }: PatchGovernancePermissionResponseBody =
+      await response.json();
+    expect(governancePermission).toEqual({
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    });
+
+    // The change is persisted and visible on the next read.
+    const getResponse = await getGovernancePermissions(workspace);
+    const { governancePermissions }: GetGovernancePermissionsResponseBody =
+      await getResponse.json();
+    expect(governancePermissions["create:agent"]?.configuration).toEqual({
+      scope: "everyone",
+    });
+  });
+
+  it("grants a capability to specific groups", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const groupA = await GroupFactory.regularManual(workspace, "A");
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "publish",
+      resourceType: "agent",
+      configuration: { scope: "groups", groupIds: [groupA.sId] },
+    });
+
+    expect(response.status).toBe(200);
+    const { governancePermission }: PatchGovernancePermissionResponseBody =
+      await response.json();
+    expect(governancePermission.configuration).toEqual({
+      scope: "groups",
+      groupIds: [groupA.sId],
+    });
+  });
+
+  it("rejects a groups configuration referencing a non-manageable group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    // `regular_auto` groups back spaces and are not user-managed, so they cannot be granted here.
+    const autoGroup = await GroupFactory.regularAuto(workspace, "auto");
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "publish",
+      resourceType: "agent",
+      configuration: { scope: "groups", groupIds: [autoGroup.sId] },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("moves a capability back to admins_only", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    // Start from a non-default state so admins_only is a real transition.
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GroupPermissionResource.setForEverybody(auth, {
+      grantType: "create",
+      resourceType: "agent",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "admins_only" },
+    });
+
+    expect(response.status).toBe(200);
+    const { governancePermission }: PatchGovernancePermissionResponseBody =
+      await response.json();
+    expect(governancePermission.configuration).toEqual({
+      scope: "admins_only",
+    });
+  });
+
+  it("lets a business admin manage an agent capability", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "business_admin",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("forbids a business admin from managing billing", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "business_admin",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "admin",
+      resourceType: "billing",
+      configuration: { scope: "everyone" },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("treats a groups configuration with no groups as admins_only", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    // Start from `everyone` so persisting admins_only is a real transition.
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GroupPermissionResource.setForEverybody(auth, {
+      grantType: "create",
+      resourceType: "agent",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "groups", groupIds: [] },
+    });
+
+    expect(response.status).toBe(200);
+    const { governancePermission }: PatchGovernancePermissionResponseBody =
+      await response.json();
+    expect(governancePermission.configuration).toEqual({
+      scope: "admins_only",
+    });
+  });
+
+  it("returns 403 for a non-business-admin user", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const response = await patchGovernancePermission(workspace, {
+      grantType: "create",
+      resourceType: "agent",
+      configuration: { scope: "everyone" },
+    });
 
     expect(response.status).toBe(403);
   });

--- a/front-api/routes/w/[wId]/governance-permissions.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.ts
@@ -58,7 +58,7 @@ app.patch(
 
     if (result.isErr()) {
       switch (result.error.code) {
-        case "capability_not_managed":
+        case "unauthorized":
           return apiError(ctx, {
             status_code: 403,
             api_error: {
@@ -66,7 +66,15 @@ app.patch(
               message: result.error.message,
             },
           });
-        case "invalid_groups":
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: result.error.message,
+            },
+          });
+        case "invalid_id":
           return apiError(ctx, {
             status_code: 400,
             api_error: {

--- a/front-api/routes/w/[wId]/governance-permissions.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.ts
@@ -1,8 +1,21 @@
-import { getWorkspaceGovernancePermissions } from "@app/lib/api/permissions/governance";
-import type { GetGovernancePermissionsResponseBody } from "@app/types/api/governance";
+import {
+  getWorkspaceGovernancePermissions,
+  setWorkspaceGovernancePermission,
+} from "@app/lib/api/permissions/governance";
+import type {
+  GetGovernancePermissionsResponseBody,
+  PatchGovernancePermissionResponseBody,
+} from "@app/types/api/governance";
+import {
+  GRANT_TYPES,
+  GROUP_PERMISSION_RESOURCE_TYPES,
+} from "@app/types/group_permissions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBusinessAdmin } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 // Mounted at /api/w/:wId/governance-permissions.
 const app = workspaceApp();
@@ -17,6 +30,56 @@ app.get(
     const governancePermissions = await getWorkspaceGovernancePermissions(auth);
 
     return ctx.json({ governancePermissions });
+  }
+);
+
+const PatchGovernancePermissionRequestBodySchema = z.object({
+  grantType: z.enum([...GRANT_TYPES]),
+  resourceType: z.enum([...GROUP_PERMISSION_RESOURCE_TYPES]),
+  configuration: z.discriminatedUnion("scope", [
+    z.object({ scope: z.literal("everyone") }),
+    z.object({ scope: z.literal("admins_only") }),
+    z.object({ scope: z.literal("groups"), groupIds: z.array(z.string()) }),
+  ]),
+});
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  ensureIsBusinessAdmin(),
+  validate("json", PatchGovernancePermissionRequestBodySchema),
+  async (ctx): HandlerResult<PatchGovernancePermissionResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await setWorkspaceGovernancePermission(
+      auth,
+      ctx.req.valid("json")
+    );
+
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "capability_not_managed":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: result.error.message,
+            },
+          });
+        case "invalid_groups":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
+        default:
+          assertNever(result.error.code);
+      }
+    }
+
+    return ctx.json({ governancePermission: result.value });
   }
 );
 

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -23,7 +23,10 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { useGovernancePermissions } from "@app/lib/swr/governance";
+import {
+  useGovernancePermissions,
+  useUpdateGovernancePermission,
+} from "@app/lib/swr/governance";
 import { useGroups } from "@app/lib/swr/groups";
 import type { GovernancePermissionsByKey } from "@app/types/api/governance";
 import type {
@@ -37,10 +40,7 @@ import {
 } from "@app/types/group_permissions";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type {
-  LightWorkspaceType,
-  WorkspaceSharingPolicy,
-} from "@app/types/user";
+import type { WorkspaceSharingPolicy } from "@app/types/user";
 import {
   ActionFrame,
   CloudArrowLeftRight,
@@ -53,12 +53,6 @@ import {
   ShapesPlus,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
-
-function useUpdateGovernancePermission(owner: LightWorkspaceType) {
-  return (input: GovernancePermission) => {
-    return true;
-  };
-}
 
 // Frame governance permissions are only relevant when the workspace sharing policy actually
 // enables the underlying capability: email invites require external email sharing, and public

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -101,7 +101,7 @@ export async function setWorkspaceGovernancePermission(
 ): Promise<
   Result<
     GovernancePermission,
-    DustError<"capability_not_managed" | "invalid_groups">
+    DustError<"group_not_found" | "invalid_id" | "unauthorized">
   >
 > {
   const capability: CapabilitySpec = { grantType, resourceType };
@@ -112,7 +112,7 @@ export async function setWorkspaceGovernancePermission(
   if (!canManage) {
     return new Err(
       new DustError(
-        "capability_not_managed",
+        "unauthorized",
         "You cannot manage this governance permission."
       )
     );
@@ -139,12 +139,7 @@ export async function setWorkspaceGovernancePermission(
         configuration.groupIds
       );
       if (groupsRes.isErr()) {
-        return new Err(
-          new DustError(
-            "invalid_groups",
-            "The groups configuration references unknown groups."
-          )
-        );
+        return groupsRes;
       }
       // Only user-managed groups can be granted a governance capability; system/global and other
       // internal kinds are never assignable here.
@@ -153,7 +148,7 @@ export async function setWorkspaceGovernancePermission(
       ) {
         return new Err(
           new DustError(
-            "invalid_groups",
+            "invalid_id",
             "The groups configuration references groups that cannot be managed."
           )
         );

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -1,15 +1,21 @@
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import type { CapabilityState } from "@app/lib/resources/group_permission_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import type { GovernancePermissionsByKey } from "@app/types/api/governance";
 import type {
   CapabilitySpec,
+  GovernancePermission,
   GovernancePermissionConfiguration,
 } from "@app/types/group_permissions";
 import {
   capabilityKey,
   GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
+import { isManageableGroupKind } from "@app/types/groups";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 
@@ -25,6 +31,24 @@ const ADMIN_CAPABILITIES: CapabilitySpec[] = [
   ...BUSINESS_ADMIN_CAPABILITIES,
   ...GOVERNANCE_CAPABILITIES.billingAndSecurity,
 ];
+
+// The capabilities the caller's role is allowed to see and manage. Admins get everything; business
+// admins get every domain except billing/identity; no other role manages any governance capability.
+function capabilitiesForRole(auth: Authenticator): CapabilitySpec[] {
+  const role = auth.role();
+  switch (role) {
+    case "admin":
+      return ADMIN_CAPABILITIES;
+    case "business_admin":
+      return BUSINESS_ADMIN_CAPABILITIES;
+    case "builder":
+    case "user":
+    case "none":
+      return [];
+    default:
+      return assertNever(role);
+  }
+}
 
 function toConfiguration(
   state: CapabilityState
@@ -46,9 +70,7 @@ function toConfiguration(
 export async function getWorkspaceGovernancePermissions(
   auth: Authenticator
 ): Promise<GovernancePermissionsByKey> {
-  const capabilities = auth.isAdmin()
-    ? ADMIN_CAPABILITIES
-    : BUSINESS_ADMIN_CAPABILITIES;
+  const capabilities = capabilitiesForRole(auth);
 
   const stateByKey = await GroupPermissionResource.getCapabilitiesState(
     auth,
@@ -69,4 +91,95 @@ export async function getWorkspaceGovernancePermissions(
   }
 
   return permissionsByKey;
+}
+
+// Write side of the Governance page: apply one capability's target configuration. The three scopes
+// are mutually exclusive, so each maps to a single resource transition that clears the others.
+export async function setWorkspaceGovernancePermission(
+  auth: Authenticator,
+  { grantType, resourceType, configuration }: GovernancePermission
+): Promise<
+  Result<
+    GovernancePermission,
+    DustError<"capability_not_managed" | "invalid_groups">
+  >
+> {
+  const capability: CapabilitySpec = { grantType, resourceType };
+
+  const canManage = capabilitiesForRole(auth).some(
+    (c) => c.grantType === grantType && c.resourceType === resourceType
+  );
+  if (!canManage) {
+    return new Err(
+      new DustError(
+        "capability_not_managed",
+        "You cannot manage this governance permission."
+      )
+    );
+  }
+
+  switch (configuration.scope) {
+    case "admins_only":
+      await GroupPermissionResource.disable(auth, capability);
+      break;
+
+    case "everyone":
+      await GroupPermissionResource.setForEverybody(auth, capability);
+      break;
+
+    case "groups": {
+      // "Groups" with no groups selected grants the capability to nobody specific, which is
+      // equivalent to admins_only.
+      if (configuration.groupIds.length === 0) {
+        await GroupPermissionResource.disable(auth, capability);
+        break;
+      }
+      const groupsRes = await GroupResource.fetchByIds(
+        auth,
+        configuration.groupIds
+      );
+      if (groupsRes.isErr()) {
+        return new Err(
+          new DustError(
+            "invalid_groups",
+            "The groups configuration references unknown groups."
+          )
+        );
+      }
+      // Only user-managed groups can be granted a governance capability; system/global and other
+      // internal kinds are never assignable here.
+      if (
+        !groupsRes.value.every((group) => isManageableGroupKind(group.kind))
+      ) {
+        return new Err(
+          new DustError(
+            "invalid_groups",
+            "The groups configuration references groups that cannot be managed."
+          )
+        );
+      }
+      await GroupPermissionResource.setGroups(
+        auth,
+        capability,
+        groupsRes.value
+      );
+      break;
+    }
+
+    default:
+      assertNever(configuration);
+  }
+
+  const key = capabilityKey(capability);
+  const stateByKey = await GroupPermissionResource.getCapabilitiesState(auth, [
+    capability,
+  ]);
+  const state = stateByKey.get(key);
+  assert(state, `Missing capability state for ${key}.`);
+
+  return new Ok({
+    grantType,
+    resourceType,
+    configuration: toConfiguration(state),
+  });
 }

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -68,10 +68,7 @@ export type DustErrorCode =
   | "workspace_not_found"
   | "plan_not_found"
   | "metronome_error"
-  | "coupon_redemption_error"
-  // Governance permission errors
-  | "capability_not_managed"
-  | "invalid_groups";
+  | "coupon_redemption_error";
 
 export class DustError<T extends DustErrorCode = DustErrorCode> extends Error {
   constructor(

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -68,7 +68,10 @@ export type DustErrorCode =
   | "workspace_not_found"
   | "plan_not_found"
   | "metronome_error"
-  | "coupon_redemption_error";
+  | "coupon_redemption_error"
+  // Governance permission errors
+  | "capability_not_managed"
+  | "invalid_groups";
 
 export class DustError<T extends DustErrorCode = DustErrorCode> extends Error {
   constructor(

--- a/front/lib/swr/governance.ts
+++ b/front/lib/swr/governance.ts
@@ -1,27 +1,38 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetGovernancePermissionsResponseBody,
   GovernancePermissionsByKey,
+  PatchGovernancePermissionResponseBody,
 } from "@app/types/api/governance";
+import type { GovernancePermission } from "@app/types/group_permissions";
+import { capabilityKey } from "@app/types/group_permissions";
 import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 // Stable empty reference so the default doesn't create a new object on every render.
 const EMPTY_GOVERNANCE_PERMISSIONS: GovernancePermissionsByKey = {};
+
+function governancePermissionsUrl(owner: LightWorkspaceType) {
+  return `/api/w/${owner.sId}/governance-permissions`;
+}
 
 export function useGovernancePermissions(
   owner: LightWorkspaceType,
   { disabled }: { disabled?: boolean } = {}
 ) {
   const { fetcher } = useFetcher();
-  const url = `/api/w/${owner.sId}/governance-permissions`;
 
   const governanceFetcher: Fetcher<GetGovernancePermissionsResponseBody> =
     fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(url, governanceFetcher, {
-    disabled,
-  });
+  const { data, error, mutate } = useSWRWithDefaults(
+    governancePermissionsUrl(owner),
+    governanceFetcher,
+    { disabled }
+  );
 
   return {
     governancePermissions:
@@ -30,4 +41,45 @@ export function useGovernancePermissions(
     isGovernancePermissionsError: !!error,
     mutateGovernancePermissions: mutate,
   };
+}
+
+export function useUpdateGovernancePermission(owner: LightWorkspaceType) {
+  const sendNotification = useSendNotification();
+  const { mutateGovernancePermissions } = useGovernancePermissions(owner, {
+    disabled: true,
+  });
+
+  return useCallback(
+    async (permission: GovernancePermission): Promise<boolean> => {
+      const res = await clientFetch(governancePermissionsUrl(owner), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(permission),
+      });
+
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update permission",
+        });
+        return false;
+      }
+
+      const { governancePermission }: PatchGovernancePermissionResponseBody =
+        await res.json();
+      await mutateGovernancePermissions(
+        (current) =>
+          current && {
+            governancePermissions: {
+              ...current.governancePermissions,
+              [capabilityKey(governancePermission)]: governancePermission,
+            },
+          },
+        { revalidate: false }
+      );
+
+      return true;
+    },
+    [owner, mutateGovernancePermissions, sendNotification]
+  );
 }

--- a/front/types/api/governance.ts
+++ b/front/types/api/governance.ts
@@ -10,3 +10,7 @@ export type GovernancePermissionsByKey = Partial<
 export type GetGovernancePermissionsResponseBody = {
   governancePermissions: GovernancePermissionsByKey;
 };
+
+export type PatchGovernancePermissionResponseBody = {
+  governancePermission: GovernancePermission;
+};


### PR DESCRIPTION
## Description

This PR adds a `PATCH /api/w/:wId/governance-permissions` endpoint to allow admins and business admins to edit workspace governance permissions.

- Implements `setWorkspaceGovernancePermission` in `front/lib/api/permissions/governance.ts`, supporting three scopes: `admins_only`, `everyone`, and `groups` (with validation that only user-manageable groups can be assigned).
- Implements the `useUpdateGovernancePermission` SWR hook in `front/lib/swr/governance.ts`, replacing the previous no-op stub in `GovernancePage.tsx`.

## Tests

Added tests covering: granting to everyone, granting to specific groups, rejecting non-manageable groups, reverting to `admins_only`, role-based access (business admin allowed/forbidden), and empty groups fallback to `admins_only`.

## Risks

Low.

## Deploy Plan

Standard deployment.