### PR TITLE
feat: governance page copy and ui updates

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -9,7 +9,7 @@ import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/Du
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharing } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { MessagingAppToggles } from "@app/components/workspace/settings/MessagingAppToggles";
-import { OpenPodPolicy } from "@app/components/workspace/settings/OpenProjectsPolicy";
+import { OpenPodPolicy } from "@app/components/workspace/settings/OpenPodsPolicy";
 import { PodKnowledgePolicy } from "@app/components/workspace/settings/PodKnowledgePolicy";
 import { PrivateConversationUrlsToggle } from "@app/components/workspace/settings/PrivateConversationUrlsToggle";
 import { SlackPersonalFooterRemovalToggle } from "@app/components/workspace/settings/SlackPersonalFooterRemovalToggle";
@@ -156,7 +156,7 @@ export const GovernancePage = () => {
       ? [
           {
             id: "frame" as const,
-            label: "Frame sharing",
+            label: "Frames",
             icon: ActionFrame,
             governancePermissions: framePermissions,
           },
@@ -241,10 +241,7 @@ export const GovernancePage = () => {
               <OpenPodPolicy owner={owner} />
               <PodKnowledgePolicy owner={owner} />
             </GovernanceSettingSection>
-            <GovernanceSettingSection
-              label="Feature policies"
-              icon={ShapesPlus}
-            >
+            <GovernanceSettingSection label="Features" icon={ShapesPlus}>
               <VoiceTranscriptionToggle owner={owner} />
               <EmailAgentsToggle owner={owner} />
               <PrivateConversationUrlsToggle owner={owner} />
@@ -254,7 +251,7 @@ export const GovernancePage = () => {
               <WorkspaceAnalyticsToggle owner={owner} />
             </GovernanceSettingSection>
             <GovernanceSettingSection
-              label="Messaging app policies"
+              label="Messaging apps"
               icon={CloudArrowLeftRight}
             >
               <MessagingAppToggles owner={owner} />

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -9,12 +9,13 @@ import {
   type PermissionConfigurationScope,
 } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
+import { removeNulls } from "@app/types/shared/utils/general";
 import {
   ButtonsSwitch,
   ButtonsSwitchList,
   ContentMessage,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type GovernanceSettingMetadata = {
   label: string;
@@ -30,39 +31,39 @@ const GOVERNANCE_SETTING_METADATA: Partial<
 > = {
   "create:agent": {
     label: "Create agents",
-    description: "Controls who can build agents in the Agent Builder.",
+    description: "Control who can build agents in the Agent Builder.",
   },
   "publish:agent": {
     label: "Publish agents",
-    description: "Controls who can publish agents to the whole workspace.",
+    description: "Control who can publish agents to the whole workspace.",
   },
   "create:skill": {
     label: "Create skills",
-    description: "Controls who can build custom skills.",
+    description: "Control who can build custom skills.",
   },
   "publish:skill": {
     label: "Publish skills",
-    description: "Controls who can publish skills to the whole workspace.",
+    description: "Control who can publish skills to the whole workspace.",
   },
   "invite:frame": {
     label: "Invite people by email",
     description:
-      "Controls who can share frames by email with people outside your organization.",
+      "Control who can share frames by email with people outside your organization.",
   },
   "publish:frame": {
     label: "Share by public link",
-    description: "Controls who can create public links to frames.",
+    description: "Control who can create public links to frames.",
   },
   "admin:billing": {
     label: "Billing access",
     description:
-      "Controls who can manage billing settings, invoices, and payment methods.",
+      "Control who can manage billing settings, invoices, and payment methods.",
     isGroupsOnly: true,
   },
   "admin:identity": {
     label: "Security access",
     description:
-      "Controls who can manage user access, identities, and provisioning.",
+      "Control who can manage user access, identities, and provisioning.",
     isGroupsOnly: true,
   },
 };
@@ -91,6 +92,31 @@ function getGovernancePermissionMetadata(
   return metadata;
 }
 
+function getGroupSelection(
+  configuration: GovernancePermissionConfiguration,
+  groups: GroupType[]
+): {
+  selectedGroups: GroupType[];
+  selectableGroups: GroupType[];
+  hasMissingGroups: boolean;
+} {
+  const orderedGroupIds =
+    configuration.scope === "groups" ? configuration.groupIds : [];
+  const selectedGroupIds = new Set(orderedGroupIds);
+  const groupsById = new Map(groups.map((g) => [g.sId, g]));
+  // Preserve selection order (newly added groups land last) instead of the `groups` array order.
+  const selectedGroups = removeNulls(
+    orderedGroupIds.map((id) => groupsById.get(id))
+  );
+  const selectableGroups = groups.filter((g) => !selectedGroupIds.has(g.sId));
+
+  return {
+    selectedGroups,
+    selectableGroups,
+    hasMissingGroups: selectedGroups.length !== selectedGroupIds.size,
+  };
+}
+
 interface GovernanceSettingRowProps {
   governancePermission: GovernancePermission;
   groups: GroupType[];
@@ -110,15 +136,16 @@ export const GovernanceSettingRow = ({
     );
   const [isSaving, setIsSaving] = useState(false);
 
-  const metadata = getGovernancePermissionMetadata(governancePermission);
-
-  const selectedGroupIds = new Set(
+  // Remember the last group selection so switching away to "everyone"/"admins_only" and back to
+  // "groups" restores what the user had picked, rather than starting from an empty selection.
+  const lastGroupIdsRef = useRef<string[]>(
     configuration.scope === "groups" ? configuration.groupIds : []
   );
-  const selectedGroups = groups.filter((g) => selectedGroupIds.has(g.sId));
-  const selectableGroups = groups.filter((g) => !selectedGroupIds.has(g.sId));
 
-  const hasMissingGroups = selectedGroups.length !== selectedGroupIds.size;
+  const metadata = getGovernancePermissionMetadata(governancePermission);
+
+  const { selectedGroups, selectableGroups, hasMissingGroups } =
+    getGroupSelection(configuration, groups);
 
   const handlePermissionChange = async ({
     scope,
@@ -131,8 +158,16 @@ export const GovernanceSettingRow = ({
       return;
     }
 
+    // When switching back to "groups" from the scope switch, no groupIds are provided: restore the
+    // last selection the user had picked. When the selection is edited directly (groupIds passed),
+    // remember it so it survives a round-trip through "everyone"/"admins_only".
+    const nextGroupIds = groupIds ?? lastGroupIdsRef.current;
+    if (scope === "groups") {
+      lastGroupIdsRef.current = nextGroupIds;
+    }
+
     const newConfiguration: GovernancePermissionConfiguration =
-      scope === "groups" ? { scope, groupIds: groupIds ?? [] } : { scope };
+      scope === "groups" ? { scope, groupIds: nextGroupIds } : { scope };
 
     // Apply optimistically, then persist. The optimistic update is the loading feedback (the
     // switch moves immediately). We intentionally do NOT re-sync from the server on success: the

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -80,6 +80,7 @@ export const GroupSelector = ({
       {selectedGroups.map((group) => (
         <Chip
           key={group.sId}
+          className="animate-in fade-in zoom-in-95 duration-200"
           label={group.name}
           size="xs"
           color="highlight"

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -36,6 +36,7 @@ export const GroupSelector = ({
         <DropdownMenuTrigger asChild>
           <Button
             variant="outline"
+            className="animate-in fade-in duration-75"
             size="xs"
             icon={Plus}
             label="Add a group"
@@ -80,7 +81,7 @@ export const GroupSelector = ({
       {selectedGroups.map((group) => (
         <Chip
           key={group.sId}
-          className="animate-in fade-in zoom-in-95 duration-200"
+          className="animate-in fade-in duration-75"
           label={group.name}
           size="xs"
           color="highlight"

--- a/front/components/workspace/ExtensionMcpToolsSection.tsx
+++ b/front/components/workspace/ExtensionMcpToolsSection.tsx
@@ -6,6 +6,11 @@ import { Page, PuzzlePiece01, SliderToggle } from "@dust-tt/sparkle";
 
 import { WorkspaceSection } from "./WorkspaceSection";
 
+const LABEL = "Browser Extension Tools";
+const DESCRIPTION =
+  "Control whether the Dust browser extension can use MCP tools such as " +
+  "listing and reading browser tabs.";
+
 interface ExtensionMcpToolsSectionProps {
   owner: LightWorkspaceType;
 }
@@ -17,11 +22,6 @@ export function ExtensionMcpToolsSection({
     useExtensionMcpToolsToggle({ owner });
   const { hasFeature } = useFeatureFlags();
 
-  const label = "Browser Extension Tools";
-  const description =
-    "Allow the Dust browser extension to use MCP tools such as listing and " +
-    "reading browser tabs.";
-
   if (!hasFeature("browser_extension_mcp_tools")) {
     return null;
   }
@@ -29,8 +29,8 @@ export function ExtensionMcpToolsSection({
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <SliderToggle
             selected={isEnabled}
@@ -43,7 +43,7 @@ export function ExtensionMcpToolsSection({
   }
 
   return (
-    <WorkspaceSection title={label} icon={PuzzlePiece01}>
+    <WorkspaceSection title={LABEL} icon={PuzzlePiece01}>
       <div className="flex w-full flex-row items-center gap-2">
         <div className="flex-1">
           <Page.P variant="secondary">

--- a/front/components/workspace/settings/AuditLogsToggle.tsx
+++ b/front/components/workspace/settings/AuditLogsToggle.tsx
@@ -63,7 +63,7 @@ export function AuditLogsGovernanceSection({ owner }: AuditLogsToggleProps) {
     <GovernanceSettingSection label="Audit" icon={LayerSingle}>
       <GovernanceSettingRowLayout
         label="Audit logs"
-        description="Emit audit events to WorkOS and expose the audit logs section in IT & Security."
+        description="Control whether audit events are emitted to WorkOS and the audit logs section is shown in IT & Security."
         action={
           <SliderToggle
             selected={isEnabled}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -2,7 +2,7 @@ import { AuditLogsToggle } from "@app/components/workspace/settings/AuditLogsTog
 import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
-import { OpenPodPolicy } from "@app/components/workspace/settings/OpenProjectsPolicy";
+import { OpenPodPolicy } from "@app/components/workspace/settings/OpenPodsPolicy";
 import { PodKnowledgePolicy } from "@app/components/workspace/settings/PodKnowledgePolicy";
 import { PrivateConversationUrlsToggle } from "@app/components/workspace/settings/PrivateConversationUrlsToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";

--- a/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
+++ b/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
@@ -17,6 +17,10 @@ interface DustMcpServerSettingsItemProps {
   owner: WorkspaceType;
 }
 
+const LABEL = "MCP server";
+const DESCRIPTION =
+  "Control whether external MCP clients can connect to this workspace.";
+
 export function DustMcpServerSettingsItem({
   owner,
 }: DustMcpServerSettingsItemProps) {
@@ -42,15 +46,12 @@ export function DustMcpServerSettingsItem({
     });
   };
 
-  const label = "MCP server";
-  const description = `Allow external MCP clients to connect to this workspace via ${mcpServerUrl}.`;
-
   return (
     <>
       {hasFeature("admin_governance") ? (
         <GovernanceSettingRowLayout
-          label={label}
-          description={description}
+          label={LABEL}
+          description={DESCRIPTION}
           action={
             <div className="flex shrink-0 items-center gap-2">
               {isEnabled && (
@@ -75,8 +76,8 @@ export function DustMcpServerSettingsItem({
         />
       ) : (
         <ContextItem
-          title={label}
-          subElement={description}
+          title={LABEL}
+          subElement={`Allow external MCP clients to connect to this workspace via ${mcpServerUrl}.`}
           visual={<Server01 className="h-6 w-6" />}
           truncateSubElement={true}
           hasSeparatorIfLast={true}

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -25,7 +25,7 @@ const ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE =
   "prompt injection.";
 
 const LABEL = "Email agents";
-const DESCRIPTION = `Allow workspace members to email agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}`;
+const DESCRIPTION = `Control whether members can reach agents by email at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`;
 const DOCUMENTATION_URL = "https://docs.dust.tt/docs/email-agents";
 
 interface EmailAgentsToggleProps {

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -44,6 +44,9 @@ const SHARING_POLICY_OPTIONS: {
   },
 ];
 
+const LABEL = "Frame access";
+const DESCRIPTION = "Control who can access frames in this workspace.";
+
 interface InteractiveContentSharingToggleProps {
   owner: WorkspaceType;
 }
@@ -103,8 +106,8 @@ export function InteractiveContentSharing({
     <>
       {hasFeature("admin_governance") ? (
         <GovernanceSettingRowLayout
-          label="Frame sharing policy"
-          description="Control how frames can be shared in this workspace"
+          label={LABEL}
+          description={DESCRIPTION}
           action={
             <InteractiveContentSharingDropdown
               selectedOption={selectedOption}

--- a/front/components/workspace/settings/MessagingAppToggles.tsx
+++ b/front/components/workspace/settings/MessagingAppToggles.tsx
@@ -27,6 +27,7 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
   } = useBotDataSources({ workspaceId: owner.sId });
 
   const isDiscordBotAvailable = hasFeature("discord_bot");
+  const hasAdminGovernanceFeature = hasFeature("admin_governance");
 
   if (isSystemSpaceLoading || isBotDataSourcesLoading || !systemSpace) {
     return (
@@ -45,7 +46,11 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
         oauth={{ provider: "slack", useCase: "bot", extraConfig: {} }}
         connectorProvider="slack_bot"
         name="Slack Bot"
-        description="Use Dust Agents in Slack with the Dust Slack app"
+        description={
+          hasAdminGovernanceFeature
+            ? "Control whether the Dust Bot can be used in Slack."
+            : "Use Dust Agents in Slack with the Dust Slack app"
+        }
         visual={<SlackLogo className="h-6 w-6" />}
         documentationUrl="https://docs.dust.tt/docs/slack"
       />
@@ -60,7 +65,11 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
         }}
         connectorProvider="microsoft_bot"
         name="Microsoft Teams Bot"
-        description="Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
+        description={
+          hasAdminGovernanceFeature
+            ? "Control whether the Dust Bot can be used in Microsoft Teams."
+            : "Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
+        }
         visual={<MicrosoftLogo className="h-6 w-6" />}
         documentationUrl="https://docs.dust.tt/docs/dust-in-teams"
       />
@@ -76,7 +85,11 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
           }}
           connectorProvider="discord_bot"
           name="Discord Bot"
-          description="Use Dust Agents in Discord with the Dust Discord app"
+          description={
+            hasAdminGovernanceFeature
+              ? "Control whether the Dust Bot can be used in Discord."
+              : "Use Dust Agents in Discord with the Dust Discord app"
+          }
           visual={<DiscordLogo className="h-6 w-6" />}
         />
       )}

--- a/front/components/workspace/settings/OpenPodsPolicy.tsx
+++ b/front/components/workspace/settings/OpenPodsPolicy.tsx
@@ -28,6 +28,10 @@ const OPEN_PODS_POLICIES = [
   },
 ] as const;
 
+const LABEL = "Pod access";
+const DESCRIPTION =
+  "Control whether Pods can be restricted only or restricted and open.";
+
 type OpenPodPolicy = (typeof OPEN_PODS_POLICIES)[number];
 
 export function OpenPodPolicy({ owner }: { owner: WorkspaceType }) {
@@ -39,15 +43,11 @@ export function OpenPodPolicy({ owner }: { owner: WorkspaceType }) {
     (policy) => policy.allowOpenProjects === allowOpenPods
   );
 
-  const label = "Pod access policy";
-  const description =
-    "Control whether Pods can be restricted only or restricted and open.";
-
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <OpenPodPolicyDropdown
             selectedPolicy={selectedPolicy}
@@ -61,8 +61,8 @@ export function OpenPodPolicy({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement={DESCRIPTION}
       visual={<CubeOutline className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/PodKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/PodKnowledgePolicy.tsx
@@ -30,6 +30,9 @@ const POD_KNOWLEDGE_POLICIES = [
 
 type PodKnowledgePolicy = (typeof POD_KNOWLEDGE_POLICIES)[number];
 
+const LABEL = "Pod files";
+const DESCRIPTION = "Control whether members can manually add files to Pods.";
+
 export function PodKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
   const {
     allowManualPodKnowledgeManagement,
@@ -44,14 +47,11 @@ export function PodKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
       allowManualPodKnowledgeManagement
   );
 
-  const label = "Pod files policy";
-  const description = "Control whether members can manually add files to Pods.";
-
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <PodKnowledgePolicyDropdown
             selectedPolicy={selectedPolicy}
@@ -65,8 +65,8 @@ export function PodKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement={DESCRIPTION}
       visual={<BookOpen01 className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
+++ b/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
@@ -4,6 +4,10 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Lock01, SliderToggle } from "@dust-tt/sparkle";
 
+const LABEL = "Private conversation URLs by default";
+const DESCRIPTION =
+  "Control whether conversation URLs are private by default, limiting access to participants.";
+
 interface PrivateConversationUrlsToggleProps {
   owner: WorkspaceType;
 }
@@ -15,15 +19,11 @@ export function PrivateConversationUrlsToggle({
     usePrivateConversationUrlsToggle({ owner });
   const { hasFeature } = useFeatureFlags();
 
-  const label = "Private conversation URLs by default";
-  const description =
-    "Restrict conversation URL access to participants only by default";
-
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <SliderToggle
             selected={isEnabled}
@@ -37,8 +37,8 @@ export function PrivateConversationUrlsToggle({
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement="Restrict conversation URL access to participants only by default"
       visual={<Lock01 className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
+++ b/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
@@ -4,6 +4,10 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, SlackLogo, SliderToggle } from "@dust-tt/sparkle";
 
+const LABEL = '"Sent via Agent" Slack footer';
+const DESCRIPTION =
+  'Control whether Slack messages posted with user credentials show the "Sent via Agent" footer.';
+
 export function SlackPersonalFooterRemovalToggle({
   owner,
 }: {
@@ -13,15 +17,11 @@ export function SlackPersonalFooterRemovalToggle({
     useSlackPersonalFooterRemovalToggle({ owner });
   const { hasFeature } = useFeatureFlags();
 
-  const label = '"Sent via Agent" Slack footer';
-  const description =
-    "Let agents remove the attribution footer on Slack messages posted with user credentials";
-
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <SliderToggle
             selected={isEnabled}
@@ -35,8 +35,8 @@ export function SlackPersonalFooterRemovalToggle({
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement="Let agents remove the attribution footer on Slack messages posted with user credentials"
       visual={<SlackLogo className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
+++ b/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
@@ -4,14 +4,15 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Microphone01, SliderToggle } from "@dust-tt/sparkle";
 
+const LABEL = "Voice transcription";
+const DESCRIPTION =
+  "Control whether members can use voice transcription in conversations.";
+
 export function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
   const { isEnabled, isChanging, doToggleVoiceTranscription } =
     useVoiceTranscriptionToggle({ owner });
   const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
-
-  const label = "Voice transcription";
-  const description = "Allow voice transcription in Dust conversations";
 
   if (subscription.plan.isByok) {
     return null;
@@ -20,8 +21,8 @@ export function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <SliderToggle
             selected={isEnabled}
@@ -35,8 +36,8 @@ export function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement="Allow voice transcription in Dust conversations"
       visual={<Microphone01 className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
+++ b/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
@@ -4,6 +4,10 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { BarChart01, ContextItem, SliderToggle } from "@dust-tt/sparkle";
 
+const LABEL = "Workspace Analyst";
+const DESCRIPTION =
+  "Control whether workspace admins get the Analyst agent and analytics tools to explore how the workspace is used.";
+
 interface WorkspaceAnalyticsToggleProps {
   owner: WorkspaceType;
 }
@@ -15,15 +19,11 @@ export function WorkspaceAnalyticsToggle({
     useWorkspaceAnalyticsToggle({ owner });
   const { hasFeature } = useFeatureFlags();
 
-  const label = "Workspace Analyst";
-  const description =
-    "Give workspace admins the Analyst agent and analytics tools to explore how the workspace is being used";
-
   if (hasFeature("admin_governance")) {
     return (
       <GovernanceSettingRowLayout
-        label={label}
-        description={description}
+        label={LABEL}
+        description={DESCRIPTION}
         action={
           <SliderToggle
             selected={isEnabled}
@@ -37,8 +37,8 @@ export function WorkspaceAnalyticsToggle({
 
   return (
     <ContextItem
-      title={label}
-      subElement={description}
+      title={LABEL}
+      subElement="Give workspace admins the Analyst agent and analytics tools to explore how the workspace is being used"
       visual={<BarChart01 className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={


### PR DESCRIPTION
## Description

This PR updates copy on the governance page. Moreover it improves the group selection behavior when switching between permission scopes.

- Updates copy
- Remembers the last group selection when a user switches away from the "groups" scope and back, restoring their previous selection
- Adds fade-in animation to group Chip components in `GroupSelector`

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.