### PR TITLE
feat(front): keep sticky session preference for input bar model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -9,6 +9,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   createContext,
@@ -17,6 +18,44 @@ import {
   useMemo,
   useState,
 } from "react";
+
+const STICKY_MODEL_OVERRIDE_STORAGE_KEY = "inputBarModelOverride_v1";
+
+function readStickyModelOverride(): ModelSelectionType | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    const raw = window.sessionStorage.getItem(
+      STICKY_MODEL_OVERRIDE_STORAGE_KEY
+    );
+    if (!raw) {
+      return undefined;
+    }
+    const parsed = ModelSelectionSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStickyModelOverride(selection: ModelSelectionType | undefined) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (selection === undefined) {
+      window.sessionStorage.removeItem(STICKY_MODEL_OVERRIDE_STORAGE_KEY);
+    } else {
+      window.sessionStorage.setItem(
+        STICKY_MODEL_OVERRIDE_STORAGE_KEY,
+        JSON.stringify(selection)
+      );
+    }
+  } catch {
+    // Best-effort write only.
+  }
+}
 
 /** Payload for the first message when creation is deferred until after navigation. */
 export type PendingConversationMessage = {
@@ -60,6 +99,8 @@ export const InputBarContext = createContext<{
   clearPendingFirstMessage: (conversationId: string) => void;
   isLoadingGoTemplate: boolean;
   setIsLoadingGoTemplate: (loading: boolean) => void;
+  stickyModelOverride: ModelSelectionType | undefined;
+  setStickyModelOverride: (selection: ModelSelectionType | undefined) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
   // Fired right before submit; the extension uses it to snapshot browser tab state.
@@ -78,6 +119,8 @@ export const InputBarContext = createContext<{
   clearPendingFirstMessage: () => {},
   isLoadingGoTemplate: false,
   setIsLoadingGoTemplate: () => {},
+  stickyModelOverride: undefined,
+  setStickyModelOverride: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -119,6 +162,20 @@ export function InputBarContextProvider({
   const [pendingInputText, setPendingInputTextState] =
     useState<PendingInputText | null>(null);
   const [isLoadingGoTemplate, setIsLoadingGoTemplate] = useState(false);
+
+  // Sticky model-picker override, hydrated from sessionStorage on mount and
+  // written through on every change so it survives reloads within the tab.
+  const [stickyModelOverride, setStickyModelOverrideState] = useState<
+    ModelSelectionType | undefined
+  >(() => readStickyModelOverride());
+
+  const setStickyModelOverride = useCallback(
+    (selection: ModelSelectionType | undefined) => {
+      writeStickyModelOverride(selection);
+      setStickyModelOverrideState(selection);
+    },
+    []
+  );
 
   // First message stashed while navigating to a newly-created conversation (deferred-send flow).
   const [
@@ -205,6 +262,8 @@ export function InputBarContextProvider({
       clearPendingFirstMessage,
       isLoadingGoTemplate,
       setIsLoadingGoTemplate,
+      stickyModelOverride,
+      setStickyModelOverride,
       captureActions,
       fileUploaderService,
       onBeforeSubmit,
@@ -220,6 +279,8 @@ export function InputBarContextProvider({
       setPendingFirstMessage,
       clearPendingFirstMessage,
       isLoadingGoTemplate,
+      stickyModelOverride,
+      setStickyModelOverride,
       captureActions,
       fileUploaderService,
       onBeforeSubmit,

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,3 +1,4 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
   MakerGroup,
@@ -37,7 +38,7 @@ import type {
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
@@ -65,6 +66,8 @@ export function InputBarModelPicker({
 }: InputBarModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
+  const { stickyModelOverride, setStickyModelOverride } =
+    useContext(InputBarContext);
   const { isDark } = useTheme();
   const isMobile = useIsMobile();
   const clientType = useClientType();
@@ -95,11 +98,13 @@ export function InputBarModelPicker({
       selection.effort === agentModel?.reasoningEffort;
 
     if ((isSelectionAuto && isDefaultAuto) || isSelectionSameModelAsAgent) {
-      // show default
+      // show default and clear override
       setUserOverride(null);
+      setStickyModelOverride(undefined);
       return;
     }
     setUserOverride(selection);
+    setStickyModelOverride(selection.toSend);
   };
 
   // Clear the manual override when the user switches which agent they address
@@ -116,8 +121,14 @@ export function InputBarModelPicker({
   });
 
   const defaultSelection = useMemo(
-    () => resolveDefaultSelection({ agentModel, lastRequestedModel, models }),
-    [agentModel, lastRequestedModel, models]
+    () =>
+      resolveDefaultSelection({
+        agentModel,
+        lastRequestedModel,
+        sessionSticky: stickyModelOverride,
+        models,
+      }),
+    [agentModel, lastRequestedModel, stickyModelOverride, models]
   );
 
   const shown: Selection = userOverride ?? defaultSelection;

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -186,31 +186,51 @@ function findAgentModel(
   );
 }
 
+function resolveRequestedSelection(
+  models: ModelConfigurationType[],
+  selection: ModelSelectionType | null | undefined
+): Selection | null {
+  const requestedModel = selection
+    ? findAvailableModel(models, selection)
+    : undefined;
+  if (!requestedModel) {
+    return null;
+  }
+  if (requestedModel.modelId === AUTO_MODEL_ID) {
+    return { kind: "auto", toSend: AUTO_MODEL_SELECTION };
+  }
+  const effort =
+    selection?.reasoningEffort ?? requestedModel.defaultReasoningEffort;
+  return {
+    kind: "model",
+    model: requestedModel,
+    effort,
+    toSend: buildModelSelection(requestedModel, effort),
+  };
+}
+
 export function resolveDefaultSelection({
   agentModel,
   lastRequestedModel,
+  sessionSticky,
   models,
 }: {
   agentModel: AgentModelConfigurationType | null;
   lastRequestedModel: ModelSelectionType | null;
+  sessionSticky?: ModelSelectionType | null;
   models: ModelConfigurationType[];
 }): Selection {
-  const requestedModel = lastRequestedModel
-    ? findAvailableModel(models, lastRequestedModel)
-    : undefined;
-  if (requestedModel) {
-    if (requestedModel.modelId === AUTO_MODEL_ID) {
-      return { kind: "auto", toSend: AUTO_MODEL_SELECTION };
-    }
-    const effort =
-      lastRequestedModel?.reasoningEffort ??
-      requestedModel.defaultReasoningEffort;
-    return {
-      kind: "model",
-      model: requestedModel,
-      effort,
-      toSend: buildModelSelection(requestedModel, effort),
-    };
+  const fromLastRequested = resolveRequestedSelection(
+    models,
+    lastRequestedModel
+  );
+  if (fromLastRequested) {
+    return fromLastRequested;
+  }
+
+  const fromSticky = resolveRequestedSelection(models, sessionSticky);
+  if (fromSticky) {
+    return fromSticky;
   }
 
   const agentDefaultModel = agentModel


### PR DESCRIPTION
## Description

The input-bar model picker (behind the `models_picker` flag) now remembers the last override the user picked for the whole browser-tab session, so it no longer has to be re-selected on every new conversation or agent switch.

The picked override is stored in `InputBarContext` and backed by `sessionStorage`, so it:
- is **global** — one override applies across all agents and conversations;
- **survives page reloads** but stays scoped to the tab (cleared when the tab/session ends — no DB, no `localStorage`);
- **defers to conversation history** — an existing conversation still shows its own last-requested model; the sticky only seeds new conversations and agent switches. Effective order: local pick this render → conversation `lastRequestedModel` → session sticky → agent default → Auto.

Reverting the picker to the agent default clears the sticky. Reads from storage are validated with the existing `ModelSelectionSchema` so a stale value can't break the picker.

## Tests

Manual, with the `models_picker` flag enabled:
- Pick a model in a conversation → start a new conversation → picker pre-selects it and sends it.
- Switch the addressed agent → override is kept (global).
- Open an existing conversation that used a different model → it shows its own last model, not the sticky.
- Revert to Default → new conversations fall back to the agent default.
- Reload the page → sticky is preserved; open/close the tab → sticky is gone.
