### PR TITLE
[front] fix: reset nested skill navigation state

### DIFF
--- a/front/components/pages/builder/skills/EditSkillPage.tsx
+++ b/front/components/pages/builder/skills/EditSkillPage.tsx
@@ -38,7 +38,12 @@ export function EditSkillPage() {
   }
 
   return (
-    <SkillBuilderProvider owner={owner} user={user} skillId={skill.sId}>
+    <SkillBuilderProvider
+      key={skill.sId}
+      owner={owner}
+      user={user}
+      skillId={skill.sId}
+    >
       <SkillBuilder skill={skill} onSaved={mutateSkill} />
     </SkillBuilderProvider>
   );

--- a/front/components/shared/CapabilityDetailsSheets.tsx
+++ b/front/components/shared/CapabilityDetailsSheets.tsx
@@ -11,6 +11,7 @@ interface CapabilityDetailsSheetsProps {
   selectedMCPServerView: MCPServerViewType | null;
   onCloseSkill: () => void;
   onCloseTool: () => void;
+  replaceOnSkillEdit?: boolean;
 }
 
 export function CapabilityDetailsSheets({
@@ -20,6 +21,7 @@ export function CapabilityDetailsSheets({
   selectedMCPServerView,
   onCloseSkill,
   onCloseTool,
+  replaceOnSkillEdit,
 }: CapabilityDetailsSheetsProps) {
   const { skill } = useSkill({
     workspaceId: owner.sId,
@@ -36,6 +38,7 @@ export function CapabilityDetailsSheets({
           owner={owner}
           user={user}
           onClose={onCloseSkill}
+          replaceOnEdit={replaceOnSkillEdit}
         />
       )}
 

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -816,6 +816,7 @@ export function SkillBuilderInstructionsEditor({
         selectedMCPServerView={selectedServerViewForDetails}
         onCloseSkill={() => setSelectedSkillIdForDetails(null)}
         onCloseTool={() => setSelectedServerViewForDetails(null)}
+        replaceOnSkillEdit
       />
     </>
   );

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -18,12 +18,14 @@ interface SkillDetailsButtonBarProps {
   skill: SkillWithoutInstructionsAndToolsWithRelationsType;
   owner: WorkspaceType;
   onClose: () => void;
+  replaceOnEdit?: boolean;
 }
 
 export function SkillDetailsButtonBar({
   skill,
   owner,
   onClose,
+  replaceOnEdit,
 }: SkillDetailsButtonBarProps) {
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
@@ -47,6 +49,7 @@ export function SkillDetailsButtonBar({
           size="sm"
           tooltip="Edit skill"
           href={getSkillBuilderRoute(owner.sId, skill.sId)}
+          replace={replaceOnEdit}
           variant="outline"
           icon={Edit04}
         />

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -35,6 +35,7 @@ type SkillDetailsProps = {
   onClose: () => void;
   owner: WorkspaceType;
   user: UserType;
+  replaceOnEdit?: boolean;
 };
 
 export function SkillDetailsSheet({
@@ -42,6 +43,7 @@ export function SkillDetailsSheet({
   onClose,
   user,
   owner,
+  replaceOnEdit,
 }: SkillDetailsProps) {
   // Fetch the full skill (with instructions/tools) for the content section,
   // since the list endpoint may not include them.
@@ -64,6 +66,7 @@ export function SkillDetailsSheet({
                 skill={skill}
                 owner={owner}
                 onClose={onClose}
+                replaceOnEdit={replaceOnEdit}
               />
             </SheetHeader>
             <SheetContainer className="pb-4">
@@ -139,12 +142,14 @@ type DescriptionSectionProps = {
   skill: SkillWithoutInstructionsAndToolsWithRelationsType;
   owner: WorkspaceType;
   onClose: () => void;
+  replaceOnEdit?: boolean;
 };
 
 const DescriptionSection = ({
   skill,
   owner,
   onClose,
+  replaceOnEdit,
 }: DescriptionSectionProps) => {
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const { editedByUser } = skill.relations;
@@ -178,7 +183,12 @@ const DescriptionSection = ({
       </div>
 
       {skill.status === "active" && (
-        <SkillDetailsButtonBar owner={owner} skill={skill} onClose={onClose} />
+        <SkillDetailsButtonBar
+          owner={owner}
+          skill={skill}
+          onClose={onClose}
+          replaceOnEdit={replaceOnEdit}
+        />
       )}
 
       {skill.status === "archived" && (


### PR DESCRIPTION
## Description

Opening a referenced skill from Skill Builder currently reuses the parent editor state: the details sheet stays open, the form can appear dirty, and Cancel steps back through each nested skill.

This PR remounts Skill Builder when the skill ID changes and replaces the current skill-editor history entry when Edit is triggered from a nested skill sheet. Editing from other skill detail entry points keeps the existing push and back behavior.

Fixes dust-tt/tasks#9690.

## Tests

- Tested locally.

## Risk

- Low. Scoped to nested skill editor navigation.

## Deploy Plan

- Deploy front.