### PR TITLE
Add pod function invocation inspection

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -622,9 +622,7 @@ export const VisualizationActionIframe = forwardRef<
     ): Promise<Result<SandboxFunctionInvocationType, Error>> => {
       try {
         if (isPublic) {
-          throw new Error(
-            "Sandbox functions are not supported in shared frames."
-          );
+          throw new Error("Pod functions are not supported in shared frames.");
         }
 
         const body: PostSandboxFunctionInvocationRequestBody = {

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2052,6 +2052,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "inspect_invocations": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "list": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -3172,6 +3176,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "db_reconcile": "never_ask",
     "db_schema": "never_ask",
     "get": "never_ask",
+    "inspect_invocations": "never_ask",
     "list": "never_ask",
     "publish": "low",
   },

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -13,40 +13,38 @@ export const SANDBOX_FUNCTIONS_SERVER_NAME = "sandbox_functions" as const;
 export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
   list: {
     description:
-      "List the sandbox functions published in the current pod, with their " +
+      "List the pod functions published in the current pod, with their " +
       "slug and description. Use the get tool to retrieve a function's input " +
       "and output schemas.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing sandbox functions...",
-      done: "Listed sandbox functions",
+      running: "Listing pod functions...",
+      done: "Listed pod functions",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
   },
   get: {
     description:
-      "Get a sandbox function's input and output JSON schemas by its slug.",
+      "Get a pod function's input and output JSON schemas by its slug.",
     schema: {
       slug: z
         .string()
         .min(1)
-        .describe(
-          "The slug of the sandbox function, as shown by the list tool."
-        ),
+        .describe("The slug of the pod function, as shown by the list tool."),
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting sandbox function...",
-      done: "Got sandbox function",
+      running: "Getting pod function...",
+      done: "Got pod function",
     },
     toolCostCategory: "basic",
     freeUsage: true,
   },
   publish: {
     description:
-      "Publish a sandbox function from a TypeScript source file in the current pod. The source " +
+      "Publish a pod function from a TypeScript source file in the current pod. The source " +
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
       "`schema` with zod `input` and `output`. It is bundled on the pod sandbox (only `zod` is " +
       "available to import) and its input and output JSON schemas are extracted from the `schema` " +
@@ -75,15 +73,15 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Publishing sandbox function...",
-      done: "Published sandbox function",
+      running: "Publishing pod function...",
+      done: "Published pod function",
     },
     toolCostCategory: "basic",
     freeUsage: true,
   },
   call: {
     description:
-      "Call a sandbox function published in the current pod by its slug, passing its input " +
+      "Call a pod function published in the current pod by its slug, passing its input " +
       "payload, and get back the function's output. Use the get tool first to see the function's " +
       "input schema. Input is validated inside the sandbox.",
     schema: {
@@ -91,7 +89,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
         .string()
         .min(1)
         .describe(
-          "The slug of the sandbox function to call, as shown by the list tool."
+          "The slug of the pod function to call, as shown by the list tool."
         ),
       input: z
         .record(z.unknown())
@@ -102,8 +100,34 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Calling sandbox function...",
-      done: "Called sandbox function",
+      running: "Calling pod function...",
+      done: "Called pod function",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  inspect_invocations: {
+    description:
+      "Inspect the most recent invocations of a pod function in the current pod, including " +
+      "their inputs, results, and errors.",
+    schema: {
+      slug: z
+        .string()
+        .min(1)
+        .describe("The slug of the pod function, as shown by the list tool."),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .optional()
+        .default(5)
+        .describe("Maximum number of recent invocations to return."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Inspecting pod function invocations...",
+      done: "Inspected pod function invocations",
     },
     toolCostCategory: "basic",
     freeUsage: true,
@@ -190,7 +214,7 @@ export const SANDBOX_FUNCTIONS_SERVER = {
     name: SANDBOX_FUNCTIONS_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Sandbox functions: schema-typed callables bundled and run on the pod's " +
+      "Pod functions: schema-typed callables bundled and run on the pod's " +
       "sandbox.",
     icon: "CommandLineIcon",
     authorization: null,

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -24,7 +24,7 @@ export async function callHandler(
   );
   if (!sandboxFunction) {
     return new Err(
-      new MCPError(`No sandbox function with slug "${slug}" in this pod.`, {
+      new MCPError(`No pod function with slug "${slug}" in this pod.`, {
         tracked: false,
       })
     );
@@ -40,7 +40,7 @@ export async function callHandler(
     // The function ran but returned an error: model- or builder-correctable, not internal.
     return new Err(
       new MCPError(
-        `Sandbox function "${slug}" returned an error (${outcome.errorKind}): ${outcome.message}`,
+        `Pod function "${slug}" returned an error (${outcome.errorKind}): ${outcome.message}`,
         { tracked: false }
       )
     );

--- a/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
@@ -6,6 +6,7 @@ import { dbQueryHandler } from "@app/lib/api/actions/servers/sandbox_functions/t
 import { dbReconcileHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/db_reconcile";
 import { dbSchemaHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/db_schema";
 import { getHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/get";
+import { inspectInvocationsHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations";
 import { listHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
 
@@ -14,6 +15,7 @@ const HANDLERS = {
   get: getHandler,
   publish: publishHandler,
   call: callHandler,
+  inspect_invocations: inspectInvocationsHandler,
   db_list: dbListHandler,
   db_schema: dbSchemaHandler,
   db_query: dbQueryHandler,

--- a/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
@@ -4,19 +4,30 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
-export function formatSandboxFunction(fn: SandboxFunctionResource): string {
+export function formatSandboxFunctionInvocations(
+  slug: string,
+  invocations: SandboxFunctionInvocationResource[]
+): string {
+  if (invocations.length === 0) {
+    return `No invocations found for pod function "${slug}".`;
+  }
+
+  const serializedInvocations = invocations.map((invocation) =>
+    invocation.toJSONForLLM()
+  );
+
   return [
-    `${fn.slug}: ${fn.description}`,
-    `input: ${JSON.stringify(fn.inputSchema)}`,
-    `output: ${JSON.stringify(fn.outputSchema)}`,
+    `Recent invocations for pod function "${slug}" (newest first):`,
+    JSON.stringify(serializedInvocations, null, 2),
   ].join("\n");
 }
 
-export async function getHandler(
-  { slug }: { slug: string },
+export async function inspectInvocationsHandler(
+  { slug, limit }: { slug: string; limit: number },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getPod(auth, { toolContext: { runContext } });
@@ -37,7 +48,15 @@ export async function getHandler(
     );
   }
 
+  const invocations = await SandboxFunctionInvocationResource.listRecent(auth, {
+    sandboxFunction,
+    limit,
+  });
+
   return new Ok([
-    { type: "text", text: formatSandboxFunction(sandboxFunction) },
+    {
+      type: "text",
+      text: formatSandboxFunctionInvocations(slug, invocations),
+    },
   ]);
 }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -48,7 +48,7 @@ async function makeFunction(
 describe("formatSandboxFunctionsList", () => {
   it("returns an explicit empty message when there are none", () => {
     expect(formatSandboxFunctionsList([])).toBe(
-      "No sandbox functions published in this pod."
+      "No pod functions published in this pod."
     );
   });
 
@@ -64,7 +64,7 @@ describe("formatSandboxFunctionsList", () => {
 
     const out = formatSandboxFunctionsList([fn]);
 
-    expect(out).toContain("Sandbox functions:");
+    expect(out).toContain("Pod functions:");
     expect(out).toContain("- greet: Greet a user by name.");
     expect(out).toContain("Use the get tool");
     // The verbose schemas live behind the get tool, not the list.

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -10,13 +10,13 @@ export function formatSandboxFunctionsList(
   sandboxFunctions: SandboxFunctionResource[]
 ): string {
   if (sandboxFunctions.length === 0) {
-    return "No sandbox functions published in this pod.";
+    return "No pod functions published in this pod.";
   }
 
   const lines = sandboxFunctions.map((fn) => `- ${fn.slug}: ${fn.description}`);
 
   return (
-    `Sandbox functions:\n${lines.join("\n")}\n\n` +
+    `Pod functions:\n${lines.join("\n")}\n\n` +
     "Use the get tool with a function's slug to see its input and output schemas."
   );
 }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -41,7 +41,7 @@ export async function publishHandler(
   return new Ok([
     {
       type: "text",
-      text: `Published sandbox function "${result.value.slug}".`,
+      text: `Published pod function "${result.value.slug}".`,
     },
   ]);
 }

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -80,7 +80,7 @@ export async function callSandboxFunction(
     const parsed = resultEnvelopeSchema.safeParse(data.result);
     if (!parsed.success) {
       return new Err(
-        new Error("Sandbox function returned an unexpected result envelope.")
+        new Error("Pod function returned an unexpected result envelope.")
       );
     }
     if (!parsed.data.ok) {
@@ -101,7 +101,5 @@ export async function callSandboxFunction(
     });
   }
 
-  return new Err(
-    new Error("Sandbox function did not return a result in time.")
-  );
+  return new Err(new Error("Pod function did not return a result in time."));
 }

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -166,7 +166,7 @@ export async function createSandboxFunctionMCPAction(
     return new Err(
       new SandboxFunctionMCPActionError(
         "invocation_not_found",
-        "Sandbox function not found."
+        "Pod function not found."
       )
     );
   }
@@ -179,7 +179,7 @@ export async function createSandboxFunctionMCPAction(
     return new Err(
       new SandboxFunctionMCPActionError(
         "invocation_not_found",
-        "Sandbox function invocation not found."
+        "Pod function invocation not found."
       )
     );
   }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1,3 +1,4 @@
+import { formatSandboxFunctionInvocations } from "@app/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations";
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
@@ -109,6 +110,87 @@ async function setupExecutionTest() {
 }
 
 describe("SandboxFunctionInvocationResource", () => {
+  it("lists the most recent invocations for one function", async () => {
+    const { authenticator, space, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    await invocation.succeed({ commentId: "comment-1" });
+
+    const secondInvocation = await SandboxFunctionInvocationResource.makeNew(
+      authenticator,
+      { sandboxFunction, input: { message: "second" } }
+    );
+    await secondInvocation.fail(new Error("second invocation failed"));
+
+    const thirdInvocation = await SandboxFunctionInvocationResource.makeNew(
+      authenticator,
+      { sandboxFunction, input: { message: "third" } }
+    );
+    await thirdInvocation.succeed({ commentId: "comment-3" });
+
+    const otherFile = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "other.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    const otherFunction = await SandboxFunctionResource.makeNew(authenticator, {
+      space,
+      file: otherFile,
+      slug: "other-function",
+      description: "Run another function.",
+      inputSchema,
+      outputSchema,
+    });
+    await SandboxFunctionInvocationResource.makeNew(authenticator, {
+      sandboxFunction: otherFunction,
+      input: { message: "other" },
+    });
+
+    const recentInvocations =
+      await SandboxFunctionInvocationResource.listRecent(authenticator, {
+        sandboxFunction,
+        limit: 2,
+      });
+
+    expect(recentInvocations.map((item) => item.sId)).toEqual([
+      thirdInvocation.sId,
+      secondInvocation.sId,
+    ]);
+    expect(recentInvocations[0]?.result).toEqual({ commentId: "comment-3" });
+    expect(recentInvocations[1]?.error).toBe("second invocation failed");
+    expect(recentInvocations[0]?.toJSONForLLM()).toMatchObject({
+      invocationId: thirdInvocation.sId,
+      status: "succeeded",
+      input: { message: "third" },
+      result: { commentId: "comment-3" },
+    });
+    expect(recentInvocations[1]?.toJSONForLLM()).toMatchObject({
+      invocationId: secondInvocation.sId,
+      status: "errored",
+      input: { message: "second" },
+      error: "second invocation failed",
+    });
+
+    const formatted = formatSandboxFunctionInvocations(
+      sandboxFunction.slug,
+      recentInvocations
+    );
+    expect(formatted).toContain('"status": "succeeded"');
+    expect(formatted).toContain('"input": {');
+    expect(formatted).toContain('"result": {');
+    expect(formatted).toContain('"error": "second invocation failed"');
+    expect(formatted).toContain('"createdAt":');
+    expect(formatted).toContain('"updatedAt":');
+  });
+
+  it("formats an explicit message when a function has no invocations", () => {
+    expect(formatSandboxFunctionInvocations("never-called", [])).toBe(
+      'No invocations found for pod function "never-called".'
+    );
+  });
+
   it("stores and reloads its input from GCS", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -30,6 +30,7 @@ import logger from "@app/logger/logger";
 import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionInvocationStatus,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
 import { isDevelopment } from "@app/types/shared/env";
@@ -60,6 +61,16 @@ const SandboxFunctionInvocationDataSchema = z.object({
 type SandboxFunctionInvocationData = z.infer<
   typeof SandboxFunctionInvocationDataSchema
 >;
+
+export interface SandboxFunctionInvocationForLLM {
+  createdAt: string;
+  error?: string;
+  input: unknown;
+  invocationId: string;
+  result?: unknown;
+  status: SandboxFunctionInvocationStatus;
+  updatedAt: string;
+}
 
 function parseSandboxFunctionInvocationData(
   content: string
@@ -140,15 +151,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
   get error(): string | undefined {
     return this.data.error;
-  }
-
-  toJSON(): SandboxFunctionInvocationType {
-    return {
-      sId: this.sId,
-      functionId: this.sandboxFunction.sId,
-      status: this.status,
-      createdAt: this.createdAt.toISOString(),
-    };
   }
 
   async fail(error: Error): Promise<void> {
@@ -267,7 +269,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         ).trim();
         return new Err(
           new Error(
-            `Sandbox function invocation failed with exit code ${exitCode}${
+            `Pod function invocation failed with exit code ${exitCode}${
               detail ? `:\n${detail}` : "."
             }`
           )
@@ -471,6 +473,29 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return invocation ?? null;
   }
 
+  static async listRecent(
+    auth: Authenticator,
+    {
+      sandboxFunction,
+      limit,
+    }: {
+      sandboxFunction: SandboxFunctionResource;
+      limit: number;
+    }
+  ): Promise<SandboxFunctionInvocationResource[]> {
+    return this.baseFetch(
+      auth,
+      { sandboxFunction },
+      {
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        limit,
+      }
+    );
+  }
+
   static async deleteAllForSandboxFunction(
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
@@ -524,5 +549,26 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+
+  toJSON(): SandboxFunctionInvocationType {
+    return {
+      sId: this.sId,
+      functionId: this.sandboxFunction.sId,
+      status: this.status,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+
+  toJSONForLLM(): SandboxFunctionInvocationForLLM {
+    return {
+      createdAt: this.createdAt.toISOString(),
+      input: this.input,
+      invocationId: this.sId,
+      status: this.status,
+      updatedAt: this.updatedAt.toISOString(),
+      ...(this.result !== undefined ? { result: this.result } : {}),
+      ...(this.error !== undefined ? { error: this.error } : {}),
+    };
   }
 }

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -156,6 +156,9 @@ Call a published function directly from this conversation with \`${toolName("cal
 its slug and an input payload matching its \`get\`-reported input schema. Call it yourself whenever
 you need the result now rather than asking a Frame to fetch it for you.
 
+To debug a function, use \`${toolName("inspect_invocations")}\` to inspect its most recent inputs,
+results, errors, statuses, and timestamps.
+
 The live databases have their own tools: \`${toolName("db_list")}\` (sizes),
 \`${toolName("db_schema")}\` (live storage types only; column modes exist only in the authored
 file), \`${toolName("db_query")}\` (one SQL statement; no schema changes; a result too large to
@@ -180,10 +183,10 @@ const { result, error } = await callFunction("<podId>/<slug>", input);
 \`input\` must match the function's declared input schema (see \`get\`). Check \`error\` and render
 loading/error state, since this is a network call like any other in the Frame. \`result\` is
 currently the raw sandbox runner envelope (\`{ ok, response: { status, body, encoding, ... } }\`)
-rather than the parsed \`schema.output\`, so parse \`response.body\` yourself. Sandbox functions are
+rather than the parsed \`schema.output\`, so parse \`response.body\` yourself. Pod functions are
 only reachable from authenticated Pod Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 2,
+  version: 3,
   icon: "PuzzleIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/agent_loop/activities/run_sandbox_function_invocation.ts
@@ -19,7 +19,7 @@ export async function runSandboxFunctionInvocationActivity(
     sandboxFunctionId
   );
   if (!sandboxFunction) {
-    throw new Error(`Sandbox function not found: ${sandboxFunctionId}`);
+    throw new Error(`Pod function not found: ${sandboxFunctionId}`);
   }
 
   const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
@@ -27,7 +27,7 @@ export async function runSandboxFunctionInvocationActivity(
     invocationId,
   });
   if (!invocation) {
-    throw new Error(`Sandbox function invocation not found: ${invocationId}`);
+    throw new Error(`Pod function invocation not found: ${invocationId}`);
   }
 
   const executionResult = await invocation.execute(auth);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -207,7 +207,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "on_demand",
   },
   sandbox_functions: {
-    description: "Enable Sandbox Function invocation endpoints",
+    description: "Enable Pod Function invocation endpoints",
     stage: "dust_only",
   },
   run_tools_from_prompt: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds a free, read-only tool for inspecting recent Pod function invocations, including status, timestamps,
input, and result or error. Results are scoped to the current Pod and returned newest-first with a configurable limit.

Also standardizes model-facing terminology around “Pod functions” while preserving internal identifiers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
