### PR TITLE
[core] fix: Pin rust builder image to bookworm variant to match runtime glibc

### DIFF
--- a/dockerfiles/core.Dockerfile
+++ b/dockerfiles/core.Dockerfile
@@ -1,5 +1,7 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.94.1 AS builder
+# Keep the builder on bookworm: the runtime stage is bookworm-slim and binaries must not link
+# against a newer glibc than the runtime provides.
+FROM rust:1.94.1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/oauth.Dockerfile
+++ b/dockerfiles/oauth.Dockerfile
@@ -1,5 +1,7 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.94.1 AS builder
+# Keep the builder on bookworm: the runtime stage is bookworm-slim and binaries must not link
+# against a newer glibc than the runtime provides.
+FROM rust:1.94.1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

core-api crashes at startup since #29151: `/lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.38 not found`.

`rust:1.94.1` switched its base to Debian trixie (glibc 2.41), while the runtime stage is `debian:bookworm-slim` (glibc 2.36). Binaries built on trixie link against glibc symbols the bookworm runtime doesn't have. `rust:1.85.0` was bookworm-based, which is why this never surfaced before.

## Fix

Pin the builder to `rust:1.94.1-bookworm` in `core.Dockerfile` and `oauth.Dockerfile`. Builder and runtime now share the same glibc, which structurally rules out this class of failure.

## Verification (actually ran the containers this time)

- Full `docker build` of both images (all stages) with the bookworm builder: success.
- Exec'd every shipped binary in its runtime container:
  - `core-api`: past the loader, clean app-level error (`CORE_DATABASE_URI is required`)
  - `sqlite-worker`: starts and serves
  - `check_table`: reaches clap argument parsing
  - `oauth`: past the loader, clean app-level error (`OAUTH_DATABASE_URI not set`)
- `rust:1.94.1-bookworm` exists on Docker Hub for amd64 and arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)