### PR TITLE
UI: fix dark mode colors for agent/skill suggestions

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -519,12 +519,12 @@ describe("InstructionSuggestionExtension", () => {
       const dimmedDeletion = editor.view.dom.querySelector(
         ".suggestion-deletion"
       );
-      expect(dimmedDeletion?.className).toContain("bg-red-50");
+      expect(dimmedDeletion?.className).toContain("bg-warning-50");
 
       const dimmedAddition = editor.view.dom.querySelector(
         ".suggestion-addition"
       );
-      expect(dimmedAddition?.className).toContain("bg-blue-50");
+      expect(dimmedAddition?.className).toContain("bg-highlight-50");
 
       // Highlight the suggestion.
       editor.commands.setHighlightedSuggestion("deco-highlight");
@@ -532,12 +532,12 @@ describe("InstructionSuggestionExtension", () => {
       const highlightedDeletion = editor.view.dom.querySelector(
         ".suggestion-deletion"
       );
-      expect(highlightedDeletion?.className).toContain("bg-red-100");
+      expect(highlightedDeletion?.className).toContain("bg-warning-100");
 
       const highlightedAddition = editor.view.dom.querySelector(
         ".suggestion-addition"
       );
-      expect(highlightedAddition?.className).toContain("bg-blue-100");
+      expect(highlightedAddition?.className).toContain("bg-highlight-100");
     });
 
     it("should render multiple deletion/addition pairs for disjoint changes in one block", () => {

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -46,12 +46,12 @@ export const SUGGESTION_ID_ATTRIBUTE = "data-suggestion-id";
 
 const CLASSES = {
   remove:
-    "suggestion-deletion rounded line-through bg-red-100 text-red-800 cursor-default",
+    "suggestion-deletion rounded line-through bg-warning-100 text-warning-800 cursor-default",
   removeDimmed:
-    "suggestion-deletion rounded line-through bg-red-50 text-muted-foreground cursor-default",
-  add: "suggestion-addition rounded bg-blue-100 text-blue-800 cursor-default",
+    "suggestion-deletion rounded line-through bg-warning-50 text-muted-foreground cursor-default",
+  add: "suggestion-addition rounded bg-highlight-100 text-highlight-800 cursor-default",
   addDimmed:
-    "suggestion-addition rounded bg-blue-50 text-muted-foreground cursor-default",
+    "suggestion-addition rounded bg-highlight-50 text-muted-foreground cursor-default",
   blockHighlightDimmed: "suggestion-highlight rounded bg-muted cursor-default",
 };
 


### PR DESCRIPTION
## Description

Fix the background color to rely on token and not on hardcoded values.

### Before

<img width="1721" height="874" alt="Screenshot 2026-07-20 at 15 52 30" src="https://github.com/user-attachments/assets/63dcf355-dfac-4d94-b678-12aff5a495d4" />
<img width="1711" height="868" alt="Screenshot 2026-07-20 at 15 50 19" src="https://github.com/user-attachments/assets/869064b8-4eb3-427d-ae8c-7dff63357ede" />


### After

<img width="1703" height="875" alt="Screenshot 2026-07-20 at 15 52 13" src="https://github.com/user-attachments/assets/d5b967a0-c477-4695-acaa-fd298003c2ff" />
<img width="1706" height="865" alt="Screenshot 2026-07-20 at 15 51 04" src="https://github.com/user-attachments/assets/95c36b09-979a-47c6-93d5-34688949b5ee" />



## Tests

tested locally

## Risk

low, easy to revert and only UI

## Deploy Plan

deploy front
