### PR TITLE
feat(front): redesign agent builder model selection dropdown

### DIFF
--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -10,6 +10,7 @@ import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import {
   Button,
+  Chip,
   cn,
   Dialog,
   DialogContainer,
@@ -21,6 +22,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   File04,
   SliderToggle,
@@ -129,18 +132,26 @@ export function AdvancedSettings() {
           <Button label="Advanced" variant="outline" size="sm" isSelect />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
+          <DropdownMenuLabel label="Model selection" />
           {autoModel && (
-            <DropdownMenuItem
-              label="Auto"
-              description="Select the best model for the task."
-              onClick={handleAutoModelSelection}
-              endComponent={
+            <DropdownMenuItem onClick={handleAutoModelSelection}>
+              <div className="flex w-full items-center gap-x-2.5">
+                <div className="flex grow flex-col">
+                  <span className="flex items-center gap-2">
+                    Auto
+                    <Chip size="xs" color="highlight" label="Recommended" />
+                  </span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    Switches model depending on current availability for
+                    balanced performance.
+                  </span>
+                </div>
                 <SliderToggle
                   selected={isAutoModelSelected}
                   onClick={handleAutoModelSelection}
                 />
-              }
-            ></DropdownMenuItem>
+              </div>
+            </DropdownMenuItem>
           )}
 
           {!isAutoModelSelected && (
@@ -151,15 +162,18 @@ export function AdvancedSettings() {
           )}
 
           {supportsResponseFormat && (
-            <DropdownMenuItem
-              label="Structured Response Format"
-              onSelect={() => {
-                setTimeout(() => {
-                  setTempResponseFormat(responseFormatField.value ?? null);
-                  setIsResponseFormatDialogOpen(true);
-                }, 0);
-              }}
-            />
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                label="Structured response format"
+                onSelect={() => {
+                  setTimeout(() => {
+                    setTempResponseFormat(responseFormatField.value ?? null);
+                    setIsResponseFormatDialogOpen(true);
+                  }, 0);
+                }}
+              />
+            </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -58,6 +58,11 @@ function ModelRadioItem({
       }
       label={modelConfig.displayName}
       disabled={!modelConfig.isSelectable}
+      onSelect={(e) => {
+        // Keep the dropdown open after picking a model so the user can adjust
+        // reasoning effort or other settings without reopening it.
+        e.preventDefault();
+      }}
       onClick={() => {
         onModelSelection(modelConfig);
       }}
@@ -124,7 +129,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger label="Model selection" />
+      <DropdownMenuSubTrigger label="Custom model" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
           {showSelectedModelSection && selectedModel && (

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -88,7 +88,7 @@ export function ReasoningEffortSubmenu({
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger label="Reasoning effort" />
+      <DropdownMenuSubTrigger label="Custom reasoning effort" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
           <DropdownMenuLabel label="Select reasoning effort" />

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -9,6 +9,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   createContext,
@@ -17,6 +18,44 @@ import {
   useMemo,
   useState,
 } from "react";
+
+const STICKY_MODEL_OVERRIDE_STORAGE_KEY = "inputBarModelOverride_v1";
+
+function readStickyModelOverride(): ModelSelectionType | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    const raw = window.sessionStorage.getItem(
+      STICKY_MODEL_OVERRIDE_STORAGE_KEY
+    );
+    if (!raw) {
+      return undefined;
+    }
+    const parsed = ModelSelectionSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStickyModelOverride(selection: ModelSelectionType | undefined) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (selection === undefined) {
+      window.sessionStorage.removeItem(STICKY_MODEL_OVERRIDE_STORAGE_KEY);
+    } else {
+      window.sessionStorage.setItem(
+        STICKY_MODEL_OVERRIDE_STORAGE_KEY,
+        JSON.stringify(selection)
+      );
+    }
+  } catch {
+    // Best-effort write only.
+  }
+}
 
 /** Payload for the first message when creation is deferred until after navigation. */
 export type PendingConversationMessage = {
@@ -60,6 +99,8 @@ export const InputBarContext = createContext<{
   clearPendingFirstMessage: (conversationId: string) => void;
   isLoadingGoTemplate: boolean;
   setIsLoadingGoTemplate: (loading: boolean) => void;
+  stickyModelOverride: ModelSelectionType | undefined;
+  setStickyModelOverride: (selection: ModelSelectionType | undefined) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
   // Fired right before submit; the extension uses it to snapshot browser tab state.
@@ -78,6 +119,8 @@ export const InputBarContext = createContext<{
   clearPendingFirstMessage: () => {},
   isLoadingGoTemplate: false,
   setIsLoadingGoTemplate: () => {},
+  stickyModelOverride: undefined,
+  setStickyModelOverride: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -119,6 +162,20 @@ export function InputBarContextProvider({
   const [pendingInputText, setPendingInputTextState] =
     useState<PendingInputText | null>(null);
   const [isLoadingGoTemplate, setIsLoadingGoTemplate] = useState(false);
+
+  // Sticky model-picker override, hydrated from sessionStorage on mount and
+  // written through on every change so it survives reloads within the tab.
+  const [stickyModelOverride, setStickyModelOverrideState] = useState<
+    ModelSelectionType | undefined
+  >(() => readStickyModelOverride());
+
+  const setStickyModelOverride = useCallback(
+    (selection: ModelSelectionType | undefined) => {
+      writeStickyModelOverride(selection);
+      setStickyModelOverrideState(selection);
+    },
+    []
+  );
 
   // First message stashed while navigating to a newly-created conversation (deferred-send flow).
   const [
@@ -205,6 +262,8 @@ export function InputBarContextProvider({
       clearPendingFirstMessage,
       isLoadingGoTemplate,
       setIsLoadingGoTemplate,
+      stickyModelOverride,
+      setStickyModelOverride,
       captureActions,
       fileUploaderService,
       onBeforeSubmit,
@@ -220,6 +279,8 @@ export function InputBarContextProvider({
       setPendingFirstMessage,
       clearPendingFirstMessage,
       isLoadingGoTemplate,
+      stickyModelOverride,
+      setStickyModelOverride,
       captureActions,
       fileUploaderService,
       onBeforeSubmit,

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -1,3 +1,4 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { ModelPickerContent } from "@app/components/assistant/conversation/input_bar/ModelPickerContent";
 import type {
   MakerGroup,
@@ -37,7 +38,7 @@ import type {
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, DropdownMenu, DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 interface InputBarModelPickerProps {
   agentModel: AgentModelConfigurationType | null;
@@ -65,6 +66,8 @@ export function InputBarModelPicker({
 }: InputBarModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
+  const { stickyModelOverride, setStickyModelOverride } =
+    useContext(InputBarContext);
   const { isDark } = useTheme();
   const isMobile = useIsMobile();
   const clientType = useClientType();
@@ -95,11 +98,13 @@ export function InputBarModelPicker({
       selection.effort === agentModel?.reasoningEffort;
 
     if ((isSelectionAuto && isDefaultAuto) || isSelectionSameModelAsAgent) {
-      // show default
+      // show default and clear override
       setUserOverride(null);
+      setStickyModelOverride(undefined);
       return;
     }
     setUserOverride(selection);
+    setStickyModelOverride(selection.toSend);
   };
 
   // Clear the manual override when the user switches which agent they address
@@ -116,8 +121,14 @@ export function InputBarModelPicker({
   });
 
   const defaultSelection = useMemo(
-    () => resolveDefaultSelection({ agentModel, lastRequestedModel, models }),
-    [agentModel, lastRequestedModel, models]
+    () =>
+      resolveDefaultSelection({
+        agentModel,
+        lastRequestedModel,
+        sessionSticky: stickyModelOverride,
+        models,
+      }),
+    [agentModel, lastRequestedModel, stickyModelOverride, models]
   );
 
   const shown: Selection = userOverride ?? defaultSelection;

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -186,31 +186,51 @@ function findAgentModel(
   );
 }
 
+function resolveRequestedSelection(
+  models: ModelConfigurationType[],
+  selection: ModelSelectionType | null | undefined
+): Selection | null {
+  const requestedModel = selection
+    ? findAvailableModel(models, selection)
+    : undefined;
+  if (!requestedModel) {
+    return null;
+  }
+  if (requestedModel.modelId === AUTO_MODEL_ID) {
+    return { kind: "auto", toSend: AUTO_MODEL_SELECTION };
+  }
+  const effort =
+    selection?.reasoningEffort ?? requestedModel.defaultReasoningEffort;
+  return {
+    kind: "model",
+    model: requestedModel,
+    effort,
+    toSend: buildModelSelection(requestedModel, effort),
+  };
+}
+
 export function resolveDefaultSelection({
   agentModel,
   lastRequestedModel,
+  sessionSticky,
   models,
 }: {
   agentModel: AgentModelConfigurationType | null;
   lastRequestedModel: ModelSelectionType | null;
+  sessionSticky?: ModelSelectionType | null;
   models: ModelConfigurationType[];
 }): Selection {
-  const requestedModel = lastRequestedModel
-    ? findAvailableModel(models, lastRequestedModel)
-    : undefined;
-  if (requestedModel) {
-    if (requestedModel.modelId === AUTO_MODEL_ID) {
-      return { kind: "auto", toSend: AUTO_MODEL_SELECTION };
-    }
-    const effort =
-      lastRequestedModel?.reasoningEffort ??
-      requestedModel.defaultReasoningEffort;
-    return {
-      kind: "model",
-      model: requestedModel,
-      effort,
-      toSend: buildModelSelection(requestedModel, effort),
-    };
+  const fromLastRequested = resolveRequestedSelection(
+    models,
+    lastRequestedModel
+  );
+  if (fromLastRequested) {
+    return fromLastRequested;
+  }
+
+  const fromSticky = resolveRequestedSelection(models, sessionSticky);
+  if (fromSticky) {
+    return fromSticky;
   }
 
   const agentDefaultModel = agentModel


### PR DESCRIPTION
## Description
<img width="1464" height="626" alt="Screenshot 2026-07-20 at 15 20 14" src="https://github.com/user-attachments/assets/943bce33-8e39-4192-b0fb-35194bef0d99" />

Redesigns the "Advanced" model settings dropdown in the agent builder instructions block, because it was a bit unclear when you opened advanced and you had only "Auto : toggle" + the description of the toggle was a bit misleading

- Adds a **Model selection** section header at the top of the dropdown.
- Turns the **Auto** option's "Recommended" label into a highlight `Chip` displayed next to the label, and rewords the description to "Switches model depending on current availability for balanced performance."
- Renames the submenu triggers to **Custom model** and **Custom reasoning effort**, and adds a separator before the **Structured response format** entry.
- Picking a model in the Custom model submenu no longer closes the dropdown (`onSelect` `preventDefault`), so users can keep adjusting reasoning effort and other settings without reopening it.

Pure UI change, no behavior change to how model settings are persisted.

## Tests

Manually verified in the agent builder: Auto toggle, custom model selection (dropdown stays open), reasoning effort selection, and structured response format dialog.
