### PR TITLE
Add opt-in lifecycle management to Dust Hive

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -186,6 +186,11 @@ external workspace is archived.
 | `status [NAME]` | Show service health |
 | `logs [NAME] [SERVICE] [-f]` | View service logs |
 | `url [NAME]` | Print front URL |
+| `lifecycle enable [NAME]` | Opt an environment into automatic cool, stop, and archive transitions |
+| `lifecycle disable [NAME]` | Disable automatic lifecycle management |
+| `lifecycle status [NAME]` | Show policy, activity, and blocked cleanup reasons |
+| `lifecycle run-once [--dry-run]` | Run one lifecycle scan |
+| `activity run -- COMMAND...` | Run tests or another command with an activity heartbeat |
 
 ### Utilities
 
@@ -236,6 +241,90 @@ Available services for `logs` command:
 | **stopped** | Nothing running |
 | **cold** | Only SDK watch running |
 | **warm** | All services running |
+
+## Automatic lifecycle management
+
+Lifecycle management is opt-in per environment. The built-in `balanced` profile cools a warm
+environment after one idle hour, stops a cold environment after eight idle hours, and archives a
+stopped environment after seven idle days:
+
+```bash
+dust-hive lifecycle enable my-feature
+
+# Per-environment duration overrides.
+dust-hive lifecycle enable my-feature \
+  --cold-after 30m \
+  --stop-after 4h \
+  --delete-after 14d
+
+# Disable a transition without disabling the whole policy.
+dust-hive lifecycle enable my-feature --delete-after never
+
+dust-hive lifecycle status my-feature
+dust-hive lifecycle run-once --dry-run
+dust-hive lifecycle disable my-feature
+```
+
+Activity resets the timer for the environment's current state. Hive tracks:
+
+- Git changes to tracked and non-ignored untracked files.
+- Requests through the environment's frontend proxy.
+- `warm`, `start`, `open`, and `restart` commands.
+- Commands run with `dust-hive activity run`.
+
+Use the activity wrapper for tests so long-running commands maintain a heartbeat:
+
+```bash
+cd front
+NODE_ENV=test dust-hive activity run -- npm test lib/resources/user_resource.test.ts
+```
+
+Frontend tracking is conservative: polling from an open background tab also counts as activity.
+Profiles that should ignore browser traffic can set `trackFrontend` to `false`.
+
+Each stage has its own timer. An environment cooled after one idle hour must then remain idle for
+the configured cold duration before it is stopped. Activity never automatically warms or starts an
+environment.
+
+Automatic archive removes Hive services, Docker volumes, the test database, the worktree, and the
+environment registration. It refuses to archive a dirty worktree and always keeps the local Git
+branch. Externally owned worktrees are kept. Set `blockDeleteIfSessionExists` when a persistent
+multiplexer session should also block archive.
+
+The lifecycle daemon starts when an environment is enabled and is restarted by subsequent
+`dust-hive` commands if needed. Manage it directly with `dust-hive lifecycle start|stop`. Its log is
+stored at `~/.dust-hive/lifecycle.log`.
+
+### Lifecycle configuration
+
+Lifecycle profiles and enrollment are stored in `~/.dust-hive/lifecycle.json`. Duration values are
+seconds; `null` disables a transition. The file is strictly validated before the daemon performs
+any action, so unknown keys and misspelled settings block lifecycle actions.
+
+```json
+{
+  "scanIntervalSeconds": 30,
+  "dryRun": false,
+  "profiles": {
+    "aggressive": {
+      "coldAfterSeconds": 1200,
+      "stopAfterSeconds": 7200,
+      "deleteAfterSeconds": 604800,
+      "trackSourceChanges": true,
+      "trackFrontend": true,
+      "blockDeleteIfSessionExists": false
+    }
+  },
+  "environments": {
+    "my-feature": {
+      "profile": "aggressive",
+      "overrides": {
+        "deleteAfterSeconds": 1209600
+      }
+    }
+  }
+}
+```
 
 ## Port Allocation
 

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -190,7 +190,7 @@ external workspace is archived.
 | `lifecycle disable [NAME]` | Disable automatic lifecycle management |
 | `lifecycle status [NAME]` | Show policy, activity, and blocked cleanup reasons |
 | `lifecycle run-once [--dry-run]` | Run one lifecycle scan |
-| `activity run -- COMMAND...` | Run tests or another command with an activity heartbeat |
+| `activity run -- COMMAND...` | Run tests or another command with an active lifecycle lease |
 
 ### Utilities
 
@@ -272,7 +272,7 @@ Activity resets the timer for the environment's current state. Hive tracks:
 - `warm`, `start`, `open`, and `restart` commands.
 - Commands run with `dust-hive activity run`.
 
-Use the activity wrapper for tests so long-running commands maintain a heartbeat:
+Use the activity wrapper for tests so long-running commands hold an active lifecycle lease:
 
 ```bash
 cd front
@@ -287,9 +287,9 @@ the configured cold duration before it is stopped. Activity never automatically 
 environment.
 
 Automatic archive removes Hive services, Docker volumes, the test database, the worktree, and the
-environment registration. It refuses to archive a dirty worktree and always keeps the local Git
-branch. Externally owned worktrees are kept. Set `blockDeleteIfSessionExists` when a persistent
-multiplexer session should also block archive.
+environment registration. It refuses to remove a dirty Hive-owned worktree and always keeps the
+local Git branch. Externally owned worktrees are kept and unregistered. Set
+`blockDeleteIfSessionExists` when a persistent multiplexer session should also block archive.
 
 The lifecycle daemon starts when an environment is enabled and is restarted by subsequent
 `dust-hive` commands if needed. Manage it directly with `dust-hive lifecycle start|stop`. Its log is

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -300,7 +300,7 @@ _dust_hive_complete() {
 
   # Top-level command completion
   if [[ -z "$cmd" ]]; then
-    local commands="spawn adopt open reload restart warm cool start stop up down destroy unregister list status logs url cd setup doctor cache refresh forward sync temporal seed-config feed flag help"
+    local commands="spawn adopt open reload restart warm cool start stop up down lifecycle activity destroy unregister list status logs url cd setup doctor cache refresh forward sync temporal seed-config feed flag help"
     COMPREPLY=($(compgen -W "$commands" -- "$cur"))
     return
   fi
@@ -403,6 +403,23 @@ _dust_hive_complete() {
       ;;
     down)
       COMPREPLY=($(compgen -W "-f --force" -- "$cur"))
+      ;;
+    lifecycle)
+      local subcommand="${COMP_WORDS[$((cmd_index + 1))]:-}"
+      if (( cword == cmd_index + 1 )); then
+        COMPREPLY=($(compgen -W "enable disable status run-once start stop" -- "$cur"))
+      elif [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "-p --profile --cold-after --stop-after --delete-after -n --dry-run" -- "$cur"))
+      elif [[ "$subcommand" == "enable" || "$subcommand" == "disable" || "$subcommand" == "status" ]]; then
+        COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+      fi
+      ;;
+    activity)
+      if (( cword == cmd_index + 1 )); then
+        COMPREPLY=($(compgen -W "touch run" -- "$cur"))
+      elif [[ "${COMP_WORDS[$((cmd_index + 1))]:-}" == "touch" ]]; then
+        COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+      fi
       ;;
     destroy|rm)
       case "$cur" in

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -286,6 +286,8 @@ _dust-hive() {
         'stop:Stop all services in environment'
         'up:Start managed services (temporal + test postgres + test redis)'
         'down:Stop all envs, temporal, test postgres, test redis'
+        'lifecycle:Manage automatic environment lifecycle'
+        'activity:Record activity or run a command with a heartbeat'
         'destroy:Remove environment'
         'unregister:Remove Hive resources but keep worktree'
         'list:Show all environments'
@@ -398,6 +400,23 @@ _dust-hive() {
           _arguments \
             '-f[Skip confirmation prompt]' \
             '--force[Skip confirmation prompt]'
+          ;;
+        lifecycle)
+          _arguments \
+            '1::subcommand:(enable disable status run-once start stop)' \
+            '2::name:_dust_hive_envs' \
+            '-p[Lifecycle profile]:profile:' \
+            '--profile[Lifecycle profile]:profile:' \
+            '--cold-after[Warm-to-cold delay]:duration:' \
+            '--stop-after[Cold-to-stopped delay]:duration:' \
+            '--delete-after[Stopped-to-archived delay]:duration:' \
+            '-n[Show actions without applying them]' \
+            '--dry-run[Show actions without applying them]'
+          ;;
+        activity)
+          _arguments \
+            '1::subcommand:(touch run)' \
+            '*::argument:'
           ;;
         destroy|rm)
           _arguments \

--- a/x/henry/dust-hive/src/commands/activity.ts
+++ b/x/henry/dust-hive/src/commands/activity.ts
@@ -1,0 +1,63 @@
+import { detectEnvironmentFromCwd, getEnvironment } from "../lib/environment";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
+
+async function resolveActivityEnvironment(nameArg?: string): Promise<Result<string, CommandError>> {
+  const name = nameArg ?? process.env["DUST_HIVE_ENV_NAME"] ?? (await detectEnvironmentFromCwd());
+  if (!name) {
+    return Err(new CommandError("Could not determine the Hive environment"));
+  }
+  if (!(await getEnvironment(name))) {
+    return Err(new CommandError(`Environment '${name}' not found`));
+  }
+  return Ok(name);
+}
+
+export async function activityTouchCommand(nameArg?: string): Promise<Result<void>> {
+  const envResult = await resolveActivityEnvironment(nameArg);
+  if (!envResult.ok) {
+    return envResult;
+  }
+  await touchLifecycleActivity(envResult.value, "command");
+  return Ok(undefined);
+}
+
+export async function activityRunCommand(command: string[]): Promise<Result<void>> {
+  if (command.length === 0) {
+    return Err(new CommandError("Usage: dust-hive activity run -- <command>"));
+  }
+  const envResult = await resolveActivityEnvironment();
+  if (!envResult.ok) {
+    return envResult;
+  }
+
+  await touchLifecycleActivity(envResult.value, "test");
+  const proc = Bun.spawn(command, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exited = proc.exited;
+  const heartbeat = async (): Promise<void> => {
+    while (true) {
+      const shouldContinue = await Promise.race([
+        exited.then(() => false),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 15_000)),
+      ]);
+      if (!shouldContinue) {
+        return;
+      }
+      await touchLifecycleActivity(envResult.value, "test");
+    }
+  };
+  const heartbeatPromise = heartbeat();
+  const exitCode = await exited;
+  await heartbeatPromise;
+  await touchLifecycleActivity(envResult.value, "test");
+  if (exitCode !== 0) {
+    return Err(new CommandError(`Command exited with code ${exitCode}`));
+  }
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/commands/activity.ts
+++ b/x/henry/dust-hive/src/commands/activity.ts
@@ -1,5 +1,5 @@
 import { detectEnvironmentFromCwd, getEnvironment } from "../lib/environment";
-import { touchLifecycleActivity } from "../lib/lifecycle-activity";
+import { touchLifecycleActivity, withLifecycleActivityLease } from "../lib/lifecycle-activity";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 
 async function resolveActivityEnvironment(nameArg?: string): Promise<Result<string, CommandError>> {
@@ -31,31 +31,16 @@ export async function activityRunCommand(command: string[]): Promise<Result<void
     return envResult;
   }
 
-  await touchLifecycleActivity(envResult.value, "test");
-  const proc = Bun.spawn(command, {
-    cwd: process.cwd(),
-    env: process.env,
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
+  const exitCode = await withLifecycleActivityLease(envResult.value, "test", async () => {
+    const proc = Bun.spawn(command, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    return proc.exited;
   });
-  const exited = proc.exited;
-  const heartbeat = async (): Promise<void> => {
-    while (true) {
-      const shouldContinue = await Promise.race([
-        exited.then(() => false),
-        new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 15_000)),
-      ]);
-      if (!shouldContinue) {
-        return;
-      }
-      await touchLifecycleActivity(envResult.value, "test");
-    }
-  };
-  const heartbeatPromise = heartbeat();
-  const exitCode = await exited;
-  await heartbeatPromise;
-  await touchLifecycleActivity(envResult.value, "test");
   if (exitCode !== 0) {
     return Err(new CommandError(`Command exited with code ${exitCode}`));
   }

--- a/x/henry/dust-hive/src/commands/cool.ts
+++ b/x/henry/dust-hive/src/commands/cool.ts
@@ -1,12 +1,13 @@
 import { withEnvironments } from "../lib/commands";
 import { pauseDocker } from "../lib/docker";
+import type { Environment } from "../lib/environment";
 import { logger } from "../lib/logger";
 import { stopService } from "../lib/process";
-import { CommandError, Err, Ok } from "../lib/result";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ALL_SERVICES, COLD_STATE_SERVICES } from "../lib/services";
 import { getStateInfo } from "../lib/state";
 
-export const coolCommand = withEnvironments("cool", async (env) => {
+export async function coolEnvironment(env: Environment): Promise<Result<void>> {
   // Check state
   const stateInfo = await getStateInfo(env);
   if (stateInfo.state !== "warm") {
@@ -42,4 +43,6 @@ export const coolCommand = withEnvironments("cool", async (env) => {
   console.log();
 
   return Ok(undefined);
-});
+}
+
+export const coolCommand = withEnvironments("cool", coolEnvironment);

--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -192,14 +192,15 @@ async function cleanupDocker(envName: string): Promise<void> {
 async function cleanupGitResources(
   env: Environment,
   plan: DestroyPlan,
-  settings: Settings
+  settings: Settings,
+  force: boolean
 ): Promise<void> {
   if (plan.keepWorktree) {
     await removeDirenvIntegration(env.name, plan.worktreePath);
     logger.info(`Keeping worktree: ${plan.worktreePath}`);
   } else {
     logger.step("Removing git worktree...");
-    await removeWorktree(env.metadata.repoRoot, plan.worktreePath);
+    await removeWorktree(env.metadata.repoRoot, plan.worktreePath, { force });
     logger.success("Git worktree removed");
   }
 
@@ -258,7 +259,17 @@ export async function destroySingleEnvironment(
     logger.warn(`Could not drop test database: ${testDbResult.error}`);
   }
 
-  await cleanupGitResources(env, plan, settings);
+  // Cleanup can take long enough for an editor or agent to modify the worktree.
+  // Re-check at the removal boundary; non-forced git removal closes the remaining race.
+  const finalSafeResult = await ensureWorktreeCanBeRemoved(
+    env,
+    plan.worktreePath,
+    options,
+    plan.keepWorktree
+  );
+  if (!finalSafeResult.ok) return finalSafeResult;
+
+  await cleanupGitResources(env, plan, settings, options.force);
 
   // Remove environment directory
   logger.step("Removing environment config...");

--- a/x/henry/dust-hive/src/commands/lifecycle.ts
+++ b/x/henry/dust-hive/src/commands/lifecycle.ts
@@ -1,7 +1,7 @@
 import { requireEnvironment } from "../lib/commands";
 import { getEnvironment } from "../lib/environment";
 import { loadLifecycleState, runLifecycleSweep } from "../lib/lifecycle";
-import { touchLifecycleActivity } from "../lib/lifecycle-activity";
+import { touchLifecycleActivityUnderLock } from "../lib/lifecycle-activity";
 import {
   DEFAULT_LIFECYCLE_PROFILE,
   formatDurationSeconds,
@@ -15,7 +15,9 @@ import {
   getLifecycleDaemonPid,
   startLifecycleDaemon,
   stopLifecycleDaemon,
+  stopLifecycleDaemonIfUnused,
 } from "../lib/lifecycle-daemon";
+import { acquireLifecycleConfigLock, acquireLifecycleLock } from "../lib/lifecycle-lock";
 import { logger } from "../lib/logger";
 import { LIFECYCLE_CONFIG_PATH, LIFECYCLE_LOG_PATH } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
@@ -60,28 +62,41 @@ export async function lifecycleEnableCommand(
   if (!envResult.ok) {
     return envResult;
   }
-  const configResult = await loadLifecycleConfig();
-  if (!configResult.ok) {
-    return configResult;
-  }
-  const profile = options.profile ?? DEFAULT_LIFECYCLE_PROFILE;
-  if (!configResult.value.profiles[profile]) {
-    return Err(new CommandError(`Unknown lifecycle profile '${profile}'`));
-  }
   const overridesResult = await buildOverrides(options);
   if (!overridesResult.ok) {
     return overridesResult;
   }
+  const profile = options.profile ?? DEFAULT_LIFECYCLE_PROFILE;
   const overrides = overridesResult.value;
   const enrollment = {
     profile,
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
   };
-  await saveLifecycleConfig({
-    ...configResult.value,
-    environments: { ...configResult.value.environments, [envResult.value.name]: enrollment },
-  });
-  await touchLifecycleActivity(envResult.value.name, "command");
+  const lock = await acquireLifecycleLock(envResult.value.name, { wait: true });
+  if (!lock) {
+    return Err(new CommandError(`Could not acquire lifecycle lock for '${envResult.value.name}'`));
+  }
+  try {
+    const configLock = await acquireLifecycleConfigLock();
+    try {
+      const configResult = await loadLifecycleConfig();
+      if (!configResult.ok) {
+        return configResult;
+      }
+      if (!configResult.value.profiles[profile]) {
+        return Err(new CommandError(`Unknown lifecycle profile '${profile}'`));
+      }
+      await touchLifecycleActivityUnderLock(envResult.value.name, "command");
+      await saveLifecycleConfig({
+        ...configResult.value,
+        environments: { ...configResult.value.environments, [envResult.value.name]: enrollment },
+      });
+    } finally {
+      await configLock.release();
+    }
+  } finally {
+    await lock.release();
+  }
 
   const daemonResult = await startLifecycleDaemon();
   if (!daemonResult.ok) {
@@ -99,18 +114,38 @@ export async function lifecycleDisableCommand(nameArg: string | undefined): Prom
   if (!envResult.ok) {
     return envResult;
   }
-  const configResult = await loadLifecycleConfig();
-  if (!configResult.ok) {
-    return configResult;
+  const lock = await acquireLifecycleLock(envResult.value.name, { wait: true });
+  if (!lock) {
+    return Err(new CommandError(`Could not acquire lifecycle lock for '${envResult.value.name}'`));
   }
-  const { [envResult.value.name]: removed, ...environments } = configResult.value.environments;
+  let removed = false;
+  let environmentCount = 0;
+  try {
+    const configLock = await acquireLifecycleConfigLock();
+    try {
+      const configResult = await loadLifecycleConfig();
+      if (!configResult.ok) {
+        return configResult;
+      }
+      const { [envResult.value.name]: currentEnrollment, ...environments } =
+        configResult.value.environments;
+      removed = currentEnrollment !== undefined;
+      environmentCount = Object.keys(environments).length;
+      if (removed) {
+        await saveLifecycleConfig({ ...configResult.value, environments });
+      }
+    } finally {
+      await configLock.release();
+    }
+  } finally {
+    await lock.release();
+  }
   if (!removed) {
     logger.info(`Lifecycle management is not enabled for '${envResult.value.name}'`);
     return Ok(undefined);
   }
-  await saveLifecycleConfig({ ...configResult.value, environments });
-  if (Object.keys(environments).length === 0) {
-    await stopLifecycleDaemon();
+  if (environmentCount === 0) {
+    await stopLifecycleDaemonIfUnused();
   }
   logger.success(`Lifecycle management disabled for '${envResult.value.name}'`);
   return Ok(undefined);
@@ -181,8 +216,12 @@ export async function lifecycleStatusCommand(name?: string): Promise<Result<void
   return Ok(undefined);
 }
 
-export async function lifecycleRunOnceCommand(dryRun: boolean): Promise<Result<void>> {
-  return runLifecycleSweep({ dryRun });
+export function getLifecycleRunOnceOptions(dryRun?: boolean): { dryRun?: boolean } {
+  return dryRun === undefined ? {} : { dryRun };
+}
+
+export async function lifecycleRunOnceCommand(dryRun?: boolean): Promise<Result<void>> {
+  return runLifecycleSweep(getLifecycleRunOnceOptions(dryRun));
 }
 
 export async function lifecycleStartCommand(): Promise<Result<void>> {

--- a/x/henry/dust-hive/src/commands/lifecycle.ts
+++ b/x/henry/dust-hive/src/commands/lifecycle.ts
@@ -1,0 +1,203 @@
+import { requireEnvironment } from "../lib/commands";
+import { getEnvironment } from "../lib/environment";
+import { loadLifecycleState, runLifecycleSweep } from "../lib/lifecycle";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
+import {
+  DEFAULT_LIFECYCLE_PROFILE,
+  formatDurationSeconds,
+  type LifecyclePolicyOverrides,
+  loadLifecycleConfig,
+  parseDurationSeconds,
+  resolveLifecyclePolicy,
+  saveLifecycleConfig,
+} from "../lib/lifecycle-config";
+import {
+  getLifecycleDaemonPid,
+  startLifecycleDaemon,
+  stopLifecycleDaemon,
+} from "../lib/lifecycle-daemon";
+import { logger } from "../lib/logger";
+import { LIFECYCLE_CONFIG_PATH, LIFECYCLE_LOG_PATH } from "../lib/paths";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
+import { getStateInfo } from "../lib/state";
+
+export interface LifecycleEnableOptions {
+  profile?: string;
+  coldAfter?: string;
+  stopAfter?: string;
+  deleteAfter?: string;
+}
+
+async function buildOverrides(
+  options: LifecycleEnableOptions
+): Promise<Result<LifecyclePolicyOverrides, CommandError>> {
+  const overrides: LifecyclePolicyOverrides = {};
+  const durations = [
+    ["coldAfterSeconds", options.coldAfter],
+    ["stopAfterSeconds", options.stopAfter],
+    ["deleteAfterSeconds", options.deleteAfter],
+  ] as const;
+
+  for (const [key, value] of durations) {
+    if (value === undefined) {
+      continue;
+    }
+    const parsed = parseDurationSeconds(value);
+    if (!parsed.ok) {
+      return parsed;
+    }
+    overrides[key] = parsed.value;
+  }
+
+  return Ok(overrides);
+}
+
+export async function lifecycleEnableCommand(
+  nameArg: string | undefined,
+  options: LifecycleEnableOptions
+): Promise<Result<void>> {
+  const envResult = await requireEnvironment(nameArg, "enable lifecycle management");
+  if (!envResult.ok) {
+    return envResult;
+  }
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  const profile = options.profile ?? DEFAULT_LIFECYCLE_PROFILE;
+  if (!configResult.value.profiles[profile]) {
+    return Err(new CommandError(`Unknown lifecycle profile '${profile}'`));
+  }
+  const overridesResult = await buildOverrides(options);
+  if (!overridesResult.ok) {
+    return overridesResult;
+  }
+  const overrides = overridesResult.value;
+  const enrollment = {
+    profile,
+    ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
+  };
+  await saveLifecycleConfig({
+    ...configResult.value,
+    environments: { ...configResult.value.environments, [envResult.value.name]: enrollment },
+  });
+  await touchLifecycleActivity(envResult.value.name, "command");
+
+  const daemonResult = await startLifecycleDaemon();
+  if (!daemonResult.ok) {
+    return daemonResult;
+  }
+  logger.success(
+    `Lifecycle management enabled for '${envResult.value.name}' with profile '${profile}'`
+  );
+  logger.info(`Lifecycle daemon running (PID: ${daemonResult.value})`);
+  return Ok(undefined);
+}
+
+export async function lifecycleDisableCommand(nameArg: string | undefined): Promise<Result<void>> {
+  const envResult = await requireEnvironment(nameArg, "disable lifecycle management");
+  if (!envResult.ok) {
+    return envResult;
+  }
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  const { [envResult.value.name]: removed, ...environments } = configResult.value.environments;
+  if (!removed) {
+    logger.info(`Lifecycle management is not enabled for '${envResult.value.name}'`);
+    return Ok(undefined);
+  }
+  await saveLifecycleConfig({ ...configResult.value, environments });
+  if (Object.keys(environments).length === 0) {
+    await stopLifecycleDaemon();
+  }
+  logger.success(`Lifecycle management disabled for '${envResult.value.name}'`);
+  return Ok(undefined);
+}
+
+async function printEnvironmentLifecycleStatus(envName: string): Promise<void> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    logger.error(configResult.error.message);
+    return;
+  }
+  const enrollment = configResult.value.environments[envName];
+  if (!enrollment) {
+    console.log(`${envName}: disabled`);
+    return;
+  }
+  const policyResult = resolveLifecyclePolicy(configResult.value, enrollment);
+  if (!policyResult.ok) {
+    console.log(`${envName}: ${policyResult.error.message}`);
+    return;
+  }
+  const env = await getEnvironment(envName);
+  if (!env) {
+    console.log(`${envName}: missing`);
+    return;
+  }
+  const stateInfo = await getStateInfo(env);
+  const lifecycleState = await loadLifecycleState(envName);
+  const policy = policyResult.value;
+
+  console.log();
+  console.log(`Environment: ${envName}`);
+  console.log(`State: ${stateInfo.state}`);
+  console.log(`Profile: ${enrollment.profile}`);
+  console.log(`Warm to cold: ${formatDurationSeconds(policy.coldAfterSeconds)}`);
+  console.log(`Cold to stopped: ${formatDurationSeconds(policy.stopAfterSeconds)}`);
+  console.log(`Stopped to archived: ${formatDurationSeconds(policy.deleteAfterSeconds)}`);
+  console.log(`Last activity: ${lifecycleState?.lastActivityAt ?? "not observed yet"}`);
+  if (lifecycleState) {
+    console.log(`Activity source: ${lifecycleState.lastActivitySource}`);
+  }
+  if (lifecycleState?.blockedReason) {
+    console.log(`Blocked: ${lifecycleState.blockedReason}`);
+  }
+}
+
+export async function lifecycleStatusCommand(name?: string): Promise<Result<void>> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  const pid = await getLifecycleDaemonPid();
+  console.log(`Lifecycle daemon: ${pid === null ? "stopped" : `running (PID: ${pid})`}`);
+  console.log(`Config: ${LIFECYCLE_CONFIG_PATH}`);
+  console.log(`Log: ${LIFECYCLE_LOG_PATH}`);
+
+  if (name) {
+    await printEnvironmentLifecycleStatus(name);
+    return Ok(undefined);
+  }
+  const envNames = Object.keys(configResult.value.environments).sort();
+  if (envNames.length === 0) {
+    console.log("No environments have lifecycle management enabled.");
+    return Ok(undefined);
+  }
+  for (const envName of envNames) {
+    await printEnvironmentLifecycleStatus(envName);
+  }
+  console.log();
+  return Ok(undefined);
+}
+
+export async function lifecycleRunOnceCommand(dryRun: boolean): Promise<Result<void>> {
+  return runLifecycleSweep({ dryRun });
+}
+
+export async function lifecycleStartCommand(): Promise<Result<void>> {
+  const result = await startLifecycleDaemon();
+  if (!result.ok) {
+    return result;
+  }
+  logger.success(`Lifecycle daemon running (PID: ${result.value})`);
+  return Ok(undefined);
+}
+
+export async function lifecycleStopCommand(): Promise<Result<void>> {
+  const stopped = await stopLifecycleDaemon();
+  logger.info(stopped ? "Lifecycle daemon stopped" : "Lifecycle daemon was not running");
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/commands/lifecycle.ts
+++ b/x/henry/dust-hive/src/commands/lifecycle.ts
@@ -124,36 +124,35 @@ async function printEnvironmentLifecycleStatus(envName: string): Promise<void> {
   }
   const enrollment = configResult.value.environments[envName];
   if (!enrollment) {
-    console.log(`${envName}: disabled`);
+    logger.info(`${envName}: disabled`);
     return;
   }
   const policyResult = resolveLifecyclePolicy(configResult.value, enrollment);
   if (!policyResult.ok) {
-    console.log(`${envName}: ${policyResult.error.message}`);
+    logger.info(`${envName}: ${policyResult.error.message}`);
     return;
   }
   const env = await getEnvironment(envName);
   if (!env) {
-    console.log(`${envName}: missing`);
+    logger.info(`${envName}: missing`);
     return;
   }
   const stateInfo = await getStateInfo(env);
   const lifecycleState = await loadLifecycleState(envName);
   const policy = policyResult.value;
 
-  console.log();
-  console.log(`Environment: ${envName}`);
-  console.log(`State: ${stateInfo.state}`);
-  console.log(`Profile: ${enrollment.profile}`);
-  console.log(`Warm to cold: ${formatDurationSeconds(policy.coldAfterSeconds)}`);
-  console.log(`Cold to stopped: ${formatDurationSeconds(policy.stopAfterSeconds)}`);
-  console.log(`Stopped to archived: ${formatDurationSeconds(policy.deleteAfterSeconds)}`);
-  console.log(`Last activity: ${lifecycleState?.lastActivityAt ?? "not observed yet"}`);
+  logger.info(`Environment: ${envName}`);
+  logger.info(`State: ${stateInfo.state}`);
+  logger.info(`Profile: ${enrollment.profile}`);
+  logger.info(`Warm to cold: ${formatDurationSeconds(policy.coldAfterSeconds)}`);
+  logger.info(`Cold to stopped: ${formatDurationSeconds(policy.stopAfterSeconds)}`);
+  logger.info(`Stopped to archived: ${formatDurationSeconds(policy.deleteAfterSeconds)}`);
+  logger.info(`Last activity: ${lifecycleState?.lastActivityAt ?? "not observed yet"}`);
   if (lifecycleState) {
-    console.log(`Activity source: ${lifecycleState.lastActivitySource}`);
+    logger.info(`Activity source: ${lifecycleState.lastActivitySource}`);
   }
   if (lifecycleState?.blockedReason) {
-    console.log(`Blocked: ${lifecycleState.blockedReason}`);
+    logger.warn(`Blocked: ${lifecycleState.blockedReason}`);
   }
 }
 
@@ -163,9 +162,9 @@ export async function lifecycleStatusCommand(name?: string): Promise<Result<void
     return configResult;
   }
   const pid = await getLifecycleDaemonPid();
-  console.log(`Lifecycle daemon: ${pid === null ? "stopped" : `running (PID: ${pid})`}`);
-  console.log(`Config: ${LIFECYCLE_CONFIG_PATH}`);
-  console.log(`Log: ${LIFECYCLE_LOG_PATH}`);
+  logger.info(`Lifecycle daemon: ${pid === null ? "stopped" : `running (PID: ${pid})`}`);
+  logger.info(`Config: ${LIFECYCLE_CONFIG_PATH}`);
+  logger.info(`Log: ${LIFECYCLE_LOG_PATH}`);
 
   if (name) {
     await printEnvironmentLifecycleStatus(name);
@@ -173,13 +172,12 @@ export async function lifecycleStatusCommand(name?: string): Promise<Result<void
   }
   const envNames = Object.keys(configResult.value.environments).sort();
   if (envNames.length === 0) {
-    console.log("No environments have lifecycle management enabled.");
+    logger.info("No environments have lifecycle management enabled.");
     return Ok(undefined);
   }
   for (const envName of envNames) {
     await printEnvironmentLifecycleStatus(envName);
   }
-  console.log();
   return Ok(undefined);
 }
 

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -1,5 +1,6 @@
 import { setLastActiveEnv } from "../lib/activity";
 import { type Environment, getEnvironment, getEnvironmentWorktreeDir } from "../lib/environment";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
 import { logger } from "../lib/logger";
 import {
   getConfiguredMultiplexer,
@@ -33,6 +34,7 @@ export async function openCommand(
   const envResult = await resolveEnvironment(nameArg);
   if (!envResult.ok) return envResult;
   const env = envResult.value;
+  await touchLifecycleActivity(env.name, "command");
 
   const multiplexer = await getConfiguredMultiplexer();
   const worktreePath = getEnvironmentWorktreeDir(env.metadata);

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
 import { requireEnvironment } from "../lib/commands";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
 import { logger } from "../lib/logger";
 import { stopService } from "../lib/process";
 import { restoreTerminal } from "../lib/prompt";
@@ -32,6 +33,7 @@ export async function restartCommand(
   if (!envResult.ok) return envResult;
 
   const env = envResult.value;
+  await touchLifecycleActivity(env.name, "command");
 
   // Handle service selection
   let service: ServiceName;

--- a/x/henry/dust-hive/src/commands/start.ts
+++ b/x/henry/dust-hive/src/commands/start.ts
@@ -1,4 +1,5 @@
 import { withEnvironments } from "../lib/commands";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
 import { logger } from "../lib/logger";
 import { isServiceRunning } from "../lib/process";
 import { startService, waitForServiceReady } from "../lib/registry";
@@ -7,6 +8,7 @@ import { COLD_STATE_SERVICES } from "../lib/services";
 import { getStateInfo } from "../lib/state";
 
 export const startCommand = withEnvironments("start", async (env) => {
+  await touchLifecycleActivity(env.name, "command");
   const stateInfo = await getStateInfo(env);
   if (stateInfo.state !== "stopped") {
     if (stateInfo.state === "cold") {

--- a/x/henry/dust-hive/src/commands/stop.ts
+++ b/x/henry/dust-hive/src/commands/stop.ts
@@ -1,12 +1,13 @@
 import { withEnvironment } from "../lib/commands";
 import { stopDocker } from "../lib/docker";
+import type { Environment } from "../lib/environment";
 import { logger } from "../lib/logger";
 import { stopAllServices, stopService } from "../lib/process";
-import { CommandError, Err, Ok } from "../lib/result";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ALL_SERVICES, isServiceName } from "../lib/services";
-import { getStateInfo, isDockerRunning } from "../lib/state";
+import { getStateInfo } from "../lib/state";
 
-export const stopCommand = withEnvironment("stop", async (env, service?: string) => {
+export async function stopEnvironment(env: Environment, service?: string): Promise<Result<void>> {
   // If a service is specified, stop just that service
   if (service !== undefined) {
     if (!isServiceName(service)) {
@@ -39,13 +40,10 @@ export const stopCommand = withEnvironment("stop", async (env, service?: string)
   await stopAllServices(env.name);
   logger.success("All services stopped");
 
-  // Stop Docker if running
-  const dockerRunning = await isDockerRunning(env.name);
-  if (dockerRunning) {
-    const dockerStopped = await stopDocker(env.name);
-    if (!dockerStopped) {
-      logger.warn("Docker containers may need manual cleanup");
-    }
+  // Remove containers even after cool stopped them.
+  const dockerStopped = await stopDocker(env.name);
+  if (!dockerStopped) {
+    logger.warn("Docker containers may need manual cleanup");
   }
 
   console.log();
@@ -57,4 +55,6 @@ export const stopCommand = withEnvironment("stop", async (env, service?: string)
   console.log();
 
   return Ok(undefined);
-});
+}
+
+export const stopCommand = withEnvironment("stop", stopEnvironment);

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -5,6 +5,7 @@ import { isInitialized, markInitialized } from "../lib/environment";
 import { startForwarder } from "../lib/forward";
 import { FORWARDER_PORTS } from "../lib/forwarderConfig";
 import { createTemporalNamespaces, runAllDbInits, runSeedScript } from "../lib/init";
+import { touchLifecycleActivity } from "../lib/lifecycle-activity";
 import { logger } from "../lib/logger";
 import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { isServiceRunning, readPid } from "../lib/process";
@@ -70,6 +71,7 @@ async function isTemporalRunning(): Promise<boolean> {
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestration function with necessary complexity
 export const warmCommand = withEnvironments("warm", async (env, options: WarmOptions) => {
+  await touchLifecycleActivity(env.name, "command");
   const startTime = Date.now();
   const noForward = options.noForward ?? false;
   const forcePorts = options.forcePorts ?? false;

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cac } from "cac";
+import { activityRunCommand, activityTouchCommand } from "./commands/activity";
 import { adoptCommand } from "./commands/adopt";
 import { cacheCommand } from "./commands/cache";
 import { cdCommand } from "./commands/cd";
@@ -12,6 +13,14 @@ import { envGetCommand, envListCommand, envSetCommand, envUnsetCommand } from ".
 import { feedCommand } from "./commands/feed";
 import { flagCommand } from "./commands/flag";
 import { forwardCommand, forwardStatusCommand, forwardStopCommand } from "./commands/forward";
+import {
+  lifecycleDisableCommand,
+  lifecycleEnableCommand,
+  lifecycleRunOnceCommand,
+  lifecycleStartCommand,
+  lifecycleStatusCommand,
+  lifecycleStopCommand,
+} from "./commands/lifecycle";
 import { listCommand } from "./commands/list";
 import { logsCommand } from "./commands/logs";
 import { openCommand } from "./commands/open";
@@ -30,6 +39,7 @@ import { upCommand } from "./commands/up";
 import { urlCommand } from "./commands/url";
 import { warmCommand } from "./commands/warm";
 import { ensureDirectories } from "./lib/config";
+import { ensureLifecycleDaemonRunning } from "./lib/lifecycle-daemon";
 import { logger } from "./lib/logger";
 import type { Result } from "./lib/result";
 
@@ -43,8 +53,14 @@ async function runCommand(resultPromise: Promise<Result<void>>): Promise<void> {
   process.exit(0);
 }
 
-async function prepareAndRun(resultPromise: Promise<Result<void>>): Promise<void> {
+async function prepareAndRun(
+  resultPromise: Promise<Result<void>>,
+  options: { ensureLifecycleDaemon?: boolean } = {}
+): Promise<void> {
   await ensureDirectories();
+  if (options.ensureLifecycleDaemon ?? true) {
+    await ensureLifecycleDaemonRunning();
+  }
   await runCommand(resultPromise);
 }
 
@@ -250,6 +266,78 @@ cli
   .option("-f, --force", "Skip confirmation prompt")
   .action(async (options: { force?: boolean }) => {
     await prepareAndRun(downCommand({ force: Boolean(options.force) }));
+  });
+
+cli
+  .command(
+    "lifecycle [subcommand] [name]",
+    "Manage automatic lifecycle: enable|disable|status|run-once|start|stop"
+  )
+  .option("-p, --profile <profile>", "Lifecycle profile (default: balanced)")
+  .option("--cold-after <duration>", "Override warm-to-cold delay (for example 30m or never)")
+  .option("--stop-after <duration>", "Override cold-to-stopped delay (for example 8h or never)")
+  .option(
+    "--delete-after <duration>",
+    "Override stopped-to-archived delay (for example 7d or never)"
+  )
+  .option("-n, --dry-run", "Show eligible actions without applying them")
+  .action(
+    async (
+      subcommand: string | undefined,
+      name: string | undefined,
+      options: {
+        profile?: string;
+        coldAfter?: string;
+        stopAfter?: string;
+        deleteAfter?: string;
+        dryRun?: boolean;
+      }
+    ) => {
+      switch (subcommand) {
+        case "enable":
+          await prepareAndRun(lifecycleEnableCommand(name, options), {
+            ensureLifecycleDaemon: false,
+          });
+          return;
+        case "disable":
+          await prepareAndRun(lifecycleDisableCommand(name), { ensureLifecycleDaemon: false });
+          return;
+        case "status":
+        case undefined:
+          await prepareAndRun(lifecycleStatusCommand(name), { ensureLifecycleDaemon: false });
+          return;
+        case "run-once":
+          await prepareAndRun(lifecycleRunOnceCommand(Boolean(options.dryRun)), {
+            ensureLifecycleDaemon: false,
+          });
+          return;
+        case "start":
+          await prepareAndRun(lifecycleStartCommand(), { ensureLifecycleDaemon: false });
+          return;
+        case "stop":
+          await prepareAndRun(lifecycleStopCommand(), { ensureLifecycleDaemon: false });
+          return;
+        default:
+          logger.error(`Unknown lifecycle command: ${subcommand}`);
+          process.exit(1);
+      }
+    }
+  );
+
+cli
+  .command("activity [subcommand] [...args]", "Record activity or run a command with a heartbeat")
+  .allowUnknownOptions()
+  .action(async (subcommand: string | undefined, args: string[], options: { "--"?: string[] }) => {
+    if (subcommand === "touch") {
+      await prepareAndRun(activityTouchCommand(args[0]));
+      return;
+    }
+    if (subcommand === "run") {
+      await prepareAndRun(activityRunCommand(options["--"] ?? args));
+      return;
+    }
+    logger.error("Usage: dust-hive activity touch [name] | activity run -- <command>");
+    process.exit(1);
   });
 
 cli

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -325,7 +325,7 @@ cli
   );
 
 cli
-  .command("activity [subcommand] [...args]", "Record activity or run a command with a heartbeat")
+  .command("activity [subcommand] [...args]", "Record activity or run a command with a lease")
   .allowUnknownOptions()
   .action(async (subcommand: string | undefined, args: string[], options: { "--"?: string[] }) => {
     if (subcommand === "touch") {

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -307,7 +307,7 @@ cli
           await prepareAndRun(lifecycleStatusCommand(name), { ensureLifecycleDaemon: false });
           return;
         case "run-once":
-          await prepareAndRun(lifecycleRunOnceCommand(Boolean(options.dryRun)), {
+          await prepareAndRun(lifecycleRunOnceCommand(options.dryRun), {
             ensureLifecycleDaemon: false,
           });
           return;

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -25,6 +25,7 @@ source "${CONFIG_ENV_PATH}"
 # every hive shares the same workspace and different users can spawn a hive
 # with the same name.
 export DEV_ENV_NAME=${username}-${name}
+export DUST_HIVE_ENV_NAME=${name}
 
 # === Ports (for services that read env vars) ===
 export PORT=${ports.front}                    # Next.js

--- a/x/henry/dust-hive/src/lib/lifecycle-activity.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-activity.ts
@@ -1,15 +1,113 @@
-import { stat } from "node:fs/promises";
+import { mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
 import { isErrnoException } from "./errors";
-import { getLifecycleActivityPath } from "./paths";
+import { acquireLifecycleLock } from "./lifecycle-lock";
+import { getLifecycleActivityPath, getLifecycleLeaseDir, getLifecycleLeasePath } from "./paths";
+import { isProcessRunning } from "./process";
 
 export const LIFECYCLE_ACTIVITY_KINDS = ["command", "frontend", "test"] as const;
 export type LifecycleActivityKind = (typeof LIFECYCLE_ACTIVITY_KINDS)[number];
+
+const LifecycleActivityLeaseSchema = z.object({
+  kind: z.enum(LIFECYCLE_ACTIVITY_KINDS),
+  pid: z.number().int().positive(),
+  token: z.string(),
+  startedAt: z.iso.datetime(),
+});
+
+export type LifecycleActivityLease = z.infer<typeof LifecycleActivityLeaseSchema>;
+
+async function writeActivityMarker(envName: string, kind: LifecycleActivityKind): Promise<void> {
+  await Bun.write(getLifecycleActivityPath(envName, kind), new Date().toISOString());
+}
 
 export async function touchLifecycleActivity(
   envName: string,
   kind: LifecycleActivityKind
 ): Promise<void> {
-  await Bun.write(getLifecycleActivityPath(envName, kind), new Date().toISOString());
+  const lock = await acquireLifecycleLock(envName, { wait: true });
+  if (!lock) {
+    throw new Error(`Could not acquire lifecycle lock for '${envName}'`);
+  }
+  try {
+    await writeActivityMarker(envName, kind);
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function withLifecycleActivityLease<T>(
+  envName: string,
+  kind: LifecycleActivityKind,
+  callback: () => Promise<T>
+): Promise<T> {
+  const token = crypto.randomUUID();
+  const lease: LifecycleActivityLease = {
+    kind,
+    pid: process.pid,
+    token,
+    startedAt: new Date().toISOString(),
+  };
+  const lock = await acquireLifecycleLock(envName, { wait: true });
+  if (!lock) {
+    throw new Error(`Could not acquire lifecycle lock for '${envName}'`);
+  }
+  try {
+    await writeActivityMarker(envName, kind);
+    await mkdir(getLifecycleLeaseDir(envName), { recursive: true });
+    await Bun.write(getLifecycleLeasePath(envName, token), JSON.stringify(lease));
+  } finally {
+    await lock.release();
+  }
+
+  try {
+    return await callback();
+  } finally {
+    const cleanupLock = await acquireLifecycleLock(envName, { wait: true });
+    if (cleanupLock) {
+      try {
+        const leasePath = getLifecycleLeasePath(envName, token);
+        const file = Bun.file(leasePath);
+        if (await file.exists()) {
+          const currentLease = LifecycleActivityLeaseSchema.safeParse(await file.json());
+          if (currentLease.success && currentLease.data.token === token) {
+            await unlink(leasePath);
+          }
+        }
+        await writeActivityMarker(envName, kind);
+      } finally {
+        await cleanupLock.release();
+      }
+    }
+  }
+}
+
+export async function getActiveLifecycleActivityLease(
+  envName: string
+): Promise<LifecycleActivityLease | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(getLifecycleLeaseDir(envName));
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const leasePath = join(getLifecycleLeaseDir(envName), entry);
+    const parsed = LifecycleActivityLeaseSchema.safeParse(await Bun.file(leasePath).json());
+    if (!parsed.success) {
+      throw new Error(`Invalid lifecycle activity lease for '${envName}'`);
+    }
+    if (isProcessRunning(parsed.data.pid)) {
+      return parsed.data;
+    }
+    await unlink(leasePath);
+  }
+  return null;
 }
 
 async function getActivityTimestampMs(

--- a/x/henry/dust-hive/src/lib/lifecycle-activity.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-activity.ts
@@ -1,0 +1,49 @@
+import { stat } from "node:fs/promises";
+import { isErrnoException } from "./errors";
+import { getLifecycleActivityPath } from "./paths";
+
+export const LIFECYCLE_ACTIVITY_KINDS = ["command", "frontend", "test"] as const;
+export type LifecycleActivityKind = (typeof LIFECYCLE_ACTIVITY_KINDS)[number];
+
+export async function touchLifecycleActivity(
+  envName: string,
+  kind: LifecycleActivityKind
+): Promise<void> {
+  await Bun.write(getLifecycleActivityPath(envName, kind), new Date().toISOString());
+}
+
+async function getActivityTimestampMs(
+  envName: string,
+  kind: LifecycleActivityKind
+): Promise<number | null> {
+  try {
+    const info = await stat(getLifecycleActivityPath(envName, kind));
+    return info.mtimeMs;
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function getLatestLifecycleActivity(
+  envName: string,
+  kinds: LifecycleActivityKind[]
+): Promise<{ kind: LifecycleActivityKind; timestampMs: number } | null> {
+  const timestamps = await Promise.all(
+    kinds.map(async (kind) => ({ kind, timestampMs: await getActivityTimestampMs(envName, kind) }))
+  );
+
+  let latest: { kind: LifecycleActivityKind; timestampMs: number } | null = null;
+  for (const activity of timestamps) {
+    if (activity.timestampMs === null) {
+      continue;
+    }
+    if (!latest || activity.timestampMs > latest.timestampMs) {
+      latest = { kind: activity.kind, timestampMs: activity.timestampMs };
+    }
+  }
+
+  return latest;
+}

--- a/x/henry/dust-hive/src/lib/lifecycle-activity.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-activity.ts
@@ -22,6 +22,14 @@ async function writeActivityMarker(envName: string, kind: LifecycleActivityKind)
   await Bun.write(getLifecycleActivityPath(envName, kind), new Date().toISOString());
 }
 
+// Call only while holding the environment's lifecycle lock.
+export async function touchLifecycleActivityUnderLock(
+  envName: string,
+  kind: LifecycleActivityKind
+): Promise<void> {
+  await writeActivityMarker(envName, kind);
+}
+
 export async function touchLifecycleActivity(
   envName: string,
   kind: LifecycleActivityKind

--- a/x/henry/dust-hive/src/lib/lifecycle-config.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-config.ts
@@ -1,0 +1,157 @@
+import { rename, unlink } from "node:fs/promises";
+import { z } from "zod";
+import { LIFECYCLE_CONFIG_PATH } from "./paths";
+import { CommandError, Err, Ok, type Result } from "./result";
+
+const NullableDurationSecondsSchema = z.number().int().positive().nullable();
+
+const LifecyclePolicySchema = z
+  .object({
+    coldAfterSeconds: NullableDurationSecondsSchema.default(60 * 60),
+    stopAfterSeconds: NullableDurationSecondsSchema.default(8 * 60 * 60),
+    deleteAfterSeconds: NullableDurationSecondsSchema.default(7 * 24 * 60 * 60),
+    trackSourceChanges: z.boolean().default(true),
+    trackFrontend: z.boolean().default(true),
+    blockDeleteIfSessionExists: z.boolean().default(false),
+  })
+  .strict();
+
+const LifecyclePolicyOverridesSchema = LifecyclePolicySchema.partial();
+
+const LifecycleEnrollmentSchema = z
+  .object({
+    profile: z.string().min(1),
+    overrides: LifecyclePolicyOverridesSchema.optional(),
+  })
+  .strict();
+
+const LifecycleConfigFileSchema = z
+  .object({
+    scanIntervalSeconds: z.number().int().min(5).default(30),
+    dryRun: z.boolean().default(false),
+    profiles: z.record(z.string(), LifecyclePolicySchema).default({}),
+    environments: z.record(z.string(), LifecycleEnrollmentSchema).default({}),
+  })
+  .strict();
+
+export type LifecyclePolicy = z.infer<typeof LifecyclePolicySchema>;
+export type LifecyclePolicyOverrides = z.infer<typeof LifecyclePolicyOverridesSchema>;
+export type LifecycleEnrollment = z.infer<typeof LifecycleEnrollmentSchema>;
+export type LifecycleConfig = z.infer<typeof LifecycleConfigFileSchema>;
+
+export const DEFAULT_LIFECYCLE_PROFILE = "balanced";
+
+const BUILT_IN_PROFILES: Record<string, LifecyclePolicy> = {
+  [DEFAULT_LIFECYCLE_PROFILE]: LifecyclePolicySchema.parse({}),
+};
+
+function defaultLifecycleConfig(): LifecycleConfig {
+  return {
+    scanIntervalSeconds: 30,
+    dryRun: false,
+    profiles: BUILT_IN_PROFILES,
+    environments: {},
+  };
+}
+
+export async function loadLifecycleConfig(): Promise<Result<LifecycleConfig, CommandError>> {
+  const file = Bun.file(LIFECYCLE_CONFIG_PATH);
+  if (!(await file.exists())) {
+    return Ok(defaultLifecycleConfig());
+  }
+
+  let data: unknown;
+  try {
+    data = await file.json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Err(new CommandError(`Invalid lifecycle config: ${message}`));
+  }
+
+  const parsed = LifecycleConfigFileSchema.safeParse(data);
+  if (!parsed.success) {
+    return Err(new CommandError(`Invalid lifecycle config: ${z.prettifyError(parsed.error)}`));
+  }
+
+  return Ok({
+    ...parsed.data,
+    profiles: { ...BUILT_IN_PROFILES, ...parsed.data.profiles },
+  });
+}
+
+export async function saveLifecycleConfig(config: LifecycleConfig): Promise<void> {
+  const parsed = LifecycleConfigFileSchema.parse(config);
+  const temporaryPath = `${LIFECYCLE_CONFIG_PATH}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    await Bun.write(temporaryPath, JSON.stringify(parsed, null, 2));
+    await rename(temporaryPath, LIFECYCLE_CONFIG_PATH);
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+export function resolveLifecyclePolicy(
+  config: LifecycleConfig,
+  enrollment: LifecycleEnrollment
+): Result<LifecyclePolicy, CommandError> {
+  const profile = config.profiles[enrollment.profile];
+  if (!profile) {
+    return Err(new CommandError(`Unknown lifecycle profile '${enrollment.profile}'`));
+  }
+
+  const parsed = LifecyclePolicySchema.safeParse({ ...profile, ...enrollment.overrides });
+  if (!parsed.success) {
+    return Err(new CommandError(`Invalid lifecycle policy: ${z.prettifyError(parsed.error)}`));
+  }
+
+  return Ok(parsed.data);
+}
+
+export function parseDurationSeconds(value: string): Result<number | null, CommandError> {
+  if (value === "never" || value === "off") {
+    return Ok(null);
+  }
+
+  const match = /^(\d+)(s|m|h|d|w)$/.exec(value);
+  if (!match) {
+    return Err(
+      new CommandError(`Invalid duration '${value}'. Use values such as 30m, 8h, 7d, or never.`)
+    );
+  }
+
+  const amount = Number.parseInt(match[1] ?? "", 10);
+  const unit = match[2];
+  const multiplierByUnit: Record<string, number> = {
+    s: 1,
+    m: 60,
+    h: 60 * 60,
+    d: 24 * 60 * 60,
+    w: 7 * 24 * 60 * 60,
+  };
+  const multiplier = unit ? multiplierByUnit[unit] : undefined;
+  if (amount <= 0 || multiplier === undefined) {
+    return Err(new CommandError(`Invalid duration '${value}'`));
+  }
+
+  return Ok(amount * multiplier);
+}
+
+export function formatDurationSeconds(durationSeconds: number | null): string {
+  if (durationSeconds === null) {
+    return "never";
+  }
+
+  const units = [
+    { suffix: "w", seconds: 7 * 24 * 60 * 60 },
+    { suffix: "d", seconds: 24 * 60 * 60 },
+    { suffix: "h", seconds: 60 * 60 },
+    { suffix: "m", seconds: 60 },
+  ];
+  for (const unit of units) {
+    if (durationSeconds % unit.seconds === 0) {
+      return `${durationSeconds / unit.seconds}${unit.suffix}`;
+    }
+  }
+
+  return `${durationSeconds}s`;
+}

--- a/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
@@ -2,6 +2,7 @@ import { open, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { isErrnoException } from "./errors";
 import { loadLifecycleConfig } from "./lifecycle-config";
+import { acquireLifecycleDaemonLock } from "./lifecycle-lock";
 import { logger } from "./logger";
 import { LIFECYCLE_LOG_PATH, LIFECYCLE_PID_PATH } from "./paths";
 import { getProcessCommand } from "./platform";
@@ -50,36 +51,41 @@ async function rotateLifecycleLog(maxSizeBytes = 10 * 1024 * 1024): Promise<void
 }
 
 export async function startLifecycleDaemon(): Promise<Result<number>> {
-  const existingPid = await getLifecycleDaemonPid();
-  if (existingPid !== null) {
-    return Ok(existingPid);
-  }
+  const daemonLock = await acquireLifecycleDaemonLock();
+  try {
+    const existingPid = await getLifecycleDaemonPid();
+    if (existingPid !== null) {
+      return Ok(existingPid);
+    }
 
-  const configResult = await loadLifecycleConfig();
-  if (!configResult.ok) {
-    return configResult;
-  }
-  if (Object.keys(configResult.value.environments).length === 0) {
-    return Err(new CommandError("No environments have lifecycle management enabled"));
-  }
+    const configResult = await loadLifecycleConfig();
+    if (!configResult.ok) {
+      return configResult;
+    }
+    if (Object.keys(configResult.value.environments).length === 0) {
+      return Err(new CommandError("No environments have lifecycle management enabled"));
+    }
 
-  await rotateLifecycleLog();
-  const logHandle = await open(LIFECYCLE_LOG_PATH, "a");
-  const daemonPath = join(dirname(import.meta.path), "..", "lifecycle-daemon.ts");
-  const proc = Bun.spawn(["bun", "run", daemonPath], {
-    stdout: logHandle.fd,
-    stderr: logHandle.fd,
-    detached: true,
-  });
-  await logHandle.close();
-  proc.unref();
+    await rotateLifecycleLog();
+    const logHandle = await open(LIFECYCLE_LOG_PATH, "a");
+    const daemonPath = join(dirname(import.meta.path), "..", "lifecycle-daemon.ts");
+    const proc = Bun.spawn(["bun", "run", daemonPath], {
+      stdout: logHandle.fd,
+      stderr: logHandle.fd,
+      detached: true,
+    });
+    await logHandle.close();
+    proc.unref();
 
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  if (!isProcessRunning(proc.pid)) {
-    return Err(new CommandError(`Lifecycle daemon failed to start. See ${LIFECYCLE_LOG_PATH}`));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    if (!isProcessRunning(proc.pid)) {
+      return Err(new CommandError(`Lifecycle daemon failed to start. See ${LIFECYCLE_LOG_PATH}`));
+    }
+    await Bun.write(LIFECYCLE_PID_PATH, String(proc.pid));
+    return Ok(proc.pid);
+  } finally {
+    await daemonLock.release();
   }
-  await Bun.write(LIFECYCLE_PID_PATH, String(proc.pid));
-  return Ok(proc.pid);
 }
 
 export async function ensureLifecycleDaemonRunning(): Promise<void> {
@@ -94,11 +100,35 @@ export async function ensureLifecycleDaemonRunning(): Promise<void> {
 }
 
 export async function stopLifecycleDaemon(): Promise<boolean> {
-  const pid = await getLifecycleDaemonPid();
-  if (pid === null) {
-    return false;
+  const daemonLock = await acquireLifecycleDaemonLock();
+  try {
+    const pid = await getLifecycleDaemonPid();
+    if (pid === null) {
+      return false;
+    }
+    await killProcess(pid, "SIGTERM");
+    await cleanupLifecyclePidFile();
+    return true;
+  } finally {
+    await daemonLock.release();
   }
-  await killProcess(pid, "SIGTERM");
-  await cleanupLifecyclePidFile();
-  return true;
+}
+
+export async function stopLifecycleDaemonIfUnused(): Promise<boolean> {
+  const daemonLock = await acquireLifecycleDaemonLock();
+  try {
+    const configResult = await loadLifecycleConfig();
+    if (!configResult.ok || Object.keys(configResult.value.environments).length > 0) {
+      return false;
+    }
+    const pid = await getLifecycleDaemonPid();
+    if (pid === null) {
+      return false;
+    }
+    await killProcess(pid, "SIGTERM");
+    await cleanupLifecyclePidFile();
+    return true;
+  } finally {
+    await daemonLock.release();
+  }
 }

--- a/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
@@ -2,6 +2,7 @@ import { open, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { isErrnoException } from "./errors";
 import { loadLifecycleConfig } from "./lifecycle-config";
+import { logger } from "./logger";
 import { LIFECYCLE_LOG_PATH, LIFECYCLE_PID_PATH } from "./paths";
 import { getProcessCommand } from "./platform";
 import { isProcessRunning, killProcess } from "./process";
@@ -86,7 +87,10 @@ export async function ensureLifecycleDaemonRunning(): Promise<void> {
   if (!configResult.ok || Object.keys(configResult.value.environments).length === 0) {
     return;
   }
-  await startLifecycleDaemon();
+  const result = await startLifecycleDaemon();
+  if (!result.ok) {
+    logger.warn(result.error.message);
+  }
 }
 
 export async function stopLifecycleDaemon(): Promise<boolean> {

--- a/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-daemon.ts
@@ -1,0 +1,100 @@
+import { open, rename, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { isErrnoException } from "./errors";
+import { loadLifecycleConfig } from "./lifecycle-config";
+import { LIFECYCLE_LOG_PATH, LIFECYCLE_PID_PATH } from "./paths";
+import { getProcessCommand } from "./platform";
+import { isProcessRunning, killProcess } from "./process";
+import { CommandError, Err, Ok, type Result } from "./result";
+
+async function cleanupLifecyclePidFile(): Promise<void> {
+  try {
+    await unlink(LIFECYCLE_PID_PATH);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+export async function getLifecycleDaemonPid(): Promise<number | null> {
+  const file = Bun.file(LIFECYCLE_PID_PATH);
+  if (!(await file.exists())) {
+    return null;
+  }
+  const pid = Number.parseInt((await file.text()).trim(), 10);
+  if (Number.isNaN(pid) || !isProcessRunning(pid)) {
+    await cleanupLifecyclePidFile();
+    return null;
+  }
+
+  const command = getProcessCommand(pid);
+  if (!command?.includes("lifecycle-daemon")) {
+    await cleanupLifecyclePidFile();
+    return null;
+  }
+  return pid;
+}
+
+async function rotateLifecycleLog(maxSizeBytes = 10 * 1024 * 1024): Promise<void> {
+  const file = Bun.file(LIFECYCLE_LOG_PATH);
+  if (!(await file.exists())) {
+    return;
+  }
+  const info = await file.stat();
+  if (info && info.size > maxSizeBytes) {
+    await rename(LIFECYCLE_LOG_PATH, `${LIFECYCLE_LOG_PATH}.${Date.now()}`);
+  }
+}
+
+export async function startLifecycleDaemon(): Promise<Result<number>> {
+  const existingPid = await getLifecycleDaemonPid();
+  if (existingPid !== null) {
+    return Ok(existingPid);
+  }
+
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  if (Object.keys(configResult.value.environments).length === 0) {
+    return Err(new CommandError("No environments have lifecycle management enabled"));
+  }
+
+  await rotateLifecycleLog();
+  const logHandle = await open(LIFECYCLE_LOG_PATH, "a");
+  const daemonPath = join(dirname(import.meta.path), "..", "lifecycle-daemon.ts");
+  const proc = Bun.spawn(["bun", "run", daemonPath], {
+    stdout: logHandle.fd,
+    stderr: logHandle.fd,
+    detached: true,
+  });
+  await logHandle.close();
+  proc.unref();
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  if (!isProcessRunning(proc.pid)) {
+    return Err(new CommandError(`Lifecycle daemon failed to start. See ${LIFECYCLE_LOG_PATH}`));
+  }
+  await Bun.write(LIFECYCLE_PID_PATH, String(proc.pid));
+  return Ok(proc.pid);
+}
+
+export async function ensureLifecycleDaemonRunning(): Promise<void> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok || Object.keys(configResult.value.environments).length === 0) {
+    return;
+  }
+  await startLifecycleDaemon();
+}
+
+export async function stopLifecycleDaemon(): Promise<boolean> {
+  const pid = await getLifecycleDaemonPid();
+  if (pid === null) {
+    return false;
+  }
+  await killProcess(pid, "SIGTERM");
+  await cleanupLifecyclePidFile();
+  return true;
+}

--- a/x/henry/dust-hive/src/lib/lifecycle-lock.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-lock.ts
@@ -2,7 +2,11 @@ import { mkdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { isErrnoException } from "./errors";
-import { getLifecycleLockPath } from "./paths";
+import {
+  getLifecycleLockPath,
+  LIFECYCLE_CONFIG_LOCK_PATH,
+  LIFECYCLE_DAEMON_LOCK_PATH,
+} from "./paths";
 import { isProcessRunning } from "./process";
 
 const LOCK_OWNER_FILE = "owner.json";
@@ -50,11 +54,10 @@ async function removeAbandonedLock(lockPath: string): Promise<boolean> {
   }
 }
 
-export async function acquireLifecycleLock(
-  envName: string,
+async function acquireLock(
+  lockPath: string,
   options: { wait?: boolean } = {}
 ): Promise<LifecycleLock | null> {
-  const lockPath = getLifecycleLockPath(envName);
   const token = crypto.randomUUID();
 
   while (true) {
@@ -94,4 +97,27 @@ export async function acquireLifecycleLock(
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }
+}
+
+export async function acquireLifecycleLock(
+  envName: string,
+  options: { wait?: boolean } = {}
+): Promise<LifecycleLock | null> {
+  return acquireLock(getLifecycleLockPath(envName), options);
+}
+
+export async function acquireLifecycleConfigLock(): Promise<LifecycleLock> {
+  const lock = await acquireLock(LIFECYCLE_CONFIG_LOCK_PATH, { wait: true });
+  if (!lock) {
+    throw new Error("Could not acquire lifecycle config lock");
+  }
+  return lock;
+}
+
+export async function acquireLifecycleDaemonLock(): Promise<LifecycleLock> {
+  const lock = await acquireLock(LIFECYCLE_DAEMON_LOCK_PATH, { wait: true });
+  if (!lock) {
+    throw new Error("Could not acquire lifecycle daemon lock");
+  }
+  return lock;
 }

--- a/x/henry/dust-hive/src/lib/lifecycle-lock.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-lock.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { z } from "zod";
 import { isErrnoException } from "./errors";
 import { getLifecycleLockPath } from "./paths";
 import { isProcessRunning } from "./process";
@@ -7,21 +8,15 @@ import { isProcessRunning } from "./process";
 const LOCK_OWNER_FILE = "owner.json";
 const INCOMPLETE_LOCK_GRACE_MS = 5_000;
 
-interface LockOwner {
-  pid: number;
-  token: string;
-}
+const LockOwnerSchema = z.object({
+  pid: z.number().int().positive(),
+  token: z.string(),
+});
+
+type LockOwner = z.infer<typeof LockOwnerSchema>;
 
 export interface LifecycleLock {
   release: () => Promise<void>;
-}
-
-function isLockOwner(value: unknown): value is LockOwner {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const owner = value as Record<string, unknown>;
-  return typeof owner["pid"] === "number" && typeof owner["token"] === "string";
 }
 
 async function removeAbandonedLock(lockPath: string): Promise<boolean> {
@@ -29,7 +24,8 @@ async function removeAbandonedLock(lockPath: string): Promise<boolean> {
   if (await ownerFile.exists()) {
     try {
       const owner: unknown = await ownerFile.json();
-      if (isLockOwner(owner) && isProcessRunning(owner.pid)) {
+      const parsed = LockOwnerSchema.safeParse(owner);
+      if (parsed.success && isProcessRunning(parsed.data.pid)) {
         return false;
       }
       await rm(lockPath, { recursive: true, force: true });
@@ -79,7 +75,8 @@ export async function acquireLifecycleLock(
             return;
           }
           const currentOwner: unknown = await ownerFile.json();
-          if (isLockOwner(currentOwner) && currentOwner.token === token) {
+          const parsed = LockOwnerSchema.safeParse(currentOwner);
+          if (parsed.success && parsed.data.token === token) {
             await rm(lockPath, { recursive: true, force: true });
           }
         },

--- a/x/henry/dust-hive/src/lib/lifecycle-lock.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-lock.ts
@@ -1,0 +1,100 @@
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { isErrnoException } from "./errors";
+import { getLifecycleLockPath } from "./paths";
+import { isProcessRunning } from "./process";
+
+const LOCK_OWNER_FILE = "owner.json";
+const INCOMPLETE_LOCK_GRACE_MS = 5_000;
+
+interface LockOwner {
+  pid: number;
+  token: string;
+}
+
+export interface LifecycleLock {
+  release: () => Promise<void>;
+}
+
+function isLockOwner(value: unknown): value is LockOwner {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const owner = value as Record<string, unknown>;
+  return typeof owner["pid"] === "number" && typeof owner["token"] === "string";
+}
+
+async function removeAbandonedLock(lockPath: string): Promise<boolean> {
+  const ownerFile = Bun.file(join(lockPath, LOCK_OWNER_FILE));
+  if (await ownerFile.exists()) {
+    try {
+      const owner: unknown = await ownerFile.json();
+      if (isLockOwner(owner) && isProcessRunning(owner.pid)) {
+        return false;
+      }
+      await rm(lockPath, { recursive: true, force: true });
+      return true;
+    } catch {
+      // A partially written owner file is handled by the grace period below.
+    }
+  }
+
+  try {
+    const info = await stat(lockPath);
+    if (Date.now() - info.mtimeMs < INCOMPLETE_LOCK_GRACE_MS) {
+      return false;
+    }
+    await rm(lockPath, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+export async function acquireLifecycleLock(
+  envName: string,
+  options: { wait?: boolean } = {}
+): Promise<LifecycleLock | null> {
+  const lockPath = getLifecycleLockPath(envName);
+  const token = crypto.randomUUID();
+
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      const owner: LockOwner = { pid: process.pid, token };
+      try {
+        await Bun.write(join(lockPath, LOCK_OWNER_FILE), JSON.stringify(owner));
+      } catch (error) {
+        await rm(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+
+      return {
+        release: async () => {
+          const ownerFile = Bun.file(join(lockPath, LOCK_OWNER_FILE));
+          if (!(await ownerFile.exists())) {
+            return;
+          }
+          const currentOwner: unknown = await ownerFile.json();
+          if (isLockOwner(currentOwner) && currentOwner.token === token) {
+            await rm(lockPath, { recursive: true, force: true });
+          }
+        },
+      };
+    } catch (error) {
+      if (!isErrnoException(error) || error.code !== "EEXIST") {
+        throw error;
+      }
+      if (await removeAbandonedLock(lockPath)) {
+        continue;
+      }
+      if (!options.wait) {
+        return null;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+}

--- a/x/henry/dust-hive/src/lib/lifecycle-source.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle-source.ts
@@ -1,0 +1,48 @@
+import { lstat } from "node:fs/promises";
+import { join } from "node:path";
+import { isErrnoException } from "./errors";
+
+async function runGit(worktreePath: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: worktreePath,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+  if (proc.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${stderr.trim() || "unknown error"}`);
+  }
+  return stdout;
+}
+
+async function getPathFingerprint(worktreePath: string, relativePath: string): Promise<string> {
+  try {
+    const info = await lstat(join(worktreePath, relativePath));
+    return `${relativePath}:${info.mtimeMs}:${info.size}`;
+  } catch (error) {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      return `${relativePath}:missing`;
+    }
+    throw error;
+  }
+}
+
+export async function getSourceFingerprint(worktreePath: string): Promise<string> {
+  const [head, changedPaths, untrackedPaths] = await Promise.all([
+    runGit(worktreePath, ["rev-parse", "HEAD"]),
+    runGit(worktreePath, ["diff", "--name-only", "-z", "HEAD", "--"]),
+    runGit(worktreePath, ["ls-files", "--others", "--exclude-standard", "-z"]),
+  ]);
+  const paths = new Set(
+    `${changedPaths}${untrackedPaths}`.split("\0").filter((path) => path.length > 0)
+  );
+  const pathFingerprints = await Promise.all(
+    [...paths].sort().map((path) => getPathFingerprint(worktreePath, path))
+  );
+
+  return Bun.hash(`${head.trim()}\0${pathFingerprints.join("\0")}`).toString(16);
+}

--- a/x/henry/dust-hive/src/lib/lifecycle.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle.ts
@@ -1,11 +1,9 @@
-import { mkdir, rmdir, stat } from "node:fs/promises";
 import { z } from "zod";
 import { coolEnvironment } from "../commands/cool";
 import { destroySingleEnvironment } from "../commands/destroy";
 import { stopEnvironment } from "../commands/stop";
 import { type Environment, getEnvironment, getEnvironmentWorktreeDir } from "./environment";
-import { isErrnoException } from "./errors";
-import { getLatestLifecycleActivity } from "./lifecycle-activity";
+import { getActiveLifecycleActivityLease, getLatestLifecycleActivity } from "./lifecycle-activity";
 import {
   type LifecycleConfig,
   type LifecycleEnrollment,
@@ -14,10 +12,11 @@ import {
   resolveLifecyclePolicy,
   saveLifecycleConfig,
 } from "./lifecycle-config";
+import { acquireLifecycleLock } from "./lifecycle-lock";
 import { getSourceFingerprint } from "./lifecycle-source";
 import { logger } from "./logger";
 import { getConfiguredMultiplexer, getSessionName } from "./multiplexer";
-import { getLifecycleLockPath, getLifecycleStatePath } from "./paths";
+import { getLifecycleStatePath } from "./paths";
 import { CommandError, Err, Ok, type Result } from "./result";
 import { loadSettings } from "./settings";
 import { type EnvironmentState, getStateInfo } from "./state";
@@ -37,10 +36,6 @@ const LifecycleStateSchema = z.object({
 
 export type LifecycleState = z.infer<typeof LifecycleStateSchema>;
 export type LifecycleTransition = "cool" | "stop" | "delete";
-
-interface EnvironmentLock {
-  release: () => Promise<void>;
-}
 
 function timestampMs(value: string): number {
   return new Date(value).getTime();
@@ -89,39 +84,6 @@ export async function loadLifecycleState(envName: string): Promise<LifecycleStat
 
 async function saveLifecycleState(envName: string, state: LifecycleState): Promise<void> {
   await Bun.write(getLifecycleStatePath(envName), JSON.stringify(state, null, 2));
-}
-
-async function acquireEnvironmentLock(envName: string): Promise<EnvironmentLock | null> {
-  const lockPath = getLifecycleLockPath(envName);
-
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      await mkdir(lockPath);
-      return {
-        release: async () => {
-          try {
-            await rmdir(lockPath);
-          } catch (error) {
-            if (isErrnoException(error) && error.code === "ENOENT") {
-              return;
-            }
-            throw error;
-          }
-        },
-      };
-    } catch (error) {
-      if (!isErrnoException(error) || error.code !== "EEXIST") {
-        throw error;
-      }
-      const lockInfo = await stat(lockPath);
-      if (Date.now() - lockInfo.mtimeMs < 5 * 60 * 1000) {
-        return null;
-      }
-      await rmdir(lockPath);
-    }
-  }
-
-  return null;
 }
 
 function createInitialState(
@@ -187,13 +149,22 @@ async function observeActivity(
     };
   }
 
+  const activeLease = await getActiveLifecycleActivityLease(env.name);
+  if (activeLease) {
+    nextState = {
+      ...nextState,
+      lastActivityAt: now.toISOString(),
+      lastActivitySource: activeLease.kind,
+    };
+  }
+
   return {
     ...nextState,
     sourceFingerprint,
   };
 }
 
-async function getDeleteBlockReason(
+export async function getDeleteBlockReason(
   env: Environment,
   policy: LifecyclePolicy
 ): Promise<string | null> {
@@ -258,7 +229,7 @@ async function runEnvironmentLifecycle(
   policy: LifecyclePolicy,
   dryRun: boolean
 ): Promise<Result<void, CommandError>> {
-  const lock = await acquireEnvironmentLock(env.name);
+  const lock = await acquireLifecycleLock(env.name);
   if (!lock) {
     return Err(new CommandError(`Lifecycle check for '${env.name}' is already running`));
   }
@@ -338,22 +309,18 @@ async function runEnrolledEnvironment(
   enrollment: LifecycleEnrollment,
   config: LifecycleConfig,
   dryRun: boolean
-): Promise<void> {
+): Promise<Result<void, CommandError>> {
   const env = await getEnvironment(envName);
   if (!env) {
     await removeEnrollment(envName);
     logger.warn(`[lifecycle] ${envName}: removed enrollment for missing environment`);
-    return;
+    return Ok(undefined);
   }
   const policyResult = resolveLifecyclePolicy(config, enrollment);
   if (!policyResult.ok) {
-    logger.warn(`[lifecycle] ${envName}: ${policyResult.error.message}`);
-    return;
+    return policyResult;
   }
-  const result = await runEnvironmentLifecycle(env, policyResult.value, dryRun);
-  if (!result.ok) {
-    logger.warn(`[lifecycle] ${envName}: ${result.error.message}`);
-  }
+  return runEnvironmentLifecycle(env, policyResult.value, dryRun);
 }
 
 export async function runLifecycleSweep(options: { dryRun?: boolean } = {}): Promise<Result<void>> {
@@ -363,16 +330,23 @@ export async function runLifecycleSweep(options: { dryRun?: boolean } = {}): Pro
   }
   const config = configResult.value;
   const dryRun = options.dryRun ?? config.dryRun;
+  const failures: string[] = [];
 
   for (const [envName, enrollment] of Object.entries(config.environments)) {
     // One broken environment must not prevent resource reclamation for the others.
     try {
-      await runEnrolledEnvironment(envName, enrollment, config, dryRun);
+      const result = await runEnrolledEnvironment(envName, enrollment, config, dryRun);
+      if (!result.ok) {
+        failures.push(`${envName}: ${result.error.message}`);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn(`[lifecycle] ${envName}: ${message}`);
+      failures.push(`${envName}: ${message}`);
     }
   }
 
+  if (failures.length > 0) {
+    return Err(new CommandError(`Lifecycle sweep failed: ${failures.join("; ")}`));
+  }
   return Ok(undefined);
 }

--- a/x/henry/dust-hive/src/lib/lifecycle.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle.ts
@@ -5,14 +5,12 @@ import { stopEnvironment } from "../commands/stop";
 import { type Environment, getEnvironment, getEnvironmentWorktreeDir } from "./environment";
 import { getActiveLifecycleActivityLease, getLatestLifecycleActivity } from "./lifecycle-activity";
 import {
-  type LifecycleConfig,
-  type LifecycleEnrollment,
   type LifecyclePolicy,
   loadLifecycleConfig,
   resolveLifecyclePolicy,
   saveLifecycleConfig,
 } from "./lifecycle-config";
-import { acquireLifecycleLock } from "./lifecycle-lock";
+import { acquireLifecycleConfigLock, acquireLifecycleLock } from "./lifecycle-lock";
 import { getSourceFingerprint } from "./lifecycle-source";
 import { logger } from "./logger";
 import { getConfiguredMultiplexer, getSessionName } from "./multiplexer";
@@ -190,16 +188,21 @@ export async function getDeleteBlockReason(
 }
 
 async function removeEnrollment(envName: string): Promise<void> {
-  const configResult = await loadLifecycleConfig();
-  if (!configResult.ok) {
-    logger.warn(configResult.error.message);
-    return;
+  const configLock = await acquireLifecycleConfigLock();
+  try {
+    const configResult = await loadLifecycleConfig();
+    if (!configResult.ok) {
+      logger.warn(configResult.error.message);
+      return;
+    }
+    const { [envName]: removed, ...environments } = configResult.value.environments;
+    if (!removed) {
+      return;
+    }
+    await saveLifecycleConfig({ ...configResult.value, environments });
+  } finally {
+    await configLock.release();
   }
-  const { [envName]: removed, ...environments } = configResult.value.environments;
-  if (!removed) {
-    return;
-  }
-  await saveLifecycleConfig({ ...configResult.value, environments });
 }
 
 async function applyTransition(
@@ -232,10 +235,40 @@ async function applyTransition(
   }
 }
 
+interface LifecycleContext {
+  policy: LifecyclePolicy;
+  dryRun: boolean;
+  signature: string;
+}
+
+async function loadLifecycleContext(
+  envName: string,
+  dryRunOverride: boolean | undefined
+): Promise<Result<LifecycleContext | null, CommandError>> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  const enrollment = configResult.value.environments[envName];
+  if (!enrollment) {
+    return Ok(null);
+  }
+  const policyResult = resolveLifecyclePolicy(configResult.value, enrollment);
+  if (!policyResult.ok) {
+    return policyResult;
+  }
+  const dryRun = dryRunOverride ?? configResult.value.dryRun;
+  return Ok({
+    policy: policyResult.value,
+    dryRun,
+    signature: JSON.stringify({ enrollment, policy: policyResult.value, dryRun }),
+  });
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: lifecycle orchestration keeps safety checks adjacent to actions
 async function runEnvironmentLifecycle(
   env: Environment,
-  policy: LifecyclePolicy,
-  dryRun: boolean
+  dryRunOverride: boolean | undefined
 ): Promise<Result<void, CommandError>> {
   const lock = await acquireLifecycleLock(env.name);
   if (!lock) {
@@ -243,6 +276,11 @@ async function runEnvironmentLifecycle(
   }
 
   try {
+    const contextResult = await loadLifecycleContext(env.name, dryRunOverride);
+    if (!contextResult.ok || contextResult.value === null) {
+      return contextResult.ok ? Ok(undefined) : contextResult;
+    }
+    const { policy, dryRun, signature } = contextResult.value;
     const stateInfo = await getStateInfo(env);
     if (stateInfo.warnings.length > 0) {
       return Err(
@@ -267,6 +305,15 @@ async function runEnvironmentLifecycle(
     // Close the observation gap before stopping processes or removing resources.
     state = await observeActivity(env, policy, stateInfo.state, state, new Date());
     if (!getEligibleLifecycleTransition(state, policy, Date.now())) {
+      await saveLifecycleState(env.name, { ...state, blockedReason: null });
+      return Ok(undefined);
+    }
+
+    const latestContextResult = await loadLifecycleContext(env.name, dryRunOverride);
+    if (!latestContextResult.ok || latestContextResult.value === null) {
+      return latestContextResult.ok ? Ok(undefined) : latestContextResult;
+    }
+    if (latestContextResult.value.signature !== signature) {
       await saveLifecycleState(env.name, { ...state, blockedReason: null });
       return Ok(undefined);
     }
@@ -314,9 +361,7 @@ async function runEnvironmentLifecycle(
 
 async function runEnrolledEnvironment(
   envName: string,
-  enrollment: LifecycleEnrollment,
-  config: LifecycleConfig,
-  dryRun: boolean
+  dryRunOverride: boolean | undefined
 ): Promise<Result<void, CommandError>> {
   const env = await getEnvironment(envName);
   if (!env) {
@@ -324,11 +369,7 @@ async function runEnrolledEnvironment(
     logger.warn(`[lifecycle] ${envName}: removed enrollment for missing environment`);
     return Ok(undefined);
   }
-  const policyResult = resolveLifecyclePolicy(config, enrollment);
-  if (!policyResult.ok) {
-    return policyResult;
-  }
-  return runEnvironmentLifecycle(env, policyResult.value, dryRun);
+  return runEnvironmentLifecycle(env, dryRunOverride);
 }
 
 export async function runLifecycleSweep(options: { dryRun?: boolean } = {}): Promise<Result<void>> {
@@ -336,14 +377,12 @@ export async function runLifecycleSweep(options: { dryRun?: boolean } = {}): Pro
   if (!configResult.ok) {
     return configResult;
   }
-  const config = configResult.value;
-  const dryRun = options.dryRun ?? config.dryRun;
   const failures: string[] = [];
 
-  for (const [envName, enrollment] of Object.entries(config.environments)) {
+  for (const envName of Object.keys(configResult.value.environments)) {
     // One broken environment must not prevent resource reclamation for the others.
     try {
-      const result = await runEnrolledEnvironment(envName, enrollment, config, dryRun);
+      const result = await runEnrolledEnvironment(envName, options.dryRun);
       if (!result.ok) {
         failures.push(`${envName}: ${result.error.message}`);
       }

--- a/x/henry/dust-hive/src/lib/lifecycle.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle.ts
@@ -341,7 +341,8 @@ async function runEnrolledEnvironment(
 ): Promise<void> {
   const env = await getEnvironment(envName);
   if (!env) {
-    logger.warn(`[lifecycle] ${envName}: environment no longer exists`);
+    await removeEnrollment(envName);
+    logger.warn(`[lifecycle] ${envName}: removed enrollment for missing environment`);
     return;
   }
   const policyResult = resolveLifecyclePolicy(config, enrollment);

--- a/x/henry/dust-hive/src/lib/lifecycle.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle.ts
@@ -1,0 +1,377 @@
+import { mkdir, rmdir, stat } from "node:fs/promises";
+import { z } from "zod";
+import { coolEnvironment } from "../commands/cool";
+import { destroySingleEnvironment } from "../commands/destroy";
+import { stopEnvironment } from "../commands/stop";
+import { type Environment, getEnvironment, getEnvironmentWorktreeDir } from "./environment";
+import { isErrnoException } from "./errors";
+import { getLatestLifecycleActivity } from "./lifecycle-activity";
+import {
+  type LifecycleConfig,
+  type LifecycleEnrollment,
+  type LifecyclePolicy,
+  loadLifecycleConfig,
+  resolveLifecyclePolicy,
+  saveLifecycleConfig,
+} from "./lifecycle-config";
+import { getSourceFingerprint } from "./lifecycle-source";
+import { logger } from "./logger";
+import { getConfiguredMultiplexer, getSessionName } from "./multiplexer";
+import { getLifecycleLockPath, getLifecycleStatePath } from "./paths";
+import { CommandError, Err, Ok, type Result } from "./result";
+import { loadSettings } from "./settings";
+import { type EnvironmentState, getStateInfo } from "./state";
+import { hasUncommittedChanges } from "./worktree";
+
+const LifecycleActivitySourceSchema = z.enum(["initial", "source", "command", "frontend", "test"]);
+export type LifecycleActivitySource = z.infer<typeof LifecycleActivitySourceSchema>;
+
+const LifecycleStateSchema = z.object({
+  observedState: z.enum(["stopped", "cold", "warm"]),
+  stateEnteredAt: z.iso.datetime(),
+  lastActivityAt: z.iso.datetime(),
+  lastActivitySource: LifecycleActivitySourceSchema,
+  sourceFingerprint: z.string().nullable(),
+  blockedReason: z.string().nullable(),
+});
+
+export type LifecycleState = z.infer<typeof LifecycleStateSchema>;
+export type LifecycleTransition = "cool" | "stop" | "delete";
+
+interface EnvironmentLock {
+  release: () => Promise<void>;
+}
+
+function timestampMs(value: string): number {
+  return new Date(value).getTime();
+}
+
+export function getEligibleLifecycleTransition(
+  state: LifecycleState,
+  policy: LifecyclePolicy,
+  nowMs: number
+): LifecycleTransition | null {
+  const idleSinceMs = Math.max(
+    timestampMs(state.lastActivityAt),
+    timestampMs(state.stateEnteredAt)
+  );
+  const idleDurationSeconds = (nowMs - idleSinceMs) / 1000;
+
+  switch (state.observedState) {
+    case "warm":
+      return policy.coldAfterSeconds !== null && idleDurationSeconds >= policy.coldAfterSeconds
+        ? "cool"
+        : null;
+    case "cold":
+      return policy.stopAfterSeconds !== null && idleDurationSeconds >= policy.stopAfterSeconds
+        ? "stop"
+        : null;
+    case "stopped":
+      return policy.deleteAfterSeconds !== null && idleDurationSeconds >= policy.deleteAfterSeconds
+        ? "delete"
+        : null;
+  }
+}
+
+export async function loadLifecycleState(envName: string): Promise<LifecycleState | null> {
+  const file = Bun.file(getLifecycleStatePath(envName));
+  if (!(await file.exists())) {
+    return null;
+  }
+
+  const data: unknown = await file.json();
+  const parsed = LifecycleStateSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(`Invalid lifecycle state for '${envName}': ${z.prettifyError(parsed.error)}`);
+  }
+  return parsed.data;
+}
+
+async function saveLifecycleState(envName: string, state: LifecycleState): Promise<void> {
+  await Bun.write(getLifecycleStatePath(envName), JSON.stringify(state, null, 2));
+}
+
+async function acquireEnvironmentLock(envName: string): Promise<EnvironmentLock | null> {
+  const lockPath = getLifecycleLockPath(envName);
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      return {
+        release: async () => {
+          try {
+            await rmdir(lockPath);
+          } catch (error) {
+            if (isErrnoException(error) && error.code === "ENOENT") {
+              return;
+            }
+            throw error;
+          }
+        },
+      };
+    } catch (error) {
+      if (!isErrnoException(error) || error.code !== "EEXIST") {
+        throw error;
+      }
+      const lockInfo = await stat(lockPath);
+      if (Date.now() - lockInfo.mtimeMs < 5 * 60 * 1000) {
+        return null;
+      }
+      await rmdir(lockPath);
+    }
+  }
+
+  return null;
+}
+
+function createInitialState(
+  actualState: EnvironmentState,
+  now: Date,
+  sourceFingerprint: string | null
+): LifecycleState {
+  const nowIso = now.toISOString();
+  return {
+    observedState: actualState,
+    stateEnteredAt: nowIso,
+    lastActivityAt: nowIso,
+    lastActivitySource: "initial",
+    sourceFingerprint,
+    blockedReason: null,
+  };
+}
+
+async function observeActivity(
+  env: Environment,
+  policy: LifecyclePolicy,
+  actualState: EnvironmentState,
+  previousState: LifecycleState | null,
+  now: Date
+): Promise<LifecycleState> {
+  const worktreePath = getEnvironmentWorktreeDir(env.metadata);
+  const sourceFingerprint = policy.trackSourceChanges
+    ? await getSourceFingerprint(worktreePath)
+    : null;
+  const state = previousState ?? createInitialState(actualState, now, sourceFingerprint);
+  const stateAfterObservedTransition: LifecycleState =
+    state.observedState === actualState
+      ? state
+      : {
+          ...state,
+          observedState: actualState,
+          stateEnteredAt: now.toISOString(),
+          blockedReason: null,
+        };
+
+  let nextState = stateAfterObservedTransition;
+  if (
+    policy.trackSourceChanges &&
+    stateAfterObservedTransition.sourceFingerprint !== null &&
+    sourceFingerprint !== stateAfterObservedTransition.sourceFingerprint
+  ) {
+    nextState = {
+      ...nextState,
+      lastActivityAt: now.toISOString(),
+      lastActivitySource: "source",
+    };
+  }
+
+  const activityKinds = policy.trackFrontend
+    ? (["command", "frontend", "test"] as const)
+    : (["command", "test"] as const);
+  const externalActivity = await getLatestLifecycleActivity(env.name, [...activityKinds]);
+  if (externalActivity && externalActivity.timestampMs > timestampMs(nextState.lastActivityAt)) {
+    nextState = {
+      ...nextState,
+      lastActivityAt: new Date(externalActivity.timestampMs).toISOString(),
+      lastActivitySource: externalActivity.kind,
+    };
+  }
+
+  return {
+    ...nextState,
+    sourceFingerprint,
+  };
+}
+
+async function getDeleteBlockReason(
+  env: Environment,
+  policy: LifecyclePolicy
+): Promise<string | null> {
+  const worktreePath = getEnvironmentWorktreeDir(env.metadata);
+  if (env.metadata.worktreeOwner !== "external" && (await hasUncommittedChanges(worktreePath))) {
+    return "worktree has uncommitted changes";
+  }
+
+  if (policy.blockDeleteIfSessionExists) {
+    const multiplexer = await getConfiguredMultiplexer();
+    if (await multiplexer.sessionExists(getSessionName(env.name))) {
+      return "terminal session still exists";
+    }
+  }
+
+  return null;
+}
+
+async function removeEnrollment(envName: string): Promise<void> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    logger.warn(configResult.error.message);
+    return;
+  }
+  const { [envName]: removed, ...environments } = configResult.value.environments;
+  if (!removed) {
+    return;
+  }
+  await saveLifecycleConfig({ ...configResult.value, environments });
+}
+
+async function applyTransition(
+  env: Environment,
+  transition: LifecycleTransition
+): Promise<Result<EnvironmentState | "deleted", CommandError>> {
+  switch (transition) {
+    case "cool": {
+      const result = await coolEnvironment(env);
+      return result.ok ? Ok("cold") : result;
+    }
+    case "stop": {
+      const result = await stopEnvironment(env);
+      return result.ok ? Ok("stopped") : result;
+    }
+    case "delete": {
+      const result = await destroySingleEnvironment(
+        env,
+        { force: false, keepBranch: true, keepWorktree: false },
+        await loadSettings()
+      );
+      if (!result.ok) {
+        return result;
+      }
+      await removeEnrollment(env.name);
+      return Ok("deleted");
+    }
+  }
+}
+
+async function runEnvironmentLifecycle(
+  env: Environment,
+  policy: LifecyclePolicy,
+  dryRun: boolean
+): Promise<Result<void, CommandError>> {
+  const lock = await acquireEnvironmentLock(env.name);
+  if (!lock) {
+    return Err(new CommandError(`Lifecycle check for '${env.name}' is already running`));
+  }
+
+  try {
+    const stateInfo = await getStateInfo(env);
+    if (stateInfo.warnings.length > 0) {
+      return Err(
+        new CommandError(`Inconsistent environment state: ${stateInfo.warnings.join(", ")}`)
+      );
+    }
+
+    const now = new Date();
+    let state = await observeActivity(
+      env,
+      policy,
+      stateInfo.state,
+      await loadLifecycleState(env.name),
+      now
+    );
+    const transition = getEligibleLifecycleTransition(state, policy, now.getTime());
+    if (!transition) {
+      await saveLifecycleState(env.name, { ...state, blockedReason: null });
+      return Ok(undefined);
+    }
+
+    // Close the observation gap before stopping processes or removing resources.
+    state = await observeActivity(env, policy, stateInfo.state, state, new Date());
+    if (!getEligibleLifecycleTransition(state, policy, Date.now())) {
+      await saveLifecycleState(env.name, { ...state, blockedReason: null });
+      return Ok(undefined);
+    }
+
+    if (transition === "delete") {
+      const blockReason = await getDeleteBlockReason(env, policy);
+      if (blockReason) {
+        await saveLifecycleState(env.name, { ...state, blockedReason: blockReason });
+        return Err(new CommandError(blockReason));
+      }
+    }
+
+    if (dryRun) {
+      await saveLifecycleState(env.name, {
+        ...state,
+        blockedReason: `dry run: would ${transition}`,
+      });
+      logger.info(`[lifecycle] ${env.name}: would ${transition}`);
+      return Ok(undefined);
+    }
+
+    const result = await applyTransition(env, transition);
+    if (!result.ok) {
+      await saveLifecycleState(env.name, { ...state, blockedReason: result.error.message });
+      return result;
+    }
+    if (result.value === "deleted") {
+      logger.success(`[lifecycle] ${env.name}: archived`);
+      return Ok(undefined);
+    }
+
+    const transitionedAt = new Date().toISOString();
+    await saveLifecycleState(env.name, {
+      ...state,
+      observedState: result.value,
+      stateEnteredAt: transitionedAt,
+      blockedReason: null,
+    });
+    logger.success(`[lifecycle] ${env.name}: ${transitionedAt} ${transition}`);
+    return Ok(undefined);
+  } finally {
+    await lock.release();
+  }
+}
+
+async function runEnrolledEnvironment(
+  envName: string,
+  enrollment: LifecycleEnrollment,
+  config: LifecycleConfig,
+  dryRun: boolean
+): Promise<void> {
+  const env = await getEnvironment(envName);
+  if (!env) {
+    logger.warn(`[lifecycle] ${envName}: environment no longer exists`);
+    return;
+  }
+  const policyResult = resolveLifecyclePolicy(config, enrollment);
+  if (!policyResult.ok) {
+    logger.warn(`[lifecycle] ${envName}: ${policyResult.error.message}`);
+    return;
+  }
+  const result = await runEnvironmentLifecycle(env, policyResult.value, dryRun);
+  if (!result.ok) {
+    logger.warn(`[lifecycle] ${envName}: ${result.error.message}`);
+  }
+}
+
+export async function runLifecycleSweep(options: { dryRun?: boolean } = {}): Promise<Result<void>> {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    return configResult;
+  }
+  const config = configResult.value;
+  const dryRun = options.dryRun ?? config.dryRun;
+
+  for (const [envName, enrollment] of Object.entries(config.environments)) {
+    // One broken environment must not prevent resource reclamation for the others.
+    try {
+      await runEnrolledEnvironment(envName, enrollment, config, dryRun);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`[lifecycle] ${envName}: ${message}`);
+    }
+  }
+
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/lib/lifecycle.ts
+++ b/x/henry/dust-hive/src/lib/lifecycle.ts
@@ -41,6 +41,10 @@ function timestampMs(value: string): number {
   return new Date(value).getTime();
 }
 
+function assertNever(value: never): never {
+  throw new Error(`Unexpected lifecycle value: ${String(value)}`);
+}
+
 export function getEligibleLifecycleTransition(
   state: LifecycleState,
   policy: LifecyclePolicy,
@@ -65,6 +69,8 @@ export function getEligibleLifecycleTransition(
       return policy.deleteAfterSeconds !== null && idleDurationSeconds >= policy.deleteAfterSeconds
         ? "delete"
         : null;
+    default:
+      return assertNever(state.observedState);
   }
 }
 
@@ -221,6 +227,8 @@ async function applyTransition(
       await removeEnrollment(env.name);
       return Ok("deleted");
     }
+    default:
+      return assertNever(transition);
   }
 }
 

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -27,6 +27,11 @@ export const FORWARDER_STATE_PATH = join(DUST_HIVE_HOME, "forward.json");
 // Activity tracking (last-interacted environment)
 export const ACTIVITY_PATH = join(DUST_HIVE_HOME, "activity.json");
 
+// Opt-in environment lifecycle management
+export const LIFECYCLE_CONFIG_PATH = join(DUST_HIVE_HOME, "lifecycle.json");
+export const LIFECYCLE_PID_PATH = join(DUST_HIVE_HOME, "lifecycle.pid");
+export const LIFECYCLE_LOG_PATH = join(DUST_HIVE_HOME, "lifecycle.log");
+
 // Temporal server paths (global, not per-env)
 export const TEMPORAL_PID_PATH = join(DUST_HIVE_HOME, "temporal.pid");
 export const TEMPORAL_LOG_PATH = join(DUST_HIVE_HOME, "temporal.log");
@@ -96,6 +101,18 @@ export function getPortsPath(name: string): string {
 
 export function getInitializedMarkerPath(name: string): string {
   return join(getEnvDir(name), "initialized");
+}
+
+export function getLifecycleStatePath(name: string): string {
+  return join(getEnvDir(name), "lifecycle-state.json");
+}
+
+export function getLifecycleActivityPath(name: string, kind: string): string {
+  return join(getEnvDir(name), `lifecycle-activity-${kind}`);
+}
+
+export function getLifecycleLockPath(name: string): string {
+  return join(getEnvDir(name), "lifecycle.lock");
 }
 
 export function getPidPath(name: string, service: string): string {

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -29,6 +29,8 @@ export const ACTIVITY_PATH = join(DUST_HIVE_HOME, "activity.json");
 
 // Opt-in environment lifecycle management
 export const LIFECYCLE_CONFIG_PATH = join(DUST_HIVE_HOME, "lifecycle.json");
+export const LIFECYCLE_CONFIG_LOCK_PATH = join(DUST_HIVE_HOME, "lifecycle-config.lock");
+export const LIFECYCLE_DAEMON_LOCK_PATH = join(DUST_HIVE_HOME, "lifecycle-daemon.lock");
 export const LIFECYCLE_PID_PATH = join(DUST_HIVE_HOME, "lifecycle.pid");
 export const LIFECYCLE_LOG_PATH = join(DUST_HIVE_HOME, "lifecycle.log");
 

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -111,6 +111,14 @@ export function getLifecycleActivityPath(name: string, kind: string): string {
   return join(getEnvDir(name), `lifecycle-activity-${kind}`);
 }
 
+export function getLifecycleLeaseDir(name: string): string {
+  return join(getEnvDir(name), "lifecycle-activity-leases");
+}
+
+export function getLifecycleLeasePath(name: string, token: string): string {
+  return join(getLifecycleLeaseDir(name), `${token}.json`);
+}
+
 export function getLifecycleLockPath(name: string): string {
   return join(getEnvDir(name), "lifecycle.lock");
 }

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -89,7 +89,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     needsNvm: false,
     needsEnvSh: false,
     buildCommand: (env) =>
-      `bun run src/proxy-daemon.ts ${env.ports.front} ${env.ports.frontApi} ${env.ports.marketing}`,
+      `bun run src/proxy-daemon.ts ${env.name} ${env.ports.front} ${env.ports.frontApi} ${env.ports.marketing}`,
     readinessCheck: {
       type: "http",
       url: (ports) => `http://localhost:${ports.front}/__hive/healthz`,

--- a/x/henry/dust-hive/src/lib/worktree.ts
+++ b/x/henry/dust-hive/src/lib/worktree.ts
@@ -160,20 +160,31 @@ export async function createWorktreeFromExistingBranch(
 }
 
 // Remove a git worktree
-export async function removeWorktree(repoRoot: string, worktreePath: string): Promise<void> {
+export async function removeWorktree(
+  repoRoot: string,
+  worktreePath: string,
+  options: { force?: boolean } = { force: true }
+): Promise<void> {
   // If repoRoot doesn't exist, the worktree is orphaned - just check if worktreePath exists
   const repoExists = await directoryExists(repoRoot);
   if (!repoExists) {
     // Can't run git commands without a valid repo, but worktree dir may still exist
     const worktreeExists = await directoryExists(worktreePath);
     if (worktreeExists) {
+      if (options.force === false) {
+        throw new Error(`Cannot safely remove worktree because repo root '${repoRoot}' is missing`);
+      }
       logger.warn(`Repo root '${repoRoot}' no longer exists, removing worktree directory directly`);
       await Bun.spawn(["rm", "-rf", worktreePath]).exited;
     }
     return;
   }
 
-  const proc = Bun.spawn(["git", "worktree", "remove", worktreePath, "--force"], {
+  const args = ["git", "worktree", "remove", worktreePath];
+  if (options.force !== false) {
+    args.push("--force");
+  }
+  const proc = Bun.spawn(args, {
     cwd: repoRoot,
     stdout: "pipe",
     stderr: "pipe",

--- a/x/henry/dust-hive/src/lifecycle-daemon.ts
+++ b/x/henry/dust-hive/src/lifecycle-daemon.ts
@@ -1,22 +1,45 @@
 #!/usr/bin/env bun
 
-import { unlinkSync } from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
 import { isErrnoException } from "./lib/errors";
 import { runLifecycleSweep } from "./lib/lifecycle";
 import { loadLifecycleConfig } from "./lib/lifecycle-config";
+import { acquireLifecycleDaemonLock } from "./lib/lifecycle-lock";
 import { logger } from "./lib/logger";
 import { LIFECYCLE_PID_PATH } from "./lib/paths";
 
-function exitDaemon(): never {
+function cleanupOwnedPidFile(): void {
   try {
-    unlinkSync(LIFECYCLE_PID_PATH);
+    const recordedPid = Number.parseInt(readFileSync(LIFECYCLE_PID_PATH, "utf8").trim(), 10);
+    if (recordedPid === process.pid) {
+      unlinkSync(LIFECYCLE_PID_PATH);
+    }
   } catch (error) {
     if (!isErrnoException(error) || error.code !== "ENOENT") {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`Could not remove lifecycle PID file: ${message}`);
     }
   }
+}
+
+function exitDaemon(): never {
+  cleanupOwnedPidFile();
   process.exit(0);
+}
+
+async function shouldExitBecauseUnused(): Promise<boolean> {
+  const daemonLock = await acquireLifecycleDaemonLock();
+  try {
+    const latestConfig = await loadLifecycleConfig();
+    if (!latestConfig.ok || Object.keys(latestConfig.value.environments).length > 0) {
+      return false;
+    }
+    // Publish that this daemon is exiting before a concurrent start checks the PID.
+    cleanupOwnedPidFile();
+    return true;
+  } finally {
+    await daemonLock.release();
+  }
 }
 
 process.on("SIGTERM", () => {
@@ -34,7 +57,9 @@ while (true) {
     continue;
   }
   if (Object.keys(configResult.value.environments).length === 0) {
-    exitDaemon();
+    if (await shouldExitBecauseUnused()) {
+      process.exit(0);
+    }
   }
 
   const result = await runLifecycleSweep();

--- a/x/henry/dust-hive/src/lifecycle-daemon.ts
+++ b/x/henry/dust-hive/src/lifecycle-daemon.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env bun
+
+import { unlinkSync } from "node:fs";
+import { isErrnoException } from "./lib/errors";
+import { runLifecycleSweep } from "./lib/lifecycle";
+import { loadLifecycleConfig } from "./lib/lifecycle-config";
+import { logger } from "./lib/logger";
+import { LIFECYCLE_PID_PATH } from "./lib/paths";
+
+function exitDaemon(): never {
+  try {
+    unlinkSync(LIFECYCLE_PID_PATH);
+  } catch (error) {
+    if (!isErrnoException(error) || error.code !== "ENOENT") {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Could not remove lifecycle PID file: ${message}`);
+    }
+  }
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  exitDaemon();
+});
+process.on("SIGINT", () => {
+  exitDaemon();
+});
+
+while (true) {
+  const configResult = await loadLifecycleConfig();
+  if (!configResult.ok) {
+    logger.error(configResult.error.message);
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    continue;
+  }
+  if (Object.keys(configResult.value.environments).length === 0) {
+    exitDaemon();
+  }
+
+  const result = await runLifecycleSweep();
+  if (!result.ok) {
+    logger.error(result.error.message);
+  }
+  await new Promise((resolve) =>
+    setTimeout(resolve, configResult.value.scanIntervalSeconds * 1000)
+  );
+}

--- a/x/henry/dust-hive/src/proxy-daemon.ts
+++ b/x/henry/dust-hive/src/proxy-daemon.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // HTTP proxy daemon - the public entry point for a hive env.
 //
-// Usage: bun run proxy-daemon.ts <listen-port> <front-api-port> <marketing-port>
+// Usage: bun run proxy-daemon.ts <env-name> <listen-port> <front-api-port> <marketing-port>
 //
 // Routing:
 //   /__hive/healthz → 200 ok (proxy's own health)
@@ -18,7 +18,7 @@
 // resolve both ends the same way.
 
 import type { ServerWebSocket } from "bun";
-
+import { touchLifecycleActivity } from "./lib/lifecycle-activity";
 import { logger } from "./lib/logger";
 
 type Target = "front-api" | "marketing";
@@ -46,7 +46,9 @@ export function routeFor(pathname: string): Target {
 
 function parsePort(value: string | undefined, label: string): number {
   if (value === undefined) {
-    logger.error("Usage: proxy-daemon.ts <listen-port> <front-api-port> <marketing-port>");
+    logger.error(
+      "Usage: proxy-daemon.ts <env-name> <listen-port> <front-api-port> <marketing-port>"
+    );
     process.exit(1);
   }
   const n = Number.parseInt(value, 10);
@@ -113,7 +115,26 @@ function safeClose(
   }
 }
 
-export function startProxy(listenPort: number, ports: Record<Target, number>) {
+async function recordFrontendActivityIfDue(
+  envName: string,
+  lastActivityWriteMs: number,
+  nowMs: number
+): Promise<number> {
+  if (nowMs - lastActivityWriteMs < 30_000) {
+    return lastActivityWriteMs;
+  }
+  try {
+    await touchLifecycleActivity(envName, "frontend");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`[proxy] Could not record lifecycle activity: ${message}`);
+  }
+  return nowMs;
+}
+
+export function startProxy(envName: string, listenPort: number, ports: Record<Target, number>) {
+  let lastActivityWriteMs = 0;
+
   return Bun.serve<WsClientData>({
     port: listenPort,
     hostname: "localhost",
@@ -123,6 +144,12 @@ export function startProxy(listenPort: number, ports: Record<Target, number>) {
       if (url.pathname === "/__hive/healthz") {
         return new Response("ok", { status: 200 });
       }
+
+      lastActivityWriteMs = await recordFrontendActivityIfDue(
+        envName,
+        lastActivityWriteMs,
+        Date.now()
+      );
 
       const target = routeFor(url.pathname);
       const upstreamPort = ports[target];
@@ -224,14 +251,20 @@ export function startProxy(listenPort: number, ports: Record<Target, number>) {
 }
 
 if (import.meta.main) {
-  const [listenPortArg, frontApiPortArg, marketingPortArg] = process.argv.slice(2);
+  const [envName, listenPortArg, frontApiPortArg, marketingPortArg] = process.argv.slice(2);
+  if (!envName) {
+    logger.error(
+      "Usage: proxy-daemon.ts <env-name> <listen-port> <front-api-port> <marketing-port>"
+    );
+    process.exit(1);
+  }
   const listenPort = parsePort(listenPortArg, "listen port");
   const ports: Record<Target, number> = {
     "front-api": parsePort(frontApiPortArg, "front-api port"),
     marketing: parsePort(marketingPortArg, "marketing port"),
   };
 
-  const server = startProxy(listenPort, ports);
+  const server = startProxy(envName, listenPort, ports);
 
   logger.info(
     `proxy daemon listening on http://${server.hostname}:${server.port} ` +

--- a/x/henry/dust-hive/tests/lib/envgen.test.ts
+++ b/x/henry/dust-hive/tests/lib/envgen.test.ts
@@ -32,6 +32,11 @@ describe("envgen", () => {
       expect(content).toMatch(/export DEV_ENV_NAME=\S+-my-feature/);
     });
 
+    it("exports the Hive environment name for activity tracking", () => {
+      const content = generateEnvSh("my-feature", ports);
+      expect(content).toContain("export DUST_HIVE_ENV_NAME=my-feature");
+    });
+
     it("exports temporal namespaces", () => {
       const content = generateEnvSh("my-feature", ports);
       expect(content).toContain("export TEMPORAL_NAMESPACE=dust-hive-my-feature");

--- a/x/henry/dust-hive/tests/lib/lifecycle-config.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatDurationSeconds,
+  type LifecycleConfig,
+  parseDurationSeconds,
+  resolveLifecyclePolicy,
+} from "../../src/lib/lifecycle-config";
+
+describe("lifecycle config", () => {
+  it("parses supported duration units and disabled transitions", () => {
+    expect(parseDurationSeconds("30m")).toEqual({ ok: true, value: 1800 });
+    expect(parseDurationSeconds("8h")).toEqual({ ok: true, value: 28800 });
+    expect(parseDurationSeconds("7d")).toEqual({ ok: true, value: 604800 });
+    expect(parseDurationSeconds("never")).toEqual({ ok: true, value: null });
+    expect(parseDurationSeconds("30").ok).toBe(false);
+  });
+
+  it("formats durations for status output", () => {
+    expect(formatDurationSeconds(1800)).toBe("30m");
+    expect(formatDurationSeconds(28800)).toBe("8h");
+    expect(formatDurationSeconds(null)).toBe("never");
+  });
+
+  it("applies per-environment overrides to a profile", () => {
+    const config: LifecycleConfig = {
+      scanIntervalSeconds: 30,
+      dryRun: false,
+      profiles: {
+        fast: {
+          coldAfterSeconds: 60,
+          stopAfterSeconds: 120,
+          deleteAfterSeconds: null,
+          trackSourceChanges: true,
+          trackFrontend: true,
+          blockDeleteIfSessionExists: false,
+        },
+      },
+      environments: {},
+    };
+    const result = resolveLifecyclePolicy(config, {
+      profile: "fast",
+      overrides: { stopAfterSeconds: 300 },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        coldAfterSeconds: 60,
+        stopAfterSeconds: 300,
+        deleteAfterSeconds: null,
+        trackSourceChanges: true,
+        trackFrontend: true,
+        blockDeleteIfSessionExists: false,
+      },
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Environment } from "../../src/lib/environment";
+import { directoryExists } from "../../src/lib/fs";
 import { getDeleteBlockReason } from "../../src/lib/lifecycle";
 import {
   getActiveLifecycleActivityLease,
@@ -12,6 +13,7 @@ import type { LifecyclePolicy } from "../../src/lib/lifecycle-config";
 import { acquireLifecycleLock } from "../../src/lib/lifecycle-lock";
 import { getEnvDir } from "../../src/lib/paths";
 import { calculatePorts } from "../../src/lib/ports";
+import { removeWorktree } from "../../src/lib/worktree";
 
 const cleanupPaths: string[] = [];
 
@@ -23,6 +25,12 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const stderr = await new Response(proc.stderr).text();
+  expect(await proc.exited, stderr).toBe(0);
 }
 
 afterEach(async () => {
@@ -138,5 +146,24 @@ describe("lifecycle safety", () => {
         policy
       )
     ).toBeNull();
+  });
+
+  it("refuses a non-forced worktree removal when changes appear", async () => {
+    const repoPath = await mkdtemp(join(tmpdir(), "dust-hive-remove-safety-"));
+    const worktreePath = `${repoPath}-worktree`;
+    cleanupPaths.push(repoPath, worktreePath);
+    await runGit(repoPath, ["init", "--quiet"]);
+    await runGit(repoPath, ["config", "user.email", "hive-test@example.com"]);
+    await runGit(repoPath, ["config", "user.name", "Hive Test"]);
+    await writeFile(join(repoPath, "README.md"), "initial\n");
+    await runGit(repoPath, ["add", "README.md"]);
+    await runGit(repoPath, ["commit", "--quiet", "-m", "Initial commit"]);
+    await runGit(repoPath, ["worktree", "add", "--quiet", "-b", "safety", worktreePath]);
+    await writeFile(join(worktreePath, "work-in-progress.ts"), "export const value = 1;\n");
+
+    await expect(removeWorktree(repoPath, worktreePath, { force: false })).rejects.toThrow(
+      "Failed to remove worktree"
+    );
+    expect(await directoryExists(worktreePath)).toBe(true);
   });
 });

--- a/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Environment } from "../../src/lib/environment";
+import { getDeleteBlockReason } from "../../src/lib/lifecycle";
+import {
+  getActiveLifecycleActivityLease,
+  withLifecycleActivityLease,
+} from "../../src/lib/lifecycle-activity";
+import type { LifecyclePolicy } from "../../src/lib/lifecycle-config";
+import { acquireLifecycleLock } from "../../src/lib/lifecycle-lock";
+import { getEnvDir } from "../../src/lib/paths";
+import { calculatePorts } from "../../src/lib/ports";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+  );
+});
+
+const policy: LifecyclePolicy = {
+  coldAfterSeconds: 60,
+  stopAfterSeconds: 120,
+  deleteAfterSeconds: 300,
+  trackSourceChanges: true,
+  trackFrontend: true,
+  blockDeleteIfSessionExists: false,
+};
+
+describe("lifecycle safety", () => {
+  it("keeps transitions locked out while a wrapped command is active", async () => {
+    const envName = `lease-${process.pid}-${crypto.randomUUID()}`;
+    const envDir = getEnvDir(envName);
+    cleanupPaths.push(envDir);
+    await mkdir(envDir, { recursive: true });
+    const transitionLock = await acquireLifecycleLock(envName);
+    expect(transitionLock).not.toBeNull();
+
+    let releaseCommand!: () => void;
+    const commandCanFinish = new Promise<void>((resolve) => {
+      releaseCommand = resolve;
+    });
+    let commandStarted!: () => void;
+    let hasCommandStarted = false;
+    const commandDidStart = new Promise<void>((resolve) => {
+      commandStarted = resolve;
+    });
+
+    const command = withLifecycleActivityLease(envName, "test", async () => {
+      hasCommandStarted = true;
+      commandStarted();
+      await commandCanFinish;
+    });
+    await Bun.sleep(20);
+    expect(hasCommandStarted).toBe(false);
+
+    await transitionLock?.release();
+    await commandDidStart;
+
+    const sweepLock = await acquireLifecycleLock(envName);
+    expect(sweepLock).not.toBeNull();
+    expect(await getActiveLifecycleActivityLease(envName)).toMatchObject({ kind: "test" });
+    await sweepLock?.release();
+
+    releaseCommand();
+    await command;
+    expect(await getActiveLifecycleActivityLease(envName)).toBeNull();
+    const lock = await acquireLifecycleLock(envName);
+    expect(lock).not.toBeNull();
+    await lock?.release();
+  });
+
+  it("keeps independent leases for concurrent wrapped commands", async () => {
+    const envName = `leases-${process.pid}-${crypto.randomUUID()}`;
+    const envDir = getEnvDir(envName);
+    cleanupPaths.push(envDir);
+    await mkdir(envDir, { recursive: true });
+
+    let releaseFirst!: () => void;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let releaseSecond!: () => void;
+    const secondCanFinish = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let markSecondStarted!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const first = withLifecycleActivityLease(envName, "test", async () => {
+      markFirstStarted();
+      await firstCanFinish;
+    });
+    const second = withLifecycleActivityLease(envName, "test", async () => {
+      markSecondStarted();
+      await secondCanFinish;
+    });
+
+    await Promise.all([firstStarted, secondStarted]);
+    releaseFirst();
+    await first;
+    const lock = await acquireLifecycleLock(envName);
+    expect(lock).not.toBeNull();
+    expect(await getActiveLifecycleActivityLease(envName)).toMatchObject({ kind: "test" });
+    await lock?.release();
+
+    releaseSecond();
+    await second;
+    expect(await getActiveLifecycleActivityLease(envName)).toBeNull();
+  });
+
+  it("blocks deletion of a dirty Hive-owned worktree but keeps external worktrees", async () => {
+    const worktreePath = await mkdtemp(join(tmpdir(), "dust-hive-delete-safety-"));
+    cleanupPaths.push(worktreePath);
+    const init = Bun.spawn(["git", "init", "--quiet"], { cwd: worktreePath });
+    expect(await init.exited).toBe(0);
+    await writeFile(join(worktreePath, "work-in-progress.ts"), "export const value = 1;\n");
+
+    const env: Environment = {
+      name: "delete-safety",
+      metadata: {
+        name: "delete-safety",
+        baseBranch: "main",
+        workspaceBranch: "delete-safety",
+        createdAt: new Date().toISOString(),
+        repoRoot: worktreePath,
+        worktreePath,
+        worktreeOwner: "hive",
+      },
+      ports: calculatePorts(10_000),
+      initialized: false,
+    };
+
+    expect(await getDeleteBlockReason(env, policy)).toBe("worktree has uncommitted changes");
+    expect(
+      await getDeleteBlockReason(
+        { ...env, metadata: { ...env.metadata, worktreeOwner: "external" } },
+        policy
+      )
+    ).toBeNull();
+  });
+});

--- a/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle-safety.test.ts
@@ -15,6 +15,16 @@ import { calculatePorts } from "../../src/lib/ports";
 
 const cleanupPaths: string[] = [];
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 afterEach(async () => {
   await Promise.all(
     cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
@@ -39,15 +49,9 @@ describe("lifecycle safety", () => {
     const transitionLock = await acquireLifecycleLock(envName);
     expect(transitionLock).not.toBeNull();
 
-    let releaseCommand!: () => void;
-    const commandCanFinish = new Promise<void>((resolve) => {
-      releaseCommand = resolve;
-    });
-    let commandStarted!: () => void;
+    const { promise: commandCanFinish, resolve: releaseCommand } = createDeferred();
     let hasCommandStarted = false;
-    const commandDidStart = new Promise<void>((resolve) => {
-      commandStarted = resolve;
-    });
+    const { promise: commandDidStart, resolve: commandStarted } = createDeferred();
 
     const command = withLifecycleActivityLease(envName, "test", async () => {
       hasCommandStarted = true;
@@ -79,22 +83,10 @@ describe("lifecycle safety", () => {
     cleanupPaths.push(envDir);
     await mkdir(envDir, { recursive: true });
 
-    let releaseFirst!: () => void;
-    const firstCanFinish = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    let releaseSecond!: () => void;
-    const secondCanFinish = new Promise<void>((resolve) => {
-      releaseSecond = resolve;
-    });
-    let markFirstStarted!: () => void;
-    const firstStarted = new Promise<void>((resolve) => {
-      markFirstStarted = resolve;
-    });
-    let markSecondStarted!: () => void;
-    const secondStarted = new Promise<void>((resolve) => {
-      markSecondStarted = resolve;
-    });
+    const { promise: firstCanFinish, resolve: releaseFirst } = createDeferred();
+    const { promise: secondCanFinish, resolve: releaseSecond } = createDeferred();
+    const { promise: firstStarted, resolve: markFirstStarted } = createDeferred();
+    const { promise: secondStarted, resolve: markSecondStarted } = createDeferred();
     const first = withLifecycleActivityLease(envName, "test", async () => {
       markFirstStarted();
       await firstCanFinish;

--- a/x/henry/dust-hive/tests/lib/lifecycle-source.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle-source.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getSourceFingerprint } from "../../src/lib/lifecycle-source";
+
+const temporaryDirectories: string[] = [];
+
+async function runGit(worktreePath: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: worktreePath,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+  if (proc.exitCode !== 0) {
+    throw new Error(stderr);
+  }
+}
+
+async function createRepository(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "dust-hive-lifecycle-"));
+  temporaryDirectories.push(path);
+  await runGit(path, ["init", "-q"]);
+  await runGit(path, ["config", "user.email", "test@example.com"]);
+  await runGit(path, ["config", "user.name", "Test"]);
+  await Bun.write(join(path, "tracked.ts"), "export const value = 1;\n");
+  await Bun.write(join(path, ".gitignore"), "ignored.log\n");
+  await runGit(path, ["add", "tracked.ts", ".gitignore"]);
+  await runGit(path, ["commit", "-qm", "Initial"]);
+  return path;
+}
+
+afterEach(async () => {
+  for (const path of temporaryDirectories.splice(0)) {
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("source activity fingerprint", () => {
+  it("changes for continued edits to an already dirty file", async () => {
+    const worktreePath = await createRepository();
+    const cleanFingerprint = await getSourceFingerprint(worktreePath);
+
+    await Bun.write(join(worktreePath, "tracked.ts"), "export const value = 2;\n");
+    const firstEditFingerprint = await getSourceFingerprint(worktreePath);
+    await Bun.write(join(worktreePath, "tracked.ts"), "export const value = 300;\n");
+    const secondEditFingerprint = await getSourceFingerprint(worktreePath);
+
+    expect(firstEditFingerprint).not.toBe(cleanFingerprint);
+    expect(secondEditFingerprint).not.toBe(firstEditFingerprint);
+  });
+
+  it("ignores generated files excluded by Git", async () => {
+    const worktreePath = await createRepository();
+    const before = await getSourceFingerprint(worktreePath);
+
+    await Bun.write(join(worktreePath, "ignored.log"), "generated output\n");
+
+    expect(await getSourceFingerprint(worktreePath)).toBe(before);
+  });
+});

--- a/x/henry/dust-hive/tests/lib/lifecycle.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { getEligibleLifecycleTransition, type LifecycleState } from "../../src/lib/lifecycle";
+import type { LifecyclePolicy } from "../../src/lib/lifecycle-config";
+
+const policy: LifecyclePolicy = {
+  coldAfterSeconds: 60,
+  stopAfterSeconds: 120,
+  deleteAfterSeconds: 300,
+  trackSourceChanges: true,
+  trackFrontend: true,
+  blockDeleteIfSessionExists: true,
+};
+
+function state(overrides: Partial<LifecycleState> = {}): LifecycleState {
+  return {
+    observedState: "warm",
+    stateEnteredAt: "2026-01-01T00:00:00.000Z",
+    lastActivityAt: "2026-01-01T00:00:00.000Z",
+    lastActivitySource: "initial",
+    sourceFingerprint: "fingerprint",
+    blockedReason: null,
+    ...overrides,
+  };
+}
+
+describe("lifecycle transitions", () => {
+  it("cools a warm environment after its idle delay", () => {
+    expect(
+      getEligibleLifecycleTransition(state(), policy, Date.parse("2026-01-01T00:01:00.000Z"))
+    ).toBe("cool");
+  });
+
+  it("uses the state entry time when it is newer than activity", () => {
+    const lifecycleState = state({
+      observedState: "cold",
+      stateEnteredAt: "2026-01-01T01:00:00.000Z",
+    });
+    expect(
+      getEligibleLifecycleTransition(lifecycleState, policy, Date.parse("2026-01-01T01:01:59.000Z"))
+    ).toBeNull();
+    expect(
+      getEligibleLifecycleTransition(lifecycleState, policy, Date.parse("2026-01-01T01:02:00.000Z"))
+    ).toBe("stop");
+  });
+
+  it("resets the timer when activity happens in the current state", () => {
+    const lifecycleState = state({
+      observedState: "stopped",
+      lastActivityAt: "2026-01-01T03:00:00.000Z",
+    });
+    expect(
+      getEligibleLifecycleTransition(lifecycleState, policy, Date.parse("2026-01-01T03:04:59.000Z"))
+    ).toBeNull();
+    expect(
+      getEligibleLifecycleTransition(lifecycleState, policy, Date.parse("2026-01-01T03:05:00.000Z"))
+    ).toBe("delete");
+  });
+
+  it("supports disabling individual transitions", () => {
+    expect(
+      getEligibleLifecycleTransition(
+        state(),
+        { ...policy, coldAfterSeconds: null },
+        Date.parse("2026-01-02T00:00:00.000Z")
+      )
+    ).toBeNull();
+  });
+});

--- a/x/henry/dust-hive/tests/lib/lifecycle.test.ts
+++ b/x/henry/dust-hive/tests/lib/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { getLifecycleRunOnceOptions } from "../../src/commands/lifecycle";
 import { getEligibleLifecycleTransition, type LifecycleState } from "../../src/lib/lifecycle";
 import type { LifecyclePolicy } from "../../src/lib/lifecycle-config";
 
@@ -64,5 +65,12 @@ describe("lifecycle transitions", () => {
         Date.parse("2026-01-02T00:00:00.000Z")
       )
     ).toBeNull();
+  });
+});
+
+describe("lifecycle sweep options", () => {
+  it("leaves configured dry-run mode authoritative when the flag is absent", () => {
+    expect(getLifecycleRunOnceOptions()).toEqual({});
+    expect(getLifecycleRunOnceOptions(true)).toEqual({ dryRun: true });
   });
 });

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -204,7 +204,7 @@ describe("registry", () => {
 
     it("proxy receives all three ports as argv", () => {
       const command = SERVICE_REGISTRY.proxy.buildCommand(mockEnv);
-      expect(command).toBe("bun run src/proxy-daemon.ts 10000 10003 10004");
+      expect(command).toBe("bun run src/proxy-daemon.ts test 10000 10003 10004");
     });
 
     it("core returns cargo run --bin core-api", () => {


### PR DESCRIPTION
## Description

Add opt-in, profile-based lifecycle management for Dust Hive environments. Enrolled environments can move from warm to cold, cold to stopped, and stopped to archived after independent idle periods.

Activity comes from Git worktree changes, frontend proxy requests, Hive commands, and an explicit process lease for wrapped tests. Activity entry, enrollment changes, and lifecycle transitions are coordinated so opt-out and active work fence automatic actions. Archive rechecks dirtiness at the removal boundary, uses non-forced Git removal, and always retains the local branch.

Profiles and per-environment overrides configure every delay and activity source. Configuration is strictly validated, global dry-run remains authoritative, and daemon start, stop, and self-exit are serialized.

## Tests

- `bun run check` in `x/henry/dust-hive` (223 tests)
- Added lifecycle safety coverage for transition ordering, concurrent activity leases, dirty-worktree deletion blocking, late worktree changes, and dry-run option handling
- Live disposable Hive test covering enable, activity tracking, dry run, disable, and cold to stopped transition with Docker cleanup

## Risk

Low for existing users because lifecycle management is disabled unless an environment is explicitly enrolled. Automatic archive preserves the branch and refuses to remove a dirty Hive-owned worktree. Invalid configuration and inconsistent environment state fail closed.

Frontend proxy activity is intentionally conservative and may treat background polling as activity; profiles can disable frontend tracking. Resource cleanup is best effort, while worktree, activity, opt-out, and dry-run safety checks are strict.

## Deploy Plan

Standard deploy. No migration is required. Users opt in with `dust-hive lifecycle enable`.