### PR TITLE
[Admin Gov] Drop group_permissions permissionType column (2/2, contract)

### DIFF
--- a/front/migrations/post-deploy/20260720202131_drop_group_permissions_permission_type.sql
+++ b/front/migrations/post-deploy/20260720202131_drop_group_permissions_permission_type.sql
@@ -1,0 +1,34 @@
+-- Admin Governance: contract step of the group_permissions "permissionType" -> "grantType" column
+-- rename. Runs AFTER the expand step (pre-deploy) is deployed and every pod is on the new code that
+-- reads/writes "grantType". Drops the mirror trigger + function, the legacy "permissionType" column
+-- and its unique index, and makes "grantType" NOT NULL.
+
+/*
+Statement 0: drop the mirror trigger and its function — no code writes "permissionType" anymore.
+*/
+SET SESSION statement_timeout = 5000;
+SET SESSION lock_timeout = 5000;
+DROP TRIGGER IF EXISTS group_permissions_mirror_grant_type_trg ON "public"."group_permissions";
+DROP FUNCTION IF EXISTS group_permissions_mirror_grant_type();
+
+/*
+Statement 1: drop the legacy unique index on "permissionType" (CONCURRENTLY, no table lock) before
+the column drop so the ACCESS EXCLUSIVE window is the column drop alone.
+*/
+DROP INDEX CONCURRENTLY IF EXISTS "group_permissions_group_ptype_rtype_rid_unique";
+
+/*
+Statement 2: drop the legacy column (metadata-only; its dependent index is already gone).
+*/
+SET SESSION statement_timeout = 5000;
+SET SESSION lock_timeout = 5000;
+ALTER TABLE "public"."group_permissions" DROP COLUMN IF EXISTS "permissionType";
+
+/*
+Statement 3: enforce NOT NULL on the new column. The expand backfill + mirror trigger guaranteed
+every row is populated. The verifying scan takes a brief ACCESS EXCLUSIVE lock; group_permissions is
+small (admin-created grants), so this is fast.
+*/
+SET SESSION statement_timeout = 30000;
+SET SESSION lock_timeout = 5000;
+ALTER TABLE "public"."group_permissions" ALTER COLUMN "grantType" SET NOT NULL;


### PR DESCRIPTION
> ⛔ **DO NOT MERGE until #29190 (the expand step) is deployed to production and pods have
> cycled.** This post-deploy migration removes `permissionType`; merging it before every pod runs
> the new `grantType` code would break the model-resolution path.

## Description

Contract step (2/2) of the `group_permissions` `permissionType` → `grantType` physical column
rename. Stacked on #29190 (expand). Post-deploy migration only — no code change (the model already
reflects the end state after the expand PR).

- Drops the mirror trigger and its function (no code writes `permissionType` anymore).
- Drops the legacy unique index on `permissionType` (`CONCURRENTLY`), then drops the
  `permissionType` column.
- Sets `grantType NOT NULL` (the expand backfill + trigger guaranteed every row is populated).

## Risks

**Blast radius:** the `group_permissions` table. By the time this runs, every pod reads/writes
`grantType` and nothing references `permissionType`.

**Risk:** Low, provided the merge ordering is respected. Verified end-to-end on a throwaway database
(expand then contract): `permissionType` and its index removed, trigger/function removed, `grantType`
left `NOT NULL` with data preserved, and new-code inserts still succeed. `SET NOT NULL` takes a brief
ACCESS EXCLUSIVE lock for the verifying scan; the table is small (admin-created grants).

## Deploy Plan

- Merge only after #29190 is live and pods have cycled.
- Post-deploy migration runs after the new code — standard for a column/trigger drop.
- Rollback: this is a one-way cleanup. If needed, re-add the column via a new expand-style migration;
  the data lives in `grantType`.