### PR TITLE
[core] chore: upgrade qdrant to 1.18

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3575,14 +3575,15 @@ dependencies = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c53f69cf32af8172f77d707618cdd605e32a4b90cd17f3c6fb48058e2181ad0"
+checksum = "82cef4e669bcf9c07471463adab5ee080dd9bc9381f3652ea4981f6030b2c309"
 dependencies = [
  "anyhow",
  "derive_builder",
  "futures",
  "futures-util",
+ "parking_lot",
  "prost 0.13.5",
  "prost-types",
  "reqwest 0.12.20",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -157,7 +157,7 @@ parking_lot = "0.12"
 pest = "2.7"
 pest_derive = "2.7"
 pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption"] }
-qdrant-client = "1.15"
+qdrant-client = "1.18"
 rand = "0.8"
 rayon = "1.10"
 redis = { version = "0.24.0", features = ["tokio-comp"] }

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -440,13 +440,18 @@ async fn migrate_shadow_embedder(
             .result
             .into_iter()
             .map(|r| {
-                qdrant::PointStruct::new(
-                    r.id.unwrap(),
-                    vectors_output_to_vectors(r.vectors.unwrap()),
+                let id =
+                    r.id.ok_or_else(|| anyhow!("expected an id on scrolled point"))?;
+                let vectors = r
+                    .vectors
+                    .ok_or_else(|| anyhow!("expected vectors on scrolled point"))?;
+                Ok(qdrant::PointStruct::new(
+                    id,
+                    vectors_output_to_vectors(vectors)?,
                     Payload::from(r.payload),
-                )
+                ))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
         // Empty upserts trigger errors.
         if count > 0 {

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -5,7 +5,7 @@ use dust::{
         data_source::{
             make_document_id_hash, DataSource, EmbedderConfig, EmbedderDataSourceConfig,
         },
-        qdrant::QdrantClients,
+        qdrant::{vectors_output_to_vectors, QdrantClients},
     },
     providers::{
         embedder::{EmbedderRequest, EmbedderVector, SupportedEmbedderModels},
@@ -19,8 +19,8 @@ use dust::{
 use futures::StreamExt;
 use futures::TryStreamExt;
 use qdrant_client::{
-    prelude::Payload,
     qdrant::{self, point_id, value, PointId},
+    Payload,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs::File};
@@ -332,7 +332,7 @@ fn get_qdrant_point_id_as_string(point_id: &PointId) -> Option<String> {
 struct ChunkInfoFromPoints {
     hash: String,
     text: String,
-    payload: HashMap<String, qdrant_client::prelude::Value>,
+    payload: HashMap<String, qdrant_client::qdrant::Value>,
 }
 
 async fn execute_embedder_with_retry(
@@ -442,7 +442,7 @@ async fn migrate_shadow_embedder(
             .map(|r| {
                 qdrant::PointStruct::new(
                     r.id.unwrap(),
-                    r.vectors.unwrap(),
+                    vectors_output_to_vectors(r.vectors.unwrap()),
                     Payload::from(r.payload),
                 )
             })
@@ -645,6 +645,7 @@ async fn refresh_chunk_count_for_updated_documents(
                 &Some(filter.clone()),
                 &None,
                 Some((batch_size, offset)),
+                false,
             )
             .await?;
 

--- a/core/bin/qdrant/migrator.rs
+++ b/core/bin/qdrant/migrator.rs
@@ -330,13 +330,18 @@ async fn migrate_shadow_write(
             .result
             .into_iter()
             .map(|r| {
-                qdrant::PointStruct::new(
-                    r.id.unwrap(),
-                    vectors_output_to_vectors(r.vectors.unwrap()),
+                let id =
+                    r.id.ok_or_else(|| anyhow!("expected an id on scrolled point"))?;
+                let vectors = r
+                    .vectors
+                    .ok_or_else(|| anyhow!("expected vectors on scrolled point"))?;
+                Ok(qdrant::PointStruct::new(
+                    id,
+                    vectors_output_to_vectors(vectors)?,
                     Payload::from(r.payload),
-                )
+                ))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
         // Empty upserts trigger errors.
         if count > 0 {

--- a/core/bin/qdrant/migrator.rs
+++ b/core/bin/qdrant/migrator.rs
@@ -1,15 +1,17 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use dust::{
-    data_sources::qdrant::{QdrantClients, QdrantCluster, QdrantDataSourceConfig},
+    data_sources::qdrant::{
+        vectors_output_to_vectors, QdrantClients, QdrantCluster, QdrantDataSourceConfig,
+    },
     stores::{postgres, store::Store},
     utils,
 };
 use futures::StreamExt;
 use futures::TryStreamExt;
 use qdrant_client::{
-    prelude::Payload,
     qdrant::{self, PointId},
+    Payload,
 };
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -330,7 +332,7 @@ async fn migrate_shadow_write(
             .map(|r| {
                 qdrant::PointStruct::new(
                     r.id.unwrap(),
-                    r.vectors.unwrap(),
+                    vectors_output_to_vectors(r.vectors.unwrap()),
                     Payload::from(r.payload),
                 )
             })

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -17,9 +17,9 @@ use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use futures::TryStreamExt;
 use itertools::Itertools;
-use qdrant_client::qdrant::vectors_output::VectorsOptions;
+use qdrant_client::qdrant::vector_output::Vector;
 use qdrant_client::qdrant::{PointId, RetrievedPoint, ScoredPoint};
-use qdrant_client::{prelude::Payload, qdrant};
+use qdrant_client::{qdrant, Payload};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -927,10 +927,8 @@ impl DataSource {
                     if let Some(qdrant::value::Kind::StringValue(chunk_text)) =
                         result.payload.get("text").and_then(|t| t.kind.as_ref())
                     {
-                        if let Some(VectorsOptions::Vector(v)) = result
-                            .vectors
-                            .as_ref()
-                            .and_then(|v| v.vectors_options.as_ref())
+                        if let Some(Vector::Dense(v)) =
+                            result.vectors.as_ref().and_then(|v| v.get_vector())
                         {
                             let text_hash = format!(
                                 "{}",
@@ -944,7 +942,7 @@ impl DataSource {
                                 text_hash,
                                 EmbedderVector {
                                     created: document.created,
-                                    vector: v.data.iter().map(|&v| v as f64).collect(),
+                                    vector: v.data.into_iter().map(|v| v as f64).collect(),
                                     model: embedder_config.model_id.clone(),
                                     provider: embedder_config.provider_id.to_string(),
                                 },

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -8,12 +8,11 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use qdrant_client::{
     config::QdrantConfig,
-    prelude::Payload,
     qdrant::{
-        self, shard_key, CountPointsBuilder, DeletePointsBuilder, ScrollPointsBuilder,
-        SearchPointsBuilder, SetPayloadPointsBuilder, UpsertPointsBuilder,
+        self, shard_key, vector_output, CountPointsBuilder, DeletePointsBuilder,
+        ScrollPointsBuilder, SearchPointsBuilder, SetPayloadPointsBuilder, UpsertPointsBuilder,
     },
-    Qdrant,
+    Payload, Qdrant,
 };
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +51,17 @@ pub fn env_var_prefix_for_cluster(cluster: QdrantCluster) -> &'static str {
     match cluster {
         QdrantCluster::Cluster0 => "QDRANT_CLUSTER_0",
     }
+}
+
+// qdrant-client 1.17 removed `From<VectorsOutput> for Vectors`; our collections only hold single
+// unnamed vectors so we convert through the dedicated vector type.
+pub fn vectors_output_to_vectors(vectors: qdrant::VectorsOutput) -> qdrant::Vectors {
+    let vector: qdrant::Vector = match vectors.get_vector().expect("expected an unnamed vector") {
+        vector_output::Vector::Dense(v) => v.into(),
+        vector_output::Vector::Sparse(v) => v.into(),
+        vector_output::Vector::MultiDense(v) => v.into(),
+    };
+    vector.into()
 }
 
 #[derive(Clone)]

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -55,13 +55,16 @@ pub fn env_var_prefix_for_cluster(cluster: QdrantCluster) -> &'static str {
 
 // qdrant-client 1.17 removed `From<VectorsOutput> for Vectors`; our collections only hold single
 // unnamed vectors so we convert through the dedicated vector type.
-pub fn vectors_output_to_vectors(vectors: qdrant::VectorsOutput) -> qdrant::Vectors {
-    let vector: qdrant::Vector = match vectors.get_vector().expect("expected an unnamed vector") {
+pub fn vectors_output_to_vectors(vectors: qdrant::VectorsOutput) -> Result<qdrant::Vectors> {
+    let vector: qdrant::Vector = match vectors
+        .get_vector()
+        .ok_or_else(|| anyhow!("expected an unnamed vector"))?
+    {
         vector_output::Vector::Dense(v) => v.into(),
         vector_output::Vector::Sparse(v) => v.into(),
         vector_output::Vector::MultiDense(v) => v.into(),
     };
-    vector.into()
+    Ok(vector.into())
 }
 
 #[derive(Clone)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 5432:5432
   qdrant_primary:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     volumes:
       - qdrant_primary:/qdrant/storage
     ports:
@@ -29,7 +29,7 @@ services:
       timeout: 10s
       retries: 1 # Only retry once to minimize delay
   qdrant_secondary:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     volumes:
       - qdrant_secondary:/qdrant/storage
     environment:
@@ -38,7 +38,7 @@ services:
       nofile:
         soft: 64000
         hard: 64000
-    command: ["./qdrant", "--bootstrap", "http://qdrant_primary:6335"]
+    command: ["./qdrant", "--bootstrap", "http://qdrant_primary:6335", "--uri", "http://qdrant_secondary:6335"]
     depends_on:
       qdrant_primary:
         condition: service_healthy # Ensure qdrant is healthy before starting qdrant_primary.

--- a/dockerfiles/core.Dockerfile
+++ b/dockerfiles/core.Dockerfile
@@ -1,5 +1,7 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.94.1 AS builder
+# Keep the builder on bookworm: the runtime stage is bookworm-slim and binaries must not link
+# against a newer glibc than the runtime provides.
+FROM rust:1.94.1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/oauth.Dockerfile
+++ b/dockerfiles/oauth.Dockerfile
@@ -1,5 +1,7 @@
 # Build stage — full Rust toolchain + cmake (needed for sentencepiece)
-FROM rust:1.94.1 AS builder
+# Keep the builder on bookworm: the runtime stage is bookworm-slim and binaries must not link
+# against a newer glibc than the runtime provides.
+FROM rust:1.94.1-bookworm AS builder
 
 RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 

--- a/x/henry/dust-hive/docker-compose.yml
+++ b/x/henry/dust-hive/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   qdrant:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     ulimits:
       nofile:
         soft: 64000


### PR DESCRIPTION
## Description

Upgrade qdrant-client to 1.18
Previous attempts were failing at run step due to a missing peer dep version in libc. (see comment in docker img)


## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy core