### PR TITLE
[front] enh: cache equipped skills prefix for OpenAI

### DIFF
--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -32,7 +32,10 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
-import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/model_ids";
+import {
+  isModel,
+  supportsOpenAIExplicitPromptCaching,
+} from "@app/lib/model_constructors/types/models";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -107,9 +110,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
-        cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
-          this.modelId
-        ),
+        cacheBreakpointOnLeadingMessage:
+          isModel(this.modelId) &&
+          supportsOpenAIExplicitPromptCaching(this.modelId),
       }),
       temperature: this.temperature ?? undefined,
       reasoning,

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -32,6 +32,7 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
+import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/model_ids";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -105,7 +106,11 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
 
     return {
       model: this.modelId,
-      input: toInput(promptText, conversation),
+      input: toInput(promptText, conversation, "developer", {
+        cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
+          this.modelId
+        ),
+      }),
       temperature: this.temperature ?? undefined,
       reasoning,
       tools: specifications.map(toTool),

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -290,8 +290,8 @@ export function toBaseMessages(
   }
 }
 
-// Places the Anthropic user-message cache breakpoints, matching the legacy
-// router. Returns a new array; does not mutate its input.
+// Places provider user-message cache breakpoints at the same boundaries as the
+// legacy Anthropic router. Returns a new array; does not mutate its input.
 //   - Equipped-skills prefix: always. When the first message is the
 //     `name: "system"` user block (the stable per agent+workspace skills list),
 //     its last content block is cached for cross-conversation reuse. Mirrors the

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -112,11 +112,21 @@ function toAssistantInputItem(
 }
 
 function toUserInputMessage(
-  message: UserMessageTypeModel
+  message: UserMessageTypeModel,
+  { cacheBreakpoint }: { cacheBreakpoint: boolean }
 ): ResponseInputItem.Message {
+  const lastContentIndex = message.content.length - 1;
   return {
     role: "user",
-    content: message.content.map(toInputContent),
+    content: message.content.map((content, index) => {
+      const inputContent = toInputContent(content);
+      return cacheBreakpoint && index === lastContentIndex
+        ? {
+            ...inputContent,
+            prompt_cache_breakpoint: { mode: "explicit" },
+          }
+        : inputContent;
+    }),
   };
 }
 
@@ -137,7 +147,8 @@ function toToolCallOutputItem(
 export function toInput(
   prompt: string,
   conversation: ModelConversationTypeMultiActions,
-  promptRole: "system" | "developer" = "developer"
+  promptRole: "system" | "developer" = "developer",
+  { cacheBreakpointOnLeadingMessage = false } = {}
 ): ResponseInput {
   const inputs: ResponseInput = [];
   inputs.push({
@@ -145,10 +156,17 @@ export function toInput(
     content: [{ type: "input_text", text: prompt }],
   });
 
-  for (const message of conversation.messages) {
+  for (const [index, message] of conversation.messages.entries()) {
     switch (message.role) {
       case "user":
-        inputs.push(toUserInputMessage(message));
+        inputs.push(
+          toUserInputMessage(message, {
+            cacheBreakpoint:
+              cacheBreakpointOnLeadingMessage &&
+              index === 0 &&
+              message.name === "system",
+          })
+        );
         break;
       case "assistant":
         const assistantItems = compact(

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -44,5 +44,39 @@ describe("toInput", () => {
         ],
       });
     });
+
+    it("does not add a cache breakpoint to a regular leading user message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        { messages: conversationMessages },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages).toEqual(inputMessages);
+    });
+
+    it("does not add a cache breakpoint to a non-leading skills message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        {
+          messages: [
+            ...conversationMessages,
+            {
+              role: "user",
+              name: "system",
+              content: [{ type: "text", text: "Available skills" }],
+            },
+          ],
+        },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages.at(-1)).toEqual({
+        role: "user",
+        content: [{ type: "input_text", text: "Available skills" }],
+      });
+    });
   });
 });

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -11,5 +11,38 @@ describe("toInput", () => {
 
       expect(messages).toEqual(inputMessages);
     });
+
+    it("adds a cache breakpoint to the leading equipped-skills message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        {
+          messages: [
+            {
+              role: "user",
+              name: "system",
+              content: [
+                { type: "text", text: "Available" },
+                { type: "text", text: "skills" },
+              ],
+            },
+            ...conversationMessages,
+          ],
+        },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages[1]).toEqual({
+        role: "user",
+        content: [
+          { type: "input_text", text: "Available" },
+          {
+            type: "input_text",
+            text: "skills",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      });
+    });
   });
 });

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -18,6 +18,7 @@ import {
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import { toToolChoiceInput } from "@app/lib/model_constructors/types/input/configuration";
 import type {
+  BaseUserTextMessage,
   Payload,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
@@ -39,7 +40,8 @@ export function WithOpenAIResponsesInputConverter<
     implements MessageItemConverters
   {
     systemMessageToInputItem = systemMessageToInputItem;
-    userTextMessageToInputItem = userTextMessageToInputItem;
+    userTextMessageToInputItem = (message: BaseUserTextMessage) =>
+      userTextMessageToInputItem(message, this.metadata());
     userImageMessageToInputItem = userImageMessageToInputItem;
     toolCallResultMessageToInputItem = toolCallResultMessageToInputItem;
     assistantTextMessageToInputItem = assistantTextMessageToInputItem;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -9,10 +9,7 @@ import type {
   BaseAssistantTextMessage,
   BaseUserTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
-import {
-  GPT_5_4,
-  GPT_5_6_SOL,
-} from "@app/lib/model_constructors/types/models";
+import { GPT_5_4, GPT_5_6_SOL } from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("assistantTextMessageToInputItem", () => {
@@ -73,6 +70,15 @@ describe("prompt cache breakpoints", () => {
   it("does not serialize a cache marker for older models", () => {
     expect(
       userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })
+    ).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "Available skills" }],
+    });
+  });
+
+  it("does not serialize a cache marker when the message has not opted in", () => {
+    expect(
+      userTextMessageToInputItem({ ...message, cache: undefined }, metadata)
     ).toEqual({
       role: "user",
       content: [{ type: "input_text", text: "Available skills" }],

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -1,11 +1,18 @@
 import {
   assistantReasoningMessageToInputItems,
   assistantTextMessageToInputItem,
+  userTextMessageToInputItem,
 } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   BaseAssistantReasoningMessage,
   BaseAssistantTextMessage,
+  BaseUserTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import {
+  GPT_5_4,
+  GPT_5_6_SOL,
+} from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("assistantTextMessageToInputItem", () => {
@@ -32,6 +39,43 @@ describe("assistantTextMessageToInputItem", () => {
     expect(assistantTextMessageToInputItem(message)).toEqual({
       role: "assistant",
       content: "no phase here",
+    });
+  });
+});
+
+describe("prompt cache breakpoints", () => {
+  const message: BaseUserTextMessage = {
+    role: "user",
+    type: "text",
+    content: { value: "Available skills" },
+    cache: "short",
+  };
+  const metadata: EndpointMetadata = {
+    lab: "openai",
+    host: "openai-responses",
+    region: "us",
+    model: GPT_5_6_SOL,
+  };
+
+  it("serializes a cache marker when explicit prompt caching is supported", () => {
+    expect(userTextMessageToInputItem(message, metadata)).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "Available skills",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+      ],
+    });
+  });
+
+  it("does not serialize a cache marker for older models", () => {
+    expect(
+      userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })
+    ).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "Available skills" }],
     });
   });
 });

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -1,3 +1,4 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   OutputFormat,
   Reasoning,
@@ -16,6 +17,7 @@ import type {
   BaseUserTextMessage,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   FunctionTool,
@@ -59,11 +61,21 @@ export function systemMessageToInputItem(
 }
 
 export function userTextMessageToInputItem(
-  message: BaseUserTextMessage
+  message: BaseUserTextMessage,
+  metadata: EndpointMetadata
 ): ResponseInputItem {
   return {
     role: "user",
-    content: [{ type: "input_text", text: message.content.value }],
+    content: [
+      {
+        type: "input_text",
+        text: message.content.value,
+        // OpenAI uses the request-wide TTL; the message cache value opts this block in.
+        ...(message.cache && supportsOpenAIExplicitPromptCaching(metadata.model)
+          ? { prompt_cache_breakpoint: { mode: "explicit" } }
+          : {}),
+      },
+    ],
   };
 }
 

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -86,6 +86,18 @@ export function isModel(value: string): value is Model {
   return (MODELS as readonly string[]).includes(value);
 }
 
+// Older models reject explicit prompt cache breakpoints.
+// https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
+  GPT_5_6_SOL,
+  GPT_5_6_TERRA,
+  GPT_5_6_LUNA,
+];
+
+export function supportsOpenAIExplicitPromptCaching(model: Model): boolean {
+  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.includes(model);
+}
+
 export const ORDERED_LARGE_MODELS = [
   CLAUDE_FABLE_5,
   CLAUDE_OPUS_4_8,


### PR DESCRIPTION
## Description

Goal is to cache the stable equipped-skills prefix separately from the changing conversation tail for OpenAI, matching the existing Anthropic behavior.

The legacy and new-router OpenAI Responses request builders now add an explicit `prompt_cache_breakpoint` to the last content block of the leading `name: "system"` user message for GPT-5.6 models. Older OpenAI models keep their existing automatic prompt caching behavior because they do not support explicit breakpoints; prompt cache keys and implicit tail caching are unchanged.

## Tests

- Added focused coverage for breakpoint placement and GPT-5.6 model gating.

## Risk

- Low. Scoped to GPT-5.6 OpenAI Responses request construction.

## Deploy Plan

- Deploy front.