### PR TITLE
fix: accept null priority in Jira issue schema

### DIFF
--- a/front/lib/api/actions/servers/jira/types.ts
+++ b/front/lib/api/actions/servers/jira/types.ts
@@ -572,9 +572,11 @@ export const JiraIssueFieldsSchema = z
     status: z.object({
       name: z.string(),
     }),
-    priority: z.object({
-      name: z.string(),
-    }),
+    priority: z
+      .object({
+        name: z.string(),
+      })
+      .nullable(),
     assignee: z
       .object({
         accountId: z.string(),


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/9656

## Description

Jira issue searches (`search_issues`, `get_issues_using_jql`) failed with "Invalid JIRA response format" whenever a result contained an issue with no priority set: `priority` was the only entity-reference field in `JiraIssueFieldsSchema` without `.nullable()` (unlike `assignee`, `reporter`, `parent`), so `"priority": null` broke parsing of the whole response.

Made it nullable.

## Tests

Parsed a search response with priority set / `null` / absent against `JiraSearchResultSchema`, all pass now, the `null` case reproduced the reported error before. Rendering already skips null field values.

## Risk

Low. `JiraCreateIssueRequestSchema` derives from this schema, so `priority: null` is now also accepted on create/update payloads.

## Deploy Plan

Deploy front.