### PR TITLE
[front] perf: avoid system space fetches for MCP views

### DIFF
--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
@@ -18,7 +18,6 @@ import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_m
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -51,11 +50,9 @@ app.get(
     const { serverType, id } = getServerTypeAndIdFromSId(serverId);
     switch (serverType) {
       case "internal": {
-        const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
         const server = await InternalMCPServerInMemoryResource.fetchById(
           auth,
-          serverId,
-          systemSpace
+          serverId
         );
 
         if (!server) {
@@ -120,11 +117,9 @@ app.patch(
       return handleRemotePatch(ctx, auth, remoteServer, body);
     }
 
-    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
     const internalServer = await InternalMCPServerInMemoryResource.fetchById(
       auth,
-      serverId,
-      systemSpace
+      serverId
     );
     if (!internalServer) {
       return apiError(ctx, {
@@ -149,16 +144,10 @@ app.delete(
 
     const { serverType } = getServerTypeAndIdFromSId(serverId);
 
-    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-
     const server =
       serverType === "remote"
         ? await RemoteMCPServerResource.fetchById(auth, serverId)
-        : await InternalMCPServerInMemoryResource.fetchById(
-            auth,
-            serverId,
-            systemSpace
-          );
+        : await InternalMCPServerInMemoryResource.fetchById(auth, serverId);
 
     if (!server) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/me/approvals.ts
+++ b/front-api/routes/w/[wId]/me/approvals.ts
@@ -1,7 +1,6 @@
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   DeleteUserApprovalsResponseBody,
   GetUserApprovalsResponseBody,
@@ -40,11 +39,9 @@ app.get("/", async (ctx): HandlerResult<GetUserApprovalsResponseBody> => {
       const { serverType } = getServerTypeAndIdFromSId(validation.mcpServerId);
 
       if (serverType === "internal") {
-        const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
         const server = await InternalMCPServerInMemoryResource.fetchById(
           auth,
-          validation.mcpServerId,
-          systemSpace
+          validation.mcpServerId
         );
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         serverName = server?.toJSON().name || "Unknown Internal Server";

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -298,20 +298,15 @@ export class InternalMCPServerInMemoryResource {
     return new Ok(1);
   }
 
-  static async fetchById(
-    auth: Authenticator,
-    id: string,
-    systemSpace: SpaceResource
-  ) {
-    const results = await this.fetchByIds(auth, [id], systemSpace);
+  static async fetchById(auth: Authenticator, id: string) {
+    const results = await this.fetchByIds(auth, [id]);
 
     return results[0] ?? null;
   }
 
   static async fetchByIds(
     auth: Authenticator,
-    ids: string[],
-    systemSpace: SpaceResource
+    ids: string[]
   ): Promise<InternalMCPServerInMemoryResource[]> {
     if (ids.length === 0) {
       return [];
@@ -328,15 +323,29 @@ export class InternalMCPServerInMemoryResource {
       (id) => getAvailabilityOfInternalMCPServerById(id) === "manual"
     );
 
-    const servers = await MCPServerViewModel.findAll({
-      attributes: ["internalMCPServerId"],
-      where: {
-        serverType: "internal",
-        internalMCPServerId: { [Op.in]: manualIds },
-        workspaceId: auth.getNonNullableWorkspace().id,
-        vaultId: systemSpace.id,
-      },
-    });
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const servers =
+      manualIds.length > 0
+        ? await MCPServerViewModel.findAll({
+            attributes: ["internalMCPServerId"],
+            include: [
+              {
+                model: SpaceResource.model,
+                attributes: [],
+                required: true,
+                where: {
+                  kind: "system",
+                  workspaceId,
+                },
+              },
+            ],
+            where: {
+              serverType: "internal",
+              internalMCPServerId: { [Op.in]: manualIds },
+              workspaceId,
+            },
+          })
+        : [];
     validIds.push(...removeNulls(servers.map((s) => s.internalMCPServerId)));
 
     const availableIds = [...new Set(validIds)];

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -4,6 +4,7 @@ import { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -372,6 +373,77 @@ describe("MCPServerViewResource", () => {
       const resultIds = results.map((v) => v.id).sort();
       const expectedIds = [view1.id, view2.id].sort();
       expect(resultIds).toEqual(expectedIds);
+    });
+  });
+
+  describe("internal MCP server resolution", () => {
+    it("resolves auto server views without fetching the system space", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const { globalSpace } = await SpaceFactory.defaults(auth);
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        auth,
+        {
+          name: "image_generation",
+          useCase: null,
+        }
+      );
+      const globalView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        globalSpace
+      );
+      const systemSpaceFetch = vi.spyOn(
+        SpaceResource,
+        "fetchWorkspaceSystemSpace"
+      );
+
+      try {
+        const fetchedView = await MCPServerViewResource.fetchById(
+          auth,
+          globalView.sId
+        );
+
+        expect(fetchedView?.sId).toBe(globalView.sId);
+        expect(systemSpaceFetch).not.toHaveBeenCalled();
+      } finally {
+        systemSpaceFetch.mockRestore();
+      }
+    });
+
+    it("only resolves manual servers with a live system-space view", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      await SpaceFactory.defaults(auth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        auth,
+        {
+          name: "github",
+          useCase: null,
+        }
+      );
+      const regularView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        regularSpace
+      );
+
+      expect(
+        await MCPServerViewResource.fetchById(auth, regularView.sId)
+      ).not.toBeNull();
+
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          internalServer.id
+        );
+      expect(systemView).not.toBeNull();
+      await systemView?.hardDelete(auth);
+
+      expect(
+        await MCPServerViewResource.fetchById(auth, regularView.sId)
+      ).toBeNull();
     });
   });
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -176,11 +176,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
       resource.remoteMCPServer = remoteServer;
     } else if (blob.internalMCPServerId) {
-      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
       const internalServer = await InternalMCPServerInMemoryResource.fetchById(
         auth,
-        blob.internalMCPServerId,
-        systemSpace
+        blob.internalMCPServerId
       );
       if (!internalServer) {
         throw new DustError(
@@ -424,11 +422,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     if (options.includeDeleted) {
       filteredViews.push(...views);
     } else {
-      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(
-        auth,
-        transaction
-      );
-
       const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
         auth,
         removeNulls(views.map((v) => v.remoteMCPServerId)),
@@ -439,8 +432,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       const internalServers =
         await InternalMCPServerInMemoryResource.fetchByIds(
           auth,
-          removeNulls(views.map((v) => v.internalMCPServerId)),
-          systemSpace
+          removeNulls(views.map((v) => v.internalMCPServerId))
         );
       const internalServerMap = new Map(internalServers.map((s) => [s.id, s]));
 


### PR DESCRIPTION
## Description

Avoid fetching and fully hydrating the workspace system space whenever MCP server views are resolved.

The system space was fetched unconditionally by `MCPServerViewResource.baseFetch`, including for empty, remote-only, and auto-internal results. The downstream resolver only needed its ID to verify that manual internal servers still had a canonical system-space view.

Auto and remote servers now skip that lookup entirely. Manual servers are validated with a targeted join between MCP server views and the system space, avoiding the expensive groups hydration. Redundant lookups in the MCP server and approvals routes are removed as well.

## Tests

- `NODE_ENV=test npm test -- lib/resources/mcp_server_view_resource.test.ts`
- `NODE_ENV=test npm test -- routes/w/[wId]/mcp/[serverId]/index.test.ts`

## Risk

Low. Biggest risk is that the new query is expensive, but will stil happen much less often.

## Deploy Plan

- deploy `front`
