### PR TITLE
Add heartbeats for temporal activity

### DIFF
--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -41,6 +41,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
+import { heartbeat } from "@app/lib/temporal";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
@@ -681,6 +682,7 @@ export async function reconcileWorkspaceUserCreditStates({
         "[ReconcileCreditState] Failed to reconcile a user's credit state"
       );
     }
+    await heartbeat();
   }
 }
 

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -15,6 +15,7 @@ import {
 import { isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { heartbeat } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -104,6 +105,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     },
     "[SeatSync] stagePendingContractSeats done"
   );
+  await heartbeat();
 
   const activeContract = activeSubscription?.metronomeContractId
     ? await getActiveContract(workspace.sId)
@@ -152,6 +154,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     return new Err(result.error);
   }
   const activeContractSummary = result.value;
+  await heartbeat();
 
   // Single-user scope: reconcile just this user from the live balances now that
   // their seat credits are assigned. Skips the whole-workspace reconcile and the
@@ -205,6 +208,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     { workspaceId, durationMs: Date.now() - reconcileStartedAt },
     "[SeatSync] reconcileWorkspaceUserCreditStates done"
   );
+  await heartbeat();
 
   // Ensure per-seat-type cap alerts exist with the current default pool limit.
   // Best-effort: a failure here must not fail the seat sync.
@@ -309,6 +313,7 @@ async function stagePendingContractSeats({
     },
     "[SeatSync] remapMembershipSeatTypesForContract done"
   );
+  await heartbeat();
   if (remapResult.isErr()) {
     logger.warn(
       { workspaceId, err: remapResult.error.message },

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -46,6 +46,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { heartbeat } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   bestEffortInvalidateCacheWithRedis,
@@ -646,6 +647,8 @@ export async function remapMembershipSeatTypesForContract({
         author: "no-author",
       });
     }
+
+    await heartbeat();
   }
 
   return new Ok(undefined);
@@ -753,6 +756,7 @@ async function grantFreeSeatCredits({
           "[Metronome] Failed to grant free seat credit"
         );
       }
+      await heartbeat();
     },
     { concurrency: 4 }
   );
@@ -784,6 +788,7 @@ async function grantFreeSeatCredits({
           "[Metronome] Failed to upsert per-user free credit alerts"
         );
       }
+      await heartbeat();
     },
     { concurrency: 4 }
   );
@@ -860,6 +865,7 @@ async function revokeFreeSeatCreditsForExFreeUsers({
           "[Metronome] Failed to clear ex-free-seat credit alerts"
         );
       }
+      await heartbeat();
     },
     { concurrency: 4 }
   );
@@ -1152,6 +1158,7 @@ async function emptyOriginSeatCreditsForTransfers({
   >();
   const emptied: SeatCreditTransfer[] = [];
   for (const t of transfers) {
+    await heartbeat();
     const recurringCreditId = recurringCreditIdBySeatType.get(t.oldSeatType);
     if (!recurringCreditId) {
       logger.warn(
@@ -1259,6 +1266,10 @@ async function carryConsumptionToNewSeatCredits({
     { creditId: string; segmentId: string; segmentStartingAt: string } | null
   >();
   for (const t of transfers) {
+    // Heartbeat at the top of the loop so every iteration is covered
+    // regardless of which `continue` branch below it takes — a bulk seat-type
+    // change can carry over many users' consumption in one sync.
+    await heartbeat();
     const recurringCreditId = recurringCreditIdBySeatType.get(t.newSeatType);
     const targetAllocation = allocationBySeatType.get(t.newSeatType);
     if (!recurringCreditId || targetAllocation === undefined) {
@@ -1857,6 +1868,7 @@ export async function syncSeatCount({
             },
             "[Metronome] reconcileSeatBasedSegment call done"
           );
+          await heartbeat();
           if (result.isErr()) {
             return new Err(result.error);
           }
@@ -1908,6 +1920,7 @@ export async function syncSeatCount({
             quantity,
             startingAt: segmentStartingAt,
           });
+          await heartbeat();
           if (updateResult.isErr()) {
             return new Err(updateResult.error);
           }

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -1,3 +1,4 @@
+import { Context } from "@temporalio/activity";
 import type {
   ConnectionOptions,
   WorkflowClientInterceptor,
@@ -163,4 +164,19 @@ export async function checkRunningUpsertWorkflows({
   }
 
   return count;
+}
+
+// This function allows to heartbeat back to the temporal workflow, but also
+// awaits a temporal sleep(0), which allows to throw an exception if the activity should be cancelled.
+export async function heartbeat() {
+  try {
+    Context.current();
+  } catch (_error) {
+    // If we're not in a temporal context, Context.current() will throw
+    // In this case, we just return without doing anything
+    // This allows the function to be called safely outside of temporal activities
+    return;
+  }
+  Context.current().heartbeat();
+  await Context.current().sleep(0);
 }

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -33,6 +33,7 @@ const { emitMetronomeUsageEventsActivity } = proxyActivities<typeof activities>(
 
 const { syncMetronomeSeatCountActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "1 minute",
 });
 
 const { reconcileApiKeyCreditStateActivity } = proxyActivities<

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -196,6 +196,7 @@ vi.mock("@app/lib/api/internal_fetch", () => ({
 
 // Mock Temporal - must be at module level
 vi.mock("@app/lib/temporal", () => ({
+  heartbeat: vi.fn().mockResolvedValue(undefined),
   getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
     schedule: {
       getHandle: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Description

`syncMetronomeSeatCountWorkflow` got permanently stuck retrying a `syncMetronomeSeatCountActivity` `StartToCloseTimeout` with zero Datadog signal: the activity's code only logs `"Activity failed"` when the activity function itself throws, but a server-side StartToClose timeout is enforced by Temporal without ever notifying the running worker code — so it never threw, never logged, and kept running orphaned in the background while Temporal silently retried a new attempt.

Adds heartbeating (via a guarded `heartbeat()` helper in `lib/temporal.ts`, ported from connectors' `src/lib/temporal.ts` — safe to call outside a Temporal activity context, where it's a no-op) at every loop/checkpoint in `syncMetronomeSeatCountActivity`'s call chain whose duration scales with workspace size: the seat reconcile loop, free-seat grant/revoke, seat-credit transfers, bulk membership remaps, and per-member credit-state reconciliation. Paired with `heartbeatTimeout: "1 minute"` on the activity's Temporal proxy config, this lets Temporal detect and cancel a stalled attempt within ~1 minute instead of only via the coarse 10-minute `startToCloseTimeout` — and because the helper's cancellation checkpoint (`Context.current().sleep(0)`) surfaces that cancellation as a normal thrown error, it now gets caught and logged as `"Activity failed"` by the existing `ActivityInboundLogInterceptor`, which is what the Datadog "Activity Failure" monitor and the "Stuck front-worker" dashboard already key off.

## Tests

Existing unit tests in `seats.test.ts`, `seats_sync.test.ts`, and `reconcile_credit_state.test.ts` cover the touched functions. Added the missing `heartbeat` export to the global `@app/lib/temporal` mock in `vite.setup.ts` (it fully replaces the module, so the new export was coming back `undefined` and failing 7 tests).

## Risk

Low. `heartbeat()` no-ops outside an activity context, so all non-Temporal callers of this shared seat-sync code (poke plugin, membership hooks, checkout flow) are unaffected. Inside the activity, the only behavior change is that a genuinely stalled attempt now gets cancelled after ~1 minute of no progress instead of running silently for up to 10 minutes.