### PR TITLE
[front] perf: throttle capability refreshes

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -14,6 +14,7 @@ import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_a
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
 import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
@@ -202,6 +203,7 @@ export function CapabilitiesPicker({
   const { spaces: globalSpaces } = useSpaces({
     workspaceId: owner.sId,
     kinds: ["global"],
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 
   const isAdmin = owner.role === "admin";
@@ -210,7 +212,11 @@ export function CapabilitiesPicker({
     serverViews,
     isLoading: isServerViewsLoading,
     mutateServerViews,
-  } = useMCPServerViewsFromSpaces(owner, globalSpaces);
+  } = useMCPServerViewsFromSpaces(
+    owner,
+    globalSpaces,
+    CAPABILITIES_SWR_OPTIONS
+  );
 
   const normalizedSearchText = searchText.trim().toLowerCase();
 
@@ -247,11 +253,13 @@ export function CapabilitiesPicker({
     useAvailableMCPServers({
       owner,
       disabled: !isAdmin,
+      swrOptions: CAPABILITIES_SWR_OPTIONS,
     });
 
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 
   const isSkillsDataReady = !isSkillsLoading;

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -5,6 +5,7 @@ import {
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -68,13 +69,15 @@ export function useInputBarSlashCommandCapabilities({
   const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
     kinds: ["global"],
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   const { serverViews, isLoading: isServerViewsLoading } =
-    useMCPServerViewsFromSpaces(owner, globalSpaces);
+    useMCPServerViewsFromSpaces(owner, globalSpaces, CAPABILITIES_SWR_OPTIONS);
 
   const capabilityItems = useMemo(
     () =>

--- a/front/lib/swr/capabilities.ts
+++ b/front/lib/swr/capabilities.ts
@@ -1,0 +1,9 @@
+import type { SWRConfiguration } from "swr";
+
+const CAPABILITIES_DEDUPING_INTERVAL_MS = 60 * 1000;
+const CAPABILITIES_FOCUS_THROTTLE_INTERVAL_MS = 5 * 60 * 1000;
+
+export const CAPABILITIES_SWR_OPTIONS = {
+  dedupingInterval: CAPABILITIES_DEDUPING_INTERVAL_MS,
+  focusThrottleInterval: CAPABILITIES_FOCUS_THROTTLE_INTERVAL_MS,
+} satisfies SWRConfiguration;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -130,10 +130,12 @@ export function useAvailableMCPServers({
   owner,
   space,
   disabled = false,
+  swrOptions,
 }: {
   owner: LightWorkspaceType;
   space?: SpaceType;
   disabled?: boolean;
+  swrOptions?: SWRConfiguration;
 }) {
   const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
@@ -143,6 +145,7 @@ export function useAvailableMCPServers({
     : `/api/w/${owner.sId}/mcp/available`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    ...swrOptions,
     disabled,
   });
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -26,7 +26,7 @@ import { Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useRef, useState } from "react";
-import type { Fetcher } from "swr";
+import type { Fetcher, SWRConfiguration } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
@@ -99,12 +99,14 @@ export function useSkills({
   status,
   globalSpaceOnly,
   isDefault,
+  swrOptions,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
   isDefault?: boolean;
+  swrOptions?: SWRConfiguration;
 }): {
   skills: SkillWithoutInstructionsAndToolsType[];
   isSkillsError: boolean;
@@ -128,7 +130,7 @@ export function useSkills({
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills${queryString ? `?${queryString}` : ""}`,
     fetcher,
-    { disabled }
+    { ...swrOptions, disabled }
   );
 
   return {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -40,16 +40,18 @@ import { isString } from "@app/types/shared/utils/general";
 import type { PodType, SpaceKind, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
-import type { Fetcher, KeyedMutator } from "swr";
+import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
 export function useSpaces({
   workspaceId,
   kinds,
   disabled,
+  swrOptions,
 }: {
   workspaceId: string;
   kinds: SpaceKind[] | "all";
   disabled?: boolean;
+  swrOptions?: SWRConfiguration;
 }) {
   const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
@@ -57,7 +59,7 @@ export function useSpaces({
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${workspaceId}/spaces`,
     spacesFetcher,
-    { disabled }
+    { ...swrOptions, disabled }
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`


### PR DESCRIPTION
## Description

Reduce repeated capability-list requests by applying a one-minute SWR deduplication window and a five-minute focus revalidation throttle.

The policy is scoped to the preloaded capabilities picker and input-bar slash menu. The shared skills, spaces, and available MCP server hooks now accept per-consumer SWR options, leaving other screens' refresh behavior unchanged.

## Tests

N/A, tested locally.

## Risk

Low. Initial loads and explicit mutations still revalidate immediately; only automatic duplicate and focus-triggered refreshes are throttled.

## Deploy Plan

- deploy `front`