### PR TITLE
[Skills] Skills restriction in pods fix

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -443,6 +443,40 @@ describe("GET /api/w/:wId/skills", () => {
     expect(globalNames).not.toContain("Member Restricted Skill");
   });
 
+  it("with podSpaceId returns global skills + skills restricted to that Pod only", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    await SkillFactory.create(auth, { name: "Global Skill" });
+
+    // Skill restricted to the Pod itself — should show for that Pod. The caller
+    // is the Pod editor so they can read it.
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await SkillFactory.create(auth, {
+      name: "Pod Skill",
+      requestedSpaceIds: [pod.id],
+    });
+
+    // Skill restricted to a different space the caller can access — should be
+    // excluded when scoping to the Pod, even though it is otherwise visible.
+    const otherSpace = await SpaceFactory.regular(workspace);
+    await otherSpace.addMembers(auth, { userIds: [user.sId] });
+    await SkillFactory.create(auth, {
+      name: "Other Space Skill",
+      requestedSpaceIds: [otherSpace.id],
+    });
+
+    const res = await getSkills(workspace, { podSpaceId: pod.sId });
+    expect(res.status).toBe(200);
+    const names = (await res.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(names).toContain("Global Skill");
+    expect(names).toContain("Pod Skill");
+    expect(names).not.toContain("Other Space Skill");
+  });
+
   it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -153,37 +153,7 @@ app.get(
     }
     const skillStatus = statusValidation.data;
 
-    const availabilityValidation =
-      SkillAvailabilitiesSchema.safeParse(availabilityParams);
-    if (!availabilityValidation.success) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Invalid availability: ${availabilityParams}. Expected "editors", "workspace_users", or "users_and_agents".`,
-        },
-      });
-    }
-    // An explicit availability takes priority over the deprecated isDefault alias.
-    const availability =
-      availabilityValidation.data && availabilityValidation.data.length > 0
-        ? availabilityValidation.data
-        : isDefault === "true"
-          ? ["users_and_agents" as const]
-          : undefined;
-
-    // Only admins may list unpublished skills they don't edit (e.g. for governance views).
-    if (bypassEditorVisibility && !auth.isAdmin()) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "app_auth_error",
-          message: "Only admins can bypass editor visibility.",
-        },
-      });
-    }
-
-    const allSkills = await SkillResource.listByWorkspace(auth, {
+    const skills = await SkillResource.listBySpace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
       podSpaceId,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -9,6 +9,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
   GetSkillsResponseBody,
@@ -134,10 +135,11 @@ app.get(
     const onlyCustom = ctx.req.query("onlyCustom");
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
-    const bypassEditorVisibility =
-      ctx.req.query("bypassEditorVisibility") === "true";
-    // Repeatable: ?availability=workspace_users&availability=users_and_agents.
-    const availabilityParams = ctx.req.queries("availability");
+    const podSpaceSId = ctx.req.query("podSpaceId");
+    const podSpaceId =
+      podSpaceSId !== undefined
+        ? (getResourceIdFromSId(podSpaceSId) ?? undefined)
+        : undefined;
 
     const statusValidation = SkillStatusSchema.safeParse(status);
     if (!statusValidation.success) {
@@ -184,6 +186,7 @@ app.get(
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
+      podSpaceId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -135,10 +135,10 @@ app.get(
     const onlyCustom = ctx.req.query("onlyCustom");
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
-    const podSpaceSId = ctx.req.query("podSpaceId");
-    const podSpaceId =
-      podSpaceSId !== undefined
-        ? (getResourceIdFromSId(podSpaceSId) ?? undefined)
+    const podSpaceId = ctx.req.query("podSpaceId");
+    const podSpaceModelId =
+      podSpaceId !== undefined
+        ? (getResourceIdFromSId(podSpaceId) ?? undefined)
         : undefined;
 
     const statusValidation = SkillStatusSchema.safeParse(status);
@@ -156,7 +156,7 @@ app.get(
     const skills = await SkillResource.listBySpace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
-      podSpaceId,
+      podSpaceId: podSpaceModelId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -214,6 +214,30 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     ).toEqual([]);
   });
 
+  it("persists a skill restricted to this Pod as a default skill", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "pod_default_skills");
+
+    // Make the caller the Pod editor so they can read/administrate it.
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    // A skill restricted to this Pod's own space — usable by exactly the Pod.
+    const podScopedSkill = await SkillFactory.create(auth, {
+      name: "Pod Scoped Skill",
+      requestedSpaceIds: [projectSpace.id],
+    });
+
+    const response = await patchMetadata(workspace, projectSpace.sId, {
+      defaultSkillIds: [podScopedSkill.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).projectMetadata.defaultSkillIds).toEqual([
+      podScopedSkill.sId,
+    ]);
+  });
+
   it("rejects unknown default skill ids", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       role: "admin",

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -169,6 +169,7 @@ interface CapabilitiesPickerProps {
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
   onOpenChange?: (open: boolean) => void;
+  podSpaceId?: string | null;
 }
 
 export function CapabilitiesPicker({
@@ -181,6 +182,7 @@ export function CapabilitiesPicker({
   disabled = false,
   buttonSize = "xs",
   onOpenChange,
+  podSpaceId,
 }: CapabilitiesPickerProps) {
   const isMobile = useIsMobile();
   const [searchText, setSearchText] = useState("");
@@ -258,6 +260,7 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podSpaceId,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -110,6 +110,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
   const isPod = space ? isProjectType(space) : false;
+  const podSpaceId = conversation?.spaceId ?? (isPod ? space?.sId : undefined);
   const defaultAgentUnavailableLabel = isPod
     ? "This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
     : "This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error.";
@@ -203,6 +204,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       onOpenChange={onCapabilitiesPickerOpenChange}
       buttonSize={buttonSize}
       disabled={isInputDisabled}
+      podSpaceId={podSpaceId}
     />
   );
   const attachmentButton = actions.includes("attachment") &&

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -120,6 +120,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     const { capabilityItems, isLoading } = useInputBarSlashCommandCapabilities({
       owner,
       query,
+      podSpaceId: spaceIdRef.current,
       selectedMCPServerViewIdsRef,
     });
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -61,11 +61,13 @@ export function useInputBarSlashCommandCapabilities({
   excludeSkillId,
   owner,
   query,
+  podSpaceId,
   selectedMCPServerViewIdsRef,
 }: {
   excludeSkillId?: string | null;
   owner: LightWorkspaceType;
   query: string;
+  podSpaceId?: string | null;
   selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
 }) {
   const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
@@ -77,6 +79,7 @@ export function useInputBarSlashCommandCapabilities({
     owner,
     status: "active",
     swrOptions: CAPABILITIES_SWR_OPTIONS,
+    podSpaceId,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a
   // conversation, no further filtering needed here.

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -180,6 +180,7 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
+    podSpaceId: pod.sId,
     disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -238,8 +238,10 @@ export function SkillBuilderRequestedSpacesSection({
             Visibility control and available data
           </h3>
           <p className="text-sm text-muted-foreground">
-            Add a space or pod to restrict usage to its members and make its
-            data available to this skill.
+            Choose which spaces and Pods this skill can access. The skill can
+            use their knowledge and capabilities, and only users with access to
+            all selected spaces and Pods can use it. A skill restricted to a Pod
+            is only available inside that Pod and not in others.
           </p>
         </div>
         <Button

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,5 +1,6 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { clientFetch } from "@app/lib/egress/client";
+import { invalidateWorkspaceSkills } from "@app/lib/swr/skill_configurations";
 import type {
   PatchSkillResponseBody,
   PostSkillResponseBody,
@@ -123,6 +124,8 @@ export async function submitSkillBuilderForm({
         }
       }
     }
+
+    await invalidateWorkspaceSkills(owner.sId);
 
     return new Ok(skill);
   } catch (error) {

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -190,7 +190,7 @@ export const joinActivationPodPlugin = createPlugin({
     requiredRoles: ["support"],
   },
   populateAsyncArgs: async (auth) => {
-    const skills = await SkillResource.listByWorkspace(auth, {
+    const skills = await SkillResource.listBySpace(auth, {
       status: "active",
       globalSpaceOnly: true,
       withInstructions: false,

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -179,7 +179,7 @@ describe("ProjectMetadataResource", () => {
       expect(afterClear!.defaultSkillsIds).toBeNull();
     });
 
-    it("drops skills that are not usable in the global space", async () => {
+    it("drops skills restricted to a space other than this Pod", async () => {
       const { workspace: skillWorkspace, authenticator } =
         await createResourceTest({ role: "admin" });
       const space = await SpaceFactory.project(skillWorkspace);
@@ -209,6 +209,40 @@ describe("ProjectMetadataResource", () => {
         space
       );
       expect(reloaded!.defaultSkillIds).toEqual([globalSkill.sId]);
+    });
+
+    it("keeps skills restricted to this Pod's own space", async () => {
+      const { workspace: skillWorkspace, authenticator } =
+        await createResourceTest({ role: "admin" });
+      const space = await SpaceFactory.project(skillWorkspace);
+
+      const globalSkill = await SkillFactory.create(authenticator, {
+        name: "global",
+      });
+      // A skill scoped to the Pod's own space — usable by exactly the Pod members.
+      const podScopedSkill = await SkillFactory.create(authenticator, {
+        name: "pod-scoped",
+        requestedSpaceIds: [space.id],
+      });
+
+      const metadata = await ProjectMetadataResource.makeNew(
+        authenticator,
+        space,
+        { description: "d" }
+      );
+
+      await metadata.setDefaultSkills(authenticator, [
+        globalSkill,
+        podScopedSkill,
+      ]);
+
+      const reloaded = await ProjectMetadataResource.fetchBySpace(
+        authenticator,
+        space
+      );
+      expect([...reloaded!.defaultSkillIds].sort()).toEqual(
+        [globalSkill.sId, podScopedSkill.sId].sort()
+      );
     });
 
     it("de-duplicates skills", async () => {

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -229,13 +229,12 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     transaction?: Transaction
   ): Promise<void> {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-    const globalSpaceSkills = skills.filter((skill) =>
-      skill.requestedSpaceIds.every((id) => id === globalSpace.id)
+    const allowedSpaceIds = new Set<ModelId>([globalSpace.id, this.spaceId]);
+    const usableSkills = skills.filter((skill) =>
+      skill.requestedSpaceIds.every((id) => allowedSpaceIds.has(id))
     );
 
-    const defaultSkillsIds = [
-      ...new Map(globalSpaceSkills.map((s) => [s.sId, s])).keys(),
-    ];
+    const defaultSkillsIds = [...new Set(usableSkills.map((s) => s.sId))];
 
     await this.update(
       {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1435,6 +1435,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
+      podSpaceId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1446,6 +1447,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
+      // When set, restricts results to skills usable inside that Pod: skills whose
+      // requested spaces are all either the global space or the Pod's own space.
+      podSpaceId?: ModelId;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1469,10 +1473,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments,
     });
 
-    if (globalSpaceOnly) {
+    // Scope to the global space (globalSpaceOnly) and/or a specific Pod's space
+    // (podSpaceId). A skill is kept only when every one of its requested spaces is
+    // in the allowed set, so Pod-restricted skills from other Pods are excluded.
+    if (globalSpaceOnly || podSpaceId !== undefined) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+      const allowedSpaceIds = new Set<ModelId>([globalSpace.id]);
+      if (podSpaceId !== undefined) {
+        allowedSpaceIds.add(podSpaceId);
+      }
       return skills.filter((skill) =>
-        skill.requestedSpaceIds.every((id) => id === globalSpace.id)
+        skill.requestedSpaceIds.every((id) => allowedSpaceIds.has(id))
       );
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1698,11 +1698,28 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       [conversation.spaceId]
     );
 
-    return this.fetchByIds(auth, projectMetadata?.defaultSkillIds ?? [], {
-      agentLoopData,
-      effectiveSpaceIds,
-      onlyActive: true,
-    });
+    const skills = await this.fetchByIds(
+      auth,
+      projectMetadata?.defaultSkillIds ?? [],
+      {
+        agentLoopData,
+        effectiveSpaceIds,
+        onlyActive: true,
+      }
+    );
+
+    if (!projectMetadata) {
+      return skills;
+    }
+
+    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+    const allowedSpaceIds = new Set<ModelId>([
+      globalSpace.id,
+      projectMetadata.spaceId,
+    ]);
+    return skills.filter((skill) =>
+      skill.requestedSpaceIds.every((id) => allowedSpaceIds.has(id))
+    );
   }
 
   static async listForAgentLoop(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -175,6 +175,18 @@ type ConversationSkillCreationAttributes =
         }
     );
 
+type ListSkillsOptions = {
+  status?: SkillStatus | SkillStatus[];
+  limit?: number;
+  onlyCustom?: boolean;
+  isDefault?: boolean;
+  updatedAfter?: Date;
+  reinforcementNotOff?: boolean;
+  withInstructions?: boolean;
+  withTools?: boolean;
+  withFileAttachments?: boolean;
+};
+
 function isSkillResourceWithVersion(
   skill: SkillResource
 ): skill is SkillResource & { version: number } {
@@ -1434,8 +1446,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       status = "active",
       limit,
-      globalSpaceOnly,
-      podSpaceId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1443,23 +1453,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withInstructions = true,
       withTools = true,
       withFileAttachments = true,
-    }: {
-      status?: SkillStatus | SkillStatus[];
-      limit?: number;
-      globalSpaceOnly?: boolean;
-      // When set, restricts results to skills usable inside that Pod: skills whose
-      // requested spaces are all either the global space or the Pod's own space.
-      podSpaceId?: ModelId;
-      onlyCustom?: boolean;
-      availability?: SkillAvailability | SkillAvailability[];
-      updatedAfter?: Date;
-      reinforcementNotOff?: boolean;
-      withInstructions?: boolean;
-      withTools?: boolean;
-      withFileAttachments?: boolean;
-    } = {}
+    }: ListSkillsOptions = {}
   ): Promise<SkillResource[]> {
-    const skills = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       where: {
         status,
         ...(availability !== undefined ? { availability } : {}),
@@ -1472,22 +1468,36 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withTools,
       withFileAttachments,
     });
+  }
 
-    // Scope to the global space (globalSpaceOnly) and/or a specific Pod's space
-    // (podSpaceId). A skill is kept only when every one of its requested spaces is
-    // in the allowed set, so Pod-restricted skills from other Pods are excluded.
-    if (globalSpaceOnly || podSpaceId !== undefined) {
-      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      const allowedSpaceIds = new Set<ModelId>([globalSpace.id]);
-      if (podSpaceId !== undefined) {
-        allowedSpaceIds.add(podSpaceId);
-      }
-      return skills.filter((skill) =>
-        skill.requestedSpaceIds.every((id) => allowedSpaceIds.has(id))
-      );
+  static async listBySpace(
+    auth: Authenticator,
+    {
+      globalSpaceOnly,
+      podSpaceId,
+      ...listOptions
+    }: ListSkillsOptions & {
+      globalSpaceOnly?: boolean;
+      // When set, restricts results to skills usable inside that Pod: skills whose
+      // requested spaces are all either the global space or the Pod's own space.
+      podSpaceId?: ModelId;
+    } = {}
+  ): Promise<SkillResource[]> {
+    const skills = await this.listByWorkspace(auth, listOptions);
+
+    if (!globalSpaceOnly && podSpaceId === undefined) {
+      return skills;
     }
 
-    return skills;
+    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+    const allowedSpaceIds = new Set<ModelId>([globalSpace.id]);
+    if (podSpaceId !== undefined) {
+      allowedSpaceIds.add(podSpaceId);
+    }
+
+    return skills.filter((skill) =>
+      skill.requestedSpaceIds.every((id) => allowedSpaceIds.has(id))
+    );
   }
 
   /**

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1114,6 +1114,7 @@ export function usePodDefaultSkills({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podSpaceId: podId,
     disabled: !enabled,
   });
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -29,6 +29,7 @@ import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 import type { Fetcher, SWRConfiguration } from "swr";
+import { mutate } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
@@ -146,6 +147,15 @@ export function useSkills({
     isSkillsLoading: isLoading,
     mutateSkills: mutate,
   };
+}
+
+export async function invalidateWorkspaceSkills(
+  workspaceId: string
+): Promise<void> {
+  await mutate(
+    (key) =>
+      typeof key === "string" && key.startsWith(`/api/w/${workspaceId}/skills`)
+  );
 }
 
 export function useSkillsWithRelations({

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -100,18 +100,16 @@ export function useSkills({
   disabled,
   status,
   globalSpaceOnly,
-  availability,
-  bypassEditorVisibility,
+  podSpaceId,
+  isDefault,
   swrOptions,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
-  availability?: SkillAvailability | SkillAvailability[];
-  // Admin-only: bypass the editor-visibility rule and also list unpublished
-  // (editors-only) skills the caller does not edit.
-  bypassEditorVisibility?: boolean;
+  podSpaceId?: string | null;
+  isDefault?: boolean;
   swrOptions?: SWRConfiguration;
 }): {
   skills: SkillWithoutInstructionsAndToolsType[];
@@ -128,16 +126,11 @@ export function useSkills({
   if (globalSpaceOnly) {
     queryParams.set("globalSpaceOnly", "true");
   }
-  if (availability) {
-    const availabilities = Array.isArray(availability)
-      ? availability
-      : [availability];
-    for (const value of availabilities) {
-      queryParams.append("availability", value);
-    }
+  if (podSpaceId) {
+    queryParams.set("podSpaceId", podSpaceId);
   }
-  if (bypassEditorVisibility) {
-    queryParams.set("bypassEditorVisibility", "true");
+  if (isDefault) {
+    queryParams.set("isDefault", "true");
   }
   const queryString = queryParams.toString();
 


### PR DESCRIPTION
## Description
Restricting a skill to a Pod/space made it unsearchable everywhere ([#29039](https://github.com/dust-tt/tasks/issues/9407)). The initial fix removed the `globalSpaceOnly: true flag` from the capabilities picker, slash command, and default-skills picker but that over-corrected.

To ensure that restricting skills follows the access rule of pods (everything in a pod must be accessible to everyone in the pod), pod skill selection are now scoped to global skills + skills restricted to that specific Pod. Skills restricted to other spaces/Pods are excluded. Outside a Pod (personal conversations, skill builder, command palette) nothing changes — all accessible skills remain available.

Ex: A skill is eligible in Pod X iff every one of its requestedSpaceIds is either the global space or X's own space. Thus a restricted skill can be used in at most one pod (if you try to restrict a skill to two pods, the logic will fail but the skill can still be used in a non-pod conversation since it passes no `podSpaceId`).

## Tests
Local tests, added tests to index, project_metadata, and project_metadata_resource.

## Risk
Low risk

## Deploy Plan
