### PR TITLE
Self-improving skill: fix permission issue to create skill suggestion

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -45,6 +45,7 @@ import type {
   GroupPermissionResourceType,
 } from "@app/types/group_permissions";
 import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
+import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
@@ -933,6 +934,9 @@ export class Authenticator {
     workspaceId: string,
     options?: {
       dangerouslyRequestAllGroups: boolean;
+      // Only applies when dangerouslyRequestAllGroups is true. Overrides the group kinds fetched,
+      // e.g. to include editor groups that are excluded by default.
+      groupKinds?: GroupKind[];
     }
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -945,6 +949,7 @@ export class Authenticator {
         if (options?.dangerouslyRequestAllGroups) {
           return GroupResource.internalFetchAllWorkspaceGroups({
             workspaceId: workspace.id,
+            ...(options.groupKinds ? { groupKinds: options.groupKinds } : {}),
           });
         } else {
           const globalGroup =

--- a/front/lib/reinforcement/utils.test.ts
+++ b/front/lib/reinforcement/utils.test.ts
@@ -1,0 +1,20 @@
+import { getAuthForWorkspace } from "@app/lib/reinforcement/utils";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { describe, expect, it } from "vitest";
+
+describe("getAuthForWorkspace", () => {
+  it("returns an auth that can edit skills", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "builder",
+    });
+    const skill = await SkillFactory.create(authenticator);
+
+    const auth = await getAuthForWorkspace(workspace.sId);
+
+    const fetchedSkill = await SkillResource.fetchById(auth, skill.sId);
+    expect(fetchedSkill).not.toBeNull();
+    expect(fetchedSkill?.canWrite(auth)).toBe(true);
+  });
+});

--- a/front/lib/reinforcement/utils.ts
+++ b/front/lib/reinforcement/utils.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { ExploratoryToolCallInfo } from "@app/lib/reinforcement/types";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import { GROUP_KINDS, isAgentEditorGroupKind } from "@app/types/groups";
 import { ApplicationFailure } from "@temporalio/common";
 
 export async function getAuthForWorkspace(
@@ -13,9 +14,11 @@ export async function getAuthForWorkspace(
       `Workspace not found: ${workspaceId}`
     );
   }
-  // The auth needs access to all groups to access conversations in projects.
+  // The auth needs access to all groups to access conversations in projects, including
+  // skill_editors groups (excluded by default) to create skill suggestions.
   return Authenticator.internalAdminForWorkspace(workspaceId, {
     dangerouslyRequestAllGroups: true,
+    groupKinds: GROUP_KINDS.filter((k) => !isAgentEditorGroupKind(k)),
   });
 }
 


### PR DESCRIPTION
## Description

Seems to be broken since https://github.com/dust-tt/dust/pull/28649
The auth needs skill editor groups to be allowed to create skill suggestion, because calling `SkillSuggestionResource.createSuggestionForSkill` requires skill.canWrite

## Tests

Added a unit test

## Risk

low

## Deploy Plan

deploy front 
