### PR TITLE
[Admin Gov] Rename group_permissions column to grantType (1/2, expand)

### DIFF
--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -363,8 +363,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
   }
 
-  // Read grants for the given groups, optionally narrowed by verb / type / resource. The
-  // (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
+  // Read grants for the given groups, optionally narrowed by grant type / resource type /
+  // resource. The (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
   static async listForGroups(
     auth: Authenticator,
     { groupModelIds, grantType, resourceType, resourceId }: ListForGroupsSpec
@@ -426,7 +426,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Grant a permission for the whole resource type (resourceId = -1). Single-group convenience over
   // grantTypeWideForGroups. Dedicated, explicitly named so a defaulted -1 can never silently reach
-  // `grant`. Idempotent. Used for type-level verbs (e.g. "create") and governance capabilities.
+  // `grant`. Idempotent. Used for type-level grant types (e.g. "create") and governance
+  // capabilities.
   static async grantTypeWide(
     auth: Authenticator,
     { group, grantType, resourceType, transaction }: TypeWideGrantSpec

--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -47,10 +47,6 @@ GroupPermissionModel.init(
     grantType: {
       type: DataTypes.STRING(256),
       allowNull: false,
-      // Physical column stays "permissionType": renaming it would break the live model-tier
-      // resolution path (ModelsTierResource) during the deploy window. The physical rename is
-      // deferred to a later expand/contract migration; the code vocabulary is "grantType".
-      field: "permissionType",
     },
     resourceType: {
       type: DataTypes.STRING(256),
@@ -69,11 +65,10 @@ GroupPermissionModel.init(
       // Dedupes grants and covers the "does this group have this grant" direction. A group belongs
       // to a single workspace, so groupId already scopes the workspace — no need for workspaceId
       // here. Its leading groupId also serves as the FK index (BACK13) for group deletion.
-      // Fields use the physical column name "permissionType" (see the grantType field mapping).
       {
-        name: "group_permissions_group_ptype_rtype_rid_unique",
+        name: "group_permissions_group_gtype_rtype_rid_unique",
         unique: true,
-        fields: ["groupId", "permissionType", "resourceType", "resourceId"],
+        fields: ["groupId", "grantType", "resourceType", "resourceId"],
       },
       // "who can act on resource X" direction.
       {

--- a/front/migrations/pre-deploy/20260720201455_expand_group_permissions_grant_type.sql
+++ b/front/migrations/pre-deploy/20260720201455_expand_group_permissions_grant_type.sql
@@ -50,10 +50,15 @@ UPDATE "public"."group_permissions" SET "grantType" = "permissionType" WHERE "gr
 
 /*
 Statement 3: new unique index on "grantType", mirroring the existing one on "permissionType". Built
-CONCURRENTLY so it does not lock writes. Generous statement_timeout because a concurrent build can
-run long on large tables; this table is small today.
+CONCURRENTLY so it does not lock writes. A failed concurrent build leaves an INVALID index behind;
+"CREATE ... IF NOT EXISTS" would then skip it on retry and leave uniqueness unenforced (which the
+contract step would compound by dropping the legacy index). So drop any leftover first and create
+unconditionally — Postgres' recommended recovery for a failed concurrent build. During this window
+the legacy "permissionType" unique index still enforces uniqueness. Generous statement_timeout
+because a concurrent build can run long on large tables; this table is small today.
 */
 SET SESSION statement_timeout = 300000;
 SET SESSION lock_timeout = 5000;
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "group_permissions_group_gtype_rtype_rid_unique"
+DROP INDEX CONCURRENTLY IF EXISTS "group_permissions_group_gtype_rtype_rid_unique";
+CREATE UNIQUE INDEX CONCURRENTLY "group_permissions_group_gtype_rtype_rid_unique"
   ON "public"."group_permissions" ("groupId", "grantType", "resourceType", "resourceId");

--- a/front/migrations/pre-deploy/20260720201455_expand_group_permissions_grant_type.sql
+++ b/front/migrations/pre-deploy/20260720201455_expand_group_permissions_grant_type.sql
@@ -1,0 +1,59 @@
+-- Admin Governance: expand step of the group_permissions "permissionType" -> "grantType" column
+-- rename. The physical column is renamed via expand/contract (not a single-shot RENAME COLUMN)
+-- because group_permissions is read on the per-message model-resolution path (ModelsTierResource):
+-- renaming in one migration would leave old pods querying a gone "permissionType" during the deploy
+-- window and break model resolution for every message.
+--
+-- This pre-deploy step adds the new "grantType" column, installs a trigger that mirrors the two
+-- columns on write (so old pods writing "permissionType" and new pods writing "grantType" both
+-- produce complete rows during the rollout), backfills existing rows, and builds the new unique
+-- index. The post-deploy contract migration drops "permissionType", the trigger, and the old index
+-- once every pod runs the new code.
+
+/*
+Statement 0: add the new column. Nullable during the transition (the trigger + backfill keep it
+populated); the contract migration sets it NOT NULL once "permissionType" is gone.
+*/
+SET SESSION statement_timeout = 5000;
+SET SESSION lock_timeout = 5000;
+ALTER TABLE "public"."group_permissions" ADD COLUMN IF NOT EXISTS "grantType" VARCHAR(256);
+
+/*
+Statement 1: mirror the two columns on write. Created before the backfill so no concurrent insert
+can slip through with a NULL counterpart. Each code version sets exactly one of the columns; the
+trigger fills the other before NOT NULL constraints are checked.
+*/
+CREATE OR REPLACE FUNCTION group_permissions_mirror_grant_type()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."grantType" IS NULL THEN
+    NEW."grantType" := NEW."permissionType";
+  END IF;
+  IF NEW."permissionType" IS NULL THEN
+    NEW."permissionType" := NEW."grantType";
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS group_permissions_mirror_grant_type_trg ON "public"."group_permissions";
+CREATE TRIGGER group_permissions_mirror_grant_type_trg
+  BEFORE INSERT OR UPDATE ON "public"."group_permissions"
+  FOR EACH ROW EXECUTE FUNCTION group_permissions_mirror_grant_type();
+
+/*
+Statement 2: backfill existing rows.
+*/
+SET SESSION statement_timeout = 30000;
+SET SESSION lock_timeout = 5000;
+UPDATE "public"."group_permissions" SET "grantType" = "permissionType" WHERE "grantType" IS NULL;
+
+/*
+Statement 3: new unique index on "grantType", mirroring the existing one on "permissionType". Built
+CONCURRENTLY so it does not lock writes. Generous statement_timeout because a concurrent build can
+run long on large tables; this table is small today.
+*/
+SET SESSION statement_timeout = 300000;
+SET SESSION lock_timeout = 5000;
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "group_permissions_group_gtype_rtype_rid_unique"
+  ON "public"."group_permissions" ("groupId", "grantType", "resourceType", "resourceId");


### PR DESCRIPTION
## Description

Renames the `group_permissions` physical column `permissionType` → `grantType` to match the code
vocabulary (the Sequelize attribute has been `grantType` since the rename PR, mapped to the physical
column via `field: "permissionType"`).

`group_permissions` is read on the per-message model-resolution path (`ModelsTierResource.resolveAllowedTierNames`),
so a single-shot `RENAME COLUMN` would break old pods still querying `permissionType` during the
rolling deploy → failed model resolution for every message. The rename is therefore done as
expand/contract. **This is the expand step (1/2):**

- **Pre-deploy migration:** add the `grantType` column, install a bidirectional mirror trigger
  (old pods write `permissionType`, new pods write `grantType`; the trigger fills the counterpart so
  every row is complete during rollout), backfill existing rows, and build the new unique index
  `CONCURRENTLY`.
- **Model:** drop the `field: "permissionType"` mapping (`grantType` now maps to the `grantType`
  column) and point the unique index at `grantType`.
- Folds in two stale verb-storage comment fixes in `group_permission_resource.ts`.

The **contract step (2/2, post-deploy)** — drop `permissionType`, the trigger and old index, and set
`grantType NOT NULL` — is a follow-up PR merged only after this is deployed and pods have cycled.

## Risks

**Blast radius:** the `group_permissions` table (governance capability grants + model-tier grants),
which is read on the model-resolution path exercised by every agent message.

**Risk:** Low. The change is additive + trigger-bridged, so during the deploy window both column
names resolve to complete data and neither old nor new pods break. The migration was verified
end-to-end on a throwaway database: backfill, both write directions (old-code `permissionType`-only
and new-code `grantType`-only inserts), the new unique index build, and idempotent re-apply. The new
column is nullable in this step (trigger + backfill keep it populated); `NOT NULL` is set in the
contract step. tsgo clean; 69 group_permission / models_tier / auth tests pass.

## Deploy Plan

- Standard: the pre-deploy migration runs before the new code. Safe against still-running old pods —
  `grantType` is just an extra column the trigger keeps mirrored.
- After this deploys and pods cycle, merge the contract PR (2/2) to drop `permissionType`, the
  trigger, and the old index, and to set `grantType NOT NULL`.
- Rollback: revert the code; the extra column and trigger are harmless and are removed by the
  contract step (or by re-running once reverted).