### PR TITLE
Fix agent reasoning effort resolution

### DIFF
--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -19,12 +19,14 @@ import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import {
   GPT_5_4_MINI_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
+  GPT_5_6_LUNA_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
   ModelIdType,
   ModelProviderIdType,
+  ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -166,9 +168,11 @@ describe("selectEnabledModel", () => {
 function makeAgentConfiguration({
   providerId,
   modelId,
+  reasoningEffort,
 }: {
   providerId: ModelProviderIdType;
   modelId: ModelIdType;
+  reasoningEffort?: ReasoningEffort;
 }): LightAgentConfigurationType {
   return {
     id: 1,
@@ -181,6 +185,7 @@ function makeAgentConfiguration({
       providerId,
       modelId,
       temperature: 0,
+      reasoningEffort,
     },
     status: "active",
     scope: "visible",
@@ -254,6 +259,45 @@ describe("resolveModel", () => {
       reasoningEffort:
         CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
     });
+  });
+
+  it("honors a supported reasoning effort configured on the agent", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+        modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+        reasoningEffort: "high",
+      }),
+      featureFlags: [],
+    });
+
+    expect(modelResolutionMethod).toBe("agent");
+    expect(resolvedModel).toEqual({
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
+    });
+  });
+
+  it("falls back to the model default for an unsupported agent effort", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { resolvedModel } = await resolveModel(auth, {
+      configuration: makeAgentConfiguration({
+        providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+        modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
+        reasoningEffort: "none",
+      }),
+      featureFlags: [],
+    });
+
+    expect(resolvedModel.reasoningEffort).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort
+    );
   });
 
   it("falls back to a workspace large model when the agent model is unavailable", async () => {

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -82,12 +82,16 @@ export async function resolveModel(
   // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.
   assert(enabled, "No enabled model found");
 
-  // Honor an explicit effort only if the model supports it; otherwise fall back
-  // to its default (raw API clients can send an unsupported effort).
+  const requestedReasoningEffort = selection
+    ? selection.reasoningEffort
+    : configuration.model.reasoningEffort;
+
+  // Honor the selected or agent-configured effort only if the resolved model
+  // supports it. Raw API clients can send an unsupported effort.
   const effort =
-    selection?.reasoningEffort &&
-    enabled.supportedReasoningEfforts[selection.reasoningEffort]
-      ? selection.reasoningEffort
+    requestedReasoningEffort &&
+    enabled.supportedReasoningEfforts[requestedReasoningEffort]
+      ? requestedReasoningEffort
       : enabled.defaultReasoningEffort;
 
   return {


### PR DESCRIPTION
## Description

Use the reasoning effort configured on an agent when model resolution does not have an explicit user selection. Keep falling back to the resolved model default when the requested effort is unsupported.

This fixes global agents configured for high effort being silently resolved at the model default effort.

## Tests

- Added regression coverage for a supported high agent effort.
- Added coverage for unsupported agent effort fallback.
- `NODE_ENV=test npm run test -- lib/api/assistant/models.test.ts` (22 tests passed)
- `npx tsgo --noEmit`
- `npx biome check --write --error-on-warnings front/lib/api/assistant/resolve_model.ts front/lib/api/assistant/models.test.ts`

## Risk

Low. The change only affects resolution without an explicit model selection. Unsupported efforts retain the current model-default fallback.

## Deploy Plan

Deploy normally. No migration or configuration change is required.