### PR TITLE
feat(front): link to Usage page for model access tiers from model providers page

### DIFF
--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -7,6 +7,7 @@ import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { useAppRouter } from "@app/lib/platform";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
@@ -14,6 +15,7 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import type { WorkspaceType } from "@app/types/user";
+import { ArrowRight, Button } from "@dust-tt/sparkle";
 import groupBy from "lodash/groupBy";
 import mapValues from "lodash/mapValues";
 import uniqBy from "lodash/uniqBy";
@@ -35,8 +37,9 @@ export function ModelProvidersPageContent({
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
-  const { featureFlags } = useFeatureFlags();
+  const { featureFlags, hasFeature } = useFeatureFlags();
   const { regionInfo } = useRegionContext();
+  const router = useAppRouter();
 
   // Filter models based on feature flags and build modelProviders dynamically
   const filteredModels = uniqBy(USED_MODEL_CONFIGS, (m) => m.modelId).filter(
@@ -82,6 +85,26 @@ export function ModelProvidersPageContent({
         </>
       )}
       <EmbeddingModelSelect workspace={workspace} />
+      {hasFeature("models_picker") && (
+        <div className="flex flex-col gap-2 p-3">
+          <div className="font-semibold">Model access tiers</div>
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-sm text-muted-foreground">
+              Model access tiers let members use models up to their highest
+              allowed tier — set per workspace, group, or member.
+            </div>
+            <Button
+              label="Manage in Usage"
+              variant="highlight-ghost"
+              size="sm"
+              iconRight={ArrowRight}
+              onClick={() => {
+                void router.push(`/w/${workspace.sId}/usage`);
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Users complained that the place to find where we restrict models to users is not easy to find, so we add another path to find it from the Models provider page

Adds a "Model access tiers" section at the bottom of the Model Providers admin page (`/w/[wId]/model-providers`) that points admins to the Usage page, where model access tiers can be configured per workspace, group, or member.

The section is gated on the `models_picker` feature flag — the same flag the Usage page uses to render its tier controls — so the link only appears when there is something to manage. It includes a short explanation and a "Manage in Usage" button (with a trailing arrow) that navigates client-side to `/w/[wId]/usage`.
<img width="1473" height="830" alt="image" src="https://github.com/user-attachments/assets/c249e1b0-1ca5-4438-8735-f0c099da2532" />
