### PR TITLE
[front] chore: simplify internal MCP metadata types

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -232,9 +232,6 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "activation_recommendations",
 ] as const;
 
-export type InternalMCPServerNameType =
-  (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
-
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
   "web_search_&_browse",
   "http_client",
@@ -1261,6 +1258,9 @@ type InternalMCPServerEntry<
   // Non restricted server cannot be in preview
   | { isPreview: false; isRestricted: undefined }
 );
+
+export type InternalMCPServerNameType =
+  (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
 
 type StaticInternalMCPToolNameType<N extends InternalMCPServerNameType> =
   (typeof INTERNAL_MCP_SERVERS)[N]["metadata"]["tools"][number]["name"];

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1256,7 +1256,7 @@ type InternalMCPServerEntryCommon = {
 
 type InternalMCPServerEntryWithMetadata<K extends InternalMCPServerNameType> =
   InternalMCPServerEntryCommon & {
-    metadata: ServerMetadata<K>;
+    metadata: ServerMetadata;
     serverInfo?: InternalMCPServerDefinitionType & { name: K };
   };
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -249,10 +249,6 @@ export const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
-type InternalMCPServerRegistry = {
-  [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
-};
-
 export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
@@ -1214,7 +1210,9 @@ export const INTERNAL_MCP_SERVERS = {
     metadata: AGENT_TEMPLATES_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
-} satisfies InternalMCPServerRegistry;
+} satisfies {
+  [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
+};
 
 type IsRestrictedCallback = (params: {
   plan: PlanType;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -232,6 +232,9 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "activation_recommendations",
 ] as const;
 
+export type InternalMCPServerNameType =
+  (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
+
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
   "web_search_&_browse",
   "http_client",
@@ -245,6 +248,10 @@ export const MCP_SERVER_AVAILABILITY = [
   "auto_hidden_builder",
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
+
+type InternalMCPServerRegistry = {
+  [K in InternalMCPServerNameType]: InternalMCPServerEntry<K>;
+};
 
 export const INTERNAL_MCP_SERVERS = {
   // Note:
@@ -1207,9 +1214,7 @@ export const INTERNAL_MCP_SERVERS = {
     metadata: AGENT_TEMPLATES_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
-} satisfies {
-  [K in InternalMCPServerNameType]: InternalMCPServerEntryBase<K>;
-};
+} satisfies InternalMCPServerRegistry;
 
 type IsRestrictedCallback = (params: {
   plan: PlanType;
@@ -1254,28 +1259,13 @@ type InternalMCPServerEntryCommon = {
   | { isPreview: false; isRestricted: undefined }
 );
 
-type InternalMCPServerEntryWithMetadata<K extends InternalMCPServerNameType> =
-  InternalMCPServerEntryCommon & {
-    metadata: ServerMetadata;
-    serverInfo?: InternalMCPServerDefinitionType & { name: K };
-  };
-
-type InternalMCPServerEntryWithoutMetadata<
-  K extends InternalMCPServerNameType,
+type InternalMCPServerEntry<
+  K extends InternalMCPServerNameType = InternalMCPServerNameType,
 > = InternalMCPServerEntryCommon & {
-  metadata?: undefined;
-  serverInfo: InternalMCPServerDefinitionType & { name: K };
+  metadata: ServerMetadata & {
+    serverInfo: InternalMCPServerDefinitionType & { name: K };
+  };
 };
-
-type InternalMCPServerEntryBase<K extends InternalMCPServerNameType> =
-  | InternalMCPServerEntryWithMetadata<K>
-  | InternalMCPServerEntryWithoutMetadata<K>;
-
-type InternalMCPServerEntry =
-  InternalMCPServerEntryBase<InternalMCPServerNameType>;
-
-export type InternalMCPServerNameType =
-  (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
 
 type StaticInternalMCPToolNameType<N extends InternalMCPServerNameType> =
   (typeof INTERNAL_MCP_SERVERS)[N]["metadata"]["tools"][number]["name"];
@@ -1463,9 +1453,9 @@ export function resolveInternalMCPServerToolStakeLevel(
   );
 }
 
-export function getInternalMCPServerToolDisplayLabels<
-  N extends InternalMCPServerNameType,
->(name: N): Record<string, ToolDisplayLabels> | null {
+export function getInternalMCPServerToolDisplayLabels(
+  name: InternalMCPServerNameType
+): Record<string, ToolDisplayLabels> | null {
   const server = INTERNAL_MCP_SERVERS[name];
   const displayLabelsByTool: Record<string, ToolDisplayLabels> = {};
   let hasDisplayLabels = false;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1231,7 +1231,9 @@ type RuntimeToolStakeLevelCallback = (
   params: RuntimeToolStakeLevelCallbackParams
 ) => MCPToolStakeLevelType;
 
-type InternalMCPServerEntryCommon = {
+type InternalMCPServerEntry<
+  K extends InternalMCPServerNameType = InternalMCPServerNameType,
+> = {
   id: number;
   availability: MCPServerAvailability;
   allowMultipleInstances: boolean;
@@ -1247,6 +1249,9 @@ type InternalMCPServerEntryCommon = {
   sensitivityLabelProvider?: string;
   // When false, the server is hidden from direct execution contexts (e.g. sandbox CLI).
   // Defaults to true.
+  metadata: ServerMetadata & {
+    serverInfo: InternalMCPServerDefinitionType & { name: K };
+  };
 } & (
   | {
       // A restricted server is not necessarily in preview (can be restricted based on the plan for instance).
@@ -1256,14 +1261,6 @@ type InternalMCPServerEntryCommon = {
   // Non restricted server cannot be in preview
   | { isPreview: false; isRestricted: undefined }
 );
-
-type InternalMCPServerEntry<
-  K extends InternalMCPServerNameType = InternalMCPServerNameType,
-> = InternalMCPServerEntryCommon & {
-  metadata: ServerMetadata & {
-    serverInfo: InternalMCPServerDefinitionType & { name: K };
-  };
-};
 
 type StaticInternalMCPToolNameType<N extends InternalMCPServerNameType> =
   (typeof INTERNAL_MCP_SERVERS)[N]["metadata"]["tools"][number]["name"];

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -33,7 +33,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
-import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { extractMetadataFromTools } from "@app/lib/actions/mcp_metadata";
 import type { MCPToolType, ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -270,8 +269,7 @@ describe("MCP Servers Metadata Snapshot", () => {
     const allBilling: Record<string, Record<string, ToolBillingSnapshot>> = {};
 
     for (const serverName of [...AVAILABLE_INTERNAL_MCP_SERVER_NAMES].sort()) {
-      const tools = getInternalMCPServerMetadata(serverName)
-        .tools as InternalMCPToolType[];
+      const tools = getInternalMCPServerMetadata(serverName).tools;
 
       const toolSnapshots: Record<string, ToolBillingSnapshot> = {};
       for (const tool of [...tools].sort((a, b) =>

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -269,7 +269,7 @@ describe("MCP Servers Metadata Snapshot", () => {
     const allBilling: Record<string, Record<string, ToolBillingSnapshot>> = {};
 
     for (const serverName of [...AVAILABLE_INTERNAL_MCP_SERVER_NAMES].sort()) {
-      const tools = getInternalMCPServerMetadata(serverName).tools;
+      const { tools } = getInternalMCPServerMetadata(serverName);
 
       const toolSnapshots: Record<string, ToolBillingSnapshot> = {};
       for (const tool of [...tools].sort((a, b) =>

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -143,22 +143,14 @@ export function buildTools<T extends Record<string, ToolMeta>>(
 }
 
 // Internal MCP server tools must have displayLabels (unlike remote servers).
-export type InternalMCPToolType<TName extends string = string> = Omit<
-  MCPToolType,
-  "name" | "displayLabels"
-> & {
-  name: TName;
+export type InternalMCPToolType = Omit<MCPToolType, "displayLabels"> & {
   displayLabels: ToolDisplayLabels;
   toolCostCategory: ToolCostCategory;
   freeUsage: boolean;
   stake: MCPToolStakeLevelType;
 };
 
-export type ServerMetadata<
-  TServerName extends
-    InternalMCPServerDefinitionType["name"] = InternalMCPServerDefinitionType["name"],
-  TToolName extends string = string,
-> = {
-  serverInfo: InternalMCPServerDefinitionType & { name: TServerName };
-  tools: InternalMCPToolType<TToolName>[];
+export type ServerMetadata = {
+  serverInfo: InternalMCPServerDefinitionType;
+  tools: InternalMCPToolType[];
 };

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -148,11 +148,6 @@ export type RemoteMCPServerType = MCPServerType & {
   allowMultipleInstances: true;
 };
 
-export type MCPServerDefinitionType = Omit<
-  MCPServerType,
-  "tools" | "sId" | "availability" | "allowMultipleInstances"
->;
-
 export type InternalMCPServerDefinitionType = Omit<
   MCPServerType,
   "tools" | "sId" | "availability" | "allowMultipleInstances"

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -29,8 +29,8 @@ import type { EditedByUser } from "@app/types/user";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { z } from "zod";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const MCP_TOOL_RETRY_POLICY_TYPES = ["retry_on_interrupt", "no_retry"] as const;
+
 export type MCPToolRetryPolicyType =
   (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
 

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -3,7 +3,6 @@ import {
   type InternalMCPServerNameType,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { InternalMCPToolType } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -81,9 +80,7 @@ export function getToolBillingInfo(
     return { toolCostCategory: "advanced", freeUsage: false };
   }
   const metadata = getInternalMCPServerMetadata(serverName);
-  const tool = (metadata.tools as InternalMCPToolType[]).find(
-    (t) => t.name === toolName
-  );
+  const tool = metadata.tools.find((t) => t.name === toolName);
   // Unknown tool on a known internal server — default to advanced, not free.
   if (!tool) {
     return { toolCostCategory: "advanced", freeUsage: false };


### PR DESCRIPTION
## Description

Part of a multi step plan to allow defining in which context a tool can be ran on the tool metadata themselves in a declarative way.

The plan goes like this:
- Remove the boilerplate helpers `createToolRecords` and `buildTools`.
- Move the `createServer` one level up.
- Add a metadata to declare which contexts each tool supports (by default all contexts) + bake it in the generic `createServer`.

This PR starts by simplifying the typing of internal MCP servers: removes unused generics and types, cleaned up the existing ones (`InternalMCPServerEntryWithoutMetadata` exists in types but we never ever populate an internal mcp server without metadata so this just makes caller's lives harder).

## Tests

- Covered by existing tests.

## Risk

- Low. Type-only cleanup around internal MCP metadata.

## Deploy Plan

- Deploy front.
