### PR TITLE
[front] enh: Offload oversized semantic search chunks to file system

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -8,6 +8,7 @@ import { augmentInputsWithConfiguration } from "@app/lib/actions/mcp_internal_ac
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isBlobResource,
+  isResourceContentWithText,
   isResourceWithName,
   isRunAgentQueryProgressOutput,
   isStoreResourceProgressOutput,
@@ -402,10 +403,9 @@ export async function processToolResults(
             };
           }
 
-          const text =
-            "text" in block.resource && typeof block.resource.text === "string"
-              ? toWellFormed(stripNullBytes(block.resource.text))
-              : null;
+          const text = isResourceContentWithText(block)
+            ? toWellFormed(stripNullBytes(block.resource.text))
+            : null;
 
           // Sanitize the entire resource object to remove null bytes from all string fields
           const sanitizedResource = sanitizeStringsDeep(block.resource);

--- a/front/lib/actions/mcp_internal_actions/utils/search_result_offload.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/search_result_offload.test.ts
@@ -1,0 +1,184 @@
+import {
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
+} from "@app/lib/actions/action_output_limits";
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { offloadLargeSearchResultChunks } from "@app/lib/actions/mcp_internal_actions/utils/search_result_offload";
+import type { ToolRunContext } from "@app/lib/actions/types";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
+import { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { assert, describe, expect, it } from "vitest";
+
+async function setupTest() {
+  const user = await UserFactory.basic();
+  const workspace = await WorkspaceFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "admin" });
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfig.sId,
+    messagesCreatedAt: [],
+  });
+
+  const toolConfiguration: LightServerSideMCPToolConfigurationType = {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_configuration",
+    name: "semantic_search",
+    originalName: "semantic_search",
+    mcpServerName: "search",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: generateRandomModelSId(),
+    dustAppConfiguration: null,
+    internalMCPServerId: null,
+    secretName: null,
+    dustProject: null,
+    availability: "auto",
+    permission: "never_ask",
+    toolServerId: generateRandomModelSId(),
+    retryPolicy: "no_retry",
+  };
+
+  const { action, agentMessage } = await ConversationFactory.createAgentMessage(
+    auth,
+    {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    }
+  );
+  assert(action, "MCP action should be created");
+
+  const { userMessage } = await ConversationFactory.createUserMessage({
+    auth,
+    workspace,
+    conversation,
+    content: "Test message",
+    rank: 1,
+  });
+
+  const { model: agentModel, ...agentConfiguration } = agentConfig;
+  const modelConfig = getSupportedModelConfig(agentModel);
+  assert(modelConfig, "Supported model config should exist");
+
+  const runContext: ToolRunContext = {
+    contextType: "agent_loop",
+    agentConfiguration,
+    model: {
+      ...agentModel,
+      ...modelConfig,
+    },
+    agentMessage,
+    action,
+    conversation,
+    stepContext: action.stepContext,
+    toolConfiguration,
+    userMessage,
+  };
+
+  return { auth, conversation, runContext };
+}
+
+function makeSearchResult(chunks: string[]): SearchResultResourceType {
+  return {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+    uri: "https://example.com/doc",
+    text: "My Document",
+    id: "doc-1",
+    tags: ["title:My Document"],
+    ref: "aa",
+    source: { provider: "notion" },
+    chunks,
+  };
+}
+
+describe("offloadLargeSearchResultChunks", () => {
+  it("keeps results under the threshold unchanged", async () => {
+    const { auth, runContext } = await setupTest();
+
+    fileStorageMock.reset();
+
+    const result = makeSearchResult(["a small chunk", "another small chunk"]);
+    const offloaded = await offloadLargeSearchResultChunks(auth, runContext, [
+      result,
+    ]);
+
+    expect(offloaded).toEqual([result]);
+    expect(
+      fileStorageMock.saveFileCalls.filter((call) =>
+        call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+      )
+    ).toHaveLength(0);
+  });
+
+  it("archives oversized chunks and replaces them with a snippet pointing at the file", async () => {
+    const { auth, conversation, runContext } = await setupTest();
+
+    fileStorageMock.reset();
+
+    const bigChunk = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
+    const result = makeSearchResult([bigChunk, "trailing chunk"]);
+    const smallResult = makeSearchResult(["a small chunk"]);
+
+    const offloaded = await offloadLargeSearchResultChunks(auth, runContext, [
+      result,
+      smallResult,
+    ]);
+
+    expect(offloaded).toHaveLength(2);
+
+    // The oversized result is slimmed to a single snippet chunk with an archive pointer, while
+    // its citation metadata is preserved.
+    const [slimmed, untouched] = offloaded;
+    expect(slimmed.chunks).toHaveLength(1);
+    expect(slimmed.chunks[0]).toContain("... (truncated)");
+    expect(slimmed.chunks[0]).toContain(
+      `[Full content archived at conversation-${conversation.sId}/${TOOL_OUTPUTS_FOLDER_NAME}/`
+    );
+    expect(slimmed.chunks[0].length).toBeLessThan(
+      FILE_OFFLOAD_SNIPPET_LENGTH + 256
+    );
+    expect(slimmed.ref).toBe(result.ref);
+    expect(slimmed.uri).toBe(result.uri);
+
+    // The small result is untouched.
+    expect(untouched).toEqual(smallResult);
+
+    // The full joined chunks were written to the .tool_outputs folder.
+    const write = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
+    );
+    expect(write).toBeDefined();
+    expect(write?.filePath).toMatch(
+      new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_my_document\\.txt$`)
+    );
+    expect(write?.content.toString()).toContain("trailing chunk");
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/utils/search_result_offload.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/search_result_offload.ts
@@ -1,0 +1,60 @@
+import {
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
+} from "@app/lib/actions/action_output_limits";
+import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolRunContext } from "@app/lib/actions/types";
+import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
+import type { Authenticator } from "@app/lib/auth";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+
+// Same separator rewriteContentForModel uses when joining chunks for the model, so the archived
+// file reads like the inline rendering would have.
+const CHUNK_SEPARATOR = "\n------------\n";
+
+/**
+ * Offloads the chunks of search results that exceed the text offload threshold: the full chunks
+ * are archived to the run context's .tool_outputs folder and replaced inline with a truncated
+ * snippet pointing at the archived file. Results under the threshold are returned unchanged.
+ * Result metadata (ref, uri, title, tags) always stays inline so citations are unaffected.
+ */
+export async function offloadLargeSearchResultChunks(
+  auth: Authenticator,
+  runContext: ToolRunContext,
+  results: SearchResultResourceType[]
+): Promise<SearchResultResourceType[]> {
+  return concurrentExecutor(
+    results,
+    async (result) => {
+      const content = result.chunks.join(CHUNK_SEPARATOR);
+      if (Buffer.byteLength(content, "utf8") <= FILE_OFFLOAD_TEXT_SIZE_BYTES) {
+        return result;
+      }
+
+      const fileName = makeFileName({
+        name: result.text || "search-result",
+        ext: ".txt",
+      });
+      const writeResult = await writeToToolOutputsFolder(auth, runContext, {
+        fileName,
+        content,
+        contentType: "text/plain",
+      });
+
+      // A failed archive must not fail the search: keep the result inline.
+      if (writeResult.isErr()) {
+        logger.error(
+          { error: writeResult.error, fileName },
+          "Failed to offload search result chunks"
+        );
+        return result;
+      }
+
+      const snippet = `${content.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)}... (truncated)\n[Full content archived at ${writeResult.value}]`;
+      return { ...result, chunks: [snippet] };
+    },
+    { concurrency: 4 }
+  );
+}

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -8,6 +8,7 @@ import {
   applyNodeIdsFilterToCoreSearchArgs,
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { offloadLargeSearchResultChunks } from "@app/lib/actions/mcp_internal_actions/utils/search_result_offload";
 import {
   isAgentLoopRunContext,
   type ToolContext,
@@ -186,8 +187,17 @@ export async function searchFunction(
     }
   );
 
+  // Archive oversized chunk payloads instead of keeping them inline in the conversation.
+  const offloadedResults = toolContext?.runContext
+    ? await offloadLargeSearchResultChunks(
+        auth,
+        toolContext.runContext,
+        results
+      )
+    : results;
+
   return new Ok(
-    results.map((result) => ({
+    offloadedResults.map((result) => ({
       type: "resource" as const,
       resource: result,
     }))


### PR DESCRIPTION
## Description

Offload semantic search tool result to a .tool-outputs after a certain threshold.
We are currently inlining a lot of outputs either as b64 blob or text resources over mcp, which has a lot of memory footprint amplification, and can bust conversation context.

So instead this stack aims at introducing a JIT file offload for the biggest offenders according to [logs](https://app.datadoghq.eu/logs?query=inline&agg_m=count&agg_m_source=base&agg_q=%40serverName%2C%40toolName&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=toplist&from_ts=1784554496351&to_ts=1784555396351&live=true)

## Tests

Unit tests

## Risk

Low

## Deploy Plan

Deploy front