### PR TITLE
[sparkle] Restyle Tooltip — new design + animation polish

### DIFF
--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -39,14 +39,13 @@ const TooltipContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-w-sm overflow-hidden whitespace-pre-wrap break-words rounded-md border",
-          "bg-overlay-background",
-          "text-foreground",
-          "border-border",
-          "px-3 py-1.5 text-sm shadow-md",
+          "z-50 max-w-sm overflow-hidden whitespace-pre-wrap break-words rounded-lg",
+          "bg-primary text-primary-50 text-xs",
+          "px-3 py-1.5",
+          "shadow-[inset_0px_1px_4px_0px_rgba(255,255,255,0.1)] dark:shadow-none",
           "origin-[var(--radix-tooltip-content-transform-origin)]",
-          "animate-in fade-in-0 zoom-in-95 duration-200 ease-enter",
-          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:duration-150 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "animate-in fade-in-0 zoom-in-95 duration-150 ease-emphasized",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:duration-100",
           "motion-reduce:animate-none",
           className || ""
         )}
@@ -88,7 +87,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
     }: TooltipProps,
     ref
   ) => (
-    <TooltipProvider delayDuration={delayDuration}>
+    <TooltipProvider delayDuration={delayDuration} skipDelayDuration={0}>
       <TooltipRoot disableHoverableContent>
         <TooltipTrigger asChild={tooltipTriggerAsChild}>
           {trigger}
@@ -96,7 +95,12 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
         <TooltipContent {...props} ref={ref}>
           <div className="inline-flex items-center gap-2">
             {label}
-            {shortcut && <KeyboardShortcut shortcut={shortcut} />}
+            {shortcut && (
+              <KeyboardShortcut
+                shortcut={shortcut}
+                className="text-xs text-primary-200"
+              />
+            )}
           </div>
         </TooltipContent>
       </TooltipRoot>


### PR DESCRIPTION
## Summary
Before:
<img width="330" height="117" alt="image" src="https://github.com/user-attachments/assets/be0b7bb6-d72d-4ae8-bc48-7fa5cbfbc877" />

<img width="341" height="114" alt="image" src="https://github.com/user-attachments/assets/79a7418d-8036-43ff-8ff6-352f27becd5d" />

After: 
<img width="333" height="121" alt="image" src="https://github.com/user-attachments/assets/fa657182-1c81-4956-bdcd-9bc787d2accc" />

<img width="333" height="133" alt="image" src="https://github.com/user-attachments/assets/db27f769-caa3-468f-95eb-7f3763175548" />




## Test plan

- [ ] Hover a tooltip in light mode — dark rounded pill, white text, snappy entry
- [ ] Hover a tooltip in dark mode — light rounded pill, dark text, readable shortcut
- [ ] Hover rapidly between multiple tooltip triggers — second+ open instantly with no delay or animation
- [ ] Verify `Tooltip With Shortcut` story — shortcut legible in both themes
- [ ] Toggle `prefers-reduced-motion` — tooltip still appears (opacity only, no transform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)