### PR TITLE
[core] fix: Bump rust builder image to 1.94.1 for qdrant-client 1.18

### DIFF
--- a/dockerfiles/core.Dockerfile
+++ b/dockerfiles/core.Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.85.0 AS builder
+FROM rust:1.94.1 AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/oauth.Dockerfile
+++ b/dockerfiles/oauth.Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.85.0 AS builder
+FROM rust:1.94.1 AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

Bump up core img to fix failing deploys on core

## Test

N/A

## Risk

Low

## Plan

Merge & deploy core