### PR TITLE
[Admin Gov] Sync a manual Builders group from the builder role

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -296,6 +296,14 @@ export async function createAndTrackMembership({
     }
   }
 
+  // After the restore above, so the group reflects the new role rather than the pre-revoke
+  // one (builder role deprecation).
+  await GroupResource.syncBuilderGroupMembership({
+    workspace: w,
+    user,
+    isBuilder: role === "builder",
+  });
+
   void ServerSideTracking.trackCreateMembership({
     user: user.toJSON(),
     workspace: w,
@@ -374,6 +382,12 @@ export async function revokeAndTrackMembership(
   });
 
   if (revokeResult.isOk()) {
+    await GroupResource.syncBuilderGroupMembership({
+      workspace,
+      user,
+      isBuilder: false,
+    });
+
     const deleteTriggerResult = await TriggerResource.deleteAllForUser(
       auth,
       user
@@ -504,6 +518,12 @@ export async function updateMembershipRoleAndTrack({
   });
 
   if (updateRes.isOk()) {
+    await GroupResource.syncBuilderGroupMembership({
+      workspace,
+      user,
+      isBuilder: newRole === "builder",
+    });
+
     void ServerSideTracking.trackUpdateMembershipRole({
       user: user.toJSON(),
       workspace,

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -461,6 +461,14 @@ export async function revokeAndTrackMembership(
         "[Metronome] Failed to remove seat for revoked member"
       );
     }
+  } else if (revokeResult.error.type === "already_revoked") {
+    // Heal drift from a retried revoke whose first attempt failed after the membership
+    // write but before the group sync.
+    await GroupResource.syncBuilderGroupMembership({
+      workspace,
+      user,
+      isBuilder: false,
+    });
   }
 
   return revokeResult;
@@ -517,13 +525,17 @@ export async function updateMembershipRoleAndTrack({
     author,
   });
 
-  if (updateRes.isOk()) {
+  // On `already_on_role`, the membership already carries `newRole`: syncing anyway heals
+  // drift from a retried role change whose first attempt failed before the group sync.
+  if (updateRes.isOk() || updateRes.error.type === "already_on_role") {
     await GroupResource.syncBuilderGroupMembership({
       workspace,
       user,
       isBuilder: newRole === "builder",
     });
+  }
 
+  if (updateRes.isOk()) {
     void ServerSideTracking.trackUpdateMembershipRole({
       user: user.toJSON(),
       workspace,

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -104,6 +104,8 @@ export const applyGroupRoles = createPlugin({
             `Failed to update role for user ${user.sId}: ${updateResult.error.type}`
           );
         } else {
+          // Per-changed-member queries, like the role update above: poke-only plugin,
+          // bounded by the number of role changes.
           await GroupResource.syncBuilderGroupMembership({
             workspace,
             user,

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -104,6 +104,11 @@ export const applyGroupRoles = createPlugin({
             `Failed to update role for user ${user.sId}: ${updateResult.error.type}`
           );
         } else {
+          await GroupResource.syncBuilderGroupMembership({
+            workspace,
+            user,
+            isBuilder: expectedRole === "builder",
+          });
           updatedCount++;
         }
       }

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -966,24 +966,6 @@ describe("GroupResource", () => {
       expect(members).toEqual([]);
     });
 
-    it("leaves a provisioned group squatting the name untouched", async () => {
-      const group = await GroupResource.makeNew({
-        name: MANUAL_BUILDERS_GROUP_NAME,
-        workspaceId: workspace.id,
-        kind: "provisioned",
-        workOSGroupId: "workos-group-builders",
-      });
-
-      await GroupResource.syncBuilderGroupMembership({
-        workspace,
-        user,
-        isBuilder: true,
-      });
-
-      const members = await group.getActiveMembers(authenticator);
-      expect(members).toEqual([]);
-    });
-
     it("coexists with a provisioned dust-builders group", async () => {
       const provisionedGroup = await GroupResource.makeNew({
         name: BUILDER_GROUP_NAME,

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -74,6 +74,7 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   BUILDER_GROUP_NAME,
   GroupResource,
+  MANUAL_BUILDERS_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
@@ -870,7 +871,7 @@ describe("GroupResource", () => {
   });
 
   describe("syncBuilderGroupMembership", () => {
-    it("creates a regular_auto dust-builders group with the user when they become a builder", async () => {
+    it("creates a regular_manual Builders group with the user when they become a builder", async () => {
       await GroupResource.syncBuilderGroupMembership({
         workspace,
         user,
@@ -879,10 +880,10 @@ describe("GroupResource", () => {
 
       const group = await GroupResource.fetchByName(
         authenticator,
-        BUILDER_GROUP_NAME
+        MANUAL_BUILDERS_GROUP_NAME
       );
       expect(group).not.toBeNull();
-      expect(group?.kind).toBe("regular_auto");
+      expect(group?.kind).toBe("regular_manual");
 
       const members = await group?.getActiveMembers(authenticator);
       expect(members?.map((m) => m.id)).toEqual([user.id]);
@@ -897,16 +898,16 @@ describe("GroupResource", () => {
 
       const group = await GroupResource.fetchByName(
         authenticator,
-        BUILDER_GROUP_NAME
+        MANUAL_BUILDERS_GROUP_NAME
       );
       expect(group).toBeNull();
     });
 
     it("adds then removes the user as the builder role comes and goes", async () => {
       const group = await GroupResource.makeNew({
-        name: BUILDER_GROUP_NAME,
+        name: MANUAL_BUILDERS_GROUP_NAME,
         workspaceId: workspace.id,
-        kind: "regular_auto",
+        kind: "regular_manual",
       });
 
       await GroupResource.syncBuilderGroupMembership({
@@ -940,7 +941,7 @@ describe("GroupResource", () => {
 
       const group = await GroupResource.fetchByName(
         authenticator,
-        BUILDER_GROUP_NAME
+        MANUAL_BUILDERS_GROUP_NAME
       );
       const membershipCount = await GroupMembershipModel.count({
         where: {
@@ -965,8 +966,26 @@ describe("GroupResource", () => {
       expect(members).toEqual([]);
     });
 
-    it("leaves provisioned dust-builders groups untouched", async () => {
+    it("leaves a provisioned group squatting the name untouched", async () => {
       const group = await GroupResource.makeNew({
+        name: MANUAL_BUILDERS_GROUP_NAME,
+        workspaceId: workspace.id,
+        kind: "provisioned",
+        workOSGroupId: "workos-group-builders",
+      });
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+
+      const members = await group.getActiveMembers(authenticator);
+      expect(members).toEqual([]);
+    });
+
+    it("coexists with a provisioned dust-builders group", async () => {
+      const provisionedGroup = await GroupResource.makeNew({
         name: BUILDER_GROUP_NAME,
         workspaceId: workspace.id,
         kind: "provisioned",
@@ -979,8 +998,17 @@ describe("GroupResource", () => {
         isBuilder: true,
       });
 
-      const members = await group.getActiveMembers(authenticator);
-      expect(members).toEqual([]);
+      const manualGroup = await GroupResource.fetchByName(
+        authenticator,
+        MANUAL_BUILDERS_GROUP_NAME
+      );
+      expect(manualGroup?.kind).toBe("regular_manual");
+      const members = await manualGroup?.getActiveMembers(authenticator);
+      expect(members?.map((m) => m.id)).toEqual([user.id]);
+
+      const provisionedMembers =
+        await provisionedGroup.getActiveMembers(authenticator);
+      expect(provisionedMembers).toEqual([]);
     });
   });
 });

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -71,7 +71,10 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
 });
 
 import type { Authenticator } from "@app/lib/auth";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  BUILDER_GROUP_NAME,
+  GroupResource,
+} from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -863,6 +866,121 @@ describe("GroupResource", () => {
         await transaction.rollback();
         throw err;
       }
+    });
+  });
+
+  describe("syncBuilderGroupMembership", () => {
+    it("creates a regular_auto dust-builders group with the user when they become a builder", async () => {
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+
+      const group = await GroupResource.fetchByName(
+        authenticator,
+        BUILDER_GROUP_NAME
+      );
+      expect(group).not.toBeNull();
+      expect(group?.kind).toBe("regular_auto");
+
+      const members = await group?.getActiveMembers(authenticator);
+      expect(members?.map((m) => m.id)).toEqual([user.id]);
+    });
+
+    it("does not create the group when the user is not a builder", async () => {
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: false,
+      });
+
+      const group = await GroupResource.fetchByName(
+        authenticator,
+        BUILDER_GROUP_NAME
+      );
+      expect(group).toBeNull();
+    });
+
+    it("adds then removes the user as the builder role comes and goes", async () => {
+      const group = await GroupResource.makeNew({
+        name: BUILDER_GROUP_NAME,
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+      let members = await group.getActiveMembers(authenticator);
+      expect(members.map((m) => m.id)).toEqual([user.id]);
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: false,
+      });
+      members = await group.getActiveMembers(authenticator);
+      expect(members).toEqual([]);
+    });
+
+    it("is idempotent", async () => {
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+
+      const group = await GroupResource.fetchByName(
+        authenticator,
+        BUILDER_GROUP_NAME
+      );
+      const membershipCount = await GroupMembershipModel.count({
+        where: {
+          groupId: group?.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(membershipCount).toBe(1);
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: false,
+      });
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: false,
+      });
+      const members = await group?.getActiveMembers(authenticator);
+      expect(members).toEqual([]);
+    });
+
+    it("leaves provisioned dust-builders groups untouched", async () => {
+      const group = await GroupResource.makeNew({
+        name: BUILDER_GROUP_NAME,
+        workspaceId: workspace.id,
+        kind: "provisioned",
+        workOSGroupId: "workos-group-dust-builders",
+      });
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+      });
+
+      const members = await group.getActiveMembers(authenticator);
+      expect(members).toEqual([]);
     });
   });
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2648,16 +2648,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     }
 
-    if (group.kind === "provisioned") {
-      // An IdP group squats the name: never mutate provisioned membership. The nightly
-      // consistency check will surface the blocked sync.
-      logger.warn(
-        { workspaceId: workspace.id, groupId: group.id },
-        "Builders group name taken by a provisioned group; skipping builder group sync"
-      );
-      return;
-    }
-
     const now = new Date();
     // Served by the (userId, groupId) index.
     const activeMembershipWhere = {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -57,6 +57,10 @@ import { col, fn, Op, QueryTypes, UniqueConstraintError } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
+// User-facing name of the manual builders group synced from the builder role (see
+// syncBuilderGroupMembership). Distinct from BUILDER_GROUP_NAME: workspaces provisioning
+// builders via SCIM keep their "dust-builders" IdP group alongside this one.
+export const MANUAL_BUILDERS_GROUP_NAME = "Builders";
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -2581,18 +2585,20 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Transitional — builder role deprecation, see
    * https://github.com/dust-tt/tasks/issues/9459.
    *
-   * Keeps a per-workspace "dust-builders" group in sync with the `builder` role so that when
-   * the role is removed, the group can be granted the builders' governance capabilities
-   * (create agents / skills) and former builders keep their rights. Until then the role is
-   * the source of truth: the group is created lazily with kind `regular_auto`, which keeps it
-   * out of user-facing group management. Once the role is removed, membership will be managed
-   * through the members UI in place of role assignment — no new "dust-builders" groups are
-   * meant to be created past that point.
+   * Keeps a per-workspace "Builders" group (`regular_manual`) in sync with the `builder`
+   * role so that when the role is removed, the group can be granted the builders' governance
+   * capabilities (create agents / skills) and former builders keep their rights. Until then
+   * the role is the source of truth: the group is created lazily and manual edits may be
+   * undone by the sync. Once the role is removed, the sync goes away and the group becomes
+   * fully admin-managed.
+   *
+   * The group is deliberately independent from SCIM provisioning: provisioned
+   * "dust-builders" groups proved unreliable (drifted membership, stale groups after
+   * deprovisioning). Workspaces provisioning builders get both groups — IdP changes flow
+   * through role assignment, which keeps this group in sync automatically.
    *
    * Idempotent ensure-state semantics: after the call, the user's active membership in the
-   * group matches `isBuilder`. Workspaces where "dust-builders" is a provisioned group are
-   * skipped: the IdP group is then synced via SCIM and is itself what grants the builder
-   * role.
+   * group matches `isBuilder`.
    *
    * Callers must invoke this after every membership write that can involve the builder role
    * (role change, membership creation, revocation) — see the `lib/api/membership.ts`
@@ -2608,7 +2614,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     isBuilder: boolean;
   }): Promise<void> {
     let group = await GroupModel.findOne({
-      where: { workspaceId: workspace.id, name: BUILDER_GROUP_NAME },
+      where: { workspaceId: workspace.id, name: MANUAL_BUILDERS_GROUP_NAME },
     });
 
     if (!group) {
@@ -2618,8 +2624,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       try {
         await GroupResource.makeNew(
           {
-            name: BUILDER_GROUP_NAME,
-            kind: "regular_auto",
+            name: MANUAL_BUILDERS_GROUP_NAME,
+            kind: "regular_manual",
             workspaceId: workspace.id,
           },
           { memberIds: [user.id] }
@@ -2633,16 +2639,22 @@ export class GroupResource extends BaseResource<GroupModel> {
           throw err;
         }
         group = await GroupModel.findOne({
-          where: { workspaceId: workspace.id, name: BUILDER_GROUP_NAME },
+          where: {
+            workspaceId: workspace.id,
+            name: MANUAL_BUILDERS_GROUP_NAME,
+          },
         });
-        assert(
-          group,
-          "dust-builders group missing after unique constraint error"
-        );
+        assert(group, "Builders group missing after unique constraint error");
       }
     }
 
     if (group.kind === "provisioned") {
+      // An IdP group squats the name: never mutate provisioned membership. The nightly
+      // consistency check will surface the blocked sync.
+      logger.warn(
+        { workspaceId: workspace.id, groupId: group.id },
+        "Builders group name taken by a provisioned group; skipping builder group sync"
+      );
       return;
     }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -53,7 +53,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { col, fn, Op, QueryTypes } from "sequelize";
+import { col, fn, Op, QueryTypes, UniqueConstraintError } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
@@ -2575,6 +2575,111 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     return provisionedGroups;
+  }
+
+  /**
+   * Transitional — builder role deprecation, see
+   * https://github.com/dust-tt/tasks/issues/9459.
+   *
+   * Keeps a per-workspace "dust-builders" group in sync with the `builder` role so that when
+   * the role is removed, the group can be granted the builders' governance capabilities
+   * (create agents / skills) and former builders keep their rights. Until then the role is
+   * the source of truth: the group is created lazily with kind `regular_auto`, which keeps it
+   * out of user-facing group management. Once the role is removed, membership will be managed
+   * through the members UI in place of role assignment — no new "dust-builders" groups are
+   * meant to be created past that point.
+   *
+   * Idempotent ensure-state semantics: after the call, the user's active membership in the
+   * group matches `isBuilder`. Workspaces where "dust-builders" is a provisioned group are
+   * skipped: the IdP group is then synced via SCIM and is itself what grants the builder
+   * role.
+   *
+   * Callers must invoke this after every membership write that can involve the builder role
+   * (role change, membership creation, revocation) — see the `lib/api/membership.ts`
+   * wrappers.
+   */
+  static async syncBuilderGroupMembership({
+    workspace,
+    user,
+    isBuilder,
+  }: {
+    workspace: LightWorkspaceType;
+    user: UserResource;
+    isBuilder: boolean;
+  }): Promise<void> {
+    let group = await GroupModel.findOne({
+      where: { workspaceId: workspace.id, name: BUILDER_GROUP_NAME },
+    });
+
+    if (!group) {
+      if (!isBuilder) {
+        return;
+      }
+      try {
+        await GroupResource.makeNew(
+          {
+            name: BUILDER_GROUP_NAME,
+            kind: "regular_auto",
+            workspaceId: workspace.id,
+          },
+          { memberIds: [user.id] }
+        );
+        return;
+      } catch (err) {
+        // Two concurrent membership writes can race on the group creation; the
+        // (workspaceId, name) unique index makes the loser land here. Fall through to the
+        // membership sync against the winner's group.
+        if (!(err instanceof UniqueConstraintError)) {
+          throw err;
+        }
+        group = await GroupModel.findOne({
+          where: { workspaceId: workspace.id, name: BUILDER_GROUP_NAME },
+        });
+        assert(group, "dust-builders group missing after unique constraint error");
+      }
+    }
+
+    if (group.kind === "provisioned") {
+      return;
+    }
+
+    const now = new Date();
+    // Single row expected; served by the (userId, groupId) index.
+    const activeMembership = await GroupMembershipModel.findOne({
+      where: {
+        groupId: group.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "active",
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+    });
+
+    if (isBuilder) {
+      if (activeMembership) {
+        return;
+      }
+      await GroupMembershipModel.create({
+        groupId: group.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        startAt: now,
+        status: "active",
+      });
+    } else {
+      if (!activeMembership) {
+        return;
+      }
+      await GroupMembershipModel.update(
+        { endAt: now },
+        { where: { id: activeMembership.id, workspaceId: workspace.id } }
+      );
+    }
+
+    await GroupResource.batchInvalidateGroupIdsCacheForUsers([
+      [{ user: { id: user.id }, workspace: { id: workspace.id } }],
+    ]);
   }
 
   /**

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2647,16 +2647,17 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const now = new Date();
-    // Single row expected; served by the (userId, groupId) index.
+    // Served by the (userId, groupId) index.
+    const activeMembershipWhere = {
+      groupId: group.id,
+      userId: user.id,
+      workspaceId: workspace.id,
+      status: "active",
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    };
     const activeMembership = await GroupMembershipModel.findOne({
-      where: {
-        groupId: group.id,
-        userId: user.id,
-        workspaceId: workspace.id,
-        status: "active",
-        startAt: { [Op.lte]: now },
-        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
-      },
+      where: activeMembershipWhere,
     });
 
     if (isBuilder) {
@@ -2674,9 +2675,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       if (!activeMembership) {
         return;
       }
+      // End every matching row, not just the one fetched: concurrent adds can leave
+      // duplicate active rows.
       await GroupMembershipModel.update(
         { endAt: now },
-        { where: { id: activeMembership.id, workspaceId: workspace.id } }
+        { where: activeMembershipWhere }
       );
     }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2635,7 +2635,10 @@ export class GroupResource extends BaseResource<GroupModel> {
         group = await GroupModel.findOne({
           where: { workspaceId: workspace.id, name: BUILDER_GROUP_NAME },
         });
-        assert(group, "dust-builders group missing after unique constraint error");
+        assert(
+          group,
+          "dust-builders group missing after unique constraint error"
+        );
       }
     }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1088,7 +1088,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
-   * Caller of this method should call `ServerSideTracking.trackCreateMembership`.
+   * Caller of this method should call `ServerSideTracking.trackCreateMembership` and
+   * `GroupResource.syncBuilderGroupMembership` (builder role deprecation). Prefer
+   * `createAndTrackMembership` from `@app/lib/api/membership` which handles both.
    */
   static async createMembership({
     user,
@@ -1191,7 +1193,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   // Use `revokeAndTrackMembership` from `@app/lib/api/membership` instead which
-  // handles tracking and usage updates.
+  // handles tracking, usage updates and the dust-builders group sync (builder
+  // role deprecation).
   static async revokeMembership({
     user,
     workspace,
@@ -1317,7 +1320,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
-   * Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole`.
+   * Caller of this method should call `ServerSideTracking.trackUpdateMembershipRole` and
+   * `GroupResource.syncBuilderGroupMembership` (builder role deprecation). Prefer
+   * `updateMembershipRoleAndTrack` from `@app/lib/api/membership` which handles both.
    */
   static async updateMembershipRole({
     user,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1193,7 +1193,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   // Use `revokeAndTrackMembership` from `@app/lib/api/membership` instead which
-  // handles tracking, usage updates and the dust-builders group sync (builder
+  // handles tracking, usage updates and the builders group sync (builder
   // role deprecation).
   static async revokeMembership({
     user,

--- a/front/scripts/unrevoke_membership.ts
+++ b/front/scripts/unrevoke_membership.ts
@@ -1,4 +1,5 @@
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { ArgumentSpecs } from "@app/scripts/helpers";
@@ -90,6 +91,12 @@ makeScript(
       });
 
       if (result.isOk()) {
+        await GroupResource.syncBuilderGroupMembership({
+          workspace,
+          user,
+          isBuilder: result.value.newRole === "builder",
+        });
+
         scriptLogger.info(
           {
             userId: user.sId,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -30,7 +30,11 @@ import {
   createOrUpdateUser,
   WORKOS_METADATA_KEY_PREFIX,
 } from "@app/lib/iam/users";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  ADMIN_GROUP_NAME,
+  BUILDER_GROUP_NAME,
+  GroupResource,
+} from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -67,9 +71,6 @@ const logger = mainLogger.child(
     msgPrefix: "[WorkOS Event] ",
   }
 );
-
-const ADMIN_GROUP_NAME = "dust-admins";
-const BUILDER_GROUP_NAME = "dust-builders";
 
 // Grace window for treating a user_added event as stale when the user was
 // revoked around the same time. Covers races where WorkOS emits both events
@@ -250,6 +251,12 @@ async function handleRoleAssignmentForGroup(
         );
       }
 
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: newRole === "builder",
+      });
+
       logger.info(
         {
           userId: user.sId,
@@ -297,6 +304,12 @@ async function handleRoleAssignmentForGroup(
           `Failed to downgrade user role for ${user.sId}: ${updateResult.error.type}`
         );
       }
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: newRole === "builder",
+      });
 
       logger.info(
         {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9459 — first PR of the builder role deprecation series (backfill  follows in a separate PR). Decisions log: [issue comments](https://github.com/dust-tt/tasks/issues/9459#issuecomment-5032168852).

Design doc: [Admin Governance §5](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48).

Keeps a per-workspace **"Builders"** group (`regular_manual`) in sync with the `builder` role, so that when the role is removed the group can be granted the builders' governance capabilities (create agents / skills) and former builders keep their rights. Once the role is removed, the sync goes away and the group becomes fully admin-managed.

The group is deliberately **independent from SCIM provisioning**: provisioned `dust-builders` groups proved unreliable in practice (drifted membership, stale groups after deprovisioning). The ~40 workspaces provisioning builders keep their IdP group *and* get the manual group — IdP changes flow through role assignment, which keeps the manual group in sync automatically. They will receive an explanation of the two groups.

`GroupResource.syncBuilderGroupMembership` implements idempotent ensure-state semantics (active membership ends up matching the role) and is called from every membership write path:
- role changes, membership creation (invite acceptance / signup flows) and revocation, via the `lib/api/membership.ts` wrappers;
- SCIM role assignment (`handleRoleAssignmentForGroup`), the poke `apply_group_roles` plugin and the `unrevoke_membership` script, which call the resource methods directly.

Non-obvious points:
- In `createAndTrackMembership`, the sync runs **after** `restoreGroupMembershipsRevokedWith` so a rejoining user's group membership reflects their new role rather than the pre-revoke one.
- Retried writes (`already_on_role`, `already_revoked`) also sync, healing drift when a first attempt failed after the role write but before the group sync.
- Group creation races (two concurrent membership writes) are resolved through the `(workspaceId, name)` unique index.

Also unifies the previously duplicated `ADMIN_GROUP_NAME` / `BUILDER_GROUP_NAME` constants in `workos_events_queue/activities.ts` with the ones exported by `GroupResource`.


## Tests
- [x] Resource tests: lazy group creation, no creation for non-builders, add/remove on role transitions, idempotency, provisioned name-squat skipped, coexistence with a provisioned dust-builders group.

## Risks
Blast radius: membership writes (role change, invite acceptance, revoke, SCIM role sync) now also write to the Builders group.
Risk: low

## Deploy Plan
- deploy front
