### PR TITLE
[front] refactor: read internal MCP stakes directly from metadata

### DIFF
--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -2,7 +2,6 @@ import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
-  MCP_TOOL_STAKE_LEVELS,
 } from "@app/lib/actions/constants";
 import {
   getMcpServerViewDescription,
@@ -11,7 +10,6 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import {
   getInternalMCPServerToolArgumentsRequiringApproval,
-  getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -77,25 +75,6 @@ export type MCPServerFormValues = ServerSettings & {
   sharingSettings: Record<string, boolean>;
 };
 
-function isToolStakesRecord(
-  value: unknown
-): value is Record<string, MCPToolStakeLevelType> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  return Object.values(value).every((v): v is MCPToolStakeLevelType =>
-    MCP_TOOL_STAKE_LEVELS.includes(v as MCPToolStakeLevelType)
-  );
-}
-
-function getToolStake(
-  stakes: Record<string, MCPToolStakeLevelType>,
-  toolName: string
-): MCPToolStakeLevelType | undefined {
-  return toolName in stakes ? stakes[toolName] : undefined;
-}
-
 export function getDefaultInternalToolStakeLevel(
   server: MCPServerViewType["server"],
   toolName: string
@@ -104,19 +83,17 @@ export function getDefaultInternalToolStakeLevel(
     return FALLBACK_MCP_TOOL_STAKE_LEVEL;
   }
 
-  const serverToolStakes = getInternalMCPServerToolStakes(server.name);
+  const {
+    metadata: { tools },
+    availability,
+  } = INTERNAL_MCP_SERVERS[server.name];
 
-  if (isToolStakesRecord(serverToolStakes)) {
-    const configuredStake = getToolStake(serverToolStakes, toolName);
-    if (configuredStake) {
-      return configuredStake;
-    }
-  }
-
-  const serverConfig = INTERNAL_MCP_SERVERS[server.name];
-  return serverConfig.availability === "manual"
-    ? FALLBACK_MCP_TOOL_STAKE_LEVEL
-    : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL;
+  return (
+    tools.find((tool) => tool.name === toolName)?.stake ??
+    (availability === "manual"
+      ? FALLBACK_MCP_TOOL_STAKE_LEVEL
+      : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL)
+  );
 }
 
 export function canToolUseMediumStakeLevel(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -34,7 +34,6 @@ import {
 import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerNameAndWorkspaceId,
-  getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
   resolveInternalMCPServerToolStakeLevel,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -170,7 +169,12 @@ export function getToolExtraFields(
       return r;
     }
     const serverName = r.value.name;
-    const defaultStakes = getInternalMCPServerToolStakes(serverName) ?? {};
+    const defaultStakes = Object.fromEntries(
+      INTERNAL_MCP_SERVERS[serverName].metadata.tools.map((t) => [
+        t.name,
+        t.stake,
+      ])
+    );
     toolsStakes = { ...defaultStakes };
     toolsRetryPolicies = INTERNAL_MCP_SERVERS[serverName].tools_retry_policies;
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1442,16 +1442,6 @@ export function getInternalMCPServerDisplayedAs(
   return server.metadata.serverInfo.displayedAs;
 }
 
-export function getInternalMCPServerToolStakes(
-  name: InternalMCPServerNameType
-): Record<string, MCPToolStakeLevelType> {
-  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
-
-  return Object.fromEntries(
-    Object.values(server.metadata.tools).map((t) => [t.name, t.stake])
-  );
-}
-
 export function getInternalMCPServerToolArgumentsRequiringApproval(
   name: InternalMCPServerNameType,
   toolName: string

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -24,12 +24,12 @@
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getInternalMCPServerMetadata,
   getInternalMCPServerToolArgumentsRequiringApproval,
-  getInternalMCPServerToolStakes,
+  INTERNAL_MCP_SERVERS,
+  type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
@@ -203,7 +203,12 @@ async function collectAllServersMetadata(): Promise<ServerMetadataSnapshot[]> {
   for (const serverName of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
     try {
       const tools = await getToolsFromServer(serverName);
-      const toolsStakes = getInternalMCPServerToolStakes(serverName);
+      const toolsStakes = Object.fromEntries(
+        INTERNAL_MCP_SERVERS[serverName].metadata.tools.map((t) => [
+          t.name,
+          t.stake,
+        ])
+      );
 
       servers.push({
         name: serverName,
@@ -307,7 +312,12 @@ describe("MCP Servers Metadata Snapshot", () => {
     const allStakes: Record<string, Record<string, MCPToolStakeLevelType>> = {};
 
     for (const serverName of [...AVAILABLE_INTERNAL_MCP_SERVER_NAMES].sort()) {
-      const stakes = getInternalMCPServerToolStakes(serverName);
+      const stakes = Object.fromEntries(
+        INTERNAL_MCP_SERVERS[serverName].metadata.tools.map((t) => [
+          t.name,
+          t.stake,
+        ])
+      );
       allStakes[serverName] = sortToolsStakes(stakes) ?? {};
     }
 
@@ -329,7 +339,12 @@ describe("MCP Servers Metadata Snapshot", () => {
 
   it("requires input scoping for every medium-stake tool", () => {
     for (const serverName of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
-      const stakes = getInternalMCPServerToolStakes(serverName);
+      const stakes = Object.fromEntries(
+        INTERNAL_MCP_SERVERS[serverName].metadata.tools.map((t) => [
+          t.name,
+          t.stake,
+        ])
+      );
 
       for (const [toolName, stake] of Object.entries(stakes)) {
         if (stake === "medium") {


### PR DESCRIPTION
## Description

Follow-up on #29090. Now that stakes live on each internal MCP tool, `getInternalMCPServerToolStakes` only rebuilds a separate record for callers to consume.

There are 2 callers and one of them rebuilds the record just to read 1 value from it. This PR removes the helper and reads stakes directly from the tools metadata.

## Tests

- Covered by existing MCP metadata tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
