### PR TITLE
[core] chore: Bump local qdrant server to v1.18.3 in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 5432:5432
   qdrant_primary:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     volumes:
       - qdrant_primary:/qdrant/storage
     ports:
@@ -29,7 +29,7 @@ services:
       timeout: 10s
       retries: 1 # Only retry once to minimize delay
   qdrant_secondary:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     volumes:
       - qdrant_secondary:/qdrant/storage
     environment:

--- a/x/henry/dust-hive/docker-compose.yml
+++ b/x/henry/dust-hive/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   qdrant:
-    image: "qdrant/qdrant:v1.13.0"
+    image: "qdrant/qdrant:v1.18.3"
     ulimits:
       nofile:
         soft: 64000


### PR DESCRIPTION
Follow-up to #29140 (client 1.18): bump the local dev Qdrant server from v1.13.0 to v1.18.3 in `docker-compose.yml` (2-node cluster) and `x/henry/dust-hive/docker-compose.yml`.

## ⚠️ Existing local volumes must be wiped

Verified empirically: a 1.18 server does **not** load 1.13 storage — the cluster crashes at startup on the shard-key persistence format (`Failed to (de)serialize from/to json: invalid type: map, expected a sequence`). Qdrant only guarantees storage compatibility between consecutive minor versions.

After pulling this change, local envs need:

```
docker compose down
docker volume rm dust_qdrant_primary dust_qdrant_secondary
docker compose up -d
```

(then re-create collections / re-index local data sources; hive envs: same for the env's qdrant volumes.)

## Verification

Reproduced the repo's compose topology (2-node cluster, `QDRANT__CLUSTER__ENABLED`, custom sharding) on scratch volumes:

- v1.13.0 → v1.18.3 in-place restart: crashes as described above (hence the wipe instructions).
- Fresh v1.18.3 cluster: 2 peers healthy; custom-sharded collection with `sharding_method: custom`, shard-key creation, upsert with shard key, and vector search all work.
- Server v1.18.3 now matches the deployed client (qdrant-client 1.18, #29140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)