### PR TITLE
[front] enh: Offload oversized slack search_messages chunks to file system

### DIFF
--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
+import { offloadLargeSearchResultChunks } from "@app/lib/actions/mcp_internal_actions/utils/search_result_offload";
 import {
   isAgentLoopRunContext,
   type ToolContext,
@@ -472,8 +473,15 @@ export function createSlackPersonalTools(
           }
         );
 
+        // Archive oversized chunk payloads instead of keeping them inline in the conversation.
+        const offloadedResults = await offloadLargeSearchResultChunks(
+          auth,
+          toolContext.runContext,
+          searchResults
+        );
+
         return new Ok(
-          searchResults.map((result) => ({
+          offloadedResults.map((result) => ({
             type: "resource" as const,
             resource: result,
           }))


### PR DESCRIPTION
## Description

Same as https://github.com/dust-tt/dust/pull/29144 but for slack search messages

## Tests


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
