### PR TITLE
Improve mention autocomplete responsiveness

### DIFF
--- a/front/components/editor/input_bar/MentionDropdown.test.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.test.tsx
@@ -53,7 +53,9 @@ vi.mock("@dust-tt/sparkle", () => {
     cn: (...classes: Array<string | false | undefined>) =>
       classes.filter(Boolean).join(" "),
     DropdownMenu: Container,
-    DropdownMenuContent: Container,
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+      <div data-testid="mention-dropdown-content">{children}</div>
+    ),
     DropdownMenuItem,
     DropdownMenuTrigger: Container,
     Spinner: () => <div data-testid="spinner" />,
@@ -108,8 +110,8 @@ const userSuggestion: RichMention = {
   description: "alice@dust.tt",
 };
 
-function renderDropdown(query: string) {
-  return render(
+function dropdown(query: string) {
+  return (
     <MentionDropdown
       query={query}
       owner={owner}
@@ -119,6 +121,10 @@ function renderDropdown(query: string) {
       select={{ agents: true, users: true }}
     />
   );
+}
+
+function renderDropdown(query: string) {
+  return render(dropdown(query));
 }
 
 describe("MentionDropdown", () => {
@@ -163,5 +169,37 @@ describe("MentionDropdown", () => {
 
     expect(screen.getByText("Code Agent")).toBeInTheDocument();
     expect(screen.queryByTestId("spinner")).toBeNull();
+  });
+
+  it("keeps the dropdown content mounted while local results update", () => {
+    useUnifiedAgentConfigurationsMock.mockReturnValue({
+      agentConfigurations: [
+        agentConfiguration,
+        {
+          ...agentConfiguration,
+          id: 2,
+          sId: "agent_writing",
+          name: "Writing Agent",
+        },
+      ],
+      isLoading: false,
+    });
+    useConversationParticipantsMock.mockReturnValue({
+      conversationParticipants: undefined,
+    });
+    useMentionSuggestionsMock.mockReturnValue({
+      suggestions: [],
+      isLoading: false,
+      isSearching: false,
+    });
+
+    const { rerender } = renderDropdown("");
+    const content = screen.getByTestId("mention-dropdown-content");
+
+    rerender(dropdown("code"));
+
+    expect(screen.getByTestId("mention-dropdown-content")).toBe(content);
+    expect(screen.getByText("Code Agent")).toBeInTheDocument();
+    expect(screen.queryByText("Writing Agent")).toBeNull();
   });
 });

--- a/front/components/editor/input_bar/MentionDropdown.test.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.test.tsx
@@ -1,0 +1,167 @@
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { RichMention } from "@app/types/assistant/mentions";
+import type { WorkspaceType } from "@app/types/user";
+import { render, screen } from "@testing-library/react";
+import { forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MentionDropdown } from "./MentionDropdown";
+
+const {
+  useConversationParticipantsMock,
+  useMentionSuggestionsMock,
+  useUnifiedAgentConfigurationsMock,
+} = vi.hoisted(() => ({
+  useConversationParticipantsMock: vi.fn(),
+  useMentionSuggestionsMock: vi.fn(),
+  useUnifiedAgentConfigurationsMock: vi.fn(),
+}));
+
+vi.mock("@app/hooks/conversations/useConversationParticipants", () => ({
+  useConversationParticipants: useConversationParticipantsMock,
+}));
+
+vi.mock("@app/lib/swr/assistants", () => ({
+  useUnifiedAgentConfigurations: useUnifiedAgentConfigurationsMock,
+}));
+
+vi.mock("@app/lib/swr/mentions", () => ({
+  useMentionSuggestions: useMentionSuggestionsMock,
+}));
+
+vi.mock("@dust-tt/sparkle", () => {
+  const Container = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  );
+  const DropdownMenuItem = forwardRef<
+    HTMLButtonElement,
+    {
+      children: ReactNode;
+      onClick?: () => void;
+      onMouseEnter?: () => void;
+    }
+  >(({ children, onClick, onMouseEnter }, _ref) => (
+    <button type="button" onClick={onClick} onMouseEnter={onMouseEnter}>
+      {children}
+    </button>
+  ));
+  DropdownMenuItem.displayName = "DropdownMenuItem";
+
+  return {
+    Avatar: () => null,
+    Chip: ({ label }: { label: string }) => <span>{label}</span>,
+    cn: (...classes: Array<string | false | undefined>) =>
+      classes.filter(Boolean).join(" "),
+    DropdownMenu: Container,
+    DropdownMenuContent: Container,
+    DropdownMenuItem,
+    DropdownMenuTrigger: Container,
+    Spinner: () => <div data-testid="spinner" />,
+  };
+});
+
+const owner: WorkspaceType = {
+  id: 1,
+  sId: "w_test",
+  name: "Test Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+  regionalModelsOnly: false,
+};
+
+const agentConfiguration: LightAgentConfigurationType = {
+  id: 1,
+  versionCreatedAt: null,
+  sId: "agent_code",
+  version: 0,
+  versionAuthorId: null,
+  instructions: null,
+  model: {
+    providerId: "anthropic",
+    modelId: "claude-haiku-4-5-20251001",
+    temperature: 0,
+  },
+  status: "active",
+  scope: "visible",
+  userFavorite: false,
+  name: "Code Agent",
+  description: "Writes code",
+  pictureUrl: "",
+  maxStepsPerRun: 8,
+  tags: [],
+  templateId: null,
+  requestedGroupIds: [],
+  requestedSpaceIds: [],
+  canRead: true,
+  canEdit: false,
+};
+
+const userSuggestion: RichMention = {
+  id: "user_alice",
+  type: "user",
+  label: "Alice",
+  pictureUrl: "",
+  description: "alice@dust.tt",
+};
+
+function renderDropdown(query: string) {
+  return render(
+    <MentionDropdown
+      query={query}
+      owner={owner}
+      conversationId={null}
+      command={vi.fn()}
+      clientRect={() => new DOMRect(0, 0, 1, 1)}
+      select={{ agents: true, users: true }}
+    />
+  );
+}
+
+describe("MentionDropdown", () => {
+  it("filters cached agents locally and requests only users from the server", () => {
+    useUnifiedAgentConfigurationsMock.mockReturnValue({
+      agentConfigurations: [agentConfiguration],
+      isLoading: false,
+    });
+    useConversationParticipantsMock.mockReturnValue({
+      conversationParticipants: undefined,
+    });
+    useMentionSuggestionsMock.mockReturnValue({
+      suggestions: [userSuggestion],
+      isLoading: false,
+    });
+
+    renderDropdown("code");
+
+    expect(screen.getByText("Code Agent")).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).toBeNull();
+    expect(useMentionSuggestionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { agents: false, users: true },
+      })
+    );
+  });
+
+  it("shows matching agents while user suggestions are loading", () => {
+    useUnifiedAgentConfigurationsMock.mockReturnValue({
+      agentConfigurations: [agentConfiguration],
+      isLoading: false,
+    });
+    useConversationParticipantsMock.mockReturnValue({
+      conversationParticipants: undefined,
+    });
+    useMentionSuggestionsMock.mockReturnValue({
+      suggestions: [],
+      isLoading: true,
+    });
+
+    renderDropdown("code");
+
+    expect(screen.getByText("Code Agent")).toBeInTheDocument();
+    expect(screen.queryByTestId("spinner")).toBeNull();
+  });
+});

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -96,16 +96,19 @@ export const MentionDropdown = forwardRef<
           agent,
         ])
       );
-      const activeAgents: RichAgentMentionInConversation[] = agentConfigurations
-        .filter((agent) => agent.status === "active")
-        .map((agent) => {
-          const participant = participantAgentsById.get(agent.sId);
-          return {
-            ...toRichAgentMentionType(agent),
-            isParticipant: participant !== undefined,
-            lastActivityAt: participant?.lastActivityAt,
-          };
+      const activeAgents: RichAgentMentionInConversation[] = [];
+      for (const agent of agentConfigurations) {
+        if (agent.status !== "active") {
+          continue;
+        }
+
+        const participant = participantAgentsById.get(agent.sId);
+        activeAgents.push({
+          ...toRichAgentMentionType(agent),
+          isParticipant: participant !== undefined,
+          lastActivityAt: participant?.lastActivityAt,
         });
+      }
 
       const sidekickParticipant = participantAgentsById.get(
         GLOBAL_AGENTS_SID.SIDEKICK

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -2,7 +2,20 @@ import type {
   MentionDropdownOnKeyDown,
   MentionDropdownProps,
 } from "@app/components/editor/input_bar/types";
+import { useConversationParticipants } from "@app/hooks/conversations/useConversationParticipants";
+import {
+  filterAndSortEditorSuggestionAgents,
+  filterEditorSuggestionUsers,
+  interleaveMentionsPreservingAgentOrder,
+} from "@app/lib/mentions/editor/suggestion";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useMentionSuggestions } from "@app/lib/swr/mentions";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { RichAgentMentionInConversation } from "@app/types/assistant/mentions";
+import {
+  isRichUserMention,
+  toRichAgentMentionType,
+} from "@app/types/assistant/mentions";
 import {
   Avatar,
   Chip,
@@ -18,6 +31,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -46,16 +60,104 @@ export const MentionDropdown = forwardRef<
     // This avoids caching stale coordinates that may be invalid (0,0) when typing @ quickly after refresh.
     const triggerRect = clientRect?.();
 
-    // Fetch suggestions from server using the query.
-    // Backend handles all prioritization logic (participants, preferred agent, etc.)
-    const { suggestions, isLoading } = useMentionSuggestions({
+    const { agentConfigurations, isLoading: areAgentsLoading } =
+      useUnifiedAgentConfigurations({
+        workspaceId: owner.sId,
+        disabled: !select.agents,
+      });
+    const { conversationParticipants } = useConversationParticipants({
+      workspaceId: owner.sId,
+      conversationId,
+      options: { disabled: !select.agents || !conversationId },
+    });
+    const {
+      suggestions: serverSuggestions,
+      isLoading: areUsersLoading,
+      isSearching: isUserSearchInProgress,
+    } = useMentionSuggestions({
       workspaceId: owner.sId,
       conversationId,
       spaceId,
       query,
-      select,
+      select: { agents: false, users: select.users },
       includeCurrentUser,
+      disabled: !select.users,
     });
+
+    const lowerCaseQuery = query.toLowerCase();
+    const agentSuggestions = useMemo(() => {
+      if (!select.agents) {
+        return [];
+      }
+
+      const participantAgentsById = new Map(
+        (conversationParticipants?.agents ?? []).map((agent) => [
+          agent.configurationId,
+          agent,
+        ])
+      );
+      const activeAgents: RichAgentMentionInConversation[] = agentConfigurations
+        .filter((agent) => agent.status === "active")
+        .map((agent) => {
+          const participant = participantAgentsById.get(agent.sId);
+          return {
+            ...toRichAgentMentionType(agent),
+            isParticipant: participant !== undefined,
+            lastActivityAt: participant?.lastActivityAt,
+          };
+        });
+
+      const sidekickParticipant = participantAgentsById.get(
+        GLOBAL_AGENTS_SID.SIDEKICK
+      );
+      const candidates =
+        sidekickParticipant &&
+        !activeAgents.some((agent) => agent.id === GLOBAL_AGENTS_SID.SIDEKICK)
+          ? [
+              ...activeAgents,
+              {
+                type: "agent" as const,
+                id: sidekickParticipant.configurationId,
+                label: sidekickParticipant.name,
+                pictureUrl: sidekickParticipant.pictureUrl,
+                description: "",
+                isParticipant: true,
+                lastActivityAt: sidekickParticipant.lastActivityAt,
+              },
+            ]
+          : activeAgents;
+
+      return filterAndSortEditorSuggestionAgents(lowerCaseQuery, candidates);
+    }, [
+      agentConfigurations,
+      conversationParticipants?.agents,
+      lowerCaseQuery,
+      select.agents,
+    ]);
+    const userSuggestions = useMemo(
+      () =>
+        filterEditorSuggestionUsers(
+          lowerCaseQuery,
+          serverSuggestions.filter(isRichUserMention)
+        ),
+      [lowerCaseQuery, serverSuggestions]
+    );
+    const suggestions = useMemo(
+      () =>
+        interleaveMentionsPreservingAgentOrder(
+          agentSuggestions,
+          userSuggestions,
+          lowerCaseQuery,
+          null,
+          conversationId
+        ),
+      [agentSuggestions, conversationId, lowerCaseQuery, userSuggestions]
+    );
+    const isLoading =
+      suggestions.length === 0 &&
+      ((areAgentsLoading && agentConfigurations.length === 0) ||
+        areUsersLoading ||
+        isUserSearchInProgress);
 
     const selectedItemRef = useRef<HTMLDivElement>(null);
 

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -223,14 +223,6 @@ export const MentionDropdown = forwardRef<
       return null;
     }
 
-    // Generate a key based on content state to force remount when content size changes significantly.
-    // This ensures Radix UI recalculates collision detection and positioning.
-    const contentKey = isLoading
-      ? "loading"
-      : suggestions.length === 0
-        ? "empty"
-        : `results-${suggestions.length}`;
-
     // Don't render the dropdown if there are no results
     if (suggestions.length === 0 && !isLoading) {
       return null;
@@ -262,7 +254,6 @@ export const MentionDropdown = forwardRef<
           <div style={virtualTriggerStyle} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          key={contentKey}
           className="w-72"
           align="start"
           side="bottom"

--- a/front/lib/api/assistant/conversation/mention_suggestions.test.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.test.ts
@@ -1,10 +1,9 @@
+import { interleaveMentionsPreservingAgentOrder } from "@app/lib/mentions/editor/suggestion";
 import type {
   RichAgentMentionInConversation,
   RichUserMentionInConversation,
 } from "@app/types/assistant/mentions";
 import { describe, expect, it } from "vitest";
-
-import { interleaveMentionsPreservingAgentOrder } from "./mention_suggestions";
 
 const buildAgent = (
   id: number,

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -4,8 +4,8 @@ import { fetchConversationParticipants } from "@app/lib/api/assistant/participan
 import type { Authenticator } from "@app/lib/auth";
 import {
   filterAndSortEditorSuggestionAgents,
+  interleaveMentionsPreservingAgentOrder,
   SUGGESTION_DISPLAY_LIMIT,
-  SUGGESTION_PRIORITY,
   sortEditorSuggestionUsers,
 } from "@app/lib/mentions/editor/suggestion";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -22,124 +22,6 @@ import {
   toRichAgentMentionType,
   toRichUserMentionType,
 } from "@app/types/assistant/mentions";
-
-export function interleaveMentionsPreservingAgentOrder(
-  agents: RichAgentMentionInConversation[],
-  users: RichUserMentionInConversation[],
-  lowerCaseQuery: string = "",
-  lastMentionedId: string | null = null,
-  conversationId: string | null = null
-): RichMention[] {
-  if (users.length === 0) {
-    return [...agents];
-  }
-
-  if (agents.length === 0) {
-    return [...users];
-  }
-
-  let result: RichMention[] = [];
-
-  let agentIndex = 0;
-  let userIndex = 0;
-
-  for (let position = 0; position < SUGGESTION_DISPLAY_LIMIT; position += 1) {
-    // Break if we have exhausted both lists
-    if (agentIndex >= agents.length && userIndex >= users.length) {
-      break;
-    }
-
-    const nextUser = users[userIndex];
-    const nextAgent = agents[agentIndex];
-
-    // First fill in users participants
-    if (nextUser?.isParticipant) {
-      result.push(nextUser);
-      userIndex += 1;
-      continue;
-    }
-
-    // Then fill in agents participants
-    if (nextAgent?.isParticipant) {
-      result.push(nextAgent);
-      agentIndex += 1;
-      continue;
-    }
-
-    // If no more participants, prioritize users/agents who start with the query
-    const nextUserStartsWithQuery =
-      lowerCaseQuery &&
-      nextUser?.label?.toLowerCase().startsWith(lowerCaseQuery);
-    const nextAgentStartsWithQuery =
-      lowerCaseQuery &&
-      nextAgent?.label?.toLowerCase().startsWith(lowerCaseQuery);
-
-    // Our high priority agents first
-    if (
-      nextAgentStartsWithQuery &&
-      SUGGESTION_PRIORITY[nextAgent.id] !== undefined
-    ) {
-      result.push(nextAgent);
-      agentIndex += 1;
-      continue;
-    }
-    if (conversationId) {
-      // In a conversation, prioritize users over agents.
-      if (nextUserStartsWithQuery) {
-        result.push(nextUser);
-        userIndex += 1;
-        continue;
-      }
-      if (nextAgentStartsWithQuery) {
-        result.push(nextAgent);
-        agentIndex += 1;
-        continue;
-      }
-    } else {
-      // Outside a conversation, prioritize agents over users.
-      if (nextAgentStartsWithQuery) {
-        result.push(nextAgent);
-        agentIndex += 1;
-        continue;
-      }
-      if (nextUserStartsWithQuery) {
-        result.push(nextUser);
-        userIndex += 1;
-        continue;
-      }
-    }
-
-    // Then interleave agents and users
-    if (position % 3 === 2 && userIndex < users.length) {
-      // Every 3rd position: add a user if available
-      result.push(users[userIndex]);
-      userIndex += 1;
-    } else if (agentIndex < agents.length) {
-      // Other positions: add an agent if available
-      result.push(agents[agentIndex]);
-      agentIndex += 1;
-    } else if (userIndex < users.length) {
-      // Fallback: if no agents left, add remaining users
-      result.push(users[userIndex]);
-      userIndex += 1;
-    }
-  }
-
-  // Move last mentioned agent to first position if specified
-  if (lastMentionedId) {
-    const lastMentioned =
-      agents.find((s) => s.id === lastMentionedId) ??
-      users.find((s) => s.id === lastMentionedId);
-    if (lastMentioned) {
-      result = [
-        lastMentioned,
-        ...result.filter((suggestion) => suggestion.id !== lastMentionedId),
-      ];
-    }
-  }
-
-  return result.slice(0, SUGGESTION_DISPLAY_LIMIT);
-}
 
 /**
  * Normalizes the `select` query parameter of the mention suggestions endpoint

--- a/front/lib/mentions/editor/suggestion.test.ts
+++ b/front/lib/mentions/editor/suggestion.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   filterAndSortEditorSuggestionAgents,
+  filterEditorSuggestionUsers,
   SUGGESTION_PRIORITY,
   sortEditorSuggestionUsers,
 } from "./suggestion";
@@ -416,6 +417,27 @@ describe("filterAndSortEditorSuggestionAgents", () => {
         expect(favoriteIndex).toBeLessThan(nonFavoriteIndex);
       }
     });
+  });
+});
+
+describe("filterEditorSuggestionUsers", () => {
+  const users: RichUserMentionInConversation[] = [
+    {
+      type: "user",
+      id: "user-1",
+      label: "Alice Smith",
+      pictureUrl: "",
+      description: "asmith@example.com",
+    },
+  ];
+
+  it("filters stale user results by name", () => {
+    expect(filterEditorSuggestionUsers("bob", users)).toEqual([]);
+    expect(filterEditorSuggestionUsers("alice", users)).toEqual(users);
+  });
+
+  it("keeps users returned from an email search", () => {
+    expect(filterEditorSuggestionUsers("asmith", users)).toEqual(users);
   });
 });
 

--- a/front/lib/mentions/editor/suggestion.ts
+++ b/front/lib/mentions/editor/suggestion.ts
@@ -5,6 +5,7 @@ import {
 import type {
   RichAgentMention,
   RichAgentMentionInConversation,
+  RichMention,
   RichUserMentionInConversation,
 } from "@app/types/assistant/mentions";
 
@@ -23,6 +24,111 @@ export const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,
   [GLOBAL_AGENTS_SID.DEEP_DIVE]: 2,
 };
+
+export function interleaveMentionsPreservingAgentOrder(
+  agents: RichAgentMentionInConversation[],
+  users: RichUserMentionInConversation[],
+  lowerCaseQuery: string = "",
+  lastMentionedId: string | null = null,
+  conversationId: string | null = null
+): RichMention[] {
+  if (users.length === 0) {
+    return agents.slice(0, SUGGESTION_DISPLAY_LIMIT);
+  }
+
+  if (agents.length === 0) {
+    return users.slice(0, SUGGESTION_DISPLAY_LIMIT);
+  }
+
+  let result: RichMention[] = [];
+  let agentIndex = 0;
+  let userIndex = 0;
+
+  for (let position = 0; position < SUGGESTION_DISPLAY_LIMIT; position += 1) {
+    if (agentIndex >= agents.length && userIndex >= users.length) {
+      break;
+    }
+
+    const nextUser = users[userIndex];
+    const nextAgent = agents[agentIndex];
+
+    if (nextUser?.isParticipant) {
+      result.push(nextUser);
+      userIndex += 1;
+      continue;
+    }
+
+    if (nextAgent?.isParticipant) {
+      result.push(nextAgent);
+      agentIndex += 1;
+      continue;
+    }
+
+    const nextUserStartsWithQuery =
+      lowerCaseQuery &&
+      nextUser?.label?.toLowerCase().startsWith(lowerCaseQuery);
+    const nextAgentStartsWithQuery =
+      lowerCaseQuery &&
+      nextAgent?.label?.toLowerCase().startsWith(lowerCaseQuery);
+
+    if (
+      nextAgentStartsWithQuery &&
+      SUGGESTION_PRIORITY[nextAgent.id] !== undefined
+    ) {
+      result.push(nextAgent);
+      agentIndex += 1;
+      continue;
+    }
+    if (conversationId) {
+      if (nextUserStartsWithQuery) {
+        result.push(nextUser);
+        userIndex += 1;
+        continue;
+      }
+      if (nextAgentStartsWithQuery) {
+        result.push(nextAgent);
+        agentIndex += 1;
+        continue;
+      }
+    } else {
+      if (nextAgentStartsWithQuery) {
+        result.push(nextAgent);
+        agentIndex += 1;
+        continue;
+      }
+      if (nextUserStartsWithQuery) {
+        result.push(nextUser);
+        userIndex += 1;
+        continue;
+      }
+    }
+
+    if (position % 3 === 2 && userIndex < users.length) {
+      result.push(users[userIndex]);
+      userIndex += 1;
+    } else if (agentIndex < agents.length) {
+      result.push(agents[agentIndex]);
+      agentIndex += 1;
+    } else if (userIndex < users.length) {
+      result.push(users[userIndex]);
+      userIndex += 1;
+    }
+  }
+
+  if (lastMentionedId) {
+    const lastMentioned =
+      agents.find((suggestion) => suggestion.id === lastMentionedId) ??
+      users.find((suggestion) => suggestion.id === lastMentionedId);
+    if (lastMentioned) {
+      result = [
+        lastMentioned,
+        ...result.filter((suggestion) => suggestion.id !== lastMentionedId),
+      ];
+    }
+  }
+
+  return result.slice(0, SUGGESTION_DISPLAY_LIMIT);
+}
 
 function compareAgentSuggestionsForSort(
   a: RichAgentMention,
@@ -90,6 +196,17 @@ export function filterAndSortEditorSuggestionAgents(
         ) || compareAgentSuggestionsForSort(a, b)
       );
     });
+}
+
+export function filterEditorSuggestionUsers(
+  lowerCaseQuery: string,
+  suggestions: RichUserMentionInConversation[]
+) {
+  return suggestions.filter(
+    (item) =>
+      subFilter(lowerCaseQuery, item.label.toLowerCase()) ||
+      subFilter(lowerCaseQuery, item.description.toLowerCase())
+  );
 }
 
 export function sortEditorSuggestionUsers(

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -75,21 +75,26 @@ export function useMentionSuggestions({
       : `/api/w/${workspaceId}/assistant/mentions/suggestions`) +
     `?${searchParams.toString()}`;
 
-  const { data, error, mutate } = useSWRWithDefaults(url, suggestionsFetcher, {
-    // Keep previous data while fetching new suggestions for better UX
-    keepPreviousData: true,
-    // We don't revalidate on focus to avoid unnecessary requests
-    revalidateOnFocus: false,
-    // Don't revalidate on reconnect for better performance
-    revalidateOnReconnect: false,
-    // Cache suggestions for 5 minutes
-    dedupingInterval: 5 * 60 * 1000,
-    disabled,
-  });
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    url,
+    suggestionsFetcher,
+    {
+      // Keep previous data while fetching new suggestions for better UX
+      keepPreviousData: true,
+      // We don't revalidate on focus to avoid unnecessary requests
+      revalidateOnFocus: false,
+      // Don't revalidate on reconnect for better performance
+      revalidateOnReconnect: false,
+      // Cache suggestions for 5 minutes
+      dedupingInterval: 5 * 60 * 1000,
+      disabled,
+    }
+  );
 
   return {
     suggestions: data?.suggestions ?? [],
-    isLoading: !error && !data,
+    isLoading: !error && !data && !disabled,
+    isSearching: !disabled && (query !== debouncedSearchQuery || isValidating),
     isError: !!error,
     mutate,
   };


### PR DESCRIPTION
## Description

Agent mention autocomplete previously waited for the server to search both agents and users after
each query change, even though the input bar already loads the workspace's accessible agents.

This change filters cached agents immediately on the client while keeping user search server-side.
It preserves participant and Sidekick prioritization, filters stale user results during debounced
requests, and shares the existing interleaving logic between the client and server paths.

The dropdown now remains responsive while users are loading and avoids redundant server-side agent
searches.

## Tests

- `NODE_ENV=test npm test components/editor/input_bar/MentionDropdown.test.tsx lib/mentions/editor/suggestion.test.ts lib/api/assistant/conversation/mention_suggestions.test.ts`

## Risk

Low. User search and the API contract are unchanged. Agent suggestions now use the same cached agent
configuration list already loaded by the input bar, with focused coverage for local filtering,
server request selection, stale user results, and loading behavior.

## Deploy Plan

- deploy `front`
