### PR TITLE
fix(files): add missing index on shareable_files.fileId to unblock workspace deletion

### DIFF
--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -178,6 +178,12 @@ ShareableFileModel.init(
       { fields: ["workspaceId", "fileId"], unique: true },
       { fields: ["workspaceId", "shareScope"], unique: false },
       { fields: ["token"], unique: true },
+      // Standalone index on the `fileId` foreign key. Without it, the
+      // `ON DELETE RESTRICT` referential-integrity check triggered when a
+      // `files` row is deleted sequentially scans `shareable_files` (the
+      // composite `(workspaceId, fileId)` index cannot serve a `fileId`-only
+      // lookup), which times out workspace deletions on large tables.
+      { fields: ["fileId"], concurrently: true },
     ],
   }
 );

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -177,9 +177,6 @@ ShareableFileModel.init(
     indexes: [
       { fields: ["workspaceId", "shareScope"], unique: false },
       { fields: ["token"], unique: true },
-      // Serves the `ON DELETE RESTRICT` check on `files` deletion and the
-      // shareable-file upsert's ON CONFLICT target. Unique on `fileId` alone
-      // is safe: a file belongs to a single workspace.
       { fields: ["fileId"], unique: true, concurrently: true },
     ],
   }

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -175,15 +175,12 @@ ShareableFileModel.init(
     modelName: "shareable_files",
     sequelize: frontSequelize,
     indexes: [
-      { fields: ["workspaceId", "fileId"], unique: true },
       { fields: ["workspaceId", "shareScope"], unique: false },
       { fields: ["token"], unique: true },
-      // Standalone index on the `fileId` foreign key. Without it, the
-      // `ON DELETE RESTRICT` referential-integrity check triggered when a
-      // `files` row is deleted sequentially scans `shareable_files` (the
-      // composite `(workspaceId, fileId)` index cannot serve a `fileId`-only
-      // lookup), which times out workspace deletions on large tables.
-      { fields: ["fileId"], concurrently: true },
+      // Serves the `ON DELETE RESTRICT` check on `files` deletion and the
+      // shareable-file upsert's ON CONFLICT target. Unique on `fileId` alone
+      // is safe: a file belongs to a single workspace.
+      { fields: ["fileId"], unique: true, concurrently: true },
     ],
   }
 );

--- a/front/migrations/post-deploy/20260721120000_drop_shareable_files_workspace_id_file_id_index.sql
+++ b/front/migrations/post-deploy/20260721120000_drop_shareable_files_workspace_id_file_id_index.sql
@@ -1,0 +1,7 @@
+/*
+Old code upserts shareable_files with ON CONFLICT ("workspaceId", "fileId"); drop only once new
+code (targeting ON CONFLICT ("fileId")) is live.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY IF EXISTS "shareable_files_workspace_id_file_id";

--- a/front/migrations/pre-deploy/20260720180500_add_index_shareable_files_file_id.sql
+++ b/front/migrations/pre-deploy/20260720180500_add_index_shareable_files_file_id.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY shareable_files_file_id ON public.shareable_files USING btree ("fileId");
+CREATE UNIQUE INDEX CONCURRENTLY shareable_files_file_id ON public.shareable_files USING btree ("fileId");

--- a/front/migrations/pre-deploy/20260720180500_add_index_shareable_files_file_id.sql
+++ b/front/migrations/pre-deploy/20260720180500_add_index_shareable_files_file_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY shareable_files_file_id ON public.shareable_files USING btree ("fileId");


### PR DESCRIPTION
## Description

Adds a standalone index on `shareable_files.fileId` to fix a systematic timeout of the workspace-deletion Temporal workflow (`deleteWorkspaceWorkflow` → `deleteWorkspaceActivity` → `FileResource.deleteAllForWorkspace`).

`shareable_files.fileId` is a foreign key to `files.id` declared `ON DELETE RESTRICT`, but the only indexes on the table are the composite `(workspaceId, fileId)` (unique), `(workspaceId, shareScope)`, and `(token)`. When `deleteAllForWorkspace` runs `DELETE FROM "files" WHERE "workspaceId" = $1`, Postgres must run the RI check `SELECT 1 FROM ONLY shareable_files WHERE "fileId" = $1 FOR KEY SHARE` for every deleted row. That check filters on `fileId` alone, which the composite `(workspaceId, fileId)` index cannot serve (wrong leading column), so Postgres sequentially scans `shareable_files` once per deleted file. On workspaces/tables of any real size this exceeds the 5-minute `statement_timeout` and the delete fails identically on every retry.

Observed in production on a GDPR workspace-deletion request: 7 consecutive `deleteWorkspaceActivity` attempts, each failing with Postgres `57014` (`canceling statement due to statement timeout`) at ~300s, `peakConcurrentQueries: 1` (not contention), all stuck in the `shareable_files` RI subquery.

This is a recurring class at Dust (missing indexes on `ON DELETE RESTRICT` FK columns causing delete-time seq scans / high DB CPU); the `shareable_files` table was already flagged for its sibling `sharedBy` FK.

Per review feedback, the new `fileId` index is **unique** and fully replaces the composite `(workspaceId, fileId)` unique index: a file belongs to a single workspace, so the composite narrows down nothing and its uniqueness guarantee is equivalent.

Changes:
- Pre-deploy migration `front/migrations/pre-deploy/20260720180500_add_index_shareable_files_file_id.sql` creating `shareable_files_file_id` with `CREATE UNIQUE INDEX CONCURRENTLY`.
- `ShareableFileModel` declares `{ fields: ["fileId"], unique: true, concurrently: true }` and drops the composite `(workspaceId, fileId)` index declaration.
- Post-deploy migration `front/migrations/post-deploy/20260721120000_drop_shareable_files_workspace_id_file_id_index.sql` dropping `shareable_files_workspace_id_file_id`. This must run **after** deploy: the shareable-file upsert in `FileResource.markAsReady` derives its `ON CONFLICT` target from the model's unique indexes, so currently-deployed code targets `ON CONFLICT ("workspaceId", "fileId")` and would start failing if the composite index were dropped before the new code (targeting `ON CONFLICT ("fileId")`) is live.

## Tests

No local validation was run in the Computer (the migrations are a `CREATE UNIQUE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` pair and the model change is an index declaration; the repo's full suite runs in CI). Validation is delegated to PR CI. Functional verification: after the index exists, the RI check becomes an index lookup and the `deleteWorkspaceActivity` `files` delete completes well under `statement_timeout`; will be confirmed by re-running the previously-failing workspace deletion.

## Risk

Low. `CREATE UNIQUE INDEX CONCURRENTLY` builds without an `ACCESS EXCLUSIVE` lock, so it does not block reads/writes on `shareable_files`. Uniqueness on `fileId` alone is already guaranteed by the existing composite unique index plus the fact that a file has a single `workspaceId`; if the data somehow violated that, the concurrent build would fail cleanly (leaving an invalid index to drop) rather than corrupt anything. The composite index is only dropped post-deploy, after no running code references it as an upsert conflict target. Rollback is a simple `DROP INDEX` (and the composite can be recreated with `CREATE UNIQUE INDEX CONCURRENTLY` if ever needed).

## Deploy Plan

1. Run the pre-deploy migration (`CREATE UNIQUE INDEX CONCURRENTLY`) in each region (US + EU) before/independent of the deploy, following the standard pre-deploy migration flow. `IF NOT EXISTS` is intentionally omitted to match the two June 25 index migrations; if a (non-unique) `shareable_files_file_id` was already created manually to mitigate the live incident, drop it first so the unique version is built.
2. Deploy the model change (the shareable-file upsert switches its conflict target from `("workspaceId", "fileId")` to `("fileId")`).
3. Run the post-deploy migration to drop `shareable_files_workspace_id_file_id`.
4. Relaunch the affected workspace deletion; confirm `deleteWorkspaceActivity` progresses past `FileResource.deleteAllForWorkspace`.

## Follow-ups (not in this PR)

- `shareable_files.sharedBy` (FK to `users`, also `ON DELETE RESTRICT`) has no standalone index either and will hit the same problem on the `deleteAllForUser` path; worth adding in a follow-up.
- Longer term, paginate `deleteAllForWorkspace`-style whole-workspace deletes rather than issuing one unbounded `DELETE`.
