### PR TITLE
[connectors] fix: bound memory in Microsoft Excel sheet ingestion

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -367,23 +367,61 @@ export async function getWorksheets(
   return { results: res.value };
 }
 
-export async function getWorksheetContent(
+// Scalar metadata of a worksheet's used range, without any cell content.
+export type WorkbookRangeMetadata = Pick<
+  WorkbookRange,
+  | "address"
+  | "cellCount"
+  | "columnCount"
+  | "columnIndex"
+  | "rowCount"
+  | "rowIndex"
+>;
+
+export async function getWorksheetUsedRangeMetadata(
   logger: LoggerInterface,
   client: Client,
   internalId: string
+): Promise<WorkbookRangeMetadata> {
+  const { nodeType, itemAPIPath: itemApiPath } =
+    typeAndPathFromInternalId(internalId);
+
+  if (nodeType !== "worksheet") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getWorksheetUsedRangeMetadata, expected worksheet`
+    );
+  }
+  // valuesOnly=true ignores formatting-only cells so the boundary reflects
+  // actual values. Selecting only scalar properties keeps the heavy 2D arrays
+  // (text, values, formulas) out of the response entirely.
+  const res = await clientApiGet(
+    logger,
+    client,
+    `${itemApiPath}/usedRange(valuesOnly=true)?$select=address,rowCount,columnCount,cellCount,rowIndex,columnIndex`
+  );
+  return res;
+}
+
+export async function getWorksheetRangeText(
+  logger: LoggerInterface,
+  client: Client,
+  internalId: string,
+  // Bounded A1 address, e.g. "B3:AO2502". Unbounded addresses (e.g. "A:F")
+  // make Graph return null cell properties and must not be used.
+  rangeAddress: string
 ): Promise<WorkbookRange> {
   const { nodeType, itemAPIPath: itemApiPath } =
     typeAndPathFromInternalId(internalId);
 
   if (nodeType !== "worksheet") {
     throw new Error(
-      `Invalid node type: ${nodeType} for getWorksheet content, expected worksheet`
+      `Invalid node type: ${nodeType} for getWorksheetRangeText, expected worksheet`
     );
   }
   const res = await clientApiGet(
     logger,
     client,
-    `${itemApiPath}/usedRange?$select=text`
+    `${itemApiPath}/range(address='${rangeAddress}')?$select=text`
   );
   return res;
 }

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.test.ts
@@ -1,0 +1,512 @@
+import { randomUUID } from "node:crypto";
+
+import { MicrosoftThrottlingError } from "@connectors/connectors/microsoft/lib/errors";
+import {
+  getDriveItemInternalId,
+  getWorksheetInternalId,
+} from "@connectors/connectors/microsoft/lib/graph_api";
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
+import type { Client } from "@microsoft/microsoft-graph-client";
+import { GraphError } from "@microsoft/microsoft-graph-client";
+import type { WorkbookWorksheet } from "@microsoft/microsoft-graph-types";
+import { stringify } from "csv-stringify/sync";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  deleteDataSourceTable: vi.fn(),
+  getColumnsFromListItem: vi.fn(),
+  getMicrosoftClient: vi.fn(),
+  getParents: vi.fn(),
+  getWorksheetRangeText: vi.fn(),
+  getWorksheets: vi.fn(),
+  getWorksheetUsedRangeMetadata: vi.fn(),
+  heartbeat: vi.fn(async () => {}),
+  upsertDataSourceFolder: vi.fn(),
+  upsertDataSourceTableFromCsv: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors/microsoft", () => ({
+  getMicrosoftClient: mocks.getMicrosoftClient,
+}));
+
+vi.mock(
+  "@connectors/connectors/microsoft/lib/graph_api",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@connectors/connectors/microsoft/lib/graph_api")
+      >();
+
+    return {
+      ...mod,
+      getWorksheetRangeText: mocks.getWorksheetRangeText,
+      getWorksheets: mocks.getWorksheets,
+      getWorksheetUsedRangeMetadata: mocks.getWorksheetUsedRangeMetadata,
+    };
+  }
+);
+
+vi.mock(
+  "@connectors/connectors/microsoft/lib/utils",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@connectors/connectors/microsoft/lib/utils")
+      >();
+
+    return {
+      ...mod,
+      getColumnsFromListItem: mocks.getColumnsFromListItem,
+    };
+  }
+);
+
+vi.mock("@connectors/connectors/microsoft/temporal/file", () => ({
+  getParents: mocks.getParents,
+}));
+
+vi.mock("@connectors/lib/data_sources", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@connectors/lib/data_sources")>();
+
+  return {
+    ...mod,
+    deleteDataSourceTable: mocks.deleteDataSourceTable,
+    upsertDataSourceFolder: mocks.upsertDataSourceFolder,
+    upsertDataSourceTableFromCsv: mocks.upsertDataSourceTableFromCsv,
+  };
+});
+
+import logger from "@connectors/logger/logger";
+
+import {
+  columnIndexToLetter,
+  computeRangeChunkAddresses,
+  handleSpreadSheet,
+  processSheet,
+} from "./spreadsheets";
+
+const fakeClient = {} as unknown as Client;
+
+function makeDriveItem(suffix: string): DriveItem {
+  return {
+    "@microsoft.graph.downloadUrl": undefined,
+    id: `item-${suffix}`,
+    name: `spreadsheet-${suffix}.xlsx`,
+    file: {
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    },
+    parentReference: { driveId: `drive-${suffix}` },
+    webUrl: `https://example.com/${suffix}`,
+    listItem: { fields: {} },
+  };
+}
+
+async function makeConnector(suffix: string) {
+  return ConnectorResource.makeNew(
+    "microsoft",
+    {
+      connectionId: `connection-${suffix}`,
+      dataSourceId: `data-source-${suffix}`,
+      workspaceAPIKey: `api-key-${suffix}`,
+      workspaceId: `workspace-${suffix}`,
+    },
+    {
+      csvEnabled: false,
+      largeFilesEnabled: false,
+      pdfEnabled: false,
+    }
+  );
+}
+
+function makeSheetFixtures(suffix: string) {
+  const file = makeDriveItem(suffix);
+  const worksheet: WorkbookWorksheet = {
+    id: `worksheet-${suffix}`,
+    name: "Sheet1",
+  };
+  const spreadsheetInternalId = getDriveItemInternalId(file);
+  const worksheetInternalId = getWorksheetInternalId(
+    worksheet,
+    spreadsheetInternalId
+  );
+
+  return { file, worksheet, spreadsheetInternalId, worksheetInternalId };
+}
+
+async function runProcessSheet(
+  connector: ConnectorResource,
+  fixtures: ReturnType<typeof makeSheetFixtures>
+) {
+  return processSheet({
+    client: fakeClient,
+    connector,
+    spreadsheet: fixtures.file,
+    spreadsheetInternalId: fixtures.spreadsheetInternalId,
+    worksheet: fixtures.worksheet,
+    worksheetInternalId: fixtures.worksheetInternalId,
+    localLogger: logger.child({}),
+    startSyncTs: Date.now(),
+    heartbeat: mocks.heartbeat,
+  });
+}
+
+describe("columnIndexToLetter", () => {
+  it("converts 0-based column indexes to A1 letters", () => {
+    expect(columnIndexToLetter(0)).toBe("A");
+    expect(columnIndexToLetter(25)).toBe("Z");
+    expect(columnIndexToLetter(26)).toBe("AA");
+    expect(columnIndexToLetter(51)).toBe("AZ");
+    expect(columnIndexToLetter(52)).toBe("BA");
+    expect(columnIndexToLetter(701)).toBe("ZZ");
+    expect(columnIndexToLetter(702)).toBe("AAA");
+    // Last column supported by Excel.
+    expect(columnIndexToLetter(16383)).toBe("XFD");
+  });
+});
+
+describe("computeRangeChunkAddresses", () => {
+  it("chunks an A1-origin range by the rows-per-chunk ceiling", () => {
+    expect(
+      computeRangeChunkAddresses({
+        rowIndex: 0,
+        columnIndex: 0,
+        rowCount: 10000,
+        columnCount: 10,
+      })
+    ).toEqual(["A1:J5000", "A5001:J10000"]);
+  });
+
+  it("offsets addresses when the used range does not start at A1", () => {
+    expect(
+      computeRangeChunkAddresses({
+        rowIndex: 2,
+        columnIndex: 1,
+        rowCount: 7000,
+        columnCount: 40,
+      })
+    ).toEqual(["B3:AO2502", "B2503:AO5002", "B5003:AO7002"]);
+  });
+
+  it("shrinks chunk row count to respect the per-request cell budget", () => {
+    // floor(100_000 / 16_384) = 6 rows per chunk.
+    expect(
+      computeRangeChunkAddresses({
+        rowIndex: 0,
+        columnIndex: 0,
+        rowCount: 10,
+        columnCount: 16384,
+      })
+    ).toEqual(["A1:XFD6", "A7:XFD10"]);
+  });
+
+  it("does not emit an empty trailing chunk on exact multiples", () => {
+    expect(
+      computeRangeChunkAddresses({
+        rowIndex: 0,
+        columnIndex: 0,
+        rowCount: 12000,
+        columnCount: 2,
+      })
+    ).toEqual(["A1:B5000", "A5001:B10000", "A10001:B12000"]);
+  });
+});
+
+describe("processSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.deleteDataSourceTable.mockResolvedValue(undefined);
+    mocks.getColumnsFromListItem.mockResolvedValue([]);
+    mocks.getMicrosoftClient.mockResolvedValue(fakeClient);
+    mocks.getParents.mockImplementation(
+      async ({ internalId }: { internalId: string }) => [internalId, "root"]
+    );
+    mocks.upsertDataSourceFolder.mockResolvedValue(undefined);
+    mocks.upsertDataSourceTableFromCsv.mockResolvedValue(undefined);
+  });
+
+  it("skips sheets with too many rows at probe time, without fetching values", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!A1:J60000",
+      cellCount: 600000,
+      columnCount: 10,
+      columnIndex: 0,
+      rowCount: 60000,
+      rowIndex: 0,
+    });
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.getWorksheetRangeText).not.toHaveBeenCalled();
+    expect(mocks.upsertDataSourceTableFromCsv).not.toHaveBeenCalled();
+    expect(mocks.deleteDataSourceTable).toHaveBeenCalledWith(
+      expect.objectContaining({ tableId: fixtures.worksheetInternalId })
+    );
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("too_many_rows");
+  });
+
+  it("skips sheets with too many cells at probe time, without fetching values", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    // 2000 x 2000 = 4M cells: passes the row cap, fails the cell cap.
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!A1:BXX2000",
+      cellCount: 4000000,
+      columnCount: 2000,
+      columnIndex: 0,
+      rowCount: 2000,
+      rowIndex: 0,
+    });
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.getWorksheetRangeText).not.toHaveBeenCalled();
+    expect(mocks.upsertDataSourceTableFromCsv).not.toHaveBeenCalled();
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("too_many_cells");
+  });
+
+  it("fetches values in sequential bounded chunks and upserts the assembled CSV", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!B3:AO7002",
+      cellCount: 280000,
+      columnCount: 40,
+      columnIndex: 1,
+      rowCount: 7000,
+      rowIndex: 2,
+    });
+
+    const chunk1 = [
+      ["header1", "header2"],
+      ["a1", "a2"],
+    ];
+    const chunk2 = [["b1", "b2"]];
+    const chunk3 = [["c1", "c2"]];
+    mocks.getWorksheetRangeText
+      .mockResolvedValueOnce({ text: chunk1 })
+      .mockResolvedValueOnce({ text: chunk2 })
+      .mockResolvedValueOnce({ text: chunk3 });
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      mocks.getWorksheetRangeText.mock.calls.map((call) => call[3])
+    ).toEqual(["B3:AO2502", "B2503:AO5002", "B5003:AO7002"]);
+    expect(mocks.heartbeat).toHaveBeenCalledTimes(3);
+
+    // The assembled CSV is byte-identical to a single-shot stringify of all rows.
+    expect(mocks.upsertDataSourceTableFromCsv).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertDataSourceTableFromCsv).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableCsv: stringify([...chunk1, ...chunk2, ...chunk3]),
+        tableId: fixtures.worksheetInternalId,
+        truncate: true,
+      })
+    );
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.nodeType).toBe("worksheet");
+    expect(node?.skipReason).toBeNull();
+  });
+
+  it("aborts accumulation and skips the sheet when the CSV byte cap is exceeded", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    // 3 chunks of 5000 rows each (10001 rows, 20 columns).
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!A1:T10001",
+      cellCount: 200020,
+      columnCount: 20,
+      columnIndex: 0,
+      rowCount: 10001,
+      rowIndex: 0,
+    });
+
+    // Two 30MB cells cross the 50MB cap on the second chunk.
+    const bigCell = "x".repeat(30 * 1024 * 1024);
+    mocks.getWorksheetRangeText
+      .mockResolvedValueOnce({ text: [[bigCell]] })
+      .mockResolvedValueOnce({ text: [[bigCell]] });
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.getWorksheetRangeText).toHaveBeenCalledTimes(2);
+    expect(mocks.upsertDataSourceTableFromCsv).not.toHaveBeenCalled();
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("csv_too_large");
+  });
+
+  it("returns an error for empty sheets without fetching values", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    // An empty worksheet probes as a single A1 cell.
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!A1",
+      cellCount: 1,
+      columnCount: 1,
+      columnIndex: 0,
+      rowCount: 1,
+      rowIndex: 0,
+    });
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isErr()).toBe(true);
+    expect(mocks.getWorksheetRangeText).not.toHaveBeenCalled();
+  });
+
+  it("marks the worksheet as skipped on a 504 during the probe", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    mocks.getWorksheetUsedRangeMetadata.mockRejectedValue(
+      new GraphError(504, "Gateway Timeout")
+    );
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("error_fetching_content");
+  });
+
+  it("marks the worksheet as skipped on a 504 during a chunk read", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    mocks.getWorksheetUsedRangeMetadata.mockResolvedValue({
+      address: "Sheet1!B3:AO7002",
+      cellCount: 280000,
+      columnCount: 40,
+      columnIndex: 1,
+      rowCount: 7000,
+      rowIndex: 2,
+    });
+
+    mocks.getWorksheetRangeText
+      .mockResolvedValueOnce({ text: [["header"], ["a"]] })
+      .mockRejectedValueOnce(new GraphError(504, "Gateway Timeout"));
+
+    const result = await runProcessSheet(connector, fixtures);
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.getWorksheetRangeText).toHaveBeenCalledTimes(2);
+    expect(mocks.upsertDataSourceTableFromCsv).not.toHaveBeenCalled();
+
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("error_fetching_content");
+  });
+
+  it("rethrows throttling errors so the activity interceptor can honor Retry-After", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    mocks.getWorksheetUsedRangeMetadata.mockRejectedValue(
+      new MicrosoftThrottlingError("/endpoint", 1000)
+    );
+
+    await expect(runProcessSheet(connector, fixtures)).rejects.toBeInstanceOf(
+      MicrosoftThrottlingError
+    );
+  });
+});
+
+describe("handleSpreadSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getColumnsFromListItem.mockResolvedValue([]);
+    mocks.getMicrosoftClient.mockResolvedValue(fakeClient);
+    mocks.getParents.mockImplementation(
+      async ({ internalId }: { internalId: string }) => [internalId, "root"]
+    );
+    mocks.upsertDataSourceFolder.mockResolvedValue(undefined);
+  });
+
+  it("honors a persisted skip reason without re-fetching or deleting the worksheet", async () => {
+    const suffix = randomUUID();
+    const connector = await makeConnector(suffix);
+    const fixtures = makeSheetFixtures(suffix);
+
+    await MicrosoftNodeResource.makeNew({
+      connectorId: connector.id,
+      internalId: fixtures.worksheetInternalId,
+      mimeType: "text/csv",
+      name: "Sheet1",
+      nodeType: "worksheet",
+      parentInternalId: fixtures.spreadsheetInternalId,
+      skipReason: "too_many_cells",
+      webUrl: null,
+    });
+
+    mocks.getWorksheets.mockResolvedValue({ results: [fixtures.worksheet] });
+
+    const result = await handleSpreadSheet({
+      connectorId: connector.id,
+      file: fixtures.file,
+      parentInternalId: `parent-${suffix}`,
+      localLogger: logger.child({}),
+      startSyncTs: Date.now(),
+      heartbeat: mocks.heartbeat,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mocks.getWorksheetUsedRangeMetadata).not.toHaveBeenCalled();
+    expect(mocks.getWorksheetRangeText).not.toHaveBeenCalled();
+
+    // The skip row survived the stale-sheet deletion pass.
+    const node = await MicrosoftNodeResource.fetchByInternalId(
+      connector.id,
+      fixtures.worksheetInternalId
+    );
+    expect(node?.skipReason).toBe("too_many_cells");
+  });
+});

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -1,11 +1,13 @@
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { getMicrosoftClient } from "@connectors/connectors/microsoft";
+import { MicrosoftThrottlingError } from "@connectors/connectors/microsoft/lib/errors";
 import {
   getAllPaginatedEntities,
   getDriveItemInternalId,
-  getWorksheetContent,
   getWorksheetInternalId,
+  getWorksheetRangeText,
   getWorksheets,
+  getWorksheetUsedRangeMetadata,
   wrapMicrosoftGraphAPIWithResult,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
@@ -38,6 +40,72 @@ import type { WorkbookWorksheet } from "@microsoft/microsoft-graph-types";
 import { stringify } from "csv-stringify/sync";
 
 const MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS = 50000;
+
+// ≈50k rows × 60 cols equivalent. Checked on used-range metadata at probe time,
+// before any cell values are fetched.
+const MAXIMUM_NUMBER_OF_EXCEL_SHEET_CELLS = 3_000_000;
+
+// Per-request cell budget: keeps each range response to ~1-2MB of JSON so parse
+// transients stay in the single-digit MB per in-flight file.
+const MAXIMUM_EXCEL_CELLS_PER_RANGE_REQUEST = 100_000;
+
+// Rows-per-chunk ceiling so narrow sheets still heartbeat regularly and
+// individual Graph reads stay fast.
+const MAXIMUM_EXCEL_CHUNK_ROWS = 5_000;
+
+// Aligned with MAX_CSV_SIZE (50MB) enforced by upsertDataSourceTableFromCsv;
+// checked incrementally during accumulation so we abort before building an
+// oversized CSV in memory.
+const MAXIMUM_EXCEL_CSV_BYTES = 50 * 1024 * 1024;
+
+// 0-based column index -> A1 letters (0 -> "A", 25 -> "Z", 26 -> "AA").
+export function columnIndexToLetter(index: number): string {
+  let n = index + 1;
+  let letters = "";
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    letters = String.fromCharCode(65 + rem) + letters;
+    n = Math.floor((n - 1) / 26);
+  }
+  return letters;
+}
+
+// Bounded A1 window addresses covering the used range, top to bottom. The used
+// range may not start at A1: rowIndex/columnIndex are the 0-based coordinates
+// of its first cell, while A1 rows are 1-based.
+export function computeRangeChunkAddresses({
+  rowIndex,
+  columnIndex,
+  rowCount,
+  columnCount,
+}: {
+  rowIndex: number;
+  columnIndex: number;
+  rowCount: number;
+  columnCount: number;
+}): string[] {
+  const effectiveColumnCount = Math.max(1, columnCount);
+  const chunkRowCount = Math.min(
+    MAXIMUM_EXCEL_CHUNK_ROWS,
+    Math.max(
+      1,
+      Math.floor(MAXIMUM_EXCEL_CELLS_PER_RANGE_REQUEST / effectiveColumnCount)
+    )
+  );
+  const firstColumnLetter = columnIndexToLetter(columnIndex);
+  const lastColumnLetter = columnIndexToLetter(
+    columnIndex + effectiveColumnCount - 1
+  );
+  const addresses: string[] = [];
+  for (let start = 0; start < rowCount; start += chunkRowCount) {
+    const firstRow = rowIndex + start + 1;
+    const lastRow = rowIndex + Math.min(start + chunkRowCount, rowCount);
+    addresses.push(
+      `${firstColumnLetter}${firstRow}:${lastColumnLetter}${lastRow}`
+    );
+  }
+  return addresses;
+}
 
 async function upsertSpreadsheetInDb(
   connector: ConnectorResource,
@@ -86,7 +154,7 @@ async function upsertMSTable(
   spreadsheet: DriveItem,
   worksheet: WorkbookWorksheet,
   parents: [string, string, ...string[]],
-  rows: string[][],
+  csv: string,
   tags: string[]
 ) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
@@ -96,8 +164,6 @@ async function upsertMSTable(
   );
 
   const tableDescription = `Structured data from the Excel Spreadsheet (${spreadsheet.name}) and sheet (${worksheet.name}`;
-
-  const csv = stringify(rows);
 
   // Upserting is safe: Core truncates any previous table with the same Id before
   // the operation. Note: Renaming a sheet in Google Drive retains its original Id.
@@ -127,7 +193,87 @@ async function upsertMSTable(
   );
 }
 
-async function processSheet({
+// Persist the skip reason (honored via knownSkippedWorksheetIds on subsequent
+// syncs) and drop any table a previous sync may have upserted so agents don't
+// keep querying stale data. deleteDataSourceTable tolerates missing tables.
+async function skipOversizedWorksheet({
+  connector,
+  spreadsheet,
+  spreadsheetInternalId,
+  worksheetInternalId,
+  reason,
+}: {
+  connector: ConnectorResource;
+  spreadsheet: DriveItem;
+  spreadsheetInternalId: string;
+  worksheetInternalId: string;
+  reason: "too_many_rows" | "too_many_cells" | "csv_too_large";
+}): Promise<void> {
+  await markInternalIdAsSkipped({
+    internalId: worksheetInternalId,
+    connectorId: connector.id,
+    parentInternalId: spreadsheetInternalId,
+    reason,
+    file: spreadsheet,
+  });
+  await deleteDataSourceTable({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
+    tableId: worksheetInternalId,
+    loggerArgs: {
+      connectorId: connector.id,
+      sheetId: worksheetInternalId,
+      spreadsheetId: spreadsheetInternalId,
+    },
+  });
+}
+
+// Shared error handling for the used-range probe and each chunked range read.
+async function handleSheetFetchError({
+  error,
+  connector,
+  spreadsheet,
+  spreadsheetInternalId,
+  worksheetInternalId,
+  localLogger,
+  loggerArgs,
+}: {
+  error: Error;
+  connector: ConnectorResource;
+  spreadsheet: DriveItem;
+  spreadsheetInternalId: string;
+  worksheetInternalId: string;
+  localLogger: Logger;
+  loggerArgs: Record<string, unknown>;
+}): Promise<Result<null, Error>> {
+  localLogger.error(
+    { ...loggerArgs, error },
+    "[Spreadsheet] Failed to fetch sheet content."
+  );
+
+  // Rethrow throttling so the activity interceptor converts it into an
+  // ApplicationFailure honoring Retry-After, instead of silently dropping the
+  // sheet for the whole sync.
+  if (error instanceof MicrosoftThrottlingError) {
+    throw error;
+  }
+
+  if (error instanceof GraphError && error.statusCode === 504) {
+    await markInternalIdAsSkipped({
+      internalId: worksheetInternalId,
+      connectorId: connector.id,
+      parentInternalId: spreadsheetInternalId,
+      reason: "error_fetching_content",
+      file: spreadsheet,
+    });
+    // Ok so the freshly-written skip row survives the stale-sheet deletion
+    // pass in handleSpreadSheet and is honored on the next sync.
+    return new Ok(null);
+  }
+
+  return new Err(error);
+}
+
+export async function processSheet({
   client,
   connector,
   spreadsheet,
@@ -136,6 +282,7 @@ async function processSheet({
   worksheetInternalId,
   localLogger,
   startSyncTs,
+  heartbeat,
 }: {
   client: Client;
   connector: ConnectorResource;
@@ -145,13 +292,11 @@ async function processSheet({
   worksheetInternalId: string;
   localLogger: Logger;
   startSyncTs: number;
+  heartbeat: () => Promise<void>;
 }): Promise<Result<null, Error>> {
   if (!worksheet.id) {
     return new Err(new Error("Worksheet has no id"));
   }
-  const content = await wrapMicrosoftGraphAPIWithResult(() =>
-    getWorksheetContent(localLogger, client, worksheetInternalId)
-  );
 
   const loggerArgs = {
     sheet: {
@@ -161,131 +306,206 @@ async function processSheet({
     },
   };
 
-  if (content.isErr()) {
-    localLogger.error(
-      { ...loggerArgs, error: content.error },
-      "[Spreadsheet] Failed to fetch sheet content."
-    );
+  // Probe the used range's dimensions before fetching any cell values, so
+  // oversized sheets are rejected without ever materializing their content.
+  const metadataRes = await wrapMicrosoftGraphAPIWithResult(() =>
+    getWorksheetUsedRangeMetadata(localLogger, client, worksheetInternalId)
+  );
 
-    if (
-      content.error instanceof GraphError &&
-      content.error.statusCode === 504
-    ) {
-      await markInternalIdAsSkipped({
-        internalId: worksheetInternalId,
-        connectorId: connector.id,
-        parentInternalId: spreadsheetInternalId,
-        reason: "error_fetching_content",
-        file: spreadsheet,
-      });
-    }
-
-    return content;
+  if (metadataRes.isErr()) {
+    return handleSheetFetchError({
+      error: metadataRes.error,
+      connector,
+      spreadsheet,
+      spreadsheetInternalId,
+      worksheetInternalId,
+      localLogger,
+      loggerArgs,
+    });
   }
 
+  const rowIndex = metadataRes.value.rowIndex ?? 0;
+  const columnIndex = metadataRes.value.columnIndex ?? 0;
+  const rowCount = metadataRes.value.rowCount ?? 0;
+  const columnCount = metadataRes.value.columnCount ?? 0;
+  // cellCount may be missing; never trust it alone.
+  const cellCount = Math.max(
+    metadataRes.value.cellCount ?? 0,
+    rowCount * columnCount
+  );
+
   localLogger.info(
-    { loggerArgs },
+    { ...loggerArgs, rowCount, columnCount, cellCount },
     "[Spreadsheet] Processing sheet in Microsoft Excel."
   );
 
-  // Content.text is guaranteed to be a 2D array with each row of the same length.
-  const rows: string[][] = content?.value?.text;
-  if (!rows) {
-    localLogger.info(`[Spreadsheet] Cannot get any row from sheet.`);
-
-    return new Err(
-      new Error(
-        `Cannot get any row from sheet ${worksheet.id} in document ${spreadsheet.id}`
-      )
-    );
-  }
-
-  if (rows.length > MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS) {
+  if (rowCount > MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS) {
     localLogger.info(
-      { ...loggerArgs, rowCount: rows.length },
-      `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS}, skipping further processing.`
+      { ...loggerArgs, rowCount },
+      `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS} rows, skipping.`
     );
-
-    // If the sheet has too many rows, return an empty array to ignore it.
-    return new Err(
-      new Error(
-        `Too many rows in sheet ${worksheet.name}, rows=${rows.length}, max=${MAXIMUM_NUMBER_OF_EXCEL_SHEET_ROWS}`
-      )
-    );
-  }
-
-  // Assuming the first line as headers, at least one additional data line is required.
-  if (rows.length > 1) {
-    const parents: [string, string, ...string[]] = [
-      worksheetInternalId,
-      ...(await getParents({
-        connectorId: connector.id,
-        internalId: spreadsheetInternalId,
-        startSyncTs,
-      })),
-    ];
-
-    if (!spreadsheet.listItem?.fields) {
-      localLogger.warn("Unexpected missing fields for spreadsheet");
-    }
-
-    const tags = await getColumnsFromListItem(
-      spreadsheet,
-      spreadsheet.listItem?.fields,
-      await getMicrosoftClient(connector.connectionId),
-      localLogger
-    );
-
-    try {
-      await upsertMSTable(
-        connector,
-        worksheetInternalId,
-        spreadsheet,
-        worksheet,
-        parents,
-        rows,
-        tags
-      );
-    } catch (err) {
-      logger.error(
-        { ...loggerArgs, error: err },
-        "[Spreadsheet] Failed to upsert table."
-      );
-      if (err instanceof TablesError) {
-        localLogger.warn(
-          { ...loggerArgs, error: err },
-          "[Spreadsheet] Tables error - skipping (but not failing)."
-        );
-        return new Ok(null);
-      }
-      if (err instanceof Error) {
-        throw new ProviderWorkflowError(
-          "microsoft",
-          `Spreadsheet failed to upsert (possibly transient): ${err.message}`,
-          "transient_upstream_activity_error",
-          err
-        );
-      } else {
-        throw err;
-      }
-    }
-
-    await upsertWorksheetInDb(
+    await skipOversizedWorksheet({
       connector,
+      spreadsheet,
+      spreadsheetInternalId,
       worksheetInternalId,
-      worksheet,
-      spreadsheet
-    );
-
+      reason: "too_many_rows",
+    });
     return new Ok(null);
   }
 
-  localLogger.info(
-    loggerArgs,
-    "[Spreadsheet] Failed to import sheet. Will be deleted if already synced."
+  if (cellCount > MAXIMUM_NUMBER_OF_EXCEL_SHEET_CELLS) {
+    localLogger.info(
+      { ...loggerArgs, rowCount, columnCount, cellCount },
+      `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_EXCEL_SHEET_CELLS} cells, skipping.`
+    );
+    await skipOversizedWorksheet({
+      connector,
+      spreadsheet,
+      spreadsheetInternalId,
+      worksheetInternalId,
+      reason: "too_many_cells",
+    });
+    return new Ok(null);
+  }
+
+  // Assuming the first line as headers, at least one additional data line is
+  // required. An empty sheet probes as a single A1 cell (rowCount 1).
+  if (rowCount <= 1) {
+    localLogger.info(
+      loggerArgs,
+      "[Spreadsheet] Failed to import sheet. Will be deleted if already synced."
+    );
+    return new Err(new Error(`Table ${worksheet.id} is empty`));
+  }
+
+  // Fetch the used range in bounded windows, strictly sequentially (Microsoft
+  // advises against parallel requests to the same workbook), and build the CSV
+  // chunk by chunk so the full cell matrix is never resident in memory. If the
+  // sheet changes between the probe and the reads, removed cells come back as
+  // "" and rows added below the probed range are picked up on the next sync.
+  const csvParts: string[] = [];
+  let csvByteLength = 0;
+  const addresses = computeRangeChunkAddresses({
+    rowIndex,
+    columnIndex,
+    rowCount,
+    columnCount,
+  });
+  for (const address of addresses) {
+    await heartbeat();
+
+    const chunkRes = await wrapMicrosoftGraphAPIWithResult(() =>
+      getWorksheetRangeText(localLogger, client, worksheetInternalId, address)
+    );
+
+    if (chunkRes.isErr()) {
+      return handleSheetFetchError({
+        error: chunkRes.error,
+        connector,
+        spreadsheet,
+        spreadsheetInternalId,
+        worksheetInternalId,
+        localLogger,
+        loggerArgs,
+      });
+    }
+
+    const chunkRows: string[][] | null | undefined = chunkRes.value.text;
+    if (!chunkRows || chunkRows.length === 0) {
+      localLogger.info(
+        { ...loggerArgs, address },
+        "[Spreadsheet] Cannot get any row from sheet."
+      );
+
+      return new Err(
+        new Error(
+          `Cannot get any row from sheet ${worksheet.id} (range ${address}) in document ${spreadsheet.id}`
+        )
+      );
+    }
+
+    const csvPart = stringify(chunkRows);
+    csvByteLength += Buffer.byteLength(csvPart);
+    if (csvByteLength > MAXIMUM_EXCEL_CSV_BYTES) {
+      localLogger.info(
+        { ...loggerArgs, csvByteLength, address },
+        `[Spreadsheet] Sheet CSV exceeds ${MAXIMUM_EXCEL_CSV_BYTES} bytes, skipping.`
+      );
+      await skipOversizedWorksheet({
+        connector,
+        spreadsheet,
+        spreadsheetInternalId,
+        worksheetInternalId,
+        reason: "csv_too_large",
+      });
+      return new Ok(null);
+    }
+    csvParts.push(csvPart);
+  }
+
+  const parents: [string, string, ...string[]] = [
+    worksheetInternalId,
+    ...(await getParents({
+      connectorId: connector.id,
+      internalId: spreadsheetInternalId,
+      startSyncTs,
+    })),
+  ];
+
+  if (!spreadsheet.listItem?.fields) {
+    localLogger.warn("Unexpected missing fields for spreadsheet");
+  }
+
+  const tags = await getColumnsFromListItem(
+    spreadsheet,
+    spreadsheet.listItem?.fields,
+    await getMicrosoftClient(connector.connectionId),
+    localLogger
   );
 
-  return new Err(new Error(`Table ${worksheet.id} is empty`));
+  try {
+    await upsertMSTable(
+      connector,
+      worksheetInternalId,
+      spreadsheet,
+      worksheet,
+      parents,
+      csvParts.join(""),
+      tags
+    );
+  } catch (err) {
+    logger.error(
+      { ...loggerArgs, error: err },
+      "[Spreadsheet] Failed to upsert table."
+    );
+    if (err instanceof TablesError) {
+      localLogger.warn(
+        { ...loggerArgs, error: err },
+        "[Spreadsheet] Tables error - skipping (but not failing)."
+      );
+      return new Ok(null);
+    }
+    if (err instanceof Error) {
+      throw new ProviderWorkflowError(
+        "microsoft",
+        `Spreadsheet failed to upsert (possibly transient): ${err.message}`,
+        "transient_upstream_activity_error",
+        err
+      );
+    } else {
+      throw err;
+    }
+  }
+
+  await upsertWorksheetInDb(
+    connector,
+    worksheetInternalId,
+    worksheet,
+    spreadsheet
+  );
+
+  return new Ok(null);
 }
 
 export async function handleSpreadSheet({
@@ -413,6 +633,7 @@ export async function handleSpreadSheet({
         worksheetInternalId,
         localLogger,
         startSyncTs,
+        heartbeat,
       });
       if (importResult.isOk()) {
         successfulSheetIdImports.push(worksheetInternalId);
@@ -421,7 +642,7 @@ export async function handleSpreadSheet({
   }
 
   // Delete any previously synced sheets that no longer exist in the current spreadsheet
-  // or have exceeded the maximum number of rows.
+  // or came back empty. Oversized or unfetchable sheets are marked skipped and kept.
   const deletedSyncedSheetIds = syncedWorksheets
     .map((synced) => synced.internalId)
     .filter((syncedId) => successfulSheetIdImports.indexOf(syncedId) === -1);


### PR DESCRIPTION
## Context

`connectors-worker-microsoft` hit 11 Node heap OOMs (`FATAL ERROR: Reached heap limit`) between Jul 7 and Jul 20 — including three crash-restart-crash cycles on one pod resuming the same sync. Strongest lead: an oversized Excel workbook on `conn_zKywRhQMss`.

The Excel path fetched each worksheet's entire `usedRange` (`?$select=text`) in a single Graph call, materializing the full 2D cell array in the heap **before** the only guard (50k rows) ran. A sheet with few rows but many columns — or a sparse sheet with a huge used range — OOMs before the guard can reject it. Worse, the too-many-rows rejection returned a plain `Err` without persisting a skip, and the stale-sheet deletion pass wiped freshly-written `skipReason` rows for previously-synced sheets, so pathological workbooks were re-fetched on every sync.

## Changes

- **Probe first**: new `getWorksheetUsedRangeMetadata` fetches `usedRange(valuesOnly=true)` scalar dimensions only (`rowCount`, `columnCount`, `cellCount`, origin) — no cell values.
- **Pre-fetch guards**: 50k-row cap (unchanged, now enforced before any fetch) plus a new 3M-cell cap. Oversized sheets are persisted via `markInternalIdAsSkipped` (`too_many_rows` / `too_many_cells`) and their stale table is deleted, so they're skipped cheaply on subsequent syncs via the existing `knownSkippedWorksheetIds` path.
- **Chunked reads**: new `getWorksheetRangeText` fetches bounded A1 windows (`range(address='B3:AO2502')`), ~100k cells per request, strictly sequential per workbook (per Microsoft guidance), with a heartbeat per chunk.
- **Incremental CSV assembly**: chunks are stringified and accumulated as CSV parts (byte-identical output to the old single-shot `stringify`); accumulation aborts at 50MB (aligned with `MAX_CSV_SIZE`) with a persisted `csv_too_large` skip. The full cell matrix is never resident.
- **Skip rows now survive the sync that writes them**: `processSheet` returns `Ok` after marking a sheet skipped (including the existing 504 path), so the stale-sheet `batchDelete` pass no longer destroys the skip marker the same sync.
- **Throttling**: `MicrosoftThrottlingError` from probe/chunk reads is rethrown instead of swallowed, letting `MicrosoftCastKnownErrorsInterceptor` honor `Retry-After` via `nextRetryDelay`.

Worst-case heap per in-flight spreadsheet drops from unbounded to ~50MB CSV + one ~1-2MB chunk.

## Tests

New `spreadsheets.test.ts` (14 tests): A1 address math incl. non-A1 origins and 16384-column sheets; probe-time skips with persisted reasons; 3-chunk happy path asserting exact window addresses and byte-identical CSV; byte-cap abort mid-loop; empty sheets; 504 on probe and mid-chunk; throttling rethrow; `handleSpreadSheet` honoring persisted skips without re-fetching.

## Risk

Sheets wider than ~60 columns at 50k rows (>3M cells) stop syncing and get a visible `skipReason` — previously they either OOMed the worker or synced by luck. Skips are permanent until cleared (same trade-off as existing `error_fetching_content` skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)