### PR TITLE
[Pods] Set pod default agent from a conversation

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -3,11 +3,13 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import {
+  DEFAULT_AGENT_TOOL_NAME,
   EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import {
+  isPodManagerDefaultAgentInput,
   isPodManagerEditInformationInput,
   isPodManagerUpdateMembersInput,
 } from "@app/lib/api/actions/servers/pod_manager/types";
@@ -146,6 +148,18 @@ const MCP_TOOL_OVERRIDES: Partial<
         return `Allow agent to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
       },
       alwaysAllowLabel: () => `Always allow agent to update Pod members`,
+    },
+    [DEFAULT_AGENT_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodManagerDefaultAgentInput(inputs)) {
+          return `Allow agent to set the Pod default agent?`;
+        }
+        if (inputs.agentName === null) {
+          return `Allow agent to reset the Pod default agent to @dust?`;
+        }
+        return `Allow agent to set the Pod default agent to @${inputs.agentName}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to set the Pod default agent`,
     },
   },
   [WAKEUPS_SERVER_NAME]: {

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -3,9 +3,9 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import {
-  DEFAULT_AGENT_TOOL_NAME,
   EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
+  SET_DEFAULT_AGENT_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import {
@@ -149,7 +149,7 @@ const MCP_TOOL_OVERRIDES: Partial<
       },
       alwaysAllowLabel: () => `Always allow agent to update Pod members`,
     },
-    [DEFAULT_AGENT_TOOL_NAME]: {
+    [SET_DEFAULT_AGENT_TOOL_NAME]: {
       title: (inputs) => {
         if (!isPodManagerDefaultAgentInput(inputs)) {
           return `Allow agent to set the Pod default agent?`;
@@ -159,7 +159,7 @@ const MCP_TOOL_OVERRIDES: Partial<
         }
         return `Allow agent to set the Pod default agent to @${inputs.agentName}?`;
       },
-      alwaysAllowLabel: () => `Always allow agent to set the Pod default agent`,
+      alwaysAllowLabel: () => "Always allow agent to set the Pod default agent",
     },
   },
   [WAKEUPS_SERVER_NAME]: {

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1802,6 +1802,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "set_default_agent": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "set_pinned_frame": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -3133,6 +3137,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "remove_content_node": "low",
     "retrieve_recent_documents": "never_ask",
     "semantic_search": "never_ask",
+    "set_default_agent": "low",
     "set_pinned_frame": "never_ask",
     "update_members": "low",
   },

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -21,6 +21,7 @@ export const SEMANTIC_SEARCH_TOOL_NAME = "semantic_search" as const;
 export const EDIT_INFORMATION_TOOL_NAME = "edit_information" as const;
 export const SET_PINNED_FRAME_TOOL_NAME = "set_pinned_frame" as const;
 export const MOVE_CONVERSATION_TOOL_NAME = "move_conversation" as const;
+export const DEFAULT_AGENT_TOOL_NAME = "default_agent" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = [
   {
@@ -143,8 +144,34 @@ export const POD_MANAGER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  {
-    name: UPDATE_MEMBERS_TOOL_NAME,
+  [DEFAULT_AGENT_TOOL_NAME]: {
+    description:
+      "Set or clear the Pod default agent — the agent that handles new conversations started in this Pod when no agent is picked explicitly. " +
+      "Provide agentName to set it (matched by name, best match wins), or pass null to reset to the default (@dust).",
+    schema: {
+      agentName: z
+        .string()
+        .nullable()
+        .describe(
+          "Name of the agent to set as the Pod default. The tool searches matching agent configurations and uses the best match. Pass null to reset to the default (@dust)."
+        ),
+      dustPod: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
+      ]
+        .optional()
+        .describe(
+          "Optional Pod to update, will fallback to the conversation's Pod."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Setting Pod default agent",
+      done: "Set Pod default agent",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  [UPDATE_MEMBERS_TOOL_NAME]: {
     description:
       "Update membership for an existing Pod: invite, add, remove, " +
       "promote, or demote teammates as Pod members or editors by user id. " +

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -21,7 +21,7 @@ export const SEMANTIC_SEARCH_TOOL_NAME = "semantic_search" as const;
 export const EDIT_INFORMATION_TOOL_NAME = "edit_information" as const;
 export const SET_PINNED_FRAME_TOOL_NAME = "set_pinned_frame" as const;
 export const MOVE_CONVERSATION_TOOL_NAME = "move_conversation" as const;
-export const DEFAULT_AGENT_TOOL_NAME = "default_agent" as const;
+export const SET_DEFAULT_AGENT_TOOL_NAME = "set_default_agent" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = [
   {
@@ -144,16 +144,17 @@ export const POD_MANAGER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [DEFAULT_AGENT_TOOL_NAME]: {
+  {
+    name: SET_DEFAULT_AGENT_TOOL_NAME,
     description:
-      "Set or clear the Pod default agent — the agent that handles new conversations started in this Pod when no agent is picked explicitly. " +
-      "Provide agentName to set it (matched by name, best match wins), or pass null to reset to the default (@dust).",
+      "Set or clear the Pod default agent: the agent that handles new conversations started in this Pod when no agent is picked explicitly. " +
+      "Provide agentName to set it, or pass null to reset to the default (Dust).",
     schema: {
       agentName: z
         .string()
         .nullable()
         .describe(
-          "Name of the agent to set as the Pod default. The tool searches matching agent configurations and uses the best match. Pass null to reset to the default (@dust)."
+          "Name of the agent to set as the Pod default. The tool searches matching agent configurations and uses the best match. Pass null to reset to the default (Dust)."
         ),
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
@@ -171,7 +172,8 @@ export const POD_MANAGER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [UPDATE_MEMBERS_TOOL_NAME]: {
+  {
+    name: UPDATE_MEMBERS_TOOL_NAME,
     description:
       "Update membership for an existing Pod: invite, add, remove, " +
       "promote, or demote teammates as Pod members or editors by user id. " +

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -28,6 +28,7 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import {
+  DEFAULT_AGENT_TOOL_NAME,
   EDIT_INFORMATION_TOOL_NAME,
   LIST_MEMBERS_TOOL_NAME,
   MOVE_CONVERSATION_TOOL_NAME,
@@ -38,7 +39,10 @@ import {
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { partitionMembersToAdd } from "@app/lib/api/actions/servers/pod_manager/types";
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
-import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
+import {
+  getAgentConfiguration,
+  resolveAgentConfigurationIdByName,
+} from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
   postUserMessage,
@@ -60,6 +64,7 @@ import { listPodsForScope } from "@app/lib/api/projects/list";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -409,6 +414,84 @@ export function createProjectManagerTools(
       }, "Failed to set Pod pinned frame");
     },
 
+    [DEFAULT_AGENT_TOOL_NAME]: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getPod(auth, {
+          toolContext,
+          dustPod: params.dustPod,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { pod } = contextRes.value;
+
+        if (!pod.canAdministrate(auth)) {
+          return new Err(
+            new MCPError(
+              "You do not have permission to edit this Pod's default agent",
+              { tracked: false }
+            )
+          );
+        }
+
+        const featureFlags = await getFeatureFlags(auth);
+        if (!featureFlags.includes("pod_default_agent")) {
+          return new Err(
+            new MCPError(
+              "Setting a Pod default agent is not enabled for this workspace.",
+              { tracked: false }
+            )
+          );
+        }
+
+        // Resolve the agent by name. A null agentName clears the default so new
+        // conversations fall back to the workspace default / @dust.
+        let defaultAgentId: string | null = null;
+        let defaultAgentName: string | null = null;
+        if (params.agentName !== null) {
+          const resolvedAgentId = await resolveAgentConfigurationIdByName(
+            auth,
+            params.agentName
+          );
+          if (!resolvedAgentId) {
+            return new Err(
+              new MCPError(`No agent found matching "${params.agentName}".`, {
+                tracked: false,
+              })
+            );
+          }
+          defaultAgentId = resolvedAgentId;
+          const agent = await getAgentConfiguration(auth, {
+            agentId: resolvedAgentId,
+            variant: "extra_light",
+          });
+          defaultAgentName = agent?.name ?? null;
+        }
+
+        let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+        if (!metadata) {
+          metadata = await ProjectMetadataResource.makeNew(auth, pod, {
+            defaultAgentId,
+          });
+        } else {
+          await metadata.updateDefaultAgentId(defaultAgentId);
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            defaultAgentId,
+            message: defaultAgentId
+              ? `Pod default agent set to ${
+                  defaultAgentName ? `@${defaultAgentName}` : defaultAgentId
+                }.`
+              : "Pod default agent reset to the default (@dust).",
+          })
+        );
+      }, "Failed to set Pod default agent");
+    },
+
     [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
@@ -603,6 +686,18 @@ export function createProjectManagerTools(
           (e) => !e.isDirectory
         ).length;
 
+        let defaultAgent: { id: string; name: string | null } | null = null;
+        if (metadata?.defaultAgentId) {
+          const agent = await getAgentConfiguration(auth, {
+            agentId: metadata.defaultAgentId,
+            variant: "extra_light",
+          });
+          defaultAgent = {
+            id: metadata.defaultAgentId,
+            name: agent?.name ?? null,
+          };
+        }
+
         // Construct project URL
         const projectPath = getPodRoute(owner.sId, pod.sId);
         const projectUrl = `${config.getAppUrl()}${projectPath}`;
@@ -617,6 +712,7 @@ export function createProjectManagerTools(
               access: pod.isOpen() ? "open" : "restricted",
               description: metadata?.description ?? null,
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
+              defaultAgent,
               contentNodes,
               files: {
                 count: projectFileCount,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -28,12 +28,12 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import {
-  DEFAULT_AGENT_TOOL_NAME,
   EDIT_INFORMATION_TOOL_NAME,
   LIST_MEMBERS_TOOL_NAME,
   MOVE_CONVERSATION_TOOL_NAME,
   POD_MANAGER_TOOLS_METADATA,
   SEMANTIC_SEARCH_TOOL_NAME,
+  SET_DEFAULT_AGENT_TOOL_NAME,
   SET_PINNED_FRAME_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
@@ -414,11 +414,11 @@ export function createProjectManagerTools(
       }, "Failed to set Pod pinned frame");
     },
 
-    [DEFAULT_AGENT_TOOL_NAME]: async (params) => {
+    [SET_DEFAULT_AGENT_TOOL_NAME]: async ({ agentName, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
           toolContext,
-          dustPod: params.dustPod,
+          dustPod,
         });
         if (contextRes.isErr()) {
           return contextRes;
@@ -446,27 +446,34 @@ export function createProjectManagerTools(
         }
 
         // Resolve the agent by name. A null agentName clears the default so new
-        // conversations fall back to the workspace default / @dust.
+        // conversations fall back to the workspace default (Dust).
         let defaultAgentId: string | null = null;
         let defaultAgentName: string | null = null;
-        if (params.agentName !== null) {
+        if (agentName !== null) {
           const resolvedAgentId = await resolveAgentConfigurationIdByName(
             auth,
-            params.agentName
+            agentName
           );
           if (!resolvedAgentId) {
             return new Err(
-              new MCPError(`No agent found matching "${params.agentName}".`, {
+              new MCPError(`No agent found matching "${agentName}".`, {
+                tracked: false,
+              })
+            );
+          }
+          const agent = await getAgentConfiguration(auth, {
+            agentId: resolvedAgentId,
+            variant: "extra_light",
+          });
+          if (!agent) {
+            return new Err(
+              new MCPError(`No agent found matching "${agentName}".`, {
                 tracked: false,
               })
             );
           }
           defaultAgentId = resolvedAgentId;
-          const agent = await getAgentConfiguration(auth, {
-            agentId: resolvedAgentId,
-            variant: "extra_light",
-          });
-          defaultAgentName = agent?.name ?? null;
+          defaultAgentName = agent.name;
         }
 
         let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
@@ -486,7 +493,7 @@ export function createProjectManagerTools(
               ? `Pod default agent set to ${
                   defaultAgentName ? `@${defaultAgentName}` : defaultAgentId
                 }.`
-              : "Pod default agent reset to the default (@dust).",
+              : "Pod default agent reset to the default (Dust).",
           })
         );
       }, "Failed to set Pod default agent");

--- a/front/lib/api/actions/servers/pod_manager/types.ts
+++ b/front/lib/api/actions/servers/pod_manager/types.ts
@@ -29,6 +29,11 @@ export const PodManagerMoveConversationInputSchema = z.object({
   dustPod: DustPodConfigurationSchema.optional(),
 });
 
+export const PodManagerDefaultAgentInputSchema = z.object({
+  agentName: z.string().nullable(),
+  dustPod: DustPodConfigurationSchema.optional(),
+});
+
 export type PodMemberRole = z.infer<typeof PodMemberRoleSchema>;
 export type PodAccess = z.infer<typeof PodAccessSchema>;
 export type PodMembersToAdd = z.infer<typeof PodMembersToAddSchema>;
@@ -40,6 +45,9 @@ export type PodManagerEditInformationInput = z.infer<
 >;
 export type PodManagerMoveConversationInput = z.infer<
   typeof PodManagerMoveConversationInputSchema
+>;
+export type PodManagerDefaultAgentInput = z.infer<
+  typeof PodManagerDefaultAgentInputSchema
 >;
 
 export function isPodManagerUpdateMembersInput(
@@ -58,6 +66,12 @@ export function isPodManagerMoveConversationInput(
   input: Record<string, unknown>
 ): input is PodManagerMoveConversationInput {
   return PodManagerMoveConversationInputSchema.safeParse(input).success;
+}
+
+export function isPodManagerDefaultAgentInput(
+  input: Record<string, unknown>
+): input is PodManagerDefaultAgentInput {
+  return PodManagerDefaultAgentInputSchema.safeParse(input).success;
 }
 
 export function partitionMembersToAdd(membersToAdd: PodMembersToAdd): {


### PR DESCRIPTION
## Description
A bug fix for the pod default agent from this [conversation](https://app.dust.tt/w/0ec9852c2f/conversation/p2T9oKSa2a).

Added a `set_default_agent` tool to the `pod_manager` MCP server, letting an agent set or clear a Pod's default agent by name from within a conversation, and surfaced the current default in the server's `get_information` output. Also created a matching approval-card title so the tool call connecting to the MCP server shows a clear "set the Pod default agent" prompt.

Note: Only workspace published agents and global agents (dust, claude, gpt, etc) can be set from conversation. Unpublished agents must be set as default through the UI to prevent permissions leaks.

A similar fix for the pod default skills will be done in a stacked branch.

## Tests
Tested locally.

## Risk
Low risk.

## Deploy Plan
Deploy front. 