### PR TITLE
Handle Slack authorization post restrictions

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -407,7 +407,7 @@ export async function botValidateToolExecution(
       throw new Error("Unreachable: bot cannot validate tool execution.");
     }
 
-    const hasChatbotAccess = await notifyIfSlackUserIsNotAllowed(
+    const hasChatbotAccessRes = await notifyIfSlackUserIsNotAllowed(
       connector,
       slackClient,
       slackUserInfo,
@@ -418,6 +418,11 @@ export async function botValidateToolExecution(
       },
       slackConfig.whitelistedDomains
     );
+    if (hasChatbotAccessRes.isErr()) {
+      return hasChatbotAccessRes;
+    }
+
+    const hasChatbotAccess = hasChatbotAccessRes.value;
     if (!hasChatbotAccess.authorized) {
       return new Ok(undefined);
     }
@@ -882,7 +887,7 @@ async function answerMessage(
     // permissions.
     skipToolsValidation = true;
   } else {
-    const hasChatbotAccess = await notifyIfSlackUserIsNotAllowed(
+    const hasChatbotAccessRes = await notifyIfSlackUserIsNotAllowed(
       connector,
       slackClient,
       slackUserInfo,
@@ -893,6 +898,11 @@ async function answerMessage(
       },
       slackConfig.whitelistedDomains
     );
+    if (hasChatbotAccessRes.isErr()) {
+      return hasChatbotAccessRes;
+    }
+
+    const hasChatbotAccess = hasChatbotAccessRes.value;
     if (!hasChatbotAccess.authorized) {
       return new Ok(undefined);
     }

--- a/connectors/src/connectors/slack/lib/workspace_limits.test.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.test.ts
@@ -1,0 +1,123 @@
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { DustAPI, Ok } from "@dust-tt/client";
+import { ErrorCode, WebClient } from "@slack/web-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@connectors/lib/api/config"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    apiConfig: {
+      ...original.apiConfig,
+      getDustFrontAPIUrl: () => "https://dust.test",
+    },
+  };
+});
+
+vi.mock(import("@connectors/lib/bot/conversation_utils"), () => ({
+  makeDustAppUrl: () => "https://dust.test",
+}));
+
+vi.mock(import("@connectors/types"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    cacheWithRedis: <T, Args extends unknown[]>(
+      fn: (...args: Args) => Promise<T>
+    ) => fn,
+  };
+});
+
+import { notifyIfSlackUserIsNotAllowed } from "./workspace_limits";
+
+const slackUserInfo: SlackUserInfo = {
+  display_name: "External User",
+  email: "external@example.com",
+  image_512: null,
+  is_bot: false,
+  is_email_confirmed: false,
+  is_restricted: false,
+  is_stranger: true,
+  is_ultra_restricted: false,
+  name: "external-user",
+  real_name: "External User",
+  teamId: "T123",
+  tz: null,
+};
+
+const slackInfos = {
+  slackChannelId: "C123",
+  slackMessageTs: "1700000000.000001",
+  slackTeamId: "T123",
+};
+
+async function makeSlackConnector() {
+  return ConnectorResource.makeNew(
+    "slack",
+    {
+      connectionId: "connection-id",
+      dataSourceId: "data-source-id",
+      workspaceAPIKey: "workspace-api-key",
+      workspaceId: "workspace-id",
+    },
+    {
+      autoReadChannelPatterns: [],
+      botEnabled: true,
+      feedbackVisibleToAuthorOnly: true,
+      restrictedSpaceAgentsEnabled: true,
+      slackTeamId: slackInfos.slackTeamId,
+    }
+  );
+}
+
+function makeSlackPlatformError(error: string) {
+  return Object.assign(new Error(error), {
+    code: ErrorCode.PlatformError,
+    data: { error, ok: false },
+  });
+}
+
+describe("notifyIfSlackUserIsNotAllowed", () => {
+  beforeEach(() => {
+    vi.spyOn(
+      DustAPI.prototype,
+      "getWorkspaceVerifiedDomains"
+    ).mockResolvedValue(new Ok([]));
+  });
+
+  it("returns unauthorized when Slack prevents posting the notification", async () => {
+    const connector = await makeSlackConnector();
+    const slackClient = new WebClient("test-token");
+    vi.spyOn(slackClient.chat, "postMessage").mockRejectedValue(
+      makeSlackPlatformError("restricted_action_read_only_channel")
+    );
+
+    const res = await notifyIfSlackUserIsNotAllowed(
+      connector,
+      slackClient,
+      slackUserInfo,
+      slackInfos
+    );
+
+    expect(res.isOk()).toBe(true);
+    expect(res.isOk() && res.value.authorized).toBe(false);
+  });
+
+  it("propagates unexpected Slack notification errors", async () => {
+    const connector = await makeSlackConnector();
+    const slackClient = new WebClient("test-token");
+    const error = new Error("network failure");
+    vi.spyOn(slackClient.chat, "postMessage").mockRejectedValue(error);
+
+    const res = await notifyIfSlackUserIsNotAllowed(
+      connector,
+      slackClient,
+      slackUserInfo,
+      slackInfos
+    );
+
+    expect(res.isErr()).toBe(true);
+    expect(res.isErr() && res.error).toBe(error);
+  });
+});

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,4 +1,7 @@
-import { SlackExternalUserError } from "@connectors/connectors/slack/lib/errors";
+import {
+  isSlackPostingPermissionError,
+  SlackExternalUserError,
+} from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import {
   getSlackConversationInfo,
@@ -13,7 +16,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { cacheWithRedis } from "@connectors/types";
 import type { Result, WorkspaceDomainType } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+import { Err, normalizeError, Ok } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
 import type {} from "@slack/web-api/dist/types/response/UsersInfoResponse";
 
@@ -129,7 +132,7 @@ async function postMessageForUnauthorizedUser(
   slackClient: WebClient,
   slackUserInfo: SlackUserInfo,
   slackInfos: SlackInfos
-) {
+): Promise<Result<undefined, Error>> {
   const { slackChannelId, slackMessageTs } = slackInfos;
 
   const autoJoinEnabled = await isAutoJoinEnabledForDomain(
@@ -147,11 +150,16 @@ async function postMessageForUnauthorizedUser(
     method: "chat.postMessage",
     channelId: slackChannelId,
   });
-  return slackClient.chat.postMessage({
-    channel: slackChannelId,
-    blocks: slackMessageBlocks,
-    thread_ts: slackMessageTs,
-  });
+  try {
+    await slackClient.chat.postMessage({
+      channel: slackChannelId,
+      blocks: slackMessageBlocks,
+      thread_ts: slackMessageTs,
+    });
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
 }
 
 export async function isBotAllowed(
@@ -197,6 +205,11 @@ interface SlackInfos {
   slackMessageTs: string;
   slackTeamId: string;
 }
+
+type SlackUserAuthorization = {
+  authorized: boolean;
+  groupIds: string[];
+};
 
 // Verify the Slack user is not an external guest to the workspace.
 // An exception is made for users from domains on the whitelist,
@@ -309,12 +322,9 @@ export async function notifyIfSlackUserIsNotAllowed(
   slackUserInfo: SlackUserInfo,
   slackInfos: SlackInfos,
   whitelistedDomains?: readonly string[]
-): Promise<{
-  authorized: boolean;
-  groupIds: string[];
-}> {
+): Promise<Result<SlackUserAuthorization, Error>> {
   if (!slackUserInfo) {
-    return { authorized: false, groupIds: [] };
+    return new Ok({ authorized: false, groupIds: [] });
   }
 
   // Handle Slack users that we consider external to the Slack workspace,
@@ -362,18 +372,34 @@ export async function notifyIfSlackUserIsNotAllowed(
       "Unauthorized Slack user attempted to access webhook."
     );
 
-    await postMessageForUnauthorizedUser(
+    const postMessageRes = await postMessageForUnauthorizedUser(
       connector,
       slackClient,
       slackUserInfo,
       slackInfos
     );
+    if (postMessageRes.isErr()) {
+      if (isSlackPostingPermissionError(postMessageRes.error)) {
+        logger.info(
+          {
+            connectorId: connector.id,
+            failureStage: "unauthorized_user_notification",
+            slackChannelId: slackInfos.slackChannelId,
+            slackErrorCode: postMessageRes.error.data.error,
+            slackTeamId: slackInfos.slackTeamId,
+          },
+          "Slack prevented Dust from posting an unauthorized-user notification."
+        );
+      } else {
+        return postMessageRes;
+      }
+    }
   }
 
   // If the user is part of the Dust workspace, they are allowed without any explicit group id.
   if (isExternal && externalAuthorization) {
-    return externalAuthorization;
+    return new Ok(externalAuthorization);
   }
 
-  return { authorized: isAllowed, groupIds: [] };
+  return new Ok({ authorized: isAllowed, groupIds: [] });
 }


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/9618

Handle Slack posting restrictions when notifying unauthorized users in channels where the Dust app cannot post.

The Slack SDK call now converts thrown errors to a `Result` at the external boundary. Expected posting-permission errors are logged at info level and authorization still returns `authorized: false`; unexpected errors continue to propagate as `Err`. Both callers compose the new Result contract.

This prevents read-only channel configuration from escalating an expected authorization denial into an unexpected bot failure.

## Tests

`NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://test:test@localhost:5433/dust_connectors_test_wk1 npm test -- src/connectors/slack/lib/workspace_limits.test.ts src/connectors/slack/lib/errors.test.ts --run`

## Risk

Low. The change is limited to unauthorized-user Slack notifications. Unknown failures preserve the existing error path.

## Deploy Plan

- deploy `connectors`
