### PR TITLE
Analytics: Add pod usage chart in agent analytics 1/3: index space_id in Elasticsearch

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -9,6 +9,9 @@
     "conversation_id": {
       "type": "keyword"
     },
+    "space_id": {
+      "type": "keyword"
+    },
     "agent_id": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260720_add_space_id_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260720_add_space_id_to_agent_message_analytics_2.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "space_id": {
+      "type": "keyword"
+    }
+  }
+}

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -103,6 +103,7 @@ async function seedProgrammaticUsage(
       agent_tag_ids: [],
       ancestor_message_ids: [],
       conversation_id: `seed-conv-${i}`,
+      space_id: null,
       cost: {
         full_awu: awuFromMicroUsd(costMicroUsd),
         llm_awu: awuFromMicroUsd(costMicroUsd),

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -123,6 +123,7 @@ export async function seedAnalytics(
       agent_tag_ids: [],
       ancestor_message_ids: [],
       conversation_id: conversationId,
+      space_id: null,
       cost: {
         full_awu: 0,
         llm_awu: 0,

--- a/front/temporal/analytics_queue/activities.test.ts
+++ b/front/temporal/analytics_queue/activities.test.ts
@@ -5,8 +5,10 @@ import { storeAgentAnalyticsActivity } from "@app/temporal/analytics_queue/activ
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TagFactory } from "@app/tests/utils/TagFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -54,9 +56,11 @@ async function seedMessages(
   {
     agentConfigurationId,
     agentConfigurationVersion,
+    spaceModelId,
   }: {
     agentConfigurationId: string;
     agentConfigurationVersion: number;
+    spaceModelId?: ModelId;
   }
 ): Promise<{
   conversationSId: string;
@@ -68,6 +72,7 @@ async function seedMessages(
   const conversation = await ConversationFactory.create(auth, {
     agentConfigurationId,
     messagesCreatedAt: [],
+    spaceId: spaceModelId,
   });
 
   const userMessageRow = await ConversationFactory.createUserMessageWithRank({
@@ -231,5 +236,54 @@ describe("storeAgentAnalyticsActivity - agent_tag_ids", () => {
     indexed = captureIndexedDocs();
     await runAnalytics(auth, seededV1);
     expect(analyticsDoc(indexed)?.agent_tag_ids).toEqual([]);
+  });
+});
+
+describe("storeAgentAnalyticsActivity - space_id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stamps the space sId when the conversation lives in a pod", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const space = await SpaceFactory.project(
+      auth.getNonNullableWorkspace(),
+      auth.getNonNullableUser().id
+    );
+    // Pick up the pod editor group membership created above.
+    await auth.refresh();
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      spaceModelId: space.id,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc).toBeDefined();
+    expect(doc?.space_id).toBe(space.sId);
+  });
+
+  it("stamps null when the conversation is not attached to a space", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc).toBeDefined();
+    expect(doc?.space_id).toBeNull();
   });
 });

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -43,6 +43,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -249,6 +250,15 @@ export async function storeAgentAnalytics(
       apiKeyName = keyResource.name;
     }
   }
+  // Space the conversation lives in (pod usage analytics). The sId is derived
+  // from the model id, no fetch needed.
+  const spaceId = conversationRow.spaceId
+    ? SpaceResource.modelIdToSId({
+        id: conversationRow.spaceId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      })
+    : null;
+
   // Build the complete analytics document.
   const document: AgentMessageAnalyticsData = {
     agent_id: agentAgentMessageRow.agentConfigurationId,
@@ -256,6 +266,7 @@ export async function storeAgentAnalytics(
     agent_tag_ids: agentTagIds,
     ancestor_message_ids: ancestorMessageIds,
     conversation_id: conversationRow.sId,
+    space_id: spaceId,
     cost,
     context_origin: contextOrigin,
     latency_ms: agentAgentMessageRow.modelInteractionDurationMs ?? 0,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -57,6 +57,9 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_tag_ids: string[];
   ancestor_message_ids: string[];
   conversation_id: string;
+  // sId of the space the conversation lives in (any kind), null when the
+  // conversation is not attached to a space.
+  space_id: string | null;
   cost: AgentMessageAnalyticsCost;
   feedbacks: AgentMessageAnalyticsFeedback[];
   context_origin: UserMessageOrigin | null;


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9348

This PR adds the pod dimension to the agent message analytics documents:

- New `space_id` keyword field on the `agent_message_analytics_2` index. It stores the sId of the space the conversation lives in (any kind, resolved to pods at query time), or `null` when the conversation is not attached to a space.

Note: no backfill — messages indexed before this change have no `space_id` and will be reported in the "No pod" bucket.

## Stack

- 1/3: https://github.com/dust-tt/dust/pull/29179
- 2/3: https://github.com/dust-tt/dust/pull/29180
- 3/3: https://github.com/dust-tt/dust/pull/29181

## Risk

Low: additive mapping change, additive field on the indexed document.

## Deploy Plan

Before deploying, apply the mapping update to Elasticsearch (in each region), as per
`front/lib/analytics/migrations/20260720_add_space_id_to_agent_message_analytics_2.http`:

```
PUT /front.agent_message_analytics_2/_mapping
{
  "properties": {
    "space_id": {
      "type": "keyword"
    }
  }
}
```

then deploy `front`