### PR TITLE
[front] fix: Remove user from projectPreferences

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -149,7 +149,7 @@ app.get(
           ? {
               sId: serialized.sId,
               spaceId: serialized.spaceId,
-              userId: serialized.userId,
+              userId: auth.getNonNullableUser().sId,
               preference: serialized.notificationPreference,
             }
           : null,
@@ -193,7 +193,7 @@ app.patch(
           ? {
               sId: serialized.sId,
               spaceId: serialized.spaceId,
-              userId: serialized.userId,
+              userId: auth.getNonNullableUser().sId,
               preference: serialized.notificationPreference,
             }
           : null,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
@@ -35,7 +35,10 @@ app.post(
       isStarred: starred,
     });
 
-    return ctx.json(pref.toJSON());
+    return ctx.json({
+      ...pref.toJSON(),
+      userId: auth.getNonNullableUser().sId,
+    });
   }
 );
 

--- a/front/lib/resources/user_project_preferences_resource.ts
+++ b/front/lib/resources/user_project_preferences_resource.ts
@@ -6,12 +6,10 @@ import type { NotificationCondition } from "@app/types/notification_preferences"
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { Attributes } from "sequelize";
 import { Op } from "sequelize";
 import { SpaceResource } from "./space_resource";
 import { UserProjectPreferencesModel } from "./storage/models/user_project_preferences";
 import { makeSId } from "./string_ids";
-import type { UserResource } from "./user_resource";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface UserProjectPreferencesResource
@@ -21,18 +19,6 @@ export interface UserProjectPreferencesResource
 export class UserProjectPreferencesResource extends BaseResource<UserProjectPreferencesModel> {
   static model: typeof UserProjectPreferencesModel =
     UserProjectPreferencesModel;
-
-  readonly user: UserResource;
-
-  constructor(
-    model: typeof UserProjectPreferencesModel,
-    blob: Attributes<UserProjectPreferencesModel>,
-    { user }: { user: UserResource }
-  ) {
-    super(UserProjectPreferencesModel, blob);
-
-    this.user = user;
-  }
 
   get sId(): string {
     return UserProjectPreferencesResource.modelIdToSId({
@@ -59,7 +45,6 @@ export class UserProjectPreferencesResource extends BaseResource<UserProjectPref
     options: ResourceFindOptions<UserProjectPreferencesModel> = {}
   ): Promise<UserProjectPreferencesResource[]> {
     const { where, ...otherOptions } = options;
-    const user = auth.getNonNullableUser();
 
     const results = await UserProjectPreferencesModel.findAll({
       where: {
@@ -69,7 +54,7 @@ export class UserProjectPreferencesResource extends BaseResource<UserProjectPref
       ...otherOptions,
     });
 
-    return results.map((r) => new this(this.model, r.get(), { user }));
+    return results.map((r) => new this(this.model, r.get()));
   }
 
   static async fetchNotificationPreferenceMap(
@@ -151,7 +136,7 @@ export class UserProjectPreferencesResource extends BaseResource<UserProjectPref
       notificationPreference,
     });
 
-    return new this(this.model, entry.get(), { user });
+    return new this(this.model, entry.get());
   }
 
   static async setStarred(
@@ -174,7 +159,7 @@ export class UserProjectPreferencesResource extends BaseResource<UserProjectPref
       isStarred,
     });
 
-    return new this(this.model, entry.get(), { user });
+    return new this(this.model, entry.get());
   }
 
   static async setStarredForUsers(
@@ -246,7 +231,6 @@ export class UserProjectPreferencesResource extends BaseResource<UserProjectPref
         id: this.spaceId,
         workspaceId: this.workspaceId,
       }),
-      userId: this.user.sId,
       notificationPreference: this.notificationPreference,
       isStarred: this.isStarred === true,
     };


### PR DESCRIPTION
## Description

Currently we derive user from auth to attach it as an exposed user atr on userProjectPreferencesResource.
It's incorrect since the pref row itself belong to a different user from the auth object, and it's making the workflow crash for messages coming from v1 api

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front