### PR TITLE
[core] enh: downsize datasource deletion's DB footprint

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -14,7 +14,6 @@ use crate::search_stores::search_store::{Indexable, NodeItem, SearchStore};
 use crate::stores::store::{DocumentCreateParams, Store};
 use crate::utils;
 use anyhow::{anyhow, Result};
-use futures::future::try_join_all;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use itertools::Itertools;
@@ -2145,24 +2144,17 @@ impl DataSource {
             "Deleting tables"
         );
 
-        // Process tables deletion in chunks to avoid too much concurrency
-        for (batch_index, chunk) in tables.chunks(100).enumerate() {
-            info!(
-                data_source_internal_id = self.internal_id(),
-                batch_index = batch_index,
-                batch_size = chunk.len(),
-                "Deleting table batch"
-            );
-
-            try_join_all(
-                chunk
-                    .iter()
-                    // not deleting from search index here, as it's done more efficiently in the
-                    // full-nodes deletion below
-                    .map(|t| t.delete(store.clone(), databases_store.clone(), None)),
-            )
-            .await?;
-        }
+        // Process tables deletion with bounded concurrency to avoid monopolizing the SQL pool.
+        stream::iter(tables.into_iter().map(|t| {
+            let store = store.clone();
+            let databases_store = databases_store.clone();
+            // not deleting from search index here, as it's done more efficiently in the
+            // full-nodes deletion below
+            async move { t.delete(store, databases_store, None).await }
+        }))
+        .buffer_unordered(16)
+        .try_collect::<Vec<_>>()
+        .await?;
 
         info!(
             data_source_internal_id = self.internal_id(),
@@ -2170,19 +2162,26 @@ impl DataSource {
             "Deleted tables"
         );
 
-        // Delete folders (concurrently).
+        // Delete folders with bounded concurrency.
         let (folders, total) = store
             .list_data_source_folders(&self.project, &self.data_source_id, &None, &None, None)
             .await?;
 
-        try_join_all(folders.iter().map(|f| {
-            store.delete_data_source_folder(&self.project, &self.data_source_id, &f.folder_id())
+        stream::iter(folders.into_iter().map(|f| {
+            let store = store.clone();
+            async move {
+                store
+                    .delete_data_source_folder(&self.project, &self.data_source_id, &f.folder_id())
+                    .await
+            }
         }))
+        .buffer_unordered(16)
+        .try_collect::<Vec<_>>()
         .await?;
 
         info!(
             data_source_internal_id = self.internal_id(),
-            table_count = total,
+            folder_count = total,
             "Deleted folders"
         );
 

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2283,9 +2283,11 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
-        // Data source documents can be numerous so we want to avoid any transaction that could
-        // potentially hurt the performance of the database. Also we delete documents in small
-        // batches to avoid long running operations.
+        // Deletion is not transactional and takes no explicit row locks: concurrent scrubs of
+        // the same data source delete batches optimistically, and any conflict surfaces as a
+        // transient error that is safe to retry, resuming where the failed attempt stopped.
+        // Documents can be numerous so we delete them in small batches to keep each statement
+        // short.
         let deletion_batch_size: u64 = 512;
         let mut total_deleted_rows: u64 = 0;
 
@@ -2299,17 +2301,7 @@ impl Store for PostgresStore {
             .await?;
 
         let stmt_documents = c
-            .prepare(
-                "WITH documents_to_delete AS (
-                   SELECT id FROM data_sources_documents
-                   WHERE id = ANY($1)
-                   ORDER BY id
-                   FOR UPDATE
-                 )
-                 DELETE FROM data_sources_documents
-                 USING documents_to_delete
-                 WHERE data_sources_documents.id = documents_to_delete.id",
-            )
+            .prepare("DELETE FROM data_sources_documents WHERE id = ANY($1)")
             .await?;
 
         // First remove active documents, which are linked to a node
@@ -2331,19 +2323,11 @@ impl Store for PostgresStore {
             }
         }
 
-        // Then remove all remaining documents
         let stmt = c
             .prepare(
-                "WITH documents_to_delete AS (
-                   SELECT id FROM data_sources_documents
-                   WHERE data_source = $1
-                   ORDER BY id
-                   LIMIT $2
-                   FOR UPDATE
-                 )
-                 DELETE FROM data_sources_documents
-                 USING documents_to_delete
-                 WHERE data_sources_documents.id = documents_to_delete.id",
+                "DELETE FROM data_sources_documents WHERE id IN (
+                   SELECT id FROM data_sources_documents WHERE data_source = $1 LIMIT $2
+                 )",
             )
             .await?;
 


### PR DESCRIPTION
## Description

Currently, datasource scrub can put very heavy strain on core database, to the point of causing downtime if left unchecked.

### What happened

1. We launch 100s of delete statements on datasource_documents, each of them executing in the most deranged way possible (more on that below). These statement perform locks
2. These statement take a very long time (up to 4hours), by this time the temporal workflow has fired, retries, fires 100 additional queries. The previous ones have not been cancelled. As a matter of fact IIUC the way we wired up pg pool in rust makes it so that queries don't get cancelled even if the other socket hanged-up.
3. Rince and repeat for enough time and you have a connection pool full of DB statements, waiting for some locks to be released, and at the same time hammering our I/O throughput (maxxxing our quotas, first time I see that congrats to us).

### So how did this huge I/O happen ?

(If you want some numbers: [slack](https://dust4ai.slack.com/archives/C050SM8NSPK/p1784288413816659) and [pganalyse](https://app.pganalyze.com/databases/-641635566/queries/12893952034/explains/fsy7ge465bejdp4xhcbmqqltgq?t=1784214000-1784221200))

PG grossly misestimated the number of rows to fetch taking into account data_source column's selectivity (hypothesis [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1784290065716899?thread_ts=1784288413.816659&cid=C050SM8NSPK)) and selected a plan that would go over all the rows, sorted by id through the pk index. This is a deranged plan, probably the worst possible because you need to scan the index (page to fetch), then for each tuple you want to filter, fetch the heap page it is in, to filter on datasource an so on an so forth.

### What we are doing about it

1. Add a default statement timeout to make sure none of these statements can stay running in the db forever, forcing it to 5 minutes ([here](https://dust4ai.slack.com/archives/C08GJ7PTW3E/p1784301386608879))
2. Reduce concurrency of deletes down to 16
3. Handle the order by created at, multiple options:
    a. Create an index on data_source, id => big table, so big index, would pay a high price JUST to make sure something that runs not that often does not take the monopoly on the DB
    b. Stop using the order by and the lock. Possible but @aubin-tchoi put it in place to prevent deadlocks, and the alternative is to complexity the logic quite a lot (explored with an agent what the code looks like, didn't love it)
    c. do `order by id + 0` trick => to pg it is no longer a column but an operation result, can't use an index for that
    d. remove the lock entirely, let deadlock happen, fix them at the root => discussed with @sfriquet and went with that one

## Tests

Unit tests

## Risk

Low 
Blast radius: scrub data sources.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
