### PR TITLE
[front] refactor: simplify internal MCP tool metadata typing

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -108,6 +108,9 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 export const USE_SUMMARY_SWITCH = "useSummary";
@@ -243,7 +246,35 @@ export const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
-export const INTERNAL_MCP_SERVERS = {
+type HasUniqueNames<
+  T extends readonly { name: string }[],
+  Seen extends string = never,
+> = T extends readonly [
+  infer Head extends { name: string },
+  ...infer Tail extends readonly { name: string }[],
+]
+  ? Head["name"] extends Seen
+    ? false
+    : HasUniqueNames<Tail, Seen | Head["name"]>
+  : true;
+
+function ensureUniqueToolNames<
+  const T extends {
+    [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
+  },
+>(
+  servers: T & {
+    [K in InternalMCPServerNameType]: HasUniqueNames<
+      T[K]["metadata"]["tools"]
+    > extends true
+      ? unknown
+      : { __duplicateToolNames: never };
+  }
+): T {
+  return servers;
+}
+
+export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
 
@@ -1204,7 +1235,7 @@ export const INTERNAL_MCP_SERVERS = {
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {
   [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
-};
+});
 
 type IsRestrictedCallback = (params: {
   plan: PlanType;
@@ -1508,12 +1539,17 @@ export function matchesInternalMCPServerName(
   return false;
 }
 
-export function getInternalMCPServerMetadata<
-  N extends InternalMCPServerNameType,
->(name: N): (typeof INTERNAL_MCP_SERVERS)[N]["metadata"] {
-  const server = INTERNAL_MCP_SERVERS[name];
+export function getInternalMCPServerMetadata(name: InternalMCPServerNameType) {
+  const { serverInfo, tools }: ServerMetadata =
+    INTERNAL_MCP_SERVERS[name].metadata;
 
-  return server.metadata;
+  return {
+    serverInfo,
+    tools: tools.map(({ schema, ...tool }) => ({
+      ...tool,
+      inputSchema: zodToJsonSchema(z.object(schema)) as JSONSchema,
+    })),
+  };
 }
 
 const SENSITIVITY_LABEL_PROVIDER_BY_SERVER: Partial<

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -3,7 +3,10 @@ import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { ACTIVATION_RECOMMENDATIONS_SERVER } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
@@ -98,6 +101,7 @@ import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspa
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import type {
   InternalMCPServerDefinitionType,
+  MCPToolType,
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
@@ -1519,6 +1523,8 @@ export function getInternalMCPServerMetadata(name: InternalMCPServerNameType) {
     serverInfo,
     tools: tools.map(({ schema, ...tool }) => ({
       ...tool,
+      // For the input schema we store a zod schema on the tool metadata, it's what's easier to use in the code because
+      // we can infer a type from it, but tool specifications expect a JSON schema.
       inputSchema: zodToJsonSchema(z.object(schema)) as JSONSchema,
     })),
   };

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -3,7 +3,10 @@ import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ServerMetadata,
+  ToolMeta,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { ACTIVATION_RECOMMENDATIONS_SERVER } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
@@ -246,7 +249,41 @@ export const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
-export const INTERNAL_MCP_SERVERS = {
+type HasUniqueNames<Tools extends readonly ToolMeta[]> = {
+  // Loop over each item in the array.
+  [I in keyof Tools]: {
+    // Only check the "name" property.
+    [Key in keyof Tools[I]]: Key extends "name"
+      ? Tools[I][Key] extends {
+          // Build an array of all the other names.
+          [J in keyof Tools]: J extends I ? never : Tools[J];
+        }[number]["name"]
+        ? // The current name (Tools[I][Key]) matches another name: we error.
+          `ERROR: Duplicate tool name detected: ${Tools[I][Key] & string}`
+        : // No match, we just fall through.
+          Tools[I][Key]
+      : // Property other than the name: we just fall through as well.
+        Tools[I][Key];
+  };
+};
+
+function ensureUniqueToolNames<
+  const T extends {
+    [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
+  },
+>(
+  servers: T & {
+    [ServerName in InternalMCPServerNameType]: {
+      metadata: {
+        tools: HasUniqueNames<T[ServerName]["metadata"]["tools"]>;
+      };
+    };
+  }
+): T {
+  return servers;
+}
+
+export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
 
@@ -1207,7 +1244,7 @@ export const INTERNAL_MCP_SERVERS = {
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {
   [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
-};
+});
 
 type IsRestrictedCallback = (params: {
   plan: PlanType;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -3,10 +3,7 @@ import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { ACTIVATION_RECOMMENDATIONS_SERVER } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
@@ -101,7 +98,6 @@ import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspa
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import type {
   InternalMCPServerDefinitionType,
-  MCPToolType,
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -246,35 +246,7 @@ export const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
-type HasUniqueNames<
-  T extends readonly { name: string }[],
-  Seen extends string = never,
-> = T extends readonly [
-  infer Head extends { name: string },
-  ...infer Tail extends readonly { name: string }[],
-]
-  ? Head["name"] extends Seen
-    ? false
-    : HasUniqueNames<Tail, Seen | Head["name"]>
-  : true;
-
-function ensureUniqueToolNames<
-  const T extends {
-    [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
-  },
->(
-  servers: T & {
-    [K in InternalMCPServerNameType]: HasUniqueNames<
-      T[K]["metadata"]["tools"]
-    > extends true
-      ? unknown
-      : { __duplicateToolNames: never };
-  }
-): T {
-  return servers;
-}
-
-export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
+export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
 
@@ -1235,7 +1207,7 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {
   [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
-});
+};
 
 type IsRestrictedCallback = (params: {
   plan: PlanType;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -8,10 +8,7 @@ import {
   ConfigurableToolInputJSONSchemas,
   ConfigurableToolInputSchemas,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import {
-  EXTRACT_DATA_MAIN_TOOL_NAME,
-  makeExtractDataToolsMetadata,
-} from "@app/lib/api/actions/servers/extract_data/metadata";
+import { makeExtractDataToolsMetadata } from "@app/lib/api/actions/servers/extract_data/metadata";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { isJSONSchemaObject } from "@app/lib/utils/json_schemas";
@@ -1106,7 +1103,7 @@ describe("extract_data configured inputs", () => {
       isTimeFrameConfigured: true,
     });
     const inputSchema = zodToJsonSchema(
-      z.object(metadata[EXTRACT_DATA_MAIN_TOOL_NAME].schema)
+      z.object(metadata[0].schema)
     ) as JSONSchema;
 
     const hiddenSchema = hideInternalConfiguration(inputSchema);
@@ -1151,7 +1148,7 @@ describe("extract_data configured inputs", () => {
       isTimeFrameConfigured: false,
     });
     const inputSchema = zodToJsonSchema(
-      z.object(metadata[EXTRACT_DATA_MAIN_TOOL_NAME].schema)
+      z.object(metadata[0].schema)
     ) as JSONSchema;
 
     const hiddenSchema = hideInternalConfiguration(inputSchema);

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -3,7 +3,6 @@ import type { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolRunContext } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
-  MCPToolType,
   ToolCostCategory,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
@@ -27,9 +26,9 @@ export type ToolHandlerExtra = RequestHandlerExtra<
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
-export type ToolHandlers<T extends Record<string, { schema: ZodRawShape }>> = {
-  [K in keyof T]: (
-    params: z.infer<z.ZodObject<T[K]["schema"]>>,
+export type ToolHandlers<T extends readonly ToolMeta[]> = {
+  [Name in T[number]["name"]]: (
+    params: z.infer<z.ZodObject<Extract<T[number], { name: Name }>["schema"]>>,
     extra: ToolHandlerExtra
   ) => Promise<ToolHandlerResult>;
 };
@@ -93,14 +92,6 @@ export type ClientToolMeta<
   TSchema extends ZodRawShape = ZodRawShape,
 > = Omit<ClientToolDefinition<TName, TSchema>, "handler">;
 
-export function createToolsRecord<
-  T extends Record<string, Omit<ToolMeta, "name">>,
->(tools: T): { [K in keyof T]: T[K] & { name: K } } {
-  return Object.fromEntries(
-    Object.entries(tools).map(([key, value]) => [key, { ...value, name: key }])
-  ) as { [K in keyof T]: T[K] & { name: K } };
-}
-
 export function createClientToolsRecord<
   T extends {
     [K in keyof T]: T[K] extends { schema: infer S extends ZodRawShape }
@@ -129,28 +120,23 @@ export function buildClientTools<T extends Record<string, ClientToolMeta>>(
   );
 }
 
-export function buildTools<T extends Record<string, ToolMeta>>(
+export function buildTools<T extends readonly ToolMeta[]>(
   metadata: T,
   handlers: ToolHandlers<T>
 ): ToolDefinition[] {
-  return (Object.keys(metadata) as (keyof T & string)[]).map(
-    (key) =>
+  return metadata.map(
+    (tool) =>
       ({
-        ...metadata[key],
-        handler: handlers[key],
+        ...tool,
+        handler: handlers[tool.name as keyof ToolHandlers<T>],
       }) as unknown as ToolDefinition
   );
 }
 
 // Internal MCP server tools must have displayLabels (unlike remote servers).
-export type InternalMCPToolType = Omit<MCPToolType, "displayLabels"> & {
-  displayLabels: ToolDisplayLabels;
-  toolCostCategory: ToolCostCategory;
-  freeUsage: boolean;
-  stake: MCPToolStakeLevelType;
-};
+export type InternalMCPToolType = ToolMeta;
 
 export type ServerMetadata = {
   serverInfo: InternalMCPServerDefinitionType;
-  tools: InternalMCPToolType[];
+  tools: readonly InternalMCPToolType[];
 };

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -29,7 +29,9 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 export type ToolHandlers<T extends readonly ToolMeta[]> = {
   [ToolName in T[number]["name"]]: (
     // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
-    params: z.infer<z.ZodObject<Extract<T[number], { name: ToolName }>["schema"]>>,
+    params: z.infer<
+      z.ZodObject<Extract<T[number], { name: ToolName }>["schema"]>
+    >,
     extra: ToolHandlerExtra
   ) => Promise<ToolHandlerResult>;
 };

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -26,11 +26,11 @@ export type ToolHandlerExtra = RequestHandlerExtra<
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
-export type ToolHandlers<T extends readonly ToolMeta[]> = {
-  [ToolName in T[number]["name"]]: (
+export type ToolHandlers<ToolsList extends readonly ToolMeta[]> = {
+  [ToolName in ToolsList[number]["name"]]: (
     // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
     params: z.infer<
-      z.ZodObject<Extract<T[number], { name: ToolName }>["schema"]>
+      z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
     extra: ToolHandlerExtra
   ) => Promise<ToolHandlerResult>;

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -27,8 +27,9 @@ export type ToolHandlerExtra = RequestHandlerExtra<
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<T extends readonly ToolMeta[]> = {
-  [Name in T[number]["name"]]: (
-    params: z.infer<z.ZodObject<Extract<T[number], { name: Name }>["schema"]>>,
+  [ToolName in T[number]["name"]]: (
+    // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
+    params: z.infer<z.ZodObject<Extract<T[number], { name: ToolName }>["schema"]>>,
     extra: ToolHandlerExtra
   ) => Promise<ToolHandlerResult>;
 };

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -136,10 +136,7 @@ export function buildTools<T extends readonly ToolMeta[]>(
   );
 }
 
-// Internal MCP server tools must have displayLabels (unlike remote servers).
-export type InternalMCPToolType = ToolMeta;
-
 export type ServerMetadata = {
   serverInfo: InternalMCPServerDefinitionType;
-  tools: readonly InternalMCPToolType[];
+  tools: readonly ToolMeta[];
 };

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -40,7 +40,7 @@ const TEST_TOOLS_METADATA = [
     toolCostCategory: "basic" as const,
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 const handlers: ToolHandlers<typeof TEST_TOOLS_METADATA> = {
   guarded_tool: async (_params, { auth }) => {

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -1,8 +1,8 @@
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   buildTools,
-  createToolsRecord,
+  type InternalMCPToolType,
+  type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -21,8 +21,9 @@ import { describe, expect, it } from "vitest";
 // Two artificial tools to exercise the guard's behaviour through the real MCP
 // stack, decoupled from any feature tool: one wraps workspaceAdminGuard, the
 // other (control) does not.
-const TEST_TOOLS_METADATA = createToolsRecord({
-  guarded_tool: {
+const TEST_TOOLS_METADATA = [
+  {
+    name: "guarded_tool",
     description: "Admin-guarded test tool.",
     schema: {},
     stake: "never_ask",
@@ -30,7 +31,8 @@ const TEST_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic" as const,
     freeUsage: false,
   },
-  open_tool: {
+  {
+    name: "open_tool",
     description: "Unguarded test tool.",
     schema: {},
     stake: "never_ask",
@@ -38,7 +40,7 @@ const TEST_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic" as const,
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 const handlers: ToolHandlers<typeof TEST_TOOLS_METADATA> = {
   guarded_tool: async (_params, { auth }) => {

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -1,7 +1,6 @@
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import {
   buildTools,
-  type InternalMCPToolType,
   type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -83,7 +83,7 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
       done: "Recommendation history fetched",
     },
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const ACTIVATION_RECOMMENDATIONS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const ACTIVATION_RECOMMENDATIONS_SERVER_NAME =

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -1,14 +1,15 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const ACTIVATION_RECOMMENDATIONS_SERVER_NAME =
   "activation_recommendations" as const;
 
-export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
-  create_recommendation: {
+export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
+  {
+    name: "create_recommendation",
     description:
       "Record a new activation recommendation that was shown to the user. " +
       "Call this immediately after surfacing a recommendation so it is tracked. " +
@@ -33,7 +34,8 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
       done: "Recommendation recorded",
     },
   },
-  update_recommendation: {
+  {
+    name: "update_recommendation",
     description:
       "Update an activation recommendation's status or link created artifacts to it. " +
       "Use status 'executed' when the user accepts and runs the recommendation, " +
@@ -66,7 +68,8 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
       done: "Recommendation updated",
     },
   },
-  list_recommendations: {
+  {
+    name: "list_recommendations",
     description:
       "List past activation recommendations for this user. " +
       "Call before generating a new recommendation to avoid repeating suggestions " +
@@ -80,7 +83,7 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = createToolsRecord({
       done: "Recommendation history fetched",
     },
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const ACTIVATION_RECOMMENDATIONS_SERVER = {
   serverInfo: {
@@ -92,13 +95,5 @@ export const ACTIVATION_RECOMMENDATIONS_SERVER = {
     icon: "ActionBrainIcon",
     documentationUrl: null,
   },
-  tools: Object.values(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const AGENT_MEMORY_SERVER_NAME = "agent_memory" as const;
 export const AGENT_MEMORY_RETRIEVE_TOOL_NAME = "retrieve";
@@ -11,8 +11,9 @@ export const AGENT_MEMORY_ERASE_TOOL_NAME = "erase_entries";
 export const AGENT_MEMORY_EDIT_TOOL_NAME = "edit_entries";
 export const AGENT_MEMORY_COMPACT_TOOL_NAME = "compact_memory";
 
-export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
-  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: {
+export const AGENT_MEMORY_TOOLS_METADATA = [
+  {
+    name: AGENT_MEMORY_RETRIEVE_TOOL_NAME,
     description:
       "Read and recall the current user's saved agent memory: what the agent remembers about them, including preferences, facts, notes, and prior context.",
     schema: {},
@@ -24,7 +25,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [AGENT_MEMORY_RECORD_TOOL_NAME]: {
+  {
+    name: AGENT_MEMORY_RECORD_TOOL_NAME,
     description:
       "Save or remember new user memory entries, such as preferences, facts, instructions, or notes to use later.",
     schema: {
@@ -42,7 +44,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [AGENT_MEMORY_ERASE_TOOL_NAME]: {
+  {
+    name: AGENT_MEMORY_ERASE_TOOL_NAME,
     description:
       "Forget, delete, or remove existing memory entries, obsolete facts, preferences, or outdated memories.",
     schema: {
@@ -60,7 +63,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [AGENT_MEMORY_EDIT_TOOL_NAME]: {
+  {
+    name: AGENT_MEMORY_EDIT_TOOL_NAME,
     description:
       "Change, update, correct, or rewrite existing memory entries by displayed index. Use when a saved memory should say something different.",
     schema: {
@@ -85,7 +89,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [AGENT_MEMORY_COMPACT_TOOL_NAME]: {
+  {
+    name: AGENT_MEMORY_COMPACT_TOOL_NAME,
     description:
       "Compact, deduplicate, and summarize memory by merging duplicate memories or shortening long memory entries.",
     schema: {
@@ -114,7 +119,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const AGENT_MEMORY_SERVER = {
   serverInfo: {
@@ -125,13 +130,5 @@ export const AGENT_MEMORY_SERVER = {
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
   },
-  tools: Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: AGENT_MEMORY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const AGENT_MEMORY_SERVER_NAME = "agent_memory" as const;

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -119,7 +119,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const AGENT_MEMORY_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const AGENT_ROUTER_SERVER_NAME = "agent_router" as const;

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -49,7 +49,7 @@ export const AGENT_ROUTER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const AGENT_ROUTER_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const AGENT_ROUTER_SERVER_NAME = "agent_router" as const;
 export const AGENT_ROUTER_ACTION_DESCRIPTION =
@@ -10,8 +10,9 @@ export const AGENT_ROUTER_ACTION_DESCRIPTION =
 
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content" as const;
 
-export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
-  list_all_published_agents: {
+export const AGENT_ROUTER_TOOLS_METADATA = [
+  {
+    name: "list_all_published_agents",
     description:
       "Return a complete list of all agents accessible to the user in the workspace, " +
       "including their personal (unpublished) agents. " +
@@ -27,7 +28,8 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_agents_for_content: {
+  {
+    name: "suggest_agents_for_content",
     description:
       "Analyze a user query and return relevant specialized agents that might be better " +
       "suited to handling specific requests. The tool uses semantic matching to find agents " +
@@ -47,7 +49,7 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const AGENT_ROUTER_SERVER = {
   serverInfo: {
@@ -58,13 +60,5 @@ export const AGENT_ROUTER_SERVER = {
     icon: "ActionRobotIcon",
     documentationUrl: null,
   },
-  tools: Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: AGENT_ROUTER_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
 export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = [
   {

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -1,11 +1,11 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
-  get_agent_info: {
+export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = [
+  {
+    name: "get_agent_info",
     description:
       "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
     schema: {},
@@ -17,7 +17,7 @@ export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
   serverInfo: {
@@ -29,13 +29,5 @@ export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
     icon: "ActionRobotIcon",
     documentationUrl: null,
   },
-  tools: Object.values(AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -17,7 +17,7 @@ export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const AGENT_SIDEKICK_AGENT_STATE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
   MAX_PENDING_KNOWLEDGE_SUGGESTIONS,
@@ -18,9 +20,7 @@ import {
   AGENT_SUGGESTION_STATES,
   INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
 } from "@app/types/suggestions/agent_suggestion";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const AGENT_SIDEKICK_CONTEXT_TOOL_NAME =
   "agent_sidekick_context" as const;
@@ -104,8 +104,9 @@ const ModelSuggestionSchema = z.object({
     .describe("Optional reasoning effort level"),
 });
 
-export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
-  get_available_models: {
+export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = [
+  {
+    name: "get_available_models",
     description:
       "Get the list of available models. Can optionally filter by provider.",
     schema: {
@@ -125,7 +126,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_available_skills: {
+  {
+    name: "get_available_skills",
     description:
       "Get the list of available skills that can be added to agents. Returns skills accessible to the current user across all spaces they have access to.",
     schema: {},
@@ -138,7 +140,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_available_tools: {
+  {
+    name: "get_available_tools",
     description:
       "Get the list of available tools (MCP servers) that can be added to agents. Returns tools accessible to the current user.",
     schema: {},
@@ -151,7 +154,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [DESCRIBE_MCP_TOOL_NAME]: {
+  {
+    name: DESCRIBE_MCP_TOOL_NAME,
     description:
       "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters.",
     schema: {
@@ -166,7 +170,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [DESCRIBE_SKILL_TOOL_NAME]: {
+  {
+    name: DESCRIBE_SKILL_TOOL_NAME,
     description:
       "Get detailed information about a skill: its name, description, instructions, and configured tools.",
     schema: {
@@ -181,7 +186,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_available_agents: {
+  {
+    name: "get_available_agents",
     description:
       "Get the list of available agents that can be used as sub-agents. Returns active agents accessible to the current user, excluding global agents.",
     schema: {
@@ -206,7 +212,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  inspect_available_agent: {
+  {
+    name: "inspect_available_agent",
     description:
       "Get detailed information about a specific agent by its ID. Returns the agent's name, description, prompt/instructions, list of tool IDs, and list of skill IDs.",
     schema: {
@@ -221,7 +228,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_agent_feedback: {
+  {
+    name: "get_agent_feedback",
     description: "Get user feedback for the agent.",
     schema: {
       limit: z
@@ -253,7 +261,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_agent_insights: {
+  {
+    name: "get_agent_insights",
     description:
       "Get insight and analytics data for the agent, including the number of active users, " +
       "the conversation and message counts, and the feedback statistics.",
@@ -274,7 +283,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
   // Suggestion tools
-  suggest_prompt_edits: {
+  {
+    name: "suggest_prompt_edits",
     description:
       "Create suggestions to modify the agent's instructions/prompt using block-based targeting. " +
       "The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). " +
@@ -299,7 +309,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_tools: {
+  {
+    name: "suggest_tools",
     description:
       "Suggest adding or removing tools from the agent's configuration. " +
       "This tool does not support sub_agent suggestions - use `suggest_sub_agent` instead for that purpose. " +
@@ -329,7 +340,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_sub_agent: {
+  {
+    name: "suggest_sub_agent",
     description:
       "Suggest adding or removing a sub-agent from the agent's configuration. A sub-agent allows the main agent to delegate tasks to a child agent. " +
       "If a pending suggestion for the same sub-agent already exists, it will be automatically marked as outdated. " +
@@ -358,7 +370,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_skills: {
+  {
+    name: "suggest_skills",
     description:
       "Suggest adding or removing skills from the agent's configuration. " +
       "If a pending suggestion for the same skill already exists, it will be automatically marked as outdated. " +
@@ -387,7 +400,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_model: {
+  {
+    name: "suggest_model",
     description:
       "Suggest changing the agent's LLM model configuration. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
     schema: {
@@ -408,7 +422,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  search_knowledge: {
+  {
+    name: "search_knowledge",
     description:
       "Browse or search workspace knowledge sources. " +
       "Without a query: lists all available data source views. " +
@@ -446,7 +461,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  suggest_knowledge: {
+  {
+    name: "suggest_knowledge",
     description:
       "Suggest adding or removing knowledge. Get sources from \`search_knowledge\` (call without a query to list all); each source has a knowledgeMethod field — use that as the method here. " +
       "method 'search': semantic search over documents, folders, websites. method 'query_tables': SQL over Snowflake/BigQuery warehouses. " +
@@ -471,7 +487,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  list_suggestions: {
+  {
+    name: "list_suggestions",
     description:
       "List existing suggestions for the agent's configuration changes.",
     schema: {
@@ -506,7 +523,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  update_suggestions_state: {
+  {
+    name: "update_suggestions_state",
     description:
       "Update the state of one or more suggestions. Use this to reject or mark suggestions as outdated.",
     schema: {
@@ -534,7 +552,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  inspect_conversation: {
+  {
+    name: "inspect_conversation",
     description:
       "Inspect a conversation to get its shape and summary. Returns the conversation title, " +
       "a timeline of messages with user messages (content and mentions) and agent messages " +
@@ -561,7 +580,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  inspect_message: {
+  {
+    name: "inspect_message",
     description:
       "Inspect a specific message in a conversation. Returns detailed information about " +
       "a user message (content, mentions, context, content fragments) or an agent message " +
@@ -579,7 +599,7 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const AGENT_SIDEKICK_CONTEXT_SERVER = {
   serverInfo: {
@@ -591,13 +611,5 @@ export const AGENT_SIDEKICK_CONTEXT_SERVER = {
     icon: "ActionRobotIcon",
     documentationUrl: null,
   },
-  tools: Object.values(AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -599,7 +599,7 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const AGENT_SIDEKICK_CONTEXT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
   MAX_PENDING_KNOWLEDGE_SUGGESTIONS,

--- a/front/lib/api/actions/servers/agent_templates/metadata.ts
+++ b/front/lib/api/actions/servers/agent_templates/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const AGENT_TEMPLATES_SERVER_NAME = "agent_templates" as const;
 
-export const AGENT_TEMPLATES_TOOLS_METADATA = createToolsRecord({
-  search_agent_templates: {
+export const AGENT_TEMPLATES_TOOLS_METADATA = [
+  {
+    name: "search_agent_templates",
     description:
       "Search published agent templates. Use jobType for tag-based filtering or query for semantic search. Returns template details including instructions.",
     schema: {
@@ -32,7 +33,8 @@ export const AGENT_TEMPLATES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_agent_template: {
+  {
+    name: "get_agent_template",
     description:
       "Fetch the full details of an agent template by id, including its instructions and guidance.",
     schema: {
@@ -46,7 +48,7 @@ export const AGENT_TEMPLATES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const AGENT_TEMPLATES_SERVER = {
   serverInfo: {
@@ -57,13 +59,5 @@ export const AGENT_TEMPLATES_SERVER = {
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
   },
-  tools: Object.values(AGENT_TEMPLATES_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: AGENT_TEMPLATES_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_templates/metadata.ts
+++ b/front/lib/api/actions/servers/agent_templates/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const AGENT_TEMPLATES_SERVER_NAME = "agent_templates" as const;

--- a/front/lib/api/actions/servers/agent_templates/metadata.ts
+++ b/front/lib/api/actions/servers/agent_templates/metadata.ts
@@ -48,7 +48,7 @@ export const AGENT_TEMPLATES_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const AGENT_TEMPLATES_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -269,7 +269,7 @@ export const ASHBY_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const ASHBY_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -1,9 +1,9 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AshbyCreateReferralInputSchema } from "@app/lib/api/actions/servers/ashby/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const DEFAULT_SEARCH_LIMIT = 20;
 export const GET_REFERRAL_FORM_TOOL_NAME = "get_referral_form";
@@ -21,8 +21,9 @@ const CandidateSearchSchema = {
     .describe("Name to search for (partial matches supported)."),
 };
 
-export const ASHBY_TOOLS_METADATA = createToolsRecord({
-  search_candidates: {
+export const ASHBY_TOOLS_METADATA = [
+  {
+    name: "search_candidates",
     description:
       "Find, search, and look up candidates in Ashby by name and/or email. " +
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
@@ -35,7 +36,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_report_data: {
+  {
+    name: "get_report_data",
     description: "Retrieve report data and save it as a CSV file.",
     schema: {
       reportUrl: z
@@ -52,7 +54,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_interview_feedback: {
+  {
+    name: "get_interview_feedback",
     description:
       "Retrieve interview feedback for a candidate. " +
       "This tool will search for the candidate by name or email and return all submitted " +
@@ -66,7 +69,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_candidate_notes: {
+  {
+    name: "get_candidate_notes",
     description:
       "Retrieve and read all existing notes recorded on a candidate's profile in Ashby. " +
       "Searches for the candidate by name or email and returns every note already on their profile.",
@@ -79,7 +83,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_openings: {
+  {
+    name: "list_openings",
     description:
       "List openings in Ashby. Returns a paginated page of openings with " +
       "their state, archive status, latest version details, linked jobs, " +
@@ -110,7 +115,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_candidate_note: {
+  {
+    name: "create_candidate_note",
     description:
       "Create and add a new note to a candidate's profile in Ashby. " +
       "The note content can include basic HTML formatting (supported tags: h1-h6, p, b, i, u, a, ul, ol, li, code, pre).",
@@ -128,7 +134,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [GET_REFERRAL_FORM_TOOL_NAME]: {
+  {
+    name: GET_REFERRAL_FORM_TOOL_NAME,
     description:
       "Retrieve the referral form definition from Ashby. " +
       "Returns all form fields with their titles, types, and whether they are required. " +
@@ -142,7 +149,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [CREATE_REFERRAL_TOOL_NAME]: {
+  {
+    name: CREATE_REFERRAL_TOOL_NAME,
     description:
       "Create a referral for a candidate in Ashby. " +
       `You must call ${GET_REFERRAL_FORM_TOOL_NAME} first to know the available fields. ` +
@@ -158,7 +166,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_job_postings: {
+  {
+    name: "list_job_postings",
     description:
       "List all published job postings in Ashby. " +
       "Returns job postings with their title, department, team, location, " +
@@ -190,7 +199,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_hire_data: {
+  {
+    name: "get_hire_data",
     description:
       "Retrieve comprehensive data for a hired candidate, including candidate details, " +
       "offer form fields (both standard and custom), job information, and application data. " +
@@ -207,7 +217,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_job_posting: {
+  {
+    name: "update_job_posting",
     description:
       "Update an existing job posting in Ashby. " +
       "You can update the title, description, and/or workplace type. " +
@@ -258,7 +269,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const ASHBY_SERVER = {
   serverInfo: {
@@ -270,13 +281,5 @@ export const ASHBY_SERVER = {
     icon: "AshbyLogo",
     documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",
   },
-  tools: Object.values(ASHBY_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ASHBY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AshbyCreateReferralInputSchema } from "@app/lib/api/actions/servers/ashby/types";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { UserQuestionSchema } from "@app/lib/actions/types";
 
 export const ASK_USER_QUESTION_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -42,7 +42,7 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const ASK_USER_QUESTION_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -1,12 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { UserQuestionSchema } from "@app/lib/actions/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
-  ask_user_question: {
+export const ASK_USER_QUESTION_TOOLS_METADATA = [
+  {
+    name: "ask_user_question",
     description:
       "Ask the user a question during execution.\n\n" +
       "This tool can serve multiple purposes:\n" +
@@ -42,7 +42,7 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const ASK_USER_QUESTION_SERVER = {
   serverInfo: {
@@ -53,13 +53,5 @@ export const ASK_USER_QUESTION_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ASK_USER_QUESTION_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
@@ -1,3 +1,4 @@
+import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby";
 import type { ServerEntry } from "@app/lib/api/actions/servers/bm25";
@@ -74,14 +75,14 @@ export interface LabeledQuery {
   maxRank?: number;
 }
 
-const RUN_AGENT_SAMPLE_TOOL_SCHEMA = zodToJsonSchema(
-  z.object({
-    ...RUN_AGENT_TOOL_SCHEMA,
-    ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
-  })
-) as JSONSchema7;
+const RUN_AGENT_SAMPLE_TOOL_SCHEMA = {
+  ...RUN_AGENT_TOOL_SCHEMA,
+  ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
+};
 
-const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
+type ToolSource = Pick<InternalMCPToolType, "name" | "description" | "schema">;
+
+const RUN_AGENT_SAMPLE_TOOLS = [
   {
     name: "run_ResearchAnalyst",
     description: getRunAgentToolDescription({
@@ -90,7 +91,7 @@ const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
       childAgentDescription:
         "Competitive market and customer research specialist for pricing, positioning, and source gathering.",
     }),
-    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+    schema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
   },
   {
     name: "run_SupportTriage",
@@ -100,7 +101,7 @@ const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
       childAgentDescription:
         "Customer support specialist that investigates tickets, refunds, escalations, and account issues.",
     }),
-    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+    schema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
   },
   {
     name: "run_CodeReviewer",
@@ -110,11 +111,14 @@ const RUN_AGENT_SAMPLE_TOOLS: ServerEntry["tools"] = [
       childAgentDescription:
         "Engineering reviewer for pull requests, regressions, implementation risks, and test coverage.",
     }),
-    inputSchema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
+    schema: RUN_AGENT_SAMPLE_TOOL_SCHEMA,
   },
-];
+] as const satisfies readonly ToolSource[];
 
-export const SERVERS: ServerEntry[] = [
+const SERVER_SOURCES: Array<{
+  name: string;
+  tools: readonly ToolSource[];
+}> = [
   { name: "agent_memory", tools: AGENT_MEMORY_SERVER.tools },
   { name: "conversation_files", tools: CONVERSATION_FILES_SERVER.tools },
   { name: "google_drive", tools: GOOGLE_DRIVE_SERVER.tools },
@@ -195,3 +199,12 @@ export const SERVERS: ServerEntry[] = [
     tools: DATA_SOURCES_FILE_SYSTEM_SERVER.tools,
   },
 ];
+
+export const SERVERS: ServerEntry[] = SERVER_SOURCES.map(({ name, tools }) => ({
+  name,
+  tools: tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: zodToJsonSchema(z.object(tool.schema)) as JSONSchema7,
+  })),
+}));

--- a/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
@@ -1,4 +1,4 @@
-import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolMeta } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby";
 import type { ServerEntry } from "@app/lib/api/actions/servers/bm25";
@@ -80,7 +80,7 @@ const RUN_AGENT_SAMPLE_TOOL_SCHEMA = {
   ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
 };
 
-type ToolSource = Pick<InternalMCPToolType, "name" | "description" | "schema">;
+type ToolSource = Pick<ToolMeta, "name" | "description" | "schema">;
 
 const RUN_AGENT_SAMPLE_TOOLS = [
   {

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const CLARI_COPILOT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -88,7 +88,7 @@ export const CLARI_COPILOT_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const CLARI_COPILOT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
-  search_calls: {
+export const CLARI_COPILOT_TOOLS_METADATA = [
+  {
+    name: "search_calls",
     description:
       "Search and list Clari Copilot sales calls, filtering by account or company " +
       "name, participant email, or date range. " +
@@ -58,7 +59,8 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_call_details: {
+  {
+    name: "get_call_details",
     description:
       "Retrieve details for a specific Clari Copilot call, including the AI summary, " +
       "topics discussed, action items, competitor mentions, and the turn-by-turn transcript. " +
@@ -86,7 +88,7 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const CLARI_COPILOT_SERVER = {
   serverInfo: {
@@ -98,13 +100,5 @@ export const CLARI_COPILOT_SERVER = {
     icon: "ClariLogo",
     documentationUrl: null,
   },
-  tools: Object.values(CLARI_COPILOT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: CLARI_COPILOT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const COMMON_UTILITIES_SERVER_NAME = "common_utilities" as const;

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const COMMON_UTILITIES_SERVER_NAME = "common_utilities" as const;
 export const SET_CONVERSATION_TITLE_TOOL_NAME =
@@ -11,8 +11,9 @@ export const SET_CONVERSATION_TITLE_TOOL_NAME =
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
 const MAX_WAIT_DURATION_MS = 3 * 60 * 1_000;
 
-export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
-  generate_random_number: {
+export const COMMON_UTILITIES_TOOLS_METADATA = [
+  {
+    name: "generate_random_number",
     description:
       "Generate a random integer (whole number) between 1 and the provided maximum (inclusive). Pick a random number in a range.",
     schema: {
@@ -33,7 +34,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  generate_random_float: {
+  {
+    name: "generate_random_float",
     description:
       "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
     schema: {},
@@ -45,7 +47,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  wait: {
+  {
+    name: "wait",
     description: `Pause execution for the provided number of milliseconds (maximum ${MAX_WAIT_DURATION_MS}).`,
     schema: {
       duration_ms: z
@@ -66,7 +69,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_current_time: {
+  {
+    name: "get_current_time",
     description:
       "Return the current date and time in multiple convenient formats.",
     schema: {
@@ -87,7 +91,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  math_operation: {
+  {
+    name: "math_operation",
     description:
       "Calculate the result of a math expression: arithmetic, percentages, and other mathematical operations.",
     schema: {
@@ -103,7 +108,8 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [SET_CONVERSATION_TITLE_TOOL_NAME]: {
+  {
+    name: SET_CONVERSATION_TITLE_TOOL_NAME,
     description:
       "Update the title of the current conversation. Use this to give the conversation a descriptive name that summarizes its topic.",
     schema: {
@@ -120,7 +126,7 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const COMMON_UTILITIES_SERVER = {
   serverInfo: {
@@ -131,13 +137,5 @@ export const COMMON_UTILITIES_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: COMMON_UTILITIES_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -126,7 +126,7 @@ export const COMMON_UTILITIES_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const COMMON_UTILITIES_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const CONFLUENCE_TOOL_NAME = "confluence" as const;

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const CONFLUENCE_TOOL_NAME = "confluence" as const;
 
-export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
-  get_current_user: {
+export const CONFLUENCE_TOOLS_METADATA = [
+  {
+    name: "get_current_user",
     description:
       "Get the currently authenticated Confluence user: who you are, your own account ID, display name, and email.",
     schema: {},
@@ -19,7 +20,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_spaces: {
+  {
+    name: "get_spaces",
     description:
       "Get a list of Confluence spaces. Returns a list of spaces with their IDs, keys, names, types, and statuses.",
     schema: {},
@@ -31,7 +33,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_pages: {
+  {
+    name: "get_pages",
     description:
       "Search Confluence to find and locate pages across spaces by keyword, title, label, or space, using CQL (Confluence Query Language). Use this to find a page when you only know its title or topic and not its ID. Only returns page objects. " +
       "Text matching operators: '~' contains, '!~' not contains, '=' exact match. " +
@@ -60,7 +63,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_page: {
+  {
+    name: "get_page",
     description:
       "Retrieve and read a single Confluence page by its ID, returning its metadata and body content. Use this when you already know the page ID.",
     schema: {
@@ -81,7 +85,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_page: {
+  {
+    name: "create_page",
     description:
       "Create a new Confluence page in a space, optionally nested under a parent page.",
     schema: {
@@ -118,7 +123,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_page: {
+  {
+    name: "update_page",
     description:
       "Update an existing Confluence page. You can update the title, content, status, space, or parent. The version number must be incremented from the current version.",
     schema: {
@@ -169,7 +175,7 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const CONFLUENCE_SERVER = {
   serverInfo: {
@@ -183,13 +189,5 @@ export const CONFLUENCE_SERVER = {
     icon: "ConfluenceLogo",
     documentationUrl: "https://docs.dust.tt/docs/confluence-tool",
   },
-  tools: Object.values(CONFLUENCE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: CONFLUENCE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -175,7 +175,7 @@ export const CONFLUENCE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const CONFLUENCE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -102,7 +102,7 @@ export const CONVERSATION_FILES_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // In file-system mode, regular files are accessed via the `files` MCP server. This server is
 // narrowed to listing the attachments that don't live on the file mount: content nodes
@@ -126,7 +126,7 @@ export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM = [
     freeUsage: true,
   },
   { name: CONVERSATION_CAT_FILE_ACTION_NAME, ...CAT_FILE_TOOL },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Union of the legacy and file-system-mode metadata. The runtime picks one or the other based on
 // the conversation's `useFileSystem` flag, but the static server descriptor surfaces every tool
@@ -134,7 +134,7 @@ export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM = [
 const ALL_CONVERSATION_FILES_TOOLS = [
   ...CONVERSATION_FILES_TOOLS_METADATA,
   CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM[0],
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const CONVERSATION_FILES_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { z } from "zod";

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -1,10 +1,10 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const CONVERSATION_FILES_SERVER_NAME = "conversation_files" as const;
 // Legacy listing action (pre file-system mode). Lists every attachment in the conversation.
@@ -64,8 +64,9 @@ const CAT_FILE_TOOL = {
   freeUsage: false,
 };
 
-export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
-  [CONVERSATION_LIST_FILES_ACTION_NAME]: {
+export const CONVERSATION_FILES_TOOLS_METADATA = [
+  {
+    name: CONVERSATION_LIST_FILES_ACTION_NAME,
     description:
       "List all files attached to the current conversation, including " +
       "available conversation file attachments, fileIds, titles, and " +
@@ -79,8 +80,9 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
-  [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
+  { name: CONVERSATION_CAT_FILE_ACTION_NAME, ...CAT_FILE_TOOL },
+  {
+    name: CONVERSATION_SEARCH_FILES_ACTION_NAME,
     description:
       "Search conversation files and content nodes semantically to find " +
       "relevant passages by meaning-based topic, concept, or terms.",
@@ -100,39 +102,39 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // In file-system mode, regular files are accessed via the `files` MCP server. This server is
 // narrowed to listing the attachments that don't live on the file mount: content nodes
 // (Notion pages, Slack threads, etc.) and queryable tables. The `cat` tool is kept so agents
 // can read content node attachments.
-export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM =
-  createToolsRecord({
-    [CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME]: {
-      description:
-        "List content-node references (for example Notion pages and Slack " +
-        "threads) and queryable tables available " +
-        "in the current conversation. Regular files are not listed here; " +
-        `they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
-      schema: {},
-      stake: "never_ask",
-      displayLabels: {
-        running: "Listing conversation attachments",
-        done: "List conversation attachments",
-      },
-      toolCostCategory: "basic",
-      freeUsage: true,
+export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM = [
+  {
+    name: CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME,
+    description:
+      "List content-node references (for example Notion pages and Slack " +
+      "threads) and queryable tables available " +
+      "in the current conversation. Regular files are not listed here; " +
+      `they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing conversation attachments",
+      done: "List conversation attachments",
     },
-    [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
-  });
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  { name: CONVERSATION_CAT_FILE_ACTION_NAME, ...CAT_FILE_TOOL },
+] as const satisfies readonly InternalMCPToolType[];
 
 // Union of the legacy and file-system-mode metadata. The runtime picks one or the other based on
 // the conversation's `useFileSystem` flag, but the static server descriptor surfaces every tool
 // name this server can register so UI discovery and monitoring labels cover both modes.
 const ALL_CONVERSATION_FILES_TOOLS = [
-  ...Object.values(CONVERSATION_FILES_TOOLS_METADATA),
-  ...Object.values(CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM),
-];
+  ...CONVERSATION_FILES_TOOLS_METADATA,
+  CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM[0],
+] as const satisfies readonly InternalMCPToolType[];
 
 export const CONVERSATION_FILES_SERVER = {
   serverInfo: {
@@ -145,13 +147,5 @@ export const CONVERSATION_FILES_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: ALL_CONVERSATION_FILES_TOOLS.map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ALL_CONVERSATION_FILES_TOOLS,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -110,7 +110,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = [
     freeUsage: false,
     enableAlerting: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 const [
   dataSourceFilesystemCatTool,
@@ -163,7 +163,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA = [
     freeUsage: false,
     enableAlerting: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   DataSourceFilesystemCatInputSchema,
   DataSourceFilesystemFindInputSchema,
@@ -12,9 +14,6 @@ import {
   FIND_TAGS_BASE_DESCRIPTION,
   findTagsSchema,
 } from "@app/lib/api/actions/tools/find_tags/metadata";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const FIND_TAGS_TOOL_NAME = "find_tags";
 export const FILESYSTEM_SEARCH_TOOL_NAME = "semantic_search";
@@ -23,8 +22,9 @@ export const FILESYSTEM_FIND_TOOL_NAME = "find";
 export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
 export const FILESYSTEM_LIST_TOOL_NAME = "list";
 
-export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
-  [FILESYSTEM_CAT_TOOL_NAME]: {
+export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = [
+  {
+    name: FILESYSTEM_CAT_TOOL_NAME,
     description:
       "Read the full text content of a connected data source document or page by its nodeId (like 'cat' in Unix). " +
       `Use to open, view, or read a specific data source file after locating it via '${FILESYSTEM_FIND_TOOL_NAME}', '${FILESYSTEM_LIST_TOOL_NAME}', or '${FILESYSTEM_SEARCH_TOOL_NAME}'. ` +
@@ -41,7 +41,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-  [FILESYSTEM_LIST_TOOL_NAME]: {
+  {
+    name: FILESYSTEM_LIST_TOOL_NAME,
     description:
       "Browse or explore the direct contents of a folder, section, or container node (like 'ls' in Unix). " +
       "Use to navigate the data source structure, see what documents or sub-folders are available, " +
@@ -57,7 +58,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-  [FILESYSTEM_SEARCH_TOOL_NAME]: {
+  {
+    name: FILESYSTEM_SEARCH_TOOL_NAME,
     description:
       "Search semantically for information, documents, or content by topic, concept, or meaning within a connected data source. " +
       "Use to find relevant passages, answer questions, look up knowledge, or retrieve content from " +
@@ -74,7 +76,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-  [FILESYSTEM_FIND_TOOL_NAME]: {
+  {
+    name: FILESYSTEM_FIND_TOOL_NAME,
     description:
       "Locate a document, page, or folder by searching its title (like 'find' in Unix). " +
       "Use to find a specific file or wiki page by name when you know (part of) its title — partial matches are supported. " +
@@ -90,7 +93,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-  [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]: {
+  {
+    name: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
     description:
       "Show the full breadcrumb path from a node back to the root of the data source (like 'pwd' in Unix). " +
       "Use to understand where a document lives in the folder hierarchy, navigate to parent sections, " +
@@ -106,46 +110,60 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
+
+const [
+  dataSourceFilesystemCatTool,
+  dataSourceFilesystemListTool,
+  dataSourceFilesystemSearchTool,
+  dataSourceFilesystemFindTool,
+  dataSourceFilesystemLocateInTreeTool,
+] = DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA;
 
 // Tool metadata with tags support for search and find tools
-export const DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA =
-  createToolsRecord({
-    [FILESYSTEM_CAT_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_CAT_TOOL_NAME],
-    [FILESYSTEM_LIST_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_LIST_TOOL_NAME],
-    [FILESYSTEM_SEARCH_TOOL_NAME]: {
-      ...DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_SEARCH_TOOL_NAME],
-      schema: {
-        ...SearchWithNodesInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
+export const DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA = [
+  {
+    ...dataSourceFilesystemCatTool,
+    name: FILESYSTEM_CAT_TOOL_NAME,
+  },
+  {
+    ...dataSourceFilesystemListTool,
+    name: FILESYSTEM_LIST_TOOL_NAME,
+  },
+  {
+    ...dataSourceFilesystemSearchTool,
+    name: FILESYSTEM_SEARCH_TOOL_NAME,
+    schema: {
+      ...SearchWithNodesInputSchema.shape,
+      ...TagsInputSchema.shape,
     },
-    [FILESYSTEM_FIND_TOOL_NAME]: {
-      ...DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_FIND_TOOL_NAME],
-      schema: {
-        ...DataSourceFilesystemFindInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
+  },
+  {
+    ...dataSourceFilesystemFindTool,
+    name: FILESYSTEM_FIND_TOOL_NAME,
+    schema: {
+      ...DataSourceFilesystemFindInputSchema.shape,
+      ...TagsInputSchema.shape,
     },
-    [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[
-        FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME
-      ],
-    [FIND_TAGS_TOOL_NAME]: {
-      description: FIND_TAGS_BASE_DESCRIPTION,
-      schema: findTagsSchema,
-      stake: "never_ask",
-      displayLabels: {
-        running: "Finding tags",
-        done: "Find tags",
-      },
-      toolCostCategory: "advanced",
-      freeUsage: false,
-      enableAlerting: true,
+  },
+  {
+    ...dataSourceFilesystemLocateInTreeTool,
+    name: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+  },
+  {
+    name: FIND_TAGS_TOOL_NAME,
+    description: FIND_TAGS_BASE_DESCRIPTION,
+    schema: findTagsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Finding tags",
+      done: "Find tags",
     },
-  });
+    toolCostCategory: "advanced",
+    freeUsage: false,
+    enableAlerting: true,
+  },
+] as const satisfies readonly InternalMCPToolType[];
 
 export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
   serverInfo: {
@@ -156,13 +174,5 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
   },
-  tools: Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   DataSourceFilesystemCatInputSchema,
   DataSourceFilesystemFindInputSchema,

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -169,7 +169,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Server metadata - used in constants.ts
 export const DATA_WAREHOUSES_SERVER = {

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -1,10 +1,10 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Constants
 const DEFAULT_LIMIT = 50;
@@ -15,8 +15,9 @@ const dataSourcesSchema =
   ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE];
 
 // Tools metadata
-export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
-  list: {
+export const DATA_WAREHOUSES_TOOLS_METADATA = [
+  {
+    name: "list",
     description:
       "Browse and list the direct contents inside a warehouse, database, or schema: child databases, schemas, nested schemas, and tables. " +
       "Use this to explore or navigate the tables hierarchy, like 'ls' in Unix. If no nodeId is provided, shows " +
@@ -55,7 +56,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  find: {
+  {
+    name: "find",
     description:
       "Find, search, or locate tables, schemas, and databases by name starting from a specific node in the warehouse hierarchy. " +
       "Use this for table-name lookup when you know a full or partial table, schema, or database name. " +
@@ -102,7 +104,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  describe_tables: {
+  {
+    name: "describe_tables",
     description:
       "Describe known warehouse tables by retrieving their schema details: columns, types, DBML definitions, " +
       "SQL dialect-specific query guidelines, and example rows. All tables must be from the same " +
@@ -127,7 +130,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  query: {
+  {
+    name: "query",
     description:
       "Run, execute, or write SQL queries on selected data warehouse tables to calculate metrics, aggregate results, analyze revenue, or answer business questions. " +
       "You MUST call describe_tables at least once before attempting to query tables to understand their structure. The query must respect the SQL dialect " +
@@ -165,7 +169,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // Server metadata - used in constants.ts
 export const DATA_WAREHOUSES_SERVER = {
@@ -177,13 +181,5 @@ export const DATA_WAREHOUSES_SERVER = {
     icon: "ActionTableIcon",
     documentationUrl: null,
   },
-  tools: Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: DATA_WAREHOUSES_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
 export const DATABRICKS_TOOLS_METADATA = [
   {

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -1,11 +1,11 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-export const DATABRICKS_TOOLS_METADATA = createToolsRecord({
-  list_warehouses: {
+export const DATABRICKS_TOOLS_METADATA = [
+  {
+    name: "list_warehouses",
     description:
       "List all SQL warehouses available in the Databricks workspace.",
     schema: {},
@@ -17,7 +17,7 @@ export const DATABRICKS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const DATABRICKS_SERVER = {
   serverInfo: {
@@ -31,13 +31,5 @@ export const DATABRICKS_SERVER = {
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/databricks",
   },
-  tools: Object.values(DATABRICKS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: DATABRICKS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -17,7 +17,7 @@ export const DATABRICKS_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const DATABRICKS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -81,7 +81,7 @@ export const EXA_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const EXA_SERVER_NAME = "exa_people_and_company" as const;
 

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const EXA_TOOLS_METADATA = createToolsRecord({
-  search_people: {
+export const EXA_TOOLS_METADATA = [
+  {
+    name: "search_people",
     description:
       "Find a person by name, job title, or employer using Exa's people directory. Looks up an individual's LinkedIn profile, professional background, and career history, or identifies who holds a given role at a specific company (e.g. 'CTO of Stripe', 'VP of Sales at French SaaS startups').",
     schema: {
@@ -42,7 +43,8 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_companies: {
+  {
+    name: "search_companies",
     description:
       "Find a company, business, or startup by name, industry, or criteria using Exa's company directory. Looks up company profiles, identifies competitors, and surfaces firms matching a sector or market (e.g. 'French fintech startups', 'competitors of Notion').",
     schema: {
@@ -79,7 +81,7 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const EXA_SERVER_NAME = "exa_people_and_company" as const;
 
@@ -93,13 +95,5 @@ export const EXA_SERVER = {
     icon: "ActionMagnifyingGlassIcon",
     documentationUrl: null,
   },
-  tools: Object.values(EXA_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: EXA_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const EXA_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -113,7 +113,7 @@ export function makeExtractDataBaseToolsMetadata({
       toolCostCategory: "advanced",
       freeUsage: false,
     },
-  ] as const satisfies readonly InternalMCPToolType[];
+  ] as const;
 }
 
 export function makeExtractDataToolsWithTagsMetadata({
@@ -155,7 +155,7 @@ export function makeExtractDataToolsWithTagsMetadata({
       toolCostCategory: "advanced",
       freeUsage: false,
     },
-  ] as const satisfies readonly InternalMCPToolType[];
+  ] as const;
 }
 
 export function makeExtractDataToolsMetadata({

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { TagsInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import {
   FIND_TAGS_BASE_DESCRIPTION,

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -1,15 +1,15 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { TagsInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import {
   FIND_TAGS_BASE_DESCRIPTION,
   findTagsSchema,
 } from "@app/lib/api/actions/tools/find_tags/metadata";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const EXTRACT_DATA_MAIN_TOOL_NAME =
   "extract_information_from_documents" as const;
@@ -100,8 +100,9 @@ export function makeExtractDataBaseToolsMetadata({
     isTimeFrameConfigured,
   });
 
-  return createToolsRecord({
-    [EXTRACT_DATA_MAIN_TOOL_NAME]: {
+  return [
+    {
+      name: EXTRACT_DATA_MAIN_TOOL_NAME,
       description: TOOL_DESCRIPTION,
       schema,
       stake: "never_ask",
@@ -112,7 +113,7 @@ export function makeExtractDataBaseToolsMetadata({
       toolCostCategory: "advanced",
       freeUsage: false,
     },
-  });
+  ] as const satisfies readonly InternalMCPToolType[];
 }
 
 export function makeExtractDataToolsWithTagsMetadata({
@@ -126,11 +127,12 @@ export function makeExtractDataToolsWithTagsMetadata({
     isJsonSchemaConfigured,
     isTimeFrameConfigured,
   });
-  const baseToolMetadata = baseMetadata[EXTRACT_DATA_MAIN_TOOL_NAME];
+  const [baseToolMetadata] = baseMetadata;
 
-  return createToolsRecord({
-    [EXTRACT_DATA_MAIN_TOOL_NAME]: {
+  return [
+    {
       ...baseToolMetadata,
+      name: EXTRACT_DATA_MAIN_TOOL_NAME,
       schema: {
         ...makeBaseExtractSchema({
           isJsonSchemaConfigured,
@@ -139,7 +141,8 @@ export function makeExtractDataToolsWithTagsMetadata({
         ...TagsInputSchema.shape,
       },
     },
-    find_tags: {
+    {
+      name: "find_tags",
       description:
         FIND_TAGS_BASE_DESCRIPTION +
         ` This tool is meant to be used before the ${EXTRACT_DATA_MAIN_TOOL_NAME} tool.`,
@@ -152,7 +155,7 @@ export function makeExtractDataToolsWithTagsMetadata({
       toolCostCategory: "advanced",
       freeUsage: false,
     },
-  });
+  ] as const satisfies readonly InternalMCPToolType[];
 }
 
 export function makeExtractDataToolsMetadata({
@@ -192,13 +195,5 @@ export const EXTRACT_DATA_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: EXTRACT_DATA_BASE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const FATHOM_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -100,7 +100,7 @@ export const FATHOM_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const FATHOM_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const FATHOM_TOOLS_METADATA = createToolsRecord({
-  list_meetings: {
+export const FATHOM_TOOLS_METADATA = [
+  {
+    name: "list_meetings",
     description:
       "List and browse your Fathom meeting and call recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns each Fathom recording with its summary, action items, and metadata.",
     schema: {
@@ -81,7 +82,8 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_transcript: {
+  {
+    name: "get_transcript",
     description:
       "Get the full word-for-word transcript of a Fathom meeting. Use recording_id from list_meetings. Large transcripts are saved as conversation files—use conversation_files__cat with offset/limit to read in chunks.",
     schema: {
@@ -98,7 +100,7 @@ export const FATHOM_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const FATHOM_SERVER = {
   serverInfo: {
@@ -113,13 +115,5 @@ export const FATHOM_SERVER = {
     icon: "FathomLogo",
     documentationUrl: null,
   },
-  tools: Object.values(FATHOM_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: FATHOM_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const FILE_GENERATION_TOOL_NAME = "file_generation" as const;

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const FILE_GENERATION_TOOL_NAME = "file_generation" as const;
 
@@ -37,8 +37,9 @@ export const BINARY_FORMATS: OutputFormatType[] = [
   "webp",
 ];
 
-export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
-  get_supported_source_formats_for_output_format: {
+export const FILE_GENERATION_TOOLS_METADATA = [
+  {
+    name: "get_supported_source_formats_for_output_format",
     description:
       "List which input source formats can be converted into a given target output format.",
     schema: {
@@ -52,7 +53,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  convert_file_format: {
+  {
+    name: "convert_file_format",
     description:
       "Convert an existing conversation file into another format, for example turn a document into a PDF.",
     schema: {
@@ -83,7 +85,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  generate_file: {
+  {
+    name: "generate_file",
     description:
       "Generate a new file by writing provided text or content out as a document.",
     schema: {
@@ -114,7 +117,7 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const FILE_GENERATION_SERVER = {
   serverInfo: {
@@ -125,13 +128,5 @@ export const FILE_GENERATION_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
   },
-  tools: Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: FILE_GENERATION_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -117,7 +117,7 @@ export const FILE_GENERATION_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const FILE_GENERATION_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
@@ -9,9 +11,7 @@ import {
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { FILE_PREVIEW_DIRECTIVE_EXAMPLE } from "@app/lib/markdown/file_preview";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const FILES_SERVER_NAME = "files" as const;
 export const FILES_LIST_ACTION_NAME = "list" as const;
@@ -162,10 +162,9 @@ const MOVE_TOOL = {
   freeUsage: true,
 };
 
-// Stake levels in this record are typed via `as const` so the object can be spread into
-// `createToolsRecord`, which expects the narrowed `MCPToolStakeLevelType` literal.
-const FILES_TOOLS_COMMON_METADATA = {
-  [FILES_RESOLVE_ACTION_NAME]: {
+const FILES_TOOLS_COMMON_METADATA = [
+  {
+    name: FILES_RESOLVE_ACTION_NAME,
     description:
       "Resolve a file ID (e.g. `fil_abc123`) to its scoped file system path " +
       "(e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`). " +
@@ -190,7 +189,8 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-  [FILES_CAT_ACTION_NAME]: {
+  {
+    name: FILES_CAT_ACTION_NAME,
     description:
       "Read the content of a file. " +
       "For text files, returns lines with their line numbers." +
@@ -230,7 +230,8 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-  [FILES_GREP_ACTION_NAME]: {
+  {
+    name: FILES_GREP_ACTION_NAME,
     description:
       "Search a text file for lines matching a regular expression pattern. " +
       "Returns each matching line with its number, which you can pass to " +
@@ -256,7 +257,8 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-  [FILES_CREATE_ACTION_NAME]: {
+  {
+    name: FILES_CREATE_ACTION_NAME,
     description:
       "Create or overwrite a file in a conversation or Pod file system. " +
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
@@ -294,7 +296,8 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-  [FILES_UPLOAD_FROM_URL_ACTION_NAME]: {
+  {
+    name: FILES_UPLOAD_FROM_URL_ACTION_NAME,
     description:
       "Download a file from a public HTTPS URL and store it in a conversation or Pod file system. " +
       "Use this for binary files (PDF, images, spreadsheets, etc.) that cannot be created with " +
@@ -330,7 +333,8 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-  [FILES_DELETE_ACTION_NAME]: {
+  {
+    name: FILES_DELETE_ACTION_NAME,
     description:
       "Delete a file from a conversation or Pod file system. " +
       "Returns an error if the file does not exist. Deletion is permanent.",
@@ -349,7 +353,7 @@ const FILES_TOOLS_COMMON_METADATA = {
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-};
+] as const satisfies readonly InternalMCPToolType[];
 
 const EDIT_TOOL = {
   description:
@@ -423,14 +427,14 @@ const EXTRACT_TEXT_TOOL = {
   freeUsage: true,
 };
 
-export const FILES_TOOLS_METADATA = createToolsRecord({
-  [FILES_LIST_ACTION_NAME]: LIST_TOOL,
+export const FILES_TOOLS_METADATA = [
+  { name: FILES_LIST_ACTION_NAME, ...LIST_TOOL },
   ...FILES_TOOLS_COMMON_METADATA,
-  [FILES_EDIT_ACTION_NAME]: EDIT_TOOL,
-  [FILES_EXTRACT_TEXT_ACTION_NAME]: EXTRACT_TEXT_TOOL,
-  [FILES_COPY_ACTION_NAME]: COPY_TOOL,
-  [FILES_MOVE_ACTION_NAME]: MOVE_TOOL,
-});
+  { name: FILES_EDIT_ACTION_NAME, ...EDIT_TOOL },
+  { name: FILES_EXTRACT_TEXT_ACTION_NAME, ...EXTRACT_TEXT_TOOL },
+  { name: FILES_COPY_ACTION_NAME, ...COPY_TOOL },
+  { name: FILES_MOVE_ACTION_NAME, ...MOVE_TOOL },
+] as const satisfies readonly InternalMCPToolType[];
 
 export const FILES_SERVER = {
   serverInfo: {
@@ -447,13 +451,5 @@ export const FILES_SERVER = {
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,
   },
-  tools: Object.values(FILES_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: FILES_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -353,7 +353,7 @@ const FILES_TOOLS_COMMON_METADATA = [
     toolCostCategory: "basic" as const,
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 const EDIT_TOOL = {
   description:
@@ -434,7 +434,7 @@ export const FILES_TOOLS_METADATA = [
   { name: FILES_EXTRACT_TEXT_ACTION_NAME, ...EXTRACT_TEXT_TOOL },
   { name: FILES_COPY_ACTION_NAME, ...COPY_TOOL },
   { name: FILES_MOVE_ACTION_NAME, ...MOVE_TOOL },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const FILES_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -1,9 +1,9 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FreshserviceTicketSchema } from "@app/lib/api/actions/servers/freshservice/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const ALLOWED_TICKET_INCLUDES = [
   "conversations",
@@ -17,9 +17,10 @@ const ALLOWED_TICKET_INCLUDES = [
   "offboarding_context",
 ] as const;
 
-export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
+export const FRESHSERVICE_TOOLS_METADATA = [
   // Ticket operations
-  list_tickets: {
+  {
+    name: "list_tickets",
     description:
       "List or show Freshservice tickets, with optional filtering (e.g. by status, requester, or update time) and pagination. Returns minimal fields (id, subject, status) by default for performance.",
     schema: {
@@ -57,7 +58,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_ticket: {
+  {
+    name: "get_ticket",
     description:
       "Get Freshservice ticket details by ID. Returns essential fields by default; pass the fields parameter to request more.",
     schema: {
@@ -79,7 +81,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_ticket_read_fields: {
+  {
+    name: "get_ticket_read_fields",
     description:
       "List the field ids available when reading a Freshservice ticket. Use only to discover field names.",
     schema: {},
@@ -91,7 +94,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_ticket_write_fields: {
+  {
+    name: "get_ticket_write_fields",
     description:
       "List all Freshservice ticket fields (standard and custom) available when creating or updating a ticket. Use only to discover field names.",
     schema: {
@@ -108,7 +112,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_ticket: {
+  {
+    name: "create_ticket",
     description:
       "Create a new Freshservice ticket. For example to log an incident, submit an IT support request, or report a problem. Required fields vary by ticket type. Pass them in custom_fields.",
     schema: {
@@ -138,7 +143,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_ticket: {
+  {
+    name: "update_ticket",
     description: "Update an existing Freshservice ticket.",
     schema: {
       ticket_id: z.string().describe("Ticket ID to update"),
@@ -166,7 +172,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_ticket_note: {
+  {
+    name: "add_ticket_note",
     description:
       "Add a private or public note to an existing Freshservice ticket.",
     schema: {
@@ -186,7 +193,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_ticket_reply: {
+  {
+    name: "add_ticket_reply",
     description:
       "Reply to the requester in a Freshservice ticket conversation.",
     schema: {
@@ -203,7 +211,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Service request items
-  list_ticket_requested_items: {
+  {
+    name: "list_ticket_requested_items",
     description:
       "List the service request items nested under a Service Request ticket. Returns each item's metadata along with its custom fields. Use this after get_ticket when the ticket is a Service Request and you need values from custom fields on the nested items.",
     schema: {
@@ -219,7 +228,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Ticket tasks
-  list_ticket_tasks: {
+  {
+    name: "list_ticket_tasks",
     description: "List all tasks associated with a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -232,7 +242,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_ticket_task: {
+  {
+    name: "get_ticket_task",
     description: "Get detailed information about a specific task on a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -246,7 +257,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_ticket_task: {
+  {
+    name: "create_ticket_task",
     description:
       "Add a new task or subtask to a Freshservice ticket, to break the ticket into smaller pieces of work.",
     schema: {
@@ -273,7 +285,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_ticket_task: {
+  {
+    name: "update_ticket_task",
     description: "Update an existing task on a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -309,7 +322,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_ticket_task: {
+  {
+    name: "delete_ticket_task",
     description: "Delete a task from a ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -325,7 +339,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Ticket approvals
-  get_ticket_approval: {
+  {
+    name: "get_ticket_approval",
     description: "Get detailed information about a specific ticket approval",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -339,7 +354,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_ticket_approvals: {
+  {
+    name: "list_ticket_approvals",
     description: "List all approvals for a specific ticket",
     schema: {
       ticket_id: z.number().describe("The ID of the ticket"),
@@ -352,7 +368,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  request_service_approval: {
+  {
+    name: "request_service_approval",
     description:
       "Request approval for a ticket. This creates an approval request that needs to be approved before the ticket can be fulfilled. Only works on tickets that have approval workflow configured.",
     schema: {
@@ -382,7 +399,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Departments, Products, On-call schedules
-  list_departments: {
+  {
+    name: "list_departments",
     description: "List all departments in Freshservice",
     schema: {
       page: z.number().optional().default(1),
@@ -396,7 +414,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_products: {
+  {
+    name: "list_products",
     description: "List all products in Freshservice",
     schema: {
       page: z.number().optional().default(1),
@@ -410,7 +429,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_oncall_schedules: {
+  {
+    name: "list_oncall_schedules",
     description: "List on-call schedules",
     schema: {
       page: z.number().optional().default(1),
@@ -426,7 +446,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Service catalog
-  list_service_categories: {
+  {
+    name: "list_service_categories",
     description:
       "List service catalog categories. Use this first to get category IDs for filtering service items.",
     schema: {
@@ -441,7 +462,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_service_items: {
+  {
+    name: "list_service_items",
     description:
       "List service catalog items. To filter by category: 1) Use list_service_categories to get category IDs, 2) Use the category_id parameter here.",
     schema: {
@@ -462,7 +484,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_service_items: {
+  {
+    name: "search_service_items",
     description:
       "Search for service items from the service catalog for a given search term. Only use this when specifically searching for items by keyword.",
     schema: {
@@ -495,7 +518,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_service_item: {
+  {
+    name: "get_service_item",
     description:
       "Get detailed information about a specific service catalog item including fields and pricing",
     schema: {
@@ -511,7 +535,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_service_item_fields: {
+  {
+    name: "get_service_item_fields",
     description:
       "Get the field configuration for a service catalog item. You must call this before request_service_item to get required fields. Returns required_fields and hidden_required_fields that must be provided.",
     schema: {
@@ -527,7 +552,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  request_service_item: {
+  {
+    name: "request_service_item",
     description:
       "Create a service request for a catalog item. This creates a new ticket. You MUST call get_service_item_fields first to get required fields, then provide all required field values in the fields parameter.",
     schema: {
@@ -561,7 +587,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Solutions (Knowledge Base)
-  list_solution_categories: {
+  {
+    name: "list_solution_categories",
     description:
       "List solution categories. These are used to organize solution folders, which are mandatory for ticket listing.",
     schema: {
@@ -576,7 +603,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_solution_folders: {
+  {
+    name: "list_solution_folders",
     description:
       "List solution folders within categories. Solution folders are mandatory for ticket listing. Use list_solution_categories first to get category IDs, then filter folders by category_id.",
     schema: {
@@ -592,7 +620,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_solution_articles: {
+  {
+    name: "list_solution_articles",
     description:
       "List the Freshservice knowledge base articles (solution articles) in a folder. Returns metadata only. Fetch an article by id for its full content.",
     schema: {
@@ -616,7 +645,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_solution_article: {
+  {
+    name: "get_solution_article",
     description:
       "Get a Freshservice knowledge base article (also called a solution article), including its full content.",
     schema: {
@@ -630,7 +660,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_solution_article: {
+  {
+    name: "create_solution_article",
     description:
       "Create a new solution article in a specific folder. To get folder_id: 1) Use list_solution_categories to get category IDs, 2) Use list_solution_folders with category_id to get folder IDs, 3) Use the folder_id here.",
     schema: {
@@ -657,7 +688,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Requesters
-  list_requesters: {
+  {
+    name: "list_requesters",
     description:
       "List Freshservice requesters: the person or people who submitted a ticket (the end users who report issues). Filter by email, phone, or mobile.",
     schema: {
@@ -675,7 +707,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_requester: {
+  {
+    name: "get_requester",
     description: "Get detailed information about a specific requester",
     schema: {
       requester_id: z.number().describe("The ID of the requester"),
@@ -690,7 +723,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Purchase Orders
-  list_purchase_orders: {
+  {
+    name: "list_purchase_orders",
     description: "List purchase orders",
     schema: {
       page: z.number().optional().default(1),
@@ -706,7 +740,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // SLA Policies
-  list_sla_policies: {
+  {
+    name: "list_sla_policies",
     description: "List SLA policies",
     schema: {},
     stake: "never_ask",
@@ -719,7 +754,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
   },
 
   // Canned responses
-  list_canned_responses: {
+  {
+    name: "list_canned_responses",
     description: "List all canned responses available in Freshservice",
     schema: {
       search: z
@@ -743,7 +779,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_canned_response: {
+  {
+    name: "get_canned_response",
     description: "Get detailed information about a specific canned response",
     schema: {
       response_id: z.number().describe("The ID of the canned response"),
@@ -756,7 +793,7 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const FRESHSERVICE_SERVER = {
   serverInfo: {
@@ -771,13 +808,5 @@ export const FRESHSERVICE_SERVER = {
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
   },
-  tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: FRESHSERVICE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FreshserviceTicketSchema } from "@app/lib/api/actions/servers/freshservice/types";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -793,7 +793,7 @@ export const FRESHSERVICE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const FRESHSERVICE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const FRONT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -354,7 +354,7 @@ export const FRONT_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const FRONT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const FRONT_TOOLS_METADATA = createToolsRecord({
-  search_conversations: {
+export const FRONT_TOOLS_METADATA = [
+  {
+    name: "search_conversations",
     description:
       "Search or find conversations in the Front inbox by keywords, customer email, tags, status, or other criteria. Returns matching conversations with their details.",
     schema: {
@@ -30,7 +31,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_conversation: {
+  {
+    name: "get_conversation",
     description:
       "Retrieve complete details of a specific conversation by its ID, including subject, status, " +
       "assignee, tags, inbox, and all metadata.",
@@ -47,7 +49,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_conversation_messages: {
+  {
+    name: "get_conversation_messages",
     description:
       "Retrieve all messages in a conversation, including both external messages (emails) and " +
       "internal comments. Returns the complete message timeline.",
@@ -64,7 +67,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_contact: {
+  {
+    name: "get_contact",
     description:
       "Look up customer/contact information by email address or contact ID. Returns contact details " +
       "including name, email, and custom fields.",
@@ -86,7 +90,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_tags: {
+  {
+    name: "list_tags",
     description: "Get all available tags for categorizing conversations.",
     schema: {},
     stake: "never_ask",
@@ -97,7 +102,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_teammates: {
+  {
+    name: "list_teammates",
     description:
       "Get all teammates in the workspace for assignment and collaboration.",
     schema: {},
@@ -109,7 +115,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_customer_history: {
+  {
+    name: "get_customer_history",
     description:
       "Retrieve a customer's past conversations in Front, by their email address.",
     schema: {
@@ -132,7 +139,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_inboxes: {
+  {
+    name: "list_inboxes",
     description: "Get all inboxes/channels available in the workspace.",
     schema: {},
     stake: "never_ask",
@@ -143,7 +151,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_conversation_drafts: {
+  {
+    name: "get_conversation_drafts",
     description:
       "List all drafts in a conversation. Returns draft IDs and version tokens needed for editing or deleting drafts.",
     schema: {
@@ -159,7 +168,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_conversation: {
+  {
+    name: "create_conversation",
     description: "Start a new outbound conversation with a customer.",
     schema: {
       inbox_id: z
@@ -181,7 +191,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_draft: {
+  {
+    name: "create_draft",
     description:
       "Create a draft reply to a conversation for review before sending.",
     schema: {
@@ -200,7 +211,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_draft: {
+  {
+    name: "delete_draft",
     description:
       "Delete a draft that is no longer needed. Requires the version token from get_conversation_drafts for optimistic concurrency.",
     schema: {
@@ -223,7 +235,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_tags: {
+  {
+    name: "add_tags",
     description:
       "Add one or more tags to a conversation for categorization (e.g., bug, feature-request, billing).",
     schema: {
@@ -240,7 +253,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_comment: {
+  {
+    name: "add_comment",
     description:
       "Add an internal comment or note to a Front conversation, visible only to your team.",
     schema: {
@@ -259,7 +273,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_links: {
+  {
+    name: "add_links",
     description:
       "Link related conversations together for better tracking and context.",
     schema: {
@@ -276,7 +291,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  send_message: {
+  {
+    name: "send_message",
     description:
       "Reply or respond to a customer on a Front conversation. Sends a customer-facing email by default. Can also post an internal note.",
     schema: {
@@ -303,7 +319,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_conversation_status: {
+  {
+    name: "update_conversation_status",
     description:
       "Update the status of a Front conversation: archive (close), reopen, delete, mark as spam, or move to trash.",
     schema: {
@@ -322,7 +339,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  assign_conversation: {
+  {
+    name: "assign_conversation",
     description: "Assign a conversation to a specific teammate for handling.",
     schema: {
       conversation_id: z.string().describe("The unique ID of the conversation"),
@@ -336,7 +354,7 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const FRONT_SERVER = {
   serverInfo: {
@@ -348,13 +366,5 @@ export const FRONT_SERVER = {
     icon: "FrontLogo",
     documentationUrl: "https://docs.dust.tt/docs/front-mcp",
   },
-  tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: FRONT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const GITHUB_TOOLS_METADATA = createToolsRecord({
-  create_issue: {
+export const GITHUB_TOOLS_METADATA = [
+  {
+    name: "create_issue",
     description:
       "Create or file a brand new issue (a bug report or feature request) on" +
       " a specified GitHub repository, optionally with assignees and labels.",
@@ -35,7 +36,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_issue: {
+  {
+    name: "update_issue",
     description:
       "Update an existing issue on a GitHub repository: its title, body," +
       " labels, assignees, milestone, and open/closed state (closing or" +
@@ -97,7 +99,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_pull_request: {
+  {
+    name: "get_pull_request",
     description:
       "Retrieve a pull request from a specified GitHub repository including" +
       " its associated description, creation time (createdAt), merge time" +
@@ -119,7 +122,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_pull_request_review: {
+  {
+    name: "create_pull_request_review",
     description:
       "Approve, request changes on, or submit a review verdict for a pull request, with optional inline line comments.",
     schema: {
@@ -167,7 +171,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_organization_projects: {
+  {
+    name: "list_organization_projects",
     description:
       "List the open projects of a GitHub organization along with their single select fields (generally used as columns)",
     schema: {
@@ -185,7 +190,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_issue_to_project: {
+  {
+    name: "add_issue_to_project",
     description:
       "Add an existing issue to a GitHub project, optionally setting a field value.",
     schema: {
@@ -225,7 +231,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  comment_on_issue: {
+  {
+    name: "comment_on_issue",
     description: "Add a comment to an existing GitHub issue.",
     schema: {
       owner: z
@@ -247,7 +254,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_discussion_categories: {
+  {
+    name: "list_discussion_categories",
     description:
       "List the available discussion categories in a GitHub repository. Use this to get the category ID required to create one.",
     schema: {
@@ -274,7 +282,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_discussion: {
+  {
+    name: "create_discussion",
     description:
       "Create and start a brand new single GitHub discussion thread under a chosen category.",
     schema: {
@@ -302,7 +311,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  comment_on_discussion: {
+  {
+    name: "comment_on_discussion",
     description:
       "Add a comment to an existing GitHub discussion. Optionally reply to an existing discussion comment.",
     schema: {
@@ -331,7 +341,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_discussion: {
+  {
+    name: "get_discussion",
     description:
       "Retrieve a discussion from a specified GitHub repository including its description, category, and comment count.",
     schema: {
@@ -351,7 +362,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_discussion_comments: {
+  {
+    name: "get_discussion_comments",
     description:
       "Retrieve, fetch, and list the comments posted on a specified GitHub discussion, with pagination.",
     schema: {
@@ -379,7 +391,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_discussions: {
+  {
+    name: "list_discussions",
     description:
       "List discussions in a GitHub repository: browse and enumerate the repository's discussions, returning many discussions with optional filtering.",
     schema: {
@@ -422,7 +435,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue: {
+  {
+    name: "get_issue",
     description:
       "Retrieve and read the full details of a single issue from a specified GitHub repository, including its description, comments, and labels.",
     schema: {
@@ -442,7 +456,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue_custom_fields: {
+  {
+    name: "get_issue_custom_fields",
     description:
       "Get custom fields set on an issue in GitHub project(s). If projectId is provided, returns custom fields for that specific project. If projectId is omitted, returns custom fields for all projects containing the issue.",
     schema: {
@@ -468,7 +483,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_issues: {
+  {
+    name: "list_issues",
     description:
       "List issues from a specified GitHub repository with optional filtering.",
     schema: {
@@ -511,7 +527,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_advanced: {
+  {
+    name: "search_advanced",
     description:
       "Search GitHub issues and pull requests using GitHub's advanced search syntax with AND/OR operators and nested filters. " +
       "Use 'is:issue' for issues, 'is:pr' for pull requests, or omit to search both. " +
@@ -541,7 +558,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_pull_requests: {
+  {
+    name: "list_pull_requests",
     description:
       "List pull requests from a specified GitHub repository with optional filtering.",
     schema: {
@@ -580,7 +598,7 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const GITHUB_SERVER = {
   serverInfo: {
@@ -594,13 +612,5 @@ export const GITHUB_SERVER = {
     icon: "GithubLogo",
     documentationUrl: null,
   },
-  tools: Object.values(GITHUB_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: GITHUB_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const GITHUB_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -598,7 +598,7 @@ export const GITHUB_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GITHUB_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const GMAIL_TOOL_NAME = "gmail" as const;
 
-export const GMAIL_TOOLS_METADATA = createToolsRecord({
-  get_drafts: {
+export const GMAIL_TOOLS_METADATA = [
+  {
+    name: "get_drafts",
     description:
       "Get and list saved, unsent email drafts from Gmail. Returns existing drafts only.",
     schema: {
@@ -30,7 +31,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_draft: {
+  {
+    name: "create_draft",
     description: `Create a new email draft in Gmail, or a reply draft to an existing message.
 - The draft will be saved in the user's Gmail account and can be reviewed and sent later.
 - The draft will include proper email headers and formatting.`,
@@ -94,7 +96,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_draft: {
+  {
+    name: "delete_draft",
     description: "Delete a draft email from Gmail.",
     schema: {
       draftId: z.string().describe("The ID of the draft to delete"),
@@ -109,7 +112,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_messages: {
+  {
+    name: "get_messages",
     description:
       "Get messages from Gmail inbox. Supports Gmail search queries to filter messages.",
     schema: {
@@ -144,7 +148,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_attachment: {
+  {
+    name: "get_attachment",
     description:
       "Download an attached file from a Gmail email message. Fetches the content of a specific attachment, which is then uploaded and made available in the conversation.",
     schema: {
@@ -183,7 +188,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_labels: {
+  {
+    name: "get_labels",
     description:
       "Retrieve all Gmail labels, including system labels and user-created labels.",
     schema: {},
@@ -195,7 +201,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  set_message_labels: {
+  {
+    name: "set_message_labels",
     description: `Modify the labels on a Gmail message to mark it read or unread, star it, archive it, or move it into or out of the inbox. Adds and removes label IDs on the message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
     schema: {
       messageId: z.string().describe("The ID of the message to modify."),
@@ -213,7 +220,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  send_mail: {
+  {
+    name: "send_mail",
     description: `Send an email directly via Gmail.
 - The email will be sent immediately without creating a draft.
 - Use this to send emails when you have all the required information.
@@ -278,7 +286,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_thread: {
+  {
+    name: "get_thread",
     description: "Get all messages in a Gmail thread/conversation.",
     schema: {
       threadId: z
@@ -295,7 +304,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const GMAIL_SERVER = {
   serverInfo: {
@@ -312,13 +321,5 @@ export const GMAIL_SERVER = {
     icon: "GmailLogo",
     documentationUrl: "https://docs.dust.tt/docs/gmail",
   },
-  tools: Object.values(GMAIL_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: GMAIL_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const GMAIL_TOOL_NAME = "gmail" as const;

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -304,7 +304,7 @@ export const GMAIL_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GMAIL_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const GONG_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -75,7 +75,7 @@ export const GONG_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GONG_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const GONG_TOOLS_METADATA = createToolsRecord({
-  list_calls: {
+export const GONG_TOOLS_METADATA = [
+  {
+    name: "list_calls",
     description:
       "List calls recorded in Gong within a date range. Returns call metadata including title, participants, duration, and timing. " +
       "Dates should be in ISO-8601 format (e.g., '2024-01-01T00:00:00Z' or '2024-01-01'). " +
@@ -36,7 +37,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_call: {
+  {
+    name: "get_call",
     description:
       "Retrieve the details and summary of a specific Gong call by its ID. Returns comprehensive call data including " +
       "participants, topics discussed, key points, action items, the call summary, and interaction statistics.",
@@ -53,7 +55,8 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_call_transcript: {
+  {
+    name: "get_call_transcript",
     description:
       "Retrieve the full transcript of a call. Returns the conversation text organized by speaker. " +
       "Useful for understanding the exact dialogue and extracting specific quotes or details from the call.",
@@ -72,7 +75,7 @@ export const GONG_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const GONG_SERVER = {
   serverInfo: {
@@ -87,13 +90,5 @@ export const GONG_SERVER = {
     icon: "GongLogo",
     documentationUrl: "https://docs.dust.tt/update/docs/gong-mcp",
   },
-  tools: Object.values(GONG_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: GONG_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const sharedEventFields = {
   transparency: z
@@ -41,8 +41,9 @@ const sharedEventFields = {
     ),
 };
 
-export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
-  list_calendars: {
+export const GOOGLE_CALENDAR_TOOLS_METADATA = [
+  {
+    name: "list_calendars",
     description:
       "List all Google Calendars accessible by the user. Supports pagination via pageToken.",
     schema: {
@@ -60,7 +61,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_events: {
+  {
+    name: "list_events",
     description:
       "List, search, or browse the events and agenda on a Google Calendar for a given day, week, or date range. If 'q' is provided, performs a free-text search of events.",
     schema: {
@@ -94,7 +96,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_event: {
+  {
+    name: "get_event",
     description:
       "Get the full details of a single event from a Google Calendar by its event ID.",
     schema: {
@@ -112,7 +115,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_event: {
+  {
+    name: "create_event",
     description:
       "Create a new event on a Google Calendar to schedule a meeting or appointment. By default: (1) add the calling user as both organizer and attendee, (2) call check_availability to verify attendee availability beforehand, (3) call get_user_timezones first to determine attendee timezones for accurate scheduling.",
     schema: {
@@ -161,7 +165,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_event: {
+  {
+    name: "update_event",
     description:
       "Update or reschedule an existing event on a Google Calendar to a new time, location, or set of attendees.",
     schema: {
@@ -207,7 +212,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_event: {
+  {
+    name: "delete_event",
     description: "Delete, cancel, or remove an event from a Google Calendar.",
     schema: {
       calendarId: z
@@ -224,7 +230,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  check_availability: {
+  {
+    name: "check_availability",
     description:
       "Find free time slots when participants are all available to meet, computing combined free/busy availability across multiple attendees within a date range using Google Calendar.",
     schema: {
@@ -293,7 +300,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_user_timezones: {
+  {
+    name: "get_user_timezones",
     description:
       "Get the timezone of attendees by looking up timezone settings for multiple users from their Google Calendar configuration. Only works for calendars shared with you.",
     schema: {
@@ -310,7 +318,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const GOOGLE_CALENDAR_SERVER = {
   serverInfo: {
@@ -327,13 +335,5 @@ export const GOOGLE_CALENDAR_SERVER = {
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
   },
-  tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: GOOGLE_CALENDAR_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 const sharedEventFields = {

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -318,7 +318,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GOOGLE_CALENDAR_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { DocumentOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/docs_resolver";
 import { SpreadsheetOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/sheets_resolver";
 import { PresentationOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/slides_resolver";

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -298,7 +298,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = [
   {
@@ -679,12 +679,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 const ALL_TOOLS_METADATA = [
   ...GOOGLE_DRIVE_TOOLS_METADATA,
   ...GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 /**
  * Returns the Google Drive server metadata with all tools including write capabilities.

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -1,11 +1,11 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { DocumentOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/docs_resolver";
 import { SpreadsheetOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/sheets_resolver";
 import { PresentationOperationsArraySchema } from "@app/lib/api/actions/servers/google_drive/resolution/slides_resolver";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
 export const MAX_FILE_SIZE = 64 * 1024 * 1024; // 64 MB max original file size
@@ -27,8 +27,9 @@ const capabilitiesSchema = z
     "The capabilities object for this file, as returned by search_files or get_file_content. Pass this value if it was returned by a previous tool call."
   );
 
-export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
-  list_drives: {
+export const GOOGLE_DRIVE_TOOLS_METADATA = [
+  {
+    name: "list_drives",
     description: "List all Google Drive shared drives accessible by the user.",
     schema: {
       pageToken: z.string().optional().describe("Page token for pagination."),
@@ -41,7 +42,8 @@ export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_files: {
+  {
+    name: "search_files",
     description:
       "Search and find files in Google Drive by name or content. Locate Google Docs documents, Google Sheets spreadsheets, Google Slides presentations, and folders in your personal drive, all shared drives, or a specific drive.",
     schema: {
@@ -116,7 +118,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_file_content: {
+  {
+    name: "get_file_content",
     description:
       "Read, open, and get the content of a Google Drive file as text with offset-based pagination. " +
       "Google Docs and Slides are exported as plain text. Google Sheets are exported as XLSX. " +
@@ -147,7 +150,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_document_structure: {
+  {
+    name: "get_document_structure",
     description:
       "Get the full structure of a Google Docs document including text, headers, footers, tables, and element indices. Supports pagination for large documents.",
     schema: {
@@ -177,7 +181,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_presentation_structure: {
+  {
+    name: "get_presentation_structure",
     description:
       "Get the full structure of a Google Slides presentation including slides, shapes, tables, text content, and object IDs. Supports pagination for large presentations.",
     schema: {
@@ -205,7 +210,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_spreadsheet: {
+  {
+    name: "get_spreadsheet",
     description:
       "Get metadata and properties of a specific Google Sheets spreadsheet, including sheet names, IDs, row/column counts, and structure. " +
       "Does not return cell values.",
@@ -222,7 +228,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_worksheet: {
+  {
+    name: "get_worksheet",
     description:
       "Get cell values from a specific range in a Google Sheets spreadsheet. Returns values in the specified format (formatted, unformatted, or formulas).",
     schema: {
@@ -249,7 +256,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_file_permissions: {
+  {
+    name: "list_file_permissions",
     description:
       "List all permissions (sharing settings) on a Google Drive file, showing who has access and their roles. Requires sharing access to the file.",
     schema: {
@@ -264,7 +272,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_comments: {
+  {
+    name: "list_comments",
     description:
       "List comments on a Google Drive file (Doc, Sheet, or Presentation). Returns comment threads with their replies.",
     schema: {
@@ -289,10 +298,11 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
-export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
-  create_document: {
+export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = [
+  {
+    name: "create_document",
     description:
       "Create a new Google Docs document. Optionally specify a folder to create it in.",
     schema: {
@@ -312,7 +322,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_spreadsheet: {
+  {
+    name: "create_spreadsheet",
     description:
       "Create a new Google Sheets spreadsheet. Optionally specify a folder to create it in.",
     schema: {
@@ -332,7 +343,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_presentation: {
+  {
+    name: "create_presentation",
     description:
       "Create a new Google Slides presentation. Optionally specify a folder to create it in.",
     schema: {
@@ -352,7 +364,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_folder: {
+  {
+    name: "create_folder",
     description:
       "Create a new Google Drive folder. Optionally specify a parent folder to create it in.",
     schema: {
@@ -372,7 +385,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  copy_file: {
+  {
+    name: "copy_file",
     description:
       "Copy, clone, or duplicate an existing Google Drive file (Doc, Sheet, or Presentation). " +
       "Creates a duplicate of the file with a new name in the same folder or a different location. " +
@@ -401,7 +415,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_comment: {
+  {
+    name: "create_comment",
     description:
       "Add a comment to a Google Drive file (Doc, Sheet, or Presentation).",
     schema: {
@@ -417,7 +432,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_reply: {
+  {
+    name: "create_reply",
     description:
       "Reply to an existing comment on a Google Drive file (Doc, Sheet, or Presentation).",
     schema: {
@@ -434,7 +450,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_document: {
+  {
+    name: "update_document",
     description:
       "Update a Google Docs document by applying one or more operations: text find/replace, position-based insert/delete/format, table cell and row/column edits, and header/footer edits. No prior call to get_document_structure is needed. Pass a `raw` operation for any Google Docs batchUpdate request the named ops don't cover.",
     schema: {
@@ -452,7 +469,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  append_to_spreadsheet: {
+  {
+    name: "append_to_spreadsheet",
     description:
       "Append rows of data to a Google Sheets spreadsheet. " +
       "This is a simple operation for adding new rows to the end of existing data. " +
@@ -489,7 +507,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_spreadsheet: {
+  {
+    name: "update_spreadsheet",
     description:
       "Update a Google Sheets spreadsheet by applying one or more operations: write cells, format ranges, find/replace, merge, sort, insert/delete rows and columns, add/delete sheets. Operations address cells by sheet name + A1 range. No prior call to get_spreadsheet is needed. Pass a `raw` operation for any Google Sheets batchUpdate request the named ops don't cover (e.g. data validation, conditional formatting, charts). For appending rows to existing data, append_to_spreadsheet is simpler.",
     schema: {
@@ -509,7 +528,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_presentation: {
+  {
+    name: "update_presentation",
     description:
       "Update a Google Slides presentation by applying one or more operations: find/replace, shape text replacement and insertion, table cell edits, speaker notes, add/delete slides and elements. Operations address slides by 1-indexed number and shapes by text content, index, or placeholder type. No prior call to get_presentation_structure is needed. Pass a `raw` operation for any Google Slides batchUpdate request the named ops don't cover. For populating templates, replaceAllText with `{{placeholder}}` patterns is simplest.",
     schema: {
@@ -529,7 +549,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  share_file: {
+  {
+    name: "share_file",
     description:
       "Share a Google Drive file with a specific person by email, or with everyone in a Google Workspace domain.",
     schema: {
@@ -580,7 +601,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_file_permission: {
+  {
+    name: "update_file_permission",
     description:
       "Update the role of an existing permission on a Google Drive file. Use list_file_permissions to find the permissionId first. To grant new access, use share_file instead.",
     schema: {
@@ -603,7 +625,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  revoke_file_sharing: {
+  {
+    name: "revoke_file_sharing",
     description:
       "Unshare a Google Drive file and stop sharing it: remove or revoke access for a specific user or domain by deleting the matching permission. Use list_file_permissions to find the permissionId first.",
     schema: {
@@ -625,7 +648,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  upload_file: {
+  {
+    name: "upload_file",
     description:
       "Upload a file from the Dust conversation to Google Drive. Optionally specify a folder to upload into.",
     schema: {
@@ -655,12 +679,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
-const ALL_TOOLS_METADATA = {
+const ALL_TOOLS_METADATA = [
   ...GOOGLE_DRIVE_TOOLS_METADATA,
   ...GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
-};
+] as const satisfies readonly InternalMCPToolType[];
 
 /**
  * Returns the Google Drive server metadata with all tools including write capabilities.
@@ -680,15 +704,7 @@ export function getGoogleDriveServerMetadata() {
       icon: "DriveLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-drive",
     },
-    tools: Object.values(ALL_TOOLS_METADATA).map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-      displayLabels: t.displayLabels,
-      toolCostCategory: t.toolCostCategory,
-      freeUsage: t.freeUsage,
-      stake: t.stake,
-    })),
+    tools: ALL_TOOLS_METADATA,
   } as const satisfies ServerMetadata;
 }
 

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const GOOGLE_SHEETS_TOOL_NAME = "google_sheets" as const;
 
-export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
-  list_spreadsheets: {
+export const GOOGLE_SHEETS_TOOLS_METADATA = [
+  {
+    name: "list_spreadsheets",
     description:
       "Search for and list your Google Sheets spreadsheets by name, across your personal and shared drives, to find a spreadsheet when you do not know its ID.",
     schema: {
@@ -31,7 +32,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_spreadsheet: {
+  {
+    name: "get_spreadsheet",
     description:
       "Get metadata and properties of a specific Google Sheets spreadsheet.",
     schema: {
@@ -47,7 +49,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_worksheet: {
+  {
+    name: "get_worksheet",
     description:
       "Read the cell values from a range in a Google Sheets worksheet (tab), returning the data found in the given A1 range.",
     schema: {
@@ -74,7 +77,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_cells: {
+  {
+    name: "update_cells",
     description: "Update cells in a Google Sheets spreadsheet.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
@@ -103,7 +107,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  append_data: {
+  {
+    name: "append_data",
     description: "Append data to a Google Sheets spreadsheet.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
@@ -136,7 +141,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  clear_range: {
+  {
+    name: "clear_range",
     description: "Clear values from a range in a Google Sheets spreadsheet.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
@@ -154,7 +160,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_spreadsheet: {
+  {
+    name: "create_spreadsheet",
     description: "Create a new Google Sheets spreadsheet.",
     schema: {
       title: z.string().describe("The title of the new spreadsheet."),
@@ -173,7 +180,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_worksheet: {
+  {
+    name: "add_worksheet",
     description:
       "Add a new worksheet to an existing Google Sheets spreadsheet.",
     schema: {
@@ -196,7 +204,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_worksheet: {
+  {
+    name: "delete_worksheet",
     description: "Delete a worksheet from a Google Sheets spreadsheet.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
@@ -210,7 +219,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  format_cells: {
+  {
+    name: "format_cells",
     description:
       "Apply formatting to a range of cells in a Google Sheets worksheet, such as bold or italic text, font size, background color, and horizontal alignment.",
     schema: {
@@ -255,7 +265,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  copy_sheet: {
+  {
+    name: "copy_sheet",
     description:
       "Copy a worksheet (tab) from one Google Sheets spreadsheet into another.",
     schema: {
@@ -281,7 +292,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  rename_worksheet: {
+  {
+    name: "rename_worksheet",
     description: "Rename a worksheet in a Google Sheets spreadsheet.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
@@ -296,7 +308,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  move_worksheet: {
+  {
+    name: "move_worksheet",
     description:
       "Move a worksheet to a new position in a Google Sheets spreadsheet.",
     schema: {
@@ -317,7 +330,7 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const GOOGLE_SHEETS_SERVER = {
   serverInfo: {
@@ -333,13 +346,5 @@ export const GOOGLE_SHEETS_SERVER = {
     icon: "GoogleSpreadsheetLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-sheets",
   },
-  tools: Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: GOOGLE_SHEETS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const GOOGLE_SHEETS_TOOL_NAME = "google_sheets" as const;

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -330,7 +330,7 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const GOOGLE_SHEETS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -1,16 +1,17 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { WEB_SEARCH_BROWSE_TOOLS_METADATA } from "@app/lib/api/actions/servers/web_search_browse/metadata";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const HTTP_CLIENT_TOOL_NAME = "http_client" as const;
 
 export const DEFAULT_TIMEOUT_MS = 30_000;
 
-export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
-  send_request: {
+export const HTTP_CLIENT_TOOLS_METADATA = [
+  {
+    name: "send_request",
     description:
       "Send an HTTP request to an external REST API and get back the status, headers, and body. " +
       "Only text-based responses are returned (binary is omitted) and bodies are truncated at ~1MB. " +
@@ -60,13 +61,13 @@ export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // Combine http_client tools with web tools for metadata
-const ALL_HTTP_CLIENT_TOOLS_METADATA = {
+const ALL_HTTP_CLIENT_TOOLS_METADATA = [
   ...HTTP_CLIENT_TOOLS_METADATA,
   ...WEB_SEARCH_BROWSE_TOOLS_METADATA,
-};
+] as const satisfies readonly InternalMCPToolType[];
 
 export const HTTP_CLIENT_SERVER = {
   serverInfo: {
@@ -81,13 +82,5 @@ export const HTTP_CLIENT_SERVER = {
     developerSecretSelectionDescription:
       "This is optional. If set, this secret will be used as a default Bearer token (Authorization header) for HTTP requests.",
   },
-  tools: Object.values(ALL_HTTP_CLIENT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ALL_HTTP_CLIENT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -61,13 +61,13 @@ export const HTTP_CLIENT_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Combine http_client tools with web tools for metadata
 const ALL_HTTP_CLIENT_TOOLS_METADATA = [
   ...HTTP_CLIENT_TOOLS_METADATA,
   ...WEB_SEARCH_BROWSE_TOOLS_METADATA,
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const HTTP_CLIENT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { WEB_SEARCH_BROWSE_TOOLS_METADATA } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts";
 import { AssociationSpecAssociationCategoryEnum } from "@hubspot/api-client/lib/codegen/crm/objects/models/AssociationSpec";
 import { z } from "zod";

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -960,7 +960,7 @@ export const HUBSPOT_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const HUBSPOT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -1,10 +1,10 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts";
 import { AssociationSpecAssociationCategoryEnum } from "@hubspot/api-client/lib/codegen/crm/objects/models/AssociationSpec";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 
@@ -54,9 +54,10 @@ const pageRequestSchema = z.object({
   objectId: z.string().optional(),
 });
 
-export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
+export const HUBSPOT_TOOLS_METADATA = [
   // Read operations
-  get_object_properties: {
+  {
+    name: "get_object_properties",
     description:
       "List all available properties for a Hubspot object. When creatableOnly is true, returns only properties that can be modified through forms (excludes hidden, calculated, read-only and file upload fields).",
     schema: {
@@ -71,7 +72,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_custom_object_schemas: {
+  {
+    name: "list_custom_object_schemas",
     description:
       "List all custom object types (schemas) defined in the HubSpot account, " +
       "with their type IDs, fully-qualified names, and properties. Use this to " +
@@ -86,7 +88,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_owners: {
+  {
+    name: "list_owners",
     description:
       "List all owners (users) in the HubSpot account with their IDs, names, and email addresses. " +
       "Use this to find owner IDs for get_user_activity calls when you want to get activity for other users. " +
@@ -100,7 +103,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_owners: {
+  {
+    name: "search_owners",
     description:
       "Search for specific owners (users) in the HubSpot account by email, name, ID, or user ID. " +
       "Supports partial matching for names and emails, and exact matching for IDs. " +
@@ -120,7 +124,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  count_objects_by_properties: {
+  {
+    name: "count_objects_by_properties",
     description: `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is 10000 objects.`,
     schema: {
       objectType: z.enum(SIMPLE_OBJECTS),
@@ -136,7 +141,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_meeting: {
+  {
+    name: "get_meeting",
     description: "Retrieve a Hubspot meeting (engagement) by its ID.",
     schema: {
       meetingId: z
@@ -151,7 +157,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_file_public_url: {
+  {
+    name: "get_file_public_url",
     description: "Retrieve a publicly available URL for a file in HubSpot.",
     schema: {
       fileId: z.string().describe("The ID of the file."),
@@ -164,7 +171,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_associated_meetings: {
+  {
+    name: "get_associated_meetings",
     description:
       "Retrieve meetings associated with a specific object (contact, company, or deal).",
     schema: {
@@ -181,7 +189,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_crm_objects: {
+  {
+    name: "search_crm_objects",
     description:
       "Search, filter, read, open, or retrieve HubSpot records: contacts, companies, deals, " +
       "leads, tickets, activity records (tasks, notes, meetings, calls, emails), and custom objects. " +
@@ -216,7 +225,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  export_crm_objects_csv: {
+  {
+    name: "export_crm_objects_csv",
     description:
       "Export CRM objects of a given type to CSV, with filters, property selection, and row limits. The resulting file is available for table queries.",
     schema: {
@@ -241,7 +251,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_hubspot_link: {
+  {
+    name: "get_hubspot_link",
     description:
       "Generate HubSpot UI links for different pages based on object types and IDs. " +
       "Supports both index pages (lists of objects) and record pages (specific object details). " +
@@ -261,7 +272,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_hubspot_portal_id: {
+  {
+    name: "get_hubspot_portal_id",
     description:
       "Get the current user's portal ID. To use before calling get_hubspot_link",
     schema: {},
@@ -273,7 +285,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_associations: {
+  {
+    name: "list_associations",
     description:
       "List all associations for a given HubSpot object (e.g., list all contacts associated with a company).",
     schema: {
@@ -294,7 +307,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_association_labels: {
+  {
+    name: "list_association_labels",
     description:
       "List the available association labels between two HubSpot object types " +
       "(e.g., the 'Parent Company'/'Child Company' labels between companies). " +
@@ -315,7 +329,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_current_user_id: {
+  {
+    name: "get_current_user_id",
     description:
       "Identify who you are in HubSpot: get the current authenticated user's " +
       "HubSpot owner ID and profile information. " +
@@ -330,7 +345,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_user_activity: {
+  {
+    name: "get_user_activity",
     description:
       "Retrieve comprehensive user activity across ALL HubSpot engagement types (tasks, notes, meetings, calls, emails) " +
       "for any time period. Solves the problem of getting complete user activity data by automatically trying multiple " +
@@ -372,7 +388,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
 
   // Marketing email operations
-  list_marketing_emails: {
+  {
+    name: "list_marketing_emails",
     description:
       "List marketing emails from HubSpot. Supports filtering by state (e.g., DRAFT, PUBLISHED, AUTOMATED) and pagination. " +
       "Returns email name, subject, state, publish date, and other metadata.",
@@ -401,7 +418,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_marketing_email: {
+  {
+    name: "get_marketing_email",
     description:
       "Retrieve a single marketing email by its ID. Returns full email details including name, subject, state, content, and metadata.",
     schema: {
@@ -417,7 +435,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_marketing_email_statistics: {
+  {
+    name: "get_marketing_email_statistics",
     description:
       "Retrieve deliverability statistics histogram for a marketing email (open rates, click rates, bounces, unsubscribes, etc.). " +
       "Provides time-bucketed data for analyzing email performance over time.",
@@ -440,7 +459,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_email_events: {
+  {
+    name: "list_email_events",
     description:
       "List email events (deliveries, opens, clicks, bounces, unsubscribes, etc.) from HubSpot. " +
       "Supports filtering by event type, campaign ID, and time range. " +
@@ -486,7 +506,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_email_campaigns: {
+  {
+    name: "list_email_campaigns",
     description:
       "List email campaigns from HubSpot. Returns campaign IDs and basic metadata. " +
       "Use get_email_campaign to get full details including deliverability counters for a specific campaign.",
@@ -509,7 +530,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_email_campaign: {
+  {
+    name: "get_email_campaign",
     description:
       "Open and read a detailed HubSpot email campaign report by campaign ID, " +
       "including name, subject, type, " +
@@ -529,7 +551,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
 
   // Create operations
-  create_contact: {
+  {
+    name: "create_contact",
     description: "Create a new contact in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -548,7 +571,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_company: {
+  {
+    name: "create_company",
     description: "Create a new company in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -567,7 +591,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_deal: {
+  {
+    name: "create_deal",
     description: "Create a new deal in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -586,7 +611,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_ticket: {
+  {
+    name: "create_ticket",
     description: "Create a new ticket in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -607,7 +633,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_lead: {
+  {
+    name: "create_lead",
     description: "Create a new lead in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -626,7 +653,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_task: {
+  {
+    name: "create_task",
     description: "Create a new task in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -647,7 +675,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_note: {
+  {
+    name: "create_note",
     description: "Create a new note in Hubspot, with optional associations.",
     schema: {
       properties: z
@@ -677,7 +706,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_communication: {
+  {
+    name: "create_communication",
     description:
       "Create a new communication (WhatsApp, LinkedIn, SMS) in Hubspot. Requires hs_communication_channel_type in properties.",
     schema: {
@@ -698,7 +728,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_meeting: {
+  {
+    name: "create_meeting",
     description:
       "Create a new meeting in Hubspot. Meeting details are in properties.",
     schema: {
@@ -719,7 +750,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_custom_object: {
+  {
+    name: "create_custom_object",
     description:
       "Create a new custom object record in Hubspot, with optional associations. " +
       "Use list_custom_object_schemas to find the object type and its properties.",
@@ -741,7 +773,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_association: {
+  {
+    name: "create_association",
     description:
       "Create an association between two existing HubSpot objects (e.g., associate a contact with a company). " +
       "To create a labeled association (e.g., set a company as the parent/child of another), first call " +
@@ -778,7 +811,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
 
   // Update operations
-  update_contact: {
+  {
+    name: "update_contact",
     description: "Update properties of a HubSpot contact by ID.",
     schema: {
       contactId: z.string().describe("The ID of the contact to update."),
@@ -796,7 +830,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_company: {
+  {
+    name: "update_company",
     description: "Update properties of a HubSpot company by ID.",
     schema: {
       companyId: z.string().describe("The ID of the company to update."),
@@ -814,7 +849,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_deal: {
+  {
+    name: "update_deal",
     description: "Update properties of a HubSpot deal by ID.",
     schema: {
       dealId: z.string().describe("The ID of the deal to update."),
@@ -832,7 +868,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_custom_object: {
+  {
+    name: "update_custom_object",
     description:
       "Update properties of a HubSpot custom object record by ID. Use " +
       "list_custom_object_schemas to find the object type and its properties.",
@@ -853,7 +890,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_task: {
+  {
+    name: "update_task",
     description:
       "Update properties of a HubSpot task by ID (e.g., hs_task_subject, hs_task_body, hs_timestamp, hs_task_priority, hs_task_status). Set hs_task_status to COMPLETED to mark the task as done.",
     schema: {
@@ -872,7 +910,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  complete_task: {
+  {
+    name: "complete_task",
     description:
       "Complete a HubSpot task by ID, setting its status to COMPLETED.",
     schema: {
@@ -886,7 +925,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_task: {
+  {
+    name: "delete_task",
     description: "Delete a HubSpot task by ID.",
     schema: {
       taskId: z.string().describe("The ID of the task to delete."),
@@ -899,7 +939,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  remove_association: {
+  {
+    name: "remove_association",
     description: "Remove an association between two HubSpot objects.",
     schema: {
       fromObjectType: z
@@ -919,7 +960,7 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const HUBSPOT_SERVER = {
   serverInfo: {
@@ -933,13 +974,5 @@ export const HUBSPOT_SERVER = {
     icon: "HubspotLogo",
     documentationUrl: "https://docs.dust.tt/docs/hubspot",
   },
-  tools: Object.values(HUBSPOT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: HUBSPOT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const IMAGE_GENERATION_SERVER_NAME = "image_generation" as const;
 
@@ -64,8 +64,9 @@ export type ImageGenerationToolInput = z.infer<
   typeof imageGenerationToolInputSchema
 >;
 
-export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
-  generate_image: {
+export const IMAGE_GENERATION_TOOLS_METADATA = [
+  {
+    name: "generate_image",
     description:
       "Generate, create, draw, or edit images from text prompts and optional reference images. " +
       "Use to produce illustrations, artwork, photos, graphics, diagrams, logos, portraits, " +
@@ -81,7 +82,7 @@ export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const IMAGE_GENERATION_SERVER = {
   serverInfo: {
@@ -93,13 +94,5 @@ export const IMAGE_GENERATION_SERVER = {
     icon: "ActionImageIcon",
     documentationUrl: null,
   },
-  tools: Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: IMAGE_GENERATION_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -82,7 +82,7 @@ export const IMAGE_GENERATION_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const IMAGE_GENERATION_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const IMAGE_GENERATION_SERVER_NAME = "image_generation" as const;

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   IncludeInputSchema,
   TagsInputSchema,
@@ -8,9 +10,6 @@ import {
   FIND_TAGS_BASE_DESCRIPTION,
   findTagsSchema,
 } from "@app/lib/api/actions/tools/find_tags/metadata";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION =
   "Load and include full document content, documents, or docs from selected data sources or the company knowledge base as conversation context. " +
@@ -18,8 +17,9 @@ const RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION =
   "so the latest pre-configured information is included when the agent needs broad full-context data or all available recent content.";
 
 // Base tool without tags support
-export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
-  retrieve_recent_documents: {
+export const INCLUDE_DATA_BASE_TOOLS_METADATA = [
+  {
+    name: "retrieve_recent_documents",
     description: RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION,
     schema: IncludeInputSchema.shape,
     stake: "never_ask",
@@ -30,7 +30,7 @@ export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // Extended schema with tags support (used when tags are dynamic)
 const includeWithTagsSchema = {
@@ -38,8 +38,9 @@ const includeWithTagsSchema = {
   ...TagsInputSchema.shape,
 };
 
-export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
-  retrieve_recent_documents: {
+export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = [
+  {
+    name: "retrieve_recent_documents",
     description: RETRIEVE_RECENT_DOCUMENTS_DESCRIPTION,
     schema: includeWithTagsSchema,
     stake: "never_ask",
@@ -50,7 +51,8 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  find_tags: {
+  {
+    name: "find_tags",
     description:
       FIND_TAGS_BASE_DESCRIPTION +
       " This tool is meant to be used before the retrieve_recent_documents tool.",
@@ -63,7 +65,7 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // For the server metadata, we use the base schema
 export const INCLUDE_DATA_SERVER = {
@@ -76,13 +78,5 @@ export const INCLUDE_DATA_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: INCLUDE_DATA_BASE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -30,7 +30,7 @@ export const INCLUDE_DATA_BASE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Extended schema with tags support (used when tags are dynamic)
 const includeWithTagsSchema = {
@@ -65,7 +65,7 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // For the server metadata, we use the base schema
 export const INCLUDE_DATA_SERVER = {

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   IncludeInputSchema,
   TagsInputSchema,

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -323,7 +323,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const INTERACTIVE_CONTENT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   frameContentType,

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -1,14 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   frameContentType,
   frameSlideshowContentType,
   INTERACTIVE_CONTENT_FILE_FORMATS,
 } from "@app/types/files";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const INTERACTIVE_CONTENT_SERVER_NAME = "interactive_content" as const;
 
@@ -40,8 +40,9 @@ export const FRAME_RECREATE_WASTE_RATIONALE =
   "a replacement Frame loses the original's identity and share URL and wastes tokens " +
   "regenerating content that did not change";
 
-export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
-  [CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+export const INTERACTIVE_CONTENT_TOOLS_METADATA = [
+  {
+    name: CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Create a new Frame: interactive content such as a dashboard, data visualization, or slideshow " +
       "presentation that users can run and interact with, beyond static viewing. Choose 'template' " +
@@ -103,7 +104,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Edit an existing Frame: change its code, for example to fix a chart, adjust colors, or " +
       "update text and layout. Replaces a specified text segment with new text; each edit creates " +
@@ -157,7 +159,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Revert a Frame to its previous version. " +
       "Each revert goes back one version in the file's history. ",
@@ -177,7 +180,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Rename a Frame. Use this to change the file name of a Frame while keeping its content unchanged.",
     schema: {
@@ -201,7 +205,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Read back the current content of an existing Frame by its file ID. " +
       "Use this to inspect a Frame you have previously created or edited, and to identify " +
@@ -222,7 +227,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {
+  {
+    name: GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME,
     description:
       "Get the share URL (share link) for a Frame. Returns the share URL if the Frame is " +
       "currently shared.",
@@ -242,7 +248,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Export a Frame as a PNG screenshot or PDF document. " +
       "PNG returns a visual snapshot of the rendered frame. " +
@@ -276,7 +283,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+  {
+    name: PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Publish a Frame from its source files, applying source edits to the live rendered Frame. " +
       "A Frame's source lives on the conversation file system at " +
@@ -315,7 +323,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const INTERACTIVE_CONTENT_SERVER = {
   serverInfo: {
@@ -327,13 +335,5 @@ export const INTERACTIVE_CONTENT_SERVER = {
     icon: "ActionFrameIcon",
     documentationUrl: null,
   },
-  tools: Object.values(INTERACTIVE_CONTENT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: INTERACTIVE_CONTENT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -442,7 +442,7 @@ export const JIRA_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const JIRA_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   ADFDocumentSchema,
   JiraCreateIssueLinkRequestSchema,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   ADFDocumentSchema,
   JiraCreateIssueLinkRequestSchema,
@@ -8,13 +10,12 @@ import {
   JiraSortSchema,
   SEARCH_USERS_MAX_RESULTS,
 } from "@app/lib/api/actions/servers/jira/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const JIRA_TOOLS_METADATA = createToolsRecord({
+export const JIRA_TOOLS_METADATA = [
   // Read operations
-  get_issue_read_fields: {
+  {
+    name: "get_issue_read_fields",
     description:
       "List the field keys, ids, and names that can be requested when reading an issue.",
     schema: {},
@@ -26,7 +27,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue: {
+  {
+    name: "get_issue",
     description:
       "Look up and retrieve a single Jira issue (ticket) by its key (e.g., 'PROJ-123'). Returns a minimal set of fields by default. Pass the fields parameter to request others.",
     schema: {
@@ -46,7 +48,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_projects: {
+  {
+    name: "get_projects",
     description: "List Jira projects available in the workspace.",
     schema: {},
     stake: "never_ask",
@@ -57,7 +60,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_project: {
+  {
+    name: "get_project",
     description: "Retrieve one Jira project by project key (e.g., 'PROJ').",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
@@ -70,7 +74,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_project_versions: {
+  {
+    name: "get_project_versions",
     description:
       "Retrieve all versions (releases) for a JIRA project. Useful for getting release reports and understanding which versions are available for filtering issues.",
     schema: {
@@ -84,7 +89,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_transitions: {
+  {
+    name: "get_transitions",
     description:
       "List which status changes a Jira issue is currently allowed to make.",
     schema: {
@@ -98,7 +104,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issues: {
+  {
+    name: "get_issues",
     description:
       "Search or list Jira issues (tickets, bugs) by filters: status (open, in progress, done), priority, labels, who they are assigned to, fixVersion, or dates. Supports fuzzy matching and sorting. Use it to browse the backlog or find issues by criteria.",
     schema: {
@@ -122,7 +129,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issues_using_jql: {
+  {
+    name: "get_issues_using_jql",
     description:
       "Search Jira issues using a raw JQL (Jira Query Language) query string. Use only when you already have a JQL expression.",
     schema: {
@@ -154,7 +162,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue_types: {
+  {
+    name: "get_issue_types",
     description: "Retrieve available issue types for a JIRA project.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
@@ -167,7 +176,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue_create_fields: {
+  {
+    name: "get_issue_create_fields",
     description:
       "List field metadata (names and ids) for a given Jira project and issue type. Use it to discover valid field names before creating or updating issues.",
     schema: {
@@ -184,7 +194,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_connection_info: {
+  {
+    name: "get_connection_info",
     description:
       "Get comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves. Also use it to authenticate when another tool reports that no access token was found.",
     schema: {},
@@ -196,7 +207,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_issue_link_types: {
+  {
+    name: "get_issue_link_types",
     description:
       "Retrieve all available issue link types that can be used when creating issue links.",
     schema: {},
@@ -208,7 +220,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_users: {
+  {
+    name: "get_users",
     description: "Find or search Jira users by email address or display name.",
     schema: {
       emailAddress: z
@@ -243,7 +256,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_attachments: {
+  {
+    name: "get_attachments",
     description:
       "Retrieve all attachments for a Jira issue, including metadata like filename, size, MIME type, and download URLs.",
     schema: {
@@ -257,7 +271,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_attachment: {
+  {
+    name: "read_attachment",
     description:
       "Read the content of an attachment on a Jira issue. Extracts text from PDF, Word, Excel, CSV, and plain-text files (with OCR for scans). Other files are returned as-is.",
     schema: {
@@ -274,7 +289,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
 
   // Write operations
-  create_comment: {
+  {
+    name: "create_comment",
     description:
       "Leave a comment or note on an existing Jira issue. Accepts plain text or rich ADF formatting.",
     schema: {
@@ -301,7 +317,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  transition_issue: {
+  {
+    name: "transition_issue",
     description:
       "Move or change a Jira issue (ticket) to a different status (e.g. to In Progress or Done). Performs a workflow transition.",
     schema: {
@@ -316,7 +333,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_issue: {
+  {
+    name: "create_issue",
     description:
       "Create a new Jira issue, or ticket, in a project. Use it to log a bug, raise a request, or open a task or story. Description fields accept plain text or rich ADF. Required fields vary by project and issue type.",
     schema: {
@@ -332,7 +350,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_issue: {
+  {
+    name: "update_issue",
     description:
       "Update or change field values on an existing Jira issue, such as its summary, description, priority, or assignee. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
     schema: {
@@ -349,7 +368,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_issue_link: {
+  {
+    name: "create_issue_link",
     description:
       "Link or mark two Jira issues as related, with a relationship type such as blocks, relates to, or duplicates.",
     schema: {
@@ -365,7 +385,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_issue_link: {
+  {
+    name: "delete_issue_link",
     description: "Delete an existing link between JIRA issues.",
     schema: {
       linkId: z.string().describe("The ID of the issue link to delete"),
@@ -378,7 +399,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  upload_attachment: {
+  {
+    name: "upload_attachment",
     description:
       "Attach a file to a Jira issue (upload). The file can come from the current Dust conversation or be provided as base64 data.",
     schema: {
@@ -420,7 +442,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const JIRA_SERVER = {
   serverInfo: {
@@ -434,13 +456,5 @@ export const JIRA_SERVER = {
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
   },
-  tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: JIRA_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -73,7 +73,7 @@ export const JIT_TESTING_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const JIT_TESTING_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -1,15 +1,16 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const JIT_TESTING_TOOL_NAME = "jit_testing" as const;
 
-export const JIT_TESTING_TOOLS_METADATA = createToolsRecord({
-  jit_all_optionals_and_defaults: {
+export const JIT_TESTING_TOOLS_METADATA = [
+  {
+    name: "jit_all_optionals_and_defaults",
     description:
       "Aggregate optional/default configs for TIME_FRAME, JSON_SCHEMA, DATA_SOURCE, and AGENT for JIT testing.",
     schema: {
@@ -72,7 +73,7 @@ export const JIT_TESTING_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const JIT_TESTING_SERVER = {
   serverInfo: {
@@ -83,13 +84,5 @@ export const JIT_TESTING_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: JIT_TESTING_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -1,16 +1,17 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   LumaApprovalStatusSchema,
   LumaGuestStatusActionSchema,
   LumaVisibilitySchema,
 } from "@app/lib/api/actions/servers/luma/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const LUMA_TOOLS_METADATA = createToolsRecord({
-  get_authenticated_user: {
+export const LUMA_TOOLS_METADATA = [
+  {
+    name: "get_authenticated_user",
     description:
       "Get the name, email, and ID of the Luma account owner whose API key is configured. " +
       "Useful to confirm which calendar the tools operate on.",
@@ -23,7 +24,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_event: {
+  {
+    name: "get_event",
     description:
       "Get the full details of a specific Luma event by its event ID.",
     schema: {
@@ -37,7 +39,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_events: {
+  {
+    name: "list_events",
     description:
       "List events from the Luma calendar. " +
       "Optionally filter by date range using ISO 8601 datetime strings.",
@@ -59,7 +62,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_event: {
+  {
+    name: "create_event",
     description:
       "Create a new event on Luma. " +
       "Requires at minimum a name and start datetime. " +
@@ -107,7 +111,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_event: {
+  {
+    name: "update_event",
     description:
       "Update an existing Luma event: edit or reschedule its name, start time, " +
       "capacity, or visibility. " +
@@ -160,7 +165,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_guests: {
+  {
+    name: "list_guests",
     description:
       "List guests for a specific Luma event. " +
       "Supports filtering by approval status and pagination via cursor.",
@@ -202,7 +208,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_guest: {
+  {
+    name: "get_guest",
     description:
       "Get the registration record of a single guest who signed up for a Luma event.",
     schema: {
@@ -217,7 +224,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_guest_status: {
+  {
+    name: "update_guest_status",
     description:
       "Approve or decline a single guest on a Luma event, including pending guests. " +
       "Use should_refund when declining guests who paid for registration.",
@@ -244,7 +252,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_guests: {
+  {
+    name: "add_guests",
     description:
       "Add one or more guests to a Luma event by email. " +
       "Guests will be added with their specified name and email.",
@@ -269,7 +278,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  send_invites: {
+  {
+    name: "send_invites",
     description:
       "Send event invitations to a list of email addresses. " +
       "Recipients will receive an email invitation to the event.",
@@ -289,7 +299,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_guests: {
+  {
+    name: "search_guests",
     description:
       "Find a specific attendee by name or email across all registrations of a Luma event. " +
       "Fetches all guests internally and filters by the query string (case-insensitive partial match). " +
@@ -312,7 +323,8 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_event_insights: {
+  {
+    name: "get_event_insights",
     description:
       "Get total registrations, approval status breakdown, check-in rate, " +
       "registration timeline, and ticket type breakdown for an event. " +
@@ -331,7 +343,7 @@ export const LUMA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const LUMA_SERVER = {
   serverInfo: {
@@ -342,13 +354,5 @@ export const LUMA_SERVER = {
     icon: "LumaLogo",
     documentationUrl: null,
   },
-  tools: Object.values(LUMA_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: LUMA_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -343,7 +343,7 @@ export const LUMA_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const LUMA_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   LumaApprovalStatusSchema,
   LumaGuestStatusActionSchema,

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const MICROSOFT_DRIVE_SERVER_NAME = "microsoft_drive" as const;

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -1,15 +1,16 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MICROSOFT_DRIVE_SERVER_NAME = "microsoft_drive" as const;
 
 const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
 
-export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
-  search_in_files: {
+export const MICROSOFT_DRIVE_TOOLS_METADATA = [
+  {
+    name: "search_in_files",
     description:
       "Search the content inside Microsoft OneDrive and SharePoint files using semantic retrieval. Answers questions from what documents contain by finding relevant passages and information within Word, Excel, PowerPoint, and other files, including external items indexed in Microsoft Graph.",
     schema: {
@@ -35,7 +36,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_drive_items: {
+  {
+    name: "search_drive_items",
     description:
       "Find and locate a file, folder, or document by its name or title in Microsoft OneDrive and SharePoint, returned in relevance order. Use when you know the item's name and want to look it up, such as a specific Word, Excel, or PowerPoint document, or a folder to upload into.",
     schema: {
@@ -53,7 +55,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_drive_items: {
+  {
+    name: "list_drive_items",
     description:
       "Browse and list items (folders and/or files) in a Microsoft OneDrive or SharePoint drive, SharePoint site, or under a specific parent folder. Use parentFolderId to drill into a specific folder; otherwise lists items at the root of the drive/site. Filter the result with itemType. Supports pagination via skipToken.",
     schema: {
@@ -104,7 +107,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_item_from_url: {
+  {
+    name: "get_item_from_url",
     description:
       "Resolve a Microsoft OneDrive or SharePoint URL (file, folder, or sharing link) to its drive item. Returns the item's id, driveId, name, type, and webUrl.",
     schema: {
@@ -122,7 +126,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_word_document: {
+  {
+    name: "update_word_document",
     description:
       "Edit and update an existing Microsoft Word document on OneDrive or SharePoint by providing new document.xml content. Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
@@ -153,7 +158,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_file_content: {
+  {
+    name: "get_file_content",
     description:
       "Read, open, and retrieve the content of a file or document from Microsoft OneDrive or SharePoint (PowerPoint, Word, Excel, PDF, etc.). Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
@@ -199,7 +205,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_folder: {
+  {
+    name: "create_folder",
     description:
       "Create a new folder in Microsoft OneDrive or SharePoint under a parent folder, or at the root of the drive. Uses driveId if provided, otherwise falls back to siteId. Returns the new folder's id.",
     schema: {
@@ -231,7 +238,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  upload_file: {
+  {
+    name: "upload_file",
     description:
       "Upload a file from the Dust conversation to Microsoft OneDrive or SharePoint. Supports files up to 250MB using the simple upload API. Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
@@ -273,7 +281,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  rename_drive_item: {
+  {
+    name: "rename_drive_item",
     description:
       "Rename a file or folder in Microsoft OneDrive or SharePoint. Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
@@ -300,7 +309,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  copy_file: {
+  {
+    name: "copy_file",
     description:
       "Copy, clone, or duplicate a file or folder to a new location in Microsoft OneDrive or SharePoint.",
     schema: {
@@ -338,7 +348,7 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const MICROSOFT_DRIVE_SERVER = {
   serverInfo: {
@@ -394,13 +404,5 @@ export const MICROSOFT_DRIVE_SERVER = {
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
   },
-  tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: MICROSOFT_DRIVE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -348,7 +348,7 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const MICROSOFT_DRIVE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const MICROSOFT_EXCEL_SERVER_NAME = "microsoft_excel" as const;

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -201,7 +201,7 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const MICROSOFT_EXCEL_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MICROSOFT_EXCEL_SERVER_NAME = "microsoft_excel" as const;
 
-export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
-  list_excel_files: {
+export const MICROSOFT_EXCEL_TOOLS_METADATA = [
+  {
+    name: "list_excel_files",
     description:
       "List and find Excel files (.xlsx, .xlsm) accessible in your organization.",
     schema: {
@@ -23,7 +24,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_worksheets: {
+  {
+    name: "get_worksheets",
     description:
       "Get a list of all worksheets (sheets/tabs) in an Excel workbook.",
     schema: {
@@ -51,7 +53,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_worksheet: {
+  {
+    name: "read_worksheet",
     description:
       "Read cell values from an Excel worksheet. Returns data as CSV. Reads the used range by default; use the range parameter to read a specific subset.",
     schema: {
@@ -86,7 +89,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  write_worksheet: {
+  {
+    name: "write_worksheet",
     description: "Write data to a specific range in an Excel worksheet.",
     schema: {
       itemId: z.string().describe("The ID of the Excel file to write to."),
@@ -126,7 +130,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_worksheet: {
+  {
+    name: "create_worksheet",
     description: "Create a new worksheet (sheet/tab) in an Excel workbook.",
     schema: {
       itemId: z
@@ -156,7 +161,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  clear_range: {
+  {
+    name: "clear_range",
     description: "Clear data from a specific range in an Excel worksheet.",
     schema: {
       itemId: z
@@ -195,7 +201,7 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const MICROSOFT_EXCEL_SERVER = {
   serverInfo: {
@@ -244,13 +250,5 @@ export const MICROSOFT_EXCEL_SERVER = {
     },
     documentationUrl: null,
   },
-  tools: Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: MICROSOFT_EXCEL_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MICROSOFT_TEAMS_SERVER_NAME = "microsoft_teams" as const;
 
-export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
-  search_messages_content: {
+export const MICROSOFT_TEAMS_TOOLS_METADATA = [
+  {
+    name: "search_messages_content",
     description:
       "Search Microsoft Teams messages by full-text keyword. Returns matching messages ranked by relevance. Use this to find a message by its words, not to browse or enumerate a conversation.",
     schema: {
@@ -23,7 +24,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_teams: {
+  {
+    name: "list_teams",
     description:
       "List all Teams that the authenticated user has joined. Returns team details including name, description, and team ID.",
     schema: {},
@@ -35,7 +37,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_users: {
+  {
+    name: "list_users",
     description:
       "List people in the Microsoft Teams organization directory. Returns each user's display name, email, and user ID. Use this to look up who is in the organization.",
     schema: {
@@ -57,7 +60,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_channels: {
+  {
+    name: "list_channels",
     description:
       "List all channels in a specific Microsoft Teams team. Returns channel details including name, description, and channel ID. Can be filtered by channel name.",
     schema: {
@@ -77,7 +81,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_chats: {
+  {
+    name: "list_chats",
     description:
       "List all Microsoft Teams chats (one-on-one or group chats) for the authenticated user. Returns chat details including chat ID, topic, and participants. Can be filtered by chat type and chat topic.",
     schema: {
@@ -107,7 +112,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_messages: {
+  {
+    name: "list_messages",
     description:
       "List messages from a Teams channel or chat (1:1, group, or meeting chat). Provide either chatId (for chats) or both teamId + channelId (for channels). For channels, returns top-level messages only; to read a full thread, call again with a messageId. messageId is supported for channels only, not for chats. For chats, returns all messages. Supports pagination and date range filtering.",
     schema: {
@@ -154,7 +160,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  post_message: {
+  {
+    name: "post_message",
     description:
       "Post a message to a Teams channel, chat, or as a reply in a thread. Can send messages to channels, direct chats, or as threaded replies. For direct messages, you can provide userIds instead of chatId to automatically create a chat if it doesn't exist (one-on-one for 1 user, group chat for multiple users). By default (if no chat, channel or users are provided), the message will be sent to the current user's self-chat.",
     schema: {
@@ -230,7 +237,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_meetings: {
+  {
+    name: "list_meetings",
     description:
       "List the authenticated user's Microsoft Teams meetings (online meetings on their calendar) within a date range. Returns each meeting's subject, organizer, attendees, times, and join URL. Filter by subject or participant.",
     schema: {
@@ -261,7 +269,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_transcript_content: {
+  {
+    name: "get_transcript_content",
     description:
       "Get the transcript (the spoken text) of a recorded Microsoft Teams meeting, identified by its join URL. Returns the transcript text if one is available.",
     schema: {
@@ -279,7 +288,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const MICROSOFT_TEAMS_SERVER = {
   serverInfo: {
@@ -368,13 +377,5 @@ export const MICROSOFT_TEAMS_SERVER = {
     },
     documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
   },
-  tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: MICROSOFT_TEAMS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -288,7 +288,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const MICROSOFT_TEAMS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const MICROSOFT_TEAMS_SERVER_NAME = "microsoft_teams" as const;

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const MONDAY_TOOLS_METADATA = createToolsRecord({
-  get_boards: {
+export const MONDAY_TOOLS_METADATA = [
+  {
+    name: "get_boards",
     description:
       "List all accessible boards in Monday.com workspace. Returns up to 100 boards.",
     schema: {},
@@ -17,7 +18,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_board_items: {
+  {
+    name: "get_board_items",
     description:
       "Retrieve items from a specific Monday.com board. Returns up to 100 items.",
     schema: {
@@ -31,7 +33,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_item_details: {
+  {
+    name: "get_item_details",
     description:
       "Retrieve detailed information about a specific Monday.com item",
     schema: {
@@ -45,7 +48,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_items: {
+  {
+    name: "search_items",
     description:
       "Search for items in Monday.com with advanced filtering options. Returns up to 100 items.",
     schema: {
@@ -85,7 +89,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_items_by_column_value: {
+  {
+    name: "get_items_by_column_value",
     description: "Retrieve items from a board by column value",
     schema: {
       boardId: z.string().describe("The board ID to search in"),
@@ -100,7 +105,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  find_user_by_name: {
+  {
+    name: "find_user_by_name",
     description: "Find a Monday.com user by name",
     schema: {
       name: z.string().describe("The name of the user to find"),
@@ -113,7 +119,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_board_values: {
+  {
+    name: "get_board_values",
     description:
       "Retrieve detailed information about a Monday.com board including columns and groups",
     schema: {
@@ -127,7 +134,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_column_values: {
+  {
+    name: "get_column_values",
     description: "Retrieve column values for a specific item and column",
     schema: {
       boardId: z.string().describe("The board ID containing the item"),
@@ -142,7 +150,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_file_column_values: {
+  {
+    name: "get_file_column_values",
     description: "Retrieve file column values for a specific item and column",
     schema: {
       itemId: z.string().describe("The item ID to get file column values from"),
@@ -158,7 +167,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_group_details: {
+  {
+    name: "get_group_details",
     description:
       "Retrieve details about a specific group in a Monday.com board",
     schema: {
@@ -173,7 +183,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_subitem_values: {
+  {
+    name: "get_subitem_values",
     description: "Retrieve subitems for a specific Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to retrieve subitems for"),
@@ -186,7 +197,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_user_details: {
+  {
+    name: "get_user_details",
     description: "Retrieve details about a specific Monday.com user",
     schema: {
       userId: z.string().describe("The user ID to retrieve details for"),
@@ -199,7 +211,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_activity_logs: {
+  {
+    name: "get_activity_logs",
     description:
       "Retrieve activity logs for a board. Useful for tracking pipeline velocity and user actions.",
     schema: {
@@ -227,7 +240,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_board_analytics: {
+  {
+    name: "get_board_analytics",
     description:
       "Retrieve analytics and statistics for a board including item counts by status, group, and assignee. Useful for CRM reporting.",
     schema: {
@@ -241,7 +255,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_item: {
+  {
+    name: "create_item",
     description: "Create a new item in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the item in"),
@@ -265,7 +280,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_item: {
+  {
+    name: "update_item",
     description: "Update column values of an existing Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to update"),
@@ -283,7 +299,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_item_name: {
+  {
+    name: "update_item_name",
     description: "Update the name of a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to update"),
@@ -297,7 +314,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_update: {
+  {
+    name: "create_update",
     description: "Add an update (comment) to a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to add the update to"),
@@ -311,7 +329,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_board: {
+  {
+    name: "create_board",
     description: "Create a new board in Monday.com",
     schema: {
       boardName: z.string().describe("The name of the new board"),
@@ -336,7 +355,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_column: {
+  {
+    name: "create_column",
     description: "Create a new column in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the column in"),
@@ -357,7 +377,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_group: {
+  {
+    name: "create_group",
     description: "Create a new group in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID to create the group in"),
@@ -375,7 +396,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_subitem: {
+  {
+    name: "create_subitem",
     description: "Create a new subitem for a Monday.com item",
     schema: {
       parentItemId: z.string().describe("The parent item ID"),
@@ -393,7 +415,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_subitem: {
+  {
+    name: "update_subitem",
     description: "Update column values of a Monday.com subitem",
     schema: {
       subitemId: z.string().describe("The subitem ID to update"),
@@ -409,7 +432,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  duplicate_group: {
+  {
+    name: "duplicate_group",
     description: "Duplicate a group in a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID containing the group"),
@@ -431,7 +455,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  upload_file_to_column: {
+  {
+    name: "upload_file_to_column",
     description: "Upload a file to a Monday.com column",
     schema: {
       itemId: z.string().describe("The item ID to upload the file to"),
@@ -446,7 +471,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_item: {
+  {
+    name: "delete_item",
     description: "Delete a Monday.com item",
     schema: {
       itemId: z.string().describe("The item ID to delete"),
@@ -459,7 +485,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_group: {
+  {
+    name: "delete_group",
     description: "Delete a group from a Monday.com board",
     schema: {
       boardId: z.string().describe("The board ID containing the group"),
@@ -473,7 +500,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  move_item_to_board: {
+  {
+    name: "move_item_to_board",
     description:
       "Move an item from one board to another. Useful for converting leads to opportunities in CRM workflows.",
     schema: {
@@ -504,7 +532,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_multiple_items: {
+  {
+    name: "create_multiple_items",
     description:
       "Create multiple items in one or more boards in a single operation. Useful for bulk importing leads or opportunities.",
     schema: {
@@ -533,7 +562,7 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const MONDAY_SERVER = {
   serverInfo: {
@@ -548,13 +577,5 @@ export const MONDAY_SERVER = {
     icon: "MondayLogo",
     documentationUrl: "https://docs.dust.tt/docs/monday",
   },
-  tools: Object.values(MONDAY_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: MONDAY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -562,7 +562,7 @@ export const MONDAY_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const MONDAY_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const MONDAY_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -583,7 +583,7 @@ export const NOTION_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const NOTION_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const NOTION_TOOL_NAME = "notion" as const;

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const NOTION_TOOL_NAME = "notion" as const;
 
@@ -218,8 +218,9 @@ export const NotionBlockSchema: z.ZodType = z.union([
   FallbackBlock,
 ]);
 
-export const NOTION_TOOLS_METADATA = createToolsRecord({
-  search: {
+export const NOTION_TOOLS_METADATA = [
+  {
+    name: "search",
     description:
       "Search Notion to find and locate pages or databases by keyword across the workspace. Use this first to find a page or database when you only know its name or topic and not its ID.",
     schema: {
@@ -245,7 +246,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  retrieve_page: {
+  {
+    name: "retrieve_page",
     description: "Retrieve a Notion page by its ID.",
     schema: {
       pageId: z.string().describe("The Notion page ID."),
@@ -258,7 +260,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  retrieve_database_schema: {
+  {
+    name: "retrieve_database_schema",
     description:
       "Retrieve the schema of a Notion database by its ID: the list of columns and property definitions and their types. Use to inspect a database's structure.",
     schema: {
@@ -272,7 +275,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  retrieve_database_content: {
+  {
+    name: "retrieve_database_content",
     description:
       "List all entries (the rows and pages) contained in a Notion database by its ID, with optional filtering and sorting. Returns every page in the database.",
     schema: {
@@ -293,7 +297,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  query_database: {
+  {
+    name: "query_database",
     description: "Query a Notion database.",
     schema: {
       databaseId: z.string().describe("The Notion database ID."),
@@ -313,7 +318,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_page: {
+  {
+    name: "create_page",
     description: "Create a new Notion page.",
     schema: {
       parent: parentPageSchema.describe(
@@ -331,7 +337,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  insert_row_into_database: {
+  {
+    name: "insert_row_into_database",
     description: "Create a new Notion page in a database.",
     schema: {
       databaseId: z.string().describe("The Notion database ID."),
@@ -347,7 +354,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_database: {
+  {
+    name: "create_database",
     description: "Create a new Notion database (table).",
     schema: {
       parent: parentPageSchema.describe(
@@ -370,7 +378,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_page: {
+  {
+    name: "update_page",
     description: "Update a Notion page's properties.",
     schema: {
       pageId: z.string().describe("The Notion page ID."),
@@ -384,7 +393,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  retrieve_block: {
+  {
+    name: "retrieve_block",
     description: "Retrieve a Notion block by its ID.",
     schema: {
       blockId: z.string().describe("The Notion block ID."),
@@ -397,7 +407,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  retrieve_block_children: {
+  {
+    name: "retrieve_block_children",
     description: "Retrieve the children of a Notion block or page by its ID.",
     schema: {
       blockId: z.string().describe("The Notion block or page ID."),
@@ -415,7 +426,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_page_content: {
+  {
+    name: "add_page_content",
     description:
       "Add a single content block to a Notion page. For multiple blocks, call this action multiple times. Only supports adding to Notion pages. Blocks that can contain children include: page, toggle, to-do, bulleted list, numbered list, callout, and quote.",
     schema: {
@@ -438,7 +450,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_comment: {
+  {
+    name: "create_comment",
     description:
       "Create a comment on a Notion page or in an existing discussion thread. Provide either a parent page ID or a discussion ID. Inline comments to start a new thread are not supported via the public API.",
     schema: {
@@ -465,7 +478,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_block: {
+  {
+    name: "delete_block",
     description:
       "Archive (delete) block content in a page. In the Notion UI, this moves the block to the 'trash,' where it can be restored if needed.",
     schema: {
@@ -479,7 +493,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_page: {
+  {
+    name: "delete_page",
     description:
       "Archive (delete) a page or database row. In the Notion UI, this moves the block to the 'trash,' where it can be restored if needed.",
     schema: {
@@ -493,7 +508,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  fetch_comments: {
+  {
+    name: "fetch_comments",
     description:
       "Retrieve a list of unresolved comment objects from a specified page or block in Notion.",
     schema: {
@@ -509,7 +525,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_row_database: {
+  {
+    name: "update_row_database",
     description:
       "Update a specific property value in a row (page) of a Notion database. Value formats depend on the property type (e.g., text, number, select, date, people, URL, files, checkbox).",
     schema: {
@@ -524,7 +541,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_schema_database: {
+  {
+    name: "update_schema_database",
     description:
       "Update the schema (columns/properties) of an existing Notion database.",
     schema: {
@@ -539,7 +557,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_users: {
+  {
+    name: "list_users",
     description: "List all users in the Notion workspace.",
     schema: {},
     stake: "never_ask",
@@ -550,7 +569,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_about_user: {
+  {
+    name: "get_about_user",
     description: "Get information about a specific user by userId.",
     schema: {
       userId: z.string().describe("The Notion user ID."),
@@ -563,7 +583,7 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const NOTION_SERVER = {
   serverInfo: {
@@ -577,13 +597,5 @@ export const NOTION_SERVER = {
     icon: "NotionLogo",
     documentationUrl: "https://docs.dust.tt/docs/notion-mcp",
   },
-  tools: Object.values(NOTION_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: NOTION_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
-  get_completions_usage: {
+export const OPENAI_USAGE_TOOLS_METADATA = [
+  {
+    name: "get_completions_usage",
     description:
       "Get OpenAI completions usage data from the Usage API. Returns token usage, model requests, and other metrics.",
     schema: {
@@ -77,7 +78,8 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_organization_costs: {
+  {
+    name: "get_organization_costs",
     description:
       "Get OpenAI organization cost data from the Costs API. Returns detailed cost breakdown by line items.",
     schema: {
@@ -125,7 +127,7 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const OPENAI_USAGE_SERVER = {
   serverInfo: {
@@ -137,13 +139,5 @@ export const OPENAI_USAGE_SERVER = {
     icon: "OpenaiLogo",
     documentationUrl: null,
   },
-  tools: Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: OPENAI_USAGE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const OPENAI_USAGE_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -127,7 +127,7 @@ export const OPENAI_USAGE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const OPENAI_USAGE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -340,7 +340,7 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const OUTLOOK_CALENDAR_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
-  get_user_timezone: {
+export const OUTLOOK_CALENDAR_TOOLS_METADATA = [
+  {
+    name: "get_user_timezone",
     description:
       "Get the user's configured timezone from their Outlook mailbox settings. This should be called before creating, updating, or searching for events to ensure proper timezone handling.",
     schema: {},
@@ -17,7 +18,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_calendars: {
+  {
+    name: "list_calendars",
     description: "List all calendars accessible by the user in Outlook.",
     schema: {
       top: z
@@ -43,7 +45,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_events: {
+  {
+    name: "list_events",
     description:
       "List or search events from an Outlook Calendar. Supports filtering and searching. For accurate timezone handling, first call get_user_timezone and pass the timezone parameter.",
     schema: {
@@ -90,7 +93,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_event: {
+  {
+    name: "get_event",
     description: "Get a single event from an Outlook Calendar by event ID.",
     schema: {
       calendarId: z
@@ -115,7 +119,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_event: {
+  {
+    name: "create_event",
     description:
       "Create a new event in an Outlook Calendar. Call get_user_timezone first and pass the userTimezone parameter for proper timezone handling.",
     schema: {
@@ -181,7 +186,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_event: {
+  {
+    name: "update_event",
     description:
       "Update an existing event in an Outlook Calendar. Call get_user_timezone first and pass the userTimezone parameter for proper timezone handling.",
     schema: {
@@ -233,7 +239,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_event: {
+  {
+    name: "delete_event",
     description: "Delete an event from an Outlook Calendar.",
     schema: {
       calendarId: z
@@ -258,7 +265,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  check_availability: {
+  {
+    name: "check_availability",
     description:
       "Check the calendar availability of specific people for a given time slot using Outlook Calendar.",
     schema: {
@@ -294,7 +302,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  check_self_availability: {
+  {
+    name: "check_self_availability",
     description:
       "Check if the authenticated user is available during a specific time slot in Outlook Calendar. " +
       "An event is considered blocking if its showAs status is 'busy', " +
@@ -331,7 +340,7 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const OUTLOOK_CALENDAR_SERVER = {
   serverInfo: {
@@ -381,13 +390,5 @@ export const OUTLOOK_CALENDAR_SERVER = {
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
   },
-  tools: Object.values(OUTLOOK_CALENDAR_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: OUTLOOK_CALENDAR_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const OUTLOOK_CALENDAR_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const OUTLOOK_TOOL_NAME = "outlook" as const;

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -574,7 +574,7 @@ export const OUTLOOK_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const OUTLOOK_MAIL_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const OUTLOOK_TOOL_NAME = "outlook" as const;
 
-export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
-  get_messages: {
+export const OUTLOOK_TOOLS_METADATA = [
+  {
+    name: "get_messages",
     description:
       "Get message metadata and previews from Outlook. Returns subject, sender, date, and a short bodyPreview snippet (~255 chars) — NOT the full body. If the task requires reading the actual content of any email, you MUST call get_message_body for each message after this call.",
     schema: {
@@ -54,7 +55,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_folders: {
+  {
+    name: "list_folders",
     description:
       "List mail folders in an Outlook mailbox. Returns the immediate children of the specified folder path, or top-level folders when no path is given. Use this to discover the full folder hierarchy before calling get_messages with a subfolder path.",
     schema: {
@@ -81,7 +83,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_attachments: {
+  {
+    name: "list_attachments",
     description:
       "List attachments on an Outlook message, returning metadata only (id, name, contentType, size, isInline). Use this first to see what attachments exist, then call get_attachment for each one you want to retrieve. Inline attachments (embedded images, signatures) are excluded by default.",
     schema: {
@@ -111,7 +114,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_attachment: {
+  {
+    name: "get_attachment",
     description:
       "Retrieve a single attachment from an Outlook message by its attachment ID. Works for any file size — for large attachments (>4MB) where the list call returns no inline content, this tool fetches via a dedicated download endpoint. Call list_attachments first to get attachment IDs.",
     schema: {
@@ -138,7 +142,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_attachments: {
+  {
+    name: "get_attachments",
     description:
       "Get all attachments from an Outlook message at once. For better control over large attachments, prefer list_attachments followed by individual get_attachment calls instead.",
     schema: {
@@ -164,7 +169,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_drafts: {
+  {
+    name: "get_drafts",
     description:
       "Get draft emails from Outlook. Returns a limited number of drafts by default to avoid overwhelming responses.",
     schema: {
@@ -199,7 +205,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_draft: {
+  {
+    name: "create_draft",
     description: `Create a new email draft in Outlook, or a reply draft to an existing message.
 - The draft will be saved in the user's Outlook account and can be reviewed and sent later.
 - The draft will include proper email headers and formatting.`,
@@ -280,7 +287,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_draft: {
+  {
+    name: "delete_draft",
     description: "Delete a draft email from Outlook.",
     schema: {
       messageId: z.string().describe("The ID of the draft to delete"),
@@ -301,7 +309,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  send_mail: {
+  {
+    name: "send_mail",
     description: `Send an email directly via Outlook.
 - The email will be sent immediately without creating a draft.
 - Use this when all required fields are known.`,
@@ -382,7 +391,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  move_messages: {
+  {
+    name: "move_messages",
     description:
       'Move one or more messages to a destination folder in Outlook. The destination is given as a path of folder names from the top level (e.g. ["Archive", "2026", "Receipts"]). Any folders along the path that do not exist are created automatically. Prefer passing all messages destined for the same folder in a single call rather than calling this tool in parallel. Note: Microsoft Graph assigns a new message ID after a move.',
     schema: {
@@ -413,7 +423,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_message_body: {
+  {
+    name: "get_message_body",
     description:
       "Get the full body of a single Outlook message. ALWAYS call this after get_messages whenever the task requires reading email content — get_messages only returns a short preview. For large emails, use startChar/endChar to read in chunks and repeat until moreAvailable is false.",
     schema: {
@@ -455,7 +466,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_contacts: {
+  {
+    name: "get_contacts",
     description:
       "Get contacts from Outlook. Supports search queries to filter contacts.",
     schema: {
@@ -488,7 +500,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_contact: {
+  {
+    name: "create_contact",
     description: "Create a new contact in Outlook.",
     schema: {
       displayName: z.string().describe("Display name of the contact"),
@@ -522,7 +535,8 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_contact: {
+  {
+    name: "update_contact",
     description: "Update an existing contact in Outlook.",
     schema: {
       contactId: z.string().describe("ID of the contact to update"),
@@ -560,7 +574,7 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const OUTLOOK_MAIL_SERVER = {
   serverInfo: {
@@ -627,13 +641,5 @@ export const OUTLOOK_MAIL_SERVER = {
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
   },
-  tools: Object.values(OUTLOOK_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: OUTLOOK_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const PLAN_MODE_SKELETON = `# <plan title>
 
@@ -21,8 +21,9 @@ export const CLOSE_PLAN_TOOL_NAME = "close_plan" as const;
 
 export const PLAN_FILE_NAME = "plan.md" as const;
 
-export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
-  create_plan: {
+export const PLAN_MODE_TOOLS_METADATA = [
+  {
+    name: "create_plan",
     description:
       `Create the conversation's \`${PLAN_FILE_NAME}\` with the markdown you pass as \`content\`. Write the ` +
       "full plan directly; do not create an empty plan and then edit it. Exactly one active " +
@@ -49,7 +50,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  edit_plan: {
+  {
+    name: "edit_plan",
     description:
       `Edit the active \`${PLAN_FILE_NAME}\` by replacing \`old_string\` with \`new_string\`. The full updated ` +
       `contents of ${PLAN_FILE_NAME} are returned so you can see your change.\n\n` +
@@ -77,7 +79,8 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  close_plan: {
+  {
+    name: "close_plan",
     description:
       `Retire the current plan. After ${CLOSE_PLAN_TOOL_NAME}, the plan is hidden from the UI and this ` +
       `skill will not reference it again. You can call \`${CREATE_PLAN_TOOL_NAME}\` to start a fresh plan ` +
@@ -100,7 +103,7 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const PLAN_MODE_SERVER = {
   serverInfo: {
@@ -114,13 +117,5 @@ export const PLAN_MODE_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: PLAN_MODE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -103,7 +103,7 @@ export const PLAN_MODE_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const PLAN_MODE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const PLAN_MODE_SKELETON = `# <plan title>

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   IncludeInputSchema,
   SearchWithNodesInputSchema,

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -564,7 +564,7 @@ export const POD_MANAGER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const POD_MANAGER_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -1,6 +1,8 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   IncludeInputSchema,
   SearchWithNodesInputSchema,
@@ -13,9 +15,7 @@ import {
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const POD_MANAGER_SERVER_NAME = "pod_manager" as const;
 export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
@@ -25,8 +25,9 @@ export const EDIT_INFORMATION_TOOL_NAME = "edit_information" as const;
 export const SET_PINNED_FRAME_TOOL_NAME = "set_pinned_frame" as const;
 export const MOVE_CONVERSATION_TOOL_NAME = "move_conversation" as const;
 
-export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
-  add_content_node: {
+export const POD_MANAGER_TOOLS_METADATA = [
+  {
+    name: "add_content_node",
     description:
       "Add a content node reference from Company Data to the Pod context. The node will be available to all conversations in this Pod.",
     schema: {
@@ -53,7 +54,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  remove_content_node: {
+  {
+    name: "remove_content_node",
     description:
       "Remove a content node reference from the Pod context. The node will no longer be available to conversations in this Pod. " +
       "Use nodeId with nodeDataSourceViewId from get_information attachments for this reference.",
@@ -80,7 +82,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [EDIT_INFORMATION_TOOL_NAME]: {
+  {
+    name: EDIT_INFORMATION_TOOL_NAME,
     description:
       "Edit Pod information: title, description, and/or access. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
@@ -115,7 +118,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [SET_PINNED_FRAME_TOOL_NAME]: {
+  {
+    name: SET_PINNED_FRAME_TOOL_NAME,
     description:
       "Set or clear the Pod banner frame — the frame pinned to the top of the Pod. " +
       "The pinned frame must be an existing Pod file path under `pod/` (pass null to unpin).",
@@ -142,7 +146,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [UPDATE_MEMBERS_TOOL_NAME]: {
+  {
+    name: UPDATE_MEMBERS_TOOL_NAME,
     description:
       "Update membership for an existing Pod: invite, add, remove, " +
       "promote, or demote teammates as Pod members or editors by user id. " +
@@ -172,7 +177,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  get_information: {
+  {
+    name: "get_information",
     description:
       "Get metadata about the Pod: URL, title, description, access, pinned frame, " +
       "and linked Company Data content-node references attached to the " +
@@ -197,7 +203,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [LIST_MEMBERS_TOOL_NAME]: {
+  {
+    name: LIST_MEMBERS_TOOL_NAME,
     description:
       "List all people in the Pod, including members and editors. " +
       "Each entry includes user ID, name, email, and role or status " +
@@ -234,7 +241,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  list_pods: {
+  {
+    name: "list_pods",
     description:
       "List non-archived Pods. Defaults to Pods where you are a member (access='member'). " +
       "Use access='open' to list all open Pods in the workspace. " +
@@ -275,7 +283,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  create_pod: {
+  {
+    name: "create_pod",
     description:
       "Create a new Pod. By default the Pod is restricted. The creator is always added as a Pod editor. " +
       "You can optionally set access to open and add initial members or editors via membersToAdd.",
@@ -310,7 +319,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  retrieve_recent_documents: {
+  {
+    name: "retrieve_recent_documents",
     description:
       "Fetch the most recent documents from this Pod's knowledge data source and from any content nodes linked in the " +
       "Pod context, in reverse chronological order up to the retrieval limit. Respects optional time window. " +
@@ -331,7 +341,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  [SEMANTIC_SEARCH_TOOL_NAME]: {
+  {
+    name: SEMANTIC_SEARCH_TOOL_NAME,
     description:
       "Find and search for information about a topic or question across Pod " +
       "files, content nodes attached to the Pod, and Pod conversation " +
@@ -373,7 +384,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  create_conversation: {
+  {
+    name: "create_conversation",
     description:
       "Create or start a new Pod conversation and post a user message. " +
       "Default for Pod work: pass an agentName so a Pod agent handles " +
@@ -412,7 +424,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  list_conversations: {
+  {
+    name: "list_conversations",
     description:
       "List conversations in the Pod updated on or after a given time (updatedSince). " +
       "Use unreadOnly=true to return only conversations with unread messages (same as narrowing unread), " +
@@ -469,7 +482,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [MOVE_CONVERSATION_TOOL_NAME]: {
+  {
+    name: MOVE_CONVERSATION_TOOL_NAME,
     description:
       "Move a conversation into a Pod or out of its Pod to the user's personal conversations. " +
       "Set destination to 'pod' to move into a Pod (requires dustPod), or 'personal' to move out of the current Pod. " +
@@ -502,7 +516,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  add_message_to_conversation: {
+  {
+    name: "add_message_to_conversation",
     description:
       "Send or post a follow-up user message to an existing conversation " +
       "in this Pod. Default for Pod work: pass an agentName so a Pod agent " +
@@ -549,7 +564,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const POD_MANAGER_SERVER = {
   serverInfo: {
@@ -563,13 +578,5 @@ export const POD_MANAGER_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(POD_MANAGER_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: POD_MANAGER_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   PodTasksCreateTasksInputSchema,
   PodTasksUpdateTasksInputSchema,

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -1,22 +1,23 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   PodTasksCreateTasksInputSchema,
   PodTasksUpdateTasksInputSchema,
 } from "@app/lib/api/actions/servers/pod_tasks/types";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const POD_TASKS_SERVER_NAME = "pod_tasks" as const;
 export const CREATE_TASKS_TOOL_NAME = "create_tasks" as const;
 export const UPDATE_TASKS_TOOL_NAME = "update_tasks" as const;
 export const START_TASK_AGENT_TOOL_NAME = "start_task_agent" as const;
 
-export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
-  list_tasks: {
+export const POD_TASKS_TOOLS_METADATA = [
+  {
+    name: "list_tasks",
     description:
       "List tasks in the Pod. " +
       "Defaults to the current user's tasks (assigneeFilter='mine') and open (statusFilter='open') items. ",
@@ -59,7 +60,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [CREATE_TASKS_TOOL_NAME]: {
+  {
+    name: CREATE_TASKS_TOOL_NAME,
     description:
       "Create one or more new tasks at once in the Pod. Omitting userId (or null) creates an unassigned task unless the Pod has exactly one assignable member, in which case that member is assigned. Pass userId when a specific person should own the task.",
     schema: PodTasksCreateTasksInputSchema.shape,
@@ -71,7 +73,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [UPDATE_TASKS_TOOL_NAME]: {
+  {
+    name: UPDATE_TASKS_TOOL_NAME,
     description: "Update one or more existing tasks at once in the Pod.",
     schema: PodTasksUpdateTasksInputSchema.shape,
     stake: "low",
@@ -82,7 +85,8 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [START_TASK_AGENT_TOOL_NAME]: {
+  {
+    name: START_TASK_AGENT_TOOL_NAME,
     description:
       "Start an agent conversation to work on one of your open tasks with status 'todo'. " +
       "If already started, it reuses the existing linked conversation.",
@@ -117,7 +121,7 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const POD_TASKS_SERVER = {
   serverInfo: {
@@ -129,13 +133,5 @@ export const POD_TASKS_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(POD_TASKS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: POD_TASKS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -121,7 +121,7 @@ export const POD_TASKS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const POD_TASKS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 // ─── Workspace Context ───────────────────────────────────────────────────────

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -403,7 +403,7 @@ export const POKE_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const POKE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 // ─── Workspace Context ───────────────────────────────────────────────────────
 
@@ -52,10 +52,11 @@ const workspaceIdSchema = {
 
 // ─── Tool Metadata ───────────────────────────────────────────────────────────
 
-export const POKE_TOOLS_METADATA = createToolsRecord({
+export const POKE_TOOLS_METADATA = [
   // ── Workspace Context ────────────────────────────────────────────────────
 
-  [GET_WORKSPACE_METADATA_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_METADATA_TOOL_NAME,
     description:
       "Fetch metadata for a target Dust workspace. Requires Dust super user privileges.",
     schema: {
@@ -72,7 +73,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_PLAN_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_PLAN_TOOL_NAME,
     description:
       "Get full plan and subscription details for a workspace: billing info, " +
       "verified domains, and creation date.",
@@ -86,7 +88,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_FEATURE_FLAGS_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_FEATURE_FLAGS_TOOL_NAME,
     description: "List all feature flags currently enabled for a workspace.",
     schema: { ...workspaceIdSchema },
     stake: "low",
@@ -98,7 +101,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_MEMBERS_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_MEMBERS_TOOL_NAME,
     description:
       "List workspace members with roles, email, auth provider, and pending invitations.",
     schema: { ...workspaceIdSchema },
@@ -111,7 +115,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_SPACES_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_SPACES_TOOL_NAME,
     description:
       "List all spaces in a workspace with their kind, permissions, and group IDs.",
     schema: { ...workspaceIdSchema },
@@ -124,7 +129,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_CREDITS_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_CREDITS_TOOL_NAME,
     description:
       "Get credit balance, usage, and excess credits for a workspace over the last 30 days.",
     schema: { ...workspaceIdSchema },
@@ -139,7 +145,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   // ── Connectors & Data Sources ────────────────────────────────────────────
 
-  [LIST_DATA_SOURCES_TOOL_NAME]: {
+  {
+    name: LIST_DATA_SOURCES_TOOL_NAME,
     description:
       "List all data sources/connectors for a workspace with status, type, and last sync time.",
     schema: { ...workspaceIdSchema },
@@ -152,7 +159,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_CONNECTOR_DETAILS_TOOL_NAME]: {
+  {
+    name: GET_CONNECTOR_DETAILS_TOOL_NAME,
     description:
       "Get full connector details: config, status, error state, provider, Temporal workflows, " +
       "and core data source info.",
@@ -171,7 +179,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [CHECK_NOTION_PAGE_TOOL_NAME]: {
+  {
+    name: CHECK_NOTION_PAGE_TOOL_NAME,
     description:
       "Check if a Notion page/DB is synced, accessible, and its parent chain.",
     schema: {
@@ -188,7 +197,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [CHECK_SLACK_CHANNEL_TOOL_NAME]: {
+  {
+    name: CHECK_SLACK_CHANNEL_TOOL_NAME,
     description:
       "Verify a Slack channel exists, is synced, and whether it is skipped.",
     schema: {
@@ -206,7 +216,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   // ── Conversations & Agents ───────────────────────────────────────────────
 
-  [GET_CONVERSATION_DETAILS_TOOL_NAME]: {
+  {
+    name: GET_CONVERSATION_DETAILS_TOOL_NAME,
     description:
       "Get the full conversation with messages, tool calls, agent actions, and errors.",
     schema: {
@@ -222,7 +233,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_MCP_SERVER_DETAILS_TOOL_NAME]: {
+  {
+    name: GET_MCP_SERVER_DETAILS_TOOL_NAME,
     description:
       "Get MCP server view details, or list all MCP server views in a workspace.",
     schema: {
@@ -243,7 +255,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   // ── Search ───────────────────────────────────────────────────────────────
 
-  [SEARCH_WORKSPACES_TOOL_NAME]: {
+  {
+    name: SEARCH_WORKSPACES_TOOL_NAME,
     description:
       "Search workspaces by name (exact), verified domain, or member email. " +
       "Returns matching workspaces with links to poke, WorkOS, Metronome, and health dashboards.",
@@ -266,7 +279,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   // ── Users & Cross-Reference ──────────────────────────────────────────────
 
-  [LIST_WORKSPACE_GROUPS_TOOL_NAME]: {
+  {
+    name: LIST_WORKSPACE_GROUPS_TOOL_NAME,
     description: "List groups in a workspace with their kind and member count.",
     schema: { ...workspaceIdSchema },
     stake: "low",
@@ -278,7 +292,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [FIND_WORKSPACE_BY_CONNECTOR_ID_TOOL_NAME]: {
+  {
+    name: FIND_WORKSPACE_BY_CONNECTOR_ID_TOOL_NAME,
     description: "Reverse-lookup workspace from a connector ID.",
     schema: {
       ...workspaceIdSchema,
@@ -297,7 +312,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
   // ── Agents & Skills ──────────────────────────────────────────────────────
 
-  [LIST_WORKSPACE_AGENTS_TOOL_NAME]: {
+  {
+    name: LIST_WORKSPACE_AGENTS_TOOL_NAME,
     description:
       "List agents in a workspace sorted by version creation date (most recent first). " +
       "Returns instructionsLength and requestedSpaceCount per agent. " +
@@ -328,7 +344,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_AGENT_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_AGENT_TOOL_NAME,
     description:
       "Get full details for a single agent: instructions, tools, author, and editors.",
     schema: {
@@ -341,7 +358,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [LIST_WORKSPACE_SKILLS_TOOL_NAME]: {
+  {
+    name: LIST_WORKSPACE_SKILLS_TOOL_NAME,
     description:
       "List custom skills in a workspace sorted by last update (most recent first). " +
       "Returns instructionsLength per skill. " +
@@ -372,7 +390,8 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
   },
 
-  [GET_WORKSPACE_SKILL_TOOL_NAME]: {
+  {
+    name: GET_WORKSPACE_SKILL_TOOL_NAME,
     description:
       "Get full details for a single skill: instructions, MCP server count, and editors.",
     schema: {
@@ -384,7 +403,7 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const POKE_SERVER = {
   serverInfo: {
@@ -396,13 +415,5 @@ export const POKE_SERVER = {
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
   },
-  tools: Object.values(POKE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: POKE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -104,7 +104,7 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Server metadata - used in constants.ts
 export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -1,10 +1,10 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Schema for tool_without_user_config
 const toolWithoutUserConfigSchema = {
@@ -79,8 +79,9 @@ const passThroughSchema = {
 };
 
 // Tools metadata
-export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
-  tool_without_user_config: {
+export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = [
+  {
+    name: "tool_without_user_config",
     description: "Test the tool without user config.",
     schema: toolWithoutUserConfigSchema,
     stake: "high",
@@ -91,7 +92,8 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  pass_through: {
+  {
+    name: "pass_through",
     description: "Pass through inputs for primitive type debugging.",
     schema: passThroughSchema,
     stake: "high",
@@ -102,7 +104,7 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // Server metadata - used in constants.ts
 export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
@@ -115,13 +117,5 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const PRODUCTBOARD_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
-  create_note: {
+export const PRODUCTBOARD_TOOLS_METADATA = [
+  {
+    name: "create_note",
     description:
       "Create a note in Productboard to capture customer feedback, insights, or support conversations.",
     schema: {
@@ -41,7 +42,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_note: {
+  {
+    name: "update_note",
     description:
       "Update an existing note in Productboard. Use the fields object for simple updates or the patch array for granular operations.",
     schema: {
@@ -78,7 +80,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_note: {
+  {
+    name: "get_note",
     description:
       "Retrieve details of a specific note by ID. Use field selection to optimize response size and avoid large returns. By default, returns all non-null fields.",
     schema: {
@@ -96,7 +99,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  query_notes: {
+  {
+    name: "query_notes",
     description:
       "Search for notes in your Productboard workspace. Notes are sorted by creation date, newest first.",
     schema: {
@@ -172,7 +176,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  query_entities: {
+  {
+    name: "query_entities",
     description:
       "Search for entities in Productboard, including products, companies, features, users, etc.",
     schema: {
@@ -234,7 +239,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_entity: {
+  {
+    name: "create_entity",
     description:
       "Create an entity in Productboard (products, components, features, initiatives, etc.)",
     schema: {
@@ -285,7 +291,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_entity: {
+  {
+    name: "update_entity",
     description:
       "Update an existing entity in Productboard. Use the fields object for simple updates or the patch array for granular operations.",
     schema: {
@@ -322,7 +329,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_relationships: {
+  {
+    name: "get_relationships",
     description:
       "Get relationships for an entity (parent, children, linked notes, etc.).\n\nUse to understand how entities are connected in the product hierarchy.",
     schema: {
@@ -343,7 +351,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_configuration: {
+  {
+    name: "get_configuration",
     description:
       "Get configuration for a specific entity type in this workspace. This is REQUIRED before creating or updating any entity or note. Returns available fields, required vs optional fields, field types, constraints, and allowed operations.",
     schema: {
@@ -375,7 +384,7 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const PRODUCTBOARD_SERVER = {
   serverInfo: {
@@ -390,13 +399,5 @@ export const PRODUCTBOARD_SERVER = {
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
   },
-  tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: PRODUCTBOARD_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -384,7 +384,7 @@ export const PRODUCTBOARD_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const PRODUCTBOARD_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -98,7 +98,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const QUERY_TABLES_V2_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -2,12 +2,12 @@ import {
   ConfigurableToolInputSchemas,
   TABLE_CONFIGURATION_URI_PATTERN,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2" as const; // Do not change the name until we fixed the extension
 export const LIST_TABLES_TOOL_NAME = "list_tables";
@@ -29,8 +29,9 @@ const tableUrisSchema = z
     "Table URIs to retrieve schema for. Use URIs returned by list_tables."
   );
 
-export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
-  [LIST_TABLES_TOOL_NAME]: {
+export const QUERY_TABLES_V2_TOOLS_METADATA = [
+  {
+    name: LIST_TABLES_TOOL_NAME,
     description:
       "List and discover the agent-configured structured data tables, datasets, and table URIs available to this agent. " +
       "Returns lightweight table metadata and URIs. Call this first to find available agent tables, then pass selected URIs to get_database_schema.",
@@ -47,7 +48,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [GET_DATABASE_SCHEMA_TOOL_NAME]: {
+  {
+    name: GET_DATABASE_SCHEMA_TOOL_NAME,
     description:
       "Inspect the schema and structure for selected agent-configured tables before SQL. Use this to answer which columns, fields, column names, sample rows, and relationships exist in tables selected from list_tables. " +
       "You MUST call list_tables first, then call this tool with the URIs of the tables you need before running SQL.",
@@ -63,7 +65,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
+  {
+    name: EXECUTE_DATABASE_QUERY_TOOL_NAME,
     description:
       "Run and execute SQL against selected agent-configured structured data tables to analyze, aggregate, filter, join, or export result rows. " +
       "Before using this tool, the agent should have already called get_database_schema for every involved table URI and should use that inspected table structure to write the SQL. " +
@@ -95,7 +98,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const QUERY_TABLES_V2_SERVER = {
   serverInfo: {
@@ -108,13 +111,5 @@ export const QUERY_TABLES_V2_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: QUERY_TABLES_V2_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -2,10 +2,7 @@ import {
   ConfigurableToolInputSchemas,
   TABLE_CONFIGURATION_URI_PATTERN,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -1,5 +1,8 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   FILES_LIST_ACTION_NAME,
@@ -8,9 +11,7 @@ import {
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 // This is a placeholder tool name used in the metadata for UI detection.
 // The actual tool name is dynamic: `run_<agent_name>`.
@@ -137,6 +138,24 @@ export const RUN_AGENT_TOOL_SCHEMA = {
     .nullable(),
 };
 
+export const RUN_AGENT_TOOLS_METADATA = [
+  {
+    name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
+    description: "Run a child agent (agent as tool).",
+    schema: {
+      ...RUN_AGENT_TOOL_SCHEMA,
+      ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
+    },
+    displayLabels: {
+      running: "Running agent",
+      done: "Run agent",
+    },
+    toolCostCategory: "basic",
+    freeUsage: false,
+    stake: "never_ask",
+  },
+] as const satisfies readonly InternalMCPToolType[];
+
 export const RUN_AGENT_SERVER = {
   serverInfo: {
     name: "run_agent",
@@ -149,23 +168,5 @@ export const RUN_AGENT_SERVER = {
   // The actual tool name is dynamic, but we need a placeholder tool
   // with the configurable properties schema so that the UI can detect that this server
   // requires child agent configuration before being added.
-  tools: [
-    {
-      name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
-      description: "Run a child agent (agent as tool).",
-      inputSchema: zodToJsonSchema(
-        z.object({
-          ...RUN_AGENT_TOOL_SCHEMA,
-          ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
-        })
-      ) as JSONSchema,
-      displayLabels: {
-        running: "Running agent",
-        done: "Run agent",
-      },
-      toolCostCategory: "basic",
-      freeUsage: false,
-      stake: "never_ask",
-    },
-  ],
+  tools: RUN_AGENT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   FILES_LIST_ACTION_NAME,
@@ -138,24 +135,6 @@ export const RUN_AGENT_TOOL_SCHEMA = {
     .nullable(),
 };
 
-export const RUN_AGENT_TOOLS_METADATA = [
-  {
-    name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
-    description: "Run a child agent (agent as tool).",
-    schema: {
-      ...RUN_AGENT_TOOL_SCHEMA,
-      ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
-    },
-    displayLabels: {
-      running: "Running agent",
-      done: "Run agent",
-    },
-    toolCostCategory: "basic",
-    freeUsage: false,
-    stake: "never_ask",
-  },
-] as const satisfies readonly InternalMCPToolType[];
-
 export const RUN_AGENT_SERVER = {
   serverInfo: {
     name: "run_agent",
@@ -168,5 +147,21 @@ export const RUN_AGENT_SERVER = {
   // The actual tool name is dynamic, but we need a placeholder tool
   // with the configurable properties schema so that the UI can detect that this server
   // requires child agent configuration before being added.
-  tools: RUN_AGENT_TOOLS_METADATA,
+  tools: [
+    {
+      name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
+      description: "Run a child agent (agent as tool).",
+      schema: {
+        ...RUN_AGENT_TOOL_SCHEMA,
+        ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
+      },
+      displayLabels: {
+        running: "Running agent",
+        done: "Run agent",
+      },
+      toolCostCategory: "basic",
+      freeUsage: false,
+      stake: "never_ask",
+    },
+  ],
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 /**

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -1,10 +1,9 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Tools metadata for run_dust_app server.
@@ -13,8 +12,9 @@ import { zodToJsonSchema } from "zod-to-json-schema";
  * the Dust app configuration. The "run_dust_app" tool here is used for the
  * configuration flow where users select which Dust app to run.
  */
-export const RUN_DUST_APP_TOOLS_METADATA = createToolsRecord({
-  run_dust_app: {
+export const RUN_DUST_APP_TOOLS_METADATA = [
+  {
+    name: "run_dust_app",
     description: "Run a Dust App with specified parameters.",
     schema: {
       dustApp:
@@ -28,7 +28,7 @@ export const RUN_DUST_APP_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const RUN_DUST_APP_SERVER = {
   serverInfo: {
@@ -39,13 +39,5 @@ export const RUN_DUST_APP_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: RUN_DUST_APP_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -28,7 +28,7 @@ export const RUN_DUST_APP_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const RUN_DUST_APP_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
-  execute_read_query: {
+export const SALESFORCE_TOOLS_METADATA = [
+  {
+    name: "execute_read_query",
     description:
       "Run a read-only SOQL query on Salesforce to retrieve or discover data. It never writes. " +
       "Use this for SOQL SELECT queries that search, filter, count, or retrieve Salesforce records, such as querying Salesforce Accounts by Industry. " +
@@ -25,7 +26,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_objects: {
+  {
+    name: "list_objects",
     description:
       "List Salesforce objects (standard, custom, or all). Use it to find an object's exact API name before describing or querying it. " +
       "Use this to discover which objects exist and to see object labels before creating or updating records.",
@@ -44,7 +46,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  describe_object: {
+  {
+    name: "describe_object",
     description:
       "Get detailed metadata for a Salesforce object from its API name (e.g. Account, Lead, MyCustomObject__c): fields with names, labels, types, and other properties; child relationship names for subqueries; record types; and other object-level properties. " +
       "This is the reliable way to confirm field and relationship names before an execute_read_query. " +
@@ -61,7 +64,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_object: {
+  {
+    name: "create_object",
     description:
       "Create one or more records in Salesforce. " +
       "Use this to insert or add new records for an object such as Account, Contact, Lead, Opportunity, or a custom object; not to update existing records.",
@@ -89,7 +93,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_object: {
+  {
+    name: "update_object",
     description:
       "Update one or more records in Salesforce. " +
       "Use this to edit or modify existing records by Id for an object such as Account, Contact, Lead, Opportunity, or a custom object; not to create new records.",
@@ -123,7 +128,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_attachments: {
+  {
+    name: "list_attachments",
     description:
       "List all attachments and files for a Salesforce record. " +
       "Use this to find attachment IDs, file IDs, filenames, and metadata before reading or downloading a PDF, document, image, or uploaded file.",
@@ -138,7 +144,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_attachment: {
+  {
+    name: "read_attachment",
     description:
       "Read content from any attachment or file on a Salesforce record. " +
       "Use this after list_attachments when you know the attachment ID or file ID and need to read or download its text or binary file.",
@@ -156,7 +163,7 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SALESFORCE_SERVER = {
   serverInfo: {
@@ -170,13 +177,5 @@ export const SALESFORCE_SERVER = {
     icon: "SalesforceLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesforce",
   },
-  tools: Object.values(SALESFORCE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SALESFORCE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SALESFORCE_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -163,7 +163,7 @@ export const SALESFORCE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SALESFORCE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -32,7 +32,7 @@ export const SALESLOFT_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SALESLOFT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
-  get_actions: {
+export const SALESLOFT_TOOLS_METADATA = [
+  {
+    name: "get_actions",
     description:
       "Get actions owned by the current user with complete related information for full context. " +
       "By default, returns only currently due or overdue actions, but can be configured to return all actions. " +
@@ -31,7 +32,7 @@ export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SALESLOFT_SERVER = {
   serverInfo: {
@@ -43,13 +44,5 @@ export const SALESLOFT_SERVER = {
     icon: "SalesloftLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",
   },
-  tools: Object.values(SALESLOFT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SALESLOFT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SALESLOFT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SANDBOX_TOOL_NAME = "sandbox" as const;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
 
@@ -31,8 +31,9 @@ const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30000;
 export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
   SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;
 
-export const SANDBOX_TOOLS_METADATA = createToolsRecord({
-  bash: {
+export const SANDBOX_TOOLS_METADATA = [
+  {
+    name: "bash",
     description:
       "Execute a shell command in an isolated sandbox environment. " +
       "The sandbox is a Linux container with common tools pre-installed. " +
@@ -72,7 +73,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     freeUsage: true,
     enableAlerting: true,
   },
-  describe_toolset: {
+  {
+    name: "describe_toolset",
     description:
       "Describe the sandbox environment and list available CLI binaries and language libraries.",
     schema: {
@@ -89,7 +91,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  add_egress_domain: {
+  {
+    name: "add_egress_domain",
     description:
       "Request user approval to add a single domain to the current " +
       "sandbox's network allowlist. Each call adds one exact domain " +
@@ -130,7 +133,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SANDBOX_SERVER = {
   serverInfo: {
@@ -142,15 +145,5 @@ export const SANDBOX_SERVER = {
     icon: "CommandLineIcon",
     documentationUrl: null,
   },
-  // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
-  // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.
-  tools: Object.values(SANDBOX_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SANDBOX_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -133,7 +133,7 @@ export const SANDBOX_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SANDBOX_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -216,7 +216,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SANDBOX_FUNCTIONS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,17 +1,18 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   POD_DATABASE_NAME_REGEX,
   SANDBOX_FUNCTION_SLUG_REGEX,
 } from "@app/types/api/sandbox_functions";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SANDBOX_FUNCTIONS_SERVER_NAME = "sandbox_functions" as const;
 
-export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
-  list: {
+export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
+  {
+    name: "list",
     description:
       "List the pod functions published in the current pod, with their " +
       "slug and description. Use the get tool to retrieve a function's input " +
@@ -25,7 +26,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get: {
+  {
+    name: "get",
     description:
       "Get a pod function's input and output JSON schemas by its slug.",
     schema: {
@@ -42,7 +44,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  publish: {
+  {
+    name: "publish",
     description:
       "Publish a pod function from a TypeScript source file in the current pod. The source " +
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
@@ -79,7 +82,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  call: {
+  {
+    name: "call",
     description:
       "Call a pod function published in the current pod by its slug, passing its input " +
       "payload, and get back the function's output. Use the get tool first to see the function's " +
@@ -106,7 +110,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  inspect_invocations: {
+  {
+    name: "inspect_invocations",
     description:
       "Inspect the most recent invocations of a pod function in the current pod, including " +
       "their inputs, results, and errors.",
@@ -132,7 +137,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  db_list: {
+  {
+    name: "db_list",
     description: "List the pod's SQLite databases and their sizes.",
     schema: {},
     stake: "never_ask",
@@ -143,7 +149,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  db_schema: {
+  {
+    name: "db_schema",
     description: "Get a pod database's live schema as a drizzle schema file.",
     schema: {
       database: z
@@ -159,7 +166,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  db_query: {
+  {
+    name: "db_query",
     description:
       "Run a single SQL statement against a pod database: SELECT and DML.",
     schema: {
@@ -183,7 +191,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  db_reconcile: {
+  {
+    name: "db_reconcile",
     description:
       "Apply a pod database's drizzle schema file to its live database (additive changes only).",
     schema: {
@@ -207,7 +216,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SANDBOX_FUNCTIONS_SERVER = {
   serverInfo: {
@@ -220,13 +229,5 @@ export const SANDBOX_FUNCTIONS_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(SANDBOX_FUNCTIONS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SANDBOX_FUNCTIONS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   POD_DATABASE_NAME_REGEX,
   SANDBOX_FUNCTION_SLUG_REGEX,

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
-  create_schedule: {
+export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = [
+  {
+    name: "create_schedule",
     description:
       "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. Pass podId to attach the schedule to a Pod so its runs land there. Limit: 20 schedule creations per user per day.",
     schema: {
@@ -47,7 +48,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  list_schedules: {
+  {
+    name: "list_schedules",
     description:
       "List all schedules for this agent and the current user. Each entry shows the Pod it is attached to, if any.",
     schema: {},
@@ -59,7 +61,8 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  disable_schedule: {
+  {
+    name: "disable_schedule",
     description: "Disable a schedule.",
     schema: {
       scheduleId: z
@@ -74,10 +77,7 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
-
-type SchedulesManagementToolKey =
-  keyof typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA;
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SCHEDULES_MANAGEMENT_SERVER = {
   serverInfo: {
@@ -88,19 +88,5 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
   },
-  tools: (
-    Object.keys(
-      SCHEDULES_MANAGEMENT_TOOLS_METADATA
-    ) as SchedulesManagementToolKey[]
-  ).map((key) => ({
-    name: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].name,
-    description: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].description,
-    inputSchema: zodToJsonSchema(
-      z.object(SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].schema)
-    ) as JSONSchema,
-    displayLabels: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
-    toolCostCategory: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
-    freeUsage: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
-    stake: SCHEDULES_MANAGEMENT_TOOLS_METADATA[key].stake,
-  })),
+  tools: SCHEDULES_MANAGEMENT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -77,7 +77,7 @@ export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SCHEDULES_MANAGEMENT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -30,7 +30,7 @@ export const SEARCH_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SEARCH_TOOL_METADATA_WITH_TAGS = [
   ...SEARCH_TOOLS_METADATA,
@@ -62,7 +62,7 @@ export const SEARCH_TOOL_METADATA_WITH_TAGS = [
     freeUsage: false,
     enableAlerting: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SEARCH_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -1,12 +1,12 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SearchWithDataSourcesInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Define constants locally to avoid circular dependency with constants.ts
 export const SEARCH_SERVER_NAME = "search";
@@ -17,8 +17,9 @@ export const SEARCH_TOOL_DESCRIPTION =
   " The search is based on semantic similarity between the query and chunks of information" +
   " from the data sources.";
 
-export const SEARCH_TOOLS_METADATA = createToolsRecord({
-  [SEARCH_TOOL_NAME]: {
+export const SEARCH_TOOLS_METADATA = [
+  {
+    name: SEARCH_TOOL_NAME,
     description: SEARCH_TOOL_DESCRIPTION,
     schema: SearchWithDataSourcesInputSchema.shape,
     stake: "never_ask" as const,
@@ -29,11 +30,12 @@ export const SEARCH_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
-export const SEARCH_TOOL_METADATA_WITH_TAGS = createToolsRecord({
+export const SEARCH_TOOL_METADATA_WITH_TAGS = [
   ...SEARCH_TOOLS_METADATA,
-  [FIND_TAGS_TOOL_NAME]: {
+  {
+    name: FIND_TAGS_TOOL_NAME,
     description:
       "Discover available tags/labels that can be used to filter content. Returns tags " +
       "with their usage counts. Only available when dynamic tags are enabled.",
@@ -60,7 +62,7 @@ export const SEARCH_TOOL_METADATA_WITH_TAGS = createToolsRecord({
     freeUsage: false,
     enableAlerting: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SEARCH_SERVER = {
   serverInfo: {
@@ -72,13 +74,5 @@ export const SEARCH_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(SEARCH_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SEARCH_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -1,8 +1,5 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SearchWithDataSourcesInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -165,7 +165,7 @@ export const SKILL_AUTHORING_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SKILL_AUTHORING_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -1,9 +1,9 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SKILL_AUTHORING_SERVER_NAME = "skill_authoring" as const;
 export const LIST_SKILLS_TOOL_NAME = "list_skills" as const;
@@ -11,8 +11,9 @@ export const GET_SKILL_TOOL_NAME = "get_skill" as const;
 export const CREATE_SKILL_TOOL_NAME = "create_skill" as const;
 export const UPDATE_SKILL_TOOL_NAME = "update_skill" as const;
 
-export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
-  [LIST_SKILLS_TOOL_NAME]: {
+export const SKILL_AUTHORING_TOOLS_METADATA = [
+  {
+    name: LIST_SKILLS_TOOL_NAME,
     description:
       "List active custom Skills in this workspace. Returns lightweight summaries (sId, name, agentFacingDescription, canWrite) paginated.",
     schema: {
@@ -44,7 +45,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [GET_SKILL_TOOL_NAME]: {
+  {
+    name: GET_SKILL_TOOL_NAME,
     description:
       "Get the full details for one custom Skill by id, including its instructions.",
     schema: {
@@ -58,7 +60,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [CREATE_SKILL_TOOL_NAME]: {
+  {
+    name: CREATE_SKILL_TOOL_NAME,
     description:
       "Create a new reusable Skill in this workspace: a named, reusable set of instructions an agent can later enable. v1 creates instructions-only skills.",
     schema: {
@@ -95,7 +98,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [UPDATE_SKILL_TOOL_NAME]: {
+  {
+    name: UPDATE_SKILL_TOOL_NAME,
     description:
       "Update an existing custom Skill by id. Provide only the fields that should change. " +
       "To change the instructions you can either replace them entirely with `instructions`, " +
@@ -161,7 +165,7 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SKILL_AUTHORING_SERVER = {
   serverInfo: {
@@ -172,13 +176,5 @@ export const SKILL_AUTHORING_SERVER = {
     icon: "ActionListCheckIcon",
     documentationUrl: null,
   },
-  tools: Object.values(SKILL_AUTHORING_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SKILL_AUTHORING_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import { z } from "zod";
 

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -1,12 +1,13 @@
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SKILL_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
-  [ENABLE_SKILL_TOOL_NAME]: {
+export const SKILL_MANAGEMENT_TOOLS_METADATA = [
+  {
+    name: ENABLE_SKILL_TOOL_NAME,
     description:
       "Enable a skill for the current conversation. " +
       "The skill will be available for subsequent messages from the same agent in this conversation.",
@@ -22,9 +23,7 @@ export const SKILL_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
-
-type SkillManagementToolKey = keyof typeof SKILL_MANAGEMENT_TOOLS_METADATA;
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SKILL_MANAGEMENT_SERVER = {
   serverInfo: {
@@ -35,17 +34,5 @@ export const SKILL_MANAGEMENT_SERVER = {
     icon: "PuzzleIcon" as const,
     documentationUrl: null,
   },
-  tools: (
-    Object.keys(SKILL_MANAGEMENT_TOOLS_METADATA) as SkillManagementToolKey[]
-  ).map((key) => ({
-    name: SKILL_MANAGEMENT_TOOLS_METADATA[key].name,
-    description: SKILL_MANAGEMENT_TOOLS_METADATA[key].description,
-    inputSchema: zodToJsonSchema(
-      z.object(SKILL_MANAGEMENT_TOOLS_METADATA[key].schema)
-    ) as JSONSchema,
-    displayLabels: SKILL_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
-    toolCostCategory: SKILL_MANAGEMENT_TOOLS_METADATA[key].toolCostCategory,
-    freeUsage: SKILL_MANAGEMENT_TOOLS_METADATA[key].freeUsage,
-    stake: SKILL_MANAGEMENT_TOOLS_METADATA[key].stake,
-  })),
+  tools: SKILL_MANAGEMENT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -1,8 +1,5 @@
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SKILL_MANAGEMENT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -23,7 +23,7 @@ export const SKILL_MANAGEMENT_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SKILL_MANAGEMENT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const MAX_CONTENT_SIZE = 32000;
 
-export const SLAB_TOOLS_METADATA = createToolsRecord({
-  search_posts: {
+export const SLAB_TOOLS_METADATA = [
+  {
+    name: "search_posts",
     description:
       "Search for posts across the Slab workspace. Returns posts matching the query.",
     schema: {
@@ -50,7 +51,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_post_contents: {
+  {
+    name: "get_post_contents",
     description:
       "Retrieve specific posts by their IDs or URLs with full content and metadata. Supports pagination for large posts.",
     schema: {
@@ -82,7 +84,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_topics: {
+  {
+    name: "get_topics",
     description:
       "Retrieve all Slab topics for navigation and organization understanding.",
     schema: {},
@@ -94,7 +97,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_post_metadata: {
+  {
+    name: "get_post_metadata",
     description:
       "Get metadata about a post without retrieving full content (faster for large posts).",
     schema: {
@@ -108,7 +112,7 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SLAB_SERVER = {
   serverInfo: {
@@ -119,13 +123,5 @@ export const SLAB_SERVER = {
     icon: "SlabLogo",
     documentationUrl: "https://docs.dust.tt/docs/slab-mcp",
   },
-  tools: Object.values(SLAB_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SLAB_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 const MAX_CONTENT_SIZE = 32000;

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -112,7 +112,7 @@ export const SLAB_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SLAB_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SLACK_BOT_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -260,7 +260,7 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SLACK_BOT_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
-  post_message: {
+export const SLACK_BOT_TOOLS_METADATA = [
+  {
+    name: "post_message",
     description:
       "Post a message to a Slack channel as the workspace bot/app (not as the user). Posts to channels only. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
@@ -63,7 +64,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  edit_message: {
+  {
+    name: "edit_message",
     description:
       "Edit a message previously posted in a Slack channel by providing its timestamp and channel.",
     schema: {
@@ -98,7 +100,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_user: {
+  {
+    name: "search_user",
     description: `Search for a Slack user by user ID or email address.
 
 Query parameter accepts:
@@ -126,7 +129,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_public_channels: {
+  {
+    name: "list_public_channels",
     description: "List all public Slack channels in the workspace",
     schema: {
       nameFilter: z
@@ -142,7 +146,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_channel_history: {
+  {
+    name: "read_channel_history",
     description:
       "Read messages from a specific channel with pagination support. The slack bot must be added to the channel before it can read messages.",
     schema: {
@@ -174,7 +179,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_thread_messages: {
+  {
+    name: "read_thread_messages",
     description:
       "Read all messages in a specific Slack thread (in channels the workspace bot belongs to) with pagination support",
     schema: {
@@ -209,7 +215,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_reaction: {
+  {
+    name: "add_reaction",
     description: "Add a reaction emoji to a Slack message as the workspace bot",
     schema: {
       channel: z.string().describe("The channel where the message is located"),
@@ -230,7 +237,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  remove_reaction: {
+  {
+    name: "remove_reaction",
     description:
       "Remove a reaction emoji from a Slack message as the workspace bot",
     schema: {
@@ -252,7 +260,7 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SLACK_BOT_SERVER = {
   serverInfo: {
@@ -267,13 +275,5 @@ export const SLACK_BOT_SERVER = {
     icon: "SlackLogo",
     documentationUrl: null,
   },
-  tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SLACK_BOT_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SLACK_TOOL_LOG_NAME = "slack" as const;

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -656,7 +656,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 // Server metadata for external consumption (e.g., by SDK).
 export const SLACK_PERSONAL_SERVER = {

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SLACK_TOOL_LOG_NAME = "slack" as const;
 
@@ -48,8 +48,9 @@ const commonSearchParams = {
 
 const MAX_CHANNEL_SEARCH_RESULTS = 20;
 
-export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
-  search_messages: {
+export const SLACK_PERSONAL_TOOLS_METADATA = [
+  {
+    name: "search_messages",
     description:
       "Search Slack messages by keyword across public channels, private channels, DMs, and group DMs where the current user is a member",
     schema: {
@@ -71,7 +72,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  semantic_search_messages: {
+  {
+    name: "semantic_search_messages",
     description:
       "Use semantic search to find Slack messages across public channels, private channels, DMs, and group DMs where the current user is a member",
     schema: {
@@ -90,7 +92,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  post_message: {
+  {
+    name: "post_message",
     description:
       "Post a message from the user's personal Slack account to a public channel, private channel, or DM. You MUST ONLY post to channels or users that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
@@ -149,7 +152,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  schedule_message: {
+  {
+    name: "schedule_message",
     description:
       "Schedule a message to be posted from the user's personal Slack account to a channel at a future time. Messages can be scheduled up to 120 days in advance. Maximum of 30 scheduled messages per 5 minutes per channel. You MUST ONLY schedule messages to channels or users that were explicitly specified by the user in their request. NEVER schedule messages to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     schema: {
@@ -206,7 +210,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_user: {
+  {
+    name: "search_user",
     description: `Search for a Slack user by Slack user ID or email address.
 
 Query parameter accepts:
@@ -239,7 +244,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_user_groups: {
+  {
+    name: "list_user_groups",
     description:
       "List all Slack user groups in the workspace. User groups (e.g., @engineering, @marketing) can be mentioned in messages.",
     schema: {},
@@ -251,7 +257,8 @@ The search_all parameter should only be set to true if the user explicitly reque
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_channels: {
+  {
+    name: "search_channels",
     description: `Search for Slack channels by channel ID or name.
 
 Query parameter accepts:
@@ -282,7 +289,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_messages: {
+  {
+    name: "list_messages",
     description:
       "List the recent messages in a Slack channel, private channel, or direct message (DM). Returns message headers with their timestamps (ts).",
     schema: {
@@ -309,7 +317,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_thread_messages: {
+  {
+    name: "read_thread_messages",
     description:
       "Read all messages in a Slack thread from a public channel, private channel, or direct message (DM). Use list_messages first to find the thread's timestamp (ts).",
     schema: {
@@ -348,7 +357,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_channel_canvases: {
+  {
+    name: "get_channel_canvases",
     description:
       "List all canvas IDs for a Slack channel (from the channel's tabs). " +
       "Use when you need to edit a channel's canvas but only have the channel ID. ",
@@ -365,7 +375,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  read_canvas: {
+  {
+    name: "read_canvas",
     description:
       "Find sections within a Slack canvas. " +
       "Returns section IDs that can be used with write_canvas to insert, replace, or delete specific sections.",
@@ -392,7 +403,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  write_canvas: {
+  {
+    name: "write_canvas",
     description:
       "Create or edit a Slack canvas (a shared document / doc / page pinned in a channel).\n\n" +
       "**Creating a new canvas** (omit canvas_id):\n" +
@@ -462,7 +474,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_channel: {
+  {
+    name: "create_channel",
     description:
       "Create a new Slack channel (public or private). Returns the created channel's details including its ID. Note: Slack always adds the authenticated user to a newly created channel. Use leave_after_creation=true to immediately leave after creating.",
     schema: {
@@ -494,7 +507,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  invite_to_channel: {
+  {
+    name: "invite_to_channel",
     description:
       "Invite one or more users to a Slack channel. Users must be specified by their Slack user IDs. Use the search_user tool first if you need to find user IDs.",
     schema: {
@@ -519,7 +533,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  archive_channel: {
+  {
+    name: "archive_channel",
     description:
       "Archive a Slack channel. Archived channels are read-only and hidden from the channel list by default. This action can be undone by unarchiving the channel.",
     schema: {
@@ -537,7 +552,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  set_user_status: {
+  {
+    name: "set_user_status",
     description:
       "Set the current user's Slack status (emoji + text). Pass empty strings to clear the status. " +
       "Status expiration is optional — omit it to set a permanent status.",
@@ -570,7 +586,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  add_reaction: {
+  {
+    name: "add_reaction",
     description:
       "Add a reaction emoji to a Slack message. Supports both standard emoji (e.g., 'thumbsup', 'heart') and custom workspace emoji.",
     schema: {
@@ -592,7 +609,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  remove_reaction: {
+  {
+    name: "remove_reaction",
     description:
       "Remove a reaction emoji from a Slack message. Supports both standard and custom workspace emoji.",
     schema: {
@@ -614,7 +632,8 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_reactions: {
+  {
+    name: "get_reactions",
     description:
       "Get all emoji reactions on a Slack message, including the emoji names and the users who reacted.",
     schema: {
@@ -637,7 +656,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 // Server metadata for external consumption (e.g., by SDK).
 export const SLACK_PERSONAL_SERVER = {
@@ -653,13 +672,5 @@ export const SLACK_PERSONAL_SERVER = {
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
   },
-  tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SLACK_PERSONAL_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -134,7 +134,7 @@ export const SNOWFLAKE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SNOWFLAKE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MAX_QUERY_ROWS = 1000;
 
@@ -14,8 +14,9 @@ export const SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME =
   "describe_semantic_view" as const;
 export const SNOWFLAKE_QUERY_TOOL_NAME = "query" as const;
 
-export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
-  [SNOWFLAKE_LIST_DATABASES_TOOL_NAME]: {
+export const SNOWFLAKE_TOOLS_METADATA = [
+  {
+    name: SNOWFLAKE_LIST_DATABASES_TOOL_NAME,
     description:
       "List all databases accessible to the authenticated Snowflake user.",
     schema: {},
@@ -27,7 +28,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME]: {
+  {
+    name: SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME,
     description: "List all schemas within a specified Snowflake database.",
     schema: {
       database: z
@@ -42,7 +44,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [SNOWFLAKE_LIST_TABLES_TOOL_NAME]: {
+  {
+    name: SNOWFLAKE_LIST_TABLES_TOOL_NAME,
     description:
       "List all tables, views, and semantic views within a specified Snowflake schema.",
     schema: {
@@ -59,7 +62,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME]: {
+  {
+    name: SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME,
     description:
       "Get the schema (column names, types, and constraints) of a Snowflake table.",
     schema: {
@@ -75,7 +79,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME]: {
+  {
+    name: SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME,
     description: `Get the structure (dimensions and metrics) of a Snowflake semantic view. Use this instead of ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} when the object kind is SEMANTIC_VIEW.`,
     schema: {
       database: z.string().describe("The name of the database."),
@@ -92,7 +97,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  [SNOWFLAKE_QUERY_TOOL_NAME]: {
+  {
+    name: SNOWFLAKE_QUERY_TOOL_NAME,
     description: `Execute a read-only SQL SELECT query against Snowflake to analyze data, answer questions, calculate metrics such as revenue, or retrieve rows. Write operations are not permitted. Before writing a query, use ${SNOWFLAKE_LIST_DATABASES_TOOL_NAME}, ${SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME}, ${SNOWFLAKE_LIST_TABLES_TOOL_NAME}, and ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} (or ${SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME} for semantic views) to explore the schema when database, schema, table, view, or column names are unknown.`,
     schema: {
       sql: z
@@ -128,7 +134,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SNOWFLAKE_SERVER = {
   serverInfo: {
@@ -143,13 +149,5 @@ export const SNOWFLAKE_SERVER = {
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
   },
-  tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SNOWFLAKE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const MAX_QUERY_ROWS = 1000;

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SOUND_STUDIO_SERVER_NAME = "sound_studio" as const;

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -47,7 +47,7 @@ export const SOUND_STUDIO_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SOUND_STUDIO_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SOUND_STUDIO_SERVER_NAME = "sound_studio" as const;
 
-export const SOUND_STUDIO_TOOLS_METADATA = createToolsRecord({
-  generate_sound_effects: {
+export const SOUND_STUDIO_TOOLS_METADATA = [
+  {
+    name: "generate_sound_effects",
     description: "Generate a short sound effect from a text prompt.",
     schema: {
       prompt: z
@@ -46,7 +47,7 @@ export const SOUND_STUDIO_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SOUND_STUDIO_SERVER = {
   serverInfo: {
@@ -57,13 +58,5 @@ export const SOUND_STUDIO_SERVER = {
     icon: "ActionNoiseIcon",
     documentationUrl: null,
   },
-  tools: Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SOUND_STUDIO_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -239,7 +239,7 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const SPEECH_GENERATOR_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const VOICE_GENDERS = ["female", "male"] as const;

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const VOICE_GENDERS = ["female", "male"] as const;
 
@@ -108,8 +108,9 @@ export function isAllowedAudioUrl(url: string): boolean {
   }
 }
 
-export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
-  speech_to_text: {
+export const SPEECH_GENERATOR_TOOLS_METADATA = [
+  {
+    name: "speech_to_text",
     description:
       "Transcribe speech from an audio or video file into text. " +
       "Supported formats: MP3, WAV, OGG, FLAC, AAC, MP4, MOV, WEBM, MKV, and most " +
@@ -150,7 +151,8 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  text_to_speech: {
+  {
+    name: "text_to_speech",
     description: "Generate speech audio from a text prompt with desired voice.",
     schema: {
       text: z
@@ -194,7 +196,8 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  text_to_dialogue: {
+  {
+    name: "text_to_dialogue",
     description: "Generate dialogue audio from multiple lines with speakers.",
     schema: {
       dialogues: z
@@ -236,7 +239,7 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const SPEECH_GENERATOR_SERVER = {
   serverInfo: {
@@ -247,13 +250,5 @@ export const SPEECH_GENERATOR_SERVER = {
     icon: "ActionSpeakIcon",
     documentationUrl: null,
   },
-  tools: Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: SPEECH_GENERATOR_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   ComponentStatusSchema,
   IncidentImpactSchema,

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -180,7 +180,7 @@ export const STATUSPAGE_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const STATUSPAGE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -1,16 +1,17 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   ComponentStatusSchema,
   IncidentImpactSchema,
   RealTimeIncidentStatusSchema,
 } from "@app/lib/api/actions/servers/statuspage/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
-  list_pages: {
+export const STATUSPAGE_TOOLS_METADATA = [
+  {
+    name: "list_pages",
     description:
       "List all status pages accessible with the configured API key. " +
       "Use this to discover available page IDs before using other tools.",
@@ -23,7 +24,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_components: {
+  {
+    name: "list_components",
     description:
       "List all components for a status page. " +
       "Components represent the services or systems displayed on the status page.",
@@ -42,7 +44,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_incidents: {
+  {
+    name: "list_incidents",
     description:
       "List incidents for a status page. " +
       "By default, returns unresolved incidents. " +
@@ -69,7 +72,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_incident: {
+  {
+    name: "get_incident",
     description:
       "Get detailed information about a specific incident, " +
       "including the full update history and affected components.",
@@ -93,7 +97,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_incident: {
+  {
+    name: "create_incident",
     description:
       "Create a new real-time incident on a status page. " +
       "Notifications will automatically be sent to subscribers. " +
@@ -133,7 +138,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_incident: {
+  {
+    name: "update_incident",
     description:
       "Update an existing incident on a status page. " +
       "Notifications will automatically be sent to subscribers. " +
@@ -174,7 +180,7 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const STATUSPAGE_SERVER = {
   serverInfo: {
@@ -185,13 +191,5 @@ export const STATUSPAGE_SERVER = {
     icon: "StatuspageLogo",
     documentationUrl: "https://docs.dust.tt/docs/statuspage-mcp",
   },
-  tools: Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: STATUSPAGE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
-  list: {
+export const TOOLSETS_TOOLS_METADATA = [
+  {
+    name: "list",
     description:
       "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
     schema: {},
@@ -18,7 +19,8 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  enable: {
+  {
+    name: "enable",
     description: "Enable a toolset for this conversation.",
     schema: {
       toolsetId: z.string().describe("The ID of the toolset to enable."),
@@ -32,7 +34,7 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const TOOLSETS_SERVER = {
   serverInfo: {
@@ -43,13 +45,5 @@ export const TOOLSETS_SERVER = {
     icon: "ActionLightbulbIcon",
     documentationUrl: null,
   },
-  tools: Object.values(TOOLSETS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: TOOLSETS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -34,7 +34,7 @@ export const TOOLSETS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const TOOLSETS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const TOOLSETS_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const UKG_READY_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -206,7 +206,7 @@ export const UKG_READY_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const UKG_READY_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const UKG_READY_TOOLS_METADATA = createToolsRecord({
-  get_my_info: {
+export const UKG_READY_TOOLS_METADATA = [
+  {
+    name: "get_my_info",
     description:
       "Get your own employee information from UKG Ready, including your employee ID, name, and username.",
     schema: {},
@@ -17,7 +18,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_pto_requests: {
+  {
+    name: "get_pto_requests",
     description:
       "Get your PTO/time-off requests. Can filter by date range and account IDs.",
     schema: {
@@ -42,7 +44,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_accrual_balances: {
+  {
+    name: "get_accrual_balances",
     description: "Get accrual balances for yourself or a specific employee.",
     schema: {
       accountId: z
@@ -66,7 +69,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_pto_request_notes: {
+  {
+    name: "get_pto_request_notes",
     description: "Get notes/comments for a specific PTO request.",
     schema: {
       noteThreadId: z
@@ -83,7 +87,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_pto_request: {
+  {
+    name: "create_pto_request",
     description:
       "Create a new time off request. Use get_accrual_balances to see available time off types.",
     schema: {
@@ -142,7 +147,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_pto_request: {
+  {
+    name: "delete_pto_request",
     description: "Delete one or more PTO/time-off requests.",
     schema: {
       requestIds: z
@@ -161,7 +167,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_schedules: {
+  {
+    name: "get_schedules",
     description: "Get work schedules for yourself or a specific employee.",
     schema: {
       username: z
@@ -187,7 +194,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_employees: {
+  {
+    name: "get_employees",
     description: "Get a list of active employees.",
     schema: {},
     stake: "never_ask",
@@ -198,7 +206,7 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const UKG_READY_SERVER = {
   serverInfo: {
@@ -213,13 +221,5 @@ export const UKG_READY_SERVER = {
     icon: "UkgLogo",
     documentationUrl: "https://docs.dust.tt/docs/ukg-ready",
   },
-  tools: Object.values(UKG_READY_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: UKG_READY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -1,16 +1,17 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { timeWindowSchemaShape } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
 import { JOB_TYPES } from "@app/types/job_type";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const USER_ANALYTICS_SERVER_NAME = "user_analytics" as const;
 
-export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
-  get_personal_usage: {
+export const USER_ANALYTICS_TOOLS_METADATA = [
+  {
+    name: "get_personal_usage",
     description:
       "Get the authenticated user's personal usage over a time window " +
       "(defaults to the last 30 days): top agents, top skills, and top tools " +
@@ -39,7 +40,8 @@ export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       done: "Fetched your usage",
     },
   },
-  get_workspace_activity: {
+  {
+    name: "get_workspace_activity",
     description:
       "Get anonymized workspace-wide activity over the last 30 days: " +
       "most popular agents by usage rank and trending skills. No individual " +
@@ -55,7 +57,7 @@ export const USER_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       done: "Fetched workspace activity",
     },
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const USER_ANALYTICS_SERVER = {
   serverInfo: {
@@ -67,13 +69,5 @@ export const USER_ANALYTICS_SERVER = {
     icon: "ActionPieChartIcon",
     documentationUrl: null,
   },
-  tools: Object.values(USER_ANALYTICS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: USER_ANALYTICS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -57,7 +57,7 @@ export const USER_ANALYTICS_TOOLS_METADATA = [
       done: "Fetched workspace activity",
     },
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const USER_ANALYTICS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/user_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/user_analytics/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { timeWindowSchemaShape } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { MIN_USERS_FOR_ANONYMITY } from "@app/lib/api/assistant/observability/anonymity";
 import { JOB_TYPES } from "@app/types/job_type";

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const USER_MENTIONS_SERVER_NAME = "user_mentions" as const;

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -49,7 +49,7 @@ export const USER_MENTIONS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const USER_MENTIONS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -1,15 +1,16 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const USER_MENTIONS_SERVER_NAME = "user_mentions" as const;
 export const SEARCH_AVAILABLE_USERS_TOOL_NAME = "search_available_users";
 export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
 
-export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
-  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: {
+export const USER_MENTIONS_TOOLS_METADATA = [
+  {
+    name: SEARCH_AVAILABLE_USERS_TOOL_NAME,
     description: "Search for users that are available to the conversation.",
     schema: {
       searchTerm: z
@@ -26,7 +27,8 @@ export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [GET_MENTION_MARKDOWN_TOOL_NAME]: {
+  {
+    name: GET_MENTION_MARKDOWN_TOOL_NAME,
     description:
       "Get the markdown directive to use to mention a list of users in a message.",
     schema: {
@@ -47,7 +49,7 @@ export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const USER_MENTIONS_SERVER = {
   serverInfo: {
@@ -58,13 +60,5 @@ export const USER_MENTIONS_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: USER_MENTIONS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const VAL_TOWN_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
-  create_val: {
+export const VAL_TOWN_TOOLS_METADATA = [
+  {
+    name: "create_val",
     description:
       "Create a new val (project) in Val Town: a serverless TypeScript/JavaScript function for HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
     schema: {
@@ -42,7 +43,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_val: {
+  {
+    name: "get_val",
     description:
       "Get a specific Val Town val (serverless script or project) by its ID, including its files and metadata.",
     schema: {
@@ -56,7 +58,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_vals: {
+  {
+    name: "list_vals",
     description:
       "List Val Town vals (serverless TypeScript/JavaScript functions and projects) available to the user's account.",
     schema: {
@@ -88,7 +91,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_vals: {
+  {
+    name: "search_vals",
     description:
       "Search for Val Town vals (serverless scripts and projects) by name, description, or code content.",
     schema: {
@@ -117,7 +121,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_val_files: {
+  {
+    name: "list_val_files",
     description:
       "List all files in a specific Val Town val (serverless project).",
     schema: {
@@ -149,7 +154,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  get_file_content: {
+  {
+    name: "get_file_content",
     description:
       "Get the content of a specific file in a val using the Val Town API",
     schema: {
@@ -166,7 +172,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  delete_file: {
+  {
+    name: "delete_file",
     description:
       "Delete or remove a specific file from a val using the Val Town API",
     schema: {
@@ -183,7 +190,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_file_content: {
+  {
+    name: "update_file_content",
     description:
       "Update the code or content of a specific file in a Val Town val. Use write_file to change the file type, name, or path.",
     schema: {
@@ -204,7 +212,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  write_file: {
+  {
+    name: "write_file",
     description:
       "Write, rename, or move files in a Val Town val. Set content, change the file type (HTTP, email, interval, script), rename a file, or move it to a new directory.",
     schema: {
@@ -235,7 +244,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  create_file: {
+  {
+    name: "create_file",
     description:
       "Create a new empty file in an existing val. Use write_file to add content and set the file type.",
     schema: {
@@ -252,7 +262,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  call_http_endpoint: {
+  {
+    name: "call_http_endpoint",
     description:
       "Run an HTTP val endpoint by getting the file's endpoint link and making a request to it",
     schema: {
@@ -280,7 +291,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const VAL_TOWN_SERVER = {
   serverInfo: {
@@ -293,13 +304,5 @@ export const VAL_TOWN_SERVER = {
     documentationUrl: "https://docs.dust.tt/docs/val-town",
     developerSecretSelection: "required",
   },
-  tools: Object.values(VAL_TOWN_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: VAL_TOWN_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -291,7 +291,7 @@ export const VAL_TOWN_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const VAL_TOWN_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -350,7 +350,7 @@ export const VANTA_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const VANTA_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -1,8 +1,8 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const PaginationSchema = {
   pageSize: z
@@ -17,8 +17,9 @@ const PaginationSchema = {
     .optional(),
 };
 
-export const VANTA_TOOLS_METADATA = createToolsRecord({
-  list_tests: {
+export const VANTA_TOOLS_METADATA = [
+  {
+    name: "list_tests",
     description:
       "List Vanta's automated security and compliance tests with optional filtering by status, category, framework, or integration",
     schema: {
@@ -73,7 +74,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_test_entities: {
+  {
+    name: "list_test_entities",
     description:
       "Get the resources monitored by a specific security test, filter by status using FAILING or DEACTIVATED",
     schema: {
@@ -92,7 +94,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_controls: {
+  {
+    name: "list_controls",
     description:
       "List security controls in your Vanta account or retrieve a specific control by ID with framework mapping details",
     schema: {
@@ -114,7 +117,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_control_tests: {
+  {
+    name: "list_control_tests",
     description:
       "Enumerate automated tests that validate a specific security control, including status and failing entity information",
     schema: {
@@ -129,7 +133,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_control_documents: {
+  {
+    name: "list_control_documents",
     description:
       "List documents mapped to a control to locate supporting evidence quickly",
     schema: {
@@ -146,7 +151,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_documents: {
+  {
+    name: "list_documents",
     description:
       "List compliance documents in your Vanta account or retrieve a specific document by ID",
     schema: {
@@ -166,7 +172,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_document_resources: {
+  {
+    name: "list_document_resources",
     description:
       "Retrieve resources linked to a document (controls, links, uploads) by choosing the desired resource type",
     schema: {
@@ -184,7 +191,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_integrations: {
+  {
+    name: "list_integrations",
     description:
       "List integrations connected to your Vanta account or retrieve details for a specific integration",
     schema: {
@@ -202,7 +210,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_frameworks: {
+  {
+    name: "list_frameworks",
     description:
       "List compliance frameworks in your Vanta account with completion status and progress metrics",
     schema: {
@@ -220,7 +229,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_framework_controls: {
+  {
+    name: "list_framework_controls",
     description:
       "Retrieve the controls required by and associated with a compliance framework, including descriptions and implementation guidance",
     schema: {
@@ -237,7 +247,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_people: {
+  {
+    name: "list_people",
     description:
       "List people in your Vanta account or retrieve a specific person by ID with role and group membership",
     schema: {
@@ -255,7 +266,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_risks: {
+  {
+    name: "list_risks",
     description:
       "List security risk scenarios in your risk register or retrieve a specific scenario to review status, scoring, and treatment",
     schema: {
@@ -273,7 +285,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_vulnerabilities: {
+  {
+    name: "list_vulnerabilities",
     description:
       "List vulnerabilities detected across your infrastructure with CVE details, severity, and impacted assets",
     schema: {
@@ -337,7 +350,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const VANTA_SERVER = {
   serverInfo: {
@@ -352,13 +365,5 @@ export const VANTA_SERVER = {
     icon: "VantaLogo",
     documentationUrl: "https://docs.dust.tt/docs/vanta",
   },
-  tools: Object.values(VANTA_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: VANTA_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 const PaginationSchema = {

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const WAKEUPS_SERVER_NAME = "wakeups" as const;

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -1,13 +1,14 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const WAKEUPS_SERVER_NAME = "wakeups" as const;
 
-export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
-  schedule_wakeup: {
+export const WAKEUPS_TOOLS_METADATA = [
+  {
+    name: "schedule_wakeup",
     description:
       "Schedule a wake-up that posts a user message at a future time to re-invoke " +
       "the agent. Useful for requests to check back on something later, remind the user, poll " +
@@ -49,7 +50,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  list_wakeups: {
+  {
+    name: "list_wakeups",
     description:
       "List wake-ups and reminders with their status, schedule, and reason, including " +
       "pending reminders and already-fired, cancelled, or expired wake-ups. Useful for checking " +
@@ -64,7 +66,8 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  cancel_wakeup: {
+  {
+    name: "cancel_wakeup",
     description:
       "Cancel or stop a previously scheduled wake-up or reminder by ID. " +
       "Useful for requests to stop a reminder set earlier, remove a scheduled follow-up, or cancel " +
@@ -85,7 +88,7 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const WAKEUPS_SERVER = {
   serverInfo: {
@@ -97,13 +100,5 @@ export const WAKEUPS_SERVER = {
     documentationUrl: null,
     displayedAs: "agent",
   },
-  tools: Object.values(WAKEUPS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: WAKEUPS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -88,7 +88,7 @@ export const WAKEUPS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const WAKEUPS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -46,7 +46,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const WEB_SEARCH_BROWSE_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -1,20 +1,20 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_BROWSE_URLS,
   WebbrowseInputSchema,
   WebsearchInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const WEB_SEARCH_BROWSE_SERVER_NAME = "web_search_&_browse" as const;
 export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
 
-export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
-  websearch: {
+export const WEB_SEARCH_BROWSE_TOOLS_METADATA = [
+  {
+    name: "websearch",
     description:
       "Search Google for web results, news, and current online information. " +
       "Look up any topic on the internet using a search query.",
@@ -29,7 +29,8 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  webbrowser: {
+  {
+    name: "webbrowser",
     description:
       `Fetch and read the content of web pages and webpages from given URLs. ` +
       `Open and browse websites to extract text, or take a viewport or ` +
@@ -45,7 +46,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const WEB_SEARCH_BROWSE_SERVER = {
   serverInfo: {
@@ -56,13 +57,5 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
   },
-  tools: Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: WEB_SEARCH_BROWSE_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_BROWSE_URLS,
   WebbrowseInputSchema,

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -26,7 +26,7 @@ export const WORKDAY_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const WORKDAY_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const WORKDAY_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/workday/metadata.ts
+++ b/front/lib/api/actions/servers/workday/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const WORKDAY_TOOLS_METADATA = createToolsRecord({
-  get_workers: {
+export const WORKDAY_TOOLS_METADATA = [
+  {
+    name: "get_workers",
     description:
       "List workers from Workday. Returns each worker's name and ID along with the total count.",
     schema: {
@@ -25,7 +26,7 @@ export const WORKDAY_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const WORKDAY_SERVER = {
   serverInfo: {
@@ -40,13 +41,5 @@ export const WORKDAY_SERVER = {
     icon: "ActionTableIcon",
     documentationUrl: "https://docs.dust.tt/docs/workday",
   },
-  tools: Object.values(WORKDAY_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: WORKDAY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -303,7 +303,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const WORKSPACE_ANALYTICS_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,5 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
@@ -8,9 +10,7 @@ import {
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const topListSchema = (entityPlural: string) => ({
   ...timeWindowSchemaShape,
@@ -116,8 +116,9 @@ const getUsageTimeseriesSchema = {
     ),
 };
 
-export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
-  get_top_agents: {
+export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
+  {
+    name: "get_top_agents",
     description:
       "Return the workspace's most-used and most active agents over a time " +
       "window (defaults to the current calendar month), ranked by message " +
@@ -133,7 +134,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_top_users: {
+  {
+    name: "get_top_users",
     description:
       "Return the workspace's most active users and members over a time " +
       "window (defaults to the current calendar month), ranked by number of " +
@@ -149,7 +151,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_top_agent_tags: {
+  {
+    name: "get_top_agent_tags",
     description:
       "List the agent tags applied across the workspace over a time window " +
       "(defaults to the current calendar month), ranked by message volume, " +
@@ -168,7 +171,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_agent_details: {
+  {
+    name: "get_agent_details",
     description:
       "Return an agent's full configuration: name, description, scope, model, " +
       "equipped skills and capabilities, and its complete system prompt and " +
@@ -183,7 +187,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_top_skills: {
+  {
+    name: "get_top_skills",
     description:
       "Return the workspace's most-used skills over a time window (defaults " +
       "to the current calendar month), ranked by execution count. Optionally " +
@@ -198,7 +203,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_top_tools: {
+  {
+    name: "get_top_tools",
     description:
       "Return the workspace's most-used MCP tools and integrations over a " +
       "time window (defaults to the current calendar month), ranked by " +
@@ -215,7 +221,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_source_breakdown: {
+  {
+    name: "get_source_breakdown",
     description:
       "Return the workspace's message volume broken down by source — where " +
       "messages originate (Conversation, Slack, API, Trigger, extension, and " +
@@ -236,7 +243,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_credit_usage: {
+  {
+    name: "get_credit_usage",
     description:
       "Estimate AWU credit consumption over a time window (defaults to the " +
       "current calendar month), optionally broken down by the top agents or " +
@@ -256,7 +264,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_credit_timeseries: {
+  {
+    name: "get_credit_timeseries",
     description:
       "Return estimated AWU credit consumption as a time series over a window " +
       "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
@@ -277,7 +286,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-  get_usage_timeseries: {
+  {
+    name: "get_usage_timeseries",
     description:
       "Return a usage time series over a window (defaults to the last 30 " +
       "days). Plot message volume (messages, conversations, active users), " +
@@ -293,7 +303,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "basic",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const WORKSPACE_ANALYTICS_SERVER = {
   serverInfo: {
@@ -306,13 +316,5 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     authorization: null,
     documentationUrl: null,
   },
-  tools: Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: WORKSPACE_ANALYTICS_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -1,11 +1,12 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type {
+  InternalMCPToolType,
+  ServerMetadata,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const ZENDESK_TOOLS_METADATA = createToolsRecord({
-  get_ticket: {
+export const ZENDESK_TOOLS_METADATA = [
+  {
+    name: "get_ticket",
     description:
       "Look up and retrieve a Zendesk support ticket by its ID. Returns subject, description, status, priority, assignee, and other metadata. Optionally include ticket metrics, the full conversation of comments, and file attachments.",
     schema: {
@@ -39,7 +40,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  search_tickets: {
+  {
+    name: "search_tickets",
     description:
       "Search and find Zendesk tickets using query syntax. Returns matching tickets with their details. Filter by status (open, pending, solved), priority (low, medium, high), type, assignee, tags, dates, and text fields.",
     schema: {
@@ -67,7 +69,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  list_ticket_fields: {
+  {
+    name: "list_ticket_fields",
     description:
       "List and enumerate all Zendesk ticket field definitions — built-in fields (Subject, Priority, Status) and custom fields — with their id, title, type, and active state. Use this to discover what fields exist on a ticket.",
     schema: {
@@ -84,7 +87,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  draft_reply: {
+  {
+    name: "draft_reply",
     description:
       "Draft a reply to a Zendesk ticket. Creates a private comment (not visible to the end user) " +
       "that can be edited before being published. This is useful for preparing responses before " +
@@ -105,7 +109,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  post_reply: {
+  {
+    name: "post_reply",
     description:
       "Post or send a public reply (response) on a Zendesk ticket, visible to the end user (the customer).",
     schema: {
@@ -124,7 +129,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  update_ticket_tags: {
+  {
+    name: "update_ticket_tags",
     description:
       "Add tags to a Zendesk ticket, or replace all of its tags. By default (override=false) the provided tags are added to the existing ones. With override=true they replace the full list (omitted tags are removed).",
     schema: {
@@ -154,7 +160,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-});
+] as const satisfies readonly InternalMCPToolType[];
 
 export const ZENDESK_SERVER = {
   serverInfo: {
@@ -169,13 +175,5 @@ export const ZENDESK_SERVER = {
     icon: "ZendeskLogo",
     documentationUrl: null,
   },
-  tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
-    displayLabels: t.displayLabels,
-    toolCostCategory: t.toolCostCategory,
-    freeUsage: t.freeUsage,
-    stake: t.stake,
-  })),
+  tools: ZENDESK_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  InternalMCPToolType,
-  ServerMetadata,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const ZENDESK_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -160,7 +160,7 @@ export const ZENDESK_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-] as const satisfies readonly InternalMCPToolType[];
+] as const;
 
 export const ZENDESK_SERVER = {
   serverInfo: {

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -8,8 +8,11 @@ import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { isPodConversation } from "@app/types/assistant/conversation";
 
-const toolName = (name: keyof typeof SANDBOX_FUNCTIONS_TOOLS_METADATA) =>
-  getPrefixedToolName(SANDBOX_FUNCTIONS_SERVER_NAME, name);
+function toolName(
+  name: (typeof SANDBOX_FUNCTIONS_TOOLS_METADATA)[number]["name"]
+): string {
+  return getPrefixedToolName(SANDBOX_FUNCTIONS_SERVER_NAME, name);
+}
 
 export const podFunctionsSkill = {
   sId: "pod_functions",

--- a/front/lib/resources/skill/code_defined/system/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/plan_mode.ts
@@ -1,4 +1,3 @@
-import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import {
   CLOSE_PLAN_TOOL_NAME,
   CREATE_PLAN_TOOL_NAME,
@@ -9,8 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 
-const ASK_USER_QUESTION_TOOL_NAME =
-  ASK_USER_QUESTION_TOOLS_METADATA.ask_user_question.name;
+const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 
 const PLAN_MODE_INSTRUCTIONS = `
 Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view, not just an approval gate. Using it is delightful UX: the user sees what you're doing without having to ask.

--- a/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
+++ b/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
@@ -16,7 +16,8 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { Logger } from "@app/logger/logger";
 
 const DEFAULT_CUTOFF_DATE = new Date("2026-03-27T00:00:00Z");
-const TOOL_NAME: keyof typeof SALESFORCE_TOOLS_METADATA = "create_object";
+const TOOL_NAME: (typeof SALESFORCE_TOOLS_METADATA)[number]["name"] =
+  "create_object";
 const INTERNAL_MCP_SERVER_NAME: InternalMCPServerNameType = "salesforce";
 const PERMISSION_LEVEL: MCPToolStakeLevelType = "medium";
 

--- a/front/tests/sidekick-evals/lib/config.ts
+++ b/front/tests/sidekick-evals/lib/config.ts
@@ -10,6 +10,9 @@ import {
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import type { SidekickConfig } from "@app/tests/sidekick-evals/lib/types";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const RUN_SIDEKICK_EVAL = process.env.RUN_SIDEKICK_EVAL === "true";
 export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
@@ -114,13 +117,11 @@ export async function getSidekickConfig(): Promise<{
 
   for (const server of SIDEKICK_MCP_SERVERS) {
     for (const tool of server.tools) {
-      if (tool.inputSchema) {
-        tools.push({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-        });
-      }
+      tools.push({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: zodToJsonSchema(z.object(tool.schema)) as JSONSchema,
+      });
     }
   }
 


### PR DESCRIPTION
## Description

Part of a multi step plan to allow defining in which context a tool can be ran on the tool metadata themselves in a declarative way.

The plan goes like this:

- Remove the boilerplate helpers `createToolRecords` and `buildTools`.
- Move the `createServer` one level up.
- Add a metadata to declare which contexts each tool supports (by default all contexts) + bake it in the generic `createServer`.

Follow up on https://github.com/dust-tt/dust/pull/29119

This PR defines tools metadata as an arrays with explicit names and zod schemas that are surfaced one layer up (this will unlock a much richer typing as we can infer a type from a zod schema, unlike a JSON schema. So we're better off sticking with the zod schema as long we can). This removes `createToolsRecord`, `createToolsArray`, and the repeated schema-conversion boilerplate from each server.

Switching from a record to an array creates a risk of allowing duplicate tool names; this PR introduces a function `ensureUniqueToolNames` (only called once, not repeated on each server) that enforces in type that tool names are unique among an MCP server.

No changes are intended to tool behavior or exposed metadata.

## Tests

- Covered by existing tests.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
