### PR TITLE
feat(activation): gate nudges on opted-out and dead pods

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -3,7 +3,11 @@ import {
   getActivationNudgeMaxUnansweredCount,
   isEligibleForNudge,
 } from "@app/lib/api/activation/nudge";
+import { ACTIVATION_WEBHOOK_SOURCE_NAME } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
@@ -13,10 +17,39 @@ import { ActivationNudgeFactory } from "@app/tests/utils/ActivationNudgeFactory"
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
 import { describe, expect, it } from "vitest";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Wires a trigger the same way `createActivationTrigger` does in production:
+// on the pod's own view of the shared Activation webhook source. This is
+// required for `isEligibleForNudge` to find it via `findActivationTrigger`,
+// which pinpoints the trigger by `webhookSourceViewId` rather than just
+// `kind === "webhook"` (a pod's space can hold other webhook triggers).
+async function createPodActivationTrigger(
+  auth: Authenticator,
+  pod: SpaceResource,
+  options: { status?: TriggerStatus } = {}
+) {
+  const workspace = auth.getNonNullableWorkspace();
+  const source = await new WebhookSourceFactory(workspace).create({
+    name: ACTIVATION_WEBHOOK_SOURCE_NAME,
+  });
+  const podView = await new WebhookSourceViewFactory(workspace).create(pod, {
+    webhookSourceId: source.sId,
+  });
+
+  return TriggerFactory.webhook(auth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    status: options.status ?? "enabled",
+    spaceId: pod.id,
+    webhookSourceViewId: podView.id,
+  });
+}
 
 describe("getActivationNudgeFrequencyCapDays", () => {
   it("falls back to the default when the workspace has no override", async () => {
@@ -63,6 +96,7 @@ describe("isEligibleForNudge", () => {
     const { authenticator, globalSpace } = await createResourceTest({
       role: "admin",
     });
+    await createPodActivationTrigger(authenticator, globalSpace);
 
     expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(true);
   });
@@ -71,9 +105,10 @@ describe("isEligibleForNudge", () => {
     const { authenticator, globalSpace } = await createResourceTest({
       role: "admin",
     });
-    const trigger = await TriggerFactory.webhook(authenticator, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-    });
+    const trigger = await createPodActivationTrigger(
+      authenticator,
+      globalSpace
+    );
     await ActivationNudgeFactory.create(authenticator, {
       pod: globalSpace,
       trigger,
@@ -93,9 +128,10 @@ describe("isEligibleForNudge", () => {
       user.sId,
       workspace.sId
     );
-    const trigger = await TriggerFactory.webhook(refreshedAuth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-    });
+    const trigger = await createPodActivationTrigger(
+      refreshedAuth,
+      globalSpace
+    );
 
     // Two nudges, both outside the frequency cap window, with no reply.
     await ActivationNudgeFactory.create(refreshedAuth, {
@@ -123,9 +159,10 @@ describe("isEligibleForNudge", () => {
       user.sId,
       workspace.sId
     );
-    const trigger = await TriggerFactory.webhook(refreshedAuth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-    });
+    const trigger = await createPodActivationTrigger(
+      refreshedAuth,
+      globalSpace
+    );
 
     await ActivationNudgeFactory.create(refreshedAuth, {
       pod: globalSpace,
@@ -151,6 +188,69 @@ describe("isEligibleForNudge", () => {
     );
 
     expect(await isEligibleForNudge(refreshedAuth, globalSpace)).toBe(true);
+  });
+
+  it("is not eligible when the trigger was disabled by the user (opted out)", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await createPodActivationTrigger(authenticator, globalSpace, {
+      status: "disabled",
+    });
+
+    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+  });
+
+  it("is not eligible when the pod has no activation trigger", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+
+    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+  });
+
+  it("is not eligible when the pod is archived (dead)", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await createPodActivationTrigger(authenticator, globalSpace);
+
+    // biome-ignore lint/plugin/noRawSql: only way to backdate a paranoid model's deletedAt in tests.
+    await frontSequelize.query(
+      `UPDATE vaults SET "deletedAt" = :deletedAt WHERE id = :id AND "workspaceId" = :workspaceId`,
+      {
+        replacements: {
+          deletedAt: new Date().toISOString(),
+          id: globalSpace.id,
+          workspaceId: authenticator.getNonNullableWorkspace().id,
+        },
+      }
+    );
+    const archivedPod = await SpaceResource.fetchById(
+      authenticator,
+      globalSpace.sId,
+      { includeDeleted: true }
+    );
+    if (!archivedPod) {
+      throw new Error("Expected the archived pod to still be fetchable.");
+    }
+
+    expect(await isEligibleForNudge(authenticator, archivedPod)).toBe(false);
+  });
+
+  it("is not eligible when the target user left the workspace (dead)", async () => {
+    const { workspace, user, globalSpace } = await createResourceTest({
+      role: "user",
+    });
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await createPodActivationTrigger(authenticator, globalSpace);
+
+    await MembershipResource.revokeMembership({ user, workspace });
+
+    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
   });
 });
 

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,7 +1,11 @@
+import { findActivationTrigger } from "@app/lib/api/activation/trigger";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
@@ -78,7 +82,35 @@ async function countUnansweredNudgeStreak(
   return streak;
 }
 
-// Gates re-nudging a pod on two conditions:
+// A pod is "dead" once it can no longer receive nudges for reasons unrelated
+// to nudge history: it was archived, or its target user was removed from or
+// left the workspace.
+async function isPodDead(
+  auth: Authenticator,
+  pod: SpaceResource,
+  trigger: TriggerResource
+): Promise<boolean> {
+  if (pod.deletedAt !== null) {
+    return true;
+  }
+
+  const [targetUser] = await UserResource.fetchByModelIds([trigger.editor]);
+  if (!targetUser) {
+    return true;
+  }
+
+  const activeMembership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user: targetUser,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+
+  return activeMembership === null;
+}
+
+// Gates re-nudging a pod on four conditions:
+// - Opted out: was the trigger disabled by the user?
+// - Dead: is the pod archived, or has its target user left the workspace?
 // - Frequency cap: was the pod nudged within the workspace's configured cap
 //   window?
 // - Unanswered cap: have the pod's most recent nudges gone unanswered (no
@@ -87,6 +119,15 @@ export async function isEligibleForNudge(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<boolean> {
+  const trigger = await findActivationTrigger(auth, pod);
+  if (!trigger || trigger.status !== "enabled") {
+    return false;
+  }
+
+  if (await isPodDead(auth, pod, trigger)) {
+    return false;
+  }
+
   const latestNudge = await ActivationNudgeResource.fetchLatestForSpace(auth, {
     pod,
   });

--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -17,7 +17,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { randomUUID } from "crypto";
 
 // A single workspace-level webhook source is shared by all Activation Pods.
-const ACTIVATION_WEBHOOK_SOURCE_NAME = "Activation";
+export const ACTIVATION_WEBHOOK_SOURCE_NAME = "Activation";
 const ACTIVATION_POD_ID_FIELD = "podId";
 const ACTIVATION_TRIGGER_CUSTOM_PROMPT = `Run the activation workflow.
 `;
@@ -156,6 +156,41 @@ export async function createActivationTrigger(
   }
 
   return new Ok({ triggerId: triggerRes.value.sId });
+}
+
+// Finds the pod's activation trigger: the trigger on the pod's own view of
+// the shared Activation webhook source (see
+// `getOrCreateActivationWebhookSourceView`). Filtering on `webhookSourceViewId`
+// rather than just `kind === "webhook"` matters because a pod's space can hold
+// other, unrelated webhook triggers. There is at most one activation trigger
+// per pod, since `createActivationTrigger` provisions exactly one per pod view.
+export async function findActivationTrigger(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<TriggerResource | null> {
+  const source = await WebhookSourceResource.fetchByName(
+    auth,
+    ACTIVATION_WEBHOOK_SOURCE_NAME
+  );
+  if (!source) {
+    return null;
+  }
+
+  // `includeDeleted` so this still resolves for archived pods: eligibility
+  // gating needs to find the trigger first to then determine the pod is dead.
+  const podViews = await WebhookSourcesViewResource.listBySpace(auth, pod, {
+    includeDeleted: true,
+  });
+  const podView = podViews.find((v) => v.webhookSourceId === source.id);
+  if (!podView) {
+    return null;
+  }
+
+  const triggers = await TriggerResource.listByWebhookSourceViewId(
+    auth,
+    podView.id
+  );
+  return triggers[0] ?? null;
 }
 
 // Fires the activation trigger for a single pod by emitting an internal webhook

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -211,6 +211,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return this.baseFetch(auth);
   }
 
+  static async listBySpace(
+    auth: Authenticator,
+    spaceId: ModelId
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        spaceId,
+      },
+    });
+  }
+
   static async listByWebhookSourceViewId(
     auth: Authenticator,
     webhookSourceViewId: ModelId

--- a/front/tests/utils/TriggerFactory.ts
+++ b/front/tests/utils/TriggerFactory.ts
@@ -15,6 +15,7 @@ interface WebhookTriggerOptions {
   configuration?: WebhookConfig;
   webhookSourceViewId?: ModelId | null;
   customPrompt?: string | null;
+  spaceId?: ModelId | null;
 }
 
 interface ScheduleTriggerOptions {
@@ -47,6 +48,7 @@ export class TriggerFactory {
       status: options.status ?? "disabled",
       configuration: options.configuration ?? { includePayload: true },
       webhookSourceViewId: options.webhookSourceViewId ?? null,
+      spaceId: options.spaceId ?? null,
       origin: "user",
     });
 


### PR DESCRIPTION
## Description

Adds two more eligibility conditions to `isEligibleForNudge`, on top of the existing frequency cap and unanswered-streak checks — both apply even to a pod that's never been nudged before:

- **Opted out**: the pod's activation trigger is missing or its `status` isn't `"enabled"` (the user disabled it).
- **Dead**: the pod is archived, or its target user (the trigger's editor) no longer has an active workspace membership.

`TriggerResource.listBySpace` was added to look up a pod's activation trigger. `TriggerFactory.webhook` in tests now accepts an optional `spaceId` so tests can wire a trigger to a specific pod.

## Tests

Added coverage for: never-nudged pod with an enabled trigger, disabled trigger (opted out), missing trigger, archived pod, and a user who left the workspace (dead).
