### PR TITLE
Extend model image signed URL validity

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -16,6 +16,7 @@ import {
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { getConversationFileMountSignedUrl } from "@app/lib/api/files/gcs_mount/files";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS } from "@app/lib/file_storage/signed_url_cache";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   replaceMentionsWithAt,
@@ -73,7 +74,9 @@ async function getDustFileSystemDownloadUrl(
     return fsResult;
   }
 
-  return fsResult.value.getDownloadUrl(filePath);
+  return fsResult.value.getDownloadUrl(filePath, {
+    expiresInMs: MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  });
 }
 
 /**

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -681,6 +681,19 @@ describe("GCSFileSystemBackend.getDownloadUrl", () => {
     );
   });
 
+  it("uses a custom expiration when requested", async () => {
+    const expirationDelayMs = 15 * 60 * 1000;
+
+    await makeBackend().getDownloadUrl(`conversation-${CONV_ID}/report.pdf`, {
+      expiresInMs: expirationDelayMs,
+    });
+
+    expect(getSignedUrlMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
+      { expirationDelayMs }
+    );
+  });
+
   it("returns Err(invalid_path) for an unrecognised scoped path", async () => {
     const result = await makeBackend().getDownloadUrl("unknown/file.pdf");
     expect(result.isErr()).toBe(true);

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -580,7 +580,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
   async getDownloadUrl(
     scopedPath: string,
-    _opts?: { expiresInMs?: number; fileName?: string }
+    opts?: { expiresInMs?: number; fileName?: string }
   ): Promise<Result<string, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
@@ -593,7 +593,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     try {
-      const url = await getCachedPrivateUploadSignedUrl(gcsPath);
+      const url = await getCachedPrivateUploadSignedUrl(gcsPath, {
+        expirationDelayMs: opts?.expiresInMs,
+      });
 
       return new Ok(url);
     } catch (err) {

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -9,10 +9,8 @@ import {
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
-  getPrivateUploadBucket,
-} from "@app/lib/file_storage";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS } from "@app/lib/file_storage/signed_url_cache";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -66,7 +64,7 @@ describe("getConversationFileMountSignedUrl", () => {
       expect(result.value).toBe("https://signed.example.com/photo.png");
     }
     expect(getSignedUrlMock).toHaveBeenCalledWith(gcsPath, {
-      expirationDelayMs: DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS,
+      expirationDelayMs: MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
     });
   });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -10,7 +10,10 @@ import {
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { getCachedPrivateUploadSignedUrl } from "@app/lib/file_storage/signed_url_cache";
+import {
+  getCachedPrivateUploadSignedUrl,
+  MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
+} from "@app/lib/file_storage/signed_url_cache";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -197,7 +200,9 @@ export async function getConversationFileMountSignedUrl(
     );
   }
   try {
-    const url = await getCachedPrivateUploadSignedUrl(gcsPath);
+    const url = await getCachedPrivateUploadSignedUrl(gcsPath, {
+      expirationDelayMs: MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
+    });
     return new Ok(url);
   } catch (err) {
     return new Err(normalizeError(err));

--- a/front/lib/file_storage/signed_url_cache.ts
+++ b/front/lib/file_storage/signed_url_cache.ts
@@ -4,6 +4,9 @@ import {
 } from "@app/lib/file_storage";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 
+// LLM providers may fetch a cached image URL several minutes after it was signed.
+export const MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS = 15 * 60 * 1000;
+
 // Cache TTL as a fraction of the signed URL's own expiration, so a served URL still has
 // real validity left instead of sitting right at its expiry.
 const SIGNED_URL_CACHE_TTL_RATIO = 0.8;

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -20,7 +20,10 @@ import {
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { getCachedPrivateUploadSignedUrl } from "@app/lib/file_storage/signed_url_cache";
+import {
+  getCachedPrivateUploadSignedUrl,
+  MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
+} from "@app/lib/file_storage/signed_url_cache";
 import { isPastedFile } from "@app/lib/files";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -1040,7 +1043,9 @@ async function getSignedUrlForVersion(
     version,
   });
 
-  return getCachedPrivateUploadSignedUrl(fileCloudStoragePath);
+  return getCachedPrivateUploadSignedUrl(fileCloudStoragePath, {
+    expirationDelayMs: MODEL_INPUT_SIGNED_URL_EXPIRATION_DELAY_MS,
+  });
 }
 
 export async function getContentFragmentFromAttachmentFile(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at fixing https://github.com/dust-tt/tasks/issues/9236.

It extends model image signed URLs to 15 minutes while retaining the 80% cache buffer. User-facing download validity remains unchanged. This reduces provider download failures caused by near-expiry cached URLs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
