### PR TITLE
Overlay sandbox function approvals over frames

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -249,12 +249,13 @@ function SandboxFunctionInvocation({
       blockedActionCard = null;
   }
 
-  // Covers the frame while the tool is blocked on user input; positioned within the component's
-  // relative root, same layering approach as the loading spinner overlay. Cards are keyed by the
-  // delivery eventId so consecutive events of the same type never reuse local card state.
+  // Overlays the frame while the tool is blocked on user input. Cards are keyed by the delivery
+  // eventId so consecutive events of the same type never reuse local card state.
   return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center overflow-auto bg-panel-background p-4">
-      <div className="w-full max-w-xl">{blockedActionCard}</div>
+    <div className="absolute inset-0 z-10 flex items-center justify-center overflow-auto bg-muted-foreground/75 p-4 dark:bg-muted-background/75">
+      <div className="flex w-full max-w-xl justify-center">
+        {blockedActionCard}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Keep visualization frames visible while sandbox function tools wait for approval or authentication. The blocking card now appears over the frame using the standard translucent dialog backdrop and is centered within the frame.

<img width="1800" height="1093" alt="Screenshot 2026-07-17 at 17 55 42" src="https://github.com/user-attachments/assets/88c7b078-65e6-4378-995f-15d619e1021c" />
<img width="530" height="1043" alt="Screenshot 2026-07-17 at 18 19 51" src="https://github.com/user-attachments/assets/13065a7a-bc90-4c1c-a727-0dad3a024bd3" />

## Tests

Tested locally

## Risk

None

## Deploy Plan

- Deploy `front`