### PR TITLE
[sdks/js] fix: retry fetch once when the connection closes before any response bytes

### DIFF
--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: "24.14.0"
       - name: Typecheck
         run: npm -w connectors run tsgo -- --version && npm -w connectors run tsgo
+      - name: Test SDK
+        run: npm -w sdks/js run test
       - name: Build Temporal Bundles
         working-directory: connectors
         env:

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -45,8 +45,9 @@ function isTimeoutError(e: unknown): boolean {
 
 const axiosWithTimeout = axios.create({
   timeout: 60000,
-  // Ensure client timeout is lower than the target server timeout.
-  // See --keepAliveTimeout in next start command from front.
+  // Keep-alive disabled: front's HTTP server closes idle connections (see
+  // KEEP_ALIVE_TIMEOUT_MS in front-api/server.ts) and axios has no safe
+  // stale-socket retry, so never reuse sockets.
   httpAgent: new http.Agent({ keepAlive: false }),
   httpsAgent: new https.Agent({ keepAlive: false }),
 });
@@ -520,7 +521,8 @@ export async function renderPrefixSection({
   };
 }
 
-// At 5mn, likeliness of connection close increases significantly. The timeout is set at 4mn30.
+// Client-side guard for slow tokenize calls on very large payloads; unrelated
+// to connection keep-alive.
 const TOKENIZE_TIMEOUT_MS = 270000;
 
 async function tokenize(text: string, ds: DataSourceConfig) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58315,7 +58315,7 @@
     },
     "sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",
@@ -58333,7 +58333,8 @@
         "esbuild": "^0.27.3",
         "npm-watch": "^0.11.0",
         "tslib": "^2.6.2",
-        "tsx": "^4.19.1"
+        "tsx": "^4.19.1",
+        "vitest": "^4.0.16"
       },
       "engines": {
         "node": ">=24.16.0"

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "engines": {
     "node": ">=24.16.0"
   },
@@ -24,6 +24,7 @@
     "build": "npm run build:types && npm run build:bundle",
     "build:types": "tsgo",
     "build:bundle": "tsx esbuild.config.ts",
+    "test": "vitest --run",
     "watch": "npm-watch",
     "tsgo": "tsgo"
   },
@@ -36,7 +37,8 @@
     "esbuild": "^0.27.3",
     "npm-watch": "^0.11.0",
     "tslib": "^2.6.2",
-    "tsx": "^4.19.1"
+    "tsx": "^4.19.1",
+    "vitest": "^4.0.16"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",

--- a/sdks/js/src/index.test.ts
+++ b/sdks/js/src/index.test.ts
@@ -1,0 +1,178 @@
+import type { Socket } from "node:net";
+import { createServer } from "node:net";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DustAPI } from "./index";
+import type { LoggerInterface } from "./types";
+
+const RETRY_LOG_MESSAGE =
+  "DustAPI retrying fetch after connection closed before response";
+
+let closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const toClose = closers;
+  closers = [];
+  await Promise.all(toClose.map((close) => close()));
+});
+
+// Raw TCP server so each connection can misbehave at the exact protocol stage
+// the retry logic discriminates on (before vs after response bytes).
+async function listen(
+  onConnection: (socket: Socket, connectionIndex: number) => void
+): Promise<{
+  port: number;
+  connectionCount: () => number;
+  close: () => Promise<void>;
+}> {
+  const sockets = new Set<Socket>();
+  let connections = 0;
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    const index = connections;
+    connections += 1;
+    onConnection(socket, index);
+  });
+  // Destroy straggler sockets first: server.close() alone waits for open
+  // connections and would hang the suite.
+  const close = () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      server.close(() => resolve());
+    });
+  closers.push(close);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected the test server to be bound to a TCP port");
+  }
+  return {
+    port: address.port,
+    connectionCount: () => connections,
+    close,
+  };
+}
+
+// Reads the full request (headers + content-length body) then serves a JSON 200.
+function respondWithJson(socket: Socket, payload: unknown) {
+  let buffered = "";
+  socket.on("data", (chunk) => {
+    buffered += chunk.toString();
+    const headerEnd = buffered.indexOf("\r\n\r\n");
+    if (headerEnd === -1) {
+      return;
+    }
+    const contentLengthMatch = buffered
+      .slice(0, headerEnd)
+      .match(/content-length: (\d+)/i);
+    const contentLength = contentLengthMatch
+      ? parseInt(contentLengthMatch[1], 10)
+      : 0;
+    if (buffered.length < headerEnd + 4 + contentLength) {
+      return;
+    }
+    const body = JSON.stringify(payload);
+    socket.end(
+      `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`
+    );
+  });
+}
+
+function makeLogger(): LoggerInterface {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+function makeAPI(port: number, logger: LoggerInterface) {
+  return new DustAPI(
+    { url: `http://127.0.0.1:${port}` },
+    { apiKey: "test-api-key", workspaceId: "test-workspace" },
+    logger
+  );
+}
+
+describe("DustAPI fetch retry on connection closed before response", () => {
+  it("retries once and succeeds when the server closes the connection before responding", async () => {
+    const server = await listen((socket, index) => {
+      if (index === 0) {
+        // Incident shape: the server FINs the connection upon receiving the
+        // request, before writing any response bytes (stale keep-alive close).
+        socket.once("data", () => socket.end());
+      } else {
+        respondWithJson(socket, { tokens: [] });
+      }
+    });
+    const logger = makeLogger();
+
+    const res = await makeAPI(server.port, logger).tokenize("hello", "ds-1");
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toEqual([]);
+    }
+    expect(server.connectionCount()).toBe(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "POST" }),
+      RETRY_LOG_MESSAGE
+    );
+  });
+
+  it("does not retry when the caller aborted the request", async () => {
+    const server = await listen((socket) =>
+      respondWithJson(socket, { tokens: [] })
+    );
+    const logger = makeLogger();
+    const controller = new AbortController();
+    controller.abort();
+
+    const res = await makeAPI(server.port, logger).tokenize("hello", "ds-1", {
+      signal: controller.signal,
+    });
+
+    expect(res.isErr()).toBe(true);
+    expect(server.connectionCount()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not retry when the connection is refused", async () => {
+    // Bind a port then release it so the subsequent connect is refused.
+    const server = await listen(() => {});
+    const { port } = server;
+    await server.close();
+    const logger = makeLogger();
+
+    const res = await makeAPI(port, logger).tokenize("hello", "ds-1");
+
+    expect(res.isErr()).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not retry when the connection dies after the response started", async () => {
+    const server = await listen((socket) => {
+      socket.once("data", () => {
+        // Advertise a 100-byte body but cut the connection mid-body: the
+        // failure surfaces from the body read, not fetch(), and must NOT be
+        // retried (the server may have processed the request).
+        socket.write(
+          'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{"tokens":',
+          () => socket.destroy()
+        );
+      });
+    });
+    const logger = makeLogger();
+
+    const res = await makeAPI(server.port, logger).tokenize("hello", "ds-1");
+
+    expect(res.isErr()).toBe(true);
+    expect(server.connectionCount()).toBe(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1,7 +1,7 @@
 import { createParser } from "eventsource-parser";
 import type { z } from "zod";
 
-import { normalizeError } from "./error_utils";
+import { errorToString, normalizeError } from "./error_utils";
 import { AgentsAPI } from "./high_level/agents";
 import { ConversationsAPI } from "./high_level/conversations";
 import { FilesAPI } from "./high_level/files";
@@ -144,6 +144,31 @@ function isStreamTerminationError(e: unknown): boolean {
   }
   return patterns.some((p) => p.test(msg));
 }
+
+// Detects a fetch() rejection caused by the connection dying before any response
+// bytes were received (typically a pooled keep-alive socket the server closed while
+// our request was in flight). Distinct from isStreamTerminationError, which covers
+// mid-stream/post-response failures and includes aborts (never retryable here).
+function isConnectionClosedError(e: unknown): boolean {
+  if (!(e instanceof TypeError)) {
+    return false;
+  }
+  const cause = "cause" in e ? e.cause : undefined;
+  if (!(cause instanceof Error)) {
+    return false;
+  }
+  const code = "code" in cause ? cause.code : undefined;
+  return (
+    code === "UND_ERR_SOCKET" ||
+    code === "ECONNRESET" ||
+    code === "EPIPE" ||
+    /other side closed|socket hang up/i.test(cause.message)
+  );
+}
+
+// Delay before the single retry in _fetchWithError — yields a full event-loop
+// turn so undici processes pending FINs and evicts stale pooled sockets first.
+const CONNECTION_CLOSED_RETRY_DELAY_MS = 100;
 
 function isTransientHttpStatus(status: number): boolean {
   // Only retry on explicit transient statuses; do NOT retry on 5xx.
@@ -2261,13 +2286,28 @@ export class DustAPI {
     } = {}
   ): Promise<Result<{ response: DustResponse; duration: number }, APIError>> {
     const now = Date.now();
+    const init = { method, headers, body, signal };
     try {
-      const res = await fetch(url, {
-        method,
-        headers,
-        body,
-        signal,
-      });
+      let res: Response;
+      try {
+        res = await fetch(url, init);
+      } catch (e) {
+        // Single retry when the connection died before any response bytes were
+        // received (stale keep-alive socket closed by the server). fetch() can
+        // only reject before response headers, so the server cannot have started
+        // responding and the string body is safe to re-send.
+        if (!isConnectionClosedError(e) || signal?.aborted) {
+          throw e;
+        }
+        this._logger.warn(
+          { url, method, error: e },
+          "DustAPI retrying fetch after connection closed before response"
+        );
+        await new Promise((resolve) =>
+          setTimeout(resolve, CONNECTION_CLOSED_RETRY_DELAY_MS)
+        );
+        res = await fetch(url, init);
+      }
 
       const responseBody = stream && res.body ? res.body : await res.text();
 
@@ -2283,7 +2323,7 @@ export class DustAPI {
       const duration = Date.now() - now;
       const err: APIError = {
         type: "unexpected_network_error",
-        message: `Unexpected network error from DustAPI: ${e}`,
+        message: `Unexpected network error from DustAPI: ${errorToString(e)}`,
       };
       this._logger.error(
         {

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description

front-api closes idle keep-alive connections after 5s (`front-api/server.ts`), that being said we encounter cases on connector where we expect the connection to be still there past that, and we have an uncaught exception bubble all the way to top.

This PR aims at retrying a fetch in case of a socket hang up on the other side at the dust-api client level


## Risk

Low - at most one extra request, only on pre-response connection death. No-op in browsers.

## Deploy Plan

- [ ] deploy `connectors`
- [ ] dispatch `publish-sdk-client.yml` (`@dust-tt/client@1.2.8`)