### PR TITLE
[front] perf: filter spaces by kind in SQL for useSpaces

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9637,9 +9637,21 @@
             "in": "query",
             "name": "kind",
             "required": false,
-            "description": "Filter by space kind (e.g. system)",
+            "description": "Filter by one or more space kinds. Repeat the parameter to include several kinds.",
+            "style": "form",
+            "explode": true,
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "global",
+                  "system",
+                  "conversations",
+                  "regular",
+                  "project"
+                ]
+              }
             }
           }
         ],

--- a/front-api/routes/w/[wId]/spaces/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/index.test.ts
@@ -1,5 +1,9 @@
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { GetSpacesResponseBody } from "@app/types/api/spaces";
+import type { SpaceKind } from "@app/types/space";
 import { describe, expect, it, vi } from "vitest";
 
 const { mockCreateSpaceAndGroup } = vi.hoisted(() => ({
@@ -26,6 +30,65 @@ function postSpace(workspace: { sId: string }, body: unknown) {
     body: JSON.stringify(body),
   });
 }
+
+function getSpaces(workspace: { sId: string }, kinds?: SpaceKind[]) {
+  const query = kinds
+    ?.map((kind) => `kind=${encodeURIComponent(kind)}`)
+    .join("&");
+
+  return honoApp.request(
+    `/api/w/${workspace.sId}/spaces${query ? `?${query}` : ""}`
+  );
+}
+
+describe("GET /api/w/:wId/spaces", () => {
+  it("filters by repeated kinds and only enriches projects", async () => {
+    const { workspace, user, auth, globalSpace } =
+      await createPrivateApiMockRequest();
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: "Project description",
+    });
+
+    const metadataFetch = vi.spyOn(
+      ProjectMetadataResource,
+      "fetchBySpaceModelIds"
+    );
+
+    const globalResponse = await getSpaces(workspace, ["global"]);
+    expect(globalResponse.status).toBe(200);
+    const globalData = (await globalResponse.json()) as GetSpacesResponseBody;
+    expect(globalData.spaces).toEqual([
+      expect.objectContaining({ sId: globalSpace.sId, kind: "global" }),
+    ]);
+    expect(metadataFetch).not.toHaveBeenCalled();
+
+    const mixedResponse = await getSpaces(workspace, ["global", "project"]);
+    expect(mixedResponse.status).toBe(200);
+    const mixedData = (await mixedResponse.json()) as GetSpacesResponseBody;
+    expect(mixedData.spaces.map((space) => space.sId)).toEqual(
+      expect.arrayContaining([globalSpace.sId, projectSpace.sId])
+    );
+    expect(mixedData.spaces).toContainEqual(
+      expect.objectContaining({
+        sId: projectSpace.sId,
+        kind: "project",
+        description: "Project description",
+      })
+    );
+    expect(metadataFetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects invalid kinds", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/spaces?kind=invalid`
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
 
 describe("POST /api/w/:wId/spaces", () => {
   it("blocks creating an open project when open projects are disabled", async () => {

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -14,12 +14,7 @@ import type {
 } from "@app/types/api/spaces";
 import { PostSpaceRequestBodySchema } from "@app/types/api/spaces";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import {
-  type PodType,
-  SPACE_KINDS,
-  type SpaceKind,
-  type SpaceType,
-} from "@app/types/space";
+import { type PodType, SPACE_KINDS, type SpaceType } from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -44,8 +39,6 @@ const GetSpacesQuerySchema = z.object({
   role: z.string().optional(),
   kind: z.union([z.enum(SPACE_KINDS), z.array(z.enum(SPACE_KINDS))]).optional(),
 });
-
-const ADMIN_SPACE_KINDS = new Set<SpaceKind>(["system", "global", "regular"]);
 
 /**
  * @swagger
@@ -171,13 +164,12 @@ app.get(
 
     let spaces: SpaceResource[] = [];
     if (role === "admin") {
-      const adminKinds = kinds?.filter((kind) => ADMIN_SPACE_KINDS.has(kind));
-      spaces =
-        adminKinds?.length === 0
-          ? []
-          : await SpaceResource.listWorkspaceSpaces(auth, {
-              kinds: adminKinds,
-            });
+      if (kind === "system") {
+        const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+        spaces = systemSpace ? [systemSpace] : [];
+      } else {
+        spaces = await SpaceResource.listWorkspaceSpaces(auth);
+      }
     } else {
       spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth, {
         kinds,

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -14,11 +14,17 @@ import type {
 } from "@app/types/api/spaces";
 import { PostSpaceRequestBodySchema } from "@app/types/api/spaces";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { PodType, SpaceType } from "@app/types/space";
+import {
+  type PodType,
+  SPACE_KINDS,
+  type SpaceKind,
+  type SpaceType,
+} from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 import spaceId from "./[spaceId]";
 import checkName from "./check-name";
 import projectsLookup from "./projects-lookup";
@@ -33,6 +39,13 @@ export type {
 // Mounted under /api/w/:wId/spaces. workspaceAuth is applied by the parent
 // workspace sub-app, so ctx.get("auth") is always available here.
 const app = workspaceApp();
+
+const GetSpacesQuerySchema = z.object({
+  role: z.string().optional(),
+  kind: z.union([z.enum(SPACE_KINDS), z.array(z.enum(SPACE_KINDS))]).optional(),
+});
+
+const ADMIN_SPACE_KINDS = new Set<SpaceKind>(["system", "global", "regular"]);
 
 /**
  * @swagger
@@ -58,9 +71,14 @@ const app = workspaceApp();
  *       - in: query
  *         name: kind
  *         required: false
- *         description: Filter by space kind (e.g. system)
+ *         description: Filter by one or more space kinds. Repeat the parameter to include several kinds.
+ *         style: form
+ *         explode: true
  *         schema:
- *           type: string
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum: [global, system, conversations, regular, project]
  *     security:
  *       - BearerAuth: []
  *     responses:
@@ -139,37 +157,50 @@ const app = workspaceApp();
  *         description: Unauthorized
  */
 
-app.get("/", async (ctx): HandlerResult<GetSpacesResponseBody> => {
-  const auth = ctx.get("auth");
-  const role = ctx.req.query("role");
-  const kind = ctx.req.query("kind");
+app.get(
+  "/",
+  validate("query", GetSpacesQuerySchema),
+  async (ctx): HandlerResult<GetSpacesResponseBody> => {
+    const auth = ctx.get("auth");
+    const { role, kind } = ctx.req.valid("query");
+    const kinds = kind
+      ? Array.isArray(kind)
+        ? Array.from(new Set(kind))
+        : [kind]
+      : undefined;
 
-  let spaces: SpaceResource[] = [];
-  if (role === "admin") {
-    if (kind === "system") {
-      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-      spaces = systemSpace ? [systemSpace] : [];
+    let spaces: SpaceResource[] = [];
+    if (role === "admin") {
+      const adminKinds = kinds?.filter((kind) => ADMIN_SPACE_KINDS.has(kind));
+      spaces =
+        adminKinds?.length === 0
+          ? []
+          : await SpaceResource.listWorkspaceSpaces(auth, {
+              kinds: adminKinds,
+            });
     } else {
-      spaces = await SpaceResource.listWorkspaceSpaces(auth);
+      spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth, {
+        kinds,
+      });
     }
-  } else {
-    spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+
+    spaces = spaces.filter((s) => s.kind !== "conversations");
+    const nonProjectSpaces = spaces.filter((s) => s.kind !== "project");
+    const projectSpaces = spaces.filter((s) => s.kind === "project");
+
+    const nonProjectsJson: SpaceType[] = nonProjectSpaces.map((s) =>
+      s.toJSON()
+    );
+    const projectsJson: PodType[] =
+      projectSpaces.length > 0
+        ? await enrichProjectsWithMetadata(auth, projectSpaces)
+        : [];
+
+    return ctx.json({
+      spaces: [...nonProjectsJson, ...projectsJson],
+    });
   }
-
-  spaces = spaces.filter((s) => s.kind !== "conversations");
-  const nonProjectSpaces = spaces.filter((s) => s.kind !== "project");
-  const projectSpaces = spaces.filter((s) => s.kind === "project");
-
-  const nonProjectsJson: SpaceType[] = nonProjectSpaces.map((s) => s.toJSON());
-  const projectsJson: PodType[] = await enrichProjectsWithMetadata(
-    auth,
-    projectSpaces
-  );
-
-  return ctx.json({
-    spaces: [...nonProjectsJson, ...projectsJson],
-  });
-});
+);
 
 app.post(
   "/",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -238,7 +238,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeConversationsSpace?: boolean;
       includeProjectSpaces?: boolean;
       includeDeleted?: boolean;
-      kinds?: SpaceKind[];
     },
     t?: Transaction
   ): Promise<SpaceResource[]> {
@@ -248,7 +247,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         includeDeleted: options?.includeDeleted,
         where: {
           kind: {
-            [Op.in]: options?.kinds ?? [
+            [Op.in]: [
               "system",
               "global",
               "regular",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -238,6 +238,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeConversationsSpace?: boolean;
       includeProjectSpaces?: boolean;
       includeDeleted?: boolean;
+      kinds?: SpaceKind[];
     },
     t?: Transaction
   ): Promise<SpaceResource[]> {
@@ -247,7 +248,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         includeDeleted: options?.includeDeleted,
         where: {
           kind: {
-            [Op.in]: [
+            [Op.in]: options?.kinds ?? [
               "system",
               "global",
               "regular",
@@ -263,8 +264,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return spaces;
   }
 
-  static async listWorkspaceSpacesAsMember(auth: Authenticator) {
-    const spaces = await this.baseFetch(auth);
+  static async listWorkspaceSpacesAsMember(
+    auth: Authenticator,
+    options?: { kinds?: SpaceKind[] }
+  ) {
+    const spaces = await this.baseFetch(auth, {
+      where: options?.kinds ? { kind: { [Op.in]: options.kinds } } : undefined,
+    });
 
     // TODO(projects): we might want to filter early on the groups membership to avoid fetching all spaces and then filtering.
     return spaces.filter((s) => s.isMember(auth));

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -36,7 +36,6 @@ import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
-import { isString } from "@app/types/shared/utils/general";
 import type { PodType, SpaceKind, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
@@ -55,9 +54,17 @@ export function useSpaces({
 }) {
   const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
+  const kindsKey = kinds === "all" ? kinds : kinds.toSorted().join(",");
+  const queryParams =
+    kinds === "all"
+      ? ""
+      : `?${kinds
+          .toSorted()
+          .map((kind) => `kind=${encodeURIComponent(kind)}`)
+          .join("&")}`;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/spaces`,
+  const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces${queryParams}`,
     spacesFetcher,
     { ...swrOptions, disabled }
   );
@@ -70,13 +77,13 @@ export function useSpaces({
     );
     // Serialize the kinds array to a string to avoid unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.spaces, isString(kinds) ? kinds : kinds.toSorted().join(",")]);
+  }, [data?.spaces, kindsKey]);
 
   return {
     spaces,
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
-    mutate,
+    mutate: mutateRegardlessOfQueryParams,
   };
 }
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -54,7 +54,6 @@ export function useSpaces({
 }) {
   const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
-  const kindsKey = kinds === "all" ? kinds : kinds.toSorted().join(",");
   const queryParams =
     kinds === "all"
       ? ""
@@ -77,7 +76,7 @@ export function useSpaces({
     );
     // Serialize the kinds array to a string to avoid unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.spaces, kindsKey]);
+  }, [data?.spaces, kinds === "all" ? kinds : kinds.toSorted().join(",")]);
 
   return {
     spaces,


### PR DESCRIPTION
## Description

Pass requested space kinds from `useSpaces` to the spaces endpoint and apply the filter in PostgreSQL before hydrating space groups.

This prevents the capabilities preloader's global-space request from loading every project and group in the workspace. Project metadata enrichment now only runs when the filtered result contains projects. Requests without a kind keep the existing full response, and SWR mutations continue to invalidate all filtered URL variants.

The private API documentation now describes the repeatable `kind` query parameter.

## Tests

- Added endpoint coverage for repeated kind filtering and conditional project metadata enrichment.
- `NODE_ENV=test npm test -- 'routes/w/[wId]/spaces/index.test.ts'`

## Risk

Medium. Touches spaces listing which is pervasively used.

## Deploy Plan

- deploy `front`