### PR TITLE
feat: add get_incident, create_incident, update_incident tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2086,7 +2086,19 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
     },
   },
   "servicenow": {
+    "create_incident": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "get_incident": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
     "list_incidents": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "update_incident": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -3195,7 +3207,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "semantic_search": "never_ask",
   },
   "servicenow": {
+    "create_incident": "low",
+    "get_incident": "never_ask",
     "list_incidents": "never_ask",
+    "update_incident": "low",
   },
   "skill_authoring": {
     "create_skill": "high",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1673,6 +1673,32 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "show me my ServiceNow tickets",
     expected: "servicenow.list_incidents",
+    maxRank: 2, // get_incident shares "ServiceNow"/"ticket" tokens
+  },
+  {
+    query: "get ServiceNow incident INC0010001",
+    expected: "servicenow.get_incident",
+  },
+  {
+    query: "look up a single ServiceNow ticket by number",
+    expected: "servicenow.get_incident",
+  },
+  {
+    query: "create a new incident in ServiceNow",
+    expected: "servicenow.create_incident",
+  },
+  {
+    query: "open a ServiceNow ticket for this issue",
+    expected: "servicenow.create_incident",
+    maxRank: 4, // get_incident's short, dense description outranks on shared tokens
+  },
+  {
+    query: "update the state of a ServiceNow incident",
+    expected: "servicenow.update_incident",
+  },
+  {
+    query: "resolve a ServiceNow ticket and add close notes",
+    expected: "servicenow.update_incident",
   },
 
   // --- slab ---

--- a/front/lib/api/actions/servers/servicenow/client.ts
+++ b/front/lib/api/actions/servers/servicenow/client.ts
@@ -18,6 +18,24 @@ export const IncidentSchema = z.object({
 });
 export type Incident = z.infer<typeof IncidentSchema>;
 
+// Fields writable via the incident CRUD tools, keyed by the ServiceNow
+// field name. Passing sysparm_input_display_value=true on write lets callers
+// use human-readable choice labels (e.g. "Resolved", "1 - Critical") instead
+// of ServiceNow's internal numeric codes.
+export type WritableIncidentFields = {
+  short_description?: string;
+  description?: string;
+  urgency?: string;
+  impact?: string;
+  priority?: string;
+  state?: string;
+  category?: string;
+  assignment_group?: string;
+  work_notes?: string;
+  close_notes?: string;
+  close_code?: string;
+};
+
 function getInstanceUrl(authInfo?: AuthInfo): string | null {
   if (!authInfo?.extra) {
     return null;
@@ -29,31 +47,27 @@ function getInstanceUrl(authInfo?: AuthInfo): string | null {
   return servicenowInstanceUrl.trim().replace(/\/$/, "");
 }
 
-async function servicenowApiCall<T extends z.ZodTypeAny>(
+async function request<T extends z.ZodTypeAny>(
   {
-    endpoint,
+    url,
     accessToken,
-    instanceUrl,
+    method,
+    body,
   }: {
-    endpoint: string;
+    url: string;
     accessToken: string;
-    instanceUrl: string;
-  },
-  schema: T,
-  options: {
-    method?: "GET" | "POST" | "PATCH";
+    method: "GET" | "POST" | "PATCH";
     body?: Record<string, unknown>;
-  } = {}
+  },
+  schema: T
 ): Promise<Result<z.infer<T>, MCPError>> {
-  const url = `${instanceUrl}${endpoint}`;
-
   const response = await untrustedFetch(url, {
-    method: options.method ?? "GET",
+    method,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       "Content-Type": "application/json",
     },
-    ...(options.body && { body: JSON.stringify(options.body) }),
+    ...(body && { body: JSON.stringify(body) }),
   });
 
   if (!response.ok) {
@@ -90,140 +104,178 @@ async function servicenowApiCall<T extends z.ZodTypeAny>(
   return new Ok(parseResult.data);
 }
 
-export async function listIncidents(
-  accessToken: string,
-  instanceUrl: string,
-  { query, limit }: { query?: string; limit?: number }
-): Promise<Result<Incident[], MCPError>> {
-  const params = new URLSearchParams();
-  params.set("sysparm_limit", String(limit ?? DEFAULT_INCIDENT_LIMIT));
-  // Return human-readable labels (e.g. "Critical", "New") for choice fields
-  // like state/priority instead of ServiceNow's raw internal codes.
-  params.set("sysparm_display_value", "true");
-  if (query) {
-    params.set("sysparm_query", query);
-  }
-
-  const result = await servicenowApiCall(
-    {
-      endpoint: `/api/now/table/incident?${params.toString()}`,
-      accessToken,
-      instanceUrl,
-    },
-    z.object({ result: z.array(IncidentSchema) })
-  );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  return new Ok(result.value.result);
-}
-
-export async function getIncidentByNumber(
-  accessToken: string,
-  instanceUrl: string,
-  incidentNumber: string
-): Promise<Result<Incident | null, MCPError>> {
-  // ServiceNow's encoded query syntax treats "^" as a condition separator (and
-  // "=" as an operator), so passing it through unescaped would let a caller
-  // turn this exact-number lookup into an arbitrary compound query.
-  if (/[\^=]/.test(incidentNumber)) {
-    return new Err(
-      new MCPError(
-        `Invalid incident number: "${incidentNumber}". Expected a plain incident number, e.g. "INC0010001".`
-      )
-    );
-  }
-
-  const params = new URLSearchParams();
-  params.set("sysparm_query", `number=${incidentNumber}`);
-  params.set("sysparm_limit", "1");
-  params.set("sysparm_display_value", "true");
-
-  const result = await servicenowApiCall(
-    {
-      endpoint: `/api/now/table/incident?${params.toString()}`,
-      accessToken,
-      instanceUrl,
-    },
-    z.object({ result: z.array(IncidentSchema) })
-  );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  return new Ok(result.value.result[0] ?? null);
-}
-
-// Fields writable via the incident CRUD tools, keyed by the ServiceNow
-// field name. Passing sysparm_input_display_value=true on write lets callers
-// use human-readable choice labels (e.g. "Resolved", "1 - Critical") instead
-// of ServiceNow's internal numeric codes.
-export type WritableIncidentFields = {
-  short_description?: string;
-  description?: string;
-  urgency?: string;
-  impact?: string;
-  priority?: string;
-  state?: string;
-  category?: string;
-  assignment_group?: string;
-  work_notes?: string;
-  close_notes?: string;
-  close_code?: string;
+type BaseRequestArgs = {
+  endpoint: string;
+  accessToken: string;
+  instanceUrl: string;
 };
 
-export async function createIncident(
-  accessToken: string,
-  instanceUrl: string,
-  fields: WritableIncidentFields
-): Promise<Result<Incident, MCPError>> {
-  const result = await servicenowApiCall(
-    {
-      endpoint:
-        "/api/now/table/incident?sysparm_display_value=true&sysparm_input_display_value=true",
-      accessToken,
-      instanceUrl,
-    },
-    z.object({ result: IncidentSchema }),
-    { method: "POST", body: fields }
+function get<T extends z.ZodTypeAny>(
+  { endpoint, accessToken, instanceUrl }: BaseRequestArgs,
+  schema: T
+): Promise<Result<z.infer<T>, MCPError>> {
+  return request(
+    { url: `${instanceUrl}${endpoint}`, accessToken, method: "GET" },
+    schema
   );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  return new Ok(result.value.result);
 }
 
-export async function updateIncident(
-  accessToken: string,
-  instanceUrl: string,
-  sysId: string,
-  fields: WritableIncidentFields
-): Promise<Result<Incident, MCPError>> {
-  const result = await servicenowApiCall(
-    {
-      endpoint: `/api/now/table/incident/${encodeURIComponent(sysId)}?sysparm_display_value=true&sysparm_input_display_value=true`,
-      accessToken,
-      instanceUrl,
-    },
-    z.object({ result: IncidentSchema }),
-    { method: "PATCH", body: fields }
+function write<T extends z.ZodTypeAny>(
+  {
+    endpoint,
+    accessToken,
+    instanceUrl,
+    method,
+    body,
+  }: BaseRequestArgs & {
+    method: "POST" | "PATCH";
+    body: Record<string, unknown>;
+  },
+  schema: T
+): Promise<Result<z.infer<T>, MCPError>> {
+  return request(
+    { url: `${instanceUrl}${endpoint}`, accessToken, method, body },
+    schema
   );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  return new Ok(result.value.result);
 }
 
-export function getServiceNowCredentials(
+export class ServiceNowClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly instanceUrl: string
+  ) {}
+
+  async listIncidents({
+    query,
+    limit,
+  }: {
+    query?: string;
+    limit?: number;
+  }): Promise<Result<Incident[], MCPError>> {
+    const params = new URLSearchParams();
+    params.set("sysparm_limit", String(limit ?? DEFAULT_INCIDENT_LIMIT));
+    // Return human-readable labels (e.g. "Critical", "New") for choice fields
+    // like state/priority instead of ServiceNow's raw internal codes.
+    params.set("sysparm_display_value", "true");
+    if (query) {
+      params.set("sysparm_query", query);
+    }
+
+    const result = await get(
+      {
+        endpoint: `/api/now/table/incident?${params.toString()}`,
+        accessToken: this.accessToken,
+        instanceUrl: this.instanceUrl,
+      },
+      z.object({ result: z.array(IncidentSchema) })
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok(result.value.result);
+  }
+
+  async getIncidentByNumber(
+    incidentNumber: string
+  ): Promise<Result<Incident | null, MCPError>> {
+    // ServiceNow's encoded query syntax treats "^" as a condition separator (and
+    // "=" as an operator), so passing it through unescaped would let a caller
+    // turn this exact-number lookup into an arbitrary compound query.
+    if (/[\^=]/.test(incidentNumber)) {
+      return new Err(
+        new MCPError(
+          `Invalid incident number: "${incidentNumber}". Expected a plain incident number, e.g. "INC0010001".`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.set("sysparm_query", `number=${incidentNumber}`);
+    params.set("sysparm_limit", "1");
+    params.set("sysparm_display_value", "true");
+
+    const result = await get(
+      {
+        endpoint: `/api/now/table/incident?${params.toString()}`,
+        accessToken: this.accessToken,
+        instanceUrl: this.instanceUrl,
+      },
+      z.object({ result: z.array(IncidentSchema) })
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok(result.value.result[0] ?? null);
+  }
+
+  async createIncident(
+    fields: WritableIncidentFields
+  ): Promise<Result<Incident, MCPError>> {
+    const result = await write(
+      {
+        endpoint:
+          "/api/now/table/incident?sysparm_display_value=true&sysparm_input_display_value=true",
+        accessToken: this.accessToken,
+        instanceUrl: this.instanceUrl,
+        method: "POST",
+        body: fields,
+      },
+      z.object({ result: IncidentSchema })
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok(result.value.result);
+  }
+
+  async updateIncident({
+    incidentNumber,
+    fields,
+  }: {
+    incidentNumber: string;
+    fields: WritableIncidentFields;
+  }): Promise<Result<Incident, MCPError>> {
+    const existingResult = await this.getIncidentByNumber(incidentNumber);
+    if (existingResult.isErr()) {
+      return existingResult;
+    }
+    if (!existingResult.value) {
+      return new Err(
+        new MCPError(`No incident found with number "${incidentNumber}".`, {
+          tracked: false,
+        })
+      );
+    }
+
+    const result = await write(
+      {
+        endpoint: `/api/now/table/incident/${encodeURIComponent(existingResult.value.sys_id)}?sysparm_display_value=true&sysparm_input_display_value=true`,
+        accessToken: this.accessToken,
+        instanceUrl: this.instanceUrl,
+        method: "PATCH",
+        body: fields,
+      },
+      z.object({ result: IncidentSchema })
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok(result.value.result);
+  }
+}
+
+export function createServiceNowClient(
   authInfo?: AuthInfo
-): Result<{ accessToken: string; instanceUrl: string }, MCPError> {
+): Result<ServiceNowClient, MCPError> {
   const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(new MCPError("No access token found"));
@@ -239,5 +291,5 @@ export function getServiceNowCredentials(
     );
   }
 
-  return new Ok({ accessToken, instanceUrl });
+  return new Ok(new ServiceNowClient(accessToken, instanceUrl));
 }

--- a/front/lib/api/actions/servers/servicenow/client.ts
+++ b/front/lib/api/actions/servers/servicenow/client.ts
@@ -104,46 +104,42 @@ async function request<T extends z.ZodTypeAny>(
   return new Ok(parseResult.data);
 }
 
-type BaseRequestArgs = {
-  endpoint: string;
-  accessToken: string;
-  instanceUrl: string;
-};
-
-function get<T extends z.ZodTypeAny>(
-  { endpoint, accessToken, instanceUrl }: BaseRequestArgs,
-  schema: T
-): Promise<Result<z.infer<T>, MCPError>> {
-  return request(
-    { url: `${instanceUrl}${endpoint}`, accessToken, method: "GET" },
-    schema
-  );
-}
-
-function write<T extends z.ZodTypeAny>(
-  {
-    endpoint,
-    accessToken,
-    instanceUrl,
-    method,
-    body,
-  }: BaseRequestArgs & {
-    method: "POST" | "PATCH";
-    body: Record<string, unknown>;
-  },
-  schema: T
-): Promise<Result<z.infer<T>, MCPError>> {
-  return request(
-    { url: `${instanceUrl}${endpoint}`, accessToken, method, body },
-    schema
-  );
-}
-
 export class ServiceNowClient {
   constructor(
     private readonly accessToken: string,
     private readonly instanceUrl: string
   ) {}
+
+  private get<T extends z.ZodTypeAny>(
+    endpoint: string,
+    schema: T
+  ): Promise<Result<z.infer<T>, MCPError>> {
+    return request(
+      {
+        url: `${this.instanceUrl}${endpoint}`,
+        accessToken: this.accessToken,
+        method: "GET",
+      },
+      schema
+    );
+  }
+
+  private mutate<T extends z.ZodTypeAny>(
+    endpoint: string,
+    method: "POST" | "PATCH",
+    body: Record<string, unknown>,
+    schema: T
+  ): Promise<Result<z.infer<T>, MCPError>> {
+    return request(
+      {
+        url: `${this.instanceUrl}${endpoint}`,
+        accessToken: this.accessToken,
+        method,
+        body,
+      },
+      schema
+    );
+  }
 
   async listIncidents({
     query,
@@ -161,12 +157,8 @@ export class ServiceNowClient {
       params.set("sysparm_query", query);
     }
 
-    const result = await get(
-      {
-        endpoint: `/api/now/table/incident?${params.toString()}`,
-        accessToken: this.accessToken,
-        instanceUrl: this.instanceUrl,
-      },
+    const result = await this.get(
+      `/api/now/table/incident?${params.toString()}`,
       z.object({ result: z.array(IncidentSchema) })
     );
 
@@ -197,12 +189,8 @@ export class ServiceNowClient {
     params.set("sysparm_limit", "1");
     params.set("sysparm_display_value", "true");
 
-    const result = await get(
-      {
-        endpoint: `/api/now/table/incident?${params.toString()}`,
-        accessToken: this.accessToken,
-        instanceUrl: this.instanceUrl,
-      },
+    const result = await this.get(
+      `/api/now/table/incident?${params.toString()}`,
       z.object({ result: z.array(IncidentSchema) })
     );
 
@@ -216,15 +204,10 @@ export class ServiceNowClient {
   async createIncident(
     fields: WritableIncidentFields
   ): Promise<Result<Incident, MCPError>> {
-    const result = await write(
-      {
-        endpoint:
-          "/api/now/table/incident?sysparm_display_value=true&sysparm_input_display_value=true",
-        accessToken: this.accessToken,
-        instanceUrl: this.instanceUrl,
-        method: "POST",
-        body: fields,
-      },
+    const result = await this.mutate(
+      "/api/now/table/incident?sysparm_display_value=true&sysparm_input_display_value=true",
+      "POST",
+      fields,
       z.object({ result: IncidentSchema })
     );
 
@@ -235,33 +218,14 @@ export class ServiceNowClient {
     return new Ok(result.value.result);
   }
 
-  async updateIncident({
-    incidentNumber,
-    fields,
-  }: {
-    incidentNumber: string;
-    fields: WritableIncidentFields;
-  }): Promise<Result<Incident, MCPError>> {
-    const existingResult = await this.getIncidentByNumber(incidentNumber);
-    if (existingResult.isErr()) {
-      return existingResult;
-    }
-    if (!existingResult.value) {
-      return new Err(
-        new MCPError(`No incident found with number "${incidentNumber}".`, {
-          tracked: false,
-        })
-      );
-    }
-
-    const result = await write(
-      {
-        endpoint: `/api/now/table/incident/${encodeURIComponent(existingResult.value.sys_id)}?sysparm_display_value=true&sysparm_input_display_value=true`,
-        accessToken: this.accessToken,
-        instanceUrl: this.instanceUrl,
-        method: "PATCH",
-        body: fields,
-      },
+  async updateIncident(
+    sysId: string,
+    fields: WritableIncidentFields
+  ): Promise<Result<Incident, MCPError>> {
+    const result = await this.mutate(
+      `/api/now/table/incident/${encodeURIComponent(sysId)}?sysparm_display_value=true&sysparm_input_display_value=true`,
+      "PATCH",
+      fields,
       z.object({ result: IncidentSchema })
     );
 

--- a/front/lib/api/actions/servers/servicenow/client.ts
+++ b/front/lib/api/actions/servers/servicenow/client.ts
@@ -39,16 +39,21 @@ async function servicenowApiCall<T extends z.ZodTypeAny>(
     accessToken: string;
     instanceUrl: string;
   },
-  schema: T
+  schema: T,
+  options: {
+    method?: "GET" | "POST" | "PATCH";
+    body?: Record<string, unknown>;
+  } = {}
 ): Promise<Result<z.infer<T>, MCPError>> {
   const url = `${instanceUrl}${endpoint}`;
 
   const response = await untrustedFetch(url, {
-    method: "GET",
+    method: options.method ?? "GET",
     headers: {
       Authorization: `Bearer ${accessToken}`,
       "Content-Type": "application/json",
     },
+    ...(options.body && { body: JSON.stringify(options.body) }),
   });
 
   if (!response.ok) {
@@ -56,7 +61,11 @@ async function servicenowApiCall<T extends z.ZodTypeAny>(
     let errorMessage = `ServiceNow API error: ${response.status} ${response.statusText}`;
     try {
       const errorJson = JSON.parse(errorBody);
-      errorMessage = errorJson.error?.message ?? errorMessage;
+      const message = errorJson.error?.message;
+      const detail = errorJson.error?.detail;
+      if (message) {
+        errorMessage = detail ? `${message}: ${detail}` : message;
+      }
     } catch {
       errorMessage = `${errorMessage} - ${errorBody}`;
     }
@@ -102,6 +111,107 @@ export async function listIncidents(
       instanceUrl,
     },
     z.object({ result: z.array(IncidentSchema) })
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok(result.value.result);
+}
+
+export async function getIncidentByNumber(
+  accessToken: string,
+  instanceUrl: string,
+  incidentNumber: string
+): Promise<Result<Incident | null, MCPError>> {
+  // ServiceNow's encoded query syntax treats "^" as a condition separator (and
+  // "=" as an operator), so passing it through unescaped would let a caller
+  // turn this exact-number lookup into an arbitrary compound query.
+  if (/[\^=]/.test(incidentNumber)) {
+    return new Err(
+      new MCPError(
+        `Invalid incident number: "${incidentNumber}". Expected a plain incident number, e.g. "INC0010001".`
+      )
+    );
+  }
+
+  const params = new URLSearchParams();
+  params.set("sysparm_query", `number=${incidentNumber}`);
+  params.set("sysparm_limit", "1");
+  params.set("sysparm_display_value", "true");
+
+  const result = await servicenowApiCall(
+    {
+      endpoint: `/api/now/table/incident?${params.toString()}`,
+      accessToken,
+      instanceUrl,
+    },
+    z.object({ result: z.array(IncidentSchema) })
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok(result.value.result[0] ?? null);
+}
+
+// Fields writable via the incident CRUD tools, keyed by the ServiceNow
+// field name. Passing sysparm_input_display_value=true on write lets callers
+// use human-readable choice labels (e.g. "Resolved", "1 - Critical") instead
+// of ServiceNow's internal numeric codes.
+export type WritableIncidentFields = {
+  short_description?: string;
+  description?: string;
+  urgency?: string;
+  impact?: string;
+  priority?: string;
+  state?: string;
+  category?: string;
+  assignment_group?: string;
+  work_notes?: string;
+  close_notes?: string;
+  close_code?: string;
+};
+
+export async function createIncident(
+  accessToken: string,
+  instanceUrl: string,
+  fields: WritableIncidentFields
+): Promise<Result<Incident, MCPError>> {
+  const result = await servicenowApiCall(
+    {
+      endpoint:
+        "/api/now/table/incident?sysparm_display_value=true&sysparm_input_display_value=true",
+      accessToken,
+      instanceUrl,
+    },
+    z.object({ result: IncidentSchema }),
+    { method: "POST", body: fields }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok(result.value.result);
+}
+
+export async function updateIncident(
+  accessToken: string,
+  instanceUrl: string,
+  sysId: string,
+  fields: WritableIncidentFields
+): Promise<Result<Incident, MCPError>> {
+  const result = await servicenowApiCall(
+    {
+      endpoint: `/api/now/table/incident/${encodeURIComponent(sysId)}?sysparm_display_value=true&sysparm_input_display_value=true`,
+      accessToken,
+      instanceUrl,
+    },
+    z.object({ result: IncidentSchema }),
+    { method: "PATCH", body: fields }
   );
 
   if (result.isErr()) {

--- a/front/lib/api/actions/servers/servicenow/metadata.ts
+++ b/front/lib/api/actions/servers/servicenow/metadata.ts
@@ -88,18 +88,26 @@ export const SERVICENOW_TOOLS_METADATA = [
   {
     name: "update_incident",
     description:
-      "Update, resolve, or close an existing ServiceNow incident (ticket) identified by its sys_id (returned by list_incidents/get_incident).",
+      "Update, resolve, or close an existing ServiceNow incident (ticket) identified by its number, e.g. 'INC0010001'.",
     schema: {
-      sysId: z.string().describe("The sys_id of the incident to update."),
+      incidentNumber: z
+        .string()
+        .describe("The ServiceNow incident number, e.g. 'INC0010001'."),
       shortDescription: z
         .string()
         .optional()
-        .describe("New short summary of the incident."),
+        .describe("Replacement short summary of the incident."),
       state: z
         .string()
         .optional()
         .describe(
-          "New state, e.g. 'New', 'In Progress', 'Resolved', 'Closed'."
+          "State to move the incident to, e.g. 'In Progress', 'Resolved', 'Closed'."
+        ),
+      priority: z
+        .string()
+        .optional()
+        .describe(
+          "Priority, e.g. '1 - Critical', '2 - High', '3 - Moderate', '4 - Low', '5 - Planning'."
         ),
       workNotes: z
         .string()
@@ -119,7 +127,6 @@ export const SERVICENOW_TOOLS_METADATA = [
         .describe(
           "Resolution code. Required by ServiceNow to move state to 'Resolved' or 'Closed'. Valid values are configured per ServiceNow instance (e.g. 'Solution provided', 'Resolved by caller') — if unsure, call list_incidents on an already-resolved incident to see a value your instance accepts."
         ),
-      ...WRITABLE_INCIDENT_FIELDS_SCHEMA,
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/servicenow/metadata.ts
+++ b/front/lib/api/actions/servers/servicenow/metadata.ts
@@ -117,7 +117,7 @@ export const SERVICENOW_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Resolution code. Required by ServiceNow to move state to 'Resolved' or 'Closed', e.g. 'Solved (Permanently)', 'Solved (Work Around)', 'Closed/Resolved by Caller'."
+          "Resolution code. Required by ServiceNow to move state to 'Resolved' or 'Closed'. Valid values are configured per ServiceNow instance (e.g. 'Solution provided', 'Resolved by caller') — if unsure, call list_incidents on an already-resolved incident to see a value your instance accepts."
         ),
       ...WRITABLE_INCIDENT_FIELDS_SCHEMA,
     },

--- a/front/lib/api/actions/servers/servicenow/metadata.ts
+++ b/front/lib/api/actions/servers/servicenow/metadata.ts
@@ -1,6 +1,32 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
+const WRITABLE_INCIDENT_FIELDS_SCHEMA = {
+  description: z
+    .string()
+    .optional()
+    .describe("Full description of the incident."),
+  urgency: z
+    .string()
+    .optional()
+    .describe("Urgency, e.g. '1 - High', '2 - Medium', '3 - Low'."),
+  impact: z
+    .string()
+    .optional()
+    .describe("Impact, e.g. '1 - High', '2 - Medium', '3 - Low'."),
+  priority: z
+    .string()
+    .optional()
+    .describe(
+      "Priority, e.g. '1 - Critical', '2 - High', '3 - Moderate', '4 - Low', '5 - Planning'."
+    ),
+  category: z.string().optional().describe("Incident category."),
+  assignmentGroup: z
+    .string()
+    .optional()
+    .describe("Name of the assignment group to assign the incident to."),
+};
+
 export const SERVICENOW_TOOLS_METADATA = [
   {
     name: "list_incidents",
@@ -22,6 +48,83 @@ export const SERVICENOW_TOOLS_METADATA = [
     displayLabels: {
       running: "Listing ServiceNow incidents",
       done: "List ServiceNow incidents",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "get_incident",
+    description:
+      "Get a single ServiceNow incident (ticket) by its number, e.g. 'INC0010001'.",
+    schema: {
+      incidentNumber: z
+        .string()
+        .describe("The ServiceNow incident number, e.g. 'INC0010001'."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving ServiceNow incident",
+      done: "Retrieve ServiceNow incident",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "create_incident",
+    description:
+      "Create (open) a new ServiceNow incident (ticket) in the connected instance.",
+    schema: {
+      shortDescription: z.string().describe("Short summary of the incident."),
+      ...WRITABLE_INCIDENT_FIELDS_SCHEMA,
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Creating ServiceNow incident",
+      done: "Create ServiceNow incident",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "update_incident",
+    description:
+      "Update, resolve, or close an existing ServiceNow incident (ticket) identified by its sys_id (returned by list_incidents/get_incident).",
+    schema: {
+      sysId: z.string().describe("The sys_id of the incident to update."),
+      shortDescription: z
+        .string()
+        .optional()
+        .describe("New short summary of the incident."),
+      state: z
+        .string()
+        .optional()
+        .describe(
+          "New state, e.g. 'New', 'In Progress', 'Resolved', 'Closed'."
+        ),
+      workNotes: z
+        .string()
+        .optional()
+        .describe(
+          "Work note to add to the incident (internal, not customer-visible)."
+        ),
+      closeNotes: z
+        .string()
+        .optional()
+        .describe(
+          "Resolution notes, typically set when resolving/closing the incident."
+        ),
+      resolutionCode: z
+        .string()
+        .optional()
+        .describe(
+          "Resolution code. Required by ServiceNow to move state to 'Resolved' or 'Closed', e.g. 'Solved (Permanently)', 'Solved (Work Around)', 'Closed/Resolved by Caller'."
+        ),
+      ...WRITABLE_INCIDENT_FIELDS_SCHEMA,
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Updating ServiceNow incident",
+      done: "Update ServiceNow incident",
     },
     toolCostCategory: "advanced",
     freeUsage: false,

--- a/front/lib/api/actions/servers/servicenow/tools/index.ts
+++ b/front/lib/api/actions/servers/servicenow/tools/index.ts
@@ -1,11 +1,7 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  createIncident,
-  getIncidentByNumber,
-  getServiceNowCredentials,
-  listIncidents,
-  updateIncident,
+  createServiceNowClient,
   type WritableIncidentFields,
 } from "@app/lib/api/actions/servers/servicenow/client";
 import { renderIncident } from "@app/lib/api/actions/servers/servicenow/helpers";
@@ -58,16 +54,13 @@ function writableFieldsFromParams({
 
 const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
   list_incidents: async ({ query, limit }, { authInfo }) => {
-    const credentialsResult = getServiceNowCredentials(authInfo);
-    if (credentialsResult.isErr()) {
-      return credentialsResult;
+    const clientResult = createServiceNowClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
     }
-    const { accessToken, instanceUrl } = credentialsResult.value;
+    const client = clientResult.value;
 
-    const result = await listIncidents(accessToken, instanceUrl, {
-      query,
-      limit,
-    });
+    const result = await client.listIncidents({ query, limit });
 
     if (result.isErr()) {
       return result;
@@ -88,17 +81,13 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
   },
 
   get_incident: async ({ incidentNumber }, { authInfo }) => {
-    const credentialsResult = getServiceNowCredentials(authInfo);
-    if (credentialsResult.isErr()) {
-      return credentialsResult;
+    const clientResult = createServiceNowClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
     }
-    const { accessToken, instanceUrl } = credentialsResult.value;
+    const client = clientResult.value;
 
-    const result = await getIncidentByNumber(
-      accessToken,
-      instanceUrl,
-      incidentNumber
-    );
+    const result = await client.getIncidentByNumber(incidentNumber);
 
     if (result.isErr()) {
       return result;
@@ -119,15 +108,13 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
   },
 
   create_incident: async (params, { authInfo }) => {
-    const credentialsResult = getServiceNowCredentials(authInfo);
-    if (credentialsResult.isErr()) {
-      return credentialsResult;
+    const clientResult = createServiceNowClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
     }
-    const { accessToken, instanceUrl } = credentialsResult.value;
+    const client = clientResult.value;
 
-    const result = await createIncident(
-      accessToken,
-      instanceUrl,
+    const result = await client.createIncident(
       writableFieldsFromParams(params)
     );
 
@@ -143,12 +130,12 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
     ]);
   },
 
-  update_incident: async ({ sysId, ...fields }, { authInfo }) => {
-    const credentialsResult = getServiceNowCredentials(authInfo);
-    if (credentialsResult.isErr()) {
-      return credentialsResult;
+  update_incident: async ({ incidentNumber, ...fields }, { authInfo }) => {
+    const clientResult = createServiceNowClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
     }
-    const { accessToken, instanceUrl } = credentialsResult.value;
+    const client = clientResult.value;
 
     const writableFields = writableFieldsFromParams(fields);
 
@@ -161,12 +148,10 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
       ]);
     }
 
-    const result = await updateIncident(
-      accessToken,
-      instanceUrl,
-      sysId,
-      writableFields
-    );
+    const result = await client.updateIncident({
+      incidentNumber,
+      fields: writableFields,
+    });
 
     if (result.isErr()) {
       return result;

--- a/front/lib/api/actions/servers/servicenow/tools/index.ts
+++ b/front/lib/api/actions/servers/servicenow/tools/index.ts
@@ -1,3 +1,4 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -6,7 +7,7 @@ import {
 } from "@app/lib/api/actions/servers/servicenow/client";
 import { renderIncident } from "@app/lib/api/actions/servers/servicenow/helpers";
 import { SERVICENOW_TOOLS_METADATA } from "@app/lib/api/actions/servers/servicenow/metadata";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 function writableFieldsFromParams({
   shortDescription,
@@ -94,12 +95,11 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
     }
 
     if (!result.value) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No incident found with number ${incidentNumber}.`,
-        },
-      ]);
+      return new Err(
+        new MCPError(`No incident found with number "${incidentNumber}".`, {
+          tracked: false,
+        })
+      );
     }
 
     return new Ok([
@@ -148,10 +148,22 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
       ]);
     }
 
-    const result = await client.updateIncident({
-      incidentNumber,
-      fields: writableFields,
-    });
+    const existingResult = await client.getIncidentByNumber(incidentNumber);
+    if (existingResult.isErr()) {
+      return existingResult;
+    }
+    if (!existingResult.value) {
+      return new Err(
+        new MCPError(`No incident found with number "${incidentNumber}".`, {
+          tracked: false,
+        })
+      );
+    }
+
+    const result = await client.updateIncident(
+      existingResult.value.sys_id,
+      writableFields
+    );
 
     if (result.isErr()) {
       return result;

--- a/front/lib/api/actions/servers/servicenow/tools/index.ts
+++ b/front/lib/api/actions/servers/servicenow/tools/index.ts
@@ -1,12 +1,60 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  createIncident,
+  getIncidentByNumber,
   getServiceNowCredentials,
   listIncidents,
+  updateIncident,
+  type WritableIncidentFields,
 } from "@app/lib/api/actions/servers/servicenow/client";
 import { renderIncident } from "@app/lib/api/actions/servers/servicenow/helpers";
 import { SERVICENOW_TOOLS_METADATA } from "@app/lib/api/actions/servers/servicenow/metadata";
 import { Ok } from "@app/types/shared/result";
+
+function writableFieldsFromParams({
+  shortDescription,
+  description,
+  urgency,
+  impact,
+  priority,
+  category,
+  assignmentGroup,
+  state,
+  workNotes,
+  closeNotes,
+  resolutionCode,
+}: {
+  shortDescription?: string;
+  description?: string;
+  urgency?: string;
+  impact?: string;
+  priority?: string;
+  category?: string;
+  assignmentGroup?: string;
+  state?: string;
+  workNotes?: string;
+  closeNotes?: string;
+  resolutionCode?: string;
+}): WritableIncidentFields {
+  return {
+    ...(shortDescription !== undefined && {
+      short_description: shortDescription,
+    }),
+    ...(description !== undefined && { description }),
+    ...(urgency !== undefined && { urgency }),
+    ...(impact !== undefined && { impact }),
+    ...(priority !== undefined && { priority }),
+    ...(category !== undefined && { category }),
+    ...(assignmentGroup !== undefined && {
+      assignment_group: assignmentGroup,
+    }),
+    ...(state !== undefined && { state }),
+    ...(workNotes !== undefined && { work_notes: workNotes }),
+    ...(closeNotes !== undefined && { close_notes: closeNotes }),
+    ...(resolutionCode !== undefined && { close_code: resolutionCode }),
+  };
+}
 
 const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
   list_incidents: async ({ query, limit }, { authInfo }) => {
@@ -37,6 +85,99 @@ const handlers: ToolHandlers<typeof SERVICENOW_TOOLS_METADATA> = {
     }
 
     return new Ok([{ type: "text" as const, text }]);
+  },
+
+  get_incident: async ({ incidentNumber }, { authInfo }) => {
+    const credentialsResult = getServiceNowCredentials(authInfo);
+    if (credentialsResult.isErr()) {
+      return credentialsResult;
+    }
+    const { accessToken, instanceUrl } = credentialsResult.value;
+
+    const result = await getIncidentByNumber(
+      accessToken,
+      instanceUrl,
+      incidentNumber
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    if (!result.value) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No incident found with number ${incidentNumber}.`,
+        },
+      ]);
+    }
+
+    return new Ok([
+      { type: "text" as const, text: renderIncident(result.value) },
+    ]);
+  },
+
+  create_incident: async (params, { authInfo }) => {
+    const credentialsResult = getServiceNowCredentials(authInfo);
+    if (credentialsResult.isErr()) {
+      return credentialsResult;
+    }
+    const { accessToken, instanceUrl } = credentialsResult.value;
+
+    const result = await createIncident(
+      accessToken,
+      instanceUrl,
+      writableFieldsFromParams(params)
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Created incident ${result.value.number}:\n${renderIncident(result.value)}`,
+      },
+    ]);
+  },
+
+  update_incident: async ({ sysId, ...fields }, { authInfo }) => {
+    const credentialsResult = getServiceNowCredentials(authInfo);
+    if (credentialsResult.isErr()) {
+      return credentialsResult;
+    }
+    const { accessToken, instanceUrl } = credentialsResult.value;
+
+    const writableFields = writableFieldsFromParams(fields);
+
+    if (Object.keys(writableFields).length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "No fields to update were provided.",
+        },
+      ]);
+    }
+
+    const result = await updateIncident(
+      accessToken,
+      instanceUrl,
+      sysId,
+      writableFields
+    );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Updated incident ${result.value.number}:\n${renderIncident(result.value)}`,
+      },
+    ]);
   },
 };
 


### PR DESCRIPTION
## Description

Third of the ServiceNow MCP stack. **Depends on #29135** (MCP skeleton) — base branch is `thomasvicaire/servicenow-mcp-skeleton`, not `main`.

Rounds out the incident CRUD surface (`list_incidents` already existed) with:
- `get_incident`: look up a single incident by number
- `create_incident`: create a new incident
- `update_incident`: update/resolve/close an existing incident by `sys_id`

Uses `sysparm_input_display_value` alongside `sysparm_display_value` so callers can read and write choice fields (state, priority, resolution code) as human-readable labels rather than ServiceNow's internal codes.

## Tests

- `npx tsgo --noEmit`: clean
- `npm run test -- bm25_tool_search.test.ts`: all passing, including new query cases for the three tools
- Ran an automated 4-angle code review before committing; fixed two real issues found:
  - `get_incident` interpolated the incident number directly into a `sysparm_query`, letting `^`/`=` turn an exact-number lookup into an arbitrary compound query — now validated and rejected upfront with a clear error.
  - `update_incident` could fire a no-op PATCH when called with zero fields to change — now short-circuits with a message instead.
- **All three tools verified end-to-end against a live ServiceNow Personal Developer Instance** via the real TypeScript code paths: `create_incident` → `update_incident` (state: Resolved, with a valid resolution code) → confirmed via `get_incident`.

## Risk

Low. Additive only (new tools on an already-flagged, already-gated server). The two fixes above tighten input handling; no existing behavior changes.

## Deploy Plan

Standard deploy, no special steps.