### PR TITLE
Prune historical reasoning in checkpointed conversation windows

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -13,11 +13,15 @@ function withTokens<T extends ModelMessageTypeMultiActions>(
   return { ...message, tokenCount };
 }
 
-function userMessage(name: string, tokenCount: number) {
+function userMessage(
+  name: string,
+  tokenCount: number,
+  { messageName = "user" }: { messageName?: string } = {}
+) {
   return withTokens(
     {
       role: "user" as const,
-      name: "user",
+      name: messageName,
       content: [{ type: "text" as const, text: name }],
     },
     tokenCount
@@ -33,6 +37,34 @@ function assistantMessage(name: string, tokenCount = 10) {
       contents: [{ type: "text_content" as const, value: name }],
     },
     tokenCount
+  );
+}
+
+function reasoningAssistantMessage(
+  name: string,
+  reasoningTokens: number,
+  { onlyReasoning = false }: { onlyReasoning?: boolean } = {}
+) {
+  return withTokens(
+    {
+      role: "assistant" as const,
+      name: "assistant",
+      contents: [
+        {
+          type: "reasoning" as const,
+          value: {
+            reasoning: `${name}_reasoning`,
+            metadata: "{}",
+            tokens: reasoningTokens,
+            provider: "anthropic" as const,
+          },
+        },
+        ...(onlyReasoning
+          ? []
+          : [{ type: "text_content" as const, value: `${name}_text` }]),
+      ],
+    },
+    reasoningTokens + (onlyReasoning ? 0 : 10)
   );
 }
 
@@ -59,6 +91,13 @@ function toolResults(state: CheckpointedConversationWindowState) {
     .renderedInteractions()
     .flatMap((item) => item.messages)
     .filter((message) => message.role === "function");
+}
+
+function assistantMessages(state: CheckpointedConversationWindowState) {
+  return state
+    .renderedInteractions()
+    .flatMap((item) => item.messages)
+    .filter((message) => message.role === "assistant");
 }
 
 function isPruned(content: unknown): boolean {
@@ -166,6 +205,90 @@ describe("CheckpointedConversationWindowState", () => {
       "pending_first_result",
       "pending_second_result",
     ]);
+  });
+
+  it("combines tool-result and historical reasoning savings into one checkpoint", () => {
+    const state = makeState({ pruningBudget: 10_000 });
+
+    state.append(
+      interaction([
+        userMessage("first_question", 10),
+        reasoningAssistantMessage("first_call", 9_000),
+        functionMessage("first_result", 12_024),
+        assistantMessage("first_answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(true);
+    expect(assistantMessages(state)[0].contents).toEqual([
+      { type: "text_content", value: "first_call_text" },
+    ]);
+  });
+
+  it("prunes eligible tool results before historical reasoning", () => {
+    const state = makeState({ pruningBudget: 31_000 });
+
+    state.append(
+      interaction([
+        userMessage("first_question", 10),
+        reasoningAssistantMessage("first_call", 10_000),
+        functionMessage("first_result", 25_024),
+        assistantMessage("first_answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(true);
+    expect(
+      assistantMessages(state)[0].contents.some(
+        (content) => content.type === "reasoning"
+      )
+    ).toBe(true);
+  });
+
+  it("preserves every reasoning block in the active user turn", () => {
+    const state = makeState({ pruningBudget: 10_000 });
+
+    state.append(
+      interaction([
+        userMessage("question", 10),
+        reasoningAssistantMessage("first_call", 15_000),
+        functionMessage("consumed", 20_024),
+        userMessage("enabled_skill", 10, { messageName: "system" }),
+        assistantMessage("second_call"),
+        functionMessage("pending", 10),
+      ])
+    );
+
+    expect(isPruned(toolResults(state)[0].content)).toBe(true);
+    expect(
+      assistantMessages(state)[0].contents.some(
+        (content) => content.type === "reasoning"
+      )
+    ).toBe(true);
+  });
+
+  it("omits a historical assistant message that contained only reasoning", () => {
+    const state = makeState({ pruningBudget: 1_000 });
+
+    state.append(
+      interaction([
+        userMessage("first_question", 10),
+        reasoningAssistantMessage("thinking", 25_000, {
+          onlyReasoning: true,
+        }),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(assistantMessages(state)).toEqual([]);
+    expect(
+      state
+        .renderedInteractions()
+        .flatMap((item) => item.messages)
+        .map((message) => message.role)
+    ).toEqual(["user", "user"]);
   });
 
   it("waits for a full checkpoint of reclaimable results before moving the frontier", () => {
@@ -288,5 +411,38 @@ describe("CheckpointedConversationWindowState", () => {
     expect(
       extendedResults.slice(0, 3).map((message) => isPruned(message.content))
     ).toEqual([true, true, false]);
+  });
+
+  it("does not restore pruned reasoning when later tool results become eligible", () => {
+    const firstTurn = interaction([
+      userMessage("first_question", 10),
+      reasoningAssistantMessage("first_call", 9_000),
+      functionMessage("first_result", 12_024),
+      assistantMessage("first_answer"),
+    ]);
+    const nextUser = interaction([userMessage("follow_up", 10)]);
+
+    const prefixState = makeState({ pruningBudget: 10_000 });
+    prefixState.append(firstTurn);
+    prefixState.append(nextUser);
+
+    const extendedState = makeState({ pruningBudget: 10_000 });
+    extendedState.append(firstTurn);
+    extendedState.append(nextUser);
+    extendedState.append(
+      interaction([
+        assistantMessage("second_call"),
+        functionMessage("second_result", 20_024),
+        assistantMessage("third_call"),
+        functionMessage("pending", 10),
+      ])
+    );
+
+    expect(prefixState.renderedInteractions()[0]).toEqual(
+      extendedState.renderedInteractions()[0]
+    );
+    expect(assistantMessages(extendedState)[0].contents).toEqual([
+      { type: "text_content", value: "first_call_text" },
+    ]);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -1,10 +1,13 @@
 import type {
+  AssistantMessageWithTokens,
   InteractionWithTokens,
   MessageWithTokens,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import {
+  getReasoningTokenSavings,
   getToolResultTokenSavings,
   PRUNING_CHECKPOINT_TOKENS,
+  pruneReasoningMessage,
   pruneToolResultMessage,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import type {
@@ -14,31 +17,36 @@ import type {
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type RegularMessageNode = {
   kind: "message";
   message: MessageWithTokens;
 };
 
+type PruningEligibility = "next_assistant" | "next_real_user";
+type PruningState = "pending" | "eligible" | "pruned";
+
 type ToolResultNode = {
   kind: "tool_result";
+  eligibility: "next_assistant";
   message: Extract<MessageWithTokens, { role: "function" }>;
+  pruningState: PruningState;
   tokenSavings: number;
 };
 
-type PendingToolResult = {
-  phase: "pending";
-  node: ToolResultNode;
+type ReasoningMessageNode = {
+  kind: "reasoning_message";
+  eligibility: "next_real_user";
+  message: AssistantMessageWithTokens;
+  omitted: boolean;
+  pruningState: PruningState;
+  tokenSavings: number;
 };
 
-type EligibleToolResult = {
-  phase: "eligible";
-  node: ToolResultNode;
-};
-
-// Interactions own these nodes. The pending and eligible queues only hold references to the same
-// tool-result nodes, so a message payload is never duplicated.
-type WindowMessageNode = RegularMessageNode | ToolResultNode;
+type PrunableMessageNode = ToolResultNode | ReasoningMessageNode;
+type PrunableMessageKind = PrunableMessageNode["kind"];
+type WindowMessageNode = RegularMessageNode | PrunableMessageNode;
 
 type WindowInteraction = {
   messages: WindowMessageNode[];
@@ -46,13 +54,39 @@ type WindowInteraction = {
 
 export const MINIMUM_PRUNING_BATCH_TOKENS = 5_000;
 
+const PRUNING_ORDER: PrunableMessageKind[] = [
+  "tool_result",
+  "reasoning_message",
+];
+
 function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
   if (message.role === "function") {
+    const tokenSavings = getToolResultTokenSavings(message);
+    if (tokenSavings === 0) {
+      return { kind: "message", message };
+    }
+
     return {
       kind: "tool_result",
+      eligibility: "next_assistant",
       message,
-      tokenSavings: getToolResultTokenSavings(message),
+      pruningState: "pending",
+      tokenSavings,
     };
+  }
+
+  if (message.role === "assistant") {
+    const tokenSavings = getReasoningTokenSavings(message);
+    if (tokenSavings > 0) {
+      return {
+        kind: "reasoning_message",
+        eligibility: "next_real_user",
+        message,
+        omitted: false,
+        pruningState: "pending",
+        tokenSavings,
+      };
+    }
   }
 
   return { kind: "message", message };
@@ -61,16 +95,18 @@ function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
 /**
  * Builds a model-facing conversation without ever removing an interaction.
  *
- * Tool results become eligible only after a later assistant message has consumed their complete
- * batch. Cleanup runs at model-input checkpoints and normally waits until the preferred 20k token
- * checkpoint can be reclaimed. If the nominal hard budget is crossed, it may accept a smaller
- * batch of at least 5k when pruning that complete batch restores fit. This keeps the pruning
- * frontier stable during normal growth without ignoring a meaningful final batch under pressure.
- * Preferred batches attempt to return one checkpoint below the soft limit.
+ * Tool results become eligible after a later assistant message has consumed their complete batch.
+ * Reasoning becomes eligible only when a later real user message starts, preserving every
+ * reasoning block in the active tool-use turn. Cleanup considers their combined savings, prunes
+ * tool results before reasoning, and normally waits until the preferred 20k token checkpoint can
+ * be reclaimed. If the nominal hard budget is crossed, it may accept a smaller batch of at least
+ * 5k when pruning that complete batch restores fit. Preferred batches attempt to return one
+ * checkpoint below the soft limit.
  *
- * If tool-result pruning cannot keep the complete interaction history below the nominal budget,
+ * If checkpointed pruning cannot keep the complete interaction history below the nominal budget,
  * the window keeps serving it and reports the excess through logs and metrics. The provider limit
- * remains the final boundary. The latest unconsumed result batch always remains intact.
+ * remains the final boundary. The latest unconsumed result batch and active-turn reasoning always
+ * remain intact.
  */
 export class CheckpointedConversationWindowState {
   private interactions: WindowInteraction[] = [];
@@ -78,10 +114,17 @@ export class CheckpointedConversationWindowState {
   private totalTokensBefore = 0;
   private prunedTokens = 0;
 
-  private pendingToolResults: PendingToolResult[] = [];
-  private eligibleToolResults: EligibleToolResult[] = [];
-  private nextEligibleToolResultIndex = 0;
-  private eligibleToolResultTokenSavings = 0;
+  // Interactions and this registry reference the same nodes, so message payloads are not copied.
+  private prunableNodes: PrunableMessageNode[] = [];
+  private eligibleTokenSavings = 0;
+  private nextEligibilityIndex: Record<PruningEligibility, number> = {
+    next_assistant: 0,
+    next_real_user: 0,
+  };
+  private nextPruningIndex: Record<PrunableMessageKind, number> = {
+    tool_result: 0,
+    reasoning_message: 0,
+  };
 
   private constructor(
     private readonly options: {
@@ -115,8 +158,12 @@ export class CheckpointedConversationWindowState {
       const message = interaction.messages[messageIndex];
       const nextMessage = interaction.messages[messageIndex + 1];
 
+      if (message.role === "user" && message.name !== "system") {
+        this.makePendingNodesEligible("next_real_user");
+      }
+
       if (message.role === "assistant") {
-        this.makePendingToolResultsEligible();
+        this.makePendingNodesEligible("next_assistant");
       }
 
       const node = makeWindowMessageNode(message);
@@ -124,8 +171,8 @@ export class CheckpointedConversationWindowState {
       this.retainedTokens += message.tokenCount;
       this.totalTokensBefore += message.tokenCount;
 
-      if (node.kind === "tool_result") {
-        this.pendingToolResults.push({ phase: "pending", node });
+      if (node.kind !== "message") {
+        this.prunableNodes.push(node);
       }
 
       if (this.isModelInputCheckpoint(message, nextMessage)) {
@@ -136,7 +183,9 @@ export class CheckpointedConversationWindowState {
 
   renderedInteractions(): InteractionWithTokens[] {
     return this.interactions.map((interaction) => ({
-      messages: interaction.messages.map((node) => node.message),
+      messages: interaction.messages.flatMap((node) =>
+        node.kind === "reasoning_message" && node.omitted ? [] : [node.message]
+      ),
     }));
   }
 
@@ -155,7 +204,7 @@ export class CheckpointedConversationWindowState {
       logger.warn(
         {
           ...logDetails,
-          windowStage: "nominal_budget_exceeded_after_tool_result_pruning",
+          windowStage: "nominal_budget_exceeded_after_checkpointed_pruning",
           totalTokens: this.retainedTokens,
           budgetForInteractions,
           tokensOverBudget: this.retainedTokens - budgetForInteractions,
@@ -188,15 +237,22 @@ export class CheckpointedConversationWindowState {
     return endsUserInput || endsToolResultBatch;
   }
 
-  private makePendingToolResultsEligible(): void {
-    for (const { node } of this.pendingToolResults) {
-      if (node.tokenSavings > 0) {
-        this.eligibleToolResults.push({ phase: "eligible", node });
-        this.eligibleToolResultTokenSavings += node.tokenSavings;
+  private makePendingNodesEligible(eligibility: PruningEligibility): void {
+    const startIndex = this.nextEligibilityIndex[eligibility];
+
+    for (
+      let nodeIndex = startIndex;
+      nodeIndex < this.prunableNodes.length;
+      nodeIndex++
+    ) {
+      const node = this.prunableNodes[nodeIndex];
+      if (node.eligibility === eligibility && node.pruningState === "pending") {
+        node.pruningState = "eligible";
+        this.eligibleTokenSavings += node.tokenSavings;
       }
     }
 
-    this.pendingToolResults = [];
+    this.nextEligibilityIndex[eligibility] = this.prunableNodes.length;
   }
 
   private applyBufferedPruning(): void {
@@ -205,11 +261,11 @@ export class CheckpointedConversationWindowState {
     }
 
     const hasPreferredBatch =
-      this.eligibleToolResultTokenSavings >= PRUNING_CHECKPOINT_TOKENS;
+      this.eligibleTokenSavings >= PRUNING_CHECKPOINT_TOKENS;
     const canRestoreNominalBudgetWithSmallerBatch =
       this.retainedTokens > this.options.budgetForInteractions &&
-      this.eligibleToolResultTokenSavings >= MINIMUM_PRUNING_BATCH_TOKENS &&
-      this.retainedTokens - this.eligibleToolResultTokenSavings <=
+      this.eligibleTokenSavings >= MINIMUM_PRUNING_BATCH_TOKENS &&
+      this.retainedTokens - this.eligibleTokenSavings <=
         this.options.budgetForInteractions;
 
     if (!hasPreferredBatch && !canRestoreNominalBudgetWithSmallerBatch) {
@@ -218,21 +274,65 @@ export class CheckpointedConversationWindowState {
 
     const targetTokens = hasPreferredBatch
       ? Math.max(this.options.pruningBudget - PRUNING_CHECKPOINT_TOKENS, 0)
-      : this.retainedTokens - this.eligibleToolResultTokenSavings;
+      : this.retainedTokens - this.eligibleTokenSavings;
 
+    for (const kind of PRUNING_ORDER) {
+      this.pruneEligibleNodes(kind, targetTokens);
+    }
+  }
+
+  private pruneEligibleNodes(
+    kind: PrunableMessageKind,
+    targetTokens: number
+  ): void {
+    let nodeIndex = this.nextPruningIndex[kind];
     while (
       this.retainedTokens > targetTokens &&
-      this.nextEligibleToolResultIndex < this.eligibleToolResults.length
+      nodeIndex < this.prunableNodes.length
     ) {
-      const { node } =
-        this.eligibleToolResults[this.nextEligibleToolResultIndex];
+      const node = this.prunableNodes[nodeIndex];
+      if (node.kind !== kind) {
+        nodeIndex += 1;
+        continue;
+      }
 
-      node.message = pruneToolResultMessage(node.message);
-      this.retainedTokens -= node.tokenSavings;
-      this.prunedTokens += node.tokenSavings;
-      this.eligibleToolResultTokenSavings -= node.tokenSavings;
-      this.nextEligibleToolResultIndex += 1;
+      // Eligibility is monotonic within a kind, so no later node of this kind can be eligible yet.
+      if (node.pruningState === "pending") {
+        break;
+      }
+
+      if (node.pruningState === "eligible") {
+        this.pruneNode(node);
+      }
+
+      nodeIndex += 1;
     }
+
+    this.nextPruningIndex[kind] = nodeIndex;
+  }
+
+  private pruneNode(node: PrunableMessageNode): void {
+    switch (node.kind) {
+      case "tool_result":
+        node.message = pruneToolResultMessage(node.message);
+        break;
+      case "reasoning_message": {
+        const prunedMessage = pruneReasoningMessage(node.message);
+        if (prunedMessage) {
+          node.message = prunedMessage;
+        } else {
+          node.omitted = true;
+        }
+        break;
+      }
+      default:
+        assertNever(node);
+    }
+
+    node.pruningState = "pruned";
+    this.eligibleTokenSavings -= node.tokenSavings;
+    this.retainedTokens -= node.tokenSavings;
+    this.prunedTokens += node.tokenSavings;
   }
 
   private stats(): ConversationPruningStats {

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -1,9 +1,11 @@
 /**
- * Mechanisms for fitting a conversation into a token budget. Two distinct operations, named
+ * Mechanisms for fitting a conversation into a token budget. The operations are named
  * consistently throughout this module and index.ts:
  *
  * - "prune" (pruneToolResults): replace a tool result's content with a small placeholder. The
  *   message stays in place, so tool_use/tool_result pairing is never broken.
+ * - "prune reasoning" (pruneReasoningMessage): remove reasoning blocks while preserving every
+ *   other assistant content item.
  * - "drop" (dropInteractionsToFit): remove whole interactions entirely, oldest first.
  *
  * The conversation window state implementations own the policy of when to apply which. This
@@ -36,6 +38,11 @@ export type MessageWithTokens = ModelMessageTypeMultiActions & {
 };
 
 export type InteractionWithTokens = Interaction<MessageWithTokens>;
+
+export type AssistantMessageWithTokens = Extract<
+  MessageWithTokens,
+  { role: "assistant" }
+>;
 
 /** Turns a function-role message into the pruned placeholder. */
 export function pruneToolResultMessage(
@@ -70,6 +77,52 @@ export function getToolResultTokenSavings(message: MessageWithTokens): number {
   return message.role === "function"
     ? Math.max(message.tokenCount - PRUNED_TOOL_RESULT_TOKENS, 0)
     : 0;
+}
+
+/** Tokens removed by dropping every reasoning block from an assistant message. */
+export function getReasoningTokenSavings(
+  message: AssistantMessageWithTokens
+): number {
+  const reasoningTokens = message.contents.reduce(
+    (sum, content) =>
+      content.type === "reasoning" ? sum + content.value.tokens : sum,
+    0
+  );
+
+  if (reasoningTokens <= 0) {
+    return 0;
+  }
+
+  const hasNonReasoningContent = message.contents.some(
+    (content) => content.type !== "reasoning"
+  );
+
+  return hasNonReasoningContent
+    ? Math.min(reasoningTokens, message.tokenCount)
+    : message.tokenCount;
+}
+
+/** Removes complete reasoning blocks while preserving every other assistant content item. */
+export function pruneReasoningMessage(
+  message: AssistantMessageWithTokens
+): AssistantMessageWithTokens | null {
+  const tokenSavings = getReasoningTokenSavings(message);
+  if (tokenSavings === 0) {
+    return message;
+  }
+
+  const contents = message.contents.filter(
+    (content) => content.type !== "reasoning"
+  );
+  if (contents.length === 0) {
+    return null;
+  }
+
+  return {
+    ...message,
+    contents,
+    tokenCount: message.tokenCount - tokenSavings,
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds historical reasoning pruning to the recently introduced checkpointed conversation window. V2 still never drops interactions: user messages, assistant answers, tool calls, and conversation ordering remain available to the model.

The pruning boundary is the latest real user message. Reasoning generated after that point is preserved unchanged, including reasoning interleaved with tool calls and results. Injected system messages do not advance this boundary. 
About providers:
- Anthropic requires this active tool-use reasoning to be returned unchanged but allows thinking from earlier assistant turns to be omitted. See Anthropic’s extended-thinking documentation
(https://platform.claude.com/docs/en/build-with-claude/extended-thinking#preserving-thinking-blocks).
- OpenAI similarly recommends preserving every reasoning and function-call item since the latest user message, while its `current_turn` mode excludes reasoning from earlier turns. OpenAI’s reasoning guidance
(https://developers.openai.com/api/docs/guides/reasoning#keeping-reasoning-items-in-context).

Historical reasoning is only removed under context pressure. It shares the existing 20k pruning checkpoint with consumed tool results, so both contribute to one predictable cache rewrite. Tool results are pruned first, reasoning is used only when they cannot provide enough headroom. Previously pruned content is never restored.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
