### PR TITLE
[LLM] align model configs with real provider specs and fix Anthropic payload/caching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,6 @@
 /front/migrations/db/                 @dust-tt/data-model-owners
 
 /front/lib/api/llm/                   @dust-tt/llm-router-owners
+/front/lib/llms/                      @dust-tt/llm-router-owners
+/front/lib/model_constructors/        @dust-tt/llm-router-owners
+/front/types/assistant/models/        @dust-tt/llm-router-owners

--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -8,7 +8,7 @@ import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
 import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { Authenticator } from "@app/lib/auth";
-import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
 import type { Region } from "@app/lib/model_constructors/types/regions";
 import { isModelId } from "@app/types/assistant/models/models";
@@ -37,7 +37,7 @@ export interface LegacyBuildParams {
 
 /** The static surface we read off a registered stream endpoint constructor. */
 export interface EndpointInfo {
-  ctor: StreamEndpointConstructor;
+  ctor: DustStreamEndpointConstructor;
   id: string;
   providerId: ProviderId;
   region: Region;
@@ -45,7 +45,7 @@ export interface EndpointInfo {
 }
 
 export function readEndpointInfo(
-  ctor: StreamEndpointConstructor
+  ctor: DustStreamEndpointConstructor
 ): EndpointInfo {
   return {
     ctor,

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -2,7 +2,9 @@ import {
   convertToOldEvent,
   reasoningContentToLegacyMetadata,
   toBaseMessages,
+  withMessageCacheBreakpoints,
 } from "@app/lib/api/llm/transitionLLM";
+import type { BaseMessage } from "@app/lib/model_constructors/types/input/messages";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { assistantReasoningMessageToInputItems } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
@@ -81,13 +83,83 @@ describe("toBaseMessages", () => {
   });
 });
 
+describe("withMessageCacheBreakpoints", () => {
+  const cacheOf = (m: BaseMessage) => ("cache" in m ? m.cache : undefined);
+
+  const equippedSkillsMessage: ModelMessageTypeMultiActionsWithoutContentFragment =
+    {
+      role: "user",
+      name: "system",
+      content: [{ type: "text", text: "equipped skills" }],
+    };
+
+  const messages: BaseMessage[] = [
+    { role: "user", type: "text", content: { value: "equipped skills" } },
+    { role: "assistant", type: "text", content: { value: "hello" } },
+    { role: "user", type: "text", content: { value: "latest turn" } },
+  ];
+
+  it("caches the equipped-skills block and, on the Anthropic API, leaves the tail to the top-level cache", () => {
+    const result = withMessageCacheBreakpoints(
+      messages,
+      equippedSkillsMessage,
+      {
+        explicitTailBreakpoint: false,
+      },
+    );
+
+    expect(cacheOf(result[0])).toBe("short");
+    expect(cacheOf(result[1])).toBeUndefined();
+    expect(cacheOf(result[2])).toBeUndefined();
+  });
+
+  it("also caches the last user message when an explicit tail breakpoint is required (Vertex/agent-platform)", () => {
+    const result = withMessageCacheBreakpoints(
+      messages,
+      equippedSkillsMessage,
+      {
+        explicitTailBreakpoint: true,
+      },
+    );
+
+    expect(cacheOf(result[0])).toBe("short");
+    expect(cacheOf(result[2])).toBe("short");
+  });
+
+  it("skips the equipped-skills breakpoint when the first message is not the name:system block", () => {
+    const firstUserTurn: ModelMessageTypeMultiActionsWithoutContentFragment = {
+      role: "user",
+      name: "user",
+      content: [{ type: "text", text: "hi" }],
+    };
+
+    const result = withMessageCacheBreakpoints(messages, firstUserTurn, {
+      explicitTailBreakpoint: false,
+    });
+
+    expect(result.every((m) => cacheOf(m) === undefined)).toBe(true);
+  });
+
+  it("does not mutate the input array", () => {
+    const input: BaseMessage[] = [
+      { role: "user", type: "text", content: { value: "equipped skills" } },
+    ];
+
+    withMessageCacheBreakpoints(input, equippedSkillsMessage, {
+      explicitTailBreakpoint: true,
+    });
+
+    expect(cacheOf(input[0])).toBeUndefined();
+  });
+});
+
 describe("toBaseMessages — reasoning signatures", () => {
   it("keeps the Anthropic signature (stored under encrypted_content) in `signature`", () => {
     const result = toBaseMessages(
       reasoningMessage({
         provider: "anthropic",
         metadata: JSON.stringify({ encrypted_content: "anthropic-sig" }),
-      })
+      }),
     );
     expect(result).toEqual([
       {
@@ -104,7 +176,7 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "google_ai_studio",
         metadata: JSON.stringify({ encrypted_content: "gemini-thought-sig" }),
-      })
+      }),
     );
     expect(result).toEqual([
       {
@@ -124,7 +196,7 @@ describe("toBaseMessages — reasoning signatures", () => {
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      })
+      }),
     );
     expect(result).toEqual([
       {
@@ -147,7 +219,7 @@ describe("OpenAI reasoning round-trip — persisted metadata to Responses input"
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      })
+      }),
     );
     if (baseMessage.type !== "reasoning") {
       throw new Error("Expected a reasoning BaseMessage.");
@@ -180,8 +252,8 @@ describe("convertToOldEvent — token_usage", () => {
           },
           metadata: endpointMetadata,
         },
-        llmMetadata
-      )
+        llmMetadata,
+      ),
     ).toEqual({
       type: "token_usage",
       content: {
@@ -215,8 +287,8 @@ describe("convertToOldEvent — token_usage", () => {
           },
           metadata: endpointMetadata,
         },
-        llmMetadata
-      )
+        llmMetadata,
+      ),
     ).toEqual({
       type: "token_usage",
       content: {
@@ -264,8 +336,8 @@ describe("convertToOldEvent", () => {
             },
           },
         },
-        llmMetadata
-      )
+        llmMetadata,
+      ),
     ).toEqual({
       type: "interaction_id",
       content: {
@@ -284,8 +356,8 @@ describe("convertToOldEvent", () => {
           content: { responseId: "msg_123" },
           metadata: endpointMetadata,
         },
-        llmMetadata
-      )
+        llmMetadata,
+      ),
     ).toEqual({
       type: "interaction_id",
       content: { modelInteractionId: "msg_123", cacheMissReason: undefined },
@@ -300,13 +372,13 @@ describe("reasoningContentToLegacyMetadata — persistence write path", () => {
       reasoningContentToLegacyMetadata({
         id: "rs_123",
         encryptedContent: "gAAAA-encrypted-blob",
-      })
+      }),
     ).toEqual({ id: "rs_123", encrypted_content: "gAAAA-encrypted-blob" });
   });
 
   it("lifts an Anthropic/Gemini signature to top-level encrypted_content", () => {
     expect(
-      reasoningContentToLegacyMetadata({ signature: "anthropic-sig" })
+      reasoningContentToLegacyMetadata({ signature: "anthropic-sig" }),
     ).toEqual({ encrypted_content: "anthropic-sig" });
   });
 

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -4,10 +4,10 @@ import {
   toBaseMessages,
   withMessageCacheBreakpoints,
 } from "@app/lib/api/llm/transitionLLM";
-import type { BaseMessage } from "@app/lib/model_constructors/types/input/messages";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { assistantReasoningMessageToInputItems } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { BaseMessage } from "@app/lib/model_constructors/types/input/messages";
 import type { ProviderPassthroughEvent } from "@app/lib/model_constructors/types/output/events";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
@@ -105,7 +105,7 @@ describe("withMessageCacheBreakpoints", () => {
       equippedSkillsMessage,
       {
         explicitTailBreakpoint: false,
-      },
+      }
     );
 
     expect(cacheOf(result[0])).toBe("short");
@@ -119,7 +119,7 @@ describe("withMessageCacheBreakpoints", () => {
       equippedSkillsMessage,
       {
         explicitTailBreakpoint: true,
-      },
+      }
     );
 
     expect(cacheOf(result[0])).toBe("short");
@@ -159,7 +159,7 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "anthropic",
         metadata: JSON.stringify({ encrypted_content: "anthropic-sig" }),
-      }),
+      })
     );
     expect(result).toEqual([
       {
@@ -176,7 +176,7 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "google_ai_studio",
         metadata: JSON.stringify({ encrypted_content: "gemini-thought-sig" }),
-      }),
+      })
     );
     expect(result).toEqual([
       {
@@ -196,7 +196,7 @@ describe("toBaseMessages — reasoning signatures", () => {
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      }),
+      })
     );
     expect(result).toEqual([
       {
@@ -219,7 +219,7 @@ describe("OpenAI reasoning round-trip — persisted metadata to Responses input"
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      }),
+      })
     );
     if (baseMessage.type !== "reasoning") {
       throw new Error("Expected a reasoning BaseMessage.");
@@ -252,8 +252,8 @@ describe("convertToOldEvent — token_usage", () => {
           },
           metadata: endpointMetadata,
         },
-        llmMetadata,
-      ),
+        llmMetadata
+      )
     ).toEqual({
       type: "token_usage",
       content: {
@@ -287,8 +287,8 @@ describe("convertToOldEvent — token_usage", () => {
           },
           metadata: endpointMetadata,
         },
-        llmMetadata,
-      ),
+        llmMetadata
+      )
     ).toEqual({
       type: "token_usage",
       content: {
@@ -336,8 +336,8 @@ describe("convertToOldEvent", () => {
             },
           },
         },
-        llmMetadata,
-      ),
+        llmMetadata
+      )
     ).toEqual({
       type: "interaction_id",
       content: {
@@ -356,8 +356,8 @@ describe("convertToOldEvent", () => {
           content: { responseId: "msg_123" },
           metadata: endpointMetadata,
         },
-        llmMetadata,
-      ),
+        llmMetadata
+      )
     ).toEqual({
       type: "interaction_id",
       content: { modelInteractionId: "msg_123", cacheMissReason: undefined },
@@ -372,13 +372,13 @@ describe("reasoningContentToLegacyMetadata — persistence write path", () => {
       reasoningContentToLegacyMetadata({
         id: "rs_123",
         encryptedContent: "gAAAA-encrypted-blob",
-      }),
+      })
     ).toEqual({ id: "rs_123", encrypted_content: "gAAAA-encrypted-blob" });
   });
 
   it("lifts an Anthropic/Gemini signature to top-level encrypted_content", () => {
     expect(
-      reasoningContentToLegacyMetadata({ signature: "anthropic-sig" }),
+      reasoningContentToLegacyMetadata({ signature: "anthropic-sig" })
     ).toEqual({ encrypted_content: "anthropic-sig" });
   });
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -15,6 +15,7 @@ import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
   LLMParameters,
+  LLMStreamMetadata,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
@@ -54,7 +55,10 @@ import type {
   ToolCallEvent as NewToolCallEvent,
   NonDeltaResponseEvent,
 } from "@app/lib/model_constructors/types/output/events";
-import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
+import {
+  AGENT_PLATFORM_API,
+  OPENAI_RESPONSES_API,
+} from "@app/lib/model_constructors/types/provider_apis";
 import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { isCacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -651,7 +655,11 @@ abstract class BaseTransition extends LLM {
     // identity). Some schemas reject provider-invalid combinations (e.g.
     // Anthropic requires temperature=1 with thinking), so the fix must land
     // before `parse`, not after.
-    parseConfig: (config: InputConfig) => InputConfig = (config) => config
+    parseConfig: (config: InputConfig) => InputConfig = (config) => config,
+    // Prompt cache key, forwarded only by surfaces whose config schema accepts
+    // it (OpenAI Responses). Left undefined elsewhere so the provider schemas
+    // that guard `cacheKey` to `undefined` still parse.
+    cacheKey?: string
   ): InputConfig {
     const {
       specifications,
@@ -677,6 +685,7 @@ abstract class BaseTransition extends LLM {
         this.responseFormat,
         this.metadata.clientId
       ),
+      cacheKey,
     };
 
     return configSchema.parse({
@@ -713,17 +722,26 @@ export class StreamEndpointTransition extends BaseTransition {
     };
   }
 
-  protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
+  protected buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters,
+    metadata?: LLMStreamMetadata
+  ) {
+    const { api } = this.model.metadata();
     // Agent-platform (Vertex) has no request-level automatic cache_control, so it
     // needs an explicit breakpoint on the conversation tail (legacy's isLast).
-    const explicitTailBreakpoint =
-      this.model.metadata().api === AGENT_PLATFORM_API;
+    const explicitTailBreakpoint = api === AGENT_PLATFORM_API;
+    // Only OpenAI Responses consumes a prompt cache key (as `prompt_cache_key`);
+    // legacy sent the conversationId. Other surfaces guard `cacheKey` to
+    // undefined, so leave it unset for them.
+    const cacheKey =
+      api === OPENAI_RESPONSES_API ? metadata?.conversationId : undefined;
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters, { explicitTailBreakpoint }),
       this.buildConfig(
         streamParameters,
         this.model.constructor.configSchema,
-        this.endpointConstructor.parseConfig
+        this.endpointConstructor.parseConfig,
+        cacheKey
       )
     );
   }

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -18,13 +18,13 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
-import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import {
   extractEncryptedContentFromMetadata,
   parseReasoningMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
 import type {
   BatchEndpoint,

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -74,7 +74,7 @@ import { isString } from "@app/types/shared/utils/general";
  */
 function mapReasoningEffort(
   effort: ReasoningEffort | null,
-  useNativeLightReasoning: boolean,
+  useNativeLightReasoning: boolean
 ): "none" | "low" | "medium" | "high" | "maximal" {
   switch (effort) {
     case null:
@@ -99,7 +99,7 @@ function mapReasoningEffort(
  * Converts an old-system message to new BaseMessage(s).
  */
 export function toBaseMessages(
-  message: ModelMessageTypeMultiActionsWithoutContentFragment,
+  message: ModelMessageTypeMultiActionsWithoutContentFragment
 ): BaseMessage[] {
   switch (message.role) {
     case "user":
@@ -124,7 +124,7 @@ export function toBaseMessages(
           : message.content.map((c) =>
               c.type === "text"
                 ? { type: "text", text: c.text }
-                : { type: "image_url", url: c.image_url.url },
+                : { type: "image_url", url: c.image_url.url }
             );
       return [
         {
@@ -146,7 +146,7 @@ export function toBaseMessages(
             | AgentTextContentType
             | AgentReasoningContentType
             | AgentFunctionCallContentType
-            | AgentProviderPassthroughContentType,
+            | AgentProviderPassthroughContentType
         ): BaseMessage[] => {
           switch (c.type) {
             case "text_content":
@@ -172,13 +172,13 @@ export function toBaseMessages(
                     type: "reasoning",
                     content: { value: c.value.reasoning },
                     signature: extractEncryptedContentFromMetadata(
-                      c.value.metadata,
+                      c.value.metadata
                     ),
                   },
                 ];
               }
               const { id, encryptedContent } = parseReasoningMetadata(
-                c.value.metadata,
+                c.value.metadata
               );
               return [
                 {
@@ -217,7 +217,7 @@ export function toBaseMessages(
             default:
               assertNever(c);
           }
-        },
+        }
       );
     case "compaction":
       return [
@@ -248,7 +248,7 @@ export function toBaseMessages(
 export function withMessageCacheBreakpoints(
   baseMessages: BaseMessage[],
   firstMessage: ModelMessageTypeMultiActionsWithoutContentFragment | undefined,
-  { explicitTailBreakpoint }: { explicitTailBreakpoint: boolean },
+  { explicitTailBreakpoint }: { explicitTailBreakpoint: boolean }
 ): BaseMessage[] {
   const result = [...baseMessages];
 
@@ -278,7 +278,7 @@ export function withMessageCacheBreakpoints(
 // the legacy top-level shape (`id` / `encrypted_content`) the replay path reads,
 // matching what the old router writes.
 export function reasoningContentToLegacyMetadata(
-  content: Record<string, unknown> | undefined,
+  content: Record<string, unknown> | undefined
 ): { id?: string; encrypted_content?: string } {
   const id = isString(content?.id) ? content.id : undefined;
   const encryptedContent = content?.encryptedContent ?? content?.signature;
@@ -295,7 +295,7 @@ export function reasoningContentToLegacyMetadata(
  */
 function convertAggregatedItem(
   item: NewTextEvent | NewReasoningEvent | NewToolCallEvent,
-  metadata: LLMClientMetadata,
+  metadata: LLMClientMetadata
 ): LLMOutputItem {
   switch (item.type) {
     case "text":
@@ -381,7 +381,7 @@ function mapErrorType(errorType: ErrorType): {
  */
 export function convertToOldEvent(
   event: ModelResponseEvent,
-  metadata: LLMClientMetadata,
+  metadata: LLMClientMetadata
 ): LLMEvent {
   switch (event.type) {
     case "response_id": {
@@ -498,17 +498,17 @@ export function convertToOldEvent(
 
     case "success": {
       const aggregated = event.content.aggregated.map((item) =>
-        convertAggregatedItem(item, metadata),
+        convertAggregatedItem(item, metadata)
       );
       const textGenerated = aggregated.find(
-        (item): item is TextGeneratedEvent => item.type === "text_generated",
+        (item): item is TextGeneratedEvent => item.type === "text_generated"
       );
       const reasoningGenerated = aggregated.find(
         (item): item is ReasoningGeneratedEvent =>
-          item.type === "reasoning_generated",
+          item.type === "reasoning_generated"
       );
       const toolCalls = aggregated.filter(
-        (item): item is OldToolCallEvent => item.type === "tool_call",
+        (item): item is OldToolCallEvent => item.type === "tool_call"
       );
       return {
         type: "success",
@@ -536,7 +536,7 @@ export function convertToOldEvent(
           isRetryable,
           originalError: event.content.originalError,
         },
-        metadata,
+        metadata
       );
     }
 
@@ -550,7 +550,7 @@ export function convertToOldEvent(
  */
 async function* convertToOldEvents(
   newEvents: AsyncGenerator<ModelResponseEvent>,
-  metadata: LLMClientMetadata,
+  metadata: LLMClientMetadata
 ): AsyncGenerator<LLMEvent> {
   for await (const event of newEvents) {
     yield convertToOldEvent(event, metadata);
@@ -563,7 +563,7 @@ async function* convertToOldEvents(
  */
 function convertBatchEventsToOld(
   events: NonDeltaResponseEvent[],
-  metadata: LLMClientMetadata,
+  metadata: LLMClientMetadata
 ): LLMEvent[] {
   return events.map((event) => convertToOldEvent(event, metadata));
 }
@@ -591,14 +591,14 @@ abstract class BaseTransition extends LLM {
     streamParameters: LLMStreamParameters,
     {
       explicitTailBreakpoint = false,
-    }: { explicitTailBreakpoint?: boolean } = {},
+    }: { explicitTailBreakpoint?: boolean } = {}
   ): Payload {
     const { conversation, prompt } = streamParameters;
 
     const baseMessages = withMessageCacheBreakpoints(
       conversation.messages.flatMap(toBaseMessages),
       conversation.messages[0],
-      { explicitTailBreakpoint },
+      { explicitTailBreakpoint }
     );
 
     const { instructions, sharedContext, ephemeralContext } =
@@ -651,7 +651,7 @@ abstract class BaseTransition extends LLM {
     // identity). Some schemas reject provider-invalid combinations (e.g.
     // Anthropic requires temperature=1 with thinking), so the fix must land
     // before `parse`, not after.
-    parseConfig: (config: InputConfig) => InputConfig = (config) => config,
+    parseConfig: (config: InputConfig) => InputConfig = (config) => config
   ): InputConfig {
     const {
       specifications,
@@ -667,7 +667,7 @@ abstract class BaseTransition extends LLM {
       reasoning: {
         effort: mapReasoningEffort(
           this.reasoningEffort,
-          this.modelConfig.useNativeLightReasoning ?? false,
+          this.modelConfig.useNativeLightReasoning ?? false
         ),
       },
       forceTool: forceToolCall,
@@ -675,7 +675,7 @@ abstract class BaseTransition extends LLM {
       toolSearchEnabled,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,
-        this.metadata.clientId,
+        this.metadata.clientId
       ),
     };
 
@@ -699,7 +699,7 @@ export class StreamEndpointTransition extends BaseTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: DustStreamEndpointConstructor,
+    modelConstructor: DustStreamEndpointConstructor
   ) {
     super(auth, modelConstructor.providerId, llmParameters);
     this.endpointConstructor = modelConstructor;
@@ -723,8 +723,8 @@ export class StreamEndpointTransition extends BaseTransition {
       this.buildConfig(
         streamParameters,
         this.model.constructor.configSchema,
-        this.endpointConstructor.parseConfig,
-      ),
+        this.endpointConstructor.parseConfig
+      )
     );
   }
 
@@ -757,17 +757,17 @@ export class NoopStreamTransition extends StreamEndpointTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: DustStreamEndpointConstructor,
+    modelConstructor: DustStreamEndpointConstructor
   ) {
     super(auth, llmParameters, modelConstructor);
     this.noopMetaData = llmParameters.metaData;
   }
 
   protected override buildStreamRequestPayload(
-    streamParameters: LLMStreamParameters,
+    streamParameters: LLMStreamParameters
   ): NoopRequest {
     const request = this.noopModel.buildRequestPayload(
-      this.buildPayload(streamParameters),
+      this.buildPayload(streamParameters)
     );
 
     const staticResponse =
@@ -815,7 +815,7 @@ export class BatchEndpointTransition extends BaseTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: BatchEndpointConstructor,
+    modelConstructor: BatchEndpointConstructor
   ) {
     super(auth, modelConstructor.providerId, llmParameters);
     this.model = new modelConstructor(llmParameters.credentials);
@@ -826,18 +826,18 @@ export class BatchEndpointTransition extends BaseTransition {
   protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters),
-      this.buildConfig(streamParameters, this.model.constructor.configSchema),
+      this.buildConfig(streamParameters, this.model.constructor.configSchema)
     );
   }
 
   protected async *sendRequest(): AsyncGenerator<LLMEvent> {
     throw new Error(
-      "Streaming is not supported on a batch transition LLM; use getStreamLLM instead.",
+      "Streaming is not supported on a batch transition LLM; use getStreamLLM instead."
     );
   }
 
   protected override async internalSendBatchProcessing(
-    conversations: Map<string, LLMStreamParameters>,
+    conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const requests = new Map<string, BatchRequest>();
     for (const [customId, streamParameters] of conversations) {
@@ -845,7 +845,7 @@ export class BatchEndpointTransition extends BaseTransition {
         payload: this.buildPayload(streamParameters),
         config: this.buildConfig(
           streamParameters,
-          this.model.constructor.configSchema,
+          this.model.constructor.configSchema
         ),
       });
     }
@@ -858,7 +858,7 @@ export class BatchEndpointTransition extends BaseTransition {
   }
 
   protected override async internalGetBatchResult(
-    batchId: string,
+    batchId: string
   ): Promise<BatchResult> {
     const results = await this.model.getBatchResult(batchId);
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -18,6 +18,7 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import {
   extractEncryptedContentFromMetadata,
   parseReasoningMetadata,
@@ -31,7 +32,6 @@ import type {
   BatchStatus,
 } from "@app/lib/model_constructors/batch/endpoint";
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { NoopRequest } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
 import { NoopGlobalNoopStream } from "@app/lib/model_constructors/stream/endpoints/noop_global_noop";
@@ -601,7 +601,12 @@ abstract class BaseTransition extends LLM {
   // own `configSchema` (stream and batch own theirs independently).
   protected buildConfig(
     streamParameters: LLMStreamParameters,
-    configSchema: BaseEndpointConfiguration["configSchema"]
+    configSchema: BaseEndpointConfiguration["configSchema"],
+    // Per-endpoint adjustment applied before schema validation (defaults to
+    // identity). Some schemas reject provider-invalid combinations (e.g.
+    // Anthropic requires temperature=1 with thinking), so the fix must land
+    // before `parse`, not after.
+    parseConfig: (config: InputConfig) => InputConfig = (config) => config
   ): InputConfig {
     const {
       specifications,
@@ -611,7 +616,7 @@ abstract class BaseTransition extends LLM {
       previousMessageId,
     } = streamParameters;
 
-    return configSchema.parse({
+    const config: InputConfig = {
       tools: specifications as ToolSpecification[],
       temperature: this.temperature ?? undefined,
       reasoning: {
@@ -627,6 +632,10 @@ abstract class BaseTransition extends LLM {
         this.responseFormat,
         this.metadata.clientId
       ),
+    };
+
+    return configSchema.parse({
+      ...parseConfig(config),
       // Prompt-cache diagnostics opt-in. Kept only by the Anthropic (direct)
       // config schema; other surfaces' schemas strip this unknown key.
       previousMessageId,
@@ -640,13 +649,15 @@ abstract class BaseTransition extends LLM {
  */
 export class StreamEndpointTransition extends BaseTransition {
   private model: StreamEndpoint;
+  private endpointConstructor: DustStreamEndpointConstructor;
 
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: StreamEndpointConstructor
+    modelConstructor: DustStreamEndpointConstructor
   ) {
     super(auth, modelConstructor.providerId, llmParameters);
+    this.endpointConstructor = modelConstructor;
     this.model = new modelConstructor(llmParameters.credentials);
 
     const { api, region } = this.model.metadata();
@@ -660,7 +671,11 @@ export class StreamEndpointTransition extends BaseTransition {
   protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters),
-      this.buildConfig(streamParameters, this.model.constructor.configSchema)
+      this.buildConfig(
+        streamParameters,
+        this.model.constructor.configSchema,
+        this.endpointConstructor.parseConfig
+      )
     );
   }
 
@@ -693,7 +708,7 @@ export class NoopStreamTransition extends StreamEndpointTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: StreamEndpointConstructor
+    modelConstructor: DustStreamEndpointConstructor
   ) {
     super(auth, llmParameters, modelConstructor);
     this.noopMetaData = llmParameters.metaData;

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -54,6 +54,7 @@ import type {
   ToolCallEvent as NewToolCallEvent,
   NonDeltaResponseEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
 import { NOOP_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { isCacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -73,7 +74,7 @@ import { isString } from "@app/types/shared/utils/general";
  */
 function mapReasoningEffort(
   effort: ReasoningEffort | null,
-  useNativeLightReasoning: boolean
+  useNativeLightReasoning: boolean,
 ): "none" | "low" | "medium" | "high" | "maximal" {
   switch (effort) {
     case null:
@@ -98,7 +99,7 @@ function mapReasoningEffort(
  * Converts an old-system message to new BaseMessage(s).
  */
 export function toBaseMessages(
-  message: ModelMessageTypeMultiActionsWithoutContentFragment
+  message: ModelMessageTypeMultiActionsWithoutContentFragment,
 ): BaseMessage[] {
   switch (message.role) {
     case "user":
@@ -123,7 +124,7 @@ export function toBaseMessages(
           : message.content.map((c) =>
               c.type === "text"
                 ? { type: "text", text: c.text }
-                : { type: "image_url", url: c.image_url.url }
+                : { type: "image_url", url: c.image_url.url },
             );
       return [
         {
@@ -145,7 +146,7 @@ export function toBaseMessages(
             | AgentTextContentType
             | AgentReasoningContentType
             | AgentFunctionCallContentType
-            | AgentProviderPassthroughContentType
+            | AgentProviderPassthroughContentType,
         ): BaseMessage[] => {
           switch (c.type) {
             case "text_content":
@@ -171,13 +172,13 @@ export function toBaseMessages(
                     type: "reasoning",
                     content: { value: c.value.reasoning },
                     signature: extractEncryptedContentFromMetadata(
-                      c.value.metadata
+                      c.value.metadata,
                     ),
                   },
                 ];
               }
               const { id, encryptedContent } = parseReasoningMetadata(
-                c.value.metadata
+                c.value.metadata,
               );
               return [
                 {
@@ -216,7 +217,7 @@ export function toBaseMessages(
             default:
               assertNever(c);
           }
-        }
+        },
       );
     case "compaction":
       return [
@@ -231,12 +232,53 @@ export function toBaseMessages(
   }
 }
 
+// Places the Anthropic user-message cache breakpoints, matching the legacy
+// router. Returns a new array; does not mutate its input.
+//   - Equipped-skills prefix: always. When the first message is the
+//     `name: "system"` user block (the stable per agent+workspace skills list),
+//     its last content block is cached for cross-conversation reuse. Mirrors the
+//     legacy `isFirst && message.name === "system"` breakpoint. `toBaseMessages`
+//     emits one BaseMessage per user content item, so messages[0]'s last block
+//     sits at index (content.length - 1).
+//   - Conversation tail: only when `explicitTailBreakpoint` is set — i.e. on
+//     surfaces without the request-level automatic cache_control (Vertex/
+//     agent-platform). The last user message is cached, mirroring legacy's
+//     Vertex-only `isLast` marker. On the Anthropic API (and batch) the tail is
+//     left to the top-level automatic cache, keeping within the 4-slot budget.
+export function withMessageCacheBreakpoints(
+  baseMessages: BaseMessage[],
+  firstMessage: ModelMessageTypeMultiActionsWithoutContentFragment | undefined,
+  { explicitTailBreakpoint }: { explicitTailBreakpoint: boolean },
+): BaseMessage[] {
+  const result = [...baseMessages];
+
+  if (firstMessage?.role === "user" && firstMessage.name === "system") {
+    const skillsBlockIndex = firstMessage.content.length - 1;
+    const skillsBlock = result[skillsBlockIndex];
+    if (skillsBlock?.role === "user") {
+      result[skillsBlockIndex] = { ...skillsBlock, cache: "short" };
+    }
+  }
+
+  if (explicitTailBreakpoint) {
+    for (let i = result.length - 1; i >= 0; i--) {
+      const msg = result[i];
+      if (msg.role === "user") {
+        result[i] = { ...msg, cache: "short" };
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
 // The new router nests reasoning replay state under `metadata.content`: OpenAI
 // uses `id` + `encryptedContent`, Anthropic/Gemini use `signature`. Persist it in
 // the legacy top-level shape (`id` / `encrypted_content`) the replay path reads,
 // matching what the old router writes.
 export function reasoningContentToLegacyMetadata(
-  content: Record<string, unknown> | undefined
+  content: Record<string, unknown> | undefined,
 ): { id?: string; encrypted_content?: string } {
   const id = isString(content?.id) ? content.id : undefined;
   const encryptedContent = content?.encryptedContent ?? content?.signature;
@@ -253,7 +295,7 @@ export function reasoningContentToLegacyMetadata(
  */
 function convertAggregatedItem(
   item: NewTextEvent | NewReasoningEvent | NewToolCallEvent,
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
 ): LLMOutputItem {
   switch (item.type) {
     case "text":
@@ -339,7 +381,7 @@ function mapErrorType(errorType: ErrorType): {
  */
 export function convertToOldEvent(
   event: ModelResponseEvent,
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
 ): LLMEvent {
   switch (event.type) {
     case "response_id": {
@@ -456,17 +498,17 @@ export function convertToOldEvent(
 
     case "success": {
       const aggregated = event.content.aggregated.map((item) =>
-        convertAggregatedItem(item, metadata)
+        convertAggregatedItem(item, metadata),
       );
       const textGenerated = aggregated.find(
-        (item): item is TextGeneratedEvent => item.type === "text_generated"
+        (item): item is TextGeneratedEvent => item.type === "text_generated",
       );
       const reasoningGenerated = aggregated.find(
         (item): item is ReasoningGeneratedEvent =>
-          item.type === "reasoning_generated"
+          item.type === "reasoning_generated",
       );
       const toolCalls = aggregated.filter(
-        (item): item is OldToolCallEvent => item.type === "tool_call"
+        (item): item is OldToolCallEvent => item.type === "tool_call",
       );
       return {
         type: "success",
@@ -494,7 +536,7 @@ export function convertToOldEvent(
           isRetryable,
           originalError: event.content.originalError,
         },
-        metadata
+        metadata,
       );
     }
 
@@ -508,7 +550,7 @@ export function convertToOldEvent(
  */
 async function* convertToOldEvents(
   newEvents: AsyncGenerator<ModelResponseEvent>,
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
 ): AsyncGenerator<LLMEvent> {
   for await (const event of newEvents) {
     yield convertToOldEvent(event, metadata);
@@ -521,7 +563,7 @@ async function* convertToOldEvents(
  */
 function convertBatchEventsToOld(
   events: NonDeltaResponseEvent[],
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
 ): LLMEvent[] {
   return events.map((event) => convertToOldEvent(event, metadata));
 }
@@ -538,23 +580,26 @@ function convertBatchEventsToOld(
 abstract class BaseTransition extends LLM {
   // Builds the provider-agnostic conversation payload (system + messages) shared
   // by both the streaming and batch surfaces.
-  protected buildPayload(streamParameters: LLMStreamParameters): Payload {
+  //
+  // `explicitTailBreakpoint` mirrors legacy's Vertex-only `isLast` marker: set it
+  // for surfaces that lack the request-level automatic `cache_control`
+  // (agent-platform/Vertex), so the conversation tail still gets a breakpoint.
+  // On the Anthropic API (and batch) it stays false — the tail is covered by the
+  // top-level automatic cache there, and adding one here would exceed the 4-slot
+  // breakpoint budget.
+  protected buildPayload(
+    streamParameters: LLMStreamParameters,
+    {
+      explicitTailBreakpoint = false,
+    }: { explicitTailBreakpoint?: boolean } = {},
+  ): Payload {
     const { conversation, prompt } = streamParameters;
 
-    const baseMessages = conversation.messages.flatMap(toBaseMessages);
-
-    // Cache breakpoint on the last user-role message so the conversation
-    // prefix is reused across turns. Mirrors the legacy cache_control:
-    // ephemeral marker on the last user content block, and the request-level
-    // cache_control that acted as a default trailing breakpoint for
-    // tool-result turns.
-    for (let i = baseMessages.length - 1; i >= 0; i--) {
-      const msg = baseMessages[i];
-      if (msg.role === "user") {
-        baseMessages[i] = { ...msg, cache: "short" };
-        break;
-      }
-    }
+    const baseMessages = withMessageCacheBreakpoints(
+      conversation.messages.flatMap(toBaseMessages),
+      conversation.messages[0],
+      { explicitTailBreakpoint },
+    );
 
     const { instructions, sharedContext, ephemeralContext } =
       normalizePrompt(prompt);
@@ -606,7 +651,7 @@ abstract class BaseTransition extends LLM {
     // identity). Some schemas reject provider-invalid combinations (e.g.
     // Anthropic requires temperature=1 with thinking), so the fix must land
     // before `parse`, not after.
-    parseConfig: (config: InputConfig) => InputConfig = (config) => config
+    parseConfig: (config: InputConfig) => InputConfig = (config) => config,
   ): InputConfig {
     const {
       specifications,
@@ -622,7 +667,7 @@ abstract class BaseTransition extends LLM {
       reasoning: {
         effort: mapReasoningEffort(
           this.reasoningEffort,
-          this.modelConfig.useNativeLightReasoning ?? false
+          this.modelConfig.useNativeLightReasoning ?? false,
         ),
       },
       forceTool: forceToolCall,
@@ -630,7 +675,7 @@ abstract class BaseTransition extends LLM {
       toolSearchEnabled,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,
-        this.metadata.clientId
+        this.metadata.clientId,
       ),
     };
 
@@ -654,7 +699,7 @@ export class StreamEndpointTransition extends BaseTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: DustStreamEndpointConstructor
+    modelConstructor: DustStreamEndpointConstructor,
   ) {
     super(auth, modelConstructor.providerId, llmParameters);
     this.endpointConstructor = modelConstructor;
@@ -669,13 +714,17 @@ export class StreamEndpointTransition extends BaseTransition {
   }
 
   protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
+    // Agent-platform (Vertex) has no request-level automatic cache_control, so it
+    // needs an explicit breakpoint on the conversation tail (legacy's isLast).
+    const explicitTailBreakpoint =
+      this.model.metadata().api === AGENT_PLATFORM_API;
     return this.model.buildRequestPayload(
-      this.buildPayload(streamParameters),
+      this.buildPayload(streamParameters, { explicitTailBreakpoint }),
       this.buildConfig(
         streamParameters,
         this.model.constructor.configSchema,
-        this.endpointConstructor.parseConfig
-      )
+        this.endpointConstructor.parseConfig,
+      ),
     );
   }
 
@@ -708,17 +757,17 @@ export class NoopStreamTransition extends StreamEndpointTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: DustStreamEndpointConstructor
+    modelConstructor: DustStreamEndpointConstructor,
   ) {
     super(auth, llmParameters, modelConstructor);
     this.noopMetaData = llmParameters.metaData;
   }
 
   protected override buildStreamRequestPayload(
-    streamParameters: LLMStreamParameters
+    streamParameters: LLMStreamParameters,
   ): NoopRequest {
     const request = this.noopModel.buildRequestPayload(
-      this.buildPayload(streamParameters)
+      this.buildPayload(streamParameters),
     );
 
     const staticResponse =
@@ -766,7 +815,7 @@ export class BatchEndpointTransition extends BaseTransition {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
-    modelConstructor: BatchEndpointConstructor
+    modelConstructor: BatchEndpointConstructor,
   ) {
     super(auth, modelConstructor.providerId, llmParameters);
     this.model = new modelConstructor(llmParameters.credentials);
@@ -777,18 +826,18 @@ export class BatchEndpointTransition extends BaseTransition {
   protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters),
-      this.buildConfig(streamParameters, this.model.constructor.configSchema)
+      this.buildConfig(streamParameters, this.model.constructor.configSchema),
     );
   }
 
   protected async *sendRequest(): AsyncGenerator<LLMEvent> {
     throw new Error(
-      "Streaming is not supported on a batch transition LLM; use getStreamLLM instead."
+      "Streaming is not supported on a batch transition LLM; use getStreamLLM instead.",
     );
   }
 
   protected override async internalSendBatchProcessing(
-    conversations: Map<string, LLMStreamParameters>
+    conversations: Map<string, LLMStreamParameters>,
   ): Promise<string> {
     const requests = new Map<string, BatchRequest>();
     for (const [customId, streamParameters] of conversations) {
@@ -796,7 +845,7 @@ export class BatchEndpointTransition extends BaseTransition {
         payload: this.buildPayload(streamParameters),
         config: this.buildConfig(
           streamParameters,
-          this.model.constructor.configSchema
+          this.model.constructor.configSchema,
         ),
       });
     }
@@ -809,7 +858,7 @@ export class BatchEndpointTransition extends BaseTransition {
   }
 
   protected override async internalGetBatchResult(
-    batchId: string
+    batchId: string,
   ): Promise<BatchResult> {
     const results = await this.model.getBatchResult(batchId);
 

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeFableFiveConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,8 @@ export function WithDustClaudeFableFiveConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Anthropic rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustClaudeFableFive;

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -8,6 +8,8 @@ export function WithDustClaudeFableFiveConfig<
     static readonly description =
       "Anthropic's Claude Fable 5 model, their most intelligent model, a new tier above Opus (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeFableFiveConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeHaikuFourDotFive<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustClaudeHaikuFourDotFive<
       "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).";
     static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
+    // Anthropic rejects a non-default temperature while thinking is active.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustClaudeHaikuFourDotFive;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeOpusFourDotEightConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -6,8 +6,10 @@ export function WithDustClaudeOpusFourDotEightConfig<
   abstract class DustClaudeOpusFourDotEight extends Base {
     static readonly displayName = "Claude Opus 4.8";
     static readonly description =
-      "Anthropic's Claude Opus 4.8 model, the latest and most capable model with stronger agentic coding, reasoning, and judgement (200k context).";
+      "Anthropic's Claude Opus 4.8 model, the latest and most capable model with stronger agentic coding, reasoning, and judgement (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeOpusFourDotEightConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,8 @@ export function WithDustClaudeOpusFourDotEightConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Anthropic rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustClaudeOpusFourDotEight;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -6,8 +6,10 @@ export function WithDustClaudeOpusFourDotSevenConfig<
   abstract class DustClaudeOpusFourDotSeven extends Base {
     static readonly displayName = "Claude Opus 4.7";
     static readonly description =
-      "Anthropic's Claude Opus 4.7 model, an advanced model with a step-change improvement in agentic coding (200k context).";
+      "Anthropic's Claude Opus 4.7 model, an advanced model with a step-change improvement in agentic coding (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeOpusFourDotSevenConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeOpusFourDotSevenConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,8 @@ export function WithDustClaudeOpusFourDotSevenConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Anthropic rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustClaudeOpusFourDotSeven;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeOpusFourDotSixConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -6,8 +6,10 @@ export function WithDustClaudeOpusFourDotSixConfig<
   abstract class DustClaudeOpusFourDotSix extends Base {
     static readonly displayName = "Claude Opus 4.6";
     static readonly description =
-      "Anthropic's Claude Opus 4.6 model, an advanced model with enhanced reasoning capabilities (200k context).";
+      "Anthropic's Claude Opus 4.6 model, an advanced model with enhanced reasoning capabilities (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeSonnetFiveConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,8 @@ export function WithDustClaudeSonnetFiveConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Anthropic rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustClaudeSonnetFive;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -6,8 +6,10 @@ export function WithDustClaudeSonnetFiveConfig<
   abstract class DustClaudeSonnetFive extends Base {
     static readonly displayName = "Claude Sonnet 5";
     static readonly description =
-      "Anthropic's Claude Sonnet 5 model, reaching near-Opus quality on coding and agentic work while balancing power and efficiency (200k context).";
+      "Anthropic's Claude Sonnet 5 model, reaching near-Opus quality on coding and agentic work while balancing power and efficiency (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeSonnetFiveConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -6,8 +6,10 @@ export function WithDustClaudeSonnetFourDotSixConfig<
   abstract class DustClaudeSonnetFourDotSix extends Base {
     static readonly displayName = "Claude Sonnet 4.6";
     static readonly description =
-      "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (200k context).";
+      "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (250k context).";
     static readonly defaultReasoningEffort = "medium";
+    // Dust caps usable context at 250k; the model itself supports 1M.
+    static readonly contextSize = 250_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -10,6 +10,8 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
+    // Dust caps output at 64k; the model itself supports 128k.
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,8 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Anthropic rejects a non-default temperature while thinking is active.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -1,7 +1,7 @@
+import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustMistralCodestralConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
+  TBase extends abstract new (...args: any[]) => object,
 >(Base: TBase) {
   abstract class DustMistralCodestral extends Base {
     static readonly displayName = "Mistral Codestral";
@@ -12,6 +12,8 @@ export function WithDustMistralCodestralConfig<
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
+    // Non-reasoning model: drop the reasoning effort the schema rejects.
+    static readonly parseConfig = dropReasoning;
   }
 
   return DustMistralCodestral;

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -9,6 +9,8 @@ export function WithDustMistralCodestralConfig<
       "Mistral's `codestral` model, specifically designed and optimized for code generation tasks.";
     // Codestral is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
+    // Legacy product value; the model has no separate output cap.
+    static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -1,7 +1,9 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustMistralCodestralConfig<
-  TBase extends abstract new (...args: any[]) => object,
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
 >(Base: TBase) {
   abstract class DustMistralCodestral extends Base {
     static readonly displayName = "Mistral Codestral";

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -1,7 +1,9 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustMistralLargeConfig<
-  TBase extends abstract new (...args: any[]) => object,
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
 >(Base: TBase) {
   abstract class DustMistralLarge extends Base {
     static readonly displayName = "Mistral Large";

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -8,6 +8,8 @@ export function WithDustMistralLargeConfig<
     static readonly description = "Mistral's `large` model (256k context).";
     // Mistral Large is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
+    // Legacy product value; the model has no separate output cap.
+    static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -1,7 +1,7 @@
+import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustMistralLargeConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
+  TBase extends abstract new (...args: any[]) => object,
 >(Base: TBase) {
   abstract class DustMistralLarge extends Base {
     static readonly displayName = "Mistral Large";
@@ -11,6 +11,8 @@ export function WithDustMistralLargeConfig<
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
+    // Non-reasoning model: drop the reasoning effort the schema rejects.
+    static readonly parseConfig = dropReasoning;
   }
 
   return DustMistralLarge;

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -8,6 +8,8 @@ export function WithDustMistralMedium35Config<
     static readonly description =
       "Mistral's `medium 3.5` model, multimodal and optimized for agentic and coding use cases (256k context).";
     static readonly defaultReasoningEffort = "none";
+    // Legacy product value; the model has no separate output cap.
+    static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,7 +1,9 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustMistralMedium35Config<
-  TBase extends abstract new (...args: any[]) => object,
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
 >(Base: TBase) {
   abstract class DustMistralMedium35 extends Base {
     static readonly displayName = "Mistral Medium 3.5";

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,7 +1,7 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustMistralMedium35Config<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
+  TBase extends abstract new (...args: any[]) => object,
 >(Base: TBase) {
   abstract class DustMistralMedium35 extends Base {
     static readonly displayName = "Mistral Medium 3.5";
@@ -11,6 +11,9 @@ export function WithDustMistralMedium35Config<
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
+    // Mistral rejects an explicit temperature on this model; drop it (matches
+    // the legacy client's REASONING_OVERWRITES and the schema's undefined temp).
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustMistralMedium35;

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -1,7 +1,7 @@
+import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustMistralSmallConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
+  TBase extends abstract new (...args: any[]) => object,
 >(Base: TBase) {
   abstract class DustMistralSmall extends Base {
     static readonly displayName = "Mistral Small";
@@ -11,6 +11,8 @@ export function WithDustMistralSmallConfig<
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
+    // Non-reasoning model: drop the reasoning effort the schema rejects.
+    static readonly parseConfig = dropReasoning;
   }
 
   return DustMistralSmall;

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -1,7 +1,9 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustMistralSmallConfig<
-  TBase extends abstract new (...args: any[]) => object,
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
 >(Base: TBase) {
   abstract class DustMistralSmall extends Base {
     static readonly displayName = "Mistral Small";

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -8,6 +8,8 @@ export function WithDustMistralSmallConfig<
     static readonly description = "Mistral's `small` model (128k context).";
     // Mistral Small is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
+    // Legacy product value; the model has no separate output cap.
+    static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/openai/models/gpt_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveConfig<
       "OpenAI's GPT-5 reasoning model (400k context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustGptFive;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotFiveConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotFiveConfig<
       "OpenAI's GPT-5.5 reasoning model, with strong reasoning and tool-use capabilities (1M context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotFive;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotFourConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotFourConfig<
       "OpenAI's GPT-5.4 reasoning model for complex reasoning and agentic tasks (1M context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotFour;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotFourMiniConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotFourMiniConfig<
       "OpenAI's faster, cost-efficient GPT-5.4 for well-defined tasks (400k context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotFourMini;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotFourNanoConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotFourNanoConfig<
       "OpenAI's fastest, most cost-efficient GPT-5.4 (400k context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotFourNano;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotOneConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotOneConfig<
       "OpenAI's GPT-5.1 reasoning model (400k context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustGptFiveDotOne;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotSixLunaConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotSixLunaConfig<
       "OpenAI's fastest, most cost-efficient GPT-5.6 model for high-volume workloads (1M context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotSixLuna;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotSixSolConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotSixSolConfig<
       "OpenAI's most capable GPT-5.6 reasoning model for complex reasoning and agentic tasks (1M context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotSixSol;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotSixTerraConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotSixTerraConfig<
       "OpenAI's balanced GPT-5.6 model for strong reasoning and tool use (1M context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotSixTerra;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveDotTwoConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveDotTwoConfig<
       "OpenAI's GPT-5.2 reasoning model for complex reasoning tasks (400k context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    static readonly parseConfig = dropTemperatureWhenReasoning;
   }
 
   return DustGptFiveDotTwo;

--- a/front/lib/llms/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_mini.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveMiniConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveMiniConfig<
       "OpenAI's faster, cost-efficient GPT-5 for well-defined tasks (400k context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustGptFiveMini;

--- a/front/lib/llms/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_nano.ts
@@ -1,3 +1,5 @@
+import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustGptFiveNanoConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -9,6 +11,8 @@ export function WithDustGptFiveNanoConfig<
       "OpenAI's fastest, most cost-efficient GPT-5 (400k context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
+    // The Responses API rejects an explicit temperature for this model.
+    static readonly parseConfig = dropTemperature;
   }
 
   return DustGptFiveNano;

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -15,6 +15,33 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
     // Behavior
     defaultReasoningEffort: ReasoningEffortOf<C>;
 
+    // Adjusts the config before it is validated by the endpoint's schema.
+    // Omitted means identity; override per endpoint for provider quirks — e.g.
+    // dropping a non-default temperature when reasoning is active, which some
+    // schemas reject outright (Anthropic requires temperature=1 with thinking).
+    parseConfig?: (config: InputConfig) => InputConfig;
+
     // Filter
     endpointFilter: Where<WorkspaceConfig>;
   };
+
+// `parseConfig` helper: some providers reject any explicit temperature while
+// reasoning is active, so drop it when reasoning is on. Providers that require a
+// specific value (e.g. Anthropic's temperature=1) re-apply it via their schema
+// default. Temperature is preserved when reasoning is off.
+export function dropTemperatureWhenReasoning<C extends InputConfig>(
+  config: C
+): C {
+  const effort = config.reasoning?.effort;
+  if (effort && effort !== "none") {
+    return { ...config, temperature: undefined };
+  }
+  return config;
+}
+
+// `parseConfig` helper: some models reject an explicit temperature outright,
+// regardless of reasoning effort (e.g. the OpenAI gpt-5 / gpt-5-mini / gpt-5-nano
+// / gpt-5.1 Responses models). Always drop it.
+export function dropTemperature<C extends InputConfig>(config: C): C {
+  return { ...config, temperature: undefined };
+}

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -30,7 +30,7 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
 // specific value (e.g. Anthropic's temperature=1) re-apply it via their schema
 // default. Temperature is preserved when reasoning is off.
 export function dropTemperatureWhenReasoning<C extends InputConfig>(
-  config: C
+  config: C,
 ): C {
   const effort = config.reasoning?.effort;
   if (effort && effort !== "none") {
@@ -44,4 +44,10 @@ export function dropTemperatureWhenReasoning<C extends InputConfig>(
 // / gpt-5.1 Responses models). Always drop it.
 export function dropTemperature<C extends InputConfig>(config: C): C {
   return { ...config, temperature: undefined };
+}
+
+// `parseConfig` helper: non-reasoning models reject `reasoning_effort`, so drop
+// the reasoning field before validation (their schemas require it undefined).
+export function dropReasoning<C extends InputConfig>(config: C): C {
+  return { ...config, reasoning: undefined };
 }

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -30,7 +30,7 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
 // specific value (e.g. Anthropic's temperature=1) re-apply it via their schema
 // default. Temperature is preserved when reasoning is off.
 export function dropTemperatureWhenReasoning<C extends InputConfig>(
-  config: C,
+  config: C
 ): C {
   const effort = config.reasoning?.effort;
   if (effort && effort !== "none") {

--- a/front/lib/model_constructors/providers/anthropic/inputConfig.ts
+++ b/front/lib/model_constructors/providers/anthropic/inputConfig.ts
@@ -2,7 +2,19 @@ import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_c
 import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { z } from "zod";
 
-export const anthropicConfigSchema = inputConfigSchema.extend({
+// Shared base for the per-model Anthropic config schemas. Carries the two
+// Anthropic-only fields every model needs: the `cacheKey` guard and the
+// prompt-cache diagnostics opt-in. Each model schema extends this (rather than
+// the generic `inputConfigSchema`) so `buildConfig`'s `parse` keeps
+// `previousMessageId` instead of stripping it as an unknown key.
+// Prompt-cache diagnostics (Claude API only): undefined = off, null = on
+// (first call), string = previous response id to diagnose against.
+export const anthropicBaseConfigSchema = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+  previousMessageId: z.string().nullable().optional(),
+});
+
+export const anthropicConfigSchema = anthropicBaseConfigSchema.extend({
   reasoning: z
     .object({
       effort: z.enum([
@@ -11,9 +23,6 @@ export const anthropicConfigSchema = inputConfigSchema.extend({
       ]),
     })
     .optional(),
-  // Prompt-cache diagnostics (Claude API only): undefined = off, null = on
-  // (first call), string = previous response id to diagnose against.
-  previousMessageId: z.string().nullable().optional(),
 });
 
 export type AnthropicInputConfig = z.infer<typeof anthropicConfigSchema>;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
@@ -1,6 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_FABLE_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -16,8 +16,7 @@ const reasoningSchema = z
   })
   .default({ effort: DEFAULT_REASONING_EFFORT });
 
-const configSchema = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
+const configSchema = anthropicBaseConfigSchema.extend({
   reasoning: reasoningSchema,
   temperature: z.undefined(),
 });

--- a/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
@@ -1,8 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import {
-  inputConfigSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_FABLE_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -12,15 +10,16 @@ const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
 const MAX_OUTPUT_TOKENS = 128_000;
 
-const reasoningSchema = z.object({
-      effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
-    })
+const reasoningSchema = z
+  .object({
+    effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+  })
   .default({ effort: DEFAULT_REASONING_EFFORT });
 
 const configSchema = inputConfigSchema.extend({
   cacheKey: z.undefined(),
   reasoning: reasoningSchema,
-  temperature: z.undefined()
+  temperature: z.undefined(),
 });
 
 export type ClaudeFableFive = z.infer<typeof configSchema>;
@@ -43,7 +42,8 @@ export function WithAnthropicClaudeFableFiveConfig<
 
     // Typed as `number` (not the literal) so the Dust layer can cap it.
     static readonly contextSize: number = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return AnthropicClaudeFableFive;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_fable_five.ts
@@ -2,39 +2,25 @@ import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/conf
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import {
   inputConfigSchema,
-  temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_FABLE_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
-// Kept aligned with the existing static Fable 5 model config for this rollout.
-const CONTEXT_SIZE = 250_000;
-const DEFAULT_REASONING_EFFORT = "medium";
-const MAX_OUTPUT_TOKENS = 64_000;
-const MIN_REASONING_EFFORT = "low";
+// Real model spec. The Dust product cap (250k) is applied in the llms layer.
+const CONTEXT_SIZE = 1_000_000;
+const DEFAULT_REASONING_EFFORT = "high";
+const MAX_OUTPUT_TOKENS = 128_000;
 
-const reasoningSchema = z
-  .union([
-    z.object({
+const reasoningSchema = z.object({
       effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
-    }),
-    // Fable has adaptive thinking always on. Preserve legacy-router behavior:
-    // callers that default to "none" are clamped to the minimum native effort.
-    z
-      .object({ effort: z.literal("none") })
-      .transform((): { effort: typeof MIN_REASONING_EFFORT } => ({
-        effort: MIN_REASONING_EFFORT,
-      })),
-  ])
+    })
   .default({ effort: DEFAULT_REASONING_EFFORT });
 
 const configSchema = inputConfigSchema.extend({
   cacheKey: z.undefined(),
   reasoning: reasoningSchema,
-  // Fable has adaptive thinking always on; omit explicit temperature rather
-  // than sending a value that can conflict with the thinking configuration.
-  temperature: temperatureSchema.optional().transform(() => undefined),
+  temperature: z.undefined()
 });
 
 export type ClaudeFableFive = z.infer<typeof configSchema>;
@@ -55,7 +41,8 @@ export function WithAnthropicClaudeFableFiveConfig<
       unknown
     > = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly contextSize: number = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -25,7 +25,7 @@ const configSchema = z.union([
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
     // Reasoning requires temperature=1.
-    temperature: temperatureSchema.optional().transform(() => 1 as const),
+    temperature: z.literal(1).optional().default(1),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
@@ -54,7 +54,8 @@ export function WithAnthropicClaudeHaikuFourDotFiveConfig<
       unknown
     > = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly contextSize: number = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
     // Haiku 4.5 has extended thinking but not adaptive thinking, so it overrides

--- a/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -56,7 +56,8 @@ export function WithAnthropicClaudeHaikuFourDotFiveConfig<
 
     // Typed as `number` (not the literal) so the Dust layer can cap it.
     static readonly contextSize: number = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
 
     // Haiku 4.5 has extended thinking but not adaptive thinking, so it overrides
     // the converter's default (adaptive) thinking leaf.

--- a/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,9 +1,7 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { reasoningToExtendedThinkingConfig } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { temperatureSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_HAIKU_4_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -12,9 +10,7 @@ const CONTEXT_SIZE = 200_000;
 const DEFAULT_REASONING_EFFORT = "low";
 const MAX_OUTPUT_TOKENS = 64_000;
 
-const baseConfig = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
-});
+const baseConfig = anthropicBaseConfigSchema;
 
 const configSchema = z.union([
   baseConfig.extend({

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -1,5 +1,5 @@
-import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { withAnthropicOpusConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 export const WithAnthropicClaudeOpusFourDotEightConfig =
-  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_8_MODEL_ID);
+  withAnthropicOpusConfig(CLAUDE_OPUS_4_8_MODEL_ID);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -1,5 +1,5 @@
-import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { withAnthropicOpusConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_7_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 export const WithAnthropicClaudeOpusFourDotSevenConfig =
-  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_7_MODEL_ID);
+  withAnthropicOpusConfig(CLAUDE_OPUS_4_7_MODEL_ID);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,8 +1,61 @@
-import { withAnthropicOpusConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_OPUS_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
-// Opus 4.6 does not support the `xhigh` reasoning effort (introduced in 4.7).
-export const WithAnthropicClaudeOpusFourDotSixConfig = withAnthropicOpusConfig(
-  CLAUDE_OPUS_4_6_MODEL_ID,
-  ["low", "medium", "high", "maximal"]
-);
+import { z } from "zod";
+
+// Real model spec. The Dust product cap (250k) is applied in the llms layer.
+const CONTEXT_SIZE = 1_000_000;
+const DEFAULT_REASONING_EFFORT = "high";
+const MAX_OUTPUT_TOKENS = 128_000;
+
+const baseConfig = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+});
+
+// Opus 4.6 has its own config rather than sharing the Opus 4.7/4.8 one because
+// it differs on two axes: it predates the `xhigh` reasoning effort (introduced
+// in 4.7), and unlike 4.7/4.8 it accepts a caller-supplied `temperature`
+// (inherited from `inputConfigSchema`).
+const configSchema = z.union([
+  baseConfig.extend({
+    reasoning: z
+      .object({
+        effort: z.enum(["low", "medium", "high", "maximal"]),
+      })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    forceTool: z.undefined(),
+  }),
+  baseConfig.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+  }),
+]);
+
+export type ClaudeOpusFourDotSix = z.infer<typeof configSchema>;
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithAnthropicClaudeOpusFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeOpusFourDotSix extends Base {
+    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
+    // instance type carries `ClaudeOpusFourDotSix` (not the wide `InputConfig`).
+    declare ["constructor"]: BaseEndpointConfiguration<ClaudeOpusFourDotSix>;
+
+    static readonly modelId = CLAUDE_OPUS_4_6_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<
+      ClaudeOpusFourDotSix,
+      z.ZodTypeDef,
+      unknown
+    > = configSchema;
+
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly contextSize: number = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return AnthropicClaudeOpusFourDotSix;
+}

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,5 +1,5 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { CLAUDE_OPUS_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -9,9 +9,7 @@ const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
 const MAX_OUTPUT_TOKENS = 128_000;
 
-const baseConfig = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
-});
+const baseConfig = anthropicBaseConfigSchema;
 
 // Opus 4.6 has its own config rather than sharing the Opus 4.7/4.8 one because
 // it differs on two axes: it predates the `xhigh` reasoning effort (introduced

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,5 +1,8 @@
-import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { withAnthropicOpusConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
-export const WithAnthropicClaudeOpusFourDotSixConfig =
-  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_6_MODEL_ID);
+// Opus 4.6 does not support the `xhigh` reasoning effort (introduced in 4.7).
+export const WithAnthropicClaudeOpusFourDotSixConfig = withAnthropicOpusConfig(
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  ["low", "medium", "high", "maximal"]
+);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -54,7 +54,8 @@ export function WithAnthropicClaudeOpusFourDotSixConfig<
 
     // Typed as `number` (not the literal) so the Dust layer can cap it.
     static readonly contextSize: number = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return AnthropicClaudeOpusFourDotSix;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
@@ -1,66 +1,51 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import type { AnthropicSupportedNonNullReasoningEffort } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
-// Shared input contract for the Claude Opus 4.x models (4.6, 4.7, 4.8): same
-// context window, output cap, and temperature handling. Reasoning efforts vary
-// slightly (4.6 does not support `xhigh`), so they are passed per model.
-export const OPUS_CONTEXT_SIZE = 250_000;
-export const OPUS_MAX_OUTPUT_TOKENS = 64_000;
+// Shared input contract for Claude Opus 4.7 and 4.8 — identical config: same
+// context window, output cap, the full reasoning-effort set (incl. `xhigh`/
+// `max`), and no caller-supplied temperature (non-default temperature/top_p/
+// top_k are rejected with a 400 on Opus 4.7+). Opus 4.6 differs on both axes
+// (no `xhigh`, and it accepts a temperature), so it has its own config in
+// `claude_opus_four_dot_six.ts` rather than sharing this one.
+// Real model spec. The Dust product cap (250k) is applied in the llms layer.
+const OPUS_CONTEXT_SIZE = 1_000_000;
+const OPUS_MAX_OUTPUT_TOKENS = 128_000;
 
 const DEFAULT_REASONING_EFFORT = "high";
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
+  temperature: z.undefined(),
 });
 
-function getConfigSchema(
-  supportedEfforts: readonly [
-    AnthropicSupportedNonNullReasoningEffort,
-    ...AnthropicSupportedNonNullReasoningEffort[],
-  ],
-) {
-  return z.union([
-    baseConfig.extend({
-      reasoning: z
-        .object({
-          effort: z.enum(supportedEfforts),
-        })
-        .default({ effort: DEFAULT_REASONING_EFFORT }),
-      forceTool: z.undefined(),
-    }),
-    baseConfig.extend({
-      reasoning: z.object({ effort: z.literal("none") }),
-    }),
-  ]);
-}
-
-// The shared config type is the superset (all efforts); per-model schemas
-// enforce their own subset at runtime.
-export const opusConfigSchema = getConfigSchema(
-  ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
-);
+const opusConfigSchema = z.union([
+  baseConfig.extend({
+    reasoning: z
+      .object({
+        effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+      })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    forceTool: z.undefined(),
+  }),
+  baseConfig.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+  }),
+]);
 
 export type AnthropicOpusInputConfig = z.infer<typeof opusConfigSchema>;
 
-// Builds the config mixin shared by every Claude Opus 4.x model. The models
-// only differ by `modelId`; everything else (schema, context window, output
-// cap) is identical, so each model file is a one-line binding of this factory.
-export function withAnthropicOpusConfig<const M extends ModelId>(
-  modelId: M,
-  supportedEfforts: readonly [
-    AnthropicSupportedNonNullReasoningEffort,
-    ...AnthropicSupportedNonNullReasoningEffort[],
-  ] = ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
-) {
-  const configSchema = getConfigSchema(supportedEfforts);
-
+// Builds the config mixin shared by Claude Opus 4.7 and 4.8. The models differ
+// only by `modelId`; everything else (schema, context window, output cap) is
+// identical, so each model file is a one-line binding of this factory.
+export function withAnthropicOpusConfig<const M extends ModelId>(modelId: M) {
   return function WithAnthropicOpusConfig<
-    TBase extends abstract new (...args: any[]) => object,
+    TBase extends abstract new (
+      ...args: any[]
+    ) => object,
   >(Base: TBase) {
     abstract class AnthropicClaudeOpus extends Base {
       // Narrow `Client`'s `["constructor"]` to this model's precise config so
@@ -73,9 +58,10 @@ export function withAnthropicOpusConfig<const M extends ModelId>(
         AnthropicOpusInputConfig,
         z.ZodTypeDef,
         unknown
-      > = configSchema;
+      > = opusConfigSchema;
 
-      static readonly contextSize = OPUS_CONTEXT_SIZE;
+      // Typed as `number` (not the literal) so the Dust layer can cap it.
+      static readonly contextSize: number = OPUS_CONTEXT_SIZE;
       static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
     }
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
@@ -1,6 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -17,8 +17,7 @@ const OPUS_MAX_OUTPUT_TOKENS = 128_000;
 
 const DEFAULT_REASONING_EFFORT = "high";
 
-const baseConfig = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
+const baseConfig = anthropicBaseConfigSchema.extend({
   temperature: z.undefined(),
 });
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
@@ -62,7 +62,8 @@ export function withAnthropicOpusConfig<const M extends ModelId>(modelId: M) {
 
       // Typed as `number` (not the literal) so the Dust layer can cap it.
       static readonly contextSize: number = OPUS_CONTEXT_SIZE;
-      static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
+      // Typed as `number` (not the literal) so the Dust layer can cap it.
+      static readonly maxOutputTokens: number = OPUS_MAX_OUTPUT_TOKENS;
     }
 
     return AnthropicClaudeOpus;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
@@ -1,15 +1,14 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import type { AnthropicSupportedNonNullReasoningEffort } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
 // Shared input contract for the Claude Opus 4.x models (4.6, 4.7, 4.8): same
-// context window, output cap, reasoning efforts, and temperature handling.
+// context window, output cap, and temperature handling. Reasoning efforts vary
+// slightly (4.6 does not support `xhigh`), so they are passed per model.
 export const OPUS_CONTEXT_SIZE = 250_000;
 export const OPUS_MAX_OUTPUT_TOKENS = 64_000;
 
@@ -17,36 +16,51 @@ const DEFAULT_REASONING_EFFORT = "high";
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
-  // Opus rejects any explicit temperature !== 1.
-  temperature: temperatureSchema.optional().transform(() => 1 as const),
 });
 
-export const opusConfigSchema = z.union([
-  baseConfig.extend({
-    reasoning: z
-      .object({
-        effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
-      })
-      .default({ effort: DEFAULT_REASONING_EFFORT }),
-    forceTool: z.undefined(),
-  }),
-  baseConfig.extend({
-    reasoning: z.object({ effort: z.literal("none") }),
-  }),
-]);
+function getConfigSchema(
+  supportedEfforts: readonly [
+    AnthropicSupportedNonNullReasoningEffort,
+    ...AnthropicSupportedNonNullReasoningEffort[],
+  ],
+) {
+  return z.union([
+    baseConfig.extend({
+      reasoning: z
+        .object({
+          effort: z.enum(supportedEfforts),
+        })
+        .default({ effort: DEFAULT_REASONING_EFFORT }),
+      forceTool: z.undefined(),
+    }),
+    baseConfig.extend({
+      reasoning: z.object({ effort: z.literal("none") }),
+    }),
+  ]);
+}
+
+// The shared config type is the superset (all efforts); per-model schemas
+// enforce their own subset at runtime.
+export const opusConfigSchema = getConfigSchema(
+  ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+);
 
 export type AnthropicOpusInputConfig = z.infer<typeof opusConfigSchema>;
 
 // Builds the config mixin shared by every Claude Opus 4.x model. The models
 // only differ by `modelId`; everything else (schema, context window, output
 // cap) is identical, so each model file is a one-line binding of this factory.
-export function makeAnthropicOpusConfigMixin<const M extends ModelId>(
-  modelId: M
+export function withAnthropicOpusConfig<const M extends ModelId>(
+  modelId: M,
+  supportedEfforts: readonly [
+    AnthropicSupportedNonNullReasoningEffort,
+    ...AnthropicSupportedNonNullReasoningEffort[],
+  ] = ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
 ) {
+  const configSchema = getConfigSchema(supportedEfforts);
+
   return function WithAnthropicOpusConfig<
-    TBase extends abstract new (
-      ...args: any[]
-    ) => object,
+    TBase extends abstract new (...args: any[]) => object,
   >(Base: TBase) {
     abstract class AnthropicClaudeOpus extends Base {
       // Narrow `Client`'s `["constructor"]` to this model's precise config so
@@ -59,7 +73,7 @@ export function makeAnthropicOpusConfigMixin<const M extends ModelId>(
         AnthropicOpusInputConfig,
         z.ZodTypeDef,
         unknown
-      > = opusConfigSchema;
+      > = configSchema;
 
       static readonly contextSize = OPUS_CONTEXT_SIZE;
       static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
@@ -1,9 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_SONNET_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -14,6 +11,7 @@ const MAX_OUTPUT_TOKENS = 64_000;
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
+  temperature: z.undefined(),
 });
 
 const configSchema = z.union([
@@ -24,11 +22,9 @@ const configSchema = z.union([
       })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
-    temperature: temperatureSchema.optional().transform(() => undefined),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
-    temperature: temperatureSchema.optional().transform(() => undefined),
   }),
 ]);
 
@@ -36,9 +32,7 @@ export type ClaudeSonnetFive = z.infer<typeof configSchema>;
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithAnthropicClaudeSonnetFiveConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
+  TBase extends abstract new (...args: any[]) => object,
 >(Base: TBase) {
   abstract class AnthropicClaudeSonnetFive extends Base {
     // Narrow `Client`'s `["constructor"]` to this model's precise config so the

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
@@ -52,7 +52,8 @@ export function WithAnthropicClaudeSonnetFiveConfig<
 
     // Typed as `number` (not the literal) so the Dust layer can cap it.
     static readonly contextSize: number = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return AnthropicClaudeSonnetFive;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
@@ -1,6 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_SONNET_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -10,8 +10,7 @@ const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
 const MAX_OUTPUT_TOKENS = 128_000;
 
-const baseConfig = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
+const baseConfig = anthropicBaseConfigSchema.extend({
   temperature: z.undefined(),
 });
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_five.ts
@@ -5,9 +5,10 @@ import { CLAUDE_SONNET_5_MODEL_ID } from "@app/lib/model_constructors/types/mode
 
 import { z } from "zod";
 
-const CONTEXT_SIZE = 250_000;
+// Real model spec. The Dust product cap (250k) is applied in the llms layer.
+const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
-const MAX_OUTPUT_TOKENS = 64_000;
+const MAX_OUTPUT_TOKENS = 128_000;
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
@@ -32,7 +33,9 @@ export type ClaudeSonnetFive = z.infer<typeof configSchema>;
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithAnthropicClaudeSonnetFiveConfig<
-  TBase extends abstract new (...args: any[]) => object,
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
 >(Base: TBase) {
   abstract class AnthropicClaudeSonnetFive extends Base {
     // Narrow `Client`'s `["constructor"]` to this model's precise config so the
@@ -47,7 +50,8 @@ export function WithAnthropicClaudeSonnetFiveConfig<
       unknown
     > = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly contextSize: number = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,8 +1,6 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { anthropicBaseConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
+import { temperatureSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
@@ -12,9 +10,7 @@ const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
 const MAX_OUTPUT_TOKENS = 128_000;
 
-const baseConfig = inputConfigSchema.extend({
-  cacheKey: z.undefined(),
-});
+const baseConfig = anthropicBaseConfigSchema;
 
 const configSchema = z.union([
   baseConfig.extend({

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,5 +1,4 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import {
   inputConfigSchema,
   temperatureSchema,
@@ -57,7 +56,8 @@ export function WithAnthropicClaudeSonnetFourDotSixConfig<
 
     // Typed as `number` (not the literal) so the Dust layer can cap it.
     static readonly contextSize: number = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return AnthropicClaudeSonnetFourDotSix;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -8,9 +8,10 @@ import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/mo
 
 import { z } from "zod";
 
-const CONTEXT_SIZE = 250_000;
+// Real model spec. The Dust product cap (250k) is applied in the llms layer.
+const CONTEXT_SIZE = 1_000_000;
 const DEFAULT_REASONING_EFFORT = "high";
-const MAX_OUTPUT_TOKENS = 64_000;
+const MAX_OUTPUT_TOKENS = 128_000;
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
@@ -20,12 +21,12 @@ const configSchema = z.union([
   baseConfig.extend({
     reasoning: z
       .object({
-        effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+        effort: z.enum(["low", "medium", "high", "maximal"]),
       })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
     // Reasoning requires temperature=1.
-    temperature: temperatureSchema.optional().transform(() => 1 as const),
+    temperature: z.literal(1).optional().default(1),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
@@ -54,7 +55,8 @@ export function WithAnthropicClaudeSonnetFourDotSixConfig<
       unknown
     > = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly contextSize: number = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 

--- a/front/lib/model_constructors/providers/mistral/inputConfig.ts
+++ b/front/lib/model_constructors/providers/mistral/inputConfig.ts
@@ -16,13 +16,11 @@ export const mistralConfigSchema = inputConfigSchema.extend({
 
 export type MistralInputConfig = z.infer<typeof mistralConfigSchema>;
 
-// Schema for non-reasoning Mistral models (Large, Small): accept `none` but drop
-// it so the request omits `reasoning_effort` (the API rejects it on these
-// models). Temperature passes through unchanged.
+// Schema for non-reasoning Mistral models (Large, Small, Codestral): the API
+// rejects `reasoning_effort`, so reasoning must be undefined. The Dust layer
+// drops it via `dropReasoning` before validation. Temperature passes through
+// unchanged.
 export const mistralNonReasoningConfigSchema = inputConfigSchema.extend({
-  reasoning: z
-    .object({ effort: z.literal("none") })
-    .optional()
-    .transform(() => undefined),
+  reasoning: z.undefined(),
   cacheKey: z.undefined(),
 });

--- a/front/lib/model_constructors/providers/mistral/models/codestral.ts
+++ b/front/lib/model_constructors/providers/mistral/models/codestral.ts
@@ -5,9 +5,10 @@ import { MISTRAL_CODESTRAL_MODEL_ID } from "@app/lib/model_constructors/types/mo
 // (2026-06-18): Codestral has a 128k-token context window. It is a code model
 // with no vision support (enforced at the model-config/agent layer).
 const CONTEXT_SIZE = 128_000;
-// Capability metadata only — the request does not send an explicit max (the
-// legacy client doesn't either), so Mistral uses its own default.
-const MAX_OUTPUT_TOKENS = 2_048;
+// Capability metadata only (not sent to the API — Mistral uses its own
+// default). Mistral publishes no separate output cap, so the ceiling is the
+// context window; the Dust layer applies the 2048 product value.
+const MAX_OUTPUT_TOKENS = CONTEXT_SIZE;
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithMistralCodestralConfig<
@@ -22,7 +23,8 @@ export function WithMistralCodestralConfig<
     static readonly configSchema = mistralNonReasoningConfigSchema;
 
     static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return MistralCodestral;

--- a/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
@@ -4,9 +4,10 @@ import { MISTRAL_LARGE_MODEL_ID } from "@app/lib/model_constructors/types/model_
 // Verified against https://docs.mistral.ai/getting-started/models/models_overview
 // (2026-06-18): Mistral Large (mistral-large-3) has a 256k-token context window.
 const CONTEXT_SIZE = 256_000;
-// Capability metadata only — the request does not send an explicit max (the
-// legacy client doesn't either), so Mistral uses its own default.
-const MAX_OUTPUT_TOKENS = 2_048;
+// Capability metadata only (not sent to the API — Mistral uses its own
+// default). Mistral publishes no separate output cap, so the ceiling is the
+// context window; the Dust layer applies the 2048 product value.
+const MAX_OUTPUT_TOKENS = CONTEXT_SIZE;
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithMistralLargeConfig<
@@ -21,7 +22,8 @@ export function WithMistralLargeConfig<
     static readonly configSchema = mistralNonReasoningConfigSchema;
 
     static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return MistralLarge;

--- a/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
@@ -25,7 +25,7 @@ const configSchema = inputConfigSchema.extend({
       effort: z.enum([...MISTRAL_SUPPORTED_REASONING_EFFORTS]),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
-  temperature: temperatureSchema.optional().transform(() => undefined),
+  temperature: z.undefined(),
   // Mistral has no explicit prompt-cache key.
   cacheKey: z.undefined(),
 });

--- a/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
@@ -7,9 +7,10 @@ import { z } from "zod";
 // Verified against https://docs.mistral.ai/getting-started/models/models_overview
 // (2026-06-18): Mistral Medium 3.5 has a 256k-token context window.
 const CONTEXT_SIZE = 256_000;
-// Capability metadata only — the request does not send an explicit max (the
-// legacy client doesn't either), so Mistral uses its own default.
-const MAX_OUTPUT_TOKENS = 2_048;
+// Capability metadata only (not sent to the API — Mistral uses its own
+// default). Mistral publishes no separate output cap, so the ceiling is the
+// context window; the Dust layer applies the 2048 product value.
+const MAX_OUTPUT_TOKENS = CONTEXT_SIZE;
 const DEFAULT_REASONING_EFFORT = "none";
 
 // Mistral Medium 3.5 is a reasoning model: it accepts `none` (off) and `high`
@@ -39,7 +40,8 @@ export function WithMistralMedium35Config<
     static readonly configSchema = configSchema;
 
     static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return MistralMedium35;

--- a/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,8 +1,5 @@
 import { MISTRAL_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/mistral/reasoning_efforts";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";

--- a/front/lib/model_constructors/providers/mistral/models/mistral_small.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_small.ts
@@ -4,9 +4,10 @@ import { MISTRAL_SMALL_MODEL_ID } from "@app/lib/model_constructors/types/model_
 // Verified against https://docs.mistral.ai/getting-started/models/models_overview
 // (2026-06-18): Mistral Small has a 128k-token context window.
 const CONTEXT_SIZE = 128_000;
-// Capability metadata only — the request does not send an explicit max (the
-// legacy client doesn't either), so Mistral uses its own default.
-const MAX_OUTPUT_TOKENS = 2_048;
+// Capability metadata only (not sent to the API — Mistral uses its own
+// default). Mistral publishes no separate output cap, so the ceiling is the
+// context window; the Dust layer applies the 2048 product value.
+const MAX_OUTPUT_TOKENS = CONTEXT_SIZE;
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithMistralSmallConfig<
@@ -21,7 +22,8 @@ export function WithMistralSmallConfig<
     static readonly configSchema = mistralNonReasoningConfigSchema;
 
     static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // Typed as `number` (not the literal) so the Dust layer can cap it.
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return MistralSmall;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five.ts
@@ -1,7 +1,6 @@
 import {
   type InputConfig,
   inputConfigSchema,
-  temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
 import { GPT_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
@@ -12,12 +11,7 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-const GPT_5_REASONING_EFFORTS = [
-  "minimal",
-  "low",
-  "medium",
-  "high",
-] as const;
+const GPT_5_REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
 
 const configSchema = inputConfigSchema.extend({
   reasoning: z

--- a/front/lib/model_constructors/providers/openai/models/gpt_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five.ts
@@ -12,12 +12,7 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5 accepts minimal/low/medium/high. It has no "none"; we accept it and map
-// it to the nearest supported effort ("minimal"). "xhigh" and the universal
-// "maximal" (mapped to "xhigh") remain unsupported and surface as an input
-// configuration error.
 const GPT_5_REASONING_EFFORTS = [
-  "none",
   "minimal",
   "low",
   "medium",
@@ -27,12 +22,9 @@ const GPT_5_REASONING_EFFORTS = [
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT })
-    .transform(({ effort }) => ({
-      effort: effort === "none" ? "minimal" : effort,
-    })),
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
   // gpt-5 rejects any explicit temperature; reasoning is always on.
-  temperature: temperatureSchema.optional().transform(() => undefined),
+  temperature: z.undefined(),
 });
 
 // Mixin carrying shared config; runtime base differs per surface.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
@@ -22,7 +22,7 @@ const configSchema = z.union([
       .object({ effort: z.enum(GPT_5_5_REASONING_EFFORTS) })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     // The Responses API rejects an explicit temperature while reasoning is on.
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.literal("none") }),

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -12,10 +12,10 @@ const CONTEXT_SIZE = 1_050_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "none";
 
-// gpt-5.4 accepts none/low/medium/high (matching the legacy router). "minimal",
-// "xhigh" and the universal "maximal" are unsupported and surface as an input
+// gpt-5.4 accepts none/low/medium/high/xhigh. "minimal" and the top "max" tier
+// (Dust's universal "maximal") are unsupported and surface as an input
 // configuration error.
-const GPT_5_4_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+const GPT_5_4_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
 
 const configSchema = z.union([
   // Reasoning off is the default; the Responses API then allows a temperature.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -8,7 +8,7 @@ import { GPT_5_4_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 import { z } from "zod";
 
 // https://developers.openai.com/api/docs/models/gpt-5.4
-const CONTEXT_SIZE = 1_000_000;
+const CONTEXT_SIZE = 1_050_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "none";
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -28,7 +28,7 @@ const configSchema = z.union([
   // Reasoning on: the Responses API rejects an explicit temperature.
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.enum(GPT_5_4_REASONING_EFFORTS) }),
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
 ]);
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -28,7 +28,7 @@ const configSchema = z.union([
   // Reasoning on: the Responses API rejects an explicit temperature.
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.enum(GPT_5_4_MINI_REASONING_EFFORTS) }),
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
 ]);
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -12,10 +12,15 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "none";
 
-// gpt-5.4-mini accepts none/low/medium/high (matching the legacy router).
-// "minimal", "xhigh" and the universal "maximal" are unsupported and surface as
-// an input configuration error.
-const GPT_5_4_MINI_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+// gpt-5.4-mini accepts none/low/medium/high/xhigh. "minimal" and the top "max"
+// tier (Dust's universal "maximal") are unsupported and surface as an input
+// configuration error.
+const GPT_5_4_MINI_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
 
 const configSchema = z.union([
   // Reasoning off is the default; the Responses API then allows a temperature.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -28,7 +28,7 @@ const configSchema = z.union([
   // Reasoning on: the Responses API rejects an explicit temperature.
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.enum(GPT_5_4_NANO_REASONING_EFFORTS) }),
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
 ]);
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -12,10 +12,15 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "none";
 
-// gpt-5.4-nano accepts none/low/medium/high (matching the legacy router).
-// "minimal", "xhigh" and the universal "maximal" are unsupported and surface as
-// an input configuration error.
-const GPT_5_4_NANO_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+// gpt-5.4-nano accepts none/low/medium/high/xhigh. "minimal" and the top "max"
+// tier (Dust's universal "maximal") are unsupported and surface as an input
+// configuration error.
+const GPT_5_4_NANO_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
 
 const configSchema = z.union([
   // Reasoning off is the default; the Responses API then allows a temperature.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
@@ -23,7 +23,7 @@ const configSchema = inputConfigSchema.extend({
     .object({ effort: z.enum(GPT_5_1_REASONING_EFFORTS) })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
   // The Responses API rejects temperature for gpt-5.1 regardless of reasoning effort.
-  temperature: temperatureSchema.optional().transform(() => undefined),
+  temperature: z.undefined(),
 });
 
 // Mixin carrying shared config; runtime base differs per surface.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
@@ -1,7 +1,6 @@
 import {
   type InputConfig,
   inputConfigSchema,
-  temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
 import { GPT_5_1_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_luna.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_luna.ts
@@ -29,7 +29,7 @@ const configSchema = z.union([
       .object({ effort: z.enum(GPT_5_6_REASONING_EFFORTS) })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     // The Responses API rejects an explicit temperature while reasoning is on.
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.literal("none") }),

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_sol.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_sol.ts
@@ -29,7 +29,7 @@ const configSchema = z.union([
       .object({ effort: z.enum(GPT_5_6_REASONING_EFFORTS) })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     // The Responses API rejects an explicit temperature while reasoning is on.
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.literal("none") }),

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_terra.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six_terra.ts
@@ -29,7 +29,7 @@ const configSchema = z.union([
       .object({ effort: z.enum(GPT_5_6_REASONING_EFFORTS) })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     // The Responses API rejects an explicit temperature while reasoning is on.
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.literal("none") }),

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
@@ -28,7 +28,7 @@ const configSchema = z.union([
   // Reasoning on: the Responses API rejects an explicit temperature.
   inputConfigSchema.extend({
     reasoning: z.object({ effort: z.enum(GPT_5_2_REASONING_EFFORTS) }),
-    temperature: temperatureSchema.optional().transform(() => undefined),
+    temperature: z.undefined(),
   }),
 ]);
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
@@ -12,10 +12,10 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "none";
 
-// gpt-5.2 accepts none/low/medium/high (matching the legacy router). "minimal",
-// "xhigh" and the universal "maximal" are unsupported and surface as an input
+// gpt-5.2 accepts none/low/medium/high/xhigh. "minimal" and the top "max" tier
+// (Dust's universal "maximal") are unsupported and surface as an input
 // configuration error.
-const GPT_5_2_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+const GPT_5_2_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
 
 const configSchema = z.union([
   // Reasoning off is the default; the Responses API then allows a temperature.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
@@ -1,7 +1,6 @@
 import {
   type InputConfig,
   inputConfigSchema,
-  temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
 import { GPT_5_MINI_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
@@ -12,12 +12,7 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5-mini accepts minimal/low/medium/high. It has no "none"; we accept it
-// and map it to the nearest supported effort ("minimal"). "xhigh" and the
-// universal "maximal" (mapped to "xhigh") remain unsupported and surface as an
-// input configuration error.
 const GPT_5_MINI_REASONING_EFFORTS = [
-  "none",
   "minimal",
   "low",
   "medium",
@@ -29,11 +24,8 @@ const GPT_5_MINI_REASONING_EFFORTS = [
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_MINI_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT })
-    .transform(({ effort }) => ({
-      effort: effort === "none" ? "minimal" : effort,
-    })),
-  temperature: temperatureSchema.optional().transform(() => undefined),
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+  temperature: z.undefined(),
 });
 
 // Mixin carrying shared config; runtime base differs per surface.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
@@ -1,7 +1,6 @@
 import {
   type InputConfig,
   inputConfigSchema,
-  temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
 import { GPT_5_NANO_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
@@ -12,12 +12,7 @@ const CONTEXT_SIZE = 400_000;
 const MAX_OUTPUT_TOKENS = 128_000;
 const DEFAULT_REASONING_EFFORT = "medium";
 
-// gpt-5-nano accepts minimal/low/medium/high. It has no "none"; we accept it
-// and map it to the nearest supported effort ("minimal"). "xhigh" and the
-// universal "maximal" (mapped to "xhigh") remain unsupported and surface as an
-// input configuration error.
 const GPT_5_NANO_REASONING_EFFORTS = [
-  "none",
   "minimal",
   "low",
   "medium",
@@ -27,12 +22,9 @@ const GPT_5_NANO_REASONING_EFFORTS = [
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.enum(GPT_5_NANO_REASONING_EFFORTS) })
-    .default({ effort: DEFAULT_REASONING_EFFORT })
-    .transform(({ effort }) => ({
-      effort: effort === "none" ? "minimal" : effort,
-    })),
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
   // The Responses API rejects an explicit temperature while reasoning is on.
-  temperature: temperatureSchema.optional().transform(() => undefined),
+  temperature: z.undefined(),
 });
 
 // Mixin carrying shared config; runtime base differs per surface.

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
@@ -17,7 +17,7 @@ import {
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import { toToolChoiceInput } from "@app/lib/model_constructors/types/input/configuration";
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
-import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
+import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 
@@ -40,10 +40,12 @@ export function WithOpenAICompletionsInputConverter<
     assistantReasoningMessageToMessage = assistantReasoningMessageToMessage;
     assistantToolCallRequestToMessage = assistantToolCallRequestToMessage;
 
+    // Returns the union (not `NonStreaming`) so streaming clients can override
+    // this and add `stream`/`stream_options` while still calling `super`.
     buildRequestPayload(
       payload: Payload,
       config: InputConfig
-    ): ChatCompletionCreateParamsNonStreaming {
+    ): ChatCompletionCreateParams {
       const { conversation } = payload;
       const { tools = [], temperature, reasoning, outputFormat } = config;
 

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
@@ -130,7 +130,6 @@ export function assistantToolCallRequestToMessage(
 ): ChatCompletionMessageParam {
   return {
     role: "assistant",
-    content: null,
     tool_calls: [
       {
         id: message.content.callId,

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -64,8 +64,13 @@ export function WithOpenAIResponsesInputConverter<
       config: InputConfig
     ): ResponseCreateParamsNonStreaming {
       const { conversation } = payload;
-      const { tools = [], temperature, reasoning, outputFormat, cacheKey } =
-        config;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        outputFormat,
+        cacheKey,
+      } = config;
 
       const reasoningConfig = reasoningToOpenAIResponsesReasoning(reasoning);
 

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -64,13 +64,15 @@ export function WithOpenAIResponsesInputConverter<
       config: InputConfig
     ): ResponseCreateParamsNonStreaming {
       const { conversation } = payload;
-      const { tools = [], temperature, reasoning, outputFormat } = config;
+      const { tools = [], temperature, reasoning, outputFormat, cacheKey } =
+        config;
 
       const reasoningConfig = reasoningToOpenAIResponsesReasoning(reasoning);
 
       return {
         model: this.constructor.modelId,
         max_output_tokens: this.constructor.maxOutputTokens,
+        ...(cacheKey ? { prompt_cache_key: cacheKey } : {}),
         input: [
           ...this.systemMessagesToInputItems(conversation.system),
           ...this.conversationToInput(conversation),

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -32,6 +32,14 @@ import type { CacheMissReason } from "@app/lib/model_constructors/utils/cache_mi
 // https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics
 const CACHE_DIAGNOSTICS_BETA_HEADER = "cache-diagnosis-2026-04-07";
 
+// The request we build for the stream: the base non-beta params plus the beta
+// Messages API extras we attach (cache-diagnostics beta header + `diagnostics`
+// opt-in). Kept on the built payload rather than added in `streamRaw` so the
+// request we construct reflects exactly what we send (and what the debug dump
+// records). Non-beta params are assignable to the beta stream params.
+type AnthropicStreamRequest = MessageCreateParamsNonStreaming &
+  Pick<BetaMessageStreamParams, "betas" | "diagnostics">;
+
 // Extract the cache-miss reason from a message_start (null when nothing to
 // compare or the background comparison is still pending).
 function toCacheMissReason(message: BetaMessage): CacheMissReason | undefined {
@@ -52,7 +60,7 @@ function toCacheMissReason(message: BetaMessage): CacheMissReason | undefined {
 export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   WithAnthropicAIOutputConverter(
     StreamEndpoint<
-      MessageCreateParamsNonStreaming,
+      AnthropicStreamRequest,
       BetaRawMessageStreamEvent,
       AnthropicInputConfig
     >
@@ -81,11 +89,23 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   async buildRequestPayload(
     payload: Payload,
     config: AnthropicInputConfig
-  ): Promise<MessageCreateParamsNonStreaming> {
-    // `diagnostics` and the beta header live on the beta Messages API, so they
-    // are attached in `streamRaw` from this opt-in rather than in the payload.
+  ): Promise<AnthropicStreamRequest> {
     this.previousMessageId = config.previousMessageId;
-    return super.buildRequestPayload(payload, config);
+    return {
+      ...(await super.buildRequestPayload(payload, config)),
+      // Top-level automatic caching: auto-places the last cache breakpoint at
+      // the tail of the request so the growing conversation prefix is reused.
+      cache_control: { type: "ephemeral" },
+      // Cache-diagnostics opt-in (Claude API only): the beta header and its
+      // `diagnostics` body are attached here, not in `streamRaw`, so the built
+      // payload reflects exactly what we send.
+      ...(this.cacheDiagnosticsEnabled
+        ? {
+            betas: [CACHE_DIAGNOSTICS_BETA_HEADER],
+            diagnostics: { previous_message_id: this.previousMessageId },
+          }
+        : {}),
+    };
   }
 
   // Cache diagnostics opt-in is tri-state: `undefined` = off; `null`/string =
@@ -95,23 +115,11 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
   }
 
   async *streamRaw(
-    input: MessageCreateParamsNonStreaming
+    input: AnthropicStreamRequest
   ): AsyncGenerator<BetaRawMessageStreamEvent> {
     this.lastCacheMissReason = undefined;
 
-    // `buildRequestPayload` is shared with batch and omits `stream`; the beta
-    // `.stream()` opts in. Non-beta payloads are assignable to the beta params.
-    const streamingInput: BetaMessageStreamParams = {
-      ...input,
-      cache_control: { type: "ephemeral" },
-      ...(this.cacheDiagnosticsEnabled
-        ? {
-            betas: [CACHE_DIAGNOSTICS_BETA_HEADER],
-            diagnostics: { previous_message_id: this.previousMessageId },
-          }
-        : {}),
-    };
-    const stream = this.client.beta.messages.stream(streamingInput);
+    const stream = this.client.beta.messages.stream(input);
 
     for await (const event of stream) {
       if (event.type === "message_start") {

--- a/front/lib/model_constructors/stream/clients/fireworks.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks.ts
@@ -6,13 +6,13 @@ import { WithOpenAICompletionsInputConverter } from "@app/lib/model_constructors
 import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_completions/converters/output/utils";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { FIREWORKS_API } from "@app/lib/model_constructors/types/provider_apis";
 import { FIREWORKS_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import OpenAI from "openai";
 import type {
   ChatCompletionChunk,
-  ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
 } from "openai/resources/chat/completions";
 
@@ -20,7 +20,7 @@ const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 
 export abstract class FireworksStream extends WithOpenAICompletionsInputConverter(
   StreamEndpoint<
-    ChatCompletionCreateParamsNonStreaming,
+    ChatCompletionCreateParamsStreaming,
     ChatCompletionChunk,
     FireworksInputConfig
   >
@@ -40,16 +40,23 @@ export abstract class FireworksStream extends WithOpenAICompletionsInputConverte
     });
   }
 
-  async *streamRaw(
-    input: ChatCompletionCreateParamsNonStreaming
-  ): AsyncGenerator<ChatCompletionChunk> {
-    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
-    const streamingInput: ChatCompletionCreateParamsStreaming = {
-      ...input,
+  // Fireworks always streams, so opt into `stream`/`stream_options` here rather
+  // than in `streamRaw`, keeping the request payload self-contained.
+  override buildRequestPayload(
+    payload: Payload,
+    config: FireworksInputConfig
+  ): ChatCompletionCreateParamsStreaming {
+    return {
+      ...super.buildRequestPayload(payload, config),
       stream: true,
       stream_options: { include_usage: true },
     };
-    const stream = await this.client.chat.completions.create(streamingInput);
+  }
+
+  async *streamRaw(
+    input: ChatCompletionCreateParamsStreaming
+  ): AsyncGenerator<ChatCompletionChunk> {
+    const stream = await this.client.chat.completions.create(input);
 
     for await (const event of stream) {
       yield event;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
@@ -1,7 +1,7 @@
 import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
 import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type { ClaudeOpusFourDotSix } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six";
 import { WithAnthropicClaudeOpusFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six";
-import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
@@ -27,5 +27,5 @@ export class AnthropicGlobalClaudeOpusFourDotSixStream extends WithAnthropicClau
 AnthropicGlobalClaudeOpusFourDotSixStream satisfies StreamEndpointConstructor<
   MessageCreateParamsNonStreaming,
   BetaRawMessageStreamEvent,
-  AnthropicOpusInputConfig
+  ClaudeOpusFourDotSix
 >;


### PR DESCRIPTION
## Description

Align the new LLM router's model configs with real provider specs (context windows, output/reasoning caps, temperature support, per-model reasoning efforts) and add a per-endpoint `parseConfig` hook, correct Anthropic wire-payload building and equipped-skills prompt caching.

## Tests

Tested locally; updated `transitionLLM.test.ts`.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`