### PR TITLE
Analytics: Add pod usage chart in agent analytics 3/3: pod usage chart in agent analytics

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/pods.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/pods.ts
@@ -64,10 +64,10 @@ app.get(
       });
     }
 
-    const buckets = result.value;
-    const total = buckets.reduce((acc, b) => acc + b.count, 0);
+    const { buckets, otherPodsCount } = result.value;
+    const total = buckets.reduce((acc, b) => acc + b.count, 0) + otherPodsCount;
 
-    return ctx.json({ total, buckets });
+    return ctx.json({ total, buckets, otherPodsCount });
   }
 );
 

--- a/front/components/agent_builder/observability/charts/PodUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/PodUsageChart.tsx
@@ -72,9 +72,12 @@ export function PodUsageChart({
       percent: toPercent(bucket.count),
     }));
 
-  const othersCount = podBuckets
-    .slice(MAX_PODS_DISPLAYED)
-    .reduce((acc, bucket) => acc + bucket.count, 0);
+  // Pods beyond the displayed top N, plus messages the backend aggregation
+  // truncated past its own bucket cap (otherPodsCount).
+  const othersCount =
+    podBuckets
+      .slice(MAX_PODS_DISPLAYED)
+      .reduce((acc, bucket) => acc + bucket.count, 0) + podUsage.otherPodsCount;
 
   const data: PodChartDatum[] = [
     ...topPods,

--- a/front/components/agent_builder/observability/charts/PodUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/PodUsageChart.tsx
@@ -1,5 +1,6 @@
 import {
   CHART_HEIGHT,
+  OTHER_LABEL,
   UNKNOWN_LABEL,
 } from "@app/components/agent_builder/observability/constants";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
@@ -14,6 +15,10 @@ import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 const NO_POD_KEY = "__no_pod__";
 const NO_POD_LABEL = "No pod";
+
+// Pods beyond this count are grouped under a single "Others" slice to keep the
+// donut and legend readable on workspaces with many pods.
+const MAX_PODS_DISPLAYED = 20;
 
 type PodChartDatum = {
   key: string;
@@ -51,14 +56,51 @@ export function PodUsageChart({
 
   const total = podUsage.total;
 
-  const data: PodChartDatum[] = podUsage.buckets.map((bucket) => ({
-    key: bucket.podId ?? NO_POD_KEY,
-    label: bucket.name ?? NO_POD_LABEL,
-    count: bucket.count,
-    percent: total > 0 ? Math.round((bucket.count / total) * 100) : 0,
-  }));
+  const toPercent = (count: number) =>
+    total > 0 ? Math.round((count / total) * 100) : 0;
 
-  const podKeys = data.filter((d) => d.key !== NO_POD_KEY).map((d) => d.label);
+  // Buckets come sorted by count descending, with the no-pod bucket last.
+  const podBuckets = podUsage.buckets.filter((b) => b.podId !== null);
+  const noPodBucket = podUsage.buckets.find((b) => b.podId === null);
+
+  const topPods: PodChartDatum[] = podBuckets
+    .slice(0, MAX_PODS_DISPLAYED)
+    .map((bucket) => ({
+      key: bucket.podId ?? NO_POD_KEY,
+      label: bucket.name ?? NO_POD_LABEL,
+      count: bucket.count,
+      percent: toPercent(bucket.count),
+    }));
+
+  const othersCount = podBuckets
+    .slice(MAX_PODS_DISPLAYED)
+    .reduce((acc, bucket) => acc + bucket.count, 0);
+
+  const data: PodChartDatum[] = [
+    ...topPods,
+    ...(othersCount > 0
+      ? [
+          {
+            key: OTHER_LABEL.key,
+            label: OTHER_LABEL.label,
+            count: othersCount,
+            percent: toPercent(othersCount),
+          },
+        ]
+      : []),
+    ...(noPodBucket
+      ? [
+          {
+            key: NO_POD_KEY,
+            label: NO_POD_LABEL,
+            count: noPodBucket.count,
+            percent: toPercent(noPodBucket.count),
+          },
+        ]
+      : []),
+  ];
+
+  const podKeys = topPods.map((d) => d.label);
 
   const getPodColor = (datum: PodChartDatum) =>
     datum.key === NO_POD_KEY

--- a/front/components/agent_builder/observability/charts/PodUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/PodUsageChart.tsx
@@ -1,0 +1,168 @@
+import {
+  CHART_HEIGHT,
+  UNKNOWN_LABEL,
+} from "@app/components/agent_builder/observability/constants";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
+import { useAgentPodUsage } from "@app/lib/swr/assistants";
+import { isString } from "@app/types/shared/utils/general";
+import { cn } from "@dust-tt/sparkle";
+import { Cell, Pie, PieChart, Tooltip } from "recharts";
+
+const NO_POD_KEY = "__no_pod__";
+const NO_POD_LABEL = "No pod";
+
+type PodChartDatum = {
+  key: string;
+  label: string;
+  count: number;
+  percent: number;
+};
+
+interface PodUsageChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
+export function PodUsageChart({
+  workspaceId,
+  agentConfigurationId,
+  isCustomAgent,
+}: PodUsageChartProps) {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+
+  const { podUsage, isPodUsageLoading, isPodUsageError } = useAgentPodUsage({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    version:
+      isCustomAgent && mode === "version" && selectedVersion
+        ? selectedVersion.version
+        : undefined,
+    disabled:
+      !workspaceId ||
+      !agentConfigurationId ||
+      (isCustomAgent && mode === "version" && !selectedVersion),
+  });
+
+  const total = podUsage.total;
+
+  const data: PodChartDatum[] = podUsage.buckets.map((bucket) => ({
+    key: bucket.podId ?? NO_POD_KEY,
+    label: bucket.name ?? NO_POD_LABEL,
+    count: bucket.count,
+    percent: total > 0 ? Math.round((bucket.count / total) * 100) : 0,
+  }));
+
+  const podKeys = data.filter((d) => d.key !== NO_POD_KEY).map((d) => d.label);
+
+  const getPodColor = (datum: PodChartDatum) =>
+    datum.key === NO_POD_KEY
+      ? UNKNOWN_LABEL.color
+      : getIndexedColor(datum.label, podKeys);
+
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
+
+  const legendItems = decorate(
+    data.map((d) => ({
+      key: d.key,
+      label: d.label,
+      colorClassName: getPodColor(d),
+    }))
+  );
+
+  return (
+    <ChartContainer
+      title="Pods"
+      description="Message volume broken down by pod."
+      isLoading={isPodUsageLoading}
+      errorMessage={
+        isPodUsageError ? "Failed to load pod usage breakdown." : undefined
+      }
+      emptyMessage={
+        data.length === 0 ? "No messages for this selection." : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <PieChart>
+        <Tooltip
+          cursor={false}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          content={({ active, payload }) => {
+            if (!active || data.length === 0) {
+              return null;
+            }
+            const rawKey = payload?.[0]?.payload?.key;
+            const hoveredKey = isString(rawKey) ? rawKey : undefined;
+            const rows = data.map((d) => ({
+              key: d.key,
+              label: d.label,
+              value: d.count,
+              percent: d.percent,
+              colorClassName: getPodColor(d),
+            }));
+            return (
+              <ChartTooltipCard
+                title="Pod breakdown"
+                rows={rows}
+                activeKey={hoveredKey ?? selectedKey}
+                selectedKey={selectedKey}
+              />
+            );
+          }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        <Pie
+          data={data}
+          dataKey="count"
+          nameKey="key"
+          innerRadius="60%"
+          outerRadius="80%"
+          minAngle={4}
+          paddingAngle={3}
+          strokeWidth={0}
+          isAnimationActive={false}
+        >
+          {data.map((entry) => (
+            <Cell
+              key={entry.key}
+              className={cn(
+                getPodColor(entry),
+                "transition-opacity",
+                isDimmed(entry.key) && "opacity-25"
+              )}
+              fill="currentColor"
+            />
+          ))}
+        </Pie>
+        {/* Center label */}
+        {total > 0 && (
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-foreground"
+          >
+            <tspan className="text-2xl font-semibold">
+              {total.toLocaleString()}
+            </tspan>
+            <tspan x="50%" dy="1.2em" className="text-sm">
+              Messages
+            </tspan>
+          </text>
+        )}
+      </PieChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -49,6 +49,15 @@ const SourceChart = safeLazy(
     })),
   { canReload }
 );
+const PodUsageChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/PodUsageChart"
+    ).then((mod) => ({
+      default: mod.PodUsageChart,
+    })),
+  { canReload }
+);
 const SkillUsageChart = safeLazy(
   () =>
     import(
@@ -276,6 +285,13 @@ export function AgentObservability({
         </SafeSuspense>
         <SafeSuspense fallback={<ChartFallback />}>
           <SourceChart
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfigurationId}
+            isCustomAgent={isCustomAgent}
+          />
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
+          <PodUsageChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}

--- a/front/lib/api/assistant/observability/pod_usage.test.ts
+++ b/front/lib/api/assistant/observability/pod_usage.test.ts
@@ -13,13 +13,18 @@ vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
   return { ...actual, searchAnalytics: vi.fn() };
 });
 
-function stubEsBuckets(buckets: { key: string; doc_count: number }[]) {
+function stubEsBuckets(
+  buckets: { key: string; doc_count: number }[],
+  sumOtherDocCount: number = 0
+) {
   const response: estypes.SearchResponse<never> = {
     took: 1,
     timed_out: false,
     _shards: { total: 1, successful: 1, failed: 0, skipped: 0 },
     hits: { hits: [] },
-    aggregations: { by_space: { buckets } },
+    aggregations: {
+      by_space: { buckets, sum_other_doc_count: sumOtherDocCount },
+    },
   };
   vi.mocked(searchAnalytics).mockResolvedValue(new Ok(response));
 }
@@ -50,9 +55,34 @@ describe("fetchPodUsageBreakdown", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual([
+      expect(result.value).toEqual({
+        buckets: [
+          { podId: pod.sId, name: pod.name, count: 12 },
+          { podId: null, name: null, count: 10 },
+        ],
+        otherPodsCount: 0,
+      });
+    }
+  });
+
+  it("surfaces the aggregation's truncated-tail count as otherPodsCount", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace);
+
+    stubEsBuckets([{ key: pod.sId, doc_count: 12 }], 805);
+
+    const result = await fetchPodUsageBreakdown(auth, {
+      bool: { filter: [] },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.otherPodsCount).toBe(805);
+      expect(result.value.buckets).toEqual([
         { podId: pod.sId, name: pod.name, count: 12 },
-        { podId: null, name: null, count: 10 },
       ]);
     }
   });
@@ -76,7 +106,10 @@ describe("fetchPodUsageBreakdown", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.map((b) => b.podId)).toEqual([podB.sId, podA.sId]);
+      expect(result.value.buckets.map((b) => b.podId)).toEqual([
+        podB.sId,
+        podA.sId,
+      ]);
     }
   });
 
@@ -93,7 +126,7 @@ describe("fetchPodUsageBreakdown", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual([]);
+      expect(result.value).toEqual({ buckets: [], otherPodsCount: 0 });
     }
   });
 });

--- a/front/lib/api/assistant/observability/pod_usage.ts
+++ b/front/lib/api/assistant/observability/pod_usage.ts
@@ -11,7 +11,7 @@ const MISSING_SPACE_ID = "__none__";
 
 // Cardinality guard: a workspace is not expected to have anywhere near this
 // many pods with activity on a single agent over the selected window.
-const MAX_POD_BUCKETS = 100;
+const MAX_POD_BUCKETS = 200;
 
 type PodUsageBucket = {
   // Pod (project space) sId, or null for messages outside of any pod.
@@ -22,10 +22,19 @@ type PodUsageBucket = {
 };
 
 type PodUsageAggs = {
-  by_space?: estypes.AggregationsMultiBucketAggregateBase<{
+  // Terms aggregate: also carries sum_other_doc_count for buckets beyond size.
+  by_space?: estypes.AggregationsTermsAggregateBase<{
     key: string;
     doc_count: number;
   }>;
+};
+
+export type PodUsageBreakdown = {
+  buckets: PodUsageBucket[];
+  // Messages counted in space buckets beyond the top MAX_POD_BUCKETS returned
+  // by the terms aggregation (sum_other_doc_count). Must be included in totals
+  // so they match the other analytics charts on high-cardinality workspaces.
+  otherPodsCount: number;
 };
 
 /**
@@ -37,7 +46,7 @@ type PodUsageAggs = {
 export async function fetchPodUsageBreakdown(
   auth: Authenticator,
   baseQuery: estypes.QueryDslQueryContainer
-): Promise<Result<PodUsageBucket[], Error>> {
+): Promise<Result<PodUsageBreakdown, Error>> {
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
     by_space: {
       terms: {
@@ -61,6 +70,9 @@ export async function fetchPodUsageBreakdown(
     key: string;
     doc_count: number;
   }>(result.value.aggregations?.by_space?.buckets);
+
+  const otherPodsCount =
+    result.value.aggregations?.by_space?.sum_other_doc_count ?? 0;
 
   const spaceIds = rawBuckets
     .map((b) => String(b.key))
@@ -92,10 +104,11 @@ export async function fetchPodUsageBreakdown(
     podBuckets.push({ podId: null, name: null, count: noPodCount });
   }
 
-  return new Ok(podBuckets);
+  return new Ok({ buckets: podBuckets, otherPodsCount });
 }
 
 export type GetPodUsageResponse = {
   total: number;
   buckets: PodUsageBucket[];
+  otherPodsCount: number;
 };

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -1021,7 +1021,7 @@ export function useAgentPodUsage(params: {
   );
 
   return {
-    podUsage: data ?? { total: 0, buckets: emptyArray() },
+    podUsage: data ?? { total: 0, buckets: emptyArray(), otherPodsCount: 0 },
     isPodUsageLoading: !error && !data && !disabled,
     isPodUsageError: error,
     isPodUsageValidating: isValidating,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -12,6 +12,7 @@ import type {
   GetLatencyResponse,
   GetUsageMetricsResponse,
 } from "@app/lib/api/assistant/observability/messages_metrics";
+import type { GetPodUsageResponse } from "@app/lib/api/assistant/observability/pod_usage";
 import type { GetSkillExecutionResponse } from "@app/lib/api/assistant/observability/skill_execution";
 import type { GetToolExecutionResponse } from "@app/lib/api/assistant/observability/tool_execution";
 import type {
@@ -992,6 +993,38 @@ export function useAgentContextOrigin(params: {
     isContextOriginLoading: !error && !data && !disabled,
     isContextOriginError: error,
     isContextOriginValidating: isValidating,
+  };
+}
+
+export function useAgentPodUsage(params: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  disabled?: boolean;
+}) {
+  const {
+    workspaceId,
+    agentConfigurationId,
+    days = DEFAULT_PERIOD_DAYS,
+    version,
+    disabled,
+  } = params;
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetPodUsageResponse> = fetcher;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/pods?days=${days}${versionParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    podUsage: data ?? { total: 0, buckets: emptyArray() },
+    isPodUsageLoading: !error && !data && !disabled,
+    isPodUsageError: error,
+    isPodUsageValidating: isValidating,
   };
 }
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9348

This PR adds the frontend:

- `useAgentPodUsage` SWR hook in `front/lib/swr/assistants.ts` hitting the new `observability/pods` endpoint.
- `PodUsageChart` donut chart (`front/components/agent_builder/observability/charts/PodUsageChart.tsx`), modeled on the existing `SourceChart`: same ring layout with the total message count in the center, tooltip and selectable legend, respects the period/version selectors. Pods use the indexed categorical palette; the "No pod" slice uses the muted color.
- Mounted in `AgentObservability` (Details section) right after the Source chart, lazy-loaded like the other charts.

## Tests

Tested locally:

<img width="1518" height="1740" alt="image" src="https://github.com/user-attachments/assets/5f7372c5-c1a2-4c24-be5d-96ca15b93971" />


## Stack

- 1/3: https://github.com/dust-tt/dust/pull/29179
- 2/3: https://github.com/dust-tt/dust/pull/29180
- 3/3: https://github.com/dust-tt/dust/pull/29181

## Risk

Low: additive UI chart.

## Deploy Plan

Deploy `front`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)