### PR TITLE
Download binary files instead of previewing them

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -1,5 +1,6 @@
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
 import type { FileEntry } from "@app/components/file_explorer/types";
+import { isFilePreviewableContentType } from "@app/components/file_explorer/utils";
 import {
   fetchFileIdFromPath,
   getFileDownloadUrl,
@@ -64,6 +65,11 @@ export function FilePreviewProvider({
           : null;
 
       if (!fileUrl || !downloadUrl) {
+        return;
+      }
+
+      if (!isFilePreviewableContentType(file.contentType)) {
+        window.open(downloadUrl, "_blank");
         return;
       }
 

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -1,5 +1,5 @@
 import type { FilePanelCategory } from "@app/components/file_explorer/types";
-import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import { getCategoryFromContentType } from "@app/components/file_explorer/utils";
 import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
@@ -28,28 +28,7 @@ export function getFilePanelCategory(
       : "frame";
   }
 
-  const previewConfig = getFilePreviewConfig(item.contentType);
-
-  switch (previewConfig.category) {
-    case "pdf":
-      return "pdf";
-    case "image":
-      return "image";
-    case "audio":
-      return "audio";
-    case "delimited":
-      return "table";
-    case "code":
-    case "viewer":
-    case "markdown":
-      return "document";
-    case "frame":
-      return "frame";
-    case "unsupported":
-      return "other";
-    default:
-      return "other";
-  }
+  return getCategoryFromContentType(item.contentType);
 }
 
 export function conversationAttachmentToRow(

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -42,10 +42,11 @@ export function getFilePanelCategory(
     case "code":
     case "viewer":
     case "markdown":
-    case "text":
       return "document";
     case "frame":
       return "frame";
+    case "unsupported":
+      return "other";
     default:
       return "other";
   }

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -44,7 +44,13 @@ describe("FileExplorer file opening", () => {
       fileName: "archive.zip",
       lastModifiedMs: 1,
     });
-    const onFileDownload = vi.fn().mockResolvedValue(undefined);
+    let finishDownload: (() => void) | undefined;
+    const onFileDownload = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDownload = resolve;
+        })
+    );
 
     render(
       <FileExplorer
@@ -56,7 +62,8 @@ describe("FileExplorer file opening", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("archive.zip"));
+    const archiveTitle = screen.getByText("archive.zip");
+    fireEvent.click(archiveTitle);
 
     await waitFor(() =>
       expect(onFileDownload).toHaveBeenCalledWith({
@@ -64,8 +71,22 @@ describe("FileExplorer file opening", () => {
         kind: "file",
       })
     );
+    expect(archiveTitle.closest("[aria-busy]")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    fireEvent.click(archiveTitle);
+    expect(onFileDownload).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(mockClientFetch).not.toHaveBeenCalled();
+
+    finishDownload?.();
+    await waitFor(() =>
+      expect(archiveTitle.closest("[aria-busy]")).toHaveAttribute(
+        "aria-busy",
+        "false"
+      )
+    );
   });
 
   it("skips binary files in preview navigation", async () => {

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -1,0 +1,109 @@
+import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClientFetch = vi.fn();
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}));
+vi.mock("@app/lib/swr/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+function makeFile({
+  contentType,
+  fileName,
+  lastModifiedMs,
+}: {
+  contentType: string;
+  fileName: string;
+  lastModifiedMs: number;
+}): FileSystemFileEntry {
+  return {
+    isDirectory: false,
+    fileName,
+    path: `conversation-c1/${fileName}`,
+    contentType,
+    fileId: `file-${fileName}`,
+    sizeBytes: 100,
+    lastModifiedMs,
+    thumbnailUrl: null,
+  };
+}
+
+describe("FileExplorer file opening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientFetch.mockResolvedValue(new Response("preview content"));
+  });
+
+  it("downloads binary files instead of opening the preview dialog", async () => {
+    const archive = makeFile({
+      contentType: "application/zip",
+      fileName: "archive.zip",
+      lastModifiedMs: 1,
+    });
+    const onFileDownload = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <FileExplorer
+        defaultViewMode="list"
+        files={[archive]}
+        getFileUrl={(path) => `/files/${path}`}
+        isLoading={false}
+        onFileDownload={onFileDownload}
+      />
+    );
+
+    fireEvent.click(screen.getByText("archive.zip"));
+
+    await waitFor(() =>
+      expect(onFileDownload).toHaveBeenCalledWith({
+        ...archive,
+        kind: "file",
+      })
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockClientFetch).not.toHaveBeenCalled();
+  });
+
+  it("skips binary files in preview navigation", async () => {
+    const first = makeFile({
+      contentType: "text/plain",
+      fileName: "first.txt",
+      lastModifiedMs: 3,
+    });
+    const archive = makeFile({
+      contentType: "application/zip",
+      fileName: "archive.zip",
+      lastModifiedMs: 2,
+    });
+    const second = makeFile({
+      contentType: "text/plain",
+      fileName: "second.txt",
+      lastModifiedMs: 1,
+    });
+
+    render(
+      <FileExplorer
+        defaultViewMode="list"
+        files={[first, archive, second]}
+        getFileUrl={(path) => `/files/${path}`}
+        isLoading={false}
+        onFileDownload={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.click(screen.getByText("first.txt"));
+    expect(
+      await screen.findByRole("dialog", { name: "first.txt" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "second.txt" })
+    ).toBeInTheDocument();
+  });
+});

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -263,9 +263,10 @@ export function FileExplorer({
   };
 
   // Only file entries participate in prev/next navigation.
-  const fileEntriesAtLevel = filesAtLevel
-    .filter((e): e is FileEntry => e.kind === "file")
-    .filter((entry) => isFilePreviewableContentType(entry.contentType));
+  const fileEntriesAtLevel = filesAtLevel.filter(
+    (entry): entry is FileEntry =>
+      entry.kind === "file" && isFilePreviewableContentType(entry.contentType)
+  );
   const previewIndex = previewFile
     ? fileEntriesAtLevel.findIndex((f) => f.path === previewFile.path)
     : -1;

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -25,6 +25,7 @@ import {
   getFolderBreadcrumbSegments,
   getScopedRelativePath,
   isFileExplorerMovableFile,
+  isFilePreviewableContentType,
 } from "@app/components/file_explorer/utils";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
@@ -251,6 +252,10 @@ export function FileExplorer({
     if (onOpenInPanel?.(entry)) {
       return;
     }
+    if (!isFilePreviewableContentType(entry.contentType)) {
+      void onFileDownload(entry);
+      return;
+    }
     setPreviewFile(entry);
     setShowPreviewSheet(true);
   };
@@ -262,9 +267,9 @@ export function FileExplorer({
   };
 
   // Only file entries participate in prev/next navigation.
-  const fileEntriesAtLevel = filesAtLevel.filter(
-    (e): e is FileEntry => e.kind === "file"
-  );
+  const fileEntriesAtLevel = filesAtLevel
+    .filter((e): e is FileEntry => e.kind === "file")
+    .filter((entry) => isFilePreviewableContentType(entry.contentType));
   const previewIndex = previewFile
     ? fileEntriesAtLevel.findIndex((f) => f.path === previewFile.path)
     : -1;

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -252,10 +252,6 @@ export function FileExplorer({
     if (onOpenInPanel?.(entry)) {
       return;
     }
-    if (!isFilePreviewableContentType(entry.contentType)) {
-      void onFileDownload(entry);
-      return;
-    }
     setPreviewFile(entry);
     setShowPreviewSheet(true);
   };

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -14,6 +14,7 @@ import {
   getCategoryFromContentType,
   getFileExplorerSearchResultTitle,
   getSingularFileCategoryLabelForContentType,
+  isFilePreviewableContentType,
 } from "@app/components/file_explorer/utils";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
@@ -43,6 +44,7 @@ export type ViewMode = "grid" | "list";
 export type FileExplorerItemProps = {
   /** Merged onto the interactive surface (e.g. grab cursor while dragging). */
   containerClassName?: string;
+  downloadOnOpen?: boolean;
   extraMenuItems?: FileExplorerMenuAction[];
   /** When set, replaces default hover / background (e.g. drop-target highlight). */
   surfaceClassName?: string;
@@ -61,6 +63,7 @@ export type FileExplorerItemProps = {
 export function FileExplorerItem(props: FileExplorerItemProps) {
   const {
     containerClassName,
+    downloadOnOpen = false,
     extraMenuItems,
     onDownload,
     onOpen,
@@ -89,11 +92,10 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
 
-  const handleDownload = async (e: React.MouseEvent) => {
-    if (!onDownload) {
+  const runDownload = async () => {
+    if (!onDownload || isDownloading) {
       return;
     }
-    e.stopPropagation();
     setIsDownloading(true);
     try {
       await onDownload();
@@ -102,6 +104,22 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
       setMenuOpen(false);
     }
   };
+
+  const handleDownload = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await runDownload();
+  };
+
+  const handleOpen = () => {
+    if (downloadOnOpen) {
+      void runDownload();
+      return;
+    }
+    onOpen();
+  };
+
+  const displayedThumbnailContent =
+    downloadOnOpen && isDownloading ? <Spinner size="sm" /> : thumbnailContent;
 
   const hasMenu = onDownload || (extraMenuItems && extraMenuItems.length > 0);
 
@@ -181,10 +199,11 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
           containerClassName,
           surfaceClassName ?? "hover:bg-muted-background"
         )}
-        onClick={onOpen}
+        aria-busy={downloadOnOpen && isDownloading}
+        onClick={handleOpen}
       >
         <div className="flex h-4 w-4 shrink-0 items-center justify-center">
-          {thumbnailContent}
+          {displayedThumbnailContent}
         </div>
         {info}
         {menu}
@@ -201,9 +220,10 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
           surfaceClassName ?? "bg-muted-background hover:brightness-95",
           props.kind === "icon" && "p-4"
         )}
-        onClick={onOpen}
+        aria-busy={downloadOnOpen && isDownloading}
+        onClick={handleOpen}
       >
-        {thumbnailContent}
+        {displayedThumbnailContent}
       </div>
       <div className="flex items-start justify-between gap-0.5">
         {info}
@@ -366,6 +386,7 @@ export function FileExplorerFileCard({
   extraMenuItems,
 }: FileExplorerFileCardProps) {
   const subtitle = getFileSubtitle(entry, viewMode);
+  const downloadOnOpen = !isFilePreviewableContentType(entry.contentType);
   const title =
     searchFolderPath !== undefined
       ? getFileExplorerSearchResultTitle(entry, searchFolderPath)
@@ -393,6 +414,7 @@ export function FileExplorerFileCard({
         title={title}
         subtitle={subtitle}
         containerClassName={dragContainerClassName}
+        downloadOnOpen={downloadOnOpen}
         onOpen={() => onOpen(entry)}
         onDownload={() => onDownload(entry)}
         extraMenuItems={extraMenuItems}
@@ -405,6 +427,7 @@ export function FileExplorerFileCard({
         title={title}
         subtitle={subtitle}
         containerClassName={dragContainerClassName}
+        downloadOnOpen={downloadOnOpen}
         onOpen={() => onOpen(entry)}
         onDownload={() => onDownload(entry)}
         extraMenuItems={extraMenuItems}

--- a/front/components/file_explorer/FilePreviewContent.tsx
+++ b/front/components/file_explorer/FilePreviewContent.tsx
@@ -202,10 +202,7 @@ export function useFilePreviewContent({
   const { category } = getFilePreviewConfig(mimeType);
 
   const needsTextContent =
-    category === "code" ||
-    category === "markdown" ||
-    category === "text" ||
-    category === "delimited";
+    category === "code" || category === "markdown" || category === "delimited";
 
   const { fileContent, isNotFound, isFileContentLoading, fileContentError } =
     useFileContentByUrl({
@@ -220,7 +217,7 @@ export function useFilePreviewContent({
   const truncatedContent = fileContent?.slice(0, MAX_TEXT_CHARS) ?? null;
 
   const processedContent =
-    (category === "markdown" || category === "text") && truncatedContent
+    category === "markdown" && truncatedContent
       ? processFileContent(truncatedContent, mimeType)
       : null;
 
@@ -329,16 +326,6 @@ export function FilePreviewContent({
       }
       return null;
 
-    case "text":
-      if (processedContent) {
-        return (
-          <div className="rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
-            <Markdown content={processedContent.text} isStreaming={false} />
-          </div>
-        );
-      }
-      return null;
-
     case "markdown":
       if (
         processedContent &&
@@ -377,6 +364,9 @@ export function FilePreviewContent({
         </div>
       );
     }
+
+    case "unsupported":
+      return null;
 
     default:
       assertNeverAndIgnore(category);

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -6,11 +6,14 @@ import {
   buildFileSystemTree,
   buildFolderTree,
   findTreeNodeByPath,
+  getCategoryFromContentType,
   getChildrenAtFolderPath,
   getExplorerRelativePath,
   getFileExplorerSearchResultTitle,
+  getFilePreviewConfig,
   getVirtualScopeRootNodes,
   isFileExplorerMovableFile,
+  isFilePreviewableContentType,
   withVirtualExplorerPath,
 } from "@app/components/file_explorer/utils";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
@@ -69,6 +72,35 @@ function makeFileEntry(contentType: string): FileEntry {
     thumbnailUrl: null,
   };
 }
+
+describe("file preview configuration", () => {
+  it.each([
+    "application/zip",
+    "application/octet-stream",
+    "application/x-tar",
+    "font/woff",
+  ])("marks %s as download-only", (contentType) => {
+    expect(getFilePreviewConfig(contentType).category).toBe("unsupported");
+    expect(isFilePreviewableContentType(contentType)).toBe(false);
+    expect(getCategoryFromContentType(contentType)).toBe("other");
+  });
+
+  it.each([
+    "text/plain; charset=utf-8",
+    "text/x-diff",
+    "application/javascript",
+    "application/json",
+    "application/problem+json",
+    "application/pdf",
+    "image/png",
+    "audio/mpeg",
+    "text/csv",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ])("keeps %s previewable", (contentType) => {
+    expect(getFilePreviewConfig(contentType).category).not.toBe("unsupported");
+    expect(isFilePreviewableContentType(contentType)).toBe(true);
+  });
+});
 
 describe("isFileExplorerMovableFile", () => {
   it("returns false for fileId-backed frames and slideshows", () => {

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -6,21 +6,32 @@ import {
   isInteractiveContentType,
   isMarkdownContentType,
   isPdfContentType,
+  isSandboxFunctionContentType,
+  stripMimeParameters,
 } from "@app/types/files";
 
-const VIEWER_CONTENT_TYPES = [
+const VIEWER_CONTENT_TYPES = new Set<string>([
   "application/msword",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.ms-excel",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-] as const;
+]);
+
+const TEXT_PREVIEW_CONTENT_TYPES = new Set<string>([
+  "application/javascript",
+  "application/json",
+  "application/typescript",
+  "application/vnd.dust.section.json",
+  "application/x-ndjson",
+  "application/xml",
+  "application/yaml",
+  "message/rfc822",
+]);
 
 function isViewerCompatible(contentType: string): boolean {
-  return VIEWER_CONTENT_TYPES.includes(
-    contentType as (typeof VIEWER_CONTENT_TYPES)[number]
-  );
+  return VIEWER_CONTENT_TYPES.has(contentType);
 }
 
 export type FilePreviewCategory =
@@ -31,8 +42,8 @@ export type FilePreviewCategory =
   | "audio"
   | "markdown"
   | "delimited"
-  | "text"
-  | "image";
+  | "image"
+  | "unsupported";
 
 export interface FilePreviewConfig {
   category: FilePreviewCategory;
@@ -41,7 +52,19 @@ export interface FilePreviewConfig {
   supportsCopyContent: boolean;
 }
 
-export function getFilePreviewConfig(contentType: string): FilePreviewConfig {
+function isTextPreviewContentType(contentType: string): boolean {
+  return (
+    contentType.startsWith("text/") ||
+    contentType.endsWith("+json") ||
+    contentType.endsWith("+xml") ||
+    TEXT_PREVIEW_CONTENT_TYPES.has(contentType)
+  );
+}
+
+export function getFilePreviewConfig(
+  rawContentType: string
+): FilePreviewConfig {
+  const contentType = stripMimeParameters(rawContentType);
   const category = getFileFormatCategory(contentType);
 
   if (isInteractiveContentType(contentType)) {
@@ -80,7 +103,11 @@ export function getFilePreviewConfig(contentType: string): FilePreviewConfig {
     };
   }
 
-  if (category === "code" || category === "data") {
+  if (
+    category === "code" ||
+    isSandboxFunctionContentType(contentType) ||
+    isTextPreviewContentType(contentType)
+  ) {
     return {
       category: "code",
       needsProcessedVersion: false,
@@ -117,11 +144,15 @@ export function getFilePreviewConfig(contentType: string): FilePreviewConfig {
   }
 
   return {
-    category: "text",
+    category: "unsupported",
     needsProcessedVersion: false,
     supportsExternalViewer: false,
-    supportsCopyContent: true,
+    supportsCopyContent: false,
   };
+}
+
+export function isFilePreviewableContentType(contentType: string): boolean {
+  return getFilePreviewConfig(contentType).category !== "unsupported";
 }
 
 import type {
@@ -191,11 +222,13 @@ export function getFileExplorerBucket(
     case "pdf":
     case "viewer":
     case "markdown":
-    case "text":
       return "texts";
 
     case "frame":
       return "frames";
+
+    case "unsupported":
+      return null;
 
     default:
       return null;
@@ -314,10 +347,11 @@ export function getCategoryFromContentType(
     case "code":
     case "viewer":
     case "markdown":
-    case "text":
       return "document";
     case "frame":
       return "frame";
+    case "unsupported":
+      return "other";
     default:
       return "other";
   }

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -16,6 +16,7 @@ const mockOwner = LightWorkspaceFactory.build({
 });
 
 const mockClientFetch = vi.fn();
+const mockWindowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
 vi.mock("@app/lib/egress/client", () => ({
   clientFetch: (...args: unknown[]) => mockClientFetch(...args),
 }));
@@ -151,6 +152,29 @@ describe("getFilePreviewPlugin", () => {
     expect(
       screen.getByRole("button", { name: "Download" })
     ).toBeInTheDocument();
+  });
+
+  it("downloads binary files without opening a preview", () => {
+    const FilePreview = getFilePreviewPlugin();
+
+    render(
+      <FilePreviewProvider owner={mockOwner}>
+        <FilePreview
+          path="conversation-c1/archive.zip"
+          title="archive.zip"
+          contentType="application/zip"
+        />
+      </FilePreviewProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "archive.zip" }));
+
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      "http://fake-url/api/w/w_test_ws/files/path/conversation-c1/archive.zip?download=1",
+      "_blank"
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockClientFetch).not.toHaveBeenCalled();
   });
 
   it("opens Frame files in the interactive content side panel", async () => {


### PR DESCRIPTION
## Description

Treat unknown and opaque MIME types as download-only instead of decoding their bytes as text. Inline citations and explorer entries now download these files directly, and preview navigation skips them.

## Tests

Added focused Vitest coverage for ZIP and octet-stream classification, citation downloads, explorer downloads, and navigation.

## Risk

Low. The preview policy uses a text and renderer allowlist; unsupported types fall back to the existing download paths.

## Deploy Plan

Standard deploy.