### PR TITLE
Allow to create contracts without cusotmer id

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -104,6 +104,7 @@ const NEW_CONTRACT_ID = "contract_new_yyy";
 const ENT_PACKAGE_ID = "pkg_ent_usd";
 const PRO_PACKAGE_ID = "pkg_pro_usd";
 const BUSINESS_PACKAGE_ID = "pkg_business_usd";
+const BUSINESS_EUR_PACKAGE_ID = "pkg_business_eur";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
 const STRIPE_CUSTOMER_ID = "cus_test_xxx";
 
@@ -259,6 +260,15 @@ beforeEach(() => {
         aliases: ["business"],
         tier: "business",
         currency: "usd",
+        seats: [],
+        billingAnchor: "contract_start_date" as const,
+      },
+      {
+        id: BUSINESS_EUR_PACKAGE_ID,
+        name: "Business EUR",
+        aliases: ["business-eur"],
+        tier: "business",
+        currency: "eur",
         seats: [],
         billingAnchor: "contract_start_date" as const,
       },
@@ -710,5 +720,51 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
     expect(config?.paygEnabled).toBe(false);
     expect(config?.usageCapCredits).toBe(100_000);
+  });
+});
+
+describe("POST /api/poke/workspaces/[wId]/switch_contract — no Stripe customer", () => {
+  it("provisions a contract with no Stripe billing config when stripeCustomerId is blank", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    const response = await postSwitchContract(
+      workspace.sId,
+      proBody({ stripeCustomerId: "" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(getStripeCustomer).not.toHaveBeenCalled();
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageAlias: "legacy-pro-monthly",
+        enableStripeBilling: false,
+      })
+    );
+  });
+
+  it("accepts a package in any currency when stripeCustomerId is blank", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    const response = await postSwitchContract(
+      workspace.sId,
+      businessBody({
+        stripeCustomerId: "",
+        metronomePackageId: BUSINESS_EUR_PACKAGE_ID,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageAlias: "business-eur",
+        enableStripeBilling: false,
+      })
+    );
   });
 });

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -17,6 +17,7 @@ import {
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
 import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import { BILLABLE_SEAT_TYPES } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { CreditUsageConfigurationSchema } from "@app/types/poke/credit_usage_configuration";
@@ -63,6 +64,10 @@ const SwitchContractFormSchema = SwitchContractBodySchema.omit({
   startMode: z
     .enum(["immediately", "retroactive_first_of_month", "select"])
     .default("select"),
+  // Billing currency picked directly by the operator when no Stripe customer
+  // is wired in (there's no Stripe currency to resolve). Not sent to the
+  // server — only the currency-matching package selection matters there.
+  manualCurrency: z.enum(SUPPORTED_CURRENCIES).default("usd"),
 });
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
@@ -147,6 +152,7 @@ export default function SwitchContractDialog({
       purchaseOrderId: "",
       startingAt: "",
       startMode: "select",
+      manualCurrency: "usd",
       endingAt: "",
       stripeCustomerId: stripeCustomerId ?? "",
       stripeCollectionMethod: "charge_automatically",
@@ -170,14 +176,20 @@ export default function SwitchContractDialog({
 
   const watchedStripeCustomerId = form.watch("stripeCustomerId");
   const trimmedStripeCustomerId = watchedStripeCustomerId.trim() || null;
+  const hasStripeCustomer = trimmedStripeCustomerId !== null;
   const {
-    currency: resolvedCurrency,
+    currency: stripeCurrency,
     isCurrencyLoading,
     currencyError,
   } = usePokeStripeCustomerCurrency({
     stripeCustomerId: trimmedStripeCustomerId,
     disabled: !open,
   });
+  // No Stripe customer means no Stripe billing config on the contract, so
+  // there's no Stripe currency to match against — the operator picks any
+  // package currency directly instead (see `manualCurrency`).
+  const manualCurrency = form.watch("manualCurrency");
+  const resolvedCurrency = hasStripeCustomer ? stripeCurrency : manualCurrency;
 
   // Fetch the existing credit config so we pre-populate form fields with
   // current values rather than schema defaults, avoiding accidental overwrites.
@@ -681,24 +693,50 @@ export default function SwitchContractDialog({
                   {error && (
                     <div className="col-span-2 text-warning">{error}</div>
                   )}
-                  <Label className="text-sm">Stripe Customer ID</Label>
+                  <Label className="text-sm">
+                    Stripe Customer ID
+                    <span className="ml-1 text-muted-foreground">
+                      (optional)
+                    </span>
+                  </Label>
                   <InputField
                     control={form.control}
                     name="stripeCustomerId"
                     hideLabel
-                    placeholder="cus_1234567890"
+                    placeholder="cus_1234567890 — leave blank for no Stripe billing"
                   />
-                  {isCurrencyLoading && (
+                  {hasStripeCustomer && isCurrencyLoading && (
                     <div className="col-span-2 flex items-center gap-2 text-sm text-muted-foreground">
                       <Spinner size="sm" />
                       <span>Resolving customer currency...</span>
                     </div>
                   )}
-                  {currencyError && (
+                  {hasStripeCustomer && currencyError && (
                     <div className="col-span-2 text-sm text-warning">
                       Failed to resolve currency from Stripe customer:{" "}
                       {currencyError.message}
                     </div>
+                  )}
+                  {!hasStripeCustomer && (
+                    <>
+                      <Label className="text-sm">Billing currency</Label>
+                      <SelectField
+                        control={form.control}
+                        name="manualCurrency"
+                        hideLabel
+                        mountPortalContainer={portalContainer}
+                        options={SUPPORTED_CURRENCIES.map((currency) => ({
+                          value: currency,
+                          display: currency.toUpperCase(),
+                        }))}
+                      />
+                      <div className="col-span-2 text-xs text-muted-foreground">
+                        No Stripe customer: Metronome still raises invoices for
+                        initial credits, scheduled charges, and seat commitments
+                        as usual — they just won't be pushed to Stripe (nothing
+                        is auto-charged; reconcile manually).
+                      </div>
+                    </>
                   )}
                 </div>
                 {/* Nothing else renders until a Stripe customer resolves to a
@@ -731,35 +769,39 @@ export default function SwitchContractDialog({
                         hideLabel
                         placeholder="PO number"
                       />
-                      <Label className="text-sm">Collection method</Label>
-                      <SelectField
-                        control={form.control}
-                        name="stripeCollectionMethod"
-                        hideLabel
-                        mountPortalContainer={portalContainer}
-                        options={[
-                          {
-                            value: "charge_automatically",
-                            display: "Charge automatically (card on file)",
-                          },
-                          {
-                            value: "send_invoice",
-                            display: "Send invoice (manual payment)",
-                          },
-                        ]}
-                      />
-                      {stripeCollectionMethod === "send_invoice" && (
+                      {hasStripeCustomer && (
                         <>
-                          <Label className="text-sm">
-                            Net payment terms (days)
-                          </Label>
-                          <InputField
+                          <Label className="text-sm">Collection method</Label>
+                          <SelectField
                             control={form.control}
-                            name="netPaymentTermsDays"
+                            name="stripeCollectionMethod"
                             hideLabel
-                            type="number"
-                            placeholder="Metronome account default"
+                            mountPortalContainer={portalContainer}
+                            options={[
+                              {
+                                value: "charge_automatically",
+                                display: "Charge automatically (card on file)",
+                              },
+                              {
+                                value: "send_invoice",
+                                display: "Send invoice (manual payment)",
+                              },
+                            ]}
                           />
+                          {stripeCollectionMethod === "send_invoice" && (
+                            <>
+                              <Label className="text-sm">
+                                Net payment terms (days)
+                              </Label>
+                              <InputField
+                                control={form.control}
+                                name="netPaymentTermsDays"
+                                hideLabel
+                                type="number"
+                                placeholder="Metronome account default"
+                              />
+                            </>
+                          )}
                         </>
                       )}
                       {isPackagesLoading && (
@@ -1180,7 +1222,9 @@ export default function SwitchContractDialog({
                                 : {
                                     amountCredits: 0,
                                     invoiceAmount: 0,
-                                    paymentSchedule: { frequency: "one_time" },
+                                    paymentSchedule: {
+                                      frequency: "one_time",
+                                    },
                                   }
                             )
                           }
@@ -1260,7 +1304,9 @@ export default function SwitchContractDialog({
                                 : {
                                     name: undefined,
                                     invoiceAmount: 0,
-                                    paymentSchedule: { frequency: "one_time" },
+                                    paymentSchedule: {
+                                      frequency: "one_time",
+                                    },
                                   }
                             )
                           }

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -309,12 +309,14 @@ async function resolveMetronomeCustomer({
   stripeCollectionMethod,
 }: {
   ownerLight: LightWorkspaceType;
+  // Empty when the contract is to be created with no Stripe billing
+  // provider — passed through as `undefined` so no billing config is set.
   stripeCustomerId: string;
   stripeCollectionMethod: "charge_automatically" | "send_invoice";
 }): Promise<Result<{ metronomeCustomerId: string }, SwitchContractError>> {
   const result = await ensureMetronomeCustomerForWorkspace({
     workspace: ownerLight,
-    stripeCustomerId,
+    stripeCustomerId: stripeCustomerId || undefined,
     stripeCollectionMethod,
   });
   if (result.isErr()) {
@@ -330,13 +332,17 @@ async function resolveMetronomeCustomer({
 
 async function resolveAndValidatePackage(
   body: SwitchContractBody,
-  resolvedCurrency: SupportedCurrency
+  // `null` when no Stripe customer is wired in — there's no Stripe currency
+  // to match against, so the package's own currency becomes the contract's
+  // resolved currency instead of being validated against it.
+  resolvedCurrency: SupportedCurrency | null
 ): Promise<
   Result<
     {
       pkg: MetronomePackageSummary;
       pkgSeatByType: Map<string, PackageSeatConfig>;
       packageAlias: string;
+      resolvedCurrency: SupportedCurrency;
     },
     SwitchContractError
   >
@@ -361,7 +367,11 @@ async function resolveAndValidatePackage(
       )
     );
   }
-  if (pkg.tier !== "free" && pkg.currency !== resolvedCurrency) {
+  if (
+    resolvedCurrency !== null &&
+    pkg.tier !== "free" &&
+    pkg.currency !== resolvedCurrency
+  ) {
     return new Err(
       new SwitchContractError(
         "invalid_request",
@@ -414,7 +424,12 @@ async function resolveAndValidatePackage(
       )
     );
   }
-  return new Ok({ pkg, pkgSeatByType, packageAlias });
+  return new Ok({
+    pkg,
+    pkgSeatByType,
+    packageAlias,
+    resolvedCurrency: resolvedCurrency ?? pkg.currency,
+  });
 }
 
 function resolveSwapTiming(
@@ -1045,15 +1060,19 @@ export async function switchContract({
   const creditConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-  const stripeResult = await resolveStripeCustomer(body.stripeCustomerId);
-  if (stripeResult.isErr()) {
-    return new Err(stripeResult.error);
+  const stripeCustomerId = body.stripeCustomerId.trim();
+  let stripeResolvedCurrency: SupportedCurrency | null = null;
+  if (stripeCustomerId) {
+    const stripeResult = await resolveStripeCustomer(stripeCustomerId);
+    if (stripeResult.isErr()) {
+      return new Err(stripeResult.error);
+    }
+    stripeResolvedCurrency = stripeResult.value.resolvedCurrency;
   }
-  const { resolvedCurrency } = stripeResult.value;
 
   const customerResult = await resolveMetronomeCustomer({
     ownerLight,
-    stripeCustomerId: body.stripeCustomerId,
+    stripeCustomerId,
     stripeCollectionMethod: body.stripeCollectionMethod,
   });
   if (customerResult.isErr()) {
@@ -1061,11 +1080,15 @@ export async function switchContract({
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  const packageResult = await resolveAndValidatePackage(body, resolvedCurrency);
+  const packageResult = await resolveAndValidatePackage(
+    body,
+    stripeResolvedCurrency
+  );
   if (packageResult.isErr()) {
     return new Err(packageResult.error);
   }
-  const { pkg, pkgSeatByType, packageAlias } = packageResult.value;
+  const { pkg, pkgSeatByType, packageAlias, resolvedCurrency } =
+    packageResult.value;
 
   const timingResult = resolveSwapTiming(body.startingAt);
   if (timingResult.isErr()) {
@@ -1133,7 +1156,7 @@ export async function switchContract({
     packageAlias,
     startingAt: startingAtDate,
     swapAt,
-    enableStripeBilling: true,
+    enableStripeBilling: Boolean(stripeCustomerId),
     planCode: body.planCode,
     fromContractId: currentSubscription?.metronomeContractId ?? undefined,
     enableSeatSync: false,

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -94,8 +94,14 @@ export const SwitchContractBodySchema = z.object({
     .min(0, "Net payment terms must be ≥ 0")
     .max(365, "Net payment terms must be ≤ 365")
     .optional(),
-  // Every contract switch must be wired to a Stripe customer.
-  stripeCustomerId: z.string().min(1, "Required"),
+  // Optional. Wires the contract to a Stripe customer for billing. Left
+  // blank, the contract is created with no Stripe billing provider
+  // configured — Metronome still raises invoices for `initialCredits`,
+  // `scheduledCharge`, and any seat `commitmentPrice` as usual, they simply
+  // aren't pushed to Stripe (nothing is auto-charged; reconcile manually).
+  // Any package currency may be picked in that case, since there's no Stripe
+  // customer currency to match against.
+  stripeCustomerId: z.string().default(""),
   // How Metronome collects Stripe invoices for this customer. Only takes
   // effect when a Stripe customer is wired in. `charge_automatically` charges
   // the card on file; `send_invoice` emails the invoice for manual payment.


### PR DESCRIPTION
## Description

Mainly useful in dev : we can create contracts without having to configure a stripe customer. No billing provider, no real invoice sent.

If no stripe id is entered, user has to select manually the currency.

## Tests

locally

## Risk

low, poke only

## Deploy Plan

deploy front
