### PR TITLE
Allow selecting open Spaces in conversations

### DIFF
--- a/front/admin/audit_log_schemas/conversation.space_selected.json
+++ b/front/admin/audit_log_schemas/conversation.space_selected.json
@@ -1,5 +1,5 @@
 {
-  "action": "conversation.restricted_space_selected",
+  "action": "conversation.space_selected",
   "targets": [
     {
       "type": "workspace"

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -13,13 +13,14 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
 
 import {
   addSelectedConversationSpaces,
-  listSelectableRestrictedSpaces,
+  listSelectableSpaces,
   type SelectedConversationSpacesError,
-  validateSelectableRestrictedSpaces,
+  validateSelectableSpaces,
 } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -48,6 +49,7 @@ function expectErrCode<T>(
 
 describe("selected conversation Spaces", () => {
   let auth: Authenticator;
+  let globalGroup: GroupResource;
   let globalSpace: SpaceResource;
   let user: UserType;
   let workspace: WorkspaceType;
@@ -55,6 +57,7 @@ describe("selected conversation Spaces", () => {
   beforeEach(async () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
+    globalGroup = setup.globalGroup;
     globalSpace = setup.globalSpace;
     user = setup.user.toJSON();
     workspace = auth.getNonNullableWorkspace();
@@ -89,6 +92,22 @@ describe("selected conversation Spaces", () => {
     return space;
   }
 
+  async function memberOpenSpace() {
+    const memberGroup = await GroupResource.makeNew({
+      name: "Open Space members",
+      workspaceId: workspace.id,
+      kind: "regular_auto",
+    });
+    return SpaceResource.makeNew(
+      {
+        name: "Open Space",
+        kind: "regular",
+        workspaceId: workspace.id,
+      },
+      { members: [memberGroup, globalGroup] }
+    );
+  }
+
   async function conversation() {
     return ConversationFactory.create(auth, {
       agentConfigurationId: "test-agent",
@@ -101,7 +120,7 @@ describe("selected conversation Spaces", () => {
     const restrictedSpace = await memberRestrictedSpace();
 
     expectErrCode(
-      await validateSelectableRestrictedSpaces(auth, {
+      await validateSelectableSpaces(auth, {
         spaceIds: [restrictedSpace.sId],
       }),
       "feature_flag_not_found"
@@ -129,17 +148,18 @@ describe("selected conversation Spaces", () => {
       "conversation_not_mutable"
     );
     expectErrCode(
-      await listSelectableRestrictedSpaces(auth, {
+      await listSelectableSpaces(auth, {
         conversation: projectConversation,
       }),
       "conversation_not_mutable"
     );
   });
 
-  it("lists selectable restricted regular Spaces and marks selected ones", async () => {
+  it("lists selectable regular Spaces and marks selected ones", async () => {
     await enableFeature();
     const selectedSpace = await memberRestrictedSpace();
     const selectableSpace = await memberRestrictedSpace();
+    const openSpace = await memberOpenSpace();
     const inaccessibleSpace = await SpaceFactory.regular(workspace);
     const projectSpace = await SpaceFactory.project(workspace, user.id);
     const conv = await conversation();
@@ -151,13 +171,14 @@ describe("selected conversation Spaces", () => {
     });
 
     const selectableSpaces = unwrapResult(
-      await listSelectableRestrictedSpaces(auth, { conversation: conv })
+      await listSelectableSpaces(auth, { conversation: conv })
     );
-    expect(selectableSpaces).toHaveLength(2);
+    expect(selectableSpaces).toHaveLength(3);
     expect(selectableSpaces).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
         expect.objectContaining({ sId: selectableSpace.sId, selected: false }),
+        expect.objectContaining({ sId: openSpace.sId, selected: false }),
       ])
     );
     expect(selectableSpaces.map((space) => space.sId)).not.toEqual(
@@ -169,27 +190,35 @@ describe("selected conversation Spaces", () => {
     );
   });
 
-  it("rejects inaccessible and non-restricted Spaces", async () => {
+  it("accepts open Spaces and rejects inaccessible or non-regular Spaces", async () => {
     await enableFeature();
     const inaccessibleSpace = await SpaceFactory.regular(workspace);
+    const openSpace = await memberOpenSpace();
 
     expectErrCode(
-      await validateSelectableRestrictedSpaces(auth, {
+      await validateSelectableSpaces(auth, {
         spaceIds: [inaccessibleSpace.sId],
       }),
       "space_not_found"
     );
+    expect(
+      (
+        await validateSelectableSpaces(auth, {
+          spaceIds: [openSpace.sId],
+        })
+      ).isOk()
+    ).toBe(true);
     expectErrCode(
-      await validateSelectableRestrictedSpaces(auth, {
+      await validateSelectableSpaces(auth, {
         spaceIds: [globalSpace.sId],
       }),
-      "space_not_restricted"
+      "space_not_selectable"
     );
   });
 
   it("materializes selected Spaces, dedupes input, and emits audit events", async () => {
     await enableFeature();
-    const selectedSpace = await memberRestrictedSpace();
+    const selectedSpace = await memberOpenSpace();
     const conv = await conversation();
 
     const result = unwrapResult(
@@ -207,7 +236,7 @@ describe("selected conversation Spaces", () => {
     expect(mockEmitAuditLogEvent).toHaveBeenCalledTimes(1);
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: "conversation.restricted_space_selected",
+        action: "conversation.space_selected",
         metadata: {
           conversation_id: conv.sId,
           origin: "input_bar",

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -28,7 +28,6 @@ export class SelectedConversationSpacesError extends Error {
       | "conversation_not_mutable"
       | "feature_flag_not_found"
       | "space_not_found"
-      | "space_not_restricted"
       | "space_not_selectable",
     message: string
   ) {
@@ -36,7 +35,7 @@ export class SelectedConversationSpacesError extends Error {
   }
 }
 
-export async function listSelectableRestrictedSpaces(
+export async function listSelectableSpaces(
   auth: Authenticator,
   {
     conversation,
@@ -50,7 +49,7 @@ export async function listSelectableRestrictedSpaces(
     return new Err(
       new SelectedConversationSpacesError(
         "conversation_not_mutable",
-        "Restricted Spaces cannot be selected from the input bar in pod conversations."
+        "Spaces cannot be selected from the input bar in pod conversations."
       )
     );
   }
@@ -60,7 +59,7 @@ export async function listSelectableRestrictedSpaces(
     return new Err(
       new SelectedConversationSpacesError(
         "feature_flag_not_found",
-        "Restricted Spaces in the input bar is not enabled for this workspace."
+        "Space selection in the input bar is not enabled for this workspace."
       )
     );
   }
@@ -76,7 +75,7 @@ export async function listSelectableRestrictedSpaces(
   );
 
   const selectableSpaces = spaces
-    .filter((space) => space.isRegularAndRestricted())
+    .filter((space) => space.isRegular())
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((space) => ({
       ...space.toJSON(),
@@ -86,7 +85,7 @@ export async function listSelectableRestrictedSpaces(
   return new Ok(selectableSpaces);
 }
 
-export async function validateSelectableRestrictedSpaces(
+export async function validateSelectableSpaces(
   auth: Authenticator,
   {
     spaceIds,
@@ -101,7 +100,7 @@ export async function validateSelectableRestrictedSpaces(
     return new Err(
       new SelectedConversationSpacesError(
         "feature_flag_not_found",
-        "Restricted Spaces in the input bar is not enabled for this workspace."
+        "Space selection in the input bar is not enabled for this workspace."
       )
     );
   }
@@ -130,11 +129,11 @@ export async function validateSelectableRestrictedSpaces(
     );
   }
 
-  if (spaces.some((space) => !space.isRegularAndRestricted())) {
+  if (spaces.some((space) => !space.isRegular())) {
     return new Err(
       new SelectedConversationSpacesError(
-        "space_not_restricted",
-        "Only restricted regular Spaces can be selected from the input bar."
+        "space_not_selectable",
+        "Only regular Spaces can be selected from the input bar."
       )
     );
   }
@@ -190,18 +189,15 @@ export async function addSelectedConversationSpaces(
       return new Err(
         new SelectedConversationSpacesError(
           "conversation_not_mutable",
-          "Restricted Spaces cannot be selected from the input bar in pod conversations."
+          "Spaces cannot be selected from the input bar in pod conversations."
         )
       );
     }
 
-    const selectableSpacesResult = await validateSelectableRestrictedSpaces(
-      auth,
-      {
-        spaceIds: dedupedSpaceIds,
-        transaction: t,
-      }
-    );
+    const selectableSpacesResult = await validateSelectableSpaces(auth, {
+      spaceIds: dedupedSpaceIds,
+      transaction: t,
+    });
     if (selectableSpacesResult.isErr()) {
       return selectableSpacesResult;
     }
@@ -269,7 +265,7 @@ export async function addSelectedConversationSpaces(
     for (const space of newlyActiveSpaces) {
       void emitAuditLogEvent({
         auth,
-        action: "conversation.restricted_space_selected",
+        action: "conversation.space_selected",
         targets: [
           buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
           buildAuditLogTarget("conversation", {

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -11,7 +11,7 @@
   "audit_log.export_configured": 2,
   "audit_log.viewed": 2,
   "conversation.accessed": 3,
-  "conversation.restricted_space_selected": 1,
+  "conversation.space_selected": 1,
   "coupon.redeemed": 1,
   "coupon.revoked": 1,
   "credentials.created": 4,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -133,7 +133,7 @@ export const AUDIT_ACTIONS = [
   "space.permissions_updated",
   // Conversations.
   "conversation.accessed",
-  "conversation.restricted_space_selected",
+  "conversation.space_selected",
   // Data Sources.
   "datasource.created",
   "datasource.updated",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -273,7 +273,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   restricted_spaces_in_input_bar: {
     description:
-      "Allow users to explicitly select restricted Spaces from the conversation input bar.",
+      "Allow users to explicitly select Spaces from the conversation input bar.",
     stage: "dust_only",
   },
   disable_formatting_prompt: {


### PR DESCRIPTION
## Description

- Allows readable open and restricted regular Spaces to be selected for a conversation.
- Keeps global, system, project, and conversation Space kinds excluded.
- Renames the service helpers and audit event to describe generic Space selection.

This PR sits before #27545.

## Tests

- Selected-Space service, resource, and audit schema suites: 25 tests
- `npm run tsgo -- --noEmit` in `front`
- `npm run tsgo -- --noEmit` in `front-api`
- `npx biome check` on changed TypeScript files
- `git diff --check`

## Risk

Low. The feature remains behind the existing Dust-only flag and no selection route is on `main` yet. Open Spaces expand runtime scope without restricting conversation visibility.

## Deploy plan

- [ ] Merge this PR before #27545.
- [ ] Deploy normally.
