### PR TITLE
fix: prevent stored XSS through canonical file serving

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -118,6 +118,35 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
     expect(response.headers.get("Content-Disposition")).toBeNull();
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it.each([
+    { fileName: "page.html", contentType: "text/html" },
+    { fileName: "logo.svg", contentType: "image/svg+xml" },
+    {
+      fileName: "blob.bin",
+      contentType: "application/x-something-unknown",
+    },
+    { fileName: "mixed.html", contentType: "TEXT/HTML; Charset=UTF-8" },
+  ])("forces unsafe content type $contentType to download as an attachment", async ({
+    fileName,
+    contentType,
+  }) => {
+    const { workspace, conversation } = await setup();
+
+    setExistingFiles([`/files/${fileName}`], { contentType, size: "42" });
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/${fileName}`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toMatch(
+      /^attachment; filename=/
+    );
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 
   it("sets Content-Disposition when ?download=1", async () => {
@@ -137,6 +166,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
     expect(response.headers.get("Content-Disposition")).toMatch(
       /attachment; filename=/
     );
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 });
 
@@ -177,6 +207,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath?thumbnail=1", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("image/png");
     expect(response.headers.get("Cache-Control")).toBe("private, max-age=3600");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(spy).toHaveBeenCalled();
   });
 
@@ -224,6 +255,7 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/csv");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(fileStorageMock.readStreamCalls).toHaveLength(0);
   });
 
@@ -260,6 +292,7 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe(frameContentType);
     expect(response.headers.get(DUST_FILE_ID_HEADER)).toBe(file.sId);
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 
   it("returns 404 when file does not exist", async () => {

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -12,7 +12,11 @@ import {
   WriteCanonicalFileContentError,
   writeCanonicalFileContent,
 } from "@app/lib/api/files/file_system_ops";
-import { DUST_FILE_ID_HEADER } from "@app/types/files";
+import {
+  DUST_FILE_ID_HEADER,
+  getFileFormat,
+  normalizeMimeType,
+} from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
@@ -74,6 +78,19 @@ function putContentTooLargeError(ctx: Context) {
       message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
     },
   });
+}
+
+function isContentTypeSafeToDisplay(contentType: string): boolean {
+  // Mirrors the isSafeToDisplay policy from getSecureFileAction (FileResource-backed serving),
+  // applied to the raw stored content type since canonical-path files may lack a FileResource.
+  return (
+    getFileFormat(normalizeMimeType(contentType))?.isSafeToDisplay ?? false
+  );
+}
+
+function contentDispositionAttachment(fileName: string): string {
+  const asciiFallback = fileName.replace(/[^\x20-\x7E\/\\]/g, "_");
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(fileName)}`;
 }
 
 const putBodyLimit = honoBodyLimit({
@@ -139,6 +156,7 @@ async function handleHeadRequest(
   const headers: Record<string, string> = {
     "Content-Type": statResult.value.contentType,
     "Content-Length": String(statResult.value.sizeBytes),
+    "X-Content-Type-Options": "nosniff",
   };
   if (linkedFileResource) {
     headers[DUST_FILE_ID_HEADER] = linkedFileResource.sId;
@@ -233,6 +251,7 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
         "Content-Disposition": `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
         "Content-Length": String(pdfBuffer.length),
         "Cache-Control": "private, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
       },
     });
   }
@@ -269,6 +288,7 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
       headers: {
         "Content-Type": contentType,
         "Cache-Control": "private, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
       },
     });
   }
@@ -298,13 +318,18 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const headers: Record<string, string> = { "Content-Type": contentType };
+  const headers: Record<string, string> = {
+    "Content-Type": contentType,
+    "X-Content-Type-Options": "nosniff",
+  };
 
-  // ?download=1 sets Content-Disposition: attachment.
-  if (download && download !== "0") {
+  // Unsafe content types and ?download=1 must always be served as attachments.
+  if (
+    !isContentTypeSafeToDisplay(contentType) ||
+    (download && download !== "0")
+  ) {
     const fileName = path.posix.basename(canonicalPath);
-    headers["Content-Disposition"] =
-      `attachment; filename="${encodeURIComponent(fileName)}"`;
+    headers["Content-Disposition"] = contentDispositionAttachment(fileName);
   }
 
   const nodeStream = readResult.value;

--- a/front/lib/api/mcp_server/tools/files/create.ts
+++ b/front/lib/api/mcp_server/tools/files/create.ts
@@ -4,10 +4,7 @@ import {
   frameFileEditRejectedError,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
-import {
-  isInteractiveContentType,
-  stripMimeParameters,
-} from "@app/types/files";
+import { isInteractiveContentType, normalizeMimeType } from "@app/types/files";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mcpError, mcpJsonResponse } from "../response";
@@ -61,8 +58,8 @@ export function registerFilesCreateTool(server: McpServer) {
       }
       const dustFs = fsResult.value;
 
-      const incomingMimeType = stripMimeParameters(content_type);
-      if (isInteractiveContentType(incomingMimeType)) {
+      const normalizedContentType = normalizeMimeType(content_type);
+      if (isInteractiveContentType(normalizedContentType)) {
         return mcpError(frameFileCreateRejectedError().message);
       }
 
@@ -70,7 +67,7 @@ export function registerFilesCreateTool(server: McpServer) {
       const exists = statResult.isOk() && statResult.value !== null;
 
       if (statResult.isOk() && statResult.value !== null) {
-        const existingMimeType = stripMimeParameters(
+        const existingMimeType = normalizeMimeType(
           statResult.value.contentType
         );
         if (isInteractiveContentType(existingMimeType)) {
@@ -78,7 +75,11 @@ export function registerFilesCreateTool(server: McpServer) {
         }
       }
 
-      const writeResult = await dustFs.write(path, contentBuffer, content_type);
+      const writeResult = await dustFs.write(
+        path,
+        contentBuffer,
+        normalizedContentType
+      );
       if (writeResult.isErr()) {
         const err = writeResult.error;
         switch (err.code) {
@@ -96,9 +97,9 @@ export function registerFilesCreateTool(server: McpServer) {
       const verb = exists ? "Updated" : "Created";
 
       return mcpJsonResponse({
-        message: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB)`,
+        message: `${verb} \`${path}\` (${normalizedContentType}, ${sizeKb} KB)`,
         path,
-        contentType: content_type,
+        contentType: normalizedContentType,
       });
     }
   );

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -1024,6 +1024,14 @@ export function stripMimeParameters(contentType: string): string {
   return contentType.split(";")[0];
 }
 
+/**
+ * MIME types are case-insensitive per RFC 2045. Use this at every upload and
+ * serving boundary so mixed-case values like TEXT/HTML cannot bypass content-type safety gating.
+ */
+export function normalizeMimeType(contentType: string): string {
+  return stripMimeParameters(contentType).toLowerCase();
+}
+
 export function stripFileExtension(fileName: string): string {
   return fileName.replace(/\.[^.]+$/, "");
 }


### PR DESCRIPTION
## Description

Fixes stored XSS via canonical-path file serving https://github.com/dust-tt/tasks/issues/9664

  - Normalize MIME types by stripping parameters and lowercasing.
  - Force unsafe, unknown, and mixed-case unsafe types to download as attachments.
  - Add X-Content-Type-Options: nosniff to file-serving responses.
  - Normalize MIME types when creating files and store the canonical value.
  - Add regression tests for HTML, SVG, unknown, and mixed-case MIME types.

  ## Tests

  - Canonical-path route tests: 26/26 passed.
  - Front-api production build passed.

  ## Risk

  Changes are limited to MIME handling and response headers. 
  Existing stored files are protected at serving time, so no migration is required. Unknown or unsupported types fail closed and download as attachments.
  The change is safely reversible by reverting the commit.
