### PR TITLE
feat: add sse warning when changing group permission model

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -707,6 +707,7 @@ async function checkDiffFiles() {
     "front/lib/models/plan.ts",
     "front/lib/models/provider_credential.ts",
     "front/lib/resources/storage/models/group_memberships.ts",
+    "front/lib/resources/storage/models/group_permissions.ts",
     "front/lib/resources/storage/models/group_spaces.ts",
     "front/lib/resources/storage/models/groups.ts",
     "front/lib/resources/storage/models/keys.ts",


### PR DESCRIPTION
## Description

This PR adds `front/lib/resources/storage/models/group_permissions.ts` to the Danger-monitored SSE file list, so that any modification to the group permissions model triggers an SSE acknowledgement warning.

## Tests

Manually.

## Risks

Low.

## Deploy Plan
