### PR TITLE
[front] fix: Make impossible to upload file to a managed datasource

### DIFF
--- a/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -185,6 +185,78 @@ describe("POST /api/w/:wId/data_sources/:dsId/files", () => {
     expect(response.status).toBe(403);
   });
 
+  it("returns 403 when the data source is managed by a connector", async () => {
+    const { auth, workspace, globalSpace, user } =
+      await createPrivateApiMockRequest({ method: "POST", role: "admin" });
+
+    const dataSourceView = await DataSourceViewFactory.fromConnector(
+      workspace,
+      globalSpace,
+      "notion"
+    );
+    const file = await FileFactory.csv(auth, user, {
+      useCase: "upsert_table",
+    });
+
+    mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
+
+    const response = await post(workspace, dataSourceView.dataSource.sId, {
+      fileId: file.sId,
+      upsertArgs: {
+        tableId: "test-table",
+        name: "Test Table",
+        title: "Test Title",
+        description: "Test Description",
+        tags: ["test"],
+        useAppForHeaderDetection: true,
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "data_source_auth_error",
+        message: "You cannot upload a file to a managed data source.",
+      },
+    });
+  });
+
+  it("returns 403 when the data source is a website", async () => {
+    const { auth, workspace, globalSpace, user } =
+      await createPrivateApiMockRequest({ method: "POST", role: "admin" });
+
+    const dataSourceView = await DataSourceViewFactory.fromConnector(
+      workspace,
+      globalSpace,
+      "webcrawler"
+    );
+    const file = await FileFactory.csv(auth, user, {
+      useCase: "upsert_table",
+    });
+
+    mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
+
+    const response = await post(workspace, dataSourceView.dataSource.sId, {
+      fileId: file.sId,
+      upsertArgs: {
+        tableId: "test-table",
+        name: "Test Table",
+        title: "Test Title",
+        description: "Test Description",
+        tags: ["test"],
+        useAppForHeaderDetection: true,
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "data_source_auth_error",
+        message: "You cannot upload a file to a managed data source.",
+      },
+    });
+  });
+
   it("successfully upserts file to data source with the right arguments", async () => {
     const { auth, workspace, globalSpace, user } =
       await createPrivateApiMockRequest({ method: "POST", role: "admin" });

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/files.ts
@@ -1,4 +1,5 @@
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import { isManaged, isWebsite } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { APIErrorType } from "@app/types/error";
@@ -67,6 +68,16 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
       api_error: {
         type: "data_source_auth_error",
         message: "You are not authorized to upsert to this data source.",
+      },
+    });
+  }
+
+  if (isManaged(dataSource) || isWebsite(dataSource)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "You cannot upload a file to a managed data source.",
       },
     });
   }

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -633,7 +633,7 @@ export const SpaceDataSourceViewContentList = ({
       <DropzoneContainer
         description="Drag and drop your files here."
         title="Add Files"
-        disabled={!canWriteInSpace}
+        disabled={!canWriteInSpace || !isFolder(dataSourceView.dataSource)}
       >
         {isEmpty && (
           <div


### PR DESCRIPTION
## Description

Currently we can upload files with contentType corresponding to the folder usecase - in datasources managed by a connector 🤯 

This PR makes it impossible to drag and drop from the frontend. And also fails with a 403 on the backend in this case.


## Tests

Tested locally


## Risk

Low

## Deploy Plan

- Deploy front