### PR TITLE
[Sparkle] Fix Mermaid graph rendering

### DIFF
--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -14,8 +14,24 @@ import {
   sameNodePosition,
 } from "@sparkle/components/markdown/utils";
 import { Stars02, Terminal } from "@sparkle/icons/v2-stroke";
+import { cssColorToHex } from "@sparkle/lib/colors";
 import { cn } from "@sparkle/lib/utils";
 import React, { memo, useContext, useEffect, useRef, useState } from "react";
+import colors from "tailwindcss/colors";
+
+const {
+  amber,
+  blue,
+  gray,
+  green,
+  indigo,
+  purple,
+  red,
+  rose,
+  sky,
+  violet,
+  yellow,
+} = colors;
 
 const PRETTY_JSON_PREFERENCE_KEY = "pretty-json-preference";
 
@@ -53,63 +69,62 @@ const setPrettyJsonPreference = (value: boolean) => {
   }
 };
 
-// Mermaid's color parser does not support the OKLCH values exported by Tailwind v4.
-const palette = {
+const getMermaidPalette = () => ({
   gray: {
-    50: "#f9fafb", // background, labelBoxBkgColor, groupBkgColor, edgeLabelBackground
-    100: "#f3f4f6", // primaryColor
-    200: "#e5e7eb", // tertiaryBorderColor, clusterBorder, labelBoxBorderColor, groupBorderColor, pieOuterStrokeColor
-    400: "#9ca3af", // lineColor, signalColor
-    600: "#4b5563", // tertiaryTextColor, sequenceNumberColor
-    700: "#374151", // signalTextColor, labelTextColor, loopTextColor, messageTextColor, groupTextColor, pieSectionTextColor
-    800: "#1f2937", // textColor, titleColor, nodeTextColor, pieTitleTextColor, pieLegendTextColor
+    50: cssColorToHex(gray[50]), // background, labelBoxBkgColor, groupBkgColor, edgeLabelBackground
+    100: cssColorToHex(gray[100]), // primaryColor
+    200: cssColorToHex(gray[200]), // tertiaryBorderColor, clusterBorder, labelBoxBorderColor, groupBorderColor, pieOuterStrokeColor
+    400: cssColorToHex(gray[400]), // lineColor, signalColor
+    600: cssColorToHex(gray[600]), // tertiaryTextColor, sequenceNumberColor
+    700: cssColorToHex(gray[700]), // signalTextColor, labelTextColor, loopTextColor, messageTextColor, groupTextColor, pieSectionTextColor
+    800: cssColorToHex(gray[800]), // textColor, titleColor, nodeTextColor, pieTitleTextColor, pieLegendTextColor
   },
   sky: {
-    100: "#e0f2fe", // primaryColor, nodeBorder, actorBkg, activationBkgColor
-    200: "#bae6fd", // actorBorder, activationBorderColor
-    300: "#7dd3fc", // actorLineColor, pie1
-    800: "#075985", // primaryTextColor, nodeTextColor, actorTextColor, defaultLinkColor
+    100: cssColorToHex(sky[100]), // primaryColor, nodeBorder, actorBkg, activationBkgColor
+    200: cssColorToHex(sky[200]), // actorBorder, activationBorderColor
+    300: cssColorToHex(sky[300]), // actorLineColor, pie1
+    800: cssColorToHex(sky[800]), // primaryTextColor, nodeTextColor, actorTextColor, defaultLinkColor
   },
   green: {
-    100: "#dcfce7", // secondaryColor
-    200: "#bbf7d0", // secondaryBorderColor
-    300: "#86efac", // pie3
-    800: "#166534", // secondaryTextColor
+    100: cssColorToHex(green[100]), // secondaryColor
+    200: cssColorToHex(green[200]), // secondaryBorderColor
+    300: cssColorToHex(green[300]), // pie3
+    800: cssColorToHex(green[800]), // secondaryTextColor
   },
   amber: {
-    50: "#fffbeb", // noteBkgColor
-    200: "#fde68a", // noteBorderColor
-    300: "#fcd34d", // pie4
+    50: cssColorToHex(amber[50]), // noteBkgColor
+    200: cssColorToHex(amber[200]), // noteBorderColor
+    300: cssColorToHex(amber[300]), // pie4
   },
   red: {
-    100: "#fee2e2", // errorBkgColor
-    300: "#fca5a5", // pie8
-    800: "#991b1b", // errorTextColor
+    100: cssColorToHex(red[100]), // errorBkgColor
+    300: cssColorToHex(red[300]), // pie8
+    800: cssColorToHex(red[800]), // errorTextColor
   },
   blue: {
-    300: "#93c5fd", // pie2
+    300: cssColorToHex(blue[300]), // pie2
   },
   purple: {
-    400: "#c084fc", // pie5
+    400: cssColorToHex(purple[400]), // pie5
   },
   yellow: {
-    300: "#fde047", // pie7
+    300: cssColorToHex(yellow[300]), // pie7
   },
   rose: {
-    300: "#fda4af", // pie10
+    300: cssColorToHex(rose[300]), // pie10
   },
   violet: {
-    300: "#c4b5fd", // pie11
+    300: cssColorToHex(violet[300]), // pie11
   },
   indigo: {
-    300: "#a5b4fc", // pie12
+    300: cssColorToHex(indigo[300]), // pie12
   },
-} as const;
+});
 
 const mermaidStyles = `
   /* Base diagram styles */
   .mermaid {
-    background: ${palette.gray[100]};
+    background: ${gray[100]};
     cursor: default;
   }
 
@@ -124,8 +139,8 @@ const mermaidStyles = `
     rx: 8px;
     ry: 8px;
     stroke-width: 1px;
-    fill: ${palette.gray["100"]};
-    stroke: ${palette.gray["200"]};
+    fill: ${gray["100"]};
+    stroke: ${gray["200"]};
   }
 
   /* Section styles */
@@ -155,6 +170,7 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
         return;
       }
 
+      const palette = getMermaidPalette();
       const mermaid = (await import("mermaid")).default;
 
       mermaid.initialize({

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -28,7 +28,7 @@ const getPrettyJsonPreference = () => {
 
   try {
     const prettyJsonPreference = localStorage.getItem(
-      PRETTY_JSON_PREFERENCE_KEY,
+      PRETTY_JSON_PREFERENCE_KEY
     );
     // Default to Pretty view when preference is not yet set.
     if (prettyJsonPreference === null) {
@@ -272,7 +272,7 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
         className={cn(
           "mermaid",
           "w-full",
-          "rounded-2xl transition-all duration-200",
+          "rounded-2xl transition-all duration-200"
         )}
       />
     </>
@@ -454,6 +454,6 @@ export const CodeBlockWithExtendedSupport = memo(
   (prev, next) =>
     sameNodePosition(prev.node, next.node) &&
     prev.className === next.className &&
-    prev.inline === next.inline,
+    prev.inline === next.inline
 );
 CodeBlockWithExtendedSupport.displayName = "CodeBlockWithExtendedSupport";

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -166,6 +166,8 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
   const graphId = `mermaid-${React.useId().replaceAll(":", "")}`;
 
   useEffect(() => {
+    let cancelled = false;
+
     const renderMermaid = async () => {
       if (!graphRef.current) {
         return;
@@ -275,11 +277,17 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
       });
 
       const { bindFunctions, svg } = await mermaid.render(graphId, chart);
+      if (cancelled || !graphRef.current) {
+        return;
+      }
       graphRef.current.innerHTML = svg;
       bindFunctions?.(graphRef.current);
     };
 
     void renderMermaid();
+    return () => {
+      cancelled = true;
+    };
   }, [chart, graphId]);
 
   return (

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -16,21 +16,6 @@ import {
 import { Stars02, Terminal } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import React, { memo, useContext, useEffect, useRef, useState } from "react";
-import colors from "tailwindcss/colors";
-
-const {
-  amber,
-  blue,
-  gray,
-  green,
-  indigo,
-  purple,
-  red,
-  rose,
-  sky,
-  violet,
-  yellow,
-} = colors;
 
 const PRETTY_JSON_PREFERENCE_KEY = "pretty-json-preference";
 
@@ -43,7 +28,7 @@ const getPrettyJsonPreference = () => {
 
   try {
     const prettyJsonPreference = localStorage.getItem(
-      PRETTY_JSON_PREFERENCE_KEY
+      PRETTY_JSON_PREFERENCE_KEY,
     );
     // Default to Pretty view when preference is not yet set.
     if (prettyJsonPreference === null) {
@@ -68,71 +53,56 @@ const setPrettyJsonPreference = (value: boolean) => {
   }
 };
 
-// Helper function to ensure we get hex values
-const toHex = (color: string) => {
-  if (color.startsWith("#")) {
-    return color;
-  }
-  // For handling rgb/rgba values if they exist
-  if (color.startsWith("rgb")) {
-    const matches = color.match(/\d+/g);
-    if (matches && matches.length >= 3) {
-      const [r, g, b] = matches.map(Number);
-      return `#${[r, g, b].map((x) => x.toString(16).padStart(2, "0")).join("")}`;
-    }
-  }
-  return color;
-};
-
+// Mermaid's color parser does not support the OKLCH values exported by Tailwind v4.
 const palette = {
   gray: {
-    50: toHex(gray[50]), // background, labelBoxBkgColor, groupBkgColor, edgeLabelBackground
-    100: toHex(gray[100]), // primaryColor
-    200: toHex(gray[200]), // tertiaryBorderColor, clusterBorder, labelBoxBorderColor, groupBorderColor, pieOuterStrokeColor
-    400: toHex(gray[400]), // lineColor, signalColor
-    600: toHex(gray[600]), // tertiaryTextColor, sequenceNumberColor
-    700: toHex(gray[700]), // signalTextColor, labelTextColor, loopTextColor, messageTextColor, groupTextColor, pieSectionTextColor
-    800: toHex(gray[800]), // textColor, titleColor, nodeTextColor, pieTitleTextColor, pieLegendTextColor
+    50: "#f9fafb", // background, labelBoxBkgColor, groupBkgColor, edgeLabelBackground
+    100: "#f3f4f6", // primaryColor
+    200: "#e5e7eb", // tertiaryBorderColor, clusterBorder, labelBoxBorderColor, groupBorderColor, pieOuterStrokeColor
+    400: "#9ca3af", // lineColor, signalColor
+    600: "#4b5563", // tertiaryTextColor, sequenceNumberColor
+    700: "#374151", // signalTextColor, labelTextColor, loopTextColor, messageTextColor, groupTextColor, pieSectionTextColor
+    800: "#1f2937", // textColor, titleColor, nodeTextColor, pieTitleTextColor, pieLegendTextColor
   },
   sky: {
-    100: toHex(sky[100]), // primaryColor, nodeBorder, actorBkg, activationBkgColor
-    200: toHex(sky[200]), // actorBorder, activationBorderColor
-    300: toHex(sky[300]), // actorLineColor, pie1
-    800: toHex(sky[800]), // primaryTextColor, nodeTextColor, actorTextColor, defaultLinkColor
+    100: "#e0f2fe", // primaryColor, nodeBorder, actorBkg, activationBkgColor
+    200: "#bae6fd", // actorBorder, activationBorderColor
+    300: "#7dd3fc", // actorLineColor, pie1
+    800: "#075985", // primaryTextColor, nodeTextColor, actorTextColor, defaultLinkColor
   },
   green: {
-    100: toHex(green[100]), // secondaryColor
-    200: toHex(green[200]), // secondaryBorderColor
-    300: toHex(green[300]), // pie3
-    800: toHex(green[800]), // secondaryTextColor
+    100: "#dcfce7", // secondaryColor
+    200: "#bbf7d0", // secondaryBorderColor
+    300: "#86efac", // pie3
+    800: "#166534", // secondaryTextColor
   },
   amber: {
-    50: toHex(amber[50]), // noteBkgColor
-    200: toHex(amber[200]), // noteBorderColor
-    300: toHex(amber[300]), // pie4
+    50: "#fffbeb", // noteBkgColor
+    200: "#fde68a", // noteBorderColor
+    300: "#fcd34d", // pie4
   },
   red: {
-    100: toHex(red[100]), // errorBkgColor
-    300: toHex(red[300]), // pie8
-    800: toHex(red[800]), // errorTextColor
+    100: "#fee2e2", // errorBkgColor
+    300: "#fca5a5", // pie8
+    800: "#991b1b", // errorTextColor
   },
   blue: {
-    300: toHex(blue[300]), // pie2
+    300: "#93c5fd", // pie2
   },
   purple: {
-    400: toHex(purple[400]), // pie5
+    400: "#c084fc", // pie5
   },
   yellow: {
-    300: toHex(yellow[300]), // pie7
+    300: "#fde047", // pie7
   },
   rose: {
-    300: toHex(rose[300]), // pie10
+    300: "#fda4af", // pie10
   },
   violet: {
-    300: toHex(violet[300]), // pie11
+    300: "#c4b5fd", // pie11
   },
   indigo: {
-    300: toHex(indigo[300]), // pie12
+    300: "#a5b4fc", // pie12
   },
 } as const;
 
@@ -302,7 +272,7 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
         className={cn(
           "mermaid",
           "w-full",
-          "rounded-2xl transition-all duration-200"
+          "rounded-2xl transition-all duration-200",
         )}
       />
     </>
@@ -484,6 +454,6 @@ export const CodeBlockWithExtendedSupport = memo(
   (prev, next) =>
     sameNodePosition(prev.node, next.node) &&
     prev.className === next.className &&
-    prev.inline === next.inline
+    prev.inline === next.inline,
 );
 CodeBlockWithExtendedSupport.displayName = "CodeBlockWithExtendedSupport";

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -163,6 +163,7 @@ const mermaidStyles = `
 
 const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
   const graphRef = useRef<HTMLDivElement | null>(null);
+  const graphId = `mermaid-${React.useId().replaceAll(":", "")}`;
 
   useEffect(() => {
     const renderMermaid = async () => {
@@ -273,12 +274,13 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
         },
       });
 
-      graphRef.current.textContent = chart;
-      await mermaid.run(undefined);
+      const { bindFunctions, svg } = await mermaid.render(graphId, chart);
+      graphRef.current.innerHTML = svg;
+      bindFunctions?.(graphRef.current);
     };
 
     void renderMermaid();
-  }, [chart]);
+  }, [chart, graphId]);
 
   return (
     <>

--- a/sparkle/src/lib/colors.ts
+++ b/sparkle/src/lib/colors.ts
@@ -67,3 +67,36 @@ export const customColors = {
     50: "#FFF1F7",
   },
 } as const;
+
+export type Rgb = { r: number; g: number; b: number };
+
+let sharedCanvasContext: CanvasRenderingContext2D | null | undefined;
+
+// Let the browser normalize any CSS color syntax, including OKLCH, to sRGB.
+export function cssColorToRgb(color: string): Rgb | null {
+  if (typeof document === "undefined" || !color) {
+    return null;
+  }
+  if (sharedCanvasContext === undefined) {
+    sharedCanvasContext = document.createElement("canvas").getContext("2d");
+  }
+  if (!sharedCanvasContext) {
+    return null;
+  }
+  sharedCanvasContext.clearRect(0, 0, 1, 1);
+  sharedCanvasContext.fillStyle = "#000";
+  sharedCanvasContext.fillStyle = color;
+  sharedCanvasContext.fillRect(0, 0, 1, 1);
+  const [r, g, b] = sharedCanvasContext.getImageData(0, 0, 1, 1).data;
+  return { r, g, b };
+}
+
+export function cssColorToHex(color: string): string {
+  const rgb = cssColorToRgb(color);
+  if (!rgb) {
+    throw new Error("CSS color conversion requires a browser canvas.");
+  }
+  return `#${[rgb.r, rgb.g, rgb.b]
+    .map((channel) => channel.toString(16).padStart(2, "0"))
+    .join("")}`;
+}

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { expect, waitFor } from "storybook/test";
 
 import { Markdown } from "../index_with_tw_base";
 
@@ -389,6 +390,11 @@ pie title Distribution
 export const ExtendedMarkdownStory: Story = {
   args: {
     content: example,
+  },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      expect(canvasElement.querySelector(".mermaid svg")).not.toBeNull();
+    });
   },
 };
 

--- a/sparkle/src/stories/foundations-helpers.tsx
+++ b/sparkle/src/stories/foundations-helpers.tsx
@@ -1,5 +1,6 @@
 import { useCopyToClipboard } from "@sparkle/hooks/useCopyToClipboard";
 import { Check, Clipboard } from "@sparkle/icons/v2-stroke";
+import { cssColorToRgb, type Rgb } from "@sparkle/lib/colors";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 
@@ -213,31 +214,6 @@ export function structuralTokens(tokens: string[]): string[] {
         !families.has(familyOf(t))
     )
     .sort();
-}
-
-type Rgb = { r: number; g: number; b: number };
-
-let sharedCanvasContext: CanvasRenderingContext2D | null | undefined;
-
-// Parse any CSS color string (hex, rgb, oklch, …) into sRGB bytes by letting the
-// browser convert it on a 1×1 canvas. Returns null when unavailable (SSR / no
-// 2d context). This is what lets us compute contrast for oklch tokens.
-export function cssColorToRgb(color: string): Rgb | null {
-  if (typeof document === "undefined" || !color) {
-    return null;
-  }
-  if (sharedCanvasContext === undefined) {
-    sharedCanvasContext = document.createElement("canvas").getContext("2d");
-  }
-  if (!sharedCanvasContext) {
-    return null;
-  }
-  sharedCanvasContext.clearRect(0, 0, 1, 1);
-  sharedCanvasContext.fillStyle = "#000";
-  sharedCanvasContext.fillStyle = color;
-  sharedCanvasContext.fillRect(0, 0, 1, 1);
-  const [r, g, b] = sharedCanvasContext.getImageData(0, 0, 1, 1).data;
-  return { r, g, b };
 }
 
 function relativeLuminance({ r, g, b }: Rgb): number {


### PR DESCRIPTION
## Description

Fixes the Mermaid regression introduced by https://github.com/dust-tt/dust/pull/27403.

Context: [sample conversation](https://app.dust.tt/w/0ec9852c2f/conversation/5mfZBN1KPJ)

Tailwind v4 changed its exported palette from hex to OKLCH values, which Mermaid cannot parse.
Sparkle now uses the browser to convert the live Tailwind palette to sRGB hex before initializing
Mermaid.

The previous global `mermaid.run()` call could also race with React Strict Mode: the replayed effect
replaced Mermaid's temporary SVG while it was measuring the graph, leaving the source text visible.
The component now renders off-node through Mermaid's direct API and installs only the completed SVG.
A Storybook interaction assertion verifies that Mermaid produces an SVG.

## Risks

Blast radius: Mermaid diagrams rendered in Markdown
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] Reproduced the Mermaid initialization failure with the Tailwind v4 palette
- [x] Verified Mermaid initializes with an sRGB hex palette
- [x] Reproduced the Strict Mode rendering race in the local sample conversation
- [x] Verified the sample conversation renders an SVG in the Hive
