### PR TITLE
Add bounded checkpoint pruning fallback

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -1,4 +1,7 @@
-import { CheckpointedConversationWindowState } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
+import {
+  CheckpointedConversationWindowState,
+  MINIMUM_PRUNING_BATCH_TOKENS,
+} from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
 import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
 import { describe, expect, it } from "vitest";
@@ -193,6 +196,64 @@ describe("CheckpointedConversationWindowState", () => {
     expect(isPruned(results[0].content)).toBe(true);
     expect(isPruned(results[1].content)).toBe(true);
     expect(results[2].content).toBe("third_result");
+  });
+
+  it("accepts a smaller batch when it restores fit at the nominal budget", () => {
+    const state = makeState({
+      pruningBudget: 10_000,
+      budgetForInteractions: 20_000,
+    });
+
+    state.append(
+      interaction([
+        userMessage("question", 15_000),
+        assistantMessage("call_tool"),
+        // Pruning retains a 24-token placeholder, so this yields exactly the minimum savings.
+        functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24),
+        assistantMessage("answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(true);
+  });
+
+  it("keeps a smaller batch intact below the minimum", () => {
+    const state = makeState({
+      pruningBudget: 10_000,
+      budgetForInteractions: 20_000,
+    });
+
+    state.append(
+      interaction([
+        userMessage("question", 15_000),
+        assistantMessage("call_tool"),
+        functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24 - 1),
+        assistantMessage("answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(false);
+  });
+
+  it("keeps a smaller batch intact when pruning it cannot restore fit", () => {
+    const state = makeState({
+      pruningBudget: 10_000,
+      budgetForInteractions: 20_000,
+    });
+
+    state.append(
+      interaction([
+        userMessage("question", 21_000),
+        assistantMessage("call_tool"),
+        functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 1_000 + 24),
+        assistantMessage("answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(false);
   });
 
   it("replays the same pruning frontier when the conversation grows", () => {

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -44,6 +44,8 @@ type WindowInteraction = {
   messages: WindowMessageNode[];
 };
 
+export const MINIMUM_PRUNING_BATCH_TOKENS = 5_000;
+
 function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
   if (message.role === "function") {
     return {
@@ -60,10 +62,11 @@ function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
  * Builds a model-facing conversation without ever removing an interaction.
  *
  * Tool results become eligible only after a later assistant message has consumed their complete
- * batch. Cleanup runs at model-input checkpoints and waits until a full token checkpoint can be
- * reclaimed. It then attempts to return one checkpoint below the soft limit. This keeps the
- * pruning frontier stable across the model calls within a long interaction and reduces how often
- * the provider cache frontier moves.
+ * batch. Cleanup runs at model-input checkpoints and normally waits until the preferred 20k token
+ * checkpoint can be reclaimed. If the nominal hard budget is crossed, it may accept a smaller
+ * batch of at least 5k when pruning that complete batch restores fit. This keeps the pruning
+ * frontier stable during normal growth without ignoring a meaningful final batch under pressure.
+ * Preferred batches attempt to return one checkpoint below the soft limit.
  *
  * If tool-result pruning cannot keep the complete interaction history below the nominal budget,
  * the window keeps serving it and reports the excess through logs and metrics. The provider limit
@@ -197,17 +200,25 @@ export class CheckpointedConversationWindowState {
   }
 
   private applyBufferedPruning(): void {
-    if (
-      this.retainedTokens <= this.options.pruningBudget ||
-      this.eligibleToolResultTokenSavings < PRUNING_CHECKPOINT_TOKENS
-    ) {
+    if (this.retainedTokens <= this.options.pruningBudget) {
       return;
     }
 
-    const targetTokens = Math.max(
-      this.options.pruningBudget - PRUNING_CHECKPOINT_TOKENS,
-      0
-    );
+    const hasPreferredBatch =
+      this.eligibleToolResultTokenSavings >= PRUNING_CHECKPOINT_TOKENS;
+    const canRestoreNominalBudgetWithSmallerBatch =
+      this.retainedTokens > this.options.budgetForInteractions &&
+      this.eligibleToolResultTokenSavings >= MINIMUM_PRUNING_BATCH_TOKENS &&
+      this.retainedTokens - this.eligibleToolResultTokenSavings <=
+        this.options.budgetForInteractions;
+
+    if (!hasPreferredBatch && !canRestoreNominalBudgetWithSmallerBatch) {
+      return;
+    }
+
+    const targetTokens = hasPreferredBatch
+      ? Math.max(this.options.pruningBudget - PRUNING_CHECKPOINT_TOKENS, 0)
+      : this.retainedTokens - this.eligibleToolResultTokenSavings;
 
     while (
       this.retainedTokens > targetTokens &&


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/29159.

This refines checkpointed conversation pruning by separating the preferred pruning batch from the minimum worthwhile fallback. Normal cleanup continues to wait for 20k reclaimable tokens to preserve provider-cache stability.

When the nominal hard budget is exceeded, pruning may accept a smaller batch of at least 5k, but only when pruning the complete eligible batch restores fit. Smaller or insufficient batches remain intact, and pending tool results stay protected.

I captured a few production traces that I'm replaying with this new context window management, and nominal over-budget checkpoints decreased with this approach.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
