### PR TITLE
[front] refactor: move tool stakes from server-level to tool-level metadata

### DIFF
--- a/.claude/skills/dust-mcp-server/SKILL.md
+++ b/.claude/skills/dust-mcp-server/SKILL.md
@@ -168,10 +168,8 @@ export const YOUR_PROVIDER_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(YOUR_PROVIDER_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;
 ```
 
@@ -584,7 +582,7 @@ Before marking implementation complete:
 ### Tools not working
 
 - verify the tool is registered
-- verify `tools_stakes` contains the tool names
+- verify every published tool includes its `stake`
 - test the API helper functions directly
 - confirm `authInfo.token` is propagated
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1468,7 +1468,9 @@ export function getInternalMCPServerToolStakes(
 ): Record<string, MCPToolStakeLevelType> {
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
 
-  return server.metadata.tools_stakes;
+  return Object.fromEntries(
+    Object.values(server.metadata.tools).map((t) => [t.name, t.stake])
+  );
 }
 
 export function getInternalMCPServerToolArgumentsRequiringApproval(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -604,13 +604,6 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
-    tools_stakes: {
-      search_in_files: "never_ask",
-      search_drive_items: "never_ask",
-      update_word_document: "high",
-      get_file_content: "never_ask",
-      upload_file: "high",
-    },
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
@@ -622,15 +615,6 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
-    tools_stakes: {
-      search_messages_content: "never_ask",
-      list_teams: "never_ask",
-      list_users: "never_ask",
-      list_channels: "never_ask",
-      list_chats: "never_ask",
-      list_messages: "never_ask",
-      post_message: "medium",
-    },
     tools_arguments_requiring_approval: {
       post_message: ["channelId"],
     },
@@ -668,11 +652,6 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("http_client_tool");
     },
     isPreview: true,
-    tools_stakes: {
-      send_request: "low",
-      websearch: "never_ask",
-      webbrowser: "never_ask",
-    },
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -122,8 +122,6 @@ export const PROCESS_TOOL_NAME = "extract_information_from_documents";
 export const WEBSEARCH_TOOL_NAME = "websearch";
 export const WEBBROWSER_TOOL_NAME = "webbrowser";
 
-export const CREATE_AGENT_TOOL_NAME = "create_agent";
-
 export const DATA_WAREHOUSES_LIST_TOOL_NAME = "list";
 export const DATA_WAREHOUSES_FIND_TOOL_NAME = "find";
 export const DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME = "describe_tables";
@@ -136,8 +134,6 @@ export const SKILL_MANAGEMENT_SERVER_NAME = "skill_management";
 export const SKILL_AUTHORING_SERVER_NAME = "skill_authoring";
 
 export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
-// Kept for backward compatibility with existing actions in conversations.
-export const EDIT_IMAGE_TOOL_NAME = "edit_image";
 
 export const SEARCH_SERVER_NAME = "search";
 
@@ -1283,7 +1279,6 @@ type InternalMCPServerEntryWithMetadata<K extends InternalMCPServerNameType> =
   InternalMCPServerEntryCommon & {
     metadata: ServerMetadata<K>;
     serverInfo?: InternalMCPServerDefinitionType & { name: K };
-    tools_stakes?: Record<string, MCPToolStakeLevelType>;
   };
 
 type InternalMCPServerEntryWithoutMetadata<
@@ -1291,7 +1286,6 @@ type InternalMCPServerEntryWithoutMetadata<
 > = InternalMCPServerEntryCommon & {
   metadata?: undefined;
   serverInfo: InternalMCPServerDefinitionType & { name: K };
-  tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
 };
 
 type InternalMCPServerEntryBase<K extends InternalMCPServerNameType> =
@@ -1370,7 +1364,7 @@ export function allowsMultipleInstancesOfInternalMCPServerById(
   if (r.isErr()) {
     return false;
   }
-  return !!INTERNAL_MCP_SERVERS[r.value.name].allowMultipleInstances;
+  return INTERNAL_MCP_SERVERS[r.value.name].allowMultipleInstances;
 }
 
 export function getInternalMCPServerNameAndWorkspaceId(sId: string): Result<

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -151,6 +151,7 @@ export type InternalMCPToolType<TName extends string = string> = Omit<
   displayLabels: ToolDisplayLabels;
   toolCostCategory: ToolCostCategory;
   freeUsage: boolean;
+  stake: MCPToolStakeLevelType;
 };
 
 export type ServerMetadata<
@@ -160,5 +161,4 @@ export type ServerMetadata<
 > = {
   serverInfo: InternalMCPServerDefinitionType & { name: TServerName };
   tools: InternalMCPToolType<TToolName>[];
-  tools_stakes: Record<TToolName, MCPToolStakeLevelType>;
 };

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -99,11 +99,6 @@ export const ACTIVATION_RECOMMENDATIONS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -132,8 +132,6 @@ export const AGENT_MEMORY_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -65,8 +65,6 @@ export const AGENT_ROUTER_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -36,11 +36,6 @@ export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -598,11 +598,6 @@ export const AGENT_SIDEKICK_CONTEXT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_templates/metadata.ts
+++ b/front/lib/api/actions/servers/agent_templates/metadata.ts
@@ -64,8 +64,6 @@ export const AGENT_TEMPLATES_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(AGENT_TEMPLATES_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -277,8 +277,6 @@ export const ASHBY_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(ASHBY_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -60,11 +60,6 @@ export const ASK_USER_QUESTION_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -105,8 +105,6 @@ export const CLARI_COPILOT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -138,8 +138,6 @@ export const COMMON_UTILITIES_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -190,8 +190,6 @@ export const CONFLUENCE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -152,8 +152,6 @@ export const CONVERSATION_FILES_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    ALL_CONVERSATION_FILES_TOOLS.map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -163,11 +163,6 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -184,8 +184,6 @@ export const DATA_WAREHOUSES_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -38,8 +38,6 @@ export const DATABRICKS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(DATABRICKS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -100,8 +100,6 @@ export const EXA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(EXA_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -199,11 +199,6 @@ export const EXTRACT_DATA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -120,8 +120,6 @@ export const FATHOM_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(FATHOM_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -132,8 +132,6 @@ export const FILE_GENERATION_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -454,8 +454,6 @@ export const FILES_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(FILES_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -778,8 +778,6 @@ export const FRESHSERVICE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -355,8 +355,6 @@ export const FRONT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(FRONT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -601,8 +601,6 @@ export const GITHUB_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(GITHUB_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -319,8 +319,6 @@ export const GMAIL_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(GMAIL_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -94,8 +94,6 @@ export const GONG_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(GONG_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -334,8 +334,6 @@ export const GOOGLE_CALENDAR_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -685,10 +685,8 @@ export function getGoogleDriveServerMetadata() {
       displayLabels: t.displayLabels,
       toolCostCategory: t.toolCostCategory,
       freeUsage: t.freeUsage,
+      stake: t.stake,
     })),
-    tools_stakes: Object.fromEntries(
-      Object.values(ALL_TOOLS_METADATA).map((t) => [t.name, t.stake])
-    ),
   } as const satisfies ServerMetadata;
 }
 

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -340,8 +340,6 @@ export const GOOGLE_SHEETS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -88,8 +88,6 @@ export const HTTP_CLIENT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(ALL_HTTP_CLIENT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -940,8 +940,6 @@ export const HUBSPOT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(HUBSPOT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -100,8 +100,6 @@ export const IMAGE_GENERATION_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -83,11 +83,6 @@ export const INCLUDE_DATA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -334,11 +334,6 @@ export const INTERACTIVE_CONTENT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -441,8 +441,6 @@ export const JIRA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(JIRA_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -90,8 +90,6 @@ export const JIT_TESTING_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -349,8 +349,6 @@ export const LUMA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(LUMA_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -401,8 +401,6 @@ export const MICROSOFT_DRIVE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -251,8 +251,6 @@ export const MICROSOFT_EXCEL_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -375,8 +375,6 @@ export const MICROSOFT_TEAMS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -15,5 +15,4 @@ export const MISSING_ACTION_CATCHER_SERVER = {
   },
   // Tools are created dynamically at runtime based on the tool context.
   tools: [],
-  tools_stakes: {},
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -555,8 +555,6 @@ export const MONDAY_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(MONDAY_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -584,8 +584,6 @@ export const NOTION_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(NOTION_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -144,8 +144,6 @@ export const OPENAI_USAGE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -388,8 +388,6 @@ export const OUTLOOK_CALENDAR_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -634,8 +634,6 @@ export const OUTLOOK_MAIL_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(OUTLOOK_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -121,8 +121,6 @@ export const PLAN_MODE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -570,8 +570,6 @@ export const POD_MANAGER_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -136,8 +136,6 @@ export const POD_TASKS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(POD_TASKS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -403,8 +403,6 @@ export const POKE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(POKE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -122,11 +122,6 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -397,8 +397,6 @@ export const PRODUCTBOARD_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -115,8 +115,6 @@ export const QUERY_TABLES_V2_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -165,11 +165,7 @@ export const RUN_AGENT_SERVER = {
       },
       toolCostCategory: "basic",
       freeUsage: false,
+      stake: "never_ask",
     },
   ],
-  // Default stake for dynamically created run_agent tools.
-  // The actual tool name is dynamic, but all run_agent tools have the same stake.
-  tools_stakes: {
-    [RUN_AGENT_PLACEHOLDER_TOOL_NAME]: "never_ask",
-  },
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -46,8 +46,6 @@ export const RUN_DUST_APP_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -177,8 +177,6 @@ export const SALESFORCE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SALESFORCE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -50,8 +50,6 @@ export const SALESLOFT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SALESLOFT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -151,8 +151,6 @@ export const SANDBOX_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -203,11 +203,6 @@ export const SANDBOX_FUNCTIONS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -95,12 +95,6 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     displayLabels: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
     toolCostCategory: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
     freeUsage: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
+    stake: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].stake,
   })),
-  tools_stakes: Object.fromEntries(
-    (
-      Object.keys(
-        SCHEDULES_MANAGEMENT_TOOLS_METADATA
-      ) as SchedulesManagementToolKey[]
-    ).map((key) => [key, SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -79,8 +79,6 @@ export const SEARCH_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SEARCH_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -179,8 +179,6 @@ export const SKILL_AUTHORING_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -46,10 +46,6 @@ export const SKILL_MANAGEMENT_SERVER = {
     displayLabels: SKILL_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
     toolCostCategory: SKILL_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
     freeUsage: SKILL_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
+    stake: SKILL_MANAGEMENT_TOOLS_METADATA[key].stake,
   })),
-  tools_stakes: Object.fromEntries(
-    (
-      Object.keys(SKILL_MANAGEMENT_TOOLS_METADATA) as SkillManagementToolKey[]
-    ).map((key) => [key, SKILL_MANAGEMENT_TOOLS_METADATA[key].stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -126,8 +126,6 @@ export const SLAB_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SLAB_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -274,8 +274,6 @@ export const SLACK_BOT_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -660,8 +660,6 @@ export const SLACK_PERSONAL_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -150,8 +150,6 @@ export const SNOWFLAKE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -64,8 +64,6 @@ export const SOUND_STUDIO_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -254,8 +254,6 @@ export const SPEECH_GENERATOR_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -192,8 +192,6 @@ export const STATUSPAGE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -50,8 +50,6 @@ export const TOOLSETS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(TOOLSETS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -220,8 +220,6 @@ export const UKG_READY_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(UKG_READY_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -74,8 +74,6 @@ export const USER_ANALYTICS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(USER_ANALYTICS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -65,8 +65,6 @@ export const USER_MENTIONS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -300,8 +300,6 @@ export const VAL_TOWN_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -359,8 +359,6 @@ export const VANTA_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(VANTA_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -104,8 +104,6 @@ export const WAKEUPS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(WAKEUPS_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -63,11 +63,6 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -47,8 +47,6 @@ export const WORKDAY_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(WORKDAY_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -313,11 +313,6 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -176,8 +176,6 @@ export const ZENDESK_SERVER = {
     displayLabels: t.displayLabels,
     toolCostCategory: t.toolCostCategory,
     freeUsage: t.freeUsage,
+    stake: t.stake,
   })),
-  tools_stakes: Object.fromEntries(
-    Object.values(ZENDESK_TOOLS_METADATA).map((t) => [t.name, t.stake])
-  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/marketing/integrations.ts
+++ b/front/lib/api/marketing/integrations.ts
@@ -1,6 +1,10 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
+  INTERNAL_MCP_SERVERS,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import type { ConnectorProvider } from "@app/types/data_source";
@@ -234,41 +238,20 @@ function formatToolName(name: string): string {
 }
 
 function extractToolsFromServer(
-  serverKey: string
+  serverMetadata: ServerMetadata
 ): { tools: IntegrationTool[]; icon: InternalAllowedIconType } | null {
-  const server = INTERNAL_MCP_SERVERS[
-    serverKey as keyof typeof INTERNAL_MCP_SERVERS
-  ] as
-    | {
-        metadata?: {
-          serverInfo: { icon: string; description: string };
-          tools_stakes: Record<string, string>;
-        };
-        tools_stakes?: Record<string, string>;
-        serverInfo?: { icon: string; description: string };
-      }
-    | undefined;
-
-  // serverInfo and tools_stakes can be at top level or inside metadata
-  const serverInfo = server?.metadata?.serverInfo ?? server?.serverInfo;
-  if (!serverInfo) {
-    return null;
-  }
-
-  const stakes = server?.tools_stakes ?? server?.metadata?.tools_stakes ?? {};
-
-  const tools: IntegrationTool[] = Object.entries(stakes).map(
-    ([name, level]) => ({
+  const tools: IntegrationTool[] = serverMetadata.tools.map(
+    ({ name, stake }) => ({
       name,
       displayName: formatToolName(name),
       description: "",
-      isWriteAction: level !== "never_ask",
+      isWriteAction: stake !== "never_ask",
     })
   );
 
   return {
     tools,
-    icon: serverInfo.icon as InternalAllowedIconType,
+    icon: serverMetadata.serverInfo.icon,
   };
 }
 
@@ -307,35 +290,19 @@ export function buildPublicIntegrationRegistry(): IntegrationBase[] {
   // Add MCP servers
   // Note: For marketing/SEO pages, we include servers that are behind feature flags
   // (isRestricted) or in preview since they are still valid integrations to advertise.
-  for (const [name, serverRaw] of Object.entries(INTERNAL_MCP_SERVERS)) {
+  for (const name of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
     // Only include user-facing (manual) servers, skip auto/internal ones
-    const entry = serverRaw as { availability: string };
-    if (entry.availability !== "manual" || EXCLUDED_MCP_SERVERS.has(name)) {
+    const server = INTERNAL_MCP_SERVERS[name];
+    if (server.availability !== "manual" || EXCLUDED_MCP_SERVERS.has(name)) {
       continue;
     }
 
-    // serverInfo can be at top level or inside metadata
-    const server = serverRaw as {
-      metadata?: {
-        serverInfo: {
-          description: string;
-          documentationUrl: string | null;
-          authorization: unknown;
-        };
-      };
-      serverInfo?: {
-        description: string;
-        documentationUrl: string | null;
-        authorization: unknown;
-      };
-    };
-
-    const serverInfo = server.metadata?.serverInfo ?? server.serverInfo;
+    const serverInfo = server.metadata.serverInfo;
     if (!serverInfo) {
       continue;
     }
 
-    const extracted = extractToolsFromServer(name);
+    const extracted = extractToolsFromServer(server.metadata);
     if (!extracted) {
       continue;
     }


### PR DESCRIPTION
## Description

Internal MCP tool stakes are currently duplicated in a server-level `tools_stakes` record, for each single MCP server (the code that collects the stakes and put them in a record is strictly the same). This PR moves this collection to the call sites (few of them). In the process, the `stake` had to be added onto each `InternalMCPToolType` (in the definition of the tool metadata we did drop it).

Also removes some duplicated tool stake definitions that were also on `INTERNAL_MCP_SERVERS`.
The internal MCP server runbook is also updated to use the new metadata shape.

The values of the stakes are not changed, only the wiring around them.

## Tests

- Tested locally, passes existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
