### PR TITLE
[Admin Gov] Give business admins read access to provisioned groups

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -152,6 +152,23 @@ describe("GET /api/w/:wId/groups", () => {
     expect(backendGroup).toBeDefined();
     expect(backendGroup.memberCount).toBe(1);
   });
+
+  it("lets a business admin list provisioned groups", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "business_admin",
+    });
+
+    await GroupFactory.provisioned(workspace, "Engineering");
+
+    const response = await getGroups(workspace, { kind: "provisioned" });
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    expect(groups.map((g: { name: string }) => g.name)).toEqual([
+      "Engineering",
+    ]);
+  });
 });
 
 describe("POST /api/w/:wId/groups", () => {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2481,6 +2481,26 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
+    // Provisioned groups are directory-synced (SCIM), so membership is not editable in-app:
+    // business admins get read (e.g. to grant them governance capabilities) but not write/admin.
+    if (this.isProvisioned()) {
+      return [
+        {
+          groups: [
+            {
+              id: this.id,
+              permissions: ["read"],
+            },
+          ],
+          roles: [
+            { role: "admin", permissions: ["read", "write", "admin"] },
+            { role: "business_admin", permissions: ["read"] },
+          ],
+          workspaceId: this.workspaceId,
+        },
+      ];
+    }
+
     return [
       {
         groups: [

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -24,6 +24,15 @@ export class GroupFactory {
     });
   }
 
+  static async provisioned(workspace: WorkspaceType, name: string) {
+    return GroupResource.makeNew({
+      name,
+      kind: "provisioned",
+      workspaceId: workspace.id,
+      workOSGroupId: `workos-group-${name}`,
+    });
+  }
+
   static async withMembers(
     auth: Authenticator,
     group: GroupResource,


### PR DESCRIPTION
## Description

Related to the review of https://github.com/dust-tt/dust/pull/29084.

`MANAGEABLE_GROUP_KINDS` includes `provisioned`, and the governance page lets business admins assign manageable groups to capabilities. But provisioned (SCIM-synced) groups fell into the default branch of `GroupResource.requestedPermissions()`, which only grants read to the `admin` role. As a result business admins could not see provisioned groups in group lists, and granting one a governance capability failed with a misleading "unknown groups" error.

This adds a dedicated `provisioned` branch granting `business_admin` **read only**: membership of provisioned groups is managed by the identity provider, so write/admin stay admin-only.

## Tests

- [x] `front-api` groups endpoint tests, including a new "business admin lists provisioned groups" test (35 passed)
- [x] `front-api` group spend limit tests (7 passed)
- [x] `front` group resource + group permission tests (64 passed)

## Risks

Blast radius: group visibility for business admins (group lists and group fetches now include provisioned groups).
Risk: low

## Deploy Plan

- deploy front