### PR TITLE
Performance improvements on seat sync

### DIFF
--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -269,10 +269,6 @@ async function stagePendingContractSeats({
   const pendingSubscription =
     await SubscriptionResource.fetchPendingByWorkspaceModelId(workspace.id);
   if (!pendingSubscription?.metronomeContractId) {
-    logger.info(
-      { workspaceId },
-      "[SeatSync] stagePendingContractSeats — no pending subscription, skipping"
-    );
     return false;
   }
   const pendingContractResult = await getMetronomeContractById({
@@ -283,10 +279,6 @@ async function stagePendingContractSeats({
     pendingContractResult.isErr() ||
     !(await hasContractSeatSubscription(pendingContractResult.value))
   ) {
-    logger.info(
-      { workspaceId },
-      "[SeatSync] stagePendingContractSeats — pending contract has no seat subscription, skipping"
-    );
     return false;
   }
   const pendingContract = pendingContractResult.value;

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -5,6 +5,7 @@ import {
   getSeatCreditNameForSeatType,
   hasContractSeatSubscription,
   promoteNoneSeatTypesForContract,
+  remapMembershipSeatTypesForContract,
   resolveRemappedSeatType,
 } from "@app/lib/metronome/seats";
 import {
@@ -13,6 +14,7 @@ import {
 } from "@app/lib/metronome/setup_common";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
+import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/client", () => ({
@@ -34,6 +36,34 @@ vi.mock("@app/lib/metronome/seat_types", async () => {
     getProductSeatTypes: mockGetProductSeatTypes,
   };
 });
+
+// Mocks for `remapMembershipSeatTypesForContract`'s resource dependencies.
+const {
+  mockGetActiveMemberships,
+  mockGetScheduledMembershipsByUserIdInWorkspace,
+  mockFetchUsersByModelIds,
+  mockFetchSeatLimitsByWorkspace,
+} = vi.hoisted(() => ({
+  mockGetActiveMemberships: vi.fn(),
+  mockGetScheduledMembershipsByUserIdInWorkspace: vi.fn(),
+  mockFetchUsersByModelIds: vi.fn(),
+  mockFetchSeatLimitsByWorkspace: vi.fn(),
+}));
+vi.mock("@app/lib/resources/membership_resource", () => ({
+  MembershipResource: {
+    getActiveMemberships: mockGetActiveMemberships,
+    getScheduledMembershipsByUserIdInWorkspace:
+      mockGetScheduledMembershipsByUserIdInWorkspace,
+  },
+}));
+vi.mock("@app/lib/resources/user_resource", () => ({
+  UserResource: { fetchByModelIds: mockFetchUsersByModelIds },
+}));
+vi.mock("@app/lib/resources/workspace_seat_limit_resource", () => ({
+  WorkspaceSeatLimitResource: {
+    fetchByWorkspace: mockFetchSeatLimitsByWorkspace,
+  },
+}));
 
 // A single seat tier on a fixture contract.
 type SeatFixture = {
@@ -534,6 +564,139 @@ describe("promoteNoneSeatTypesForContract", () => {
         forceSeatType: "pro",
       })
     ).toEqual(["pro", "pro", "free"]);
+  });
+});
+
+describe("remapMembershipSeatTypesForContract — scheduled-remap no-op", () => {
+  const { contract, productSeatTypes } = makeContract({
+    seats: [{ seatType: "pro", awu: 8000 }],
+  });
+  const workspace = { sId: "ws_1", id: 1 } as unknown as LightWorkspaceType;
+  const startingAt = new Date("2026-08-01T00:00:00.000Z");
+
+  function makeMembership(userId: number, seatType: MembershipSeatType) {
+    return {
+      userId,
+      seatType,
+      scheduleSeatChange: vi.fn().mockResolvedValue(undefined),
+      updateMembershipSeat: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProductSeatTypes.mockResolvedValue(productSeatTypes);
+    mockFetchSeatLimitsByWorkspace.mockResolvedValue(new Map());
+    mockFetchUsersByModelIds.mockResolvedValue([{ id: 1, sId: "user_1" }]);
+  });
+
+  it("schedules the change when there is no existing matching schedule", async () => {
+    const membership = makeMembership(1, "none");
+    mockGetActiveMemberships.mockResolvedValue({ memberships: [membership] });
+    mockGetScheduledMembershipsByUserIdInWorkspace.mockResolvedValue(new Map());
+
+    const result = await remapMembershipSeatTypesForContract({
+      metronomeCustomerId: "cust_1",
+      contractId: "contract_1",
+      workspace,
+      swapAt: "next-hour",
+      startingAt,
+      contract,
+      promoteNoneSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(membership.scheduleSeatChange).toHaveBeenCalledTimes(1);
+    expect(membership.scheduleSeatChange).toHaveBeenCalledWith(
+      expect.objectContaining({ newSeatType: "pro", scheduledAt: startingAt })
+    );
+  });
+
+  it("does not re-schedule when an existing scheduled row already matches the target", async () => {
+    const membership = makeMembership(1, "none");
+    mockGetActiveMemberships.mockResolvedValue({ memberships: [membership] });
+    mockGetScheduledMembershipsByUserIdInWorkspace.mockResolvedValue(
+      new Map([[1, { seatType: "pro", startAt: startingAt }]])
+    );
+
+    const result = await remapMembershipSeatTypesForContract({
+      metronomeCustomerId: "cust_1",
+      contractId: "contract_1",
+      workspace,
+      swapAt: "next-hour",
+      startingAt,
+      contract,
+      promoteNoneSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(membership.scheduleSeatChange).not.toHaveBeenCalled();
+  });
+
+  it("re-schedules when an existing scheduled row targets a different seat type", async () => {
+    const membership = makeMembership(1, "none");
+    mockGetActiveMemberships.mockResolvedValue({ memberships: [membership] });
+    mockGetScheduledMembershipsByUserIdInWorkspace.mockResolvedValue(
+      new Map([[1, { seatType: "max", startAt: startingAt }]])
+    );
+
+    const result = await remapMembershipSeatTypesForContract({
+      metronomeCustomerId: "cust_1",
+      contractId: "contract_1",
+      workspace,
+      swapAt: "next-hour",
+      startingAt,
+      contract,
+      promoteNoneSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(membership.scheduleSeatChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-schedules when an existing scheduled row matches the seat type but not the start date", async () => {
+    const membership = makeMembership(1, "none");
+    mockGetActiveMemberships.mockResolvedValue({ memberships: [membership] });
+    mockGetScheduledMembershipsByUserIdInWorkspace.mockResolvedValue(
+      new Map([
+        [1, { seatType: "pro", startAt: new Date("2026-07-01T00:00:00.000Z") }],
+      ])
+    );
+
+    const result = await remapMembershipSeatTypesForContract({
+      metronomeCustomerId: "cust_1",
+      contractId: "contract_1",
+      workspace,
+      swapAt: "next-hour",
+      startingAt,
+      contract,
+      promoteNoneSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(membership.scheduleSeatChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies immediately (no scheduled-row lookup) when swapAt is current-hour", async () => {
+    const membership = makeMembership(1, "none");
+    mockGetActiveMemberships.mockResolvedValue({ memberships: [membership] });
+
+    const result = await remapMembershipSeatTypesForContract({
+      metronomeCustomerId: "cust_1",
+      contractId: "contract_1",
+      workspace,
+      swapAt: "current-hour",
+      startingAt,
+      contract,
+      promoteNoneSeatType: "pro",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      mockGetScheduledMembershipsByUserIdInWorkspace
+    ).not.toHaveBeenCalled();
+    expect(membership.updateMembershipSeat).toHaveBeenCalledTimes(1);
+    expect(membership.scheduleSeatChange).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -59,6 +59,7 @@ import {
   isPaidSeatType,
   SEAT_TYPE_ORDER,
 } from "@app/types/memberships";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -538,12 +539,6 @@ export async function remapMembershipSeatTypesForContract({
     return new Ok(undefined);
   }
 
-  const [users, seatLimits] = await Promise.all([
-    UserResource.fetchByModelIds(memberships.map((m) => m.userId)),
-    WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
-  ]);
-  const userByModelId = new Map(users.map((u) => [u.id, u]));
-
   // Apply immediately when the contract already started — either the operator
   // swapped at the current hour, or backdated the start to the past. Scheduling
   // a seat change at a past timestamp would retroactively close the current row
@@ -552,6 +547,25 @@ export async function remapMembershipSeatTypesForContract({
   // the only case that schedules.
   const applyImmediately =
     swapAt === "current-hour" || startingAt.getTime() <= Date.now();
+
+  // When scheduling (not applying immediately), a member already correctly
+  // scheduled from a previous call must be detected here: `scheduleSeatChange`
+  // never touches the *active* row's `seatType` (it only closes that row and
+  // creates a separate future-dated one), so comparing against the active
+  // row alone can never see a prior schedule — every not-yet-migrated member
+  // would otherwise be re-scheduled (a full destroy+update+create) on every
+  // single call to this function, for as long as their change stays pending.
+  const [users, seatLimits, scheduledByUserId] = await Promise.all([
+    UserResource.fetchByModelIds(memberships.map((m) => m.userId)),
+    WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
+    applyImmediately
+      ? Promise.resolve(new Map<ModelId, MembershipResource>())
+      : MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
+          workspace,
+          userIds: memberships.map((m) => m.userId),
+        }),
+  ]);
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
 
   const remapTargets = memberships.flatMap((membership) => {
     const user = userByModelId.get(membership.userId);
@@ -593,7 +607,12 @@ export async function remapMembershipSeatTypesForContract({
     { membership, user, baseTarget },
   ] of remapTargets.entries()) {
     const target = promotedTargets[index];
-    if (target === membership.seatType) {
+    const existingSchedule = scheduledByUserId.get(membership.userId);
+    const alreadyScheduled =
+      !applyImmediately &&
+      existingSchedule?.seatType === target &&
+      existingSchedule.startAt.getTime() === startingAt.getTime();
+    if (target === membership.seatType || alreadyScheduled) {
       logger.info(
         {
           workspaceId: workspace.sId,
@@ -601,6 +620,7 @@ export async function remapMembershipSeatTypesForContract({
           userId: user.sId,
           currentSeatType: membership.seatType,
           target,
+          alreadyScheduled,
         },
         "[Metronome][remap] No seat-type change for membership"
       );
@@ -1488,25 +1508,46 @@ export async function syncSeatCount({
     }
 
     type ScheduledChange = {
-      userSId: string;
+      userId: string;
       newSeatType: MembershipSeatType;
       at: Date;
     };
     const scheduledChanges: ScheduledChange[] = [];
     for (const m of futureMemberships) {
-      const userSId = m.user?.sId;
+      const userId = m.user?.sId;
       // Same `firstUsedAt` filter as the current-seat map above: a scheduled
       // change carries the current row's `firstUsedAt` (see `scheduleSeatChange`),
       // so provisioned-but-never-used members (SCIM on enterprise contracts) are
       // scheduled by contract switches / migrations yet must stay uncounted, just
       // like Stripe. Without this the future segment would re-introduce them.
-      if (userSId && m.firstUsedAt !== null) {
+      if (userId && m.firstUsedAt !== null) {
         scheduledChanges.push({
-          userSId,
+          userId,
           newSeatType: m.seatType,
           at: m.startAt,
         });
       }
+    }
+
+    // Grouped by user so `seatTypeAt` below doesn't rescan every scheduled
+    // change in the workspace for every user at every timestamp — with
+    // `seatSubscriptions.length * effectiveTimestampsMs.length` calls each
+    // walking all `users`, an unindexed scan over all `scheduledChanges` made
+    // the whole reconcile loop O(subs * timestamps * users * scheduledChanges),
+    // quadratic in workspace size whenever most users have a pending change
+    // (e.g. mid-migration). Sorted ascending per user so `seatTypeAt` can walk
+    // forward and stop at the first change past `tMs`.
+    const scheduledChangesByUserId = new Map<string, ScheduledChange[]>();
+    for (const change of scheduledChanges) {
+      const existing = scheduledChangesByUserId.get(change.userId);
+      if (existing) {
+        existing.push(change);
+      } else {
+        scheduledChangesByUserId.set(change.userId, [change]);
+      }
+    }
+    for (const changes of scheduledChangesByUserId.values()) {
+      changes.sort((a, b) => a.at.getTime() - b.at.getTime());
     }
 
     // Surface memberships whose seat type has no matching entitled subscription
@@ -1603,14 +1644,19 @@ export async function syncSeatCount({
     };
 
     // Compute the desired seat type per user at a given timestamp, by walking
-    // scheduled changes from earliest up to (and including) `tMs`.
+    // that user's own scheduled changes (ascending) from earliest up to (and
+    // including) `tMs`.
     const seatTypeAt = (
       userSId: string,
       tMs: number
     ): MembershipSeatType | undefined => {
       let seatType = currentSeatByUserSId.get(userSId);
-      for (const c of scheduledChanges) {
-        if (c.userSId === userSId && c.at.getTime() <= tMs) {
+      const changes = scheduledChangesByUserId.get(userSId);
+      if (changes) {
+        for (const c of changes) {
+          if (c.at.getTime() > tMs) {
+            break;
+          }
           seatType = c.newSeatType;
         }
       }
@@ -1623,7 +1669,7 @@ export async function syncSeatCount({
     // themselves onto it.
     const allUserSIds = new Set<string>([
       ...currentSeatByUserSId.keys(),
-      ...scheduledChanges.map((c) => c.userSId),
+      ...scheduledChanges.map((c) => c.userId),
     ]);
     const desiredSIdsAt = (
       subSeatType: MembershipSeatType,


### PR DESCRIPTION
## Description

Two more seat-sync performance fixes, found from production logs on a ~500-user workspace mid the legacy Pro → Business migration, whose `syncMetronomeSeatCountWorkflow` had been stuck retrying `syncMetronomeSeatCountActivity` (10-minute `startToCloseTimeout`) 1740 times — i.e. the sync had never once completed within the timeout.

- **`remapMembershipSeatTypesForContract` was re-scheduling every not-yet-migrated member on every single membership event** (`lib/metronome/seats.ts`). This is called from `stagePendingContractSeats`, which runs on every membership add/change/revoke while a workspace has a pending contract — not just during the migration script's bulk run. Its no-op check compared the computed target against the *active* membership row's `seatType`, but the scheduling path (`scheduleSeatChange`) never touches that row — it only closes it and creates a separate future-dated row. So a member already correctly scheduled by a previous call still looked unmigrated on the next one, and got re-scheduled (a full destroy+update+create transaction) again — for every not-yet-migrated member, on every membership event in the workspace, for the whole migration window. Now the function also fetches each member's existing scheduled row (`MembershipResource.getScheduledMembershipsByUserIdInWorkspace`, one batched query) and skips re-scheduling when it already matches the target seat type and start date.

- **`syncSeatCount`'s per-timestamp reconcile was quadratic in workspace size** (`lib/metronome/seats.ts`). `desiredSIdsAt` is called once per `(seat subscription × distinct effective timestamp)`, and for each call, `seatTypeAt` walked the *entire* `scheduledChanges` list for every single user to find that user's own changes. With most users mid-migration carrying a pending scheduled change, that's `subscriptions × timestamps × users × scheduledChanges` comparisons — for 500 users this reaches into the millions of iterations, run synchronously. `scheduledChanges` is now grouped into a `Map<userId, ScheduledChange[]>` (sorted ascending) once up front, so each lookup only walks that one user's own changes instead of the whole workspace's.

- Removed two `logger.info` calls in `stagePendingContractSeats` (`lib/api/metronome/seat_sync.ts`) that fired on every sync for every workspace *without* a pending contract — pure log-volume noise, since the vast majority of workspaces hit this path on every membership change.

## Tests

- Added 5 test cases for `remapMembershipSeatTypesForContract` in `seats.test.ts`, covering: no existing schedule (schedules), an existing schedule that already matches (no-op), a mismatched seat type (re-schedules), a mismatched start date (re-schedules), and the immediate-apply path (never looks up scheduled rows, applies directly). Full `lib/metronome` suite (70 tests) passes.
- Not yet verified live against the previously-stuck workflow — waiting to see whether it now completes and clears its retry count once deployed.

## Risk

- Both fixes preserve behavior for the case they don't optimize: the "already scheduled" no-op requires *both* the seat type and the start date to match, so a genuine change (e.g. the pending contract's start date itself moves) still triggers a re-schedule. The `seatTypeAt` grouping produces the exact same per-user/per-timestamp result as before, just without rescanning the whole workspace to get it.
- No schema or migration changes, no feature flag. Safe to roll back — reverts to the previous (slower, but already-correct) behavior.

## Deploy Plan

Standard deploy. Once live, re-run "Sync Metronome Seat Count" from poke (or wait for the next membership event) on the workspace whose workflow was stuck retrying, and confirm it completes within the activity timeout instead of continuing to retry.
