### PR TITLE
Reduce dependency on metronome webhook

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -98,6 +98,25 @@ vi.mock("@app/lib/plans/stripe", async () => {
   };
 });
 
+// These tests exercise the production behavior of switchContract, where the
+// Metronome webhook is configured and drives the subscription swap
+// (`contract.start`) asynchronously. Stub a webhook secret so
+// `stepImmediateSubscriptionSwapWithoutWebhook` no-ops here, same as in a
+// real deployment — otherwise it would run inline against the unmocked
+// Metronome client.
+vi.mock("@app/lib/api/config", async () => {
+  const actual = await vi.importActual<typeof import("@app/lib/api/config")>(
+    "@app/lib/api/config"
+  );
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      getMetronomeWebhookSecret: vi.fn().mockReturnValue("test-secret"),
+    },
+  };
+});
+
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const EXISTING_CONTRACT_ID = "contract_existing_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";

--- a/front/lib/api/metronome/legacy_credit_migration.ts
+++ b/front/lib/api/metronome/legacy_credit_migration.ts
@@ -3,6 +3,8 @@ import { addCreditToContract } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_FREE_SEAT_CREDIT,
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
   getProductFreeCreditId,
   getProductPrepaidCommitId,
@@ -157,6 +159,9 @@ export async function applyLegacyCreditMigrationAtActivation({
       uniquenessKey: `legacy-credit-conversion:${workspace.sId}:${metronomeContractId}`,
       applicableProductTags: [USAGE_TAG],
       priority: AWU_PRIORITY_PURCHASED_COMMIT,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
     });
     if (res.isErr()) {
       logger.error(
@@ -184,6 +189,9 @@ export async function applyLegacyCreditMigrationAtActivation({
       uniquenessKey: `legacy-migration-bonus:${workspace.sId}:${metronomeContractId}`,
       applicableProductTags: [USAGE_TAG],
       priority: AWU_PRIORITY_FREE_SEAT_CREDIT,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
     });
     if (res.isErr()) {
       logger.error(

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -571,11 +571,300 @@ async function handlePerUserSpendThresholdEvent({
   return new Ok(undefined);
 }
 
-// If the started contract was stamped for the legacy → Business migration,
-// convert the workspace's convertible legacy credits to AWU and grant the
-// per-user free bonus — computed now, so the amounts reflect the workspace's
-// state at activation. Shared by both `contract.start` swap paths (pending row
-// activation and immediate swap). Best-effort: failures are logged, never throw.
+// Perform the subscription-affecting side effects of a Metronome
+// `contract.start` event: carry over renewal balances, reconcile credit
+// state, and swap (or activate a pending) local Subscription row onto the
+// new contract.
+export async function applyContractStartSubscriptionSwap({
+  workspace,
+  contractId,
+  customerId,
+}: {
+  workspace: WorkspaceResource;
+  contractId: string;
+  customerId: string;
+}): Promise<Result<undefined, ProcessMetronomeWebhookError>> {
+  // Read the PLAN_CODE custom field to know which plan to swap the
+  // workspace subscription onto. The actual swap is gated below on
+  // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
+  // Stripe) handle their own state transitions, and contracts whose
+  // start aligns with a synchronous DB flip get caught by the
+  // idempotency check. Fetched up-front because the carry-over below also
+  // needs the contract's transition lineage and start.
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId: customerId,
+    metronomeContractId: contractId,
+  });
+  if (contractResult.isErr()) {
+    logger.error(
+      {
+        contractId,
+        customerId,
+        error: contractResult.error,
+        workspaceId: workspace.sId,
+      },
+      "[Metronome Webhook] contract.start: failed to fetch contract"
+    );
+    return new Err(
+      new ProcessMetronomeWebhookError(
+        "processing_failed",
+        `Error fetching contract: ${contractResult.error.message}`
+      )
+    );
+  }
+
+  // The contract was archived (cancelled) after the start webhook was
+  // enqueued but before it was delivered — skip to avoid swapping the
+  // active subscription onto a dead contract.
+  if (contractResult.value.archived_at) {
+    logger.info(
+      { contractId, workspaceId: workspace.sId },
+      "[Metronome Webhook] contract.start: contract is archived, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const renewalTransition = contractResult.value.transitions?.find(
+    (t) => t.to_contract_id === contractId
+  );
+  logger.info(
+    {
+      contractId,
+      customerId,
+      workspaceId: workspace.sId,
+      transitions: contractResult.value.transitions,
+      renewalFromContractId: renewalTransition?.from_contract_id ?? null,
+    },
+    "[Metronome Webhook] contract.start: renewal transition lookup"
+  );
+  if (renewalTransition) {
+    const carryResult = await carryOverContractBalancesOnRenewal({
+      metronomeCustomerId: customerId,
+      fromContractId: renewalTransition.from_contract_id,
+      toContractId: contractId,
+      toContractStart: new Date(contractResult.value.starting_at),
+    });
+    if (carryResult.isErr()) {
+      logger.error(
+        {
+          contractId,
+          customerId,
+          fromContractId: renewalTransition.from_contract_id,
+          error: carryResult.error,
+          workspaceId: workspace.sId,
+        },
+        "[Metronome Webhook] contract.start: failed to carry over balances"
+      );
+    }
+  }
+
+  // Reconcile the workspace pool credit state against the new contract's
+  // live AWU balance. Replaces the in-process call we previously made
+  // from `provisionMetronomeContract` (removed to break a dependency
+  // cycle through auth → subscription_resource → contracts). Without
+  // this, a workspace whose previous contract ended `depleted` would
+  // stay stuck after the new contract spins up with a fresh commit.
+  await syncPoolCreditStateFromBalance({
+    workspace,
+    metronomeCustomerId: customerId,
+  });
+
+  // Reconcile per-user credit states against the new contract's live
+  // per-seat balances. Seats were synced to this contract at provision
+  // time (`syncSeatCount`), but that path does
+  // not touch per-user credit states; now that the contract is active the
+  // balances are live, so this lands each user in the right seat↔pool
+  // state. Without it, a switch that changes seat allocations (e.g. moving
+  // onto a business plan) leaves users stuck in their previous state.
+  // Mirrors the pool reconcile above; pass the new contract id directly
+  // since the subscription swap below may not have happened yet.
+  const targetPlanCode =
+    contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
+
+  await reconcileWorkspaceUserCreditStates({
+    workspace: renderLightWorkspaceType({ workspace }),
+    metronomeCustomerId: customerId,
+    metronomeContractId: contractId,
+    planCode: targetPlanCode ?? "",
+  });
+  if (!targetPlanCode) {
+    logger.info(
+      { contractId, workspaceId: workspace.sId },
+      `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
+    );
+    return new Ok(undefined);
+  }
+
+  // Payment-gated subscription activation: skip the automatic swap here.
+  // The payment_gate.payment_status webhook handles the plan switch once
+  // payment succeeds, ensuring the workspace stays on CP_FREE_PLAN until paid.
+  const paymentGateType =
+    contractResult.value.custom_fields?.[PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY];
+  if (paymentGateType === PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION) {
+    logger.info(
+      { contractId, workspaceId: workspace.sId },
+      "[Metronome Webhook] contract.start: payment-gated activation contract, skipping — payment_gate.payment_status will activate"
+    );
+    return new Ok(undefined);
+  }
+
+  // The calling code that provisioned this contract already created the
+  // workspace's DB subscription row synchronously (e.g.
+  // provisionCreditPricedFreePlan) to avoid racing with this webhook's
+  // own swap logic below — skip it entirely.
+  if (
+    contractResult.value.custom_fields?.[
+      SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY
+    ]
+  ) {
+    logger.info(
+      { contractId, workspaceId: workspace.sId },
+      "[Metronome Webhook] contract.start: subscription swap handled inline by caller, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const targetPlan = await PlanModel.findOne({
+    where: { code: targetPlanCode },
+  });
+  if (!targetPlan) {
+    logger.info(
+      { contractId, targetPlanCode, workspaceId: workspace.sId },
+      `[Metronome Webhook] contract.start: ${PLAN_CODE_CUSTOM_FIELD_KEY} not found, leaving subscription alone`
+    );
+    return new Ok(undefined);
+  }
+
+  const activeSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+
+  // Idempotency: re-deliveries land here with the active subscription
+  // already pointing at the new contract.
+  if (activeSubscription.metronomeContractId === contractId) {
+    logger.info(
+      { contractId, workspaceId: workspace.sId },
+      "[Metronome Webhook] contract.start: subscription already swapped, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  // Preferred path: a pending (created_backend_only) subscription was
+  // staged when the contract was provisioned. Flip it to active and
+  // end whatever active sub the workspace currently holds.
+  const pendingSubscription =
+    await SubscriptionResource.fetchByMetronomeContractId(
+      workspace,
+      contractId
+    );
+  if (
+    pendingSubscription &&
+    pendingSubscription.status === "created_backend_only"
+  ) {
+    const previousPlanCode = activeSubscription.getPlan().code;
+    // `activatePending` flushes the contract cache itself.
+    await pendingSubscription.activatePending();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await restoreWorkspaceAfterSubscription(auth);
+
+    await applyStampedLegacyCreditMigration({
+      auth,
+      workspace,
+      contract: contractResult.value,
+      metronomeCustomerId: customerId,
+      metronomeContractId: contractId,
+    });
+    await ensureWorkOSOrganizationForPaidPlan({
+      workspace: renderLightWorkspaceType({ workspace }),
+      planCode: targetPlan.code,
+      contractId,
+    });
+    emitSubscriptionChangedAuditEvent({
+      auth,
+      planCode: targetPlanCode,
+      previousPlanCode,
+      metronomeContractId: contractId,
+    });
+    logger.info(
+      {
+        contractId,
+        planCode: targetPlan.code,
+        workspaceId: workspace.sId,
+      },
+      "[Metronome Webhook] contract.start: pending subscription activated"
+    );
+    return new Ok(undefined);
+  }
+
+  // No pending row was staged (e.g. an immediate switch). Swap the active
+  // subscription onto the new contract regardless of its current billing
+  // rail — switchContract is used this way routinely. The ONLY contract we
+  // must NOT swap onto is a shadow contract: a Metronome contract that runs
+  // in parallel to a Stripe subscription with no billing-provider delivery
+  // (Stripe owns billing). That is a property of the contract itself — it has
+  // no `customer_billing_provider_configuration` — and only applies while the
+  // workspace is still Stripe-billed (so free / Metronome-only contracts,
+  // which also lack a delivery config, are not mistaken for shadows).
+  const startedContractIsShadow =
+    !contractResult.value.customer_billing_provider_configuration &&
+    !!activeSubscription.stripeSubscriptionId;
+  if (startedContractIsShadow) {
+    logger.info(
+      {
+        contractId,
+        targetPlanCode,
+        workspaceId: workspace.sId,
+      },
+      "[Metronome Webhook] contract.start: shadow contract started, leaving subscription alone (Stripe drives billing)"
+    );
+    return new Ok(undefined);
+  }
+
+  // End the current subscription as `ended_backend_only` and create
+  // a new active subscription on the target plan + new contract.
+  const legacyPreviousPlanCode = activeSubscription.getPlan().code;
+  // `swapMetronomeContract` flushes the contract cache itself.
+  await activeSubscription.swapMetronomeContract({
+    metronomeContractId: contractId,
+    planCode: targetPlan.code,
+  });
+
+  // Cancel any scheduled scrub workflow, unpause connectors, re-enable
+  // triggers. Idempotent — safe to call regardless of prior state.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  await restoreWorkspaceAfterSubscription(auth);
+
+  await applyStampedLegacyCreditMigration({
+    auth,
+    workspace,
+    contract: contractResult.value,
+    metronomeCustomerId: customerId,
+    metronomeContractId: contractId,
+  });
+
+  emitSubscriptionChangedAuditEvent({
+    auth,
+    planCode: targetPlan.code,
+    previousPlanCode: legacyPreviousPlanCode,
+    metronomeContractId: contractId,
+  });
+
+  await ensureWorkOSOrganizationForPaidPlan({
+    workspace: renderLightWorkspaceType({ workspace }),
+    planCode: targetPlan.code,
+    contractId,
+  });
+
+  logger.info(
+    {
+      contractId,
+      planCode: targetPlan.code,
+      workspaceId: workspace.sId,
+    },
+    "[Metronome Webhook] contract.start: subscription upgraded"
+  );
+  return new Ok(undefined);
+}
+
 async function applyStampedLegacyCreditMigration({
   auth,
   workspace,
@@ -1249,290 +1538,11 @@ export async function processMetronomeWebhook({
 
     case "contract.start": {
       const { contract_id: contractId, customer_id: customerId } = event;
-
-      // Read the PLAN_CODE custom field to know which plan to swap the
-      // workspace subscription onto. The actual swap is gated below on
-      // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
-      // Stripe) handle their own state transitions, and contracts whose
-      // start aligns with a synchronous DB flip get caught by the
-      // idempotency check. Fetched up-front because the carry-over below also
-      // needs the contract's transition lineage and start.
-      const contractResult = await getMetronomeContractById({
-        metronomeCustomerId: customerId,
-        metronomeContractId: contractId,
-      });
-      if (contractResult.isErr()) {
-        logger.error(
-          {
-            contractId,
-            customerId,
-            error: contractResult.error,
-            workspaceId: workspace.sId,
-          },
-          "[Metronome Webhook] contract.start: failed to fetch contract"
-        );
-        return new Err(
-          new ProcessMetronomeWebhookError(
-            "processing_failed",
-            `Error fetching contract: ${contractResult.error.message}`
-          )
-        );
-      }
-
-      // The contract was archived (cancelled) after the start webhook was
-      // enqueued but before it was delivered — skip to avoid swapping the
-      // active subscription onto a dead contract.
-      if (contractResult.value.archived_at) {
-        logger.info(
-          { contractId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: contract is archived, skipping"
-        );
-        break;
-      }
-
-      const renewalTransition = contractResult.value.transitions?.find(
-        (t) => t.to_contract_id === contractId
-      );
-      logger.info(
-        {
-          contractId,
-          customerId,
-          workspaceId: workspace.sId,
-          transitions: contractResult.value.transitions,
-          renewalFromContractId: renewalTransition?.from_contract_id ?? null,
-        },
-        "[Metronome Webhook] contract.start: renewal transition lookup"
-      );
-      if (renewalTransition) {
-        const carryResult = await carryOverContractBalancesOnRenewal({
-          metronomeCustomerId: customerId,
-          fromContractId: renewalTransition.from_contract_id,
-          toContractId: contractId,
-          toContractStart: new Date(contractResult.value.starting_at),
-        });
-        if (carryResult.isErr()) {
-          logger.error(
-            {
-              contractId,
-              customerId,
-              fromContractId: renewalTransition.from_contract_id,
-              error: carryResult.error,
-              workspaceId: workspace.sId,
-            },
-            "[Metronome Webhook] contract.start: failed to carry over balances"
-          );
-        }
-      }
-
-      // Reconcile the workspace pool credit state against the new contract's
-      // live AWU balance. Replaces the in-process call we previously made
-      // from `provisionMetronomeContract` (removed to break a dependency
-      // cycle through auth → subscription_resource → contracts). Without
-      // this, a workspace whose previous contract ended `depleted` would
-      // stay stuck after the new contract spins up with a fresh commit.
-      await syncPoolCreditStateFromBalance({
+      return applyContractStartSubscriptionSwap({
         workspace,
-        metronomeCustomerId: customerId,
-      });
-
-      // Reconcile per-user credit states against the new contract's live
-      // per-seat balances. Seats were synced to this contract at provision
-      // time (`syncSeatCount`), but that path does
-      // not touch per-user credit states; now that the contract is active the
-      // balances are live, so this lands each user in the right seat↔pool
-      // state. Without it, a switch that changes seat allocations (e.g. moving
-      // onto a business plan) leaves users stuck in their previous state.
-      // Mirrors the pool reconcile above; pass the new contract id directly
-      // since the subscription swap below may not have happened yet.
-      const targetPlanCode =
-        contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
-
-      await reconcileWorkspaceUserCreditStates({
-        workspace: renderLightWorkspaceType({ workspace }),
-        metronomeCustomerId: customerId,
-        metronomeContractId: contractId,
-        planCode: targetPlanCode ?? "",
-      });
-      if (!targetPlanCode) {
-        logger.info(
-          { contractId, workspaceId: workspace.sId },
-          `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
-        );
-        break;
-      }
-
-      // Payment-gated subscription activation: skip the automatic swap here.
-      // The payment_gate.payment_status webhook handles the plan switch once
-      // payment succeeds, ensuring the workspace stays on CP_FREE_PLAN until paid.
-      const paymentGateType =
-        contractResult.value.custom_fields?.[
-          PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY
-        ];
-      if (paymentGateType === PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION) {
-        logger.info(
-          { contractId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: payment-gated activation contract, skipping — payment_gate.payment_status will activate"
-        );
-        break;
-      }
-
-      // The calling code that provisioned this contract already created the
-      // workspace's DB subscription row synchronously (e.g.
-      // provisionCreditPricedFreePlan) to avoid racing with this webhook's
-      // own swap logic below — skip it entirely.
-      if (
-        contractResult.value.custom_fields?.[
-          SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY
-        ]
-      ) {
-        logger.info(
-          { contractId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: subscription swap handled inline by caller, skipping"
-        );
-        break;
-      }
-
-      const targetPlan = await PlanModel.findOne({
-        where: { code: targetPlanCode },
-      });
-      if (!targetPlan) {
-        logger.info(
-          { contractId, targetPlanCode, workspaceId: workspace.sId },
-          `[Metronome Webhook] contract.start: ${PLAN_CODE_CUSTOM_FIELD_KEY} not found, leaving subscription alone`
-        );
-        break;
-      }
-
-      const activeSubscription =
-        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-
-      // Idempotency: re-deliveries land here with the active subscription
-      // already pointing at the new contract.
-      if (activeSubscription.metronomeContractId === contractId) {
-        logger.info(
-          { contractId, workspaceId: workspace.sId },
-          "[Metronome Webhook] contract.start: subscription already swapped, skipping"
-        );
-        break;
-      }
-
-      // Preferred path: a pending (created_backend_only) subscription was
-      // staged when the contract was provisioned. Flip it to active and
-      // end whatever active sub the workspace currently holds.
-      const pendingSubscription =
-        await SubscriptionResource.fetchByMetronomeContractId(
-          workspace,
-          contractId
-        );
-      if (
-        pendingSubscription &&
-        pendingSubscription.status === "created_backend_only"
-      ) {
-        const previousPlanCode = activeSubscription.getPlan().code;
-        // `activatePending` flushes the contract cache itself.
-        await pendingSubscription.activatePending();
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
-        await restoreWorkspaceAfterSubscription(auth);
-
-        await applyStampedLegacyCreditMigration({
-          auth,
-          workspace,
-          contract: contractResult.value,
-          metronomeCustomerId: customerId,
-          metronomeContractId: contractId,
-        });
-        await ensureWorkOSOrganizationForPaidPlan({
-          workspace: renderLightWorkspaceType({ workspace }),
-          planCode: targetPlan.code,
-          contractId,
-        });
-        emitSubscriptionChangedAuditEvent({
-          auth,
-          planCode: targetPlanCode,
-          previousPlanCode,
-          metronomeContractId: contractId,
-        });
-        logger.info(
-          {
-            contractId,
-            planCode: targetPlan.code,
-            workspaceId: workspace.sId,
-          },
-          "[Metronome Webhook] contract.start: pending subscription activated"
-        );
-        break;
-      }
-
-      // No pending row was staged (e.g. an immediate switch). Swap the active
-      // subscription onto the new contract regardless of its current billing
-      // rail — switchContract is used this way routinely. The ONLY contract we
-      // must NOT swap onto is a shadow contract: a Metronome contract that runs
-      // in parallel to a Stripe subscription with no billing-provider delivery
-      // (Stripe owns billing). That is a property of the contract itself — it has
-      // no `customer_billing_provider_configuration` — and only applies while the
-      // workspace is still Stripe-billed (so free / Metronome-only contracts,
-      // which also lack a delivery config, are not mistaken for shadows).
-      const startedContractIsShadow =
-        !contractResult.value.customer_billing_provider_configuration &&
-        !!activeSubscription.stripeSubscriptionId;
-      if (startedContractIsShadow) {
-        logger.info(
-          {
-            contractId,
-            targetPlanCode,
-            workspaceId: workspace.sId,
-          },
-          "[Metronome Webhook] contract.start: shadow contract started, leaving subscription alone (Stripe drives billing)"
-        );
-        break;
-      }
-
-      // End the current subscription as `ended_backend_only` and create
-      // a new active subscription on the target plan + new contract.
-      const legacyPreviousPlanCode = activeSubscription.getPlan().code;
-      // `swapMetronomeContract` flushes the contract cache itself.
-      await activeSubscription.swapMetronomeContract({
-        metronomeContractId: contractId,
-        planCode: targetPlan.code,
-      });
-
-      // Cancel any scheduled scrub workflow, unpause connectors, re-enable
-      // triggers. Idempotent — safe to call regardless of prior state.
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-      await restoreWorkspaceAfterSubscription(auth);
-
-      await applyStampedLegacyCreditMigration({
-        auth,
-        workspace,
-        contract: contractResult.value,
-        metronomeCustomerId: customerId,
-        metronomeContractId: contractId,
-      });
-
-      emitSubscriptionChangedAuditEvent({
-        auth,
-        planCode: targetPlan.code,
-        previousPlanCode: legacyPreviousPlanCode,
-        metronomeContractId: contractId,
-      });
-
-      await ensureWorkOSOrganizationForPaidPlan({
-        workspace: renderLightWorkspaceType({ workspace }),
-        planCode: targetPlan.code,
         contractId,
+        customerId,
       });
-
-      logger.info(
-        {
-          contractId,
-          planCode: targetPlan.code,
-          workspaceId: workspace.sId,
-        },
-        "[Metronome Webhook] contract.start: subscription upgraded"
-      );
-      break;
     }
 
     case "contract.end": {

--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -228,6 +228,9 @@ export const grantAwuCreditsPlugin = createPlugin({
         idempotencyKey,
         priority: AWU_PRIORITY_PURCHASED_COMMIT,
         applicableProductTags: ["usage"],
+        customFields: {
+          [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+        },
       });
 
       if (result.isErr()) {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -1,3 +1,5 @@
+import config from "@app/lib/api/config";
+import { applyContractStartSubscriptionSwap } from "@app/lib/api/metronome/process_webhook";
 import { cancelPendingContract } from "@app/lib/api/poke/cancel_pending_contract";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
@@ -53,6 +55,7 @@ import {
 } from "@app/lib/plans/stripe";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -906,6 +909,41 @@ async function stepPendingSubscription({
   }
 }
 
+// In environments without a Metronome webhook secret configured (e.g. local
+// dev), Metronome's `contract.start` event is never delivered, so an
+// immediate switch would otherwise leave the workspace with no Subscription
+// row at all — not even a pending one, since `stepPendingSubscription` only
+// stages one for future-dated starts. Replay the same transition
+// synchronously here instead. Production/staging always have the secret
+// configured and rely exclusively on the real webhook, since it also covers
+// re-deliveries and future-dated activations.
+async function stepImmediateSubscriptionSwapWithoutWebhook({
+  workspaceId,
+  metronomeCustomerId,
+  metronomeContractId,
+  alignedStart,
+}: PostProvisionCtx): Promise<string | null> {
+  if (config.getMetronomeWebhookSecret()) {
+    return null;
+  }
+  if (alignedStart.getTime() > Date.now()) {
+    return null;
+  }
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    return `dev_subscription_swap: workspace ${workspaceId} not found`;
+  }
+  const result = await applyContractStartSubscriptionSwap({
+    workspace,
+    contractId: metronomeContractId,
+    customerId: metronomeCustomerId,
+  });
+  if (result.isErr()) {
+    return `dev_subscription_swap: ${result.error.message}`;
+  }
+  return null;
+}
+
 // If the workspace is currently Stripe-billed, schedule the Stripe sub to
 // cancel at the swap moment so the two rails don't double-bill.
 // If the contract was backdated, alignedStart is already in the past and
@@ -1211,6 +1249,7 @@ export async function switchContract({
   warn(await stepSeatRemap(ctx));
   warn(await stepSeatSync(ctx));
   warn(await stepPendingSubscription(ctx));
+  warn(await stepImmediateSubscriptionSwapWithoutWebhook(ctx));
   warn(await stepStripeCancellation(ctx));
   warn(await stepScheduleContractEnd(ctx));
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2955,6 +2955,7 @@ export async function createMetronomeCredit({
   idempotencyKey,
   applicableProductTags,
   priority,
+  customFields,
 }: {
   metronomeCustomerId: string;
   productId: string;
@@ -2966,6 +2967,7 @@ export async function createMetronomeCredit({
   idempotencyKey: string;
   applicableProductTags?: string[];
   priority: number;
+  customFields?: Record<string, string>;
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(new Date(startingAt));
@@ -2980,6 +2982,7 @@ export async function createMetronomeCredit({
       ...(applicableProductTags
         ? { applicable_product_tags: applicableProductTags }
         : {}),
+      ...(customFields ? { custom_fields: customFields } : {}),
       access_schedule: {
         credit_type_id: creditTypeId,
         schedule_items: [

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -15,6 +15,8 @@ import {
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductFreeCreditId,
@@ -143,6 +145,9 @@ export async function createSeatCouponCredit({
   };
 
   if (metronomeContractId) {
+    // Seat-subscription discount, denominated in fiat (`creditTypeId` is a
+    // currency credit type, never AWU) — not part of the AWU pool balance,
+    // so it must not carry the DUST_CONTRACT_CREDIT_TYPE=pool stamp.
     const result = await addCreditToContract({
       ...sharedParams,
       metronomeContractId,
@@ -209,6 +214,9 @@ async function createPoolTopupCouponCredit({
       ...sharedParams,
       metronomeContractId,
       uniquenessKey: `coupon-credits-${redemptionId}-0`,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
     });
     if (result.isErr()) {
       return new Err(result.error);
@@ -219,6 +227,9 @@ async function createPoolTopupCouponCredit({
   const result = await createMetronomeCredit({
     ...sharedParams,
     idempotencyKey: `coupon-credits-${redemptionId}-0`,
+    customFields: {
+      [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+    },
   });
 
   if (result.isErr()) {

--- a/front/lib/metronome/renewal_carry_over.ts
+++ b/front/lib/metronome/renewal_carry_over.ts
@@ -7,6 +7,7 @@ import {
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   FOREVER_ENDING_BEFORE,
 } from "@app/lib/metronome/constants";
 import type {
@@ -178,7 +179,15 @@ export async function carryOverContractBalancesOnRenewal({
       uniquenessKey: `carry:${toContractId}:${commit.id}`,
       applicableProductIds: commit.applicable_product_ids,
       applicableProductTags: commit.applicable_product_tags,
-      customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry },
+      customFields: {
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry,
+        ...(commit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]
+          ? {
+              [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]:
+                commit.custom_fields[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY],
+            }
+          : {}),
+      },
     });
     if (regrant.isErr()) {
       return new Err(regrant.error);
@@ -214,7 +223,15 @@ export async function carryOverContractBalancesOnRenewal({
       name: credit.name ?? "Carried-over balance",
       uniquenessKey: `carry:${toContractId}:${credit.id}`,
       applicableProductTags: credit.applicable_product_tags,
-      customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry },
+      customFields: {
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry,
+        ...(credit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]
+          ? {
+              [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]:
+                credit.custom_fields[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY],
+            }
+          : {}),
+      },
     });
     if (regrant.isErr()) {
       return new Err(regrant.error);


### PR DESCRIPTION
## Description

In dev/local environments Metronome webhooks are never delivered (no `METRONOME_WEBHOOK_SECRET` / no reachable endpoint). Two consequences, fixed here:

**1. `switchContract` created no Subscription row at all for immediate switches.**
Subscription creation/swap for an immediate contract switch only happened in the `contract.start` webhook handler (`process_webhook.ts`). Without the webhook, `switchContract` provisioned the Metronome contract but left the workspace with zero local Subscription rows — not even a pending one.

Fix: extracted the `contract.start` handling into a standalone `applyContractStartSubscriptionSwap({ workspace, contractId, customerId })` (same idempotency/shadow-contract checks, no behavior change for the real webhook path). `switchContract` now calls it synchronously right after provisioning, but **only** when no Metronome webhook secret is configured and the switch is immediate (a future-dated switch still stages a pending row and waits for the real webhook). Production/staging always have the secret set and continue to rely exclusively on the webhook.

**2. Several AWU credit/commit grants depended on the webhook to retroactively stamp `DUST_CONTRACT_CREDIT_TYPE`.**
`credit.create`/`commit.create` (and related) webhook handlers stamp a `pool`/`excess` custom field used by balance alerts and pool-state reconciliation. Without the webhook, newly granted credits/commits stayed unstamped in dev. Since the one-time `add_commits`/`add_credits` (and `v1.customers.credits.create`) Metronome APIs already accept `custom_fields` at creation time, the following call sites now stamp directly instead of waiting on the webhook:
- Legacy credit migration (converted + bonus credits) — always `pool` (never the excess product).
- Coupon credits — the AWU pool top-up coupon stamps `pool`; the seat-subscription coupon credit (fiat-denominated, never AWU) is explicitly **not** stamped.
- Poke "Grant AWU credits" plugin, free-credit path (the paid/commit path already stamped at creation).
- Renewal carry-over (commit + credit regrants) — copies the `DUST_CONTRACT_CREDIT_TYPE` value forward from the source commit/credit rather than reclassifying it, so it works regardless of pool/excess/unstamped.

Excess credits are auto-created by Metronome package templates (never explicitly granted by our code), so they're out of scope here and still rely on the webhook — not carried over on renewal either, so this doesn't affect them.

## Tests

- `npx tsgo --noEmit` clean.
- `biome check` clean on all changed files.
- Existing Vitest suites pass unchanged: `process_webhook.test.ts` (25), `coupons.test.ts` (37), `client.test.ts` (22), `renewal_carry_over.test.ts` (8).
- Manually reasoned through each webhook consumer (`lib/metronome/alerts/balance_threshold.ts`, `lib/api/credits/awu_pool_summary.ts`) to confirm the `pool` stamp is always combined with an explicit AWU `credit_type_id` filter downstream, so no behavior change for non-AWU credits.

## Risk

Low.
- The `switchContract` change is gated on the absence of a webhook secret, so prod/staging (which always have it configured) are unaffected — behavior there is unchanged, still driven exclusively by the real `contract.start` webhook.
- The stamping changes are purely additive (`custom_fields` passed at creation); the webhook's own stamping logic is unchanged and still re-checks/no-ops if already stamped, so webhook re-delivery remains safe.
- Rollback is a straight revert — no data migration involved.

## Deploy Plan

Standard deploy, no feature flag, no migration.