### PR TITLE
Add checkpointed no-drop conversation window

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -1,0 +1,231 @@
+import { CheckpointedConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import { describe, expect, it } from "vitest";
+
+function withTokens<T extends ModelMessageTypeMultiActions>(
+  message: T,
+  tokenCount: number
+): T & { tokenCount: number } {
+  return { ...message, tokenCount };
+}
+
+function userMessage(name: string, tokenCount: number) {
+  return withTokens(
+    {
+      role: "user" as const,
+      name: "user",
+      content: [{ type: "text" as const, text: name }],
+    },
+    tokenCount
+  );
+}
+
+function assistantMessage(name: string, tokenCount = 10) {
+  return withTokens(
+    {
+      role: "assistant" as const,
+      name: "assistant",
+      content: name,
+      contents: [{ type: "text_content" as const, value: name }],
+    },
+    tokenCount
+  );
+}
+
+function functionMessage(name: string, tokenCount: number) {
+  return withTokens(
+    {
+      role: "function" as const,
+      name,
+      function_call_id: `${name}_call`,
+      content: `${name}_result`,
+    },
+    tokenCount
+  );
+}
+
+function interaction(
+  messages: InteractionWithTokens["messages"]
+): InteractionWithTokens {
+  return { messages };
+}
+
+function toolResults(state: CheckpointedConversationWindowState) {
+  return state
+    .renderedInteractions()
+    .flatMap((item) => item.messages)
+    .filter((message) => message.role === "function");
+}
+
+function isPruned(content: unknown): boolean {
+  return typeof content === "string" && content.includes("no longer available");
+}
+
+function makeState({
+  pruningBudget = 30_000,
+  budgetForInteractions = 100_000,
+}: {
+  pruningBudget?: number;
+  budgetForInteractions?: number;
+} = {}) {
+  return CheckpointedConversationWindowState.empty({
+    pruningBudget,
+    budgetForInteractions,
+    logDetails: {},
+  });
+}
+
+describe("CheckpointedConversationWindowState", () => {
+  it("preserves interaction boundaries and message data when no pruning is needed", () => {
+    const state = makeState();
+    const interactions = [
+      interaction([userMessage("first", 10), assistantMessage("first_answer")]),
+      interaction([
+        userMessage("second", 10),
+        assistantMessage("second_call"),
+        functionMessage("second_result", 100),
+      ]),
+    ];
+
+    for (const item of interactions) {
+      state.append(item);
+    }
+
+    expect(state.renderedInteractions()).toEqual(interactions);
+  });
+
+  it("keeps complete interactions when non-tool history crosses the pruning budget", () => {
+    const state = makeState();
+
+    state.append(interaction([userMessage("first", 20_000)]));
+    state.append(interaction([userMessage("second", 20_000)]));
+    state.append(interaction([userMessage("third", 20_000)]));
+
+    expect(state.fit().isOk()).toBe(true);
+    expect(state.renderedInteractions()).toHaveLength(3);
+    expect(
+      state
+        .renderedInteractions()
+        .flatMap((item) => item.messages)
+        .filter((message) => message.role === "user")
+        .map((message) => message.content[0])
+    ).toEqual([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+      { type: "text", text: "third" },
+    ]);
+  });
+
+  it("keeps serving intact interactions past the nominal budget", () => {
+    const state = makeState({ budgetForInteractions: 50_000 });
+
+    state.append(interaction([userMessage("first", 30_000)]));
+    state.append(interaction([userMessage("second", 30_000)]));
+
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.stats.totalTokensAfterFloorDropping).toBe(60_000);
+    expect(result.value.stats.budgetForInteractions).toBe(50_000);
+    expect(state.renderedInteractions()).toHaveLength(2);
+  });
+
+  it("prunes consumed results in a buffered checkpoint and protects the pending batch", () => {
+    const state = makeState();
+    const input = interaction([
+      userMessage("question", 10),
+      assistantMessage("call_first"),
+      functionMessage("first", 11_000),
+      assistantMessage("call_second"),
+      functionMessage("second", 11_000),
+      assistantMessage("call_parallel"),
+      functionMessage("pending_first", 11_000),
+      functionMessage("pending_second", 11_000),
+    ]);
+
+    state.append(input);
+
+    const results = toolResults(state);
+    expect(isPruned(results[0].content)).toBe(true);
+    expect(isPruned(results[1].content)).toBe(true);
+    expect(results[2].content).toBe("pending_first_result");
+    expect(results[3].content).toBe("pending_second_result");
+    expect(
+      input.messages
+        .filter((message) => message.role === "function")
+        .map((message) => message.content)
+    ).toEqual([
+      "first_result",
+      "second_result",
+      "pending_first_result",
+      "pending_second_result",
+    ]);
+  });
+
+  it("waits for a full checkpoint of reclaimable results before moving the frontier", () => {
+    const state = makeState({ pruningBudget: 15_000 });
+
+    state.append(
+      interaction([
+        userMessage("question", 10),
+        assistantMessage("call_first"),
+        functionMessage("first", 10_100),
+        assistantMessage("call_second"),
+        functionMessage("second", 10_100),
+      ])
+    );
+
+    expect(
+      toolResults(state).every((message) => !isPruned(message.content))
+    ).toBe(true);
+
+    state.append(
+      interaction([
+        assistantMessage("call_third"),
+        functionMessage("third", 1_000),
+      ])
+    );
+
+    const results = toolResults(state);
+    expect(isPruned(results[0].content)).toBe(true);
+    expect(isPruned(results[1].content)).toBe(true);
+    expect(results[2].content).toBe("third_result");
+  });
+
+  it("replays the same pruning frontier when the conversation grows", () => {
+    const prefix = interaction([
+      userMessage("question", 10),
+      assistantMessage("call_first"),
+      functionMessage("first", 11_000),
+      assistantMessage("call_second"),
+      functionMessage("second", 11_000),
+      assistantMessage("call_third"),
+      functionMessage("third", 11_000),
+    ]);
+    const prefixState = makeState();
+    prefixState.append(prefix);
+
+    const extendedState = makeState();
+    extendedState.append(prefix);
+    extendedState.append(
+      interaction([
+        assistantMessage("call_fourth"),
+        functionMessage("fourth", 1_000),
+      ])
+    );
+
+    const prefixResults = toolResults(prefixState);
+    const extendedResults = toolResults(extendedState);
+    expect(prefixResults.map((message) => isPruned(message.content))).toEqual([
+      true,
+      true,
+      false,
+    ]);
+    expect(
+      extendedResults.slice(0, 3).map((message) => isPruned(message.content))
+    ).toEqual([true, true, false]);
+  });
+});

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -1,0 +1,243 @@
+import type {
+  InteractionWithTokens,
+  MessageWithTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+import {
+  getToolResultTokenSavings,
+  PRUNING_CHECKPOINT_TOKENS,
+  pruneToolResultMessage,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type {
+  ConversationPruningStats,
+  ConversationWindowResult,
+} from "@app/lib/api/assistant/conversation_rendering/window_types";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+type RegularMessageNode = {
+  kind: "message";
+  message: MessageWithTokens;
+};
+
+type ToolResultNode = {
+  kind: "tool_result";
+  message: Extract<MessageWithTokens, { role: "function" }>;
+  tokenSavings: number;
+};
+
+type PendingToolResult = {
+  phase: "pending";
+  node: ToolResultNode;
+};
+
+type EligibleToolResult = {
+  phase: "eligible";
+  node: ToolResultNode;
+};
+
+// Interactions own these nodes. The pending and eligible queues only hold references to the same
+// tool-result nodes, so a message payload is never duplicated.
+type WindowMessageNode = RegularMessageNode | ToolResultNode;
+
+type WindowInteraction = {
+  messages: WindowMessageNode[];
+};
+
+function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
+  if (message.role === "function") {
+    return {
+      kind: "tool_result",
+      message,
+      tokenSavings: getToolResultTokenSavings(message),
+    };
+  }
+
+  return { kind: "message", message };
+}
+
+/**
+ * Builds a model-facing conversation without ever removing an interaction.
+ *
+ * Tool results become eligible only after a later assistant message has consumed their complete
+ * batch. Cleanup runs at model-input checkpoints and waits until a full token checkpoint can be
+ * reclaimed. It then attempts to return one checkpoint below the soft limit. This keeps the
+ * pruning frontier stable across the model calls within a long interaction and reduces how often
+ * the provider cache frontier moves.
+ *
+ * If tool-result pruning cannot keep the complete interaction history below the nominal budget,
+ * the window keeps serving it and reports the excess through logs and metrics. The provider limit
+ * remains the final boundary. The latest unconsumed result batch always remains intact.
+ */
+export class CheckpointedConversationWindowState {
+  private interactions: WindowInteraction[] = [];
+  private retainedTokens = 0;
+  private totalTokensBefore = 0;
+  private prunedTokens = 0;
+
+  private pendingToolResults: PendingToolResult[] = [];
+  private eligibleToolResults: EligibleToolResult[] = [];
+  private nextEligibleToolResultIndex = 0;
+  private eligibleToolResultTokenSavings = 0;
+
+  private constructor(
+    private readonly options: {
+      pruningBudget: number;
+      budgetForInteractions: number;
+      logDetails: Record<string, unknown>;
+    }
+  ) {}
+
+  static empty(options: {
+    pruningBudget: number;
+    budgetForInteractions: number;
+    logDetails: Record<string, unknown>;
+  }): CheckpointedConversationWindowState {
+    return new CheckpointedConversationWindowState(options);
+  }
+
+  append(interaction: InteractionWithTokens): void {
+    if (interaction.messages.length === 0) {
+      return;
+    }
+
+    const windowInteraction: WindowInteraction = { messages: [] };
+    this.interactions.push(windowInteraction);
+
+    for (
+      let messageIndex = 0;
+      messageIndex < interaction.messages.length;
+      messageIndex++
+    ) {
+      const message = interaction.messages[messageIndex];
+      const nextMessage = interaction.messages[messageIndex + 1];
+
+      if (message.role === "assistant") {
+        this.makePendingToolResultsEligible();
+      }
+
+      const node = makeWindowMessageNode(message);
+      windowInteraction.messages.push(node);
+      this.retainedTokens += message.tokenCount;
+      this.totalTokensBefore += message.tokenCount;
+
+      if (node.kind === "tool_result") {
+        this.pendingToolResults.push({ phase: "pending", node });
+      }
+
+      if (this.isModelInputCheckpoint(message, nextMessage)) {
+        this.applyBufferedPruning();
+      }
+    }
+  }
+
+  renderedInteractions(): InteractionWithTokens[] {
+    return this.interactions.map((interaction) => ({
+      messages: interaction.messages.map((node) => node.message),
+    }));
+  }
+
+  fit(): Result<ConversationWindowResult, Error> {
+    const { budgetForInteractions, logDetails } = this.options;
+
+    if (this.interactions.length === 0) {
+      return new Ok({
+        interactions: [],
+        prunedContext: false,
+        stats: this.stats(),
+      });
+    }
+
+    if (this.retainedTokens > budgetForInteractions) {
+      logger.warn(
+        {
+          ...logDetails,
+          windowStage: "nominal_budget_exceeded_after_tool_result_pruning",
+          totalTokens: this.retainedTokens,
+          budgetForInteractions,
+          tokensOverBudget: this.retainedTokens - budgetForInteractions,
+        },
+        "Render Conversation V2: complete interaction history exceeds the nominal budget."
+      );
+    }
+
+    // Crossing the nominal budget remains non-fatal. At 80% utilization the UI requires
+    // compaction before the next user turn, while an active agent run continues to the provider
+    // limit.
+    return new Ok({
+      interactions: this.renderedInteractions(),
+      prunedContext: this.prunedTokens > 0,
+      stats: this.stats(),
+    });
+  }
+
+  private isModelInputCheckpoint(
+    message: MessageWithTokens,
+    nextMessage: MessageWithTokens | undefined
+  ): boolean {
+    const endsUserInput =
+      message.role === "user" &&
+      nextMessage?.role !== "user" &&
+      nextMessage?.role !== "content_fragment";
+    const endsToolResultBatch =
+      message.role === "function" && nextMessage?.role !== "function";
+
+    return endsUserInput || endsToolResultBatch;
+  }
+
+  private makePendingToolResultsEligible(): void {
+    for (const { node } of this.pendingToolResults) {
+      if (node.tokenSavings > 0) {
+        this.eligibleToolResults.push({ phase: "eligible", node });
+        this.eligibleToolResultTokenSavings += node.tokenSavings;
+      }
+    }
+
+    this.pendingToolResults = [];
+  }
+
+  private applyBufferedPruning(): void {
+    if (
+      this.retainedTokens <= this.options.pruningBudget ||
+      this.eligibleToolResultTokenSavings < PRUNING_CHECKPOINT_TOKENS
+    ) {
+      return;
+    }
+
+    const targetTokens = Math.max(
+      this.options.pruningBudget - PRUNING_CHECKPOINT_TOKENS,
+      0
+    );
+
+    while (
+      this.retainedTokens > targetTokens &&
+      this.nextEligibleToolResultIndex < this.eligibleToolResults.length
+    ) {
+      const { node } =
+        this.eligibleToolResults[this.nextEligibleToolResultIndex];
+
+      node.message = pruneToolResultMessage(node.message);
+      this.retainedTokens -= node.tokenSavings;
+      this.prunedTokens += node.tokenSavings;
+      this.eligibleToolResultTokenSavings -= node.tokenSavings;
+      this.nextEligibleToolResultIndex += 1;
+    }
+  }
+
+  private stats(): ConversationPruningStats {
+    const totalTokensAfterPruning = this.totalTokensBefore - this.prunedTokens;
+
+    return {
+      totalTokensBefore: this.totalTokensBefore,
+      totalTokensAfterPruning,
+      totalTokensAfterDropping: totalTokensAfterPruning,
+      totalTokensAfterFloorPruning: totalTokensAfterPruning,
+      totalTokensAfterFloorDropping: totalTokensAfterPruning,
+      interactionsBefore: this.interactions.length,
+      interactionsAfterDropping: this.interactions.length,
+      interactionsAfterFloorDropping: this.interactions.length,
+      pruningBudget: this.options.pruningBudget,
+      budgetForInteractions: this.options.budgetForInteractions,
+    };
+  }
+}

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -1,8 +1,6 @@
 import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
-import type {
-  ConversationPruningStats,
-  ConversationRenderingMetricsCaller,
-} from "@app/lib/api/assistant/conversation_rendering/instrumentation";
+import { CheckpointedConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import type { ConversationRenderingMetricsCaller } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
 import {
   emitConversationRenderingError,
   emitConversationRenderingMetrics,
@@ -14,6 +12,10 @@ import type {
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import { sumInteractionTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import { ConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/window_state";
+import type {
+  ConversationPruningStats,
+  ConversationWindowStrategy,
+} from "@app/lib/api/assistant/conversation_rendering/window_types";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -51,12 +53,13 @@ export const TOKENS_MARGIN = 1024;
 // conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
 
+export type { ConversationWindowStrategy } from "@app/lib/api/assistant/conversation_rendering/window_types";
+
 /**
  * Replays the conversation chronologically so cleanup decisions are deterministic for every
- * interaction prefix. Old tool results are pruned before interactions are dropped. Soft drops
- * preserve the latest three interactions. Hard-budget pressure can drop every previous
- * interaction. The current interaction is never dropped and its latest tool result is never
- * pruned.
+ * interaction prefix. The legacy strategy can drop interactions after pruning. The checkpointed
+ * strategy only prunes consumed tool results and keeps serving intact history past the nominal
+ * budget.
  */
 function pruneConversationToBudget(
   interactions: InteractionWithTokens[],
@@ -64,10 +67,12 @@ function pruneConversationToBudget(
     pruningBudget,
     budgetForInteractions,
     logDetails,
+    windowStrategy,
   }: {
     pruningBudget: number;
     budgetForInteractions: number;
     logDetails: Record<string, unknown>;
+    windowStrategy: ConversationWindowStrategy;
   }
 ): Result<
   {
@@ -77,11 +82,17 @@ function pruneConversationToBudget(
   },
   Error
 > {
-  const state = ConversationWindowState.empty({
-    pruningBudget,
-    budgetForInteractions,
-    logDetails,
-  });
+  const options = { pruningBudget, budgetForInteractions, logDetails };
+  const state = (() => {
+    switch (windowStrategy) {
+      case "legacy":
+        return ConversationWindowState.empty(options);
+      case "checkpointed":
+        return CheckpointedConversationWindowState.empty(options);
+      default:
+        return assertNever(windowStrategy);
+    }
+  })();
 
   for (const interaction of interactions) {
     state.append(interaction);
@@ -105,6 +116,7 @@ export async function renderConversationForModel(
     agentConfiguration,
     enabledSkills,
     metricsCaller,
+    windowStrategy = "legacy",
   }: {
     leadingMessages?: ModelMessageTypeMultiActionsWithoutContentFragment[];
     conversation: ConversationType;
@@ -122,6 +134,7 @@ export async function renderConversationForModel(
     // history injection, reinforcement batches, scripts) whose renders would skew the pruning
     // dashboards, so only callers that name themselves are measured.
     metricsCaller?: ConversationRenderingMetricsCaller;
+    windowStrategy?: ConversationWindowStrategy;
   }
 ): Promise<
   Result<
@@ -239,6 +252,7 @@ export async function renderConversationForModel(
     pruningBudget,
     budgetForInteractions,
     logDetails,
+    windowStrategy,
   });
   if (pruneRes.isErr()) {
     if (metricsCaller) {
@@ -247,6 +261,7 @@ export async function renderConversationForModel(
         caller: metricsCaller,
         providerId: model.providerId,
         modelId: model.modelId,
+        windowStrategy,
       });
     }
     return pruneRes;
@@ -310,6 +325,7 @@ export async function renderConversationForModel(
         caller: metricsCaller,
         providerId: model.providerId,
         modelId: model.modelId,
+        windowStrategy,
       });
     }
     return new Err(
@@ -339,6 +355,7 @@ export async function renderConversationForModel(
       modelId: model.modelId,
       contextSize: model.contextSize,
       tokensUsed,
+      windowStrategy,
     });
   }
 

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
@@ -26,6 +26,8 @@ describe("computeConversationRenderingMetrics", () => {
 
     expect(metrics.outcome).toBe("fits");
     expect(metrics.saturated).toBe(false);
+    expect(metrics.overBudget).toBe(false);
+    expect(metrics.tokensOverBudget).toBe(0);
     expect(metrics.prunedTokens).toBe(0);
     expect(metrics.droppedTokens).toBe(0);
     expect(metrics.dropSlackTokens).toBeNull();
@@ -62,6 +64,20 @@ describe("computeConversationRenderingMetrics", () => {
 
     expect(metrics.outcome).toBe("pruned");
     expect(metrics.saturated).toBe(true);
+  });
+
+  it("measures context served beyond the nominal interaction budget", () => {
+    const metrics = computeConversationRenderingMetrics({
+      ...statsWhereNothingHappened(),
+      totalTokensBefore: 175_000,
+      totalTokensAfterPruning: 175_000,
+      totalTokensAfterDropping: 175_000,
+      totalTokensAfterFloorPruning: 175_000,
+      totalTokensAfterFloorDropping: 175_000,
+    });
+
+    expect(metrics.overBudget).toBe(true);
+    expect(metrics.tokensOverBudget).toBe(15_000);
   });
 
   it("measures drop slack, the headroom that predicts when the next full cache miss comes", () => {

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.ts
@@ -4,6 +4,11 @@
  * the only file here that talks to StatsD, so the decision logic stays free of I/O and tests can
  * assert on data instead of mocking a metrics client.
  */
+
+import type {
+  ConversationPruningStats,
+  ConversationWindowStrategy,
+} from "@app/lib/api/assistant/conversation_rendering/window_types";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type {
   ModelIdType,
@@ -12,18 +17,7 @@ import type {
 
 // Token totals and interaction counts snapshotted after each escalation layer, plus the budgets
 // the layers ran against. Layers that did nothing leave their snapshot equal to the previous one.
-export type ConversationPruningStats = {
-  totalTokensBefore: number;
-  totalTokensAfterPruning: number;
-  totalTokensAfterDropping: number;
-  totalTokensAfterFloorPruning: number;
-  totalTokensAfterFloorDropping: number;
-  interactionsBefore: number;
-  interactionsAfterDropping: number;
-  interactionsAfterFloorDropping: number;
-  pruningBudget: number;
-  budgetForInteractions: number;
-};
+export type { ConversationPruningStats } from "@app/lib/api/assistant/conversation_rendering/window_types";
 
 export type ConversationRenderingOutcome =
   | "fits"
@@ -35,10 +29,12 @@ export type ConversationRenderingOutcome =
 export type ConversationRenderingMetrics = {
   // The deepest escalation layer that changed anything.
   outcome: ConversationRenderingOutcome;
-  // True when pruning ran out of eligible tool results while still over its budget. Those
-  // renders sit in the regime where every new tool step slides the preserved window and rewrites
-  // bytes, the population the quantized-floor follow-up would fix.
+  // True when the rendered context remains above the proactive pruning budget. This can happen
+  // because the remaining tool results are pending, less than one pruning checkpoint is eligible,
+  // or non-tool history alone exceeds the budget.
   saturated: boolean;
+  overBudget: boolean;
+  tokensOverBudget: number;
   prunedTokens: number;
   floorPrunedTokens: number;
   droppedTokens: number;
@@ -64,6 +60,10 @@ export function computeConversationRenderingMetrics(
     stats.interactionsBefore - stats.interactionsAfterDropping;
   const floorDroppedInteractions =
     stats.interactionsAfterDropping - stats.interactionsAfterFloorDropping;
+  const tokensOverBudget = Math.max(
+    stats.totalTokensAfterFloorDropping - stats.budgetForInteractions,
+    0
+  );
 
   let outcome: ConversationRenderingOutcome = "fits";
   if (prunedTokens > 0) {
@@ -82,6 +82,8 @@ export function computeConversationRenderingMetrics(
   return {
     outcome,
     saturated: stats.totalTokensAfterPruning > stats.pruningBudget,
+    overBudget: tokensOverBudget > 0,
+    tokensOverBudget,
     prunedTokens,
     floorPrunedTokens,
     droppedTokens,
@@ -108,6 +110,7 @@ export function emitConversationRenderingMetrics({
   modelId,
   contextSize,
   tokensUsed,
+  windowStrategy,
 }: {
   stats: ConversationPruningStats;
   caller: ConversationRenderingMetricsCaller;
@@ -115,6 +118,7 @@ export function emitConversationRenderingMetrics({
   modelId: ModelIdType;
   contextSize: number;
   tokensUsed: number;
+  windowStrategy: ConversationWindowStrategy;
 }): void {
   const metrics = computeConversationRenderingMetrics(stats);
   const statsD = getStatsDClient();
@@ -122,6 +126,8 @@ export function emitConversationRenderingMetrics({
     `client_id:${providerId}`,
     `model_id:${modelId}`,
     `caller:${caller}`,
+    `window_strategy:${windowStrategy}`,
+    `over_budget:${metrics.overBudget}`,
   ];
 
   statsD.increment("conversation_rendering.renders", 1, [
@@ -183,6 +189,13 @@ export function emitConversationRenderingMetrics({
       baseTags
     );
   }
+  if (metrics.tokensOverBudget > 0) {
+    statsD.distribution(
+      "conversation_rendering.tokens_over_budget",
+      metrics.tokensOverBudget,
+      baseTags
+    );
+  }
 }
 
 // Renders that fail never reach the success emission above, so without this counter the metric
@@ -194,16 +207,19 @@ export function emitConversationRenderingError({
   caller,
   providerId,
   modelId,
+  windowStrategy,
 }: {
   kind: "context_overflow" | "no_messages";
   caller: ConversationRenderingMetricsCaller;
   providerId: ModelProviderIdType;
   modelId: ModelIdType;
+  windowStrategy: ConversationWindowStrategy;
 }): void {
   getStatsDClient().increment("conversation_rendering.errors", 1, [
     `client_id:${providerId}`,
     `model_id:${modelId}`,
     `caller:${caller}`,
     `kind:${kind}`,
+    `window_strategy:${windowStrategy}`,
   ]);
 }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -6,8 +6,8 @@
  *   message stays in place, so tool_use/tool_result pairing is never broken.
  * - "drop" (dropInteractionsToFit): remove whole interactions entirely, oldest first.
  *
- * ConversationWindowState owns the policy of when to apply which. This module owns the
- * mechanisms.
+ * The conversation window state implementations own the policy of when to apply which. This
+ * module owns the mechanisms.
  */
 import type { Interaction } from "@app/lib/api/assistant/conversation/interactions";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
@@ -38,7 +38,7 @@ export type MessageWithTokens = ModelMessageTypeMultiActions & {
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
 
 /** Turns a function-role message into the pruned placeholder. */
-function pruneToolResultMessage(
+export function pruneToolResultMessage(
   message: Extract<MessageWithTokens, { role: "function" }>
 ): Extract<MessageWithTokens, { role: "function" }> {
   return {

--- a/front/lib/api/assistant/conversation_rendering/window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_state.ts
@@ -1,4 +1,3 @@
-import type { ConversationPruningStats } from "@app/lib/api/assistant/conversation_rendering/instrumentation";
 import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import {
   DROP_CHECKPOINT_TOKENS,
@@ -9,6 +8,7 @@ import {
   pruneToolResults,
   sumInteractionTokens,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import type { ConversationWindowResult } from "@app/lib/api/assistant/conversation_rendering/window_types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -19,12 +19,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
 
 const INTERACTIONS_TO_PRESERVE_AT_SOFT_LIMIT = 3;
-
-type ConversationWindowResult = {
-  interactions: InteractionWithTokens[];
-  prunedContext: boolean;
-  stats: ConversationPruningStats;
-};
 
 /**
  * Deterministically replays an append-only sequence of interactions into a bounded model context.

--- a/front/lib/api/assistant/conversation_rendering/window_types.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_types.ts
@@ -1,0 +1,22 @@
+import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+
+export type ConversationWindowStrategy = "legacy" | "checkpointed";
+
+export type ConversationPruningStats = {
+  totalTokensBefore: number;
+  totalTokensAfterPruning: number;
+  totalTokensAfterDropping: number;
+  totalTokensAfterFloorPruning: number;
+  totalTokensAfterFloorDropping: number;
+  interactionsBefore: number;
+  interactionsAfterDropping: number;
+  interactionsAfterFloorDropping: number;
+  pruningBudget: number;
+  budgetForInteractions: number;
+};
+
+export type ConversationWindowResult = {
+  interactions: InteractionWithTokens[];
+  prunedContext: boolean;
+  stats: ConversationPruningStats;
+};

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -657,6 +657,11 @@ export async function runModel(
           leadingMessages,
           enabledSkills,
           metricsCaller: "agent_loop",
+          windowStrategy: featureFlags.includes(
+            "checkpointed_conversation_window"
+          )
+            ? "checkpointed"
+            : "legacy",
         })
       )
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,6 +28,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Defer non-default (cold) MCP tools via Anthropic's tool search tool so mid-run tool additions append inline instead of mutating the cached prefix",
     stage: "dust_only",
   },
+  checkpointed_conversation_window: {
+    description:
+      "Use checkpoint-buffered tool-result pruning without dropping complete interactions",
+    stage: "dust_only",
+  },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -728,6 +728,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "anthropic_vertex_fallback"
   | "anthropic_cache_diagnostics"
   | "anthropic_tool_search"
+  | "checkpointed_conversation_window"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following all our recent attempts at improving our pruning, this new approach considers a way simpler way.
 
This new strategy exclusively prune eligible (already consumed / not current assistant turn) tool results. If despite pruning it does not fit a follow up PR will add auto compaction as a natural escalation. We are not dropping anymore, since we noticed that it might give some headroom but we eventually end up pruning/dropping on every subsequent turns which lead to bursting the cache too often. 

This PR introduces a feature-flagged conversation-window strategy that preserves every interaction and limits
context reduction to consumed tool results. The existing strategy remains the default rollout and rollback path.

Tool results are represented by lightweight internal nodes, with pending and eligible queues referencing the
same payload. A complete result batch remains protected until consumed by the model. Pruning begins at 60%
utilization and advances only in meaningful token checkpoints, creating runway while reducing repeated prompt-cache invalidations.

When pruning cannot recover enough space, the complete history continues beyond the conservative nominal budget instead of failing or silently removing interactions. Existing UI thresholds handle compaction between agent runs, while strategy-specific saturation and budget-overrun metrics provide rollout visibility.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
