### PR TITLE
feat(activation): gate nudges on unanswered-reply streak

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -1,15 +1,22 @@
 import {
   getActivationNudgeFrequencyCapDays,
+  getActivationNudgeMaxUnansweredCount,
   isEligibleForNudge,
 } from "@app/lib/api/activation/nudge";
 import { Authenticator } from "@app/lib/auth";
-import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS } from "@app/temporal/activation_scheduler/config";
+import {
+  DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
+  DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
+} from "@app/temporal/activation_scheduler/config";
+import { ActivationNudgeFactory } from "@app/tests/utils/ActivationNudgeFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { describe, expect, it } from "vitest";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("getActivationNudgeFrequencyCapDays", () => {
   it("falls back to the default when the workspace has no override", async () => {
@@ -67,11 +74,118 @@ describe("isEligibleForNudge", () => {
     const trigger = await TriggerFactory.webhook(authenticator, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
     });
-    await ActivationNudgeResource.makeNew(authenticator, {
+    await ActivationNudgeFactory.create(authenticator, {
       pod: globalSpace,
       trigger,
     });
 
     expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+  });
+
+  it("is not eligible once the max unanswered nudge count is reached, even outside the cap window", async () => {
+    const { workspace, user, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeMaxUnansweredCount: 2,
+    });
+    const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const trigger = await TriggerFactory.webhook(refreshedAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    });
+
+    // Two nudges, both outside the frequency cap window, with no reply.
+    await ActivationNudgeFactory.create(refreshedAuth, {
+      pod: globalSpace,
+      trigger,
+      createdAt: new Date(Date.now() - 10 * DAY_MS),
+    });
+    await ActivationNudgeFactory.create(refreshedAuth, {
+      pod: globalSpace,
+      trigger,
+      createdAt: new Date(Date.now() - 5 * DAY_MS),
+    });
+
+    expect(await isEligibleForNudge(refreshedAuth, globalSpace)).toBe(false);
+  });
+
+  it("is eligible again once the user replies after the most recent nudge", async () => {
+    const { workspace, user, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeMaxUnansweredCount: 2,
+    });
+    const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const trigger = await TriggerFactory.webhook(refreshedAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    });
+
+    await ActivationNudgeFactory.create(refreshedAuth, {
+      pod: globalSpace,
+      trigger,
+      createdAt: new Date(Date.now() - 10 * DAY_MS),
+    });
+    await ActivationNudgeFactory.create(refreshedAuth, {
+      pod: globalSpace,
+      trigger,
+      createdAt: new Date(Date.now() - 5 * DAY_MS),
+    });
+
+    // The user replied in the conversation created by the trigger firing.
+    const conversation = await ConversationFactory.create(refreshedAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      spaceId: globalSpace.id,
+      messagesCreatedAt: [new Date(Date.now() - 4 * DAY_MS)],
+    });
+    await ConversationFactory.setTriggerIdForTest(
+      conversation.id,
+      workspace.id,
+      trigger.id
+    );
+
+    expect(await isEligibleForNudge(refreshedAuth, globalSpace)).toBe(true);
+  });
+});
+
+describe("getActivationNudgeMaxUnansweredCount", () => {
+  it("falls back to the default when the workspace has no override", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    expect(getActivationNudgeMaxUnansweredCount(authenticator)).toBe(
+      DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT
+    );
+  });
+
+  it("uses the workspace-configured override when valid", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeMaxUnansweredCount: 5,
+    });
+    const refreshedAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    expect(getActivationNudgeMaxUnansweredCount(refreshedAuth)).toBe(5);
+  });
+
+  it("falls back to the default when the override is not a number", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      activationNudgeMaxUnansweredCount: "not-a-number",
+    });
+    const refreshedAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    expect(getActivationNudgeMaxUnansweredCount(refreshedAuth)).toBe(
+      DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT
+    );
   });
 });

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,8 +1,13 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS } from "@app/temporal/activation_scheduler/config";
+import {
+  DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
+  DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
+} from "@app/temporal/activation_scheduler/config";
 import isNumber from "lodash/isNumber";
+import uniq from "lodash/uniq";
 
 export function getActivationNudgeFrequencyCapDays(
   auth: Authenticator
@@ -17,8 +22,67 @@ export function getActivationNudgeFrequencyCapDays(
   return DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS;
 }
 
-// Frequency cap: gates re-nudging a pod that was already nudged within the
-// workspace's configured cap window.
+export function getActivationNudgeMaxUnansweredCount(
+  auth: Authenticator
+): number {
+  const workspace = auth.getNonNullableWorkspace();
+  const customMaxUnansweredCount =
+    workspace.metadata?.activationNudgeMaxUnansweredCount;
+
+  if (isNumber(customMaxUnansweredCount)) {
+    return customMaxUnansweredCount;
+  }
+  return DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT;
+}
+
+// Counts how many of the pod's most recent nudges, starting from the latest
+// and going backwards, got no message from the nudged user (a nudge is
+// "unanswered" if the pod has no message from that user since it fired). The
+// count stops at the first answered nudge, so a reply resets the streak.
+async function countUnansweredNudgeStreak(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { limit }: { limit: number }
+): Promise<number> {
+  const recentNudges = await ActivationNudgeResource.listRecentForSpace(auth, {
+    pod,
+    limit,
+  });
+  if (recentNudges.length === 0) {
+    return 0;
+  }
+
+  const oldestNudge = recentNudges[recentNudges.length - 1];
+  const triggerIds = uniq(recentNudges.map((nudge) => nudge.triggerId));
+  const replyTimestamps =
+    await ConversationResource.listUserMessageTimestampsForTriggers(auth, {
+      triggerIds,
+      userId: oldestNudge.userId,
+      since: oldestNudge.createdAt,
+    });
+
+  let streak = 0;
+  for (let i = 0; i < recentNudges.length; i++) {
+    const windowStart = recentNudges[i].createdAt;
+    const windowEnd = i === 0 ? new Date() : recentNudges[i - 1].createdAt;
+
+    const wasAnswered = replyTimestamps.some(
+      (t) => t >= windowStart && t < windowEnd
+    );
+    if (wasAnswered) {
+      break;
+    }
+    streak++;
+  }
+
+  return streak;
+}
+
+// Gates re-nudging a pod on two conditions:
+// - Frequency cap: was the pod nudged within the workspace's configured cap
+//   window?
+// - Unanswered cap: have the pod's most recent nudges gone unanswered (no
+//   user message since they fired), up to the workspace's configured max?
 export async function isEligibleForNudge(
   auth: Authenticator,
   pod: SpaceResource
@@ -32,6 +96,15 @@ export async function isEligibleForNudge(
 
   const frequencyCapDays = getActivationNudgeFrequencyCapDays(auth);
   const frequencyCapMs = frequencyCapDays * 24 * 60 * 60 * 1000;
+  const msSinceLastNudge = Date.now() - latestNudge.createdAt.getTime();
+  if (msSinceLastNudge < frequencyCapMs) {
+    return false;
+  }
 
-  return Date.now() - latestNudge.createdAt.getTime() >= frequencyCapMs;
+  const maxUnansweredCount = getActivationNudgeMaxUnansweredCount(auth);
+  const unansweredStreak = await countUnansweredNudgeStreak(auth, pod, {
+    limit: maxUnansweredCount,
+  });
+
+  return unansweredStreak < maxUnansweredCount;
 }

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -77,15 +77,25 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
     auth: Authenticator,
     { pod }: { pod: SpaceResource }
   ): Promise<ActivationNudgeResource | null> {
-    const nudge = await this.model.findOne({
+    const [latest] = await this.listRecentForSpace(auth, { pod, limit: 1 });
+    return latest ?? null;
+  }
+
+  // Fetches the `limit` most recent nudges recorded for a pod, newest first.
+  static async listRecentForSpace(
+    auth: Authenticator,
+    { pod, limit }: { pod: SpaceResource; limit: number }
+  ): Promise<ActivationNudgeResource[]> {
+    const nudges = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         spaceId: pod.id,
       },
       order: [["createdAt", "DESC"]],
+      limit,
     });
 
-    return nudge ? new this(this.model, nudge.get()) : null;
+    return nudges.map((nudge) => new this(this.model, nudge.get()));
   }
 
   async delete(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1628,6 +1628,53 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return result;
   }
 
+  /**
+   * Returns the timestamps of messages authored by `userId` in conversations
+   * created by any of `triggerIds`, created at or after `since`. Used by the
+   * activation scheduler to determine whether a user replied following a
+   * nudge (each nudge fires a trigger, which creates its own conversation).
+   */
+  static async listUserMessageTimestampsForTriggers(
+    auth: Authenticator,
+    {
+      triggerIds,
+      userId,
+      since,
+    }: {
+      triggerIds: ModelId[];
+      userId: ModelId;
+      since: Date;
+    }
+  ): Promise<Date[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const messages = await MessageModel.findAll({
+      attributes: ["createdAt"],
+      where: {
+        workspaceId,
+        createdAt: { [Op.gte]: since },
+      },
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: true,
+          attributes: [],
+          where: { userId },
+        },
+        {
+          model: ConversationModel,
+          as: "conversation",
+          required: true,
+          attributes: [],
+          where: { triggerId: { [Op.in]: triggerIds } },
+        },
+      ],
+    });
+
+    return messages.map((m) => m.createdAt);
+  }
+
   static async fetchConversationWithoutContent(
     auth: Authenticator,
     sId: string,

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -4,3 +4,8 @@ export const QUEUE_NAME = `activation-scheduler-queue-v${QUEUE_VERSION}`;
 // Default number of days to wait before nudging the same pod again. Workspaces
 // can override this via the `activationNudgeFrequencyCapDays` metadata key.
 export const DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS = 2;
+
+// Default number of consecutive unanswered nudges (no user message since the
+// nudge fired) after which the scheduler stops nudging a pod. Workspaces can
+// override this via the `activationNudgeMaxUnansweredCount` metadata key.
+export const DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT = 3;

--- a/front/tests/utils/ActivationNudgeFactory.ts
+++ b/front/tests/utils/ActivationNudgeFactory.ts
@@ -1,0 +1,30 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+
+export class ActivationNudgeFactory {
+  static async create(
+    auth: Authenticator,
+    {
+      pod,
+      trigger,
+      createdAt,
+    }: { pod: SpaceResource; trigger: TriggerResource; createdAt?: Date }
+  ): Promise<ActivationNudgeResource> {
+    const nudge = await ActivationNudgeResource.makeNew(auth, {
+      pod,
+      trigger,
+    });
+
+    if (createdAt) {
+      await ActivationNudgeModel.update(
+        { createdAt },
+        { where: { id: nudge.id } }
+      );
+    }
+
+    return nudge;
+  }
+}


### PR DESCRIPTION
## Description

Adds a second gate to `isEligibleForNudge`, on top of the existing frequency cap: a pod stops getting nudged once its most recent nudges have gone unanswered too many times in a row (workspace-configurable, defaults to 3).

- A nudge counts as "unanswered" if the nudged user hasn't posted a message in the conversation created by that trigger firing (`ConversationModel.triggerId`) since the nudge fired.
- The streak is counted from the latest nudge backwards and stops at the first answered one, so a single reply resets it.
- `ConversationResource.listUserMessageTimestampsForTriggers` and `ActivationNudgeResource.listRecentForSpace` back the new checks.
- `ActivationNudgeFactory` added under `tests/utils` for constructing (optionally backdated) nudges in tests, replacing an ad-hoc test helper.

## Tests

Added unit tests covering: the default/overridden/invalid config value, the streak blocking eligibility, and eligibility resuming after a reply.
