### PR TITLE
[Activation] Create activation nudge convo from poke

### DIFF
--- a/front-api/routes/poke/plugins/index.ts
+++ b/front-api/routes/poke/plugins/index.ts
@@ -47,8 +47,16 @@ app.get(
 
     const userRoles = ctx.get("pokeRoles");
 
-    const pluginList = plugins
-      .filter((p) => !resourceId || p.isApplicableTo(auth, resource))
+    // Resolve applicability first since `isApplicableTo` may be async. The plugin list
+    // per resource type is small and bounded, so a sequential pass is fine here.
+    const applicablePlugins = [];
+    for (const p of plugins) {
+      if (!resourceId || (await p.isApplicableTo(auth, resource))) {
+        applicablePlugins.push(p);
+      }
+    }
+
+    const pluginList = applicablePlugins
       .filter((p) => !p.manifest.isHidden)
       // During maintenance, only show readonly plugins.
       .filter((p) => !maintenance || p.manifest.readonly)

--- a/front/lib/api/poke/plugins/spaces/index.ts
+++ b/front/lib/api/poke/plugins/spaces/index.ts
@@ -1,4 +1,5 @@
 export * from "./force_run_task_generation";
 export * from "./import_app";
 export * from "./join_activation_pod";
+export * from "./send_activation_nudge";
 export * from "./update_pod_members";

--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -1,31 +1,14 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import {
-  createConversation,
-  postUserMessage,
-} from "@app/lib/api/assistant/conversation";
+import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
-import { serializeMention } from "@app/lib/mentions/format";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { UserMessageContext } from "@app/types/assistant/conversation";
-import type { EnumValue } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
 
 const sendActivationNudgeLogger = logger.child({
   activity: "send-activation-nudge",
 });
-
-// The "All pod members" sentinel value for the recipients dropdown.
-// Selecting this creates a new activation nudge conversation for each member.
-const ALL_MEMBERS_VALUE = "__all_pod_members__";
-
-const ACTIVATION_NUDGE_MESSAGE = `Run the activation workflow.`;
 
 // Whether the pod was provisioned through the activation flow. Gates both
 // visibility (isApplicableTo) and execution.
@@ -41,73 +24,19 @@ async function isActivationPod(
   return metadata?.provisioningSource === "activation";
 }
 
-function memberLabel(user: UserResource): string {
-  const fullName = user.fullName();
-  return fullName ? `${fullName} (${user.email})` : user.email;
-}
-
-// Resolves the selected dropdown values to the actual recipient users. Selecting
-// the "All pod members" sentinel (or selecting nothing) targets every current
-// pod member; otherwise only the explicitly selected members are targeted.
-async function resolveRecipients(
-  auth: Authenticator,
-  pod: SpaceResource,
-  selected: string[]
-): Promise<UserResource[]> {
-  const members = await pod.fetchDistinctActiveManualGroupMembers(auth);
-
-  const wantsAll =
-    selected.length === 0 || selected.includes(ALL_MEMBERS_VALUE);
-  if (wantsAll) {
-    return members;
-  }
-
-  const selectedIds = new Set(selected);
-  return members.filter((member) => selectedIds.has(member.sId));
-}
-
 export const sendActivationNudgePlugin = createPlugin({
   manifest: {
     id: "send-activation-nudge",
     name: "Send Activation Nudge",
     description:
-      "Create and send an activation nudge conversation to selected pod members (or all of them).",
+      "Nudge all members of this Activation Pod. Emits a single activation " +
+      "event; the pod's per-member triggers each start a @dust conversation " +
+      "running the activation workflow.",
     resourceTypes: ["spaces"],
-    args: {
-      recipients: {
-        type: "enum",
-        label: "Recipients",
-        description:
-          "Pod members to nudge. Select 'All pod members' (or leave empty) to " +
-          "nudge everyone. One conversation is created per recipient.",
-        async: true,
-        values: [],
-        multiple: true,
-      },
-    },
+    args: {},
     requiredRoles: ["support"],
   },
-  populateAsyncArgs: async (auth, pod) => {
-    if (!pod) {
-      return new Ok({ recipients: [] });
-    }
-
-    const members = await pod.fetchDistinctActiveManualGroupMembers(auth);
-
-    const recipients: EnumValue[] = [
-      { label: "All pod members", value: ALL_MEMBERS_VALUE, checked: true },
-      ...members
-        .map((member) => ({
-          label: memberLabel(member),
-          value: member.sId,
-          checked: false,
-        }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    ];
-
-    return new Ok({ recipients });
-  },
-  execute: async (auth, pod, { recipients: selectedRecipients }) => {
+  execute: async (auth, pod) => {
     if (!pod) {
       return new Err(new Error("Pod not found."));
     }
@@ -118,133 +47,35 @@ export const sendActivationNudgePlugin = createPlugin({
 
     const workspace = auth.getNonNullableWorkspace();
 
-    const recipients = await resolveRecipients(
-      auth,
-      pod,
-      selectedRecipients ?? []
+    // Emit a single activation event for the pod which creates individual
+    // conversations for all pod members.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
     );
-    if (recipients.length === 0) {
-      return new Err(new Error("No matching pod members to nudge."));
-    }
 
-    // The activation skill, referenced the same way join_activation_pod does
-    // (by its stable sId, active only), so it can be attached to each
-    // conversation.
-    const [activationSkillResource] = await SkillResource.fetchByIds(
-      auth,
-      [activationSkill.sId],
-      { onlyActive: true }
-    );
-    if (!activationSkillResource) {
+    const emitResult = await emitActivationEvent(adminAuth, pod);
+    if (emitResult.isErr()) {
       return new Err(
-        new Error("Activation skill not found in this workspace.")
+        new Error(
+          `Failed to emit activation event for pod ${pod.sId}: ${emitResult.error.message}`
+        )
       );
-    }
-
-    // The agent the nudge is addressed to (@dust), fetched once so its mention
-    // can be serialized into the first message, mirroring how a trigger posts
-    // its initial message.
-    const dustAgent = await getAgentConfiguration(auth, {
-      agentId: GLOBAL_AGENTS_SID.DUST,
-      variant: "full",
-    });
-    if (!dustAgent) {
-      return new Err(new Error("Dust agent not found in this workspace."));
-    }
-
-    // One conversation per recipient. Sequential DB writes to avoid
-    // connection-pool pressure. Each conversation runs as the recipient (a pod
-    // member) so it is created, skilled, and posted on their behalf.
-    const created: { userId: string; conversationId: string }[] = [];
-    for (const recipient of recipients) {
-      const recipientAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        recipient.sId,
-        workspace.sId
-      );
-
-      const conversation = await createConversation(recipientAuth, {
-        title: `Activation Nudge — ${recipient.fullName() ?? recipient.email}`,
-        visibility: "unlisted",
-        spaceId: pod.id,
-      });
-
-      // Attach the activation skill to the conversation so @dust runs it.
-      const skillRes = await SkillResource.upsertConversationSkills(
-        recipientAuth,
-        {
-          conversation,
-          skills: [activationSkillResource],
-          enabled: true,
-        }
-      );
-      if (skillRes.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to add activation skill to conversation for ${recipient.sId}: ${skillRes.error.message}`
-          )
-        );
-      }
-
-      const userJson = recipient.toJSON();
-      const context: UserMessageContext = {
-        username: userJson.username,
-        fullName: userJson.fullName,
-        email: userJson.email,
-        profilePictureUrl: userJson.image,
-        // UTC since this runs server-side without the user's timezone.
-        timezone: "UTC",
-        origin: "triggered",
-      };
-
-      // Post the nudge as the user's first message to @dust: the serialized
-      // agent mention followed by the nudge body, exactly like a trigger's
-      // initial message (serializeMention + customPrompt).
-      const postRes = await postUserMessage(recipientAuth, {
-        conversation,
-        content:
-          serializeMention(dustAgent) +
-          (ACTIVATION_NUDGE_MESSAGE ? `\n\n${ACTIVATION_NUDGE_MESSAGE}` : ""),
-        mentions: [{ configurationId: dustAgent.sId }],
-        context,
-        skipToolsValidation: false,
-      });
-      if (postRes.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to post nudge for ${recipient.sId}: ${postRes.error.api_error.message}`
-          )
-        );
-      }
-
-      created.push({
-        userId: recipient.sId,
-        conversationId: conversation.sId,
-      });
     }
 
     sendActivationNudgeLogger.info(
       {
         action: "send_activation_nudge",
-        conversations: created,
-        recipientCount: created.length,
         spaceId: pod.sId,
         workspaceId: workspace.sId,
       },
-      "Created activation nudge conversation(s) via poke"
+      "Emitted activation nudge event via poke"
     );
-
-    if (created.length === 1) {
-      return new Ok({
-        display: "textWithLink",
-        value: `Activation nudge conversation created for 1 pod member.`,
-        link: `/poke/${workspace.sId}/conversation/${created[0].conversationId}`,
-        linkText: "Open conversation in Poke",
-      });
-    }
 
     return new Ok({
       display: "text",
-      value: `Created ${created.length} activation nudge conversation(s), one per pod member.`,
+      value:
+        "Activation nudge event emitted. Each pod member with an activation " +
+        "trigger will receive a @dust conversation.",
     });
   },
   isApplicableTo: (auth, pod) => (pod ? isActivationPod(auth, pod) : false),

--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -1,0 +1,251 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  createConversation,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Authenticator } from "@app/lib/auth";
+import { serializeMention } from "@app/lib/mentions/format";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { UserMessageContext } from "@app/types/assistant/conversation";
+import type { EnumValue } from "@app/types/poke/plugins";
+import { Err, Ok } from "@app/types/shared/result";
+
+const sendActivationNudgeLogger = logger.child({
+  activity: "send-activation-nudge",
+});
+
+// The "All pod members" sentinel value for the recipients dropdown.
+// Selecting this creates a new activation nudge conversation for each member.
+const ALL_MEMBERS_VALUE = "__all_pod_members__";
+
+const ACTIVATION_NUDGE_MESSAGE = `Run the activation workflow.`;
+
+// Whether the pod was provisioned through the activation flow. Gates both
+// visibility (isApplicableTo) and execution.
+async function isActivationPod(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<boolean> {
+  if (!pod.isProject()) {
+    return false;
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  return metadata?.provisioningSource === "activation";
+}
+
+function memberLabel(user: UserResource): string {
+  const fullName = user.fullName();
+  return fullName ? `${fullName} (${user.email})` : user.email;
+}
+
+// Resolves the selected dropdown values to the actual recipient users. Selecting
+// the "All pod members" sentinel (or selecting nothing) targets every current
+// pod member; otherwise only the explicitly selected members are targeted.
+async function resolveRecipients(
+  auth: Authenticator,
+  pod: SpaceResource,
+  selected: string[]
+): Promise<UserResource[]> {
+  const members = await pod.fetchDistinctActiveManualGroupMembers(auth);
+
+  const wantsAll =
+    selected.length === 0 || selected.includes(ALL_MEMBERS_VALUE);
+  if (wantsAll) {
+    return members;
+  }
+
+  const selectedIds = new Set(selected);
+  return members.filter((member) => selectedIds.has(member.sId));
+}
+
+export const sendActivationNudgePlugin = createPlugin({
+  manifest: {
+    id: "send-activation-nudge",
+    name: "Send Activation Nudge",
+    description:
+      "Create and send an activation nudge conversation to selected pod members (or all of them).",
+    resourceTypes: ["spaces"],
+    args: {
+      recipients: {
+        type: "enum",
+        label: "Recipients",
+        description:
+          "Pod members to nudge. Select 'All pod members' (or leave empty) to " +
+          "nudge everyone. One conversation is created per recipient.",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+    },
+    requiredRoles: ["support"],
+  },
+  populateAsyncArgs: async (auth, pod) => {
+    if (!pod) {
+      return new Ok({ recipients: [] });
+    }
+
+    const members = await pod.fetchDistinctActiveManualGroupMembers(auth);
+
+    const recipients: EnumValue[] = [
+      { label: "All pod members", value: ALL_MEMBERS_VALUE, checked: true },
+      ...members
+        .map((member) => ({
+          label: memberLabel(member),
+          value: member.sId,
+          checked: false,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    ];
+
+    return new Ok({ recipients });
+  },
+  execute: async (auth, pod, { recipients: selectedRecipients }) => {
+    if (!pod) {
+      return new Err(new Error("Pod not found."));
+    }
+
+    if (!(await isActivationPod(auth, pod))) {
+      return new Err(new Error("This plugin only applies to Activation Pods."));
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const recipients = await resolveRecipients(
+      auth,
+      pod,
+      selectedRecipients ?? []
+    );
+    if (recipients.length === 0) {
+      return new Err(new Error("No matching pod members to nudge."));
+    }
+
+    // The activation skill, referenced the same way join_activation_pod does
+    // (by its stable sId, active only), so it can be attached to each
+    // conversation.
+    const [activationSkillResource] = await SkillResource.fetchByIds(
+      auth,
+      [activationSkill.sId],
+      { onlyActive: true }
+    );
+    if (!activationSkillResource) {
+      return new Err(
+        new Error("Activation skill not found in this workspace.")
+      );
+    }
+
+    // The agent the nudge is addressed to (@dust), fetched once so its mention
+    // can be serialized into the first message, mirroring how a trigger posts
+    // its initial message.
+    const dustAgent = await getAgentConfiguration(auth, {
+      agentId: GLOBAL_AGENTS_SID.DUST,
+      variant: "full",
+    });
+    if (!dustAgent) {
+      return new Err(new Error("Dust agent not found in this workspace."));
+    }
+
+    // One conversation per recipient. Sequential DB writes to avoid
+    // connection-pool pressure. Each conversation runs as the recipient (a pod
+    // member) so it is created, skilled, and posted on their behalf.
+    const created: { userId: string; conversationId: string }[] = [];
+    for (const recipient of recipients) {
+      const recipientAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        recipient.sId,
+        workspace.sId
+      );
+
+      const conversation = await createConversation(recipientAuth, {
+        title: `Activation Nudge — ${recipient.fullName() ?? recipient.email}`,
+        visibility: "unlisted",
+        spaceId: pod.id,
+      });
+
+      // Attach the activation skill to the conversation so @dust runs it.
+      const skillRes = await SkillResource.upsertConversationSkills(
+        recipientAuth,
+        {
+          conversation,
+          skills: [activationSkillResource],
+          enabled: true,
+        }
+      );
+      if (skillRes.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to add activation skill to conversation for ${recipient.sId}: ${skillRes.error.message}`
+          )
+        );
+      }
+
+      const userJson = recipient.toJSON();
+      const context: UserMessageContext = {
+        username: userJson.username,
+        fullName: userJson.fullName,
+        email: userJson.email,
+        profilePictureUrl: userJson.image,
+        // UTC since this runs server-side without the user's timezone.
+        timezone: "UTC",
+        origin: "triggered",
+      };
+
+      // Post the nudge as the user's first message to @dust: the serialized
+      // agent mention followed by the nudge body, exactly like a trigger's
+      // initial message (serializeMention + customPrompt).
+      const postRes = await postUserMessage(recipientAuth, {
+        conversation,
+        content:
+          serializeMention(dustAgent) +
+          (ACTIVATION_NUDGE_MESSAGE ? `\n\n${ACTIVATION_NUDGE_MESSAGE}` : ""),
+        mentions: [{ configurationId: dustAgent.sId }],
+        context,
+        skipToolsValidation: false,
+      });
+      if (postRes.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to post nudge for ${recipient.sId}: ${postRes.error.api_error.message}`
+          )
+        );
+      }
+
+      created.push({
+        userId: recipient.sId,
+        conversationId: conversation.sId,
+      });
+    }
+
+    sendActivationNudgeLogger.info(
+      {
+        action: "send_activation_nudge",
+        conversations: created,
+        recipientCount: created.length,
+        spaceId: pod.sId,
+        workspaceId: workspace.sId,
+      },
+      "Created activation nudge conversation(s) via poke"
+    );
+
+    if (created.length === 1) {
+      return new Ok({
+        display: "textWithLink",
+        value: `Activation nudge conversation created for 1 pod member.`,
+        link: `/poke/${workspace.sId}/conversation/${created[0].conversationId}`,
+        linkText: "Open conversation in Poke",
+      });
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Created ${created.length} activation nudge conversation(s), one per pod member.`,
+    });
+  },
+  isApplicableTo: (auth, pod) => (pod ? isActivationPod(auth, pod) : false),
+});

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -104,7 +104,7 @@ interface BasePlugin<
   isApplicableTo: (
     auth: Authenticator,
     resource: ResourceTypeMap[R] | null
-  ) => boolean;
+  ) => boolean | Promise<boolean>;
 }
 
 // Plugin with required async args function.
@@ -157,7 +157,7 @@ export function createPlugin<
   isApplicableTo?: (
     auth: Authenticator,
     resource: ResourceTypeMap[R] | null
-  ) => boolean;
+  ) => boolean | Promise<boolean>;
 } & (HasAsyncFields<T> extends true
   ? {
       populateAsyncArgs: (


### PR DESCRIPTION
## Description
Create an activation nudge conversation from a poke plugin that only shows up for activation pods (image shown below). A separate conversation is created for each user, and nudge conversations are created for **all** members of the pod at one time.

This reuses the same trigger/webhook flow as "join activation pod" to emit a single activation webhook event and each activation pod member's trigger starts a nudge conversation.

<img width="1881" height="776" alt="Screenshot 2026-07-17 at 13 48 12" src="https://github.com/user-attachments/assets/43eaf08e-659a-44d1-b95e-1f5bb03c4029" />

## Tests
Manual tests on Poke and local.

## Risk
Low risk. A Poke Plugin only liked to Activation pods.

## Deploy Plan