### PR TITLE
Fix free seat credits cleanup + ui

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -213,6 +213,7 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
                       Your Credits
                     </span>
                     {nextCreditResetAt &&
+                      myUsage?.seatType !== "free" &&
                       (() => {
                         const d = new Date(nextCreditResetAt);
                         const month = d.toLocaleDateString("en-US", {

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -121,13 +121,24 @@ export function ChangeSeatModal({
   // Default the active tab to the frequency of the user's current seat — falls
   // back to the first frequency that has any seats to show. The effect below
   // resets the selection when a different member opens the modal.
+  //
+  // Only trust the current seat's own frequency if it's actually one of the
+  // selectable buckets: a "free" member's billing frequency (e.g. "monthly")
+  // may not match any *other* seat type's frequency, since "free" itself is
+  // filtered out of `seatTypes`/`seatTypesByFrequency` above — trusting it
+  // blindly could land on an empty bucket with nothing to render and no
+  // Monthly/Yearly switch to escape it (that switch only shows when more than
+  // one bucket is populated).
   const currentFrequency =
     currentSeatType && seatPlans[currentSeatType]
       ? seatPlans[currentSeatType].billingFrequency
       : null;
-  const [activeFrequency, setActiveFrequency] = useState<SeatBillingFrequency>(
-    currentFrequency ?? availableFrequencies[0] ?? "monthly"
-  );
+  const initialFrequency: SeatBillingFrequency =
+    (currentFrequency && seatTypesByFrequency[currentFrequency].length > 0
+      ? currentFrequency
+      : availableFrequencies[0]) ?? "monthly";
+  const [activeFrequency, setActiveFrequency] =
+    useState<SeatBillingFrequency>(initialFrequency);
 
   // Reset transient state when the dialog closes and initialize the selected
   // seat + active tab once per member open. Do not re-run on seat plan
@@ -149,19 +160,14 @@ export function ChangeSeatModal({
     }
 
     setSelectedSeat(nextSelectedSeat);
-    if (currentFrequency) {
-      setActiveFrequency(currentFrequency);
-    } else if (availableFrequencies[0]) {
-      setActiveFrequency(availableFrequencies[0]);
-    }
+    setActiveFrequency(initialFrequency);
     initializedMemberIdRef.current = displayedMemberId;
     setIsSaving(false);
   }, [
-    availableFrequencies,
-    currentFrequency,
     displayedMemberId,
     displayedMemberSeatType,
     firstSeatType,
+    initialFrequency,
     isOpen,
   ]);
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2631,66 +2631,26 @@ export async function addPerUserCreditToCustomer({
 }
 
 /**
- * Return the set of seat user sIds that already have a per-user customer credit
- * named `creditName`. Includes archived/expired credits so past grants are not
- * re-issued — the uniqueness key also enforces this server-side.
+ * Shared core for listing a customer's per-user credits of a given
+ * `contractCreditType`, keyed by user sId (from the `DUST_PER_USER_CREDIT_USER`
+ * custom field — old plain-sId and new free-prefixed formats collapse to the
+ * same key). Includes archived/expired credits so a past grant is never
+ * mistaken for missing, and a fully-consumed credit still appears (balance 0)
+ * rather than being absent.
+ *
+ * `includeBalances: false` skips requesting `include_balance` from Metronome,
+ * which otherwise computes a live balance for every credit and makes the
+ * call meaningfully heavier — `balanceAwu` is meaningless (always 0) in that
+ * case; only pass `true` when a caller actually reads it.
  */
-export async function listCustomerPerUserCreditUserIds({
+async function listCustomerPerUserCreditEntries({
   metronomeCustomerId,
   contractCreditType,
+  includeBalances,
 }: {
   metronomeCustomerId: string;
   contractCreditType: ContractCreditType;
-}): Promise<Result<Set<string>, Error>> {
-  if (!config.getMetronomeApiKey()) {
-    return new Ok(new Set());
-  }
-
-  const client = getMetronomeClient();
-
-  try {
-    const userIds = new Set<string>();
-    for await (const entry of client.v1.customers.credits.list({
-      customer_id: metronomeCustomerId,
-      include_balance: false,
-      include_archived: true,
-    })) {
-      if (
-        entry.contract ||
-        entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
-          contractCreditType
-      ) {
-        continue;
-      }
-      for (const specifier of entry.specifiers ?? []) {
-        const userId = specifier.presentation_group_values?.user_id;
-        if (userId) {
-          userIds.add(userId);
-        }
-      }
-    }
-    return new Ok(userIds);
-  } catch (err) {
-    const error = normalizeError(err);
-    logger.error(
-      { error, metronomeCustomerId },
-      "[Metronome] Failed to list per-user customer credits"
-    );
-    return new Err(error);
-  }
-}
-
-/**
- * Return the live AWU balance of each free-seat per-user customer credit, keyed
- * by user sId (from the `DUST_PER_USER_CREDIT_USER` custom field). Only active
- * (not yet expired or archived) credits are included.
- */
-export async function listCustomerPerUserCreditBalances({
-  metronomeCustomerId,
-  contractCreditType,
-}: {
-  metronomeCustomerId: string;
-  contractCreditType: ContractCreditType;
+  includeBalances: boolean;
 }): Promise<
   Result<
     Map<
@@ -2713,9 +2673,7 @@ export async function listCustomerPerUserCreditBalances({
     >();
     for await (const entry of client.v1.customers.credits.list({
       customer_id: metronomeCustomerId,
-      include_balance: true,
-      // Include archived (exhausted) credits so fully-consumed free-seat
-      // credits appear with balance 0 rather than being absent from the map.
+      include_balance: includeBalances,
       include_archived: true,
     })) {
       if (entry.contract) {
@@ -2732,9 +2690,6 @@ export async function listCustomerPerUserCreditBalances({
       ) {
         continue;
       }
-      // Strip the "free-" prefix so the map is keyed by plain sId. All
-      // callers look up by membership.user.sId; old-format credits without
-      // the prefix keep their raw value as the key.
       const userId = fromFreeMetronomeUserId(rawUserId) ?? rawUserId;
       const startingBalanceAwu = (
         entry.access_schedule?.schedule_items ?? []
@@ -2752,10 +2707,89 @@ export async function listCustomerPerUserCreditBalances({
     const error = normalizeError(err);
     logger.error(
       { error, metronomeCustomerId },
-      "[Metronome] Failed to list per-user customer credit balances"
+      "[Metronome] Failed to list per-user customer credits"
     );
     return new Err(error);
   }
+}
+
+/**
+ * Return each per-user customer credit's id(s), keyed by user sId — without
+ * requesting balances. Use this instead of `listCustomerPerUserCreditBalances`
+ * wherever a caller only needs to know which users have a credit and its
+ * id(s) to act on (e.g. revoke), not the balance itself.
+ */
+export async function listCustomerPerUserCreditIds({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<Result<Map<string, string[]>, Error>> {
+  const result = await listCustomerPerUserCreditEntries({
+    metronomeCustomerId,
+    contractCreditType,
+    includeBalances: false,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(
+    new Map(
+      [...result.value].map(([userId, entry]) => [userId, entry.creditIds])
+    )
+  );
+}
+
+/**
+ * Return the set of (plain-sId, normalized) users that already have a
+ * per-user customer credit of `contractCreditType`. Includes archived/expired
+ * credits so past grants are not re-issued — the uniqueness key also
+ * enforces this server-side. Thin wrapper over `listCustomerPerUserCreditIds`
+ * for callers that only need to test membership, not the credit id(s).
+ */
+export async function listCustomerPerUserCreditUserIds({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<Result<Set<string>, Error>> {
+  const result = await listCustomerPerUserCreditIds({
+    metronomeCustomerId,
+    contractCreditType,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(new Set(result.value.keys()));
+}
+
+/**
+ * Return the live AWU balance of each free-seat per-user customer credit, keyed
+ * by user sId (from the `DUST_PER_USER_CREDIT_USER` custom field). Only active
+ * (not yet expired or archived) credits are included.
+ */
+export async function listCustomerPerUserCreditBalances({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<
+  Result<
+    Map<
+      string,
+      { creditIds: string[]; balanceAwu: number; startingBalanceAwu: number }
+    >,
+    Error
+  >
+> {
+  return listCustomerPerUserCreditEntries({
+    metronomeCustomerId,
+    contractCreditType,
+    includeBalances: true,
+  });
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -9,7 +9,7 @@ import {
   getMetronomeContractById,
   getMetronomeSeatActiveSince,
   getMetronomeSubscriptionSeatState,
-  listCustomerPerUserCreditBalances,
+  listCustomerPerUserCreditIds,
   listCustomerPerUserCreditUserIds,
   listMetronomeSeatBalances,
   revokePerUserCustomerCredit,
@@ -21,7 +21,6 @@ import {
   AWU_PRIORITY_FREE_SEAT_CREDIT,
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   FREE_SEAT_LIFETIME_AWU_CREDITS,
-  fromFreeMetronomeUserId,
   getCreditTypeAwuId,
   getProductSeatSubscriptionCreditsId,
   toFreeMetronomeUserId,
@@ -531,7 +530,7 @@ export async function remapMembershipSeatTypesForContract({
       workspaceId: workspace.sId,
       contractId,
       membershipCount: memberships.length,
-      currentSeatTypes: memberships.map((m) => m.seatType),
+      currentSeatTypes: [...new Set(memberships.map((m) => m.seatType))],
     },
     "[Metronome][remap] Active memberships to consider"
   );
@@ -613,17 +612,6 @@ export async function remapMembershipSeatTypesForContract({
       existingSchedule?.seatType === target &&
       existingSchedule.startAt.getTime() === startingAt.getTime();
     if (target === membership.seatType || alreadyScheduled) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          contractId,
-          userId: user.sId,
-          currentSeatType: membership.seatType,
-          target,
-          alreadyScheduled,
-        },
-        "[Metronome][remap] No seat-type change for membership"
-      );
       continue;
     }
     logger.info(
@@ -734,11 +722,9 @@ async function grantFreeSeatCredits({
   const grantedUserIds = alreadyGranted.isOk()
     ? alreadyGranted.value
     : new Set<string>();
-  // Credits are stored in Metronome with the free-prefixed user id; compare
-  // against the same form so already-granted users are skipped correctly.
-  const toGrant = userIds.filter(
-    (userId) => !grantedUserIds.has(toFreeMetronomeUserId(userId))
-  );
+  // `listCustomerPerUserCreditUserIds` returns plain (normalized) sIds, so
+  // compare directly — no need to re-derive the free-prefixed form.
+  const toGrant = userIds.filter((userId) => !grantedUserIds.has(userId));
 
   // Grant the credit only for users that don't have one yet.
   await concurrentExecutor(
@@ -817,7 +803,10 @@ async function revokeFreeSeatCreditsForExFreeUsers({
   workspaceId: string;
   currentFreeUserIds: Set<string>;
 }): Promise<void> {
-  const activeCreditsResult = await listCustomerPerUserCreditBalances({
+  // Only credit ids are needed here (to revoke) — not balances, which
+  // Metronome computes for every credit and makes the listing meaningfully
+  // heavier.
+  const activeCreditsResult = await listCustomerPerUserCreditIds({
     metronomeCustomerId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
@@ -828,13 +817,14 @@ async function revokeFreeSeatCreditsForExFreeUsers({
     );
     return;
   }
-  // Only process new-format credits (keyed by "free-<sId>"); old-format credits
-  // (plain sId) are ignored — they will eventually expire naturally.
+  // `activeCreditsResult` is already keyed by the plain sId regardless of
+  // whether the credit was stored under the old (plain) or new
+  // (free-prefixed) format — `listCustomerPerUserCreditIds` normalizes both,
+  // and it was already scoped to `CONTRACT_CREDIT_TYPE_FREE_SEAT`, so every
+  // entry here is a free-seat credit. Anyone not in `currentFreeUserIds` is
+  // no longer free and should be revoked.
   const toRevoke = [...activeCreditsResult.value.entries()].filter(
-    ([metronomeUserId]) => {
-      const rawUserId = fromFreeMetronomeUserId(metronomeUserId);
-      return rawUserId !== null && !currentFreeUserIds.has(rawUserId);
-    }
+    ([userId]) => !currentFreeUserIds.has(userId)
   );
   if (toRevoke.length === 0) {
     return;
@@ -842,7 +832,7 @@ async function revokeFreeSeatCreditsForExFreeUsers({
 
   await concurrentExecutor(
     toRevoke,
-    async ([userId, { creditIds }]) => {
+    async ([userId, creditIds]) => {
       for (const creditId of creditIds) {
         const revokeResult = await revokePerUserCustomerCredit({
           metronomeCustomerId,
@@ -855,10 +845,14 @@ async function revokeFreeSeatCreditsForExFreeUsers({
           );
         }
       }
+      // Alerts are created with the free-prefixed user id (see
+      // `grantFreeSeatCredits`'s `upsertPerUserCreditBalanceAlerts` call) —
+      // must clear with the same form or `clearMetronomeAlert` targets a
+      // uniqueness key that was never created.
       const clearResult = await clearPerUserCreditBalanceAlerts({
         metronomeCustomerId,
         workspaceId,
-        userId,
+        userId: toFreeMetronomeUserId(userId),
       });
       if (clearResult.isErr()) {
         logger.error(

--- a/front/scripts/revoke_stray_free_seat_credits.ts
+++ b/front/scripts/revoke_stray_free_seat_credits.ts
@@ -1,0 +1,198 @@
+/**
+ * Revoke stray free-seat credits (and clear their alerts): users who
+ * currently hold a Metronome `free_seat` per-user credit but whose DB
+ * membership seat type isn't (or is no longer) `free`.
+ *
+ * Written for legacy-contract workspaces where a bug in `syncSeatCount`
+ * (fixed separately) wrongly treated every member as "currently free" and
+ * granted a `free-<sId>` credit + alerts for all of them. On a legacy
+ * contract no membership should ever have `seatType === "free"`, so every
+ * credit found there is stray — but the script still cross-checks against
+ * current DB membership state rather than assuming that, so it's safe to
+ * run against any workspace with stray free-seat credits, legacy or not.
+ *
+ * Iterates every workspace with a metronomeCustomerId by default; pass
+ * --workspaceId to scope to just one. Dry-run by default; pass --execute to
+ * actually revoke/clear.
+ *
+ *   npx tsx scripts/revoke_stray_free_seat_credits.ts
+ *   npx tsx scripts/revoke_stray_free_seat_credits.ts --workspaceId <wId> --execute
+ */
+import { clearPerUserCreditBalanceAlerts } from "@app/lib/metronome/alerts/per_user_credit_balance";
+import {
+  listCustomerPerUserCreditIds,
+  revokePerUserCustomerCredit,
+} from "@app/lib/metronome/client";
+import {
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  toFreeMetronomeUserId,
+} from "@app/lib/metronome/constants";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+// Metronome publishes an 11 RPS API limit. Cap this script well under it to
+// leave headroom for concurrent production traffic on the same API key.
+const METRONOME_MAX_RPS = 8;
+const METRONOME_MIN_INTERVAL_MS = 1000 / METRONOME_MAX_RPS;
+let metronomeNextSlotAt = 0;
+
+async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const slot = Math.max(now, metronomeNextSlotAt);
+  metronomeNextSlotAt = slot + METRONOME_MIN_INTERVAL_MS;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  return fn();
+}
+
+async function revokeStrayFreeSeatCreditsForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  const currentFreeUserIds = new Set(
+    memberships.flatMap((m) =>
+      m.user?.sId && m.seatType === "free" ? [m.user.sId] : []
+    )
+  );
+
+  // Only credit ids are needed here (to revoke) — not balances, which
+  // Metronome computes for every credit and makes the listing meaningfully
+  // heavier.
+  const creditsResult = await paceMetronome(() =>
+    listCustomerPerUserCreditIds({
+      metronomeCustomerId,
+      contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+    })
+  );
+  if (creditsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: creditsResult.error },
+      "Failed to list per-user free-seat credits"
+    );
+    return;
+  }
+  if (creditsResult.value.size === 0) {
+    return;
+  }
+
+  // `listCustomerPerUserCreditIds` already strips the "free-" prefix, so its
+  // map is keyed by the plain sId.
+  const toRevoke = [...creditsResult.value.entries()].filter(
+    ([userId]) => !currentFreeUserIds.has(userId)
+  );
+  if (toRevoke.length === 0) {
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      totalFreeSeatCredits: creditsResult.value.size,
+      currentFreeUserCount: currentFreeUserIds.size,
+      strayCount: toRevoke.length,
+    },
+    execute
+      ? "Revoking stray free-seat credits"
+      : "[DRY RUN] Would revoke these stray free-seat credits"
+  );
+
+  await concurrentExecutor(
+    toRevoke,
+    async ([userId, creditIds]) => {
+      if (!execute) {
+        logger.info(
+          { workspaceId: workspace.sId, userId, creditIds },
+          "[DRY RUN] Would revoke credit(s) and clear alerts"
+        );
+        return;
+      }
+
+      for (const creditId of creditIds) {
+        const revokeResult = await paceMetronome(() =>
+          revokePerUserCustomerCredit({ metronomeCustomerId, creditId })
+        );
+        if (revokeResult.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              userId,
+              creditId,
+              error: revokeResult.error,
+            },
+            "Failed to revoke stray free-seat credit"
+          );
+        }
+      }
+
+      // Alerts are created with the free-prefixed user id (see
+      // `grantFreeSeatCredits`'s `upsertPerUserCreditBalanceAlerts` call) —
+      // must clear with the same form or `clearMetronomeAlert` targets a
+      // uniqueness key that was never created.
+      const clearResult = await paceMetronome(() =>
+        clearPerUserCreditBalanceAlerts({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+          userId: toFreeMetronomeUserId(userId),
+        })
+      );
+      if (clearResult.isErr()) {
+        logger.error(
+          { workspaceId: workspace.sId, userId, error: clearResult.error },
+          "Failed to clear stray free-seat credit alerts"
+        );
+      } else {
+        logger.info(
+          { workspaceId: workspace.sId, userId },
+          "Revoked credit and cleared alerts"
+        );
+      }
+    },
+    { concurrency: 4 }
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      demandOption: false,
+    },
+    fromWorkspaceId: {
+      type: "number" as const,
+      description:
+        "Resume from this numeric workspace model id (skips workspaces with id < this value)",
+      demandOption: false,
+    },
+  },
+  async ({ workspaceId, fromWorkspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await revokeStrayFreeSeatCreditsForWorkspace(
+          workspace,
+          execute,
+          logger
+        );
+      },
+      { concurrency: 4, wId: workspaceId, fromWorkspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

A few fixes around free-seat credits, found while cleaning up after the legacy-contract sync bug fixed in #29124.

- **`ChangeSeatModal` showed no options at all for some workspaces** (`components/workspace/ChangeSeatModal.tsx`): the modal seeds its initial Monthly/Yearly tab from the *current* seat's own billing frequency, but `"free"` is filtered out of the selectable seat types before that — so on a workspace whose only selectable seat types are e.g. `pro_yearly`/`max_yearly` (both "annual"), a free-seat member's own frequency (e.g. "monthly") could seed a tab with nothing in it, and the Monthly/Yearly switch only renders when more than one tab actually has options — so there was no way to escape it. Now the initial tab only trusts the current seat's frequency when it's actually a populated bucket, otherwise falls back to the first available one (the same fallback that already existed, just not reached here).

- **`revokeFreeSeatCreditsForExFreeUsers` never actually revoked or cleared anything** (`lib/metronome/seats.ts`): two stacked bugs.
  1. Its filter re-stripped an already-normalized user id (`listCustomerPerUserCreditBalances` already returns plain sIds), so `fromFreeMetronomeUserId` always returned `null` and the revoke list was always empty.
  2. Even fixed, the alert-clear call used the plain user id, but alerts are created with the free-prefixed id (`grantFreeSeatCredits` → `upsertPerUserCreditBalanceAlerts`) — so it was targeting a uniqueness key that never existed.

  Both fixed: the filter now compares plain ids directly, and the alert clear now re-derives the prefixed id to match how it was created.

- **`listCustomerPerUserCreditIds`** (`lib/metronome/client.ts`, new): a lighter variant of `listCustomerPerUserCreditBalances` that skips Metronome's balance computation (`include_balance: false`) for the two call sites that only ever needed credit ids to revoke, not balances — `revokeFreeSeatCreditsForExFreeUsers` and the new cleanup script below. `listCustomerPerUserCreditUserIds` (used by `grantFreeSeatCredits`'s already-granted check) is now a thin wrapper over it instead of duplicating the same listing/filtering with a second, different (and only coincidentally equivalent) user-id extraction path.

- **`scripts/revoke_stray_free_seat_credits.ts`** (new): one-off cleanup for the stray `free-<sId>` credits/alerts created by the legacy-contract bug — cross-checks live DB membership state against Metronome's per-user free-seat credits and revokes/clears anything that no longer matches a real free-seat member. Iterates every workspace with a `metronomeCustomerId` (or a single one via `--workspaceId`), rate-limited to stay under Metronome's published RPS cap, dry-run by default (`--execute` to apply).

## Tests

`lib/metronome` suite (client.test.ts, seats.test.ts, seats_sync.test.ts — 92 tests) passes. No test coverage for `ChangeSeatModal` (no existing test infra for this component).

## Risk

The credit/alert fixes only change previously-broken (no-op) behavior — nothing to regress. The `listCustomerPerUserCreditUserIds` refactor changes its output format from raw/prefixed to normalized ids; its one caller was updated to match. No schema/migration changes, no feature flag.

## Deploy Plan

Standard deploy. Once live, run `scripts/revoke_stray_free_seat_credits.ts` (dry-run first) against the affected workspace(s) to clean up the stray credits/alerts left by the earlier bug.
