### PR TITLE
Self-improving skills: Delete the batch in a separate activity

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -388,6 +388,11 @@ export interface BatchDownloadResult {
 /**
  * Download batch results from the LLM and store them as agent messages in the
  * corresponding conversations.
+ *
+ * Note: the batch is NOT deleted here. Deleting it inside this function would make callers
+ * non-idempotent (a retry after a downstream failure would 404 on getBatchResult). Callers are
+ * responsible for guaranteeing deletion once the results are consumed (e.g. via a dedicated
+ * Temporal activity in a workflow-level finally block).
  */
 export async function downloadBatchResultFromLlm(
   auth: Authenticator,
@@ -425,20 +430,6 @@ export async function downloadBatchResultFromLlm(
       { runIds: [dustRunId] }
     );
     storedResultInfo.set(conversationId, info);
-  }
-
-  const deleted = await llm.deleteBatch(batchId);
-  if (!deleted) {
-    const metadata = llm.getMetadata();
-    logger.warn(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        providerId: metadata.clientId,
-        modelId: metadata.modelId,
-        batchId,
-      },
-      "Failed to delete batch after downloading results"
-    );
   }
 
   return { events, storedResultInfo };

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -33,7 +33,12 @@ import {
   getModel,
 } from "@app/lib/api/llm/clients/anthropic/utils/vertex";
 import { LLM } from "@app/lib/api/llm/llm";
-import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchDeletionOutcome,
+  BatchResult,
+  BatchStatus,
+} from "@app/lib/api/llm/types/batch";
+import { isBatchNotFoundError } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
@@ -51,6 +56,9 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
@@ -385,9 +393,18 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     return batch.id;
   }
 
-  override async deleteBatch(batchId: string): Promise<boolean> {
-    await this.client.messages.batches.delete(batchId);
-    return true;
+  override async deleteBatch(
+    batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    try {
+      await this.client.messages.batches.delete(batchId);
+      return new Ok("deleted");
+    } catch (err) {
+      if (isBatchNotFoundError(err)) {
+        return new Ok("do_not_exist");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -18,7 +18,12 @@ import {
   toToolConfigParam,
 } from "@app/lib/api/llm/clients/google/utils/to_thinking";
 import { LLM } from "@app/lib/api/llm/llm";
-import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchDeletionOutcome,
+  BatchResult,
+  BatchStatus,
+} from "@app/lib/api/llm/types/batch";
+import { isBatchNotFoundError } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
@@ -30,7 +35,10 @@ import type {
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { ApiError, GoogleGenAI, JobState } from "@google/genai";
 import assert from "assert";
 import { z } from "zod";
@@ -216,10 +224,19 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     return GoogleLLM.encodeBatchId(batch.name, customIds);
   }
 
-  override async deleteBatch(batchId: string): Promise<boolean> {
-    const { batchName } = GoogleLLM.decodeBatchId(batchId);
-    await this.client.batches.delete({ name: batchName });
-    return true;
+  override async deleteBatch(
+    batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    try {
+      const { batchName } = GoogleLLM.decodeBatchId(batchId);
+      await this.client.batches.delete({ name: batchName });
+      return new Ok("deleted");
+    } catch (err) {
+      if (isBatchNotFoundError(err)) {
+        return new Ok("do_not_exist");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -18,7 +18,12 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/clients/mistral/utils/mistral_to_events";
 import { LLM } from "@app/lib/api/llm/llm";
-import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchDeletionOutcome,
+  BatchResult,
+  BatchStatus,
+} from "@app/lib/api/llm/types/batch";
+import { isBatchNotFoundError } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
@@ -29,7 +34,10 @@ import type {
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Mistral } from "@mistralai/mistralai";
 import type { ChatCompletionRequest } from "@mistralai/mistralai/models/components";
 import {
@@ -157,19 +165,30 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     return job.id;
   }
 
-  override async deleteBatch(batchId: string): Promise<boolean> {
-    const job = await this.client.batch.jobs.get({ jobId: batchId });
+  override async deleteBatch(
+    batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    try {
+      const job = await this.client.batch.jobs.get({ jobId: batchId });
 
-    const fileIds = [job.inputFiles, job.outputFile]
-      .flat()
-      .filter((id): id is string => !!id);
+      const fileIds = [job.inputFiles, job.outputFile]
+        .flat()
+        .filter((id): id is string => !!id);
 
-    // At most 2 elements (input + output files).
-    const results = await Promise.all(
-      fileIds.map((fileId) => this.client.files.delete({ fileId }))
-    );
+      // At most 2 elements (input + output files).
+      const results = await Promise.all(
+        fileIds.map((fileId) => this.client.files.delete({ fileId }))
+      );
 
-    return results.every((result) => result.deleted);
+      return results.every((result) => result.deleted)
+        ? new Ok("deleted")
+        : new Err(new Error(`Failed to delete batch files for ${batchId}`));
+    } catch (err) {
+      if (isBatchNotFoundError(err)) {
+        return new Ok("do_not_exist");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -4,7 +4,12 @@ import {
   overwriteLLMParameters,
 } from "@app/lib/api/llm/clients/openai/types";
 import { LLM } from "@app/lib/api/llm/llm";
-import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchDeletionOutcome,
+  BatchResult,
+  BatchStatus,
+} from "@app/lib/api/llm/types/batch";
+import { isBatchNotFoundError } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
@@ -28,7 +33,10 @@ import {
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import { APIError, OpenAI, toFile } from "openai";
 import type {
@@ -183,19 +191,30 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return batch.id;
   }
 
-  override async deleteBatch(batchId: string): Promise<boolean> {
-    const batch = await this.client.batches.retrieve(batchId);
+  override async deleteBatch(
+    batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    try {
+      const batch = await this.client.batches.retrieve(batchId);
 
-    const fileIds = [batch.input_file_id, batch.output_file_id].filter(
-      (id): id is string => !!id
-    );
+      const fileIds = [batch.input_file_id, batch.output_file_id].filter(
+        (id): id is string => !!id
+      );
 
-    // At most 2 elements (input + output files).
-    const results = await Promise.all(
-      fileIds.map((fileId) => this.client.files.delete(fileId))
-    );
+      // At most 2 elements (input + output files).
+      const results = await Promise.all(
+        fileIds.map((fileId) => this.client.files.delete(fileId))
+      );
 
-    return results.every((result) => result.deleted);
+      return results.every((result) => result.deleted)
+        ? new Ok("deleted")
+        : new Err(new Error(`Failed to delete batch files for ${batchId}`));
+    } catch (err) {
+      if (isBatchNotFoundError(err)) {
+        return new Ok("do_not_exist");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -9,6 +9,7 @@ import type {
   LLMTraceCustomization,
 } from "@app/lib/api/llm/traces/types";
 import type {
+  BatchDeletionOutcome,
   BatchResult,
   BatchResultWithRunIds,
   BatchStatus,
@@ -36,6 +37,8 @@ import type {
   ModelProviderIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import { type LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
@@ -480,11 +483,13 @@ export abstract class LLM<TPayload = unknown> {
   }
 
   /**
-   * Delete a batch. Returns true if the batch was successfully deleted.
-   * By default returns false (deletion not supported).
+   * Delete a batch's data on the provider.
+   * By default the provider does not support deletion.
    */
-  async deleteBatch(_batchId: string): Promise<boolean> {
-    return false;
+  async deleteBatch(
+    _batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    return new Ok("unsupported");
   }
 
   /**

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -322,7 +322,10 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
           }
 
           const deleted = await llm.deleteBatch(batchId);
-          expect(deleted).toBe(true);
+          expect(deleted.isOk()).toBe(true);
+          if (deleted.isOk()) {
+            expect(deleted.value).toBe("deleted");
+          }
         },
         TEST_TIMEOUT_MS
       );

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,5 +1,9 @@
 import { LLM } from "@app/lib/api/llm/llm";
-import type { BatchResult } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchDeletionOutcome,
+  BatchResult,
+} from "@app/lib/api/llm/types/batch";
+import { isBatchNotFoundError } from "@app/lib/api/llm/types/batch";
 import {
   handleGenericError,
   type LLMErrorType,
@@ -70,7 +74,10 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 
 /**
@@ -887,7 +894,17 @@ export class BatchEndpointTransition extends BaseTransition {
     return batchResult;
   }
 
-  override async deleteBatch(batchId: string): Promise<boolean> {
-    return this.model.deleteBatch(batchId);
+  override async deleteBatch(
+    batchId: string
+  ): Promise<Result<BatchDeletionOutcome, Error>> {
+    try {
+      const deleted = await this.model.deleteBatch(batchId);
+      return new Ok(deleted ? "deleted" : "unsupported");
+    } catch (err) {
+      if (isBatchNotFoundError(err)) {
+        return new Ok("do_not_exist");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 }

--- a/front/lib/api/llm/types/batch.ts
+++ b/front/lib/api/llm/types/batch.ts
@@ -9,6 +9,28 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 export type BatchStatus = "computing" | "ready" | "aborted";
 
 /**
+ * Outcome of a batch deletion:
+ * - "deleted": the batch data was deleted from the provider.
+ * - "do_not_exist": the batch no longer exists on the provider.
+ * - "unsupported": the provider does not support batch deletion.
+ */
+export type BatchDeletionOutcome = "deleted" | "do_not_exist" | "unsupported";
+
+/**
+ * Check whether a provider SDK error is an HTTP 404 (batch or file not found).
+ * Provider SDKs expose the HTTP status as `status` (Anthropic, OpenAI, Google)
+ * or `statusCode` (Mistral).
+ */
+export function isBatchNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (("status" in err && err.status === 404) ||
+      ("statusCode" in err && err.statusCode === 404))
+  );
+}
+
+/**
  * Maps each conversation's custom_id to the sequence of LLM events produced for it.
  */
 export type BatchResult = Map<string, LLMEvent[]>;

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -1062,6 +1062,66 @@ export async function checkBatchStatusActivity({
   return llm.getBatchStatus(batchId);
 }
 
+function isBatchNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    err.status === 404
+  );
+}
+
+/**
+ * Delete a batch's data on the provider once its results have been consumed.
+ * Idempotent: a batch that no longer exists is treated as already deleted, so
+ * the activity can be safely retried.
+ */
+export async function deleteBatchActivity({
+  workspaceId,
+  batchId,
+}: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const llm = await getReinforcedSkillsLLM(
+    auth,
+    "reinforcement_analyze_conversation"
+  );
+  if (!llm) {
+    throw ApplicationFailure.nonRetryable(
+      "ReinforcedSkills: no LLM available for batch deletion"
+    );
+  }
+
+  try {
+    const deleted = await llm.deleteBatch(batchId);
+    if (!deleted) {
+      const metadata = llm.getMetadata();
+      logger.warn(
+        {
+          workspaceId,
+          providerId: metadata.clientId,
+          modelId: metadata.modelId,
+          batchId,
+        },
+        "ReinforcedSkills: Failed to delete batch"
+      );
+    }
+  } catch (err) {
+    // The batch may already have been deleted by a previous attempt of this activity.
+    if (isBatchNotFoundError(err)) {
+      logger.info(
+        { workspaceId, batchId },
+        "ReinforcedSkills: batch to delete not found, it may already be deleted"
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
 export interface ConversationContinuationInfo {
   analysedConversationId: string;
   reinforcementConversationId: string;

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -1062,15 +1062,6 @@ export async function checkBatchStatusActivity({
   return llm.getBatchStatus(batchId);
 }
 
-function isBatchNotFoundError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "status" in err &&
-    err.status === 404
-  );
-}
-
 /**
  * Delete a batch's data on the provider once its results have been consumed.
  * Idempotent: a batch that no longer exists is treated as already deleted, so
@@ -1095,9 +1086,21 @@ export async function deleteBatchActivity({
     );
   }
 
-  try {
-    const deleted = await llm.deleteBatch(batchId);
-    if (!deleted) {
+  const result = await llm.deleteBatch(batchId);
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  switch (result.value) {
+    case "deleted":
+      return;
+    case "do_not_exist":
+      logger.info(
+        { workspaceId, batchId },
+        "ReinforcedSkills: batch to delete not found, it may already be deleted"
+      );
+      return;
+    case "unsupported": {
       const metadata = llm.getMetadata();
       logger.warn(
         {
@@ -1106,19 +1109,12 @@ export async function deleteBatchActivity({
           modelId: metadata.modelId,
           batchId,
         },
-        "ReinforcedSkills: Failed to delete batch"
-      );
-    }
-  } catch (err) {
-    // The batch may already have been deleted by a previous attempt of this activity.
-    if (isBatchNotFoundError(err)) {
-      logger.info(
-        { workspaceId, batchId },
-        "ReinforcedSkills: batch to delete not found, it may already be deleted"
+        "ReinforcedSkills: batch deletion not supported by provider"
       );
       return;
     }
-    throw err;
+    default:
+      assertNever(result.value);
   }
 }
 

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -223,8 +223,48 @@ export async function ensureReinforcementWorkspaceSchedules(): Promise<{
     { concurrency: CONCURRENCY }
   );
 
+  // Migrate existing schedules that point at an outdated task queue: the task
+  // queue is baked into the schedule action at creation time, so a
+  // QUEUE_VERSION bump would otherwise strand them on the old queue forever.
+  const toCheck = [...runningWorkspaceIds].filter((id) =>
+    reinforcedWorkspaceIds.has(id)
+  );
+  const updated = await concurrentExecutor(
+    toCheck,
+    async (workspaceId) => {
+      const handle = client.schedule.getHandle(
+        makeWorkspaceWorkflowId(workspaceId)
+      );
+      const description = await handle.describe();
+      if (
+        description.action.type !== "startWorkflow" ||
+        description.action.taskQueue === QUEUE_NAME
+      ) {
+        return null;
+      }
+      logger.info(
+        { workspaceId, previousTaskQueue: description.action.taskQueue },
+        "[Reinforcement] Updating schedule to current task queue."
+      );
+      await handle.update((previous) => ({
+        ...previous,
+        action: {
+          ...previous.action,
+          taskQueue: QUEUE_NAME,
+        },
+      }));
+      return workspaceId;
+    },
+    { concurrency: CONCURRENCY }
+  );
+  const updatedCount = updated.filter((id) => id !== null).length;
+
   logger.info(
-    { startedCount: started.length, stoppedCount: stopped.length },
+    {
+      startedCount: started.length,
+      stoppedCount: stopped.length,
+      updatedCount,
+    },
     "[Reinforcement] Ensured reinforcement workspace schedules."
   );
 

--- a/front/temporal/reinforcement/config.ts
+++ b/front/temporal/reinforcement/config.ts
@@ -1,2 +1,2 @@
-const QUEUE_VERSION = 1;
+const QUEUE_VERSION = 2;
 export const QUEUE_NAME = `reinforcement-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -73,6 +73,16 @@ const { checkBatchStatusActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
 
+// Batch deletion must always run once the results are consumed, so it gets a
+// generous retry budget. The activity is idempotent (an already-deleted batch
+// is treated as success).
+const { deleteBatchActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    maximumAttempts: 10,
+  },
+});
+
 const {
   startSkillConversationAnalysisBatchActivity,
   startSkillAggregationBatchActivity,
@@ -252,14 +262,25 @@ async function aggregateSkillWithMultiStepBatch({
       ...batchResult.reinforcementConversationIds
     );
 
-    await waitForBatch({ workspaceId, batchId: batchResult.batchId });
+    let result: Awaited<
+      ReturnType<typeof processSkillAggregationBatchResultActivity>
+    >;
+    try {
+      await waitForBatch({ workspaceId, batchId: batchResult.batchId });
 
-    const result = await processSkillAggregationBatchResultActivity({
-      workspaceId,
-      skillId,
-      batchId: batchResult.batchId,
-      reinforcementConversationIds: batchResult.reinforcementConversationIds,
-    });
+      result = await processSkillAggregationBatchResultActivity({
+        workspaceId,
+        skillId,
+        batchId: batchResult.batchId,
+        reinforcementConversationIds: batchResult.reinforcementConversationIds,
+      });
+    } finally {
+      // Always delete the batch data once consumed, even if processing failed.
+      await deleteBatchActivity({
+        workspaceId,
+        batchId: batchResult.batchId,
+      });
+    }
 
     totalSuggestionsCreated += result.suggestionsCreated;
     allApprovedSourceSuggestionIds.push(...result.approvedSourceSuggestionIds);
@@ -375,20 +396,29 @@ export async function reinforcementWorkspaceWorkflow({
         break;
       }
 
-      await waitForBatch({ workspaceId, batchId: batchResult.batchId });
-
       reinforcementConversationMap = batchResult.reinforcementConversationMap;
       usageConversationIds.push(...Object.values(reinforcementConversationMap));
 
-      const continuations =
-        await processSkillConversationAnalysisBatchResultActivity({
+      let continuations: activities.ConversationContinuationInfo[];
+      try {
+        await waitForBatch({ workspaceId, batchId: batchResult.batchId });
+
+        continuations =
+          await processSkillConversationAnalysisBatchResultActivity({
+            workspaceId,
+            batchId: batchResult.batchId,
+            reinforcementConversationMap,
+            conversationSkillMap: Object.fromEntries(
+              pendingConversations.map((c) => [c.conversationId, c.skillIds])
+            ),
+          });
+      } finally {
+        // Always delete the batch data once consumed, even if processing failed.
+        await deleteBatchActivity({
           workspaceId,
           batchId: batchResult.batchId,
-          reinforcementConversationMap,
-          conversationSkillMap: Object.fromEntries(
-            pendingConversations.map((c) => [c.conversationId, c.skillIds])
-          ),
         });
+      }
 
       if (continuations.length === 0) {
         break;


### PR DESCRIPTION
## Description

Run batch data deletion in a separate activity so the activity processing the batch is idempotent and can be retried after failure.
The new activity always run to make sure we delete the data even if the previous activities fail.
We don't retry the deletion if the batch is not found 

## Tests

Tested locally:
The new delete activity happens after the processing activity
<img width="2796" height="872" alt="image" src="https://github.com/user-attachments/assets/790ae843-ba4c-441d-9d18-e0ce91c8a227" />


## Risk

low
The risk is to not correctly delete the user data after usage, but the try/catch activity mecanism make is actaully safer than before

## Deploy Plan

deploy front

```
# Kill the ensure-schedules cron pinned to the old v1 queue, and restart it on v2.
  npx tsx temporal/reinforcement/admin/cli.ts stop-ensure
  npx tsx temporal/reinforcement/admin/cli.ts start-ensure
```