### PR TITLE
[LLM] Preserve OpenAI Responses phase through the new router

### DIFF
--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -74,6 +74,7 @@ import type {
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import { isAgentMessagePhase } from "@app/types/assistant/agent_message_content";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import type {
   ModelIdType,
@@ -211,6 +212,7 @@ export function toBaseMessages(
                   role: "assistant",
                   type: "text",
                   content: { value: c.value },
+                  phase: c.metadata?.phase,
                 },
               ];
             case "reasoning": {
@@ -461,12 +463,19 @@ export function convertToOldEvent(
         metadata,
       };
 
-    case "text":
+    case "text": {
+      // Carry the Responses API phase (commentary/final_answer) back onto the
+      // legacy text event so it is persisted and resent on follow-up turns.
+      const phase = event.metadata.content?.phase;
       return {
         type: "text_generated",
         content: { text: event.content.value },
-        metadata,
+        metadata: {
+          ...metadata,
+          ...(isString(phase) && isAgentMessagePhase(phase) ? { phase } : {}),
+        },
       };
+    }
 
     case "reasoning_delta":
       return {

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -1,6 +1,40 @@
-import { assistantReasoningMessageToInputItems } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
-import type { BaseAssistantReasoningMessage } from "@app/lib/model_constructors/types/input/messages";
+import {
+  assistantReasoningMessageToInputItems,
+  assistantTextMessageToInputItem,
+} from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type {
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
 import { describe, expect, it } from "vitest";
+
+describe("assistantTextMessageToInputItem", () => {
+  it("resends the phase when present", () => {
+    const message: BaseAssistantTextMessage = {
+      role: "assistant",
+      type: "text",
+      content: { value: "here is the answer" },
+      phase: "final_answer",
+    };
+    expect(assistantTextMessageToInputItem(message)).toEqual({
+      role: "assistant",
+      content: "here is the answer",
+      phase: "final_answer",
+    });
+  });
+
+  it("omits the phase key when absent", () => {
+    const message: BaseAssistantTextMessage = {
+      role: "assistant",
+      type: "text",
+      content: { value: "no phase here" },
+    };
+    expect(assistantTextMessageToInputItem(message)).toEqual({
+      role: "assistant",
+      content: "no phase here",
+    });
+  });
+});
 
 describe("assistantReasoningMessageToInputItems", () => {
   it("returns an empty array when there is no signature", () => {

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -104,7 +104,11 @@ export function toolCallResultMessageToInputItem(
 export function assistantTextMessageToInputItem(
   message: BaseAssistantTextMessage
 ): ResponseInputItem {
-  return { role: "assistant", content: message.content.value };
+  return {
+    role: "assistant",
+    content: message.content.value,
+    ...(message.phase ? { phase: message.phase } : {}),
+  };
 }
 
 export function assistantReasoningMessageToInputItems(

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -13,6 +13,7 @@ import type {
   ToolCallEvent,
   ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import type { Phase } from "@app/lib/model_constructors/types/phases";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
 import {
   assertNever,
@@ -67,7 +68,8 @@ export interface OutputEventConverters {
   accumulatedTextToTextEvent(
     metadata: EndpointMetadata,
     text: string,
-    id?: string
+    id?: string,
+    phase?: Phase
   ): TextEvent;
   accumulatedReasoningToReasoningEvent(
     metadata: EndpointMetadata,
@@ -136,14 +138,19 @@ export function argumentsDeltaToToolCallDeltaEvent(
 export function accumulatedTextToTextEvent(
   metadata: EndpointMetadata,
   text: string,
-  id?: string
+  id?: string,
+  phase?: Phase
 ): TextEvent {
+  // Thread the message item id (so the input converter can resend it) and the
+  // phase (so downstream persistence keeps it) through metadata.content.
+  const content = { ...(id ? { id } : {}), ...(phase ? { phase } : {}) };
   return {
     type: "text",
     content: { value: text },
-    // Thread the message item id through so the input converter can resend it
-    // on the next turn.
-    metadata: { ...metadata, ...(id ? { content: { id } } : {}) },
+    metadata: {
+      ...metadata,
+      ...(Object.keys(content).length ? { content } : {}),
+    },
   };
 }
 
@@ -342,7 +349,8 @@ export function outputItemToEvents(
               converters.accumulatedTextToTextEvent(
                 metadata,
                 part.text,
-                item.id
+                item.id,
+                item.phase ?? undefined
               ),
             ];
           case "refusal":

--- a/front/lib/model_constructors/types/input/messages.ts
+++ b/front/lib/model_constructors/types/input/messages.ts
@@ -1,4 +1,5 @@
 import type { PassthroughLab } from "@app/lib/model_constructors/types/output/events";
+import type { Phase } from "@app/lib/model_constructors/types/phases";
 
 const CACHE_OPTIONS = ["short", "long"] as const;
 export type CacheOption = (typeof CACHE_OPTIONS)[number];
@@ -44,6 +45,10 @@ export type BaseAssistantTextMessage = {
   role: "assistant";
   type: "text";
   content: { value: string };
+  // Responses API commentary/final_answer phase, resent verbatim on replay
+  // (OpenAI recommends preserving it; dropping it degrades quality on
+  // gpt-5.3-codex and beyond).
+  phase?: Phase;
 };
 
 export type BaseAssistantReasoningMessage = {

--- a/front/lib/model_constructors/types/phases.ts
+++ b/front/lib/model_constructors/types/phases.ts
@@ -1,0 +1,2 @@
+export const PHASES = ["commentary", "final_answer"] as const;
+export type Phase = (typeof PHASES)[number];


### PR DESCRIPTION
## Description

Thread the OpenAI Responses `commentary`/`final_answer` phase through the new router — output converter, message type, transition layer, and input converter — so it is persisted and resent verbatim on follow-up turns (OpenAI recommends preserving it; dropping it degrades quality on gpt-5.3-codex and beyond).

## Tests

Added unit tests for `assistantTextMessageToInputItem` covering the phase-present and phase-absent cases.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`