### PR TITLE
Default flagged Dust to GPT 5.6 Luna

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -86,9 +86,9 @@ interface DustLikeGlobalAgentArgs {
   // Workspace feature flags, forwarded to model selection so it runs the exact
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
-  // When set, the @dust agent defaults to GPT 5.5 (medium reasoning) instead of
-  // Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_5_default` feature flag.
-  preferGpt55DefaultModel?: boolean;
+  // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
+  // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.
+  preferGpt56LunaDefaultModel?: boolean;
   // When set, the @dust agent defaults to Claude Sonnet 5 instead of Claude
   // Sonnet 4.6. Gated by the `dust_agent_sonnet_5_default` feature flag.
   preferSonnet5DefaultModel?: boolean;
@@ -472,10 +472,13 @@ export function _getDustGlobalAgent(
     name: "dust",
     preferredModelConfiguration: args.preferSonnet5DefaultModel
       ? CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG
-      : args.preferGpt55DefaultModel
-        ? GPT_5_5_MODEL_CONFIG
+      : args.preferGpt56LunaDefaultModel
+        ? GPT_5_6_LUNA_MODEL_CONFIG
         : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort: "medium",
+    preferredReasoningEffort:
+      args.preferGpt56LunaDefaultModel && !args.preferSonnet5DefaultModel
+        ? "high"
+        : "medium",
   });
 }
 

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -2,6 +2,7 @@ import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_age
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { CLAUDE_SONNET_5_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import {
   GPT_5_6_LUNA_MODEL_ID,
   GPT_5_6_SOL_MODEL_ID,
@@ -243,6 +244,45 @@ describe("getGlobalAgents custom model agents", () => {
 });
 
 describe("getGlobalAgents OpenAI Dust agents", () => {
+  it("uses GPT 5.6 Luna with high reasoning as the flagged Dust default", async () => {
+    const auth = await createAuthenticatorWithFlags([
+      "dust_agent_gpt_5_6_luna_default",
+    ]);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DUST],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({
+      providerId: "openai",
+      modelId: GPT_5_6_LUNA_MODEL_ID,
+      reasoningEffort: "high",
+    });
+  });
+
+  it("keeps Sonnet 5 at medium reasoning when both default flags are set", async () => {
+    const auth = await createAuthenticatorWithFlags([
+      "dust_agent_gpt_5_6_luna_default",
+      "dust_agent_sonnet_5_default",
+    ]);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DUST],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({
+      providerId: "anthropic",
+      modelId: CLAUDE_SONNET_5_MODEL_ID,
+      reasoningEffort: "medium",
+    });
+  });
+
   it("hides Luna variants without the internal global agents feature flag", async () => {
     const auth = await createAuthenticatorWithFlags([]);
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -150,7 +150,7 @@ function getGlobalAgent({
   hasSandbox,
   globalAgentContext,
   excludeProviders,
-  preferGpt55DefaultModel,
+  preferGpt56LunaDefaultModel,
   preferSonnet5DefaultModel,
   featureFlags,
 }: {
@@ -164,7 +164,7 @@ function getGlobalAgent({
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
-  preferGpt55DefaultModel: boolean;
+  preferGpt56LunaDefaultModel: boolean;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType | null {
@@ -379,7 +379,7 @@ function getGlobalAgent({
         featureFlags,
         globalAgentContext,
         excludeProviders,
-        preferGpt55DefaultModel,
+        preferGpt56LunaDefaultModel,
         preferSonnet5DefaultModel,
       });
       break;
@@ -1202,7 +1202,9 @@ export async function getGlobalAgents(
       hasSandbox: isComputerFeatureEnabled(flags),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
-      preferGpt55DefaultModel: flags.includes("dust_agent_gpt_5_5_default"),
+      preferGpt56LunaDefaultModel: flags.includes(
+        "dust_agent_gpt_5_6_luna_default"
+      ),
       preferSonnet5DefaultModel: flags.includes("dust_agent_sonnet_5_default"),
       featureFlags: flags,
     })

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -46,9 +46,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to internal global agents (dust-edge, dust-quick, dust-oai, dust-goog, custom model agents and their variants)",
     stage: "dust_only",
   },
-  dust_agent_gpt_5_5_default: {
+  dust_agent_gpt_5_6_luna_default: {
     description:
-      "Use GPT 5.5 (medium reasoning) as the default model for the @dust agent",
+      "Use GPT 5.6 Luna (high reasoning) as the default model for the @dust agent",
     stage: "dust_only",
   },
   dust_agent_sonnet_5_default: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -742,7 +742,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disallow_agent_creation_to_users"
   | "discord_bot"
   | "dummy_feature_for_flag_testing"
-  | "dust_agent_gpt_5_5_default"
+  | "dust_agent_gpt_5_6_luna_default"
   | "dust_agent_sonnet_5_default"
   | "dust_internal_global_agents"
   | "fireworks_new_model_feature"


### PR DESCRIPTION
## Description

Replace `dust_agent_gpt_5_5_default` with `dust_agent_gpt_5_6_luna_default`. The new flag routes `@dust` to GPT 5.6 Luna with high reasoning and keeps the SDK flag type in sync.

## Tests

Added coverage for the Luna/high default and Sonnet 5 precedence when both default flags are enabled.

## Risk

Workspaces carrying the old flag will fall back to the regular Dust default until they are enabled with the new flag. Rollback restores the old flag behavior because existing rows are not deleted.

## Deploy Plan

Standard deploy, then enable `dust_agent_gpt_5_6_luna_default` for the intended pilot workspaces.