### PR TITLE
perf: throttle sandbox runtime refreshes

### DIFF
--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -70,11 +70,23 @@ vi.mock("@app/lib/api/sandbox/telemetry", () => ({
   startTelemetry: mockStartTelemetry,
 }));
 
-vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
-  ConversationSandboxAdapter: {
-    ensureSandboxActive: mockEnsureSandboxActive,
-  },
-}));
+vi.mock(
+  "@app/lib/resources/conversation_sandbox_adapter",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/resources/conversation_sandbox_adapter")
+      >();
+    return {
+      ConversationSandboxAdapter: {
+        ensureSandboxActive: mockEnsureSandboxActive,
+        fetchSandbox: actual.ConversationSandboxAdapter.fetchSandbox.bind(
+          actual.ConversationSandboxAdapter
+        ),
+      },
+    };
+  }
+);
 
 vi.mock("@app/lib/resources/pod_sandbox_adapter", () => ({
   PodSandboxAdapter: {
@@ -93,6 +105,13 @@ vi.mock("@app/logger/logger", () => {
   return { default: logger };
 });
 
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import {
   ensureConversationSandboxReady,
   ensurePodSandboxReady,
@@ -112,11 +131,11 @@ function createDeferred<T>() {
 }
 
 describe("ensureConversationSandboxReady", () => {
-  const auth = { getNonNullableWorkspace: () => ({ sId: "workspace-id" }) };
-  const conversation = { sId: "conversation-id" };
-  const conversationOwner = {
-    kind: "conversation",
-    conversationId: conversation.sId,
+  let auth: Authenticator;
+  let conversation: ConversationType;
+  let conversationOwner: {
+    kind: "conversation";
+    conversationId: string;
   };
   const pod = { sId: "space-id" };
   const podOwner = {
@@ -124,19 +143,27 @@ describe("ensureConversationSandboxReady", () => {
     spaceId: pod.sId,
   };
   const image = { name: "dust-base" };
-  const mockRequestKill = vi.fn().mockResolvedValue(undefined);
-  const sandbox = {
-    providerId: "provider-id",
-    sId: "sandbox-id",
-    requestKill: mockRequestKill,
-  };
+  let sandbox: SandboxResource;
   const mockFs = {
     setupSandboxMount: mockSetupSandboxMount,
     refreshSandboxMount: mockRefreshSandboxMount,
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    const testSetup = await createResourceTest({ role: "admin" });
+    auth = testSetup.authenticator;
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    conversationOwner = {
+      kind: "conversation",
+      conversationId: conversation.sId,
+    };
+    sandbox = await SandboxFactory.create(auth, conversation);
 
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
@@ -185,6 +212,7 @@ describe("ensureConversationSandboxReady", () => {
       egressPolicyOwnerId: conversation.sId,
       wokeFromSleep: false,
     });
+    expect(sandbox.lastRuntimeRefreshAt).toEqual(expect.any(Date));
 
     expect(mockSetupSandboxMount.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]
@@ -195,7 +223,7 @@ describe("ensureConversationSandboxReady", () => {
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
-    const podConversation = { sId: "conversation-id", spaceId: "space-id" };
+    const podConversation = { sId: conversation.sId, spaceId: "space-id" };
 
     const result = await ensureConversationSandboxReady(
       auth as never,
@@ -250,6 +278,7 @@ describe("ensureConversationSandboxReady", () => {
   });
 
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {
+    await sandbox.updateLastRuntimeRefreshAt(new Date());
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: true })
     );
@@ -277,10 +306,10 @@ describe("ensureConversationSandboxReady", () => {
   });
 
   it("refreshes the GCS token for already-running sandboxes", async () => {
-    const result = await ensureConversationSandboxReady(
-      auth as never,
-      conversation as never
-    );
+    const staleRefreshAt = new Date(Date.now() - 6 * 60 * 1000);
+    await sandbox.updateLastRuntimeRefreshAt(staleRefreshAt);
+
+    const result = await ensureConversationSandboxReady(auth, conversation);
 
     expect(result.isOk()).toBe(true);
     expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
@@ -291,6 +320,23 @@ describe("ensureConversationSandboxReady", () => {
     expect(mockRefreshSandboxMount.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]
     );
+    expect(sandbox.lastRuntimeRefreshAt?.getTime()).toBeGreaterThan(
+      staleRefreshAt.getTime()
+    );
+  });
+
+  it("skips GCS and egress refreshes for recently-refreshed sandboxes", async () => {
+    const recentRefreshAt = new Date(Date.now() - 4 * 60 * 1000);
+    await sandbox.updateLastRuntimeRefreshAt(recentRefreshAt);
+
+    const result = await ensureConversationSandboxReady(auth, conversation);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetSandboxImage).not.toHaveBeenCalled();
+    expect(mockForConversation).not.toHaveBeenCalled();
+    expect(mockRefreshSandboxMount).not.toHaveBeenCalled();
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
+    expect(sandbox.lastRuntimeRefreshAt).toEqual(recentRefreshAt);
   });
 
   it("uses pod owner plumbing and pod filesystem mounts for pod sandboxes", async () => {
@@ -372,7 +418,7 @@ describe("ensureConversationSandboxReady", () => {
     if (result.isErr()) {
       expect(result.error).toBe(podStateError);
     }
-    expect(mockRequestKill).toHaveBeenCalledTimes(1);
+    expect(sandbox.killRequestedAt).toEqual(expect.any(Date));
     expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
   });
 
@@ -497,6 +543,7 @@ describe("ensureConversationSandboxReady", () => {
 
     expect(result.isErr()).toBe(true);
     expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
+    expect(sandbox.lastRuntimeRefreshAt).toBeNull();
   });
 
   it("short-circuits when ensure-on-exec fails", async () => {
@@ -511,5 +558,6 @@ describe("ensureConversationSandboxReady", () => {
 
     expect(result.isErr()).toBe(true);
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledTimes(1);
+    expect(sandbox.lastRuntimeRefreshAt).toBeNull();
   });
 });

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -24,6 +24,8 @@ import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok, type Result } from "@app/types/shared/result";
 
+const SANDBOX_RUNTIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 export interface EnsureSandboxReadyResult {
   sandbox: SandboxResource;
   freshlyCreated: boolean;
@@ -71,6 +73,23 @@ async function ensureOwnerSandboxReady(
       const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
       cold = freshlyCreated;
 
+      const shouldRefreshRuntime =
+        freshlyCreated ||
+        wokeFromSleep ||
+        !sandbox.lastRuntimeRefreshAt ||
+        Date.now() - sandbox.lastRuntimeRefreshAt.getTime() >=
+          SANDBOX_RUNTIME_REFRESH_INTERVAL_MS;
+
+      if (freshlyCreated || wokeFromSleep) {
+        void startTelemetry(auth, sandbox, runtimeOwner).catch((err) =>
+          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+        );
+      }
+
+      if (!shouldRefreshRuntime) {
+        return new Ok({ sandbox, freshlyCreated });
+      }
+
       // Synchronous and cheap: not worth a span (it would always read ~0ms).
       const imageResult = getSandboxImage(auth);
       if (imageResult.isErr()) {
@@ -82,12 +101,6 @@ async function ensureOwnerSandboxReady(
         return imageResult;
       }
       const image = imageResult.value;
-
-      if (freshlyCreated || wokeFromSleep) {
-        void startTelemetry(auth, sandbox, runtimeOwner).catch((err) =>
-          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
-        );
-      }
 
       // Only mount on first creation. e2b preserves the FUSE mount and the
       // token server across betaPause + connect (verified empirically), so on
@@ -179,6 +192,8 @@ async function ensureOwnerSandboxReady(
         status = "error";
         return ensureEgressResult;
       }
+
+      await sandbox.updateLastRuntimeRefreshAt(new Date());
 
       return new Ok({ sandbox, freshlyCreated });
     });

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -9,6 +9,7 @@ const {
   mockProviderCreate,
   mockProviderDestroy,
   mockProviderExec,
+  mockProviderWake,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockDeleteLegacySandboxPolicy: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockProviderCreate: vi.fn(),
   mockProviderDestroy: vi.fn(),
   mockProviderExec: vi.fn(),
+  mockProviderWake: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
 
@@ -709,6 +711,7 @@ describe("SandboxResource.ensureActive", () => {
       create: mockProviderCreate,
       destroy: mockProviderDestroy,
       exec: mockProviderExec,
+      wake: mockProviderWake,
     });
     mockGetSandboxImage.mockReturnValue(
       new Ok({
@@ -725,6 +728,7 @@ describe("SandboxResource.ensureActive", () => {
       })
     );
     mockProviderCreate.mockResolvedValue(new Ok({ providerId: "provider-id" }));
+    mockProviderWake.mockResolvedValue(new Ok(undefined));
     mockProviderExec.mockResolvedValue(
       new Ok({ exitCode: 0, stdout: "", stderr: "" })
     );
@@ -863,11 +867,12 @@ describe("SandboxResource.ensureActive", () => {
   });
 
   it("refreshes baseImage and version when recreating from a deleted row", async () => {
-    await SandboxFactory.create(authenticator, conversation, {
+    const stale = await SandboxFactory.create(authenticator, conversation, {
       status: "deleted",
       baseImage: "stale-image",
       version: "0.0.0-old",
     });
+    await stale.updateLastRuntimeRefreshAt(new Date());
 
     const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
@@ -883,7 +888,27 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
     expect(persisted?.providerId).toBe("provider-id");
+    expect(persisted?.lastRuntimeRefreshAt).toBeNull();
     expect(mockProviderExec).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the runtime refresh timestamp after wake", async () => {
+    const sleeping = await SandboxFactory.create(authenticator, conversation, {
+      status: "sleeping",
+    });
+    await sleeping.updateLastRuntimeRefreshAt(new Date());
+
+    const result = await ConversationSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    const persisted = await ConversationSandboxAdapter.fetchSandbox(
+      authenticator,
+      conversation
+    );
+    expect(persisted?.lastRuntimeRefreshAt).toBeNull();
   });
 
   it("destroys and recreates when killRequestedAt is set on the existing row", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -298,6 +298,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return this.update({ lastActivityAt: new Date() }, transaction);
   }
 
+  async updateLastRuntimeRefreshAt(
+    lastRuntimeRefreshAt: Date | null
+  ): Promise<[affectedCount: number]> {
+    return this.update({ lastRuntimeRefreshAt });
+  }
+
   /**
    * Mark this sandbox for destruction: the reaper's kill sweep destroys it,
    * and ensureActive's kill-requested branch destroys-and-recreates it on the
@@ -647,6 +653,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             baseImage: createConfig.imageId.imageName,
             version: createConfig.imageId.tag,
             killRequestedAt: null,
+            lastRuntimeRefreshAt: null,
           });
           freshlyCreated = true;
 
@@ -662,6 +669,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
         default:
           assertNever(effectiveStatus);
+      }
+
+      if (wokeFromSleep) {
+        await existing.updateLastRuntimeRefreshAt(null);
       }
 
       await existing.updateStatus("running", { ctx });
@@ -1209,6 +1220,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       providerId: this.providerId,
       status: this.status,
       lastActivityAt: this.lastActivityAt.toISOString(),
+      lastRuntimeRefreshAt: this.lastRuntimeRefreshAt?.toISOString() ?? null,
       baseImage: this.baseImage,
       version: this.version,
       killRequestedAt: this.killRequestedAt?.toISOString() ?? null,

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -19,6 +19,7 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare status: SandboxStatus;
   declare statusChangedAt: CreationOptional<Date>;
   declare lastActivityAt: Date;
+  declare lastRuntimeRefreshAt: CreationOptional<Date | null>;
   declare baseImage: CreationOptional<string | null>;
   declare version: CreationOptional<string | null>;
   declare killRequestedAt: CreationOptional<Date | null>;
@@ -53,6 +54,10 @@ SandboxModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    lastRuntimeRefreshAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     baseImage: {
       type: DataTypes.STRING,

--- a/front/migrations/pre-deploy/20260720103335_add_last_runtime_refresh_at_to_sandboxes.sql
+++ b/front/migrations/pre-deploy/20260720103335_add_last_runtime_refresh_at_to_sandboxes.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandboxes" ADD COLUMN "lastRuntimeRefreshAt" timestamp with time zone;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Warm sandbox executions currently refresh the GCS credential and run the egress health check before every command. Representative traces show ~ 370 ms for GCS and ~ 418 ms for egress, adding hundreds of ms even when both were refreshed moments earlier.

This change stores the last successful runtime refresh timestamp in the database. Warm executions refreshed within the previous five minutes skip both operations and avoid any additional sandbox roundtrip.

Missing or expired timestamps trigger the existing GCS refresh followed by the egress health check. The
timestamp advances only after both operations succeed. If either fails, execution remains blocked and the timestamp is unchanged, ensuring subsequent commands retry instead of treating a partial refresh as valid.

Cold starts and sandbox wakes always bypass the guard. Wakes and provider recreation invalidate any previous timestamp so a recent value from the former runtime cannot suppress required initialization or retries.

Concurrent requests at the five-minute boundary may perform duplicate refreshes, but this is safe and avoids introducing another distributed lock or local cache.

The new database column is nullable, making the migration safe for existing rows. Existing sandboxes perform one refresh on their first execution after deployment.

Moved the tests to use a persisted database-backed sandbox resources.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply SQL migration
- [ ] Deploy front
