### PR TITLE
Separate code and text preview categories

### DIFF
--- a/front/components/file_explorer/FilePreviewContent.tsx
+++ b/front/components/file_explorer/FilePreviewContent.tsx
@@ -202,7 +202,10 @@ export function useFilePreviewContent({
   const { category } = getFilePreviewConfig(mimeType);
 
   const needsTextContent =
-    category === "code" || category === "markdown" || category === "delimited";
+    category === "code" ||
+    category === "text" ||
+    category === "markdown" ||
+    category === "delimited";
 
   const { fileContent, isNotFound, isFileContentLoading, fileContentError } =
     useFileContentByUrl({
@@ -345,7 +348,8 @@ export function FilePreviewContent({
       }
       return null;
 
-    case "code": {
+    case "code":
+    case "text": {
       const lang = getCodeLanguage(entry.fileName);
       const raw = fileContent?.slice(0, MAX_TEXT_CHARS) ?? "";
       let displayContent = raw;

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getCategoryFromContentType,
   getChildrenAtFolderPath,
   getExplorerRelativePath,
+  getFileExplorerBucket,
   getFileExplorerSearchResultTitle,
   getFilePreviewConfig,
   getVirtualScopeRootNodes,
@@ -99,6 +100,42 @@ describe("file preview configuration", () => {
   ])("keeps %s previewable", (contentType) => {
     expect(getFilePreviewConfig(contentType).category).not.toBe("unsupported");
     expect(isFilePreviewableContentType(contentType)).toBe(true);
+  });
+
+  it.each([
+    "text/javascript",
+    "application/javascript",
+    "text/typescript",
+  ])("classifies %s as code", (contentType) => {
+    expect(getFilePreviewConfig(contentType).category).toBe("code");
+  });
+
+  it.each([
+    "text/plain",
+    "text/x-diff",
+    "application/json",
+    "application/problem+json",
+  ])("classifies %s as text", (contentType) => {
+    expect(getFilePreviewConfig(contentType).category).toBe("text");
+  });
+
+  it("keeps code and text in separate explorer filters", () => {
+    const node: FileSystemTreeNode = {
+      name: "file",
+      path: "file",
+      isDirectory: false,
+      contentType: "text/javascript",
+      fileId: "file-1",
+      children: [],
+    };
+
+    expect(getFileExplorerBucket(node)).toBe("code");
+    expect(
+      getFileExplorerBucket({
+        ...node,
+        contentType: "text/plain",
+      })
+    ).toBe("texts");
   });
 });
 

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -19,10 +19,13 @@ const VIEWER_CONTENT_TYPES = new Set<string>([
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ]);
 
-const TEXT_PREVIEW_CONTENT_TYPES = new Set<string>([
+const CODE_PREVIEW_CONTENT_TYPES = new Set<string>([
   "application/javascript",
-  "application/json",
   "application/typescript",
+]);
+
+const TEXT_PREVIEW_CONTENT_TYPES = new Set<string>([
+  "application/json",
   "application/vnd.dust.section.json",
   "application/x-ndjson",
   "application/xml",
@@ -37,6 +40,7 @@ function isViewerCompatible(contentType: string): boolean {
 export type FilePreviewCategory =
   | "frame"
   | "code"
+  | "text"
   | "pdf"
   | "viewer"
   | "audio"
@@ -106,10 +110,19 @@ export function getFilePreviewConfig(
   if (
     category === "code" ||
     isSandboxFunctionContentType(contentType) ||
-    isTextPreviewContentType(contentType)
+    CODE_PREVIEW_CONTENT_TYPES.has(contentType)
   ) {
     return {
       category: "code",
+      needsProcessedVersion: false,
+      supportsExternalViewer: false,
+      supportsCopyContent: true,
+    };
+  }
+
+  if (isTextPreviewContentType(contentType)) {
+    return {
+      category: "text",
       needsProcessedVersion: false,
       supportsExternalViewer: false,
       supportsCopyContent: true,
@@ -215,6 +228,9 @@ export function getFileExplorerBucket(
 
     case "code":
       return "code";
+
+    case "text":
+      return "texts";
 
     case "delimited":
       return "tables";
@@ -345,6 +361,7 @@ export function getCategoryFromContentType(
     case "delimited":
       return "table";
     case "code":
+    case "text":
     case "viewer":
     case "markdown":
       return "document";


### PR DESCRIPTION
## Description

Split code and text preview categories on top of #29161. Text files keep the existing raw-content renderer but now appear under the Texts filter instead of Code.

## Tests

Added focused coverage for JavaScript, plain text, JSON, structured JSON, and explorer filter classification.

## Risk

Low. Preview rendering is unchanged; only the internal category and explorer filter differ.

## Deploy Plan

Merge after #29161, then standard deploy.