### PR TITLE
[front] perf: limit rendered capability entries

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -1,7 +1,8 @@
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
 import {
-  matchesSlashCommandCapabilityQuery,
-  sortSlashCommandCapabilityMatches,
+  type CapabilitySearchIndexItem,
+  MAX_RENDERED_CAPABILITY_ITEMS,
+  searchCapabilityIndex,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import {
@@ -27,7 +28,10 @@ import {
   trackEvent,
 } from "@app/lib/tracking";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
@@ -44,17 +48,15 @@ import {
   LoadingBlock,
   ShapesPlus,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-interface CapabilityPickerItemBase {
+interface CapabilityPickerItemBase extends CapabilitySearchIndexItem {
   description?: string;
-  icon: DropdownMenuItemProps["icon"];
   id: string;
   label: string;
-  sortName: string;
 }
 
-type CapabilityPickerItem = CapabilityPickerItemBase &
+type CapabilityPickerSearchItem = CapabilityPickerItemBase &
   (
     | {
         kind: "skill";
@@ -69,6 +71,10 @@ type CapabilityPickerItem = CapabilityPickerItemBase &
         server: MCPServerType;
       }
   );
+
+type CapabilityPickerItem = CapabilityPickerSearchItem & {
+  icon: DropdownMenuItemProps["icon"];
+};
 
 function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
   return (
@@ -90,6 +96,7 @@ function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
 
 interface CapabilitiesPickerItemsListProps {
   emptyMessage: string;
+  hasMoreItems?: boolean;
   items: CapabilityPickerItem[];
   onItemSelect: (item: CapabilityPickerItem) => void;
   onSkillDetails?: (skillId: string) => void;
@@ -98,13 +105,12 @@ interface CapabilitiesPickerItemsListProps {
 
 export function CapabilitiesPickerItemsList({
   emptyMessage,
+  hasMoreItems = false,
   items,
   onItemSelect,
   onSkillDetails,
   onToolDetails,
 }: CapabilitiesPickerItemsListProps) {
-  const listRef = useRef<HTMLDivElement>(null);
-
   if (items.length === 0) {
     return (
       <div className="px-2 py-4 text-center text-sm text-muted-foreground">
@@ -114,7 +120,7 @@ export function CapabilitiesPickerItemsList({
   }
 
   return (
-    <div ref={listRef}>
+    <div>
       {items.map((item) => {
         const endComponent =
           item.kind === "uninstalled_tool" ? (
@@ -152,6 +158,12 @@ export function CapabilitiesPickerItemsList({
           />
         );
       })}
+      {hasMoreItems && (
+        <div className="px-3 py-2 text-center text-xs text-muted-foreground">
+          Showing the first {MAX_RENDERED_CAPABILITY_ITEMS} results. Keep typing
+          to narrow the list.
+        </div>
+      )}
     </div>
   );
 }
@@ -320,8 +332,8 @@ export function CapabilitiesPicker({
     }
   };
 
-  const capabilityPickerItems = (() => {
-    const items: CapabilityPickerItem[] = [];
+  const capabilityPickerIndex = useMemo(() => {
+    const items: CapabilityPickerSearchItem[] = [];
     const selectedMCPServerViewIds = new Set(
       selectedMCPServerViews.map((v) => v.sId)
     );
@@ -330,26 +342,14 @@ export function CapabilitiesPicker({
       for (const skill of skills) {
         const description = skill.userFacingDescription;
 
-        if (
-          !matchesSlashCommandCapabilityQuery({
-            description,
-            label: skill.name,
-            query: normalizedSearchText,
-          })
-        ) {
-          continue;
-        }
-
-        const SkillAvatar = getSkillAvatarIcon(skill);
-
         items.push({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
-          icon: <SkillAvatar size="xs" />,
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,
+          normalizedDescription: description?.toLowerCase(),
         });
       }
 
@@ -359,12 +359,7 @@ export function CapabilitiesPicker({
 
         if (
           !isJITMCPServerView(serverView) ||
-          selectedMCPServerViewIds.has(serverView.sId) ||
-          !matchesSlashCommandCapabilityQuery({
-            description,
-            label,
-            query: normalizedSearchText,
-          })
+          selectedMCPServerViewIds.has(serverView.sId)
         ) {
           continue;
         }
@@ -373,10 +368,10 @@ export function CapabilitiesPicker({
           kind: "tool",
           serverView,
           id: `capabilities-picker-${serverView.sId}`,
-          icon: getAvatar(serverView.server, "xs"),
           label,
           sortName: label.toLowerCase(),
           description,
+          normalizedDescription: description?.toLowerCase(),
         });
       }
     }
@@ -392,12 +387,7 @@ export function CapabilitiesPicker({
 
         if (
           installedServerNames.has(server.name) ||
-          server.availability !== "manual" ||
-          !matchesSlashCommandCapabilityQuery({
-            description,
-            label,
-            query: normalizedSearchText,
-          })
+          server.availability !== "manual"
         ) {
           continue;
         }
@@ -406,27 +396,56 @@ export function CapabilitiesPicker({
           kind: "uninstalled_tool",
           server,
           id: `tools-to-install-${server.sId}`,
-          icon: getAvatar(server, "xs"),
           label,
           sortName: label.toLowerCase(),
+          sortGroup: 1,
           description,
+          normalizedDescription: description?.toLowerCase(),
         });
       }
     }
 
-    const installedItems = items.filter((i) => i.kind !== "uninstalled_tool");
-    const uninstalledItems = items.filter((i) => i.kind === "uninstalled_tool");
-    return [
-      ...sortSlashCommandCapabilityMatches({
-        items: installedItems,
-        normalizedQuery: normalizedSearchText,
+    return items;
+  }, [
+    availableMCPServers,
+    isAdmin,
+    isSkillsDataReady,
+    isToolsDataReady,
+    selectedMCPServerViews,
+    serverViews,
+    skills,
+  ]);
+
+  const capabilityPickerSearchResults = useMemo(
+    () =>
+      searchCapabilityIndex({
+        items: capabilityPickerIndex,
+        query: normalizedSearchText,
       }),
-      ...sortSlashCommandCapabilityMatches({
-        items: uninstalledItems,
-        normalizedQuery: normalizedSearchText,
+    [capabilityPickerIndex, normalizedSearchText]
+  );
+
+  const capabilityPickerItems = useMemo(
+    () =>
+      capabilityPickerSearchResults.items.map((item) => {
+        switch (item.kind) {
+          case "skill": {
+            const SkillAvatar = getSkillAvatarIcon(item.skill);
+            return { ...item, icon: <SkillAvatar size="xs" /> };
+          }
+          case "tool":
+            return { ...item, icon: getAvatar(item.serverView.server, "xs") };
+          case "uninstalled_tool":
+            return { ...item, icon: getAvatar(item.server, "xs") };
+          default:
+            return assertNever(item);
+        }
       }),
-    ];
-  })();
+    [capabilityPickerSearchResults.items]
+  );
+
+  const hasMoreCapabilityPickerItems =
+    capabilityPickerSearchResults.totalMatches > capabilityPickerItems.length;
 
   const hasNoVisibleItems =
     isSkillsDataReady && isToolsDataReady && capabilityPickerItems.length === 0;
@@ -487,6 +506,7 @@ export function CapabilitiesPicker({
                   ? "No capabilities found"
                   : "No more capabilities to select"
               }
+              hasMoreItems={hasMoreCapabilityPickerItems}
               items={capabilityPickerItems}
               onItemSelect={selectCapabilityPickerItem}
               onSkillDetails={(skillId) => {

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -1,7 +1,6 @@
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
 import {
   type CapabilitySearchIndexItem,
-  MAX_RENDERED_CAPABILITY_ITEMS,
   searchCapabilityIndex,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
@@ -96,7 +95,6 @@ function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
 
 interface CapabilitiesPickerItemsListProps {
   emptyMessage: string;
-  hasMoreItems?: boolean;
   items: CapabilityPickerItem[];
   onItemSelect: (item: CapabilityPickerItem) => void;
   onSkillDetails?: (skillId: string) => void;
@@ -105,7 +103,6 @@ interface CapabilitiesPickerItemsListProps {
 
 export function CapabilitiesPickerItemsList({
   emptyMessage,
-  hasMoreItems = false,
   items,
   onItemSelect,
   onSkillDetails,
@@ -158,12 +155,6 @@ export function CapabilitiesPickerItemsList({
           />
         );
       })}
-      {hasMoreItems && (
-        <div className="px-3 py-2 text-center text-xs text-muted-foreground">
-          Showing the first {MAX_RENDERED_CAPABILITY_ITEMS} results. Keep typing
-          to narrow the list.
-        </div>
-      )}
     </div>
   );
 }
@@ -427,7 +418,7 @@ export function CapabilitiesPicker({
 
   const capabilityPickerItems = useMemo(
     () =>
-      capabilityPickerSearchResults.items.map((item) => {
+      capabilityPickerSearchResults.map((item) => {
         switch (item.kind) {
           case "skill": {
             const SkillAvatar = getSkillAvatarIcon(item.skill);
@@ -441,11 +432,8 @@ export function CapabilitiesPicker({
             return assertNever(item);
         }
       }),
-    [capabilityPickerSearchResults.items]
+    [capabilityPickerSearchResults]
   );
-
-  const hasMoreCapabilityPickerItems =
-    capabilityPickerSearchResults.totalMatches > capabilityPickerItems.length;
 
   const hasNoVisibleItems =
     isSkillsDataReady && isToolsDataReady && capabilityPickerItems.length === 0;
@@ -506,7 +494,6 @@ export function CapabilitiesPicker({
                   ? "No capabilities found"
                   : "No more capabilities to select"
               }
-              hasMoreItems={hasMoreCapabilityPickerItems}
               items={capabilityPickerItems}
               onItemSelect={selectCapabilityPickerItem}
               onSkillDetails={(skillId) => {

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -120,7 +120,7 @@ describe("searchCapabilityIndex ranking", () => {
       query: "",
     });
 
-    expect(result.items.map((item) => item.id)).toEqual(["a", "z"]);
+    expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
   it("breaks fuzzy ties alphabetically when a query is provided", () => {
@@ -132,10 +132,7 @@ describe("searchCapabilityIndex ranking", () => {
       query: "test",
     });
 
-    expect(result.items.map((item) => item.id)).toEqual([
-      "longtest",
-      "testlonger",
-    ]);
+    expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
   });
 
   it("ranks title matches above description-only matches", () => {
@@ -155,10 +152,7 @@ describe("searchCapabilityIndex ranking", () => {
       query: "docs",
     });
 
-    expect(result.items.map((item) => item.id)).toEqual([
-      "title-match",
-      "desc-only",
-    ]);
+    expect(result.map((item) => item.id)).toEqual(["title-match", "desc-only"]);
   });
 });
 
@@ -175,10 +169,9 @@ describe("searchCapabilityIndex", () => {
       query: "",
     });
 
-    expect(result.totalMatches).toBe(MAX_RENDERED_CAPABILITY_ITEMS + 10);
-    expect(result.items).toHaveLength(MAX_RENDERED_CAPABILITY_ITEMS);
-    expect(result.items[0]?.id).toBe(0);
-    expect(result.items.at(-1)?.id).toBe(MAX_RENDERED_CAPABILITY_ITEMS - 1);
+    expect(result).toHaveLength(MAX_RENDERED_CAPABILITY_ITEMS);
+    expect(result[0]?.id).toBe(0);
+    expect(result.at(-1)?.id).toBe(MAX_RENDERED_CAPABILITY_ITEMS - 1);
   });
 
   it("searches normalized descriptions and preserves group ordering", () => {
@@ -199,7 +192,7 @@ describe("searchCapabilityIndex", () => {
       query: "docs",
     });
 
-    expect(result.items.map((item) => item.id)).toEqual([
+    expect(result.map((item) => item.id)).toEqual([
       "installed-description-match",
       "uninstalled-title-match",
     ]);

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, it } from "vitest";
 import {
   getSkillSlashCommandItem,
   getToolSlashCommandItem,
+  MAX_RENDERED_CAPABILITY_ITEMS,
   matchesSlashCommandCapabilityQuery,
   type SlashCommandSkillSuggestion,
   type SlashCommandToolSuggestion,
-  sortSlashCommandCapabilityMatches,
+  searchCapabilityIndex,
 } from "./SlashCommandCapabilitiesItems";
 
 function toolSuggestion({
@@ -109,49 +110,99 @@ describe("matchesSlashCommandCapabilityQuery", () => {
   });
 });
 
-describe("sortSlashCommandCapabilityMatches", () => {
+describe("searchCapabilityIndex ranking", () => {
   it("sorts capabilities alphabetically when no query is provided", () => {
-    const result = sortSlashCommandCapabilityMatches({
-      normalizedQuery: "",
+    const result = searchCapabilityIndex({
       items: [
         { id: "z", sortName: "zendesk" },
         { id: "a", sortName: "asana" },
       ],
+      query: "",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["a", "z"]);
+    expect(result.items.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
   it("breaks fuzzy ties alphabetically when a query is provided", () => {
-    const result = sortSlashCommandCapabilityMatches({
-      normalizedQuery: "test",
+    const result = searchCapabilityIndex({
       items: [
         { id: "testlonger", sortName: "testlonger" },
         { id: "longtest", sortName: "longtest" },
       ],
+      query: "test",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
+    expect(result.items.map((item) => item.id)).toEqual([
+      "longtest",
+      "testlonger",
+    ]);
   });
 
   it("ranks title matches above description-only matches", () => {
-    const result = sortSlashCommandCapabilityMatches({
-      normalizedQuery: "docs",
+    const result = searchCapabilityIndex({
       items: [
         {
           id: "desc-only",
+          normalizedDescription: "search and retrieve docs",
           sortName: "linear",
-          description: "Search and retrieve docs",
         },
         {
           id: "title-match",
+          normalizedDescription: "view files",
           sortName: "docs viewer",
-          description: "View files",
         },
       ],
+      query: "docs",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["title-match", "desc-only"]);
+    expect(result.items.map((item) => item.id)).toEqual([
+      "title-match",
+      "desc-only",
+    ]);
+  });
+});
+
+describe("searchCapabilityIndex", () => {
+  it("returns only the first ranked result window", () => {
+    const result = searchCapabilityIndex({
+      items: Array.from(
+        { length: MAX_RENDERED_CAPABILITY_ITEMS + 10 },
+        (_, index) => ({
+          id: index,
+          sortName: `capability ${index.toString().padStart(2, "0")}`,
+        })
+      ),
+      query: "",
+    });
+
+    expect(result.totalMatches).toBe(MAX_RENDERED_CAPABILITY_ITEMS + 10);
+    expect(result.items).toHaveLength(MAX_RENDERED_CAPABILITY_ITEMS);
+    expect(result.items[0]?.id).toBe(0);
+    expect(result.items.at(-1)?.id).toBe(MAX_RENDERED_CAPABILITY_ITEMS - 1);
+  });
+
+  it("searches normalized descriptions and preserves group ordering", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        {
+          id: "uninstalled-title-match",
+          normalizedDescription: "create an issue",
+          sortGroup: 1,
+          sortName: "linear docs",
+        },
+        {
+          id: "installed-description-match",
+          normalizedDescription: "search docs",
+          sortName: "search",
+        },
+      ],
+      query: "docs",
+    });
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      "installed-description-match",
+      "uninstalled-title-match",
+    ]);
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -30,7 +30,7 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
   items: T[];
   query: string;
   limit?: number;
-}): { items: T[]; totalMatches: number } {
+}): T[] {
   const normalizedQuery = query.trim().toLowerCase();
   const matches: { item: T; titleMatches: boolean }[] = [];
 
@@ -74,10 +74,7 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
     return a.item.sortName.localeCompare(b.item.sortName);
   });
 
-  return {
-    items: sortedMatches.slice(0, limit).map(({ item }) => item),
-    totalMatches: sortedMatches.length,
-  };
+  return sortedMatches.slice(0, limit).map(({ item }) => item);
 }
 
 export type SlashCommandSkillSuggestion = Pick<

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -14,6 +14,71 @@ export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
 export const SELECT_TOOL_SLASH_COMMAND_ACTION = "select-tool";
 export const RUN_COMMAND_SLASH_COMMAND_ACTION = "run-command";
 export const INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION = "insert-knowledge-node";
+export const MAX_RENDERED_CAPABILITY_ITEMS = 50;
+
+export interface CapabilitySearchIndexItem {
+  normalizedDescription?: string;
+  sortGroup?: number;
+  sortName: string;
+}
+
+export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
+  items,
+  query,
+  limit = MAX_RENDERED_CAPABILITY_ITEMS,
+}: {
+  items: T[];
+  query: string;
+  limit?: number;
+}): { items: T[]; totalMatches: number } {
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches: { item: T; titleMatches: boolean }[] = [];
+
+  for (const item of items) {
+    const titleMatches =
+      normalizedQuery.length === 0 || subFilter(normalizedQuery, item.sortName);
+    const descriptionMatches =
+      normalizedQuery.length > 0 &&
+      item.normalizedDescription !== undefined &&
+      subFilter(normalizedQuery, item.normalizedDescription);
+
+    if (titleMatches || descriptionMatches) {
+      matches.push({ item, titleMatches });
+    }
+  }
+
+  const sortedMatches = matches.toSorted((a, b) => {
+    const groupComparison = (a.item.sortGroup ?? 0) - (b.item.sortGroup ?? 0);
+    if (groupComparison !== 0) {
+      return groupComparison;
+    }
+
+    if (normalizedQuery.length === 0) {
+      return a.item.sortName.localeCompare(b.item.sortName);
+    }
+
+    if (a.titleMatches !== b.titleMatches) {
+      return a.titleMatches ? -1 : 1;
+    }
+
+    if (a.titleMatches) {
+      return (
+        compareForFuzzySort(
+          normalizedQuery,
+          a.item.sortName,
+          b.item.sortName
+        ) || a.item.sortName.localeCompare(b.item.sortName)
+      );
+    }
+
+    return a.item.sortName.localeCompare(b.item.sortName);
+  });
+
+  return {
+    items: sortedMatches.slice(0, limit).map(({ item }) => item),
+    totalMatches: sortedMatches.length,
+  };
+}
 
 export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
@@ -103,35 +168,6 @@ export function matchesSlashCommandCapabilityQuery({
     subFilter(query, label.toLowerCase()) ||
     (description !== undefined && subFilter(query, description.toLowerCase()))
   );
-}
-
-export function sortSlashCommandCapabilityMatches<
-  T extends { description?: string; sortName: string },
->({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
-  return items.toSorted((a, b) => {
-    if (normalizedQuery.length === 0) {
-      return a.sortName.localeCompare(b.sortName);
-    }
-
-    const aTitleMatch = subFilter(normalizedQuery, a.sortName);
-    const bTitleMatch = subFilter(normalizedQuery, b.sortName);
-
-    // Title matches rank above description-only matches.
-    if (aTitleMatch !== bTitleMatch) {
-      return aTitleMatch ? -1 : 1;
-    }
-
-    // Within title matches, use fuzzy sort on the title.
-    if (aTitleMatch) {
-      return (
-        compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
-        a.sortName.localeCompare(b.sortName)
-      );
-    }
-
-    // Both are description-only matches: sort alphabetically by title.
-    return a.sortName.localeCompare(b.sortName);
-  });
 }
 
 export function getToolSlashCommandLabel(tool: SlashCommandToolSuggestion) {

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -1,11 +1,11 @@
 import {
+  type CapabilitySearchIndexItem,
   getSkillSlashCommandItem,
   getToolSlashCommandItem,
   getToolSlashCommandLabel,
-  matchesSlashCommandCapabilityQuery,
   type SlashCommandSkillSuggestion,
   type SlashCommandToolSuggestion,
-  sortSlashCommandCapabilityMatches,
+  searchCapabilityIndex,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
@@ -29,59 +29,80 @@ export function filterSlashCommandItems(
   );
 }
 
-export function buildCapabilitySlashCommandItems({
+type CapabilitySlashCommandSearchItem = CapabilitySearchIndexItem &
+  (
+    | {
+        kind: "skill";
+        skill: SlashCommandSkillSuggestion;
+      }
+    | {
+        kind: "tool";
+        tool: SlashCommandToolSuggestion;
+      }
+  );
+
+export function buildCapabilitySlashCommandIndex({
   excludeSkillId,
-  query,
   skillFilter,
   skills,
   toolFilter,
   tools,
 }: {
   excludeSkillId?: string | null;
-  query: string;
   skillFilter?: (skill: SlashCommandSkillSuggestion) => boolean;
   skills: SlashCommandSkillSuggestion[];
   toolFilter?: (tool: SlashCommandToolSuggestion) => boolean;
   tools: SlashCommandToolSuggestion[];
-}): SlashCommand[] {
-  const normalizedQuery = query.trim().toLowerCase();
+}): CapabilitySlashCommandSearchItem[] {
+  const index: CapabilitySlashCommandSearchItem[] = [];
 
-  const matches = sortSlashCommandCapabilityMatches({
-    normalizedQuery,
-    items: [
-      ...skills
-        .filter((skill) => skill.sId !== excludeSkillId)
-        .filter((skill) => skillFilter?.(skill) ?? true)
-        .filter((skill) =>
-          matchesSlashCommandCapabilityQuery({
-            description: skill.userFacingDescription,
-            label: skill.name,
-            query: normalizedQuery,
-          })
-        )
-        .map((skill) => ({
-          description: skill.userFacingDescription?.toLowerCase(),
-          kind: "skill" as const,
-          skill,
-          sortName: skill.name.toLowerCase(),
-        })),
-      ...tools
-        .filter((tool) => toolFilter?.(tool) ?? true)
-        .filter((tool) =>
-          matchesSlashCommandCapabilityQuery({
-            description: getMcpServerViewDescription(tool),
-            label: getToolSlashCommandLabel(tool),
-            query: normalizedQuery,
-          })
-        )
-        .map((tool) => ({
-          description: getMcpServerViewDescription(tool)?.toLowerCase(),
-          kind: "tool" as const,
-          tool,
-          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
-        })),
-    ],
-  });
+  for (const skill of skills) {
+    if (skill.sId === excludeSkillId || !(skillFilter?.(skill) ?? true)) {
+      continue;
+    }
+
+    index.push({
+      kind: "skill",
+      normalizedDescription: skill.userFacingDescription?.toLowerCase(),
+      skill,
+      sortName: skill.name.toLowerCase(),
+    });
+  }
+
+  for (const tool of tools) {
+    if (!(toolFilter?.(tool) ?? true)) {
+      continue;
+    }
+
+    index.push({
+      kind: "tool",
+      normalizedDescription: getMcpServerViewDescription(tool)?.toLowerCase(),
+      tool,
+      sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+    });
+  }
+
+  return index;
+}
+
+export function searchCapabilitySlashCommandIndex({
+  excludedToolIds,
+  index,
+  query,
+}: {
+  excludedToolIds?: ReadonlySet<string>;
+  index: CapabilitySlashCommandSearchItem[];
+  query: string;
+}): SlashCommand[] {
+  const searchableIndex = excludedToolIds
+    ? index.filter(
+        (item) => item.kind !== "tool" || !excludedToolIds.has(item.tool.sId)
+      )
+    : index;
+  const matches = searchCapabilityIndex({
+    items: searchableIndex,
+    query,
+  }).items;
 
   return matches.map((match) => {
     switch (match.kind) {

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -1,5 +1,4 @@
 import {
-  type CapabilitySearchIndexItem,
   getSkillSlashCommandItem,
   getToolSlashCommandItem,
   getToolSlashCommandLabel,
@@ -29,80 +28,46 @@ export function filterSlashCommandItems(
   );
 }
 
-type CapabilitySlashCommandSearchItem = CapabilitySearchIndexItem &
-  (
-    | {
-        kind: "skill";
-        skill: SlashCommandSkillSuggestion;
-      }
-    | {
-        kind: "tool";
-        tool: SlashCommandToolSuggestion;
-      }
-  );
-
-export function buildCapabilitySlashCommandIndex({
+export function buildCapabilitySlashCommandItems({
   excludeSkillId,
+  query,
   skillFilter,
   skills,
   toolFilter,
   tools,
 }: {
   excludeSkillId?: string | null;
+  query: string;
   skillFilter?: (skill: SlashCommandSkillSuggestion) => boolean;
   skills: SlashCommandSkillSuggestion[];
   toolFilter?: (tool: SlashCommandToolSuggestion) => boolean;
   tools: SlashCommandToolSuggestion[];
-}): CapabilitySlashCommandSearchItem[] {
-  const index: CapabilitySlashCommandSearchItem[] = [];
-
-  for (const skill of skills) {
-    if (skill.sId === excludeSkillId || !(skillFilter?.(skill) ?? true)) {
-      continue;
-    }
-
-    index.push({
-      kind: "skill",
-      normalizedDescription: skill.userFacingDescription?.toLowerCase(),
-      skill,
-      sortName: skill.name.toLowerCase(),
-    });
-  }
-
-  for (const tool of tools) {
-    if (!(toolFilter?.(tool) ?? true)) {
-      continue;
-    }
-
-    index.push({
-      kind: "tool",
-      normalizedDescription: getMcpServerViewDescription(tool)?.toLowerCase(),
-      tool,
-      sortName: getToolSlashCommandLabel(tool).toLowerCase(),
-    });
-  }
-
-  return index;
-}
-
-export function searchCapabilitySlashCommandIndex({
-  excludedToolIds,
-  index,
-  query,
-}: {
-  excludedToolIds?: ReadonlySet<string>;
-  index: CapabilitySlashCommandSearchItem[];
-  query: string;
 }): SlashCommand[] {
-  const searchableIndex = excludedToolIds
-    ? index.filter(
-        (item) => item.kind !== "tool" || !excludedToolIds.has(item.tool.sId)
-      )
-    : index;
+  const normalizedQuery = query.trim().toLowerCase();
+
   const matches = searchCapabilityIndex({
-    items: searchableIndex,
-    query,
-  }).items;
+    query: normalizedQuery,
+    items: [
+      ...skills
+        .filter((skill) => skill.sId !== excludeSkillId)
+        .filter((skill) => skillFilter?.(skill) ?? true)
+        .map((skill) => ({
+          kind: "skill" as const,
+          normalizedDescription: skill.userFacingDescription?.toLowerCase(),
+          skill,
+          sortName: skill.name.toLowerCase(),
+        })),
+      ...tools
+        .filter((tool) => toolFilter?.(tool) ?? true)
+        .map((tool) => ({
+          kind: "tool" as const,
+          normalizedDescription:
+            getMcpServerViewDescription(tool)?.toLowerCase(),
+          tool,
+          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+        })),
+    ],
+  });
 
   return matches.map((match) => {
     switch (match.kind) {

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -11,10 +11,7 @@ import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
 import { type RefObject, useMemo } from "react";
 
-import {
-  buildCapabilitySlashCommandIndex,
-  searchCapabilitySlashCommandIndex,
-} from "./buildSlashCommandItems";
+import { buildCapabilitySlashCommandItems } from "./buildSlashCommandItems";
 
 function getSkillBuilderSlashCommandTools({
   serverViews,
@@ -79,24 +76,20 @@ export function useInputBarSlashCommandCapabilities({
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(owner, globalSpaces);
 
-  const capabilityIndex = useMemo(
-    () =>
-      buildCapabilitySlashCommandIndex({
-        excludeSkillId,
-        skills,
-        tools: serverViews,
-        toolFilter: isJITMCPServerView,
-      }),
-    [excludeSkillId, serverViews, skills]
-  );
   const capabilityItems = useMemo(
     () =>
-      searchCapabilitySlashCommandIndex({
-        excludedToolIds: selectedMCPServerViewIdsRef?.current ?? undefined,
-        index: capabilityIndex,
+      buildCapabilitySlashCommandItems({
+        excludeSkillId,
         query,
+        skills,
+        tools: serverViews,
+        toolFilter: (serverView) =>
+          isJITMCPServerView(serverView) &&
+          !(selectedMCPServerViewIdsRef?.current ?? new Set()).has(
+            serverView.sId
+          ),
       }),
-    [capabilityIndex, query, selectedMCPServerViewIdsRef]
+    [excludeSkillId, query, selectedMCPServerViewIdsRef, serverViews, skills]
   );
 
   return {
@@ -134,18 +127,17 @@ export function useSkillBuilderSlashCommandCapabilities({
     [serverViews, spaces]
   );
 
-  const capabilityIndex = useMemo(
+  const capabilityItems = useMemo(
     () =>
-      buildCapabilitySlashCommandIndex({
+      buildCapabilitySlashCommandItems({
         excludeSkillId,
+        query,
         skills,
         tools,
+        toolFilter: (serverView) =>
+          getMCPServerRequirements(serverView).noRequirement,
       }),
-    [excludeSkillId, skills, tools]
-  );
-  const capabilityItems = useMemo(
-    () => searchCapabilitySlashCommandIndex({ index: capabilityIndex, query }),
-    [capabilityIndex, query]
+    [excludeSkillId, query, skills, tools]
   );
 
   return {

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -11,7 +11,10 @@ import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
 import { type RefObject, useMemo } from "react";
 
-import { buildCapabilitySlashCommandItems } from "./buildSlashCommandItems";
+import {
+  buildCapabilitySlashCommandIndex,
+  searchCapabilitySlashCommandIndex,
+} from "./buildSlashCommandItems";
 
 function getSkillBuilderSlashCommandTools({
   serverViews,
@@ -76,20 +79,24 @@ export function useInputBarSlashCommandCapabilities({
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(owner, globalSpaces);
 
-  const capabilityItems = useMemo(
+  const capabilityIndex = useMemo(
     () =>
-      buildCapabilitySlashCommandItems({
+      buildCapabilitySlashCommandIndex({
         excludeSkillId,
-        query,
         skills,
         tools: serverViews,
-        toolFilter: (serverView) =>
-          isJITMCPServerView(serverView) &&
-          !(selectedMCPServerViewIdsRef?.current ?? new Set()).has(
-            serverView.sId
-          ),
+        toolFilter: isJITMCPServerView,
       }),
-    [excludeSkillId, query, selectedMCPServerViewIdsRef, serverViews, skills]
+    [excludeSkillId, serverViews, skills]
+  );
+  const capabilityItems = useMemo(
+    () =>
+      searchCapabilitySlashCommandIndex({
+        excludedToolIds: selectedMCPServerViewIdsRef?.current ?? undefined,
+        index: capabilityIndex,
+        query,
+      }),
+    [capabilityIndex, query, selectedMCPServerViewIdsRef]
   );
 
   return {
@@ -127,17 +134,18 @@ export function useSkillBuilderSlashCommandCapabilities({
     [serverViews, spaces]
   );
 
-  const capabilityItems = useMemo(
+  const capabilityIndex = useMemo(
     () =>
-      buildCapabilitySlashCommandItems({
+      buildCapabilitySlashCommandIndex({
         excludeSkillId,
-        query,
         skills,
         tools,
-        toolFilter: (serverView) =>
-          getMCPServerRequirements(serverView).noRequirement,
       }),
-    [excludeSkillId, query, skills, tools]
+    [excludeSkillId, skills, tools]
+  );
+  const capabilityItems = useMemo(
+    () => searchCapabilitySlashCommandIndex({ index: capabilityIndex, query }),
+    [capabilityIndex, query]
   );
 
   return {


### PR DESCRIPTION
## Description

Limit capability menus to the first 50 ranked matches and reuse a normalized search index in the input-bar picker.

Previously, each picker search keystroke rebuilt display metadata and instantiated every matching capability row, including icons, buttons, Radix items, and registry refs. Large workspaces therefore paid rendering cost proportional to their full capability count.

The picker and slash menus still search and rank the complete client-side dataset, but only materialize the first 50 results.

## Tests

- `NODE_ENV=test npm test components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts`

## Risk

Low. Users can still find capabilities beyond the first 50 by refining their search, but can no longer browse every match in a single unfiltered list.

## Deploy Plan

- deploy `front`