### PR TITLE
[front] feat: add skill favorite resource methods

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2,8 +2,12 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
+import {
+  SkillConfigurationModel,
+  SkillDataSourceConfigurationModel,
+} from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { SkillUserFavoriteModel } from "@app/lib/models/skill/skill_user_favorite";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -83,6 +87,56 @@ describe("SkillResource", () => {
 
       expect(skill.instructions).toBe("");
       expect(skill.instructionsHtml).toBeNull();
+    });
+  });
+
+  describe("favorites", () => {
+    it("stores one row per user and updates custom skill favorite counts", async () => {
+      const skillA = await SkillFactory.create(testContext.authenticator, {
+        name: "Favorite Skill A",
+      });
+      const skillB = await SkillFactory.create(testContext.authenticator, {
+        name: "Favorite Skill B",
+      });
+
+      await skillA.setFavorite(testContext.authenticator, false);
+      expect(
+        await SkillUserFavoriteModel.count({
+          where: {
+            workspaceId: testContext.workspace.id,
+            userId: testContext.user.id,
+          },
+        })
+      ).toBe(0);
+
+      await skillA.setFavorite(testContext.authenticator, true);
+      await skillA.setFavorite(testContext.authenticator, true);
+      await skillB.setFavorite(testContext.authenticator, true);
+
+      const favoriteRows = await SkillUserFavoriteModel.findAll({
+        where: {
+          workspaceId: testContext.workspace.id,
+          userId: testContext.user.id,
+        },
+      });
+      expect(favoriteRows).toHaveLength(1);
+      expect(favoriteRows[0].skillIds).toEqual([skillA.sId, skillB.sId]);
+
+      await skillA.setFavorite(testContext.authenticator, false);
+      await skillA.setFavorite(testContext.authenticator, false);
+
+      await favoriteRows[0].reload();
+      expect(favoriteRows[0].skillIds).toEqual([skillB.sId]);
+
+      const [skillAModel, skillBModel] = await SkillConfigurationModel.findAll({
+        where: {
+          id: [skillA.id, skillB.id],
+          workspaceId: testContext.workspace.id,
+        },
+        order: [["id", "ASC"]],
+      });
+      expect(skillAModel.favoriteCount).toBe(0);
+      expect(skillBModel.favoriteCount).toBe(1);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -101,6 +101,9 @@ describe("SkillResource", () => {
 
       await skillA.setFavorite(testContext.authenticator, false);
       expect(
+        await skillA.isFavoriteForCurrentUser(testContext.authenticator)
+      ).toBe(false);
+      expect(
         await SkillUserFavoriteModel.count({
           where: {
             workspaceId: testContext.workspace.id,
@@ -112,6 +115,12 @@ describe("SkillResource", () => {
       await skillA.setFavorite(testContext.authenticator, true);
       await skillA.setFavorite(testContext.authenticator, true);
       await skillB.setFavorite(testContext.authenticator, true);
+      expect(
+        await skillA.isFavoriteForCurrentUser(testContext.authenticator)
+      ).toBe(true);
+      expect(
+        await skillB.isFavoriteForCurrentUser(testContext.authenticator)
+      ).toBe(true);
 
       const favoriteRows = await SkillUserFavoriteModel.findAll({
         where: {
@@ -127,6 +136,9 @@ describe("SkillResource", () => {
 
       await favoriteRows[0].reload();
       expect(favoriteRows[0].skillIds).toEqual([skillB.sId]);
+      expect(
+        await skillA.isFavoriteForCurrentUser(testContext.authenticator)
+      ).toBe(false);
 
       const [skillAModel, skillBModel] = await SkillConfigurationModel.findAll({
         where: {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -26,6 +26,7 @@ import {
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
+import { SkillUserFavoriteModel } from "@app/lib/models/skill/skill_user_favorite";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -1113,6 +1114,100 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.globalSId
       ? { globalSkillId: this.globalSId }
       : { customSkillId: this.id };
+  }
+
+  static async listFavoritesForCurrentUser(
+    auth: Authenticator,
+    {
+      agentLoopData,
+    }: {
+      agentLoopData?: AgentLoopExecutionData;
+    } = {}
+  ): Promise<SkillResource[]> {
+    const user = auth.user();
+    if (!user) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const favorites = await SkillUserFavoriteModel.findOne({
+      attributes: ["skillIds"],
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+      },
+    });
+
+    if (!favorites || favorites.skillIds.length === 0) {
+      return [];
+    }
+
+    return this.fetchByIds(auth, favorites.skillIds, {
+      agentLoopData,
+      onlyActive: true,
+    });
+  }
+
+  async isFavoriteForCurrentUser(auth: Authenticator): Promise<boolean> {
+    const favoriteSkills =
+      await SkillResource.listFavoritesForCurrentUser(auth);
+
+    return favoriteSkills.some((skill) => skill.sId === this.sId);
+  }
+
+  async setFavorite(
+    auth: Authenticator,
+    isFavorite: boolean
+  ): Promise<Result<undefined, Error>> {
+    const user = auth.user();
+    if (!user) {
+      return new Err(new Error("User must be authenticated"));
+    }
+
+    if (this.status !== "active") {
+      return new Err(
+        new Error("Only active skills can update favorite state.")
+      );
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const favorites = await SkillUserFavoriteModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+      },
+    });
+
+    const wasFavorite = favorites?.skillIds.includes(this.sId) ?? false;
+    if (wasFavorite === isFavorite) {
+      return new Ok(undefined);
+    }
+
+    if (favorites) {
+      await favorites.update({
+        skillIds: isFavorite
+          ? [...favorites.skillIds, this.sId]
+          : favorites.skillIds.filter((skillId) => skillId !== this.sId),
+      });
+    } else {
+      await SkillUserFavoriteModel.create({
+        workspaceId: workspace.id,
+        userId: user.id,
+        skillIds: [this.sId],
+      });
+    }
+
+    if (!this.globalSId) {
+      await this.model.increment("favoriteCount", {
+        by: isFavorite ? 1 : -1,
+        where: {
+          id: this.id,
+          workspaceId: workspace.id,
+        },
+      });
+    }
+
+    return new Ok(undefined);
   }
 
   static async listByAgentConfiguration(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1155,16 +1155,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     const workspace = auth.getNonNullableWorkspace();
-    const favorite = await SkillUserFavoriteModel.findOne({
-      attributes: ["id"],
+    const favorites = await SkillUserFavoriteModel.findOne({
+      attributes: ["skillIds"],
       where: {
         workspaceId: workspace.id,
         userId: user.id,
-        skillIds: { [Op.contains]: [this.sId] },
       },
     });
 
-    return favorite !== null;
+    return favorites?.skillIds.includes(this.sId) ?? false;
   }
 
   async setFavorite(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1149,10 +1149,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async isFavoriteForCurrentUser(auth: Authenticator): Promise<boolean> {
-    const favoriteSkills =
-      await SkillResource.listFavoritesForCurrentUser(auth);
+    const user = auth.user();
+    if (!user) {
+      return false;
+    }
 
-    return favoriteSkills.some((skill) => skill.sId === this.sId);
+    const workspace = auth.getNonNullableWorkspace();
+    const favorite = await SkillUserFavoriteModel.findOne({
+      attributes: ["id"],
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+        skillIds: { [Op.contains]: [this.sId] },
+      },
+    });
+
+    return favorite !== null;
   }
 
   async setFavorite(


### PR DESCRIPTION
## Description

Adds the resource-layer methods for per-user skill favorites on top of the existing `skill_user_favorites` data model. `SkillResource` can list the current user's active favorites, check whether a skill is favorited, and update favorite state while maintaining aggregate counts for custom skills.

Next PR will implement the endpoints (which will call these methods).

Overall plan here: https://github.com/dust-tt/dust/pull/28017

## Tests

- Added some tests.

## Risk

- Low. No user-facing callers.

## Deploy Plan

- Deploy front.
