### PR TITLE
feat(activation): gate nudges on the pod's user credit state

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -22,7 +22,15 @@ import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { TriggerStatus } from "@app/types/assistant/triggers";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockIsUserBlocked } = vi.hoisted(() => ({
+  mockIsUserBlocked: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/user_block", () => ({
+  isUserBlocked: mockIsUserBlocked,
+}));
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -101,13 +109,20 @@ describe("getActivationNudgeFrequencyCapDays", () => {
 });
 
 describe("isEligibleForNudge", () => {
+  beforeEach(() => {
+    mockIsUserBlocked.mockReset();
+    mockIsUserBlocked.mockResolvedValue(null);
+  });
+
   it("is eligible when the pod has never been nudged", async () => {
     const { authenticator, globalSpace } = await createResourceTest({
       role: "admin",
     });
     await createPodActivationTrigger(authenticator, globalSpace);
 
-    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(true);
+    expect(
+      await isEligibleForNudge(authenticator, globalSpace, { user: null })
+    ).toBe(true);
   });
 
   it("is not eligible right after a nudge, within the cap window", async () => {
@@ -123,7 +138,44 @@ describe("isEligibleForNudge", () => {
       trigger,
     });
 
-    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+    expect(
+      await isEligibleForNudge(authenticator, globalSpace, { user: null })
+    ).toBe(false);
+  });
+
+  it("is not eligible when the pod's user is blocked, even if never nudged", async () => {
+    mockIsUserBlocked.mockResolvedValue("credits_exhausted");
+    const { authenticator, user, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await createPodActivationTrigger(authenticator, globalSpace);
+
+    expect(await isEligibleForNudge(authenticator, globalSpace, { user })).toBe(
+      false
+    );
+  });
+
+  it("is eligible when a user is provided but not blocked", async () => {
+    mockIsUserBlocked.mockResolvedValue(null);
+    const { authenticator, user, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await createPodActivationTrigger(authenticator, globalSpace);
+
+    expect(await isEligibleForNudge(authenticator, globalSpace, { user })).toBe(
+      true
+    );
+  });
+
+  it("does not check the credit gate when no user is provided", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await createPodActivationTrigger(authenticator, globalSpace);
+
+    await isEligibleForNudge(authenticator, globalSpace, { user: null });
+
+    expect(mockIsUserBlocked).not.toHaveBeenCalled();
   });
 
   it("is not eligible once the max unanswered nudge count is reached, even outside the cap window", async () => {
@@ -154,7 +206,9 @@ describe("isEligibleForNudge", () => {
       createdAt: new Date(Date.now() - 5 * DAY_MS),
     });
 
-    expect(await isEligibleForNudge(refreshedAuth, globalSpace)).toBe(false);
+    expect(
+      await isEligibleForNudge(refreshedAuth, globalSpace, { user: null })
+    ).toBe(false);
   });
 
   it("is eligible again once the user replies after the most recent nudge", async () => {
@@ -196,7 +250,9 @@ describe("isEligibleForNudge", () => {
       trigger.id
     );
 
-    expect(await isEligibleForNudge(refreshedAuth, globalSpace)).toBe(true);
+    expect(
+      await isEligibleForNudge(refreshedAuth, globalSpace, { user: null })
+    ).toBe(true);
   });
 
   it("is not eligible when the trigger was disabled by the user (opted out)", async () => {
@@ -207,7 +263,9 @@ describe("isEligibleForNudge", () => {
       status: "disabled",
     });
 
-    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+    expect(
+      await isEligibleForNudge(authenticator, globalSpace, { user: null })
+    ).toBe(false);
   });
 
   it("is not eligible when the pod has no activation trigger", async () => {
@@ -215,7 +273,9 @@ describe("isEligibleForNudge", () => {
       role: "admin",
     });
 
-    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+    expect(
+      await isEligibleForNudge(authenticator, globalSpace, { user: null })
+    ).toBe(false);
   });
 
   it("is not eligible when the pod is archived (dead)", async () => {
@@ -244,7 +304,9 @@ describe("isEligibleForNudge", () => {
       throw new Error("Expected the archived pod to still be fetchable.");
     }
 
-    expect(await isEligibleForNudge(authenticator, archivedPod)).toBe(false);
+    expect(
+      await isEligibleForNudge(authenticator, archivedPod, { user: null })
+    ).toBe(false);
   });
 
   it("is not eligible when the target user left the workspace (dead)", async () => {
@@ -259,7 +321,9 @@ describe("isEligibleForNudge", () => {
 
     await MembershipResource.revokeMembership({ user, workspace });
 
-    expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
+    expect(
+      await isEligibleForNudge(authenticator, globalSpace, { user: null })
+    ).toBe(false);
   });
 });
 

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { isUserBlocked } from "@app/lib/metronome/user_block";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -6,6 +7,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
@@ -108,16 +110,19 @@ async function isPodDead(
   return activeMembership === null;
 }
 
-// Gates re-nudging a pod on four conditions:
+// Gates re-nudging a pod on five conditions:
 // - Opted out: was the trigger disabled by the user?
 // - Dead: is the pod archived, or has its target user left the workspace?
+// - Credit gate: is the pod's user blocked (workspace credit pool exhausted
+//   or their per-user cap reached)?
 // - Frequency cap: was the pod nudged within the workspace's configured cap
 //   window?
 // - Unanswered cap: have the pod's most recent nudges gone unanswered (no
 //   user message since they fired), up to the workspace's configured max?
 export async function isEligibleForNudge(
   auth: Authenticator,
-  pod: SpaceResource
+  pod: SpaceResource,
+  { user }: { user: UserResource | null }
 ): Promise<boolean> {
   const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
   if (!activationPod || activationPod.triggerId === null) {
@@ -133,6 +138,15 @@ export async function isEligibleForNudge(
 
   if (await isPodDead(auth, pod, trigger)) {
     return false;
+  }
+
+  if (user) {
+    const workspace = renderLightWorkspaceType({
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    if (await isUserBlocked(workspace, user)) {
+      return false;
+    }
   }
 
   const latestNudge = await ActivationNudgeResource.fetchLatestForActivationPod(

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,8 +1,12 @@
 import { evaluateActivation } from "@app/lib/api/activation/evaluator";
+import { isEligibleForNudge } from "@app/lib/api/activation/nudge";
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -157,6 +161,15 @@ export async function runActivationForWorkspace({
   const pods = await SpaceResource.fetchByIds(auth, uniqueSpaceIds);
   const podBySId = new Map(pods.map((pod) => [pod.sId, pod]));
 
+  const users = await UserResource.fetchByIds([
+    ...new Set(plan.eligible.map((p) => p.targetUserId)),
+  ]);
+  const userBySId = new Map(users.map((user) => [user.sId, user]));
+
+  // Collected across pods so the trigger lookup and the nudge inserts below
+  // can each run as a single batched query instead of one per pod.
+  const firedTriggersByPod: { pod: SpaceResource; triggerId: string }[] = [];
+
   await concurrentExecutor(
     plan.eligible,
     async ({ spaceId, targetUserId }) => {
@@ -168,16 +181,63 @@ export async function runActivationForWorkspace({
         );
         return;
       }
+
+      const user = userBySId.get(targetUserId) ?? null;
+      if (!(await isEligibleForNudge(auth, pod, { user }))) {
+        logger.info(
+          { workspaceId, spaceId, userId: targetUserId },
+          "[Activation] Pod is not eligible for a nudge, skipping."
+        );
+        return;
+      }
+
       const result = await emitActivationEvent(auth, pod, targetUserId);
       if (result.isErr()) {
         logger.error(
           { workspaceId, spaceId, userId: targetUserId, error: result.error },
           "[Activation] Failed to emit activation event for user."
         );
+        return;
       }
+
+      const { triggerId } = result.value;
+      if (!triggerId) {
+        logger.warn(
+          { workspaceId, spaceId, userId: targetUserId },
+          "[Activation] Activation event did not fire the pod's trigger."
+        );
+        return;
+      }
+
+      firedTriggersByPod.push({ pod, triggerId });
     },
     { concurrency: 3 }
   );
+
+  if (firedTriggersByPod.length > 0) {
+    const triggers = await TriggerResource.fetchByIds(
+      auth,
+      firedTriggersByPod.map(({ triggerId }) => triggerId)
+    );
+    const triggerById = new Map(
+      triggers.map((trigger) => [trigger.sId, trigger])
+    );
+
+    const nudges: { pod: SpaceResource; trigger: TriggerResource }[] = [];
+    for (const { pod, triggerId } of firedTriggersByPod) {
+      const trigger = triggerById.get(triggerId);
+      if (!trigger) {
+        logger.error(
+          { workspaceId, spaceId: pod.sId, triggerId },
+          "[Activation] Activation trigger not found after firing."
+        );
+        continue;
+      }
+      nudges.push({ pod, trigger });
+    }
+
+    await ActivationNudgeResource.bulkCreate(auth, nudges);
+  }
 
   return new Ok(plan);
 }


### PR DESCRIPTION
## Description

Skip re-nudging an Activation Pod when its user is out of credits. Since each
pod is single-user, `isEligibleForNudge` now takes that user and consults
`isUserBlocked` (workspace pool exhausted or per-user cap reached) alongside
the existing frequency-cap and unanswered-cap gates. The scheduler activity
batch-fetches each pod's member (`fetchDistinctActiveManualGroupMembersBySpaces`)
to avoid an N+1 lookup across pods.

## Tests

Added unit tests to `nudge.test.ts` covering: pod skipped when the user is
blocked (even if never nudged before), pod still eligible when the user is
not blocked, and the credit gate is skipped entirely when no user is
resolved for the pod. `isUserBlocked` is mocked, matching the existing
pattern in `credit_check.test.ts`.
