### PR TITLE
feat(front): explain model tiers with an info modal

### DIFF
--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -1,4 +1,5 @@
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
+import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import { useGroups, useUpdateGroupSpendLimit } from "@app/lib/swr/groups";
 import type { GroupSpendLimit } from "@app/types/api/groups/spend_limit";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
@@ -145,7 +146,12 @@ export function GroupsUsageTable({
         ? [
             {
               id: "modelTiers",
-              header: "Models tier",
+              header: () => (
+                <span className="flex items-center gap-1">
+                  Models tier
+                  <ModelTiersInfoButton />
+                </span>
+              ),
               meta: { className: "w-64" },
               cell: (info: GroupInfo) => (
                 <GroupModelTierPickerDropdown

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -2,6 +2,7 @@ import {
   SEAT_TYPE_ICONS,
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
+import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import {
   getSeatBarClasses,
@@ -529,7 +530,12 @@ function buildConsumedAwuCreditsColumn(
 
 const modelTiersColumn: ColumnDef<RowData, string> = {
   id: "modelTiers" as const,
-  header: "Models tier",
+  header: () => (
+    <span className="flex items-center gap-1">
+      Models tier
+      <ModelTiersInfoButton />
+    </span>
+  ),
   enableSorting: false,
   accessorFn: (row) => row.modelTiersSummary,
   cell: (info: Info) => {

--- a/front/components/workspace/ModelTiersInfoModal.tsx
+++ b/front/components/workspace/ModelTiersInfoModal.tsx
@@ -1,0 +1,155 @@
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { ModelTierExplainerTier } from "@app/lib/client/model_tiers_explainer";
+import { getModelTierExplainer } from "@app/lib/client/model_tiers_explainer";
+import {
+  Button,
+  ChevronDown,
+  ChevronRight,
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+} from "@dust-tt/sparkle";
+import { InformationCircleIcon } from "@heroicons/react/20/solid";
+import { useMemo, useState } from "react";
+
+const TIER_PRESENTATION: Record<ModelsTierName, { priceClassName: string }> = {
+  cost_efficient: { priceClassName: "text-emerald-500" },
+  balanced: { priceClassName: "text-blue-500" },
+  premium: { priceClassName: "text-amber-500" },
+};
+
+interface TierCardProps {
+  tier: ModelTierExplainerTier;
+}
+
+function TierCard({ tier }: TierCardProps) {
+  const { priceClassName } = TIER_PRESENTATION[tier.name];
+
+  return (
+    <Collapsible>
+      <div className="rounded-2xl border border-border bg-muted-background dark:border-border-dark dark:bg-muted-background-night">
+        <CollapsibleTrigger
+          hideChevron
+          className="w-full rounded-2xl p-4 text-left"
+        >
+          <div className="flex w-full items-center gap-3">
+            <span
+              className={`w-8 shrink-0 text-sm font-semibold ${priceClassName}`}
+            >
+              {"$".repeat(tier.priceLevel)}
+            </span>
+            <div className="flex flex-1 flex-col gap-0.5">
+              <span className="heading-sm text-foreground dark:text-foreground-night">
+                {tier.displayName}
+              </span>
+              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {tier.description}
+              </span>
+            </div>
+            <Icon
+              visual={ChevronRight}
+              size="sm"
+              className="shrink-0 text-muted-foreground group-data-[state=open]/col:hidden dark:text-muted-foreground-night"
+            />
+            <Icon
+              visual={ChevronDown}
+              size="sm"
+              className="hidden shrink-0 text-muted-foreground group-data-[state=open]/col:block dark:text-muted-foreground-night"
+            />
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="flex flex-col px-4 pb-2">
+            <div className="flex items-center justify-between gap-3 border-t border-border py-2 dark:border-border-dark">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+                Model
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+                Reasoning effort
+              </span>
+            </div>
+            {tier.models.map((model) => (
+              <div
+                key={model.displayName}
+                className="flex items-center justify-between gap-3 border-t border-border py-3 dark:border-border-dark"
+              >
+                <span className="text-sm text-foreground dark:text-foreground-night">
+                  {model.displayName}
+                </span>
+                <Chip size="xs" color="primary" label={model.effortsLabel} />
+              </div>
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+interface ModelTiersInfoDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function ModelTiersInfoDialog({ isOpen, onClose }: ModelTiersInfoDialogProps) {
+  const tiers = useMemo(() => getModelTierExplainer(), []);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>How model tiers work</DialogTitle>
+        </DialogHeader>
+        {/* Content-sized scroll region: min-h-0 lets it shrink below its content
+            so it scrolls once it hits the dialog's max-height, while staying
+            compact (no empty space) when the tiers are collapsed. */}
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto px-5 py-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Each tier groups <b>model + reasoning-effort</b> options based on
+            cost. A member capped at a tier can use that tier and every cheaper
+            one — “Up to Balanced” means Balanced and Cost Efficient. Open a
+            tier to see what's inside.
+          </p>
+          <div className="flex flex-col gap-2">
+            {tiers.map((tier) => (
+              <TierCard key={tier.name} tier={tier} />
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ModelTiersInfoButtonProps {
+  className?: string;
+}
+
+// Info (ⓘ) affordance that opens the "How model tiers work" modal. Drop it next
+// to any "Models tier" label (column headers, settings pickers).
+export function ModelTiersInfoButton({ className }: ModelTiersInfoButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="xs"
+        icon={InformationCircleIcon}
+        tooltip="How model tiers work"
+        className={className}
+        onClick={(event) => {
+          event.stopPropagation();
+          setIsOpen(true);
+        }}
+      />
+      <ModelTiersInfoDialog isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -1,4 +1,5 @@
 import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
+import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getWorkspaceModelTierOptions } from "@app/lib/client/model_tier_options";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
@@ -29,8 +30,9 @@ export function ModelTiersSettingsCard({
 
   return (
     <Page.Vertical gap="sm" align="stretch">
-      <span className="heading-base text-foreground dark:text-foreground-night">
+      <span className="flex items-center gap-1 heading-base text-foreground dark:text-foreground-night">
         Models tier
+        <ModelTiersInfoButton />
       </span>
       <SettingsList>
         <SettingsList.Row

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -1,0 +1,79 @@
+import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  MODELS_TIERS,
+  STATIC_MODEL_TIERS,
+} from "@app/lib/api/assistant/token_pricing/tiers";
+import { getTierIndex } from "@app/lib/model_tiers/tier_order";
+import { isStaticModelId } from "@app/types/assistant/models/models";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
+import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
+import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
+
+export interface ModelTierExplainerEntry {
+  displayName: string;
+  effortsLabel: string;
+}
+
+export interface ModelTierExplainerTier {
+  name: ModelsTierName;
+  displayName: string;
+  description: string;
+  priceLevel: number;
+  models: ModelTierExplainerEntry[];
+}
+
+const HIDDEN_PROVIDER_IDS = new Set(["auto", "noop"]);
+
+function formatEffortsLabel(
+  inTierEfforts: ReasoningEffort[],
+  supportedEfforts: ReasoningEffort[]
+): string {
+  if (
+    inTierEfforts.length === supportedEfforts.length &&
+    supportedEfforts.length > 1
+  ) {
+    return "all efforts";
+  }
+
+  return inTierEfforts.join(" · ");
+}
+
+export function getModelTierExplainer(): ModelTierExplainerTier[] {
+  return MODELS_TIERS.map((tier) => {
+    const models: ModelTierExplainerEntry[] = [];
+
+    for (const config of USED_MODEL_CONFIGS) {
+      if (
+        HIDDEN_PROVIDER_IDS.has(config.providerId) ||
+        !isStaticModelId(config.modelId)
+      ) {
+        continue;
+      }
+
+      const tiersByEffort = STATIC_MODEL_TIERS[config.modelId];
+      const supportedEfforts = getAvailableReasoningEfforts(
+        config.supportedReasoningEfforts
+      );
+      const inTierEfforts = supportedEfforts.filter(
+        (effort) => tiersByEffort[effort] === tier.name
+      );
+      if (inTierEfforts.length === 0) {
+        continue;
+      }
+
+      models.push({
+        displayName: config.displayName,
+        effortsLabel: formatEffortsLabel(inTierEfforts, supportedEfforts),
+      });
+    }
+
+    return {
+      name: tier.name,
+      displayName: formatAsDisplayName(tier.name),
+      description: tier.description,
+      priceLevel: getTierIndex(tier.name) + 1,
+      models,
+    };
+  });
+}


### PR DESCRIPTION
## Description
<img width="703" height="826" alt="Screenshot 2026-07-20 at 18 36 39" src="https://github.com/user-attachments/assets/17af8c23-b3a1-4555-8d2e-6c9e72ee60cd" />

Admins see a "Models tier" column (values like "Up to Premium" / "Up to Balanced") across the Usage pages, but there was nothing explaining what a tier actually is.

This adds a "How model tiers work" info modal, opened from an ⓘ button placed consistently next to every "Models tier" label:

- **Members** table column header
- **Groups** tab column header
- **Settings** workspace tier-picker heading

The modal explains that a tier groups (model + reasoning-effort) options by cost, that a cap is cumulative ("Up to Balanced" grants Balanced + Cost Efficient), and lists — per tier — the currently-available models with the reasoning-effort settings that land in that tier.

The per-tier breakdown is derived entirely from the existing data (`USED_MODEL_CONFIGS` × `STATIC_MODEL_TIERS`), so it stays in sync automatically as models and tiers change — no hand-maintained list. Effort badges read as the specific efforts mapping to the tier ("medium", "light · medium") or "all efforts" when every supported effort maps there.

UI only; no API, schema, or data changes.

## Tests

Verified manually. The tier → models derivation (`getModelTierExplainer`) was exercised in isolation to confirm sensible, non-empty output across all three tiers (e.g. Claude Sonnet 4.6 correctly appears in Cost Efficient/Balanced/Premium at light/medium/high).
