### PR TITLE
Self-improving skills: drop the legacy tool edit type

### DIFF
--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -1,5 +1,3 @@
-import { getDefaultMCPAction } from "@app/components/agent_builder/types";
-import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
@@ -36,8 +34,6 @@ export function SkillBuilderSuggestionsPanel({
     () => getValues("agentFacingDescription") ?? "",
     [getValues]
   );
-  const { mcpServerViews } = useMCPServerViewsContext();
-
   const { suggestions, isSuggestionsLoading, mutateSuggestions } =
     useSkillSuggestions({
       skillId,
@@ -50,38 +46,6 @@ export function SkillBuilderSuggestionsPanel({
     skillId,
     workspaceId: owner.sId,
   });
-
-  const applyToolEdits = useCallback(
-    (suggestion: SkillSuggestionType) => {
-      const { toolEdits } = suggestion.suggestion;
-      if (!toolEdits || toolEdits.length === 0) {
-        return;
-      }
-
-      let currentTools = getValues("tools");
-
-      for (const edit of toolEdits) {
-        if (edit.action === "add") {
-          const alreadyAdded = currentTools.some(
-            (t) => t.configuration.mcpServerViewId === edit.toolId
-          );
-          if (!alreadyAdded) {
-            const view = mcpServerViews.find((v) => v.sId === edit.toolId);
-            if (view) {
-              currentTools = [...currentTools, getDefaultMCPAction(view)];
-            }
-          }
-        } else {
-          currentTools = currentTools.filter(
-            (t) => t.configuration.mcpServerViewId !== edit.toolId
-          );
-        }
-      }
-
-      setValue("tools", currentTools, { shouldDirty: true });
-    },
-    [getValues, setValue, mcpServerViews]
-  );
 
   const applyAgentFacingDescriptionEdit = useCallback(
     (suggestion: SkillSuggestionType) => {
@@ -106,7 +70,6 @@ export function SkillBuilderSuggestionsPanel({
       const result = await patchSuggestions([suggestion.sId], "approved");
       if (result) {
         acceptInstructionEdits?.(suggestion.sId);
-        applyToolEdits(suggestion);
         applyAgentFacingDescriptionEdit(suggestion);
         setSelectedSuggestionId(null);
         await mutateSuggestions();
@@ -116,7 +79,6 @@ export function SkillBuilderSuggestionsPanel({
       patchSuggestions,
       mutateSuggestions,
       acceptInstructionEdits,
-      applyToolEdits,
       applyAgentFacingDescriptionEdit,
       setSelectedSuggestionId,
       disabled,

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,86 +1,15 @@
-import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getBlockOuterHtml } from "@app/components/shared/utils";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import type {
   SkillAgentFacingDescriptionEditType,
   SkillInstructionEditItemType,
   SkillSuggestionType,
-  SkillToolEditItemType,
 } from "@app/types/suggestions/skill_suggestion";
-import { Button, Card, Chip, DiffBlock, Hoverable } from "@dust-tt/sparkle";
+import { Button, Card, DiffBlock, Hoverable } from "@dust-tt/sparkle";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { useMemo } from "react";
 
 const MAX_VISIBLE_CONVERSATIONS = 3;
-
-function useToolDisplayNames(
-  toolEdits: SkillToolEditItemType[]
-): Map<string, string> {
-  const ctx = useMaybeMCPServerViewsContext();
-
-  return useMemo(() => {
-    const map = new Map<string, string>();
-    for (const edit of toolEdits) {
-      const view = ctx?.mcpServerViews.find((v) => v.sId === edit.toolId);
-      map.set(
-        edit.toolId,
-        view ? getMcpServerViewDisplayName(view) : edit.toolId
-      );
-    }
-    return map;
-  }, [toolEdits, ctx]);
-}
-
-interface ToolEditsSectionProps {
-  toolEdits: SkillToolEditItemType[];
-}
-
-function ToolEditsSection({ toolEdits }: ToolEditsSectionProps) {
-  const displayNames = useToolDisplayNames(toolEdits);
-
-  const toolsToAdd = toolEdits.filter((e) => e.action === "add");
-  const toolsToRemove = toolEdits.filter((e) => e.action === "remove");
-
-  return (
-    <div className="flex flex-col gap-2">
-      {toolsToAdd.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-foreground">
-            Tools to add
-          </span>
-          <div className="flex flex-wrap gap-2">
-            {toolsToAdd.map((edit) => (
-              <Chip
-                key={edit.toolId}
-                size="sm"
-                color="highlight"
-                label={displayNames.get(edit.toolId) ?? edit.toolId}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-      {toolsToRemove.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-foreground">
-            Tools to remove
-          </span>
-          <div className="flex flex-wrap gap-2">
-            {toolsToRemove.map((edit) => (
-              <Chip
-                key={edit.toolId}
-                size="sm"
-                color="warning"
-                label={displayNames.get(edit.toolId) ?? edit.toolId}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 interface AgentFacingDescriptionEditSectionProps {
   edit: SkillAgentFacingDescriptionEditType;
@@ -242,7 +171,7 @@ export function SkillSuggestionCard({
   workspaceId,
   disabled = false,
 }: SkillSuggestionCardProps) {
-  const { instructionEdits, toolEdits, agentFacingDescriptionEdit } =
+  const { instructionEdits, agentFacingDescriptionEdit } =
     suggestion.suggestion;
   const isClickable = !!onSelect;
   const hasActions = !!onAccept && !!onDecline;
@@ -286,10 +215,6 @@ export function SkillSuggestionCard({
             edit={agentFacingDescriptionEdit}
             currentAgentFacingDescription={getCurrentAgentFacingDescription()}
           />
-        )}
-
-        {toolEdits && toolEdits.length > 0 && (
-          <ToolEditsSection toolEdits={toolEdits} />
         )}
 
         {instructionEdits && instructionEdits.length > 0 && (

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -60,27 +60,6 @@ function makeInstructionSuggestion(
   } as SkillSuggestionType;
 }
 
-function makeToolSuggestion(
-  overrides: Partial<SkillSuggestionType> = {}
-): SkillSuggestionType {
-  return {
-    sId: "sug-2",
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-    skillConfigurationId: "skl_abc123",
-    analysis: "Needs search capability",
-    title: null,
-    state: "pending",
-    source: "synthetic",
-    sourceConversationsCount: 0,
-    kind: "edit",
-    suggestion: {
-      toolEdits: [{ action: "add", toolId: "tool-search" }],
-    },
-    ...overrides,
-  } as SkillSuggestionType;
-}
-
 function makeAgentFacingDescriptionSuggestion(
   overrides: Partial<SkillSuggestionType> = {}
 ): SkillSuggestionType {
@@ -139,18 +118,6 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).toContain("New improved instructions.");
   });
 
-  it("formats tool suggestions with action and toolId", () => {
-    const { userMessage } = buildSkillAggregationPrompt(
-      makeSkill(),
-      [makeToolSuggestion()],
-      { pending: [], rejected: [] }
-    );
-
-    expect(userMessage).toContain('kind="edit"');
-    expect(userMessage).toContain('action="add"');
-    expect(userMessage).toContain('toolId="tool-search"');
-  });
-
   it("shows N/A when analysis is null", () => {
     const suggestion = makeInstructionSuggestion({ analysis: null });
     const { userMessage } = buildSkillAggregationPrompt(
@@ -165,7 +132,10 @@ describe("buildSkillAggregationPrompt", () => {
   it("numbers multiple suggestions sequentially", () => {
     const { userMessage } = buildSkillAggregationPrompt(
       makeSkill(),
-      [makeInstructionSuggestion(), makeToolSuggestion()],
+      [
+        makeInstructionSuggestion(),
+        makeAgentFacingDescriptionSuggestion({ sId: "sug-2" }),
+      ],
       { pending: [], rejected: [] }
     );
 
@@ -177,7 +147,7 @@ describe("buildSkillAggregationPrompt", () => {
     const { userMessage } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
-      { pending: [makeToolSuggestion()], rejected: [] }
+      { pending: [makeAgentFacingDescriptionSuggestion()], rejected: [] }
     );
 
     expect(userMessage).toContain(
@@ -199,7 +169,7 @@ describe("buildSkillAggregationPrompt", () => {
     const { userMessage } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
-      { pending: [], rejected: [makeToolSuggestion()] }
+      { pending: [], rejected: [makeAgentFacingDescriptionSuggestion()] }
     );
 
     expect(userMessage).toContain(
@@ -226,7 +196,6 @@ describe("buildSkillAggregationPrompt", () => {
 
     expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("inline <tool>");
-    expect(systemPrompt).toContain('Do NOT include "toolEdits"');
   });
 
   it("formats agent-facing description edits with the new content", () => {

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -53,7 +53,7 @@ It is ok to simply call no tool if all suggestions are minor.
   aggregation_rules: `
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
-- For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
+- For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits.
 - For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement. Max description size is ${AGENT_FACING_DESCRIPTION_MAX_LENGTH} characters.
 NEVER create more than one suggestion per (skill, topic) pair.
 
@@ -78,7 +78,6 @@ There may be situations where suggestions are co-dependent. For example, there m
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
 The exceptions are:
 - The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
-- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.
 
 For "analysis": Provide a user-facing explanation of why the suggestion is impactful and how many conversations support it. The end user does NOT care about the technical considerations behind your thought process.
 
@@ -105,13 +104,6 @@ function formatSuggestion(s: SkillSuggestionType): string {
           xml += `<instructionEdit targetBlockId="${escapeXml(e.targetBlockId)}" type="${escapeXml(e.type)}"><content>${escapeXml(e.content)}</content></instructionEdit>`;
         }
         xml += "</instructionEdits>";
-      }
-      if (s.suggestion.toolEdits?.length) {
-        xml += "<toolEdits>";
-        for (const t of s.suggestion.toolEdits) {
-          xml += `<toolEdit action="${escapeXml(t.action)}" toolId="${escapeXml(t.toolId)}"/>`;
-        }
-        xml += "</toolEdits>";
       }
       if (s.suggestion.agentFacingDescriptionEdit) {
         xml += `<agentFacingDescriptionEdit><content>${escapeXml(s.suggestion.agentFacingDescriptionEdit.content)}</content></agentFacingDescriptionEdit>`;

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -111,7 +111,7 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
 - When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
-- Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions. NEVER use separate tool edits.
+- Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 
   agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -4,7 +4,6 @@ import {
   instructionEditSetsConflict,
   pruneConflictingSkillEditSuggestions,
   pruneOutdatedSkillEditSuggestions,
-  toolEditSetsConflict,
 } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -34,13 +33,6 @@ function makeInstructionEdit(targetBlockId: string): {
     content: `<p>Content for ${targetBlockId}</p>`,
     type: "replace",
   };
-}
-
-function makeToolEdit(
-  toolId: string,
-  action: "add" | "remove" = "add"
-): { toolId: string; action: "add" | "remove" } {
-  return { toolId, action };
 }
 
 const EMPTY_DESCENDANT_MAP = new Map<string, Set<string>>();
@@ -183,46 +175,11 @@ describe("instructionEditSetsConflict", () => {
   });
 });
 
-describe("toolEditSetsConflict", () => {
-  it("returns false when sets target different tool IDs", () => {
-    expect(
-      toolEditSetsConflict(
-        [makeToolEdit("tool-search")],
-        [makeToolEdit("tool-calendar")]
-      )
-    ).toBe(false);
-  });
-
-  it("conflicts when sets share a tool ID", () => {
-    expect(
-      toolEditSetsConflict(
-        [makeToolEdit("tool-search", "add")],
-        [makeToolEdit("tool-search", "remove")]
-      )
-    ).toBe(true);
-  });
-
-  it("conflicts when both sets add the same tool ID", () => {
-    expect(
-      toolEditSetsConflict(
-        [makeToolEdit("tool-search", "add")],
-        [makeToolEdit("tool-search", "add")]
-      )
-    ).toBe(true);
-  });
-
-  it("returns false when either set is empty", () => {
-    expect(toolEditSetsConflict([], [makeToolEdit("tool-search")])).toBe(false);
-    expect(toolEditSetsConflict([makeToolEdit("tool-search")], [])).toBe(false);
-  });
-});
-
 function makeSuggestion(
   overrides: Partial<SkillEditSuggestionType> = {}
 ): SkillEditSuggestionType {
   return {
     instructionEdits: [],
-    toolEdits: [],
     ...overrides,
   } as SkillEditSuggestionType;
 }
@@ -282,32 +239,6 @@ describe("hasSuggestionSelfConflict", () => {
         HIERARCHY_HTML
       )
     ).toBe(true);
-  });
-
-  it("conflicts when two tool edits target the same tool ID", () => {
-    expect(
-      hasSuggestionSelfConflict(
-        makeSuggestion({
-          toolEdits: [
-            makeToolEdit("tool-search", "add"),
-            makeToolEdit("tool-search", "remove"),
-          ],
-        }),
-        null
-      )
-    ).toBe(true);
-  });
-
-  it("returns false for mixed non-conflicting instruction and tool edits", () => {
-    expect(
-      hasSuggestionSelfConflict(
-        makeSuggestion({
-          instructionEdits: [makeInstructionEdit("para-1")],
-          toolEdits: [makeToolEdit("tool-search")],
-        }),
-        HIERARCHY_HTML
-      )
-    ).toBe(false);
   });
 });
 
@@ -466,16 +397,16 @@ describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", 
     expect(newerRefetched?.state).toBe("pending");
   });
 
-  it("a new description-edit suggestion does NOT outdate a tool-only suggestion", async () => {
+  it("a new description-edit suggestion does NOT outdate an instruction-only suggestion", async () => {
     const skill = await SkillFactory.create(authenticator, {
       instructionsHtml: '<p data-block-id="block-1">Content.</p>',
     });
-    const toolOnly = await SkillSuggestionFactory.createEdit(
+    const instructionOnly = await SkillSuggestionFactory.createEdit(
       authenticator,
       skill,
       {
         suggestion: {
-          toolEdits: [{ action: "add", toolId: "tool-search" }],
+          instructionEdits: [makeInstructionEdit("block-1")],
         },
       }
     );
@@ -493,7 +424,7 @@ describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", 
 
     const refetched = await SkillSuggestionResource.fetchById(
       authenticator,
-      toolOnly.sId
+      instructionOnly.sId
     );
     expect(refetched?.state).toBe("pending");
   });

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -10,7 +10,6 @@ import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_
 import type {
   SkillEditSuggestionType,
   SkillInstructionEditItemType,
-  SkillToolEditItemType,
 } from "@app/types/suggestions/skill_suggestion";
 
 /**
@@ -37,17 +36,6 @@ export function instructionEditSetsConflict(
 }
 
 /**
- * Returns true if two sets of tool edits target the same tool ID.
- */
-export function toolEditSetsConflict(
-  editsA: SkillToolEditItemType[],
-  editsB: SkillToolEditItemType[]
-): boolean {
-  const toolIdsA = new Set(editsA.map((e) => e.toolId));
-  return editsB.some((e) => toolIdsA.has(e.toolId));
-}
-
-/**
  * Returns true if a single suggestion's edits are internally inconsistent.
  */
 export function hasSuggestionSelfConflict(
@@ -55,7 +43,6 @@ export function hasSuggestionSelfConflict(
   instructionsHtml: string | null
 ): boolean {
   const instructionEdits = suggestion.instructionEdits ?? [];
-  const toolEdits = suggestion.toolEdits ?? [];
 
   // O(n²) acceptable: instructionEdits is bounded by LLM output (< 20 elements per suggestion).
   // Precompute descendant map once to avoid repeated HTML parsing across all pair checks.
@@ -79,11 +66,6 @@ export function hasSuggestionSelfConflict(
         return true;
       }
     }
-  }
-
-  const toolIds = toolEdits.map((e) => e.toolId);
-  if (new Set(toolIds).size < toolIds.length) {
-    return true;
   }
 
   return false;
@@ -112,7 +94,6 @@ export async function pruneConflictingSkillEditSuggestions(
   }
 
   const newInstructionEdits = newSuggestion.suggestion.instructionEdits ?? [];
-  const newToolEdits = newSuggestion.suggestion.toolEdits ?? [];
   const newHasAgentFacingDescriptionEdit =
     newSuggestion.suggestion.agentFacingDescriptionEdit !== undefined;
 
@@ -156,7 +137,6 @@ export async function pruneConflictingSkillEditSuggestions(
         skill.instructionsHtml,
         descendantMap
       ) ||
-      toolEditSetsConflict(newToolEdits, existing.suggestion.toolEdits ?? []) ||
       (newHasAgentFacingDescriptionEdit &&
         existingHasAgentFacingDescriptionEdit)
     );
@@ -186,23 +166,12 @@ export async function pruneOutdatedSkillEditSuggestions(
     return;
   }
 
-  const currentToolIds = new Set(skill.mcpServerViews.map((v) => v.sId));
   const currentBlockIds = skill.instructionsHtml
     ? getAllBlockIds(skill.instructionsHtml)
     : new Set<string>();
 
   const outdated = pending.filter((p) => {
-    const { instructionEdits, toolEdits } = p.suggestion;
-
-    for (const edit of toolEdits ?? []) {
-      const cannotApply =
-        edit.action === "add"
-          ? currentToolIds.has(edit.toolId)
-          : !currentToolIds.has(edit.toolId);
-      if (cannotApply) {
-        return true;
-      }
-    }
+    const { instructionEdits } = p.suggestion;
 
     // We do not do a diff check to determine if the content of a specific instruction block has changed.
     // Taking this simplification as it is a low impact edge case.

--- a/front/migrations/20260720_drop_skill_suggestion_tool_edits.ts
+++ b/front/migrations/20260720_drop_skill_suggestion_tool_edits.ts
@@ -1,0 +1,45 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  await runOnAllWorkspaces(
+    async (workspace) => {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const suggestions = await SkillSuggestionResource.listByWorkspace(auth, {
+        sources: ["reinforcement", "synthetic"],
+        dangerouslyBypassConversationsVisibilityCheck: true,
+      });
+      const withToolEdits = suggestions.filter(
+        (s) => "toolEdits" in s.suggestion
+      );
+
+      if (withToolEdits.length === 0) {
+        return;
+      }
+
+      if (!execute) {
+        logger.info(
+          { workspaceId: workspace.sId, count: withToolEdits.length },
+          "Would delete skill suggestions containing legacy toolEdits"
+        );
+        return;
+      }
+
+      const result = await SkillSuggestionResource.bulkDelete(
+        auth,
+        withToolEdits
+      );
+      if (result.isErr()) {
+        throw result.error;
+      }
+      logger.info(
+        { workspaceId: workspace.sId, deleted: result.value },
+        "Deleted skill suggestions containing legacy toolEdits"
+      );
+    },
+    { concurrency: 4 }
+  );
+});

--- a/front/scripts/seed/factories/seedSkillSuggestions.ts
+++ b/front/scripts/seed/factories/seedSkillSuggestions.ts
@@ -1,62 +1,8 @@
-import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  isAutoInternalMCPServerName,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
 
 import type { SeedContext, SkillSuggestionAsset } from "./types";
-
-/**
- * Resolves tool edit IDs from internal MCP server names to workspace-specific MCPServerView sIds.
- */
-async function resolveToolEdits(
-  ctx: SeedContext,
-  toolEdits: { action: "add" | "remove"; toolId: string }[]
-): Promise<{ action: "add" | "remove"; toolId: string }[]> {
-  const { auth } = ctx;
-
-  const serverNamesToResolve = toolEdits
-    .map((edit) => edit.toolId)
-    .filter((id) => isInternalMCPServerName(id))
-    .filter((id): id is AutoInternalMCPServerNameType =>
-      isAutoInternalMCPServerName(id)
-    );
-
-  if (serverNamesToResolve.length === 0) {
-    return toolEdits;
-  }
-
-  const mcpServerViews =
-    await MCPServerViewResource.getMCPServerViewsForAutoInternalTools(
-      auth,
-      serverNamesToResolve
-    );
-
-  const serverNameToViewId = new Map<string, string>();
-  for (const view of mcpServerViews) {
-    const viewJson = view.toJSON();
-    if (viewJson) {
-      serverNameToViewId.set(viewJson.server.name, viewJson.sId);
-    }
-  }
-
-  return toolEdits.map((edit) => {
-    const resolvedId = serverNameToViewId.get(edit.toolId);
-    if (isInternalMCPServerName(edit.toolId) && resolvedId === undefined) {
-      throw new Error(
-        `Failed to resolve MCP server view ID for tool "${edit.toolId}"`
-      );
-    }
-    return {
-      ...edit,
-      toolId: resolvedId ?? edit.toolId,
-    };
-  });
-}
 
 export async function seedSkillSuggestions(
   ctx: SeedContext,
@@ -64,13 +10,6 @@ export async function seedSkillSuggestions(
   skills: Map<string, SkillResource>
 ): Promise<void> {
   const { auth, execute, logger } = ctx;
-
-  const hasToolEdits = suggestions.some(
-    (s) => s.suggestion.toolEdits && s.suggestion.toolEdits.length > 0
-  );
-  if (hasToolEdits) {
-    await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-  }
 
   for (const suggestionAsset of suggestions) {
     const skill = skills.get(suggestionAsset.skillName);
@@ -88,14 +27,6 @@ export async function seedSkillSuggestions(
     );
 
     if (execute) {
-      const resolvedSuggestion = { ...suggestionAsset.suggestion };
-      if (resolvedSuggestion.toolEdits) {
-        resolvedSuggestion.toolEdits = await resolveToolEdits(
-          ctx,
-          resolvedSuggestion.toolEdits
-        );
-      }
-
       let sourceConversationIds: number[] | null = null;
       if (suggestionAsset.sourceConversationIds) {
         sourceConversationIds = await resolveConversationModelIds(
@@ -106,7 +37,7 @@ export async function seedSkillSuggestions(
 
       const created = await SkillSuggestionFactory.create(auth, skill, {
         kind: suggestionAsset.kind,
-        suggestion: resolvedSuggestion,
+        suggestion: suggestionAsset.suggestion,
         analysis: suggestionAsset.analysis,
         title: suggestionAsset.title ?? null,
         state: suggestionAsset.state,

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -54,7 +54,6 @@ export interface SkillSuggestionAsset {
       content: string;
       type: "replace";
     }[];
-    toolEdits?: { action: "add" | "remove"; toolId: string }[];
   };
 }
 

--- a/front/scripts/seed/reinforcement/seed.test.ts
+++ b/front/scripts/seed/reinforcement/seed.test.ts
@@ -155,13 +155,12 @@ describe("reinforcement seed script integration test", () => {
     });
     expect(withInlineToolReference).toBeDefined();
 
-    // Second suggestion has 2 instruction edits and no tool edits
+    // Second suggestion has 2 instruction edits
     const withOnlyInstructionEdits = skillSuggestions.find((s) => {
       const json = s.toJSON();
       return (
         json.suggestion.instructionEdits &&
-        json.suggestion.instructionEdits.length === 2 &&
-        (!json.suggestion.toolEdits || json.suggestion.toolEdits.length === 0)
+        json.suggestion.instructionEdits.length === 2
       );
     });
     expect(withOnlyInstructionEdits).toBeDefined();

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -13,28 +13,12 @@ interface InstructionEditItem {
   type: string;
 }
 
-interface ToolEditItem {
-  action: string;
-  toolId: string;
-}
-
 function isInstructionEditItem(value: unknown): value is InstructionEditItem {
   return (
     typeof value === "object" &&
     value !== null &&
     "targetBlockId" in value &&
     typeof value.targetBlockId === "string"
-  );
-}
-
-function isToolEditItem(value: unknown): value is ToolEditItem {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "toolId" in value &&
-    typeof value.toolId === "string" &&
-    "action" in value &&
-    typeof value.action === "string"
   );
 }
 
@@ -77,14 +61,6 @@ function getInstructionEdits(
     return [];
   }
   return edits.filter(isInstructionEditItem);
-}
-
-function getToolEdits(args: Record<string, unknown>): ToolEditItem[] {
-  const edits = args.toolEdits;
-  if (!Array.isArray(edits)) {
-    return [];
-  }
-  return edits.filter(isToolEditItem);
 }
 
 function instructionEditsContainToolReference(
@@ -153,37 +129,12 @@ export function validateToolCallAssertion(
       }
       return { success: true };
     }
-    case "editSkillWithTool": {
-      const call = findEditSkillCall(
-        toolCalls,
-        (c) =>
-          getSkillId(c.arguments) === assertion.skillId &&
-          getToolEdits(c.arguments).some((t) => t.toolId === assertion.toolId)
-      );
-      if (!call) {
-        return {
-          success: false,
-          error: `Expected an edit_skill call with toolEdit toolId "${assertion.toolId}" for skillId "${assertion.skillId}", but no such call was made`,
-        };
-      }
-      if (assertion.sourceSuggestionIds) {
-        const sourceResult = validateSourceSuggestionIds(
-          call,
-          assertion.sourceSuggestionIds
-        );
-        if (sourceResult) {
-          return sourceResult;
-        }
-      }
-      return { success: true };
-    }
     case "editSkillWithInlineToolReference": {
       const call = findEditSkillCall(toolCalls, (c) => {
         const instructionEdits = getInstructionEdits(c.arguments);
         return (
           getSkillId(c.arguments) === assertion.skillId &&
           instructionEdits.length > 0 &&
-          getToolEdits(c.arguments).length === 0 &&
           instructionEditsContainToolReference(
             instructionEdits,
             assertion.toolId
@@ -193,7 +144,7 @@ export function validateToolCallAssertion(
       if (!call) {
         return {
           success: false,
-          error: `Expected an edit_skill call with instructionEdits referencing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", and no toolEdits, but no such call was made`,
+          error: `Expected an edit_skill call with instructionEdits referencing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {
@@ -213,7 +164,6 @@ export function validateToolCallAssertion(
         return (
           getSkillId(c.arguments) === assertion.skillId &&
           instructionEdits.length > 0 &&
-          getToolEdits(c.arguments).length === 0 &&
           !instructionEditsContainToolReference(
             instructionEdits,
             assertion.toolId
@@ -223,7 +173,7 @@ export function validateToolCallAssertion(
       if (!call) {
         return {
           success: false,
-          error: `Expected an edit_skill call with instructionEdits removing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", and no toolEdits, but no such call was made`,
+          error: `Expected an edit_skill call with instructionEdits removing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {
@@ -289,17 +239,12 @@ export function validateToolCallAssertion(
           continue;
         }
         const instructionEdits = getInstructionEdits(tc.arguments);
-        const toolEdits = getToolEdits(tc.arguments);
         const hasDescriptionEdit =
           getAgentFacingDescriptionEditContent(tc.arguments) !== undefined;
-        if (
-          instructionEdits.length > 0 ||
-          toolEdits.length > 0 ||
-          hasDescriptionEdit
-        ) {
+        if (instructionEdits.length > 0 || hasDescriptionEdit) {
           return {
             success: false,
-            error: `Expected no suggestions, but edit_skill was called with ${instructionEdits.length} instructionEdit(s), ${toolEdits.length} toolEdit(s)${hasDescriptionEdit ? ", and an agentFacingDescriptionEdit" : ""}`,
+            error: `Expected no suggestions, but edit_skill was called with ${instructionEdits.length} instructionEdit(s)${hasDescriptionEdit ? " and an agentFacingDescriptionEdit" : ""}`,
           };
         }
       }

--- a/front/tests/reinforcement-evals/lib/judge.ts
+++ b/front/tests/reinforcement-evals/lib/judge.ts
@@ -53,7 +53,6 @@ IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST ap
 1. **Correct Tool Usage**: Did the analyst call edit_skill with the right fields?
    - instructionEdits for instruction improvements and tool reference changes
    - Tool reference changes must add/remove inline <tool id="..." name="..."/> tags in instructionEdits content
-   - toolEdits should not be used in final edit_skill calls
 2. **Suggestion Quality**: Are the suggestions specific, actionable, and well-reasoned?
    - Does the analysis field explain WHY the change is needed?
    - Is the suggested content appropriate and well-written?

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -201,12 +201,6 @@ export type ToolCallAssertion =
       sourceSuggestionIds?: string[];
     }
   | {
-      type: "editSkillWithTool";
-      skillId: string;
-      toolId: string;
-      sourceSuggestionIds?: string[];
-    }
-  | {
       type: "editSkillWithInlineToolReference";
       skillId: string;
       toolId: string;
@@ -239,15 +233,6 @@ export function editSkillWithInstructions(
   sourceSuggestionIds?: string[]
 ): ToolCallAssertion {
   return { type: "editSkillWithInstructions", skillId, sourceSuggestionIds };
-}
-
-/** Expects an edit_skill call with a toolEdit for the given skill and tool. */
-export function editSkillWithTool(
-  skillId: string,
-  toolId: string,
-  sourceSuggestionIds?: string[]
-): ToolCallAssertion {
-  return { type: "editSkillWithTool", skillId, toolId, sourceSuggestionIds };
 }
 
 /** Expects an edit_skill call that adds/references a tool via instructionEdits. */

--- a/front/tests/reinforcement-evals/reinforcement-eval.test.ts
+++ b/front/tests/reinforcement-evals/reinforcement-eval.test.ts
@@ -39,15 +39,6 @@ function formatToolCallSummary(tc: ToolCall): string {
       if (instructionEdits?.length) {
         parts.push(`${instructionEdits.length} instructionEdit(s)`);
       }
-      const toolEdits = Array.isArray(args.toolEdits)
-        ? args.toolEdits
-        : undefined;
-      if (toolEdits?.length) {
-        const items = toolEdits
-          .map((t) => `${t.action ?? "?"} ${t.toolId ?? "?"}`)
-          .join(", ");
-        parts.push(`toolEdits=[${items}]`);
-      }
       return `edit_skill(${parts.join(", ")})`;
     }
     default:

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -221,10 +221,9 @@ as an inline <tool id="mcp_jira" name="JIRA" /> reference to skill "skill_engine
 - Merge the 3 individual suggestions into a single recommendation
 - Mention that 3 conversations support this suggestion
 - Include a comprehensive analysis covering the different use cases (ticket creation, sprint status, assignment)
-- Merge the 3 inline <tool> instruction edits into a single instruction edit that keeps exactly one inline <tool id="mcp_jira" name="JIRA" /> reference; it MUST NOT include toolEdits
+- Merge the 3 inline <tool> instruction edits into a single instruction edit that keeps exactly one inline <tool id="mcp_jira" name="JIRA" /> reference
 
 Score 0 if no edit_skill call or if it creates 3 separate calls.
-Score 0 if the final edit_skill call uses toolEdits instead of an inline <tool> instruction edit.
 Score 1 if merged but analysis doesn't reference multiple conversations/use cases.
 Score 2 if properly merged with multi-conversation reference but analysis could be better.
 Score 3 if well-merged with clear analysis covering all use cases and conversation count.`,
@@ -500,11 +499,10 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
       judgeCriteria: `Two of the three drafts target the agent-facing description (both about narrowing routing), and one is unrelated tooling work (adding JIRA). Aggregation rules require:
 - ONE description-edit suggestion per skill, merging both description drafts (sug-desc-1 + sug-desc-2). The merged description must explicitly limit the skill to payment failures + chargebacks AND steer the agent away from generic billing/invoice/account-management requests.
 - The description edit MUST be its own standalone edit_skill call. Do NOT bundle it with the tool addition (different topic, different fix).
-- A separate edit_skill call that keeps the JIRA tool addition (sug-tool-1) as its own instruction edit with an inline <tool id="mcp_jira" name="JIRA" /> reference. It MUST NOT include toolEdits.
+- A separate edit_skill call that keeps the JIRA tool addition (sug-tool-1) as its own instruction edit with an inline <tool id="mcp_jira" name="JIRA" /> reference.
 
 Score 0 if no edit_skill call carries an agentFacingDescriptionEdit for skill_payment_resolver.
 Score 0 if the description edit and the tool addition are bundled into a single edit_skill call.
-Score 0 if the JIRA addition is output as toolEdits instead of an inline <tool> instruction edit.
 Score 0 if more than 2 edit_skill calls are produced (failure to merge sug-desc-1 + sug-desc-2).
 Score 1 if 2 separate edit_skill calls are made but the merged description doesn't explicitly carve out billing/invoice routing (i.e. it stays vague).
 Score 2 if 2 separate edit_skill calls are made and the merged description narrows scope but does not reference both supporting drafts (sug-desc-1 + sug-desc-2 in sourceSuggestionIds).

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -265,12 +265,11 @@ Score 3 if the suggestion provides clear, actionable instructions that would pre
       judgeCriteria: `The analyst MUST call edit_skill with instructionEdits to suggest adding the Web Search tool
 as an inline <tool id="mcp_web_search" name="Web Search" /> reference in skill "skill_research". The suggestion should:
 - Discover available tools before authoring the inline <tool> reference
-- Add Web Search through an instruction edit; it MUST NOT include toolEdits
+- Add Web Search through an instruction edit
 - Include an analysis explaining that the skill's purpose requires web search for current information
 - Reference that the agent couldn't fulfill the user's core request without this capability
 
 Score 0 if no edit_skill with instructionEdits call is made.
-Score 0 if the suggestion uses toolEdits instead of an inline <tool> tag.
 Score 0-1 if edit_skill is called but with the wrong tool ID or wrong skill ID.
 Score 2 if the correct inline tool reference is suggested but the analysis is weak.
 Score 3 if the correct inline tool reference is suggested with a clear, well-reasoned analysis.`,
@@ -330,12 +329,11 @@ Score 3 if the correct inline tool reference is suggested with a clear, well-rea
       ],
       judgeCriteria: `The analyst MUST call edit_skill with instructionEdits to remove the inline Calendar tool
 reference (<tool id="mcp_calendar" name="Calendar" />) from skill "skill_code_review". The suggestion should:
-- Remove Calendar through an instruction edit; it MUST NOT include toolEdits
+- Remove Calendar through an instruction edit
 - Include an analysis explaining that Calendar is irrelevant to code review and caused confusion
 - Reference the failed tool call and user complaint
 
 Score 0 if no edit_skill with instructionEdits call is made.
-Score 0 if the suggestion uses toolEdits instead of removing the inline <tool> tag.
 Score 0-1 if edit_skill is called but it removes the wrong inline tool reference.
 Score 2 if the correct inline tool removal is suggested but the analysis is weak.
 Score 3 if the correct removal is suggested with a clear analysis referencing the confusion it caused.`,
@@ -380,12 +378,10 @@ Score 3 if the correct removal is suggested with a clear analysis referencing th
       ],
       judgeCriteria: `The analyst MUST call edit_skill with instructionEdits for skill "skill_bug_reporter".
 The instruction edit must add the JIRA capability as an inline <tool id="mcp_jira" name="JIRA" /> reference and update the surrounding instructions to use JIRA for filing bugs.
-The suggestion MUST NOT include toolEdits.
 
 The inline tool reference and instruction change are co-dependent and should be expressed together in the instruction edit.
 
 Score 0 if no edit_skill with instructionEdits call is made.
-Score 0 if the suggestion uses toolEdits instead of an inline <tool> tag.
 Score 1 if the inline JIRA tag is added but the instructions don't explain how to use it, or the analysis is weak.
 Score 2 if the JIRA tag and instructions are both present but the instruction/tool connection isn't explicit.
 Score 3 if the instruction edit clearly adds JIRA as an inline tool reference, tells the skill to file bugs through it, and explains the mismatch.`,
@@ -898,7 +894,7 @@ The analyst MUST call edit_skill with an agentFacingDescriptionEdit for skill "s
 - Stay focused on routing signals (when to use vs. not), not behavior (which lives in the instructions)
 
 Score 0 if no edit_skill call with agentFacingDescriptionEdit is made for skill_payment_resolver.
-Score 0 if the suggestion is bundled with instructionEdits or toolEdits — per the analysis prompt, description edits should be a standalone edit_skill call when the routing problem is the only issue (the instructions and tools here are correct).
+Score 0 if the suggestion is bundled with instructionEdits — per the analysis prompt, description edits should be a standalone edit_skill call when the routing problem is the only issue (the instructions and tools here are correct).
 Score 1 if a description edit is made but it does not narrow the scope (still vague) OR does not steer away from billing/address-style requests.
 Score 2 if the new description narrows the skill but the language is weak or does not call out what to skip.
 Score 3 if the new description clearly limits the skill to payment failures + chargebacks AND explicitly tells the agent not to use it for unrelated billing/account-management changes.`,

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -52,7 +52,6 @@ export class SkillSuggestionFactory {
           content: string;
           type: "replace";
         }[];
-        toolEdits?: { action: "add" | "remove"; toolId: string }[];
         agentFacingDescriptionEdit?: { content: string };
       };
       analysis: string | null;

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -54,13 +54,6 @@ export type SkillInstructionEditItemType = z.infer<
   typeof SkillInstructionEditItemSchema
 >;
 
-export const SkillToolEditItemSchema = z.object({
-  action: z.enum(["add", "remove"]),
-  toolId: z.string(),
-});
-
-export type SkillToolEditItemType = z.infer<typeof SkillToolEditItemSchema>;
-
 export const SkillAgentFacingDescriptionEditSchema = z.object({
   content: z
     .string()
@@ -80,10 +73,6 @@ export const SkillEditSuggestionSchema = z
       .array(SkillInstructionEditItemSchema)
       .optional()
       .describe("Block-targeted edits to the skill instructions."),
-    toolEdits: z
-      .array(SkillToolEditItemSchema)
-      .optional()
-      .describe("Tools to add or remove from the skill."),
     agentFacingDescriptionEdit:
       SkillAgentFacingDescriptionEditSchema.optional().describe(
         "Replacement for the skill's agent-facing description."
@@ -92,9 +81,8 @@ export const SkillEditSuggestionSchema = z
   .refine(
     (d) =>
       (d.instructionEdits && d.instructionEdits.length > 0) ||
-      (d.toolEdits && d.toolEdits.length > 0) ||
       d.agentFacingDescriptionEdit !== undefined,
-    "At least one of instructionEdits, toolEdits, or agentFacingDescriptionEdit must be provided."
+    "At least one of instructionEdits or agentFacingDescriptionEdit must be provided."
   );
 
 export type SkillEditSuggestionType = z.infer<typeof SkillEditSuggestionSchema>;


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8733

The edit skill type of suggestion is actually unused.
This delete all remaining entries in the DB and drop all the usage.
Nothing has generated these kind of suggestion for months so nothing valuable will be removed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

lock front
merge
Apply migration to delete the suggestion containing tool edits
```
npx tsx migrations/20260720_drop_skill_suggestion_tool_edits.ts
```
deploy front
unlock front
