### PR TITLE
Fix task-list checkbox alignment in markdown

### DIFF
--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -8,22 +8,44 @@ import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
 import React, { memo } from "react";
 
-export const ulBlockVariants = cva(["list-disc pb-2 pl-6 flex flex-col gap-1"]);
+export const ulBlockVariants = cva("pb-2 flex flex-col gap-1", {
+  variants: {
+    taskList: {
+      false: "list-disc pl-6",
+      true: "",
+    },
+  },
+  defaultVariants: {
+    taskList: false,
+  },
+});
 
 interface UlBlockProps {
   children: React.ReactNode;
+  className?: string;
   node?: MarkdownNode;
 }
 
 export const UlBlock = memo(
-  ({ children }: UlBlockProps) => {
+  ({ children, className }: UlBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
+    const isTaskList = className?.includes("contains-task-list");
     return (
-      <ul className={cn(ulBlockVariants(), textColor, textSize)}>{children}</ul>
+      <ul
+        className={cn(
+          ulBlockVariants({ taskList: isTaskList }),
+          textColor,
+          textSize,
+          className
+        )}
+      >
+        {children}
+      </ul>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.className === next.className
 );
 UlBlock.displayName = "UlBlock";
 


### PR DESCRIPTION
## Description

Fixed the alignment of task lists

Result in storybook: 
<img width="221" height="179" alt="Screenshot 2026-07-21 at 09 38 53" src="https://github.com/user-attachments/assets/edcc8007-5b5b-468f-aee8-92985a467e83" />

## Tests

Tested locally result in storybook 

## Risk

Low

## Deploy Plan

Deploy of sparkle