### PR TITLE
feat(front): support drag-and-drop and paste image uploads in agent builder sidekick

### DIFF
--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -5,12 +5,14 @@ import { BlockedActionsProvider } from "@app/components/assistant/conversation/B
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
+import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import {
   getSidekickSuggestionPlugin,
   sidekickSuggestionDirective,
 } from "@app/components/markdown/suggestion/SidekickSuggestionDirective";
+import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -113,15 +115,25 @@ function SidekickContent({
             </div>
           )}
           {user && (
-            <ConversationViewer
-              owner={owner}
-              user={user}
-              conversationId={conversation.sId}
-              agentBuilderContext={agentBuilderContext}
-              additionalMarkdownComponents={additionalMarkdownComponents}
-              additionalMarkdownPlugins={additionalMarkdownPlugins}
-              key={conversation.sId}
-            />
+            <FileDropProvider>
+              <DropzoneContainer
+                title="Attach files to Sidekick"
+                description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
+                // `relative` scopes the DropzoneOverlay to this panel (else it
+                // covers a far ancestor); `h-full` sizes it to the panel height.
+                className="relative min-h-0 h-full"
+              >
+                <ConversationViewer
+                  owner={owner}
+                  user={user}
+                  conversationId={conversation.sId}
+                  agentBuilderContext={agentBuilderContext}
+                  additionalMarkdownComponents={additionalMarkdownComponents}
+                  additionalMarkdownPlugins={additionalMarkdownPlugins}
+                  key={conversation.sId}
+                />
+              </DropzoneContainer>
+            </FileDropProvider>
           )}
         </div>
       </div>

--- a/front/components/misc/DropzoneContainer.tsx
+++ b/front/components/misc/DropzoneContainer.tsx
@@ -9,6 +9,7 @@ interface DropzoneContainerProps {
   description: string;
   title: string;
   disabled?: boolean;
+  className?: string;
 }
 
 export function DropzoneContainer({
@@ -16,6 +17,7 @@ export function DropzoneContainer({
   description,
   title,
   disabled,
+  className,
 }: DropzoneContainerProps) {
   const isMobile = useIsMobile();
   const { setDroppedFiles } = useFileDrop();
@@ -61,7 +63,7 @@ export function DropzoneContainer({
         "flex w-full flex-col items-center",
         isMobile
           ? MOBILE_DOCUMENT_SCROLL_CLASSES.dropzoneContainer
-          : "min-h-0 h-panel"
+          : (className ?? "min-h-0 h-panel")
       )}
       onPaste={onPaste}
     >


### PR DESCRIPTION
## Description
<img width="1512" height="860" alt="Screenshot 2026-07-20 at 11 29 35" src="https://github.com/user-attachments/assets/3b8ea13b-ee0d-49dc-9015-8f78dde2fd55" />

Closes https://github.com/dust-tt/tasks/issues/7757

Enables drag-and-drop and copy-paste of images (and other files) into the **Sidekick** panel of the agent builder.

The Sidekick already rendered the standard `ConversationViewer` → `InputBar` stack, and the `InputBar` already knows how to upload dropped files and shows the file-picker button. What was missing was the plumbing that captures OS drops and clipboard file pastes: in the main conversation this comes from `FileDropProvider` + `DropzoneContainer` (provided by `ConversationLayout`/`ConversationContainer`), but the agent builder does not sit under those layouts.

Changes:
- Wrap the Sidekick's `ConversationViewer` in `FileDropProvider` + `DropzoneContainer`, reusing the exact pattern from the main conversation. Files dropped/pasted now flow into the already-wired `InputBar` uploader.
- Add an optional `className` prop to `DropzoneContainer` so it can be sized for a nested panel. The default `h-panel` is a `100dvh`-based utility meant for the full-page conversation column and would overflow the Sidekick; the Sidekick passes `min-h-0 h-full` plus `relative` (the latter scopes the drop overlay to the panel instead of a far positioned ancestor). Existing consumers are unaffected.

## Tests

Manually verified in the agent builder Sidekick:
- Drag-and-drop an image onto the Sidekick panel → overlay appears scoped to the panel, file attaches.
- Copy-paste an image into the Sidekick input → file attaches.
- Confirmed the main conversation drop overlay is unchanged (no `relative` change leaked into the shared component base).
