### PR TITLE
fix: expose agent config instructions as per-block array

### DIFF
--- a/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
@@ -1,4 +1,5 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { splitInstructionsHtmlBlocks } from "@app/components/shared/utils";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -28,7 +29,7 @@ Use this to understand what the user is currently configuring for their agent.
 
 The response includes:
 - Agent settings (name, description, scope, model, tools, skills)
-- instructionsHtml: HTML version of instructions with data-block-id attributes on each block.
+- instructionsHtmlBlocks: instructions as an array of top-level HTML blocks, one per entry, each with a data-block-id attribute.
   Use these block IDs when making instruction suggestions to target specific blocks.
 - pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user`,
       _meta: {
@@ -66,7 +67,7 @@ The response includes:
       const config = {
         name: formData.agentSettings.name,
         description: formData.agentSettings.description,
-        instructionsHtml,
+        instructionsHtmlBlocks: splitInstructionsHtmlBlocks(instructionsHtml),
         scope: formData.agentSettings.scope,
         model: {
           modelId: formData.generationSettings.modelSettings?.modelId,

--- a/front/components/shared/utils.ts
+++ b/front/components/shared/utils.ts
@@ -7,3 +7,15 @@ export function getBlockOuterHtml(
   const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
   return targetElement ? targetElement.outerHTML : "";
 }
+
+// Splits serialized instructions HTML into its top-level blocks (each keeps its
+// `data-block-id`). Emitting one block per array entry keeps `get_agent_config`
+// output paginatable line-by-line: a single escaped >20KB string is unreachable
+// past the file-read byte cap, whereas one block per line is not.
+export function splitInstructionsHtmlBlocks(
+  instructionsHtml: string
+): string[] {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(instructionsHtml, "text/html");
+  return Array.from(doc.body.children).map((el) => el.outerHTML);
+}

--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -116,9 +116,9 @@ next to it. To add or remove blocks, target their parent.
 Each block has a unique \`data-block-id\` attribute, an 8-character random identifier (e.g., "7f3a2b1c").
 These IDs are persisted and stable across editing sessions.
 
-When you receive the agent instructions via \`get_agent_config\`, they will be in HTML format with block IDs:
-\`\`\`html
-<p data-block-id="7f3a2b1c">You are a helpful assistant.</p>
+When you receive the agent instructions via \`get_agent_config\`, they come as \`instructionsHtmlBlocks\`: an array of top-level HTML blocks, one per entry, each with a block ID:
+\`\`\`json
+["<p data-block-id=\\"7f3a2b1c\\">You are a helpful assistant.</p>"]
 \`\`\`
 
 <block_editing_principles>


### PR DESCRIPTION
## Description

`get_agent_config` (Sidekick's primary tool) serialized `instructionsHtml` as a single JSON string. For agents with large prompts (we have one that is ~44KB), that value lands on one >20KB line. Once the tool output is offloaded to a conversation file, Sidekick reads it back with `files cat`, whose byte cap truncates the oversized line at 20KB, and since its `offset` is a line number, there's no way to page into the remainder. So Sidekick could never read the full instructions and edits to long prompts broke.

Fix at the source: emit instructions as an array of top-level HTML blocks (`instructionsHtmlBlocks`) instead of one escaped string. Pretty-printed JSON then puts one block per line, keeping the output paginatable line-by-line while preserving each block's `data-block-id`.

- `getAgentConfig.ts`: field `instructionsHtml` → `instructionsHtmlBlocks`, plus updated tool description.
- `shared/utils.ts`: new `splitInstructionsHtmlBlocks` helper (DOMParser, same pattern as `getBlockOuterHtml`).
- `agent_suggestions_shared.ts`: updated the Sidekick prompt to describe the array shape.

## Tests

Typecheck + biome pass (also via pre-commit hooks). No automated test covers this client-side tool's output today. Verified manually that `splitInstructionsHtmlBlocks` returns one entry per top-level block with `data-block-id` intact, and `[]` for empty instructions.

## Risk

Low. 

## Deploy Plan

Standard front deploy.