### PR TITLE
[perf]: skip telemetry startup for warm sandboxes

### DIFF
--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -262,6 +262,11 @@ describe("ensureConversationSandboxReady", () => {
     expect(result.isOk()).toBe(true);
     expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
     expect(mockSetupSandboxMount).not.toHaveBeenCalled();
+    expect(mockStartTelemetry).toHaveBeenCalledWith(
+      auth,
+      sandbox,
+      conversationOwner
+    );
     expect(mockForConversation).toHaveBeenCalledWith(auth, conversation);
     expect(mockRefreshSandboxMount).toHaveBeenCalledWith(sandbox, image);
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
@@ -280,6 +285,7 @@ describe("ensureConversationSandboxReady", () => {
     expect(result.isOk()).toBe(true);
     expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
     expect(mockSetupSandboxMount).not.toHaveBeenCalled();
+    expect(mockStartTelemetry).not.toHaveBeenCalled();
     expect(mockForConversation).toHaveBeenCalledWith(auth, conversation);
     expect(mockRefreshSandboxMount).toHaveBeenCalledWith(sandbox, image);
     expect(mockRefreshSandboxMount.mock.invocationCallOrder[0]).toBeLessThan(

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -83,9 +83,11 @@ async function ensureOwnerSandboxReady(
       }
       const image = imageResult.value;
 
-      void startTelemetry(auth, sandbox, runtimeOwner).catch((err) =>
-        logger.error({ err }, "Telemetry start failed (fire-and-forget)")
-      );
+      if (freshlyCreated || wokeFromSleep) {
+        void startTelemetry(auth, sandbox, runtimeOwner).catch((err) =>
+          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+        );
+      }
 
       // Only mount on first creation. e2b preserves the FUSE mount and the
       // token server across betaPause + connect (verified empirically), so on


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Zooming on pod functions poor performances, we can definitely speed things up. 

<img width="540" height="104" alt="image" src="https://github.com/user-attachments/assets/8e83486e-b734-4682-8ce0-12aa16b1a4a7" />

_One trace among many trace, order of magnitude is similar across many traces_

Warm sandbox executions restarted Fluent Bit on every readiness check, adding a few ms per command despite telemetry already running. This starts telemetry only after sandbox creation or wake, preserving logging while removing the redundant provider round trip.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
