### PR TITLE
Clarify additive Space selection in the input bar

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -37,7 +38,7 @@ export function InputBarSpacesPicker({
 }: InputBarSpacesPickerProps) {
   const selectedSpaceIdsSet = useMemo(
     () => new Set(selectedSpaceIds),
-    [selectedSpaceIds]
+    [selectedSpaceIds],
   );
   const [searchText, setSearchText] = useState("");
   const filteredSpaces = useMemo(() => {
@@ -47,14 +48,14 @@ export function InputBarSpacesPicker({
     }
 
     return spaces.filter((space) =>
-      space.name.toLowerCase().includes(normalizedSearchText)
+      space.name.toLowerCase().includes(normalizedSearchText),
     );
   }, [searchText, spaces]);
 
   const tooltip =
     selectedSpaceIds.length > 0
-      ? `${selectedSpaceIds.length} Space${selectedSpaceIds.length > 1 ? "s" : ""} selected`
-      : "Select Spaces";
+      ? `${selectedSpaceIds.length} additional Space${selectedSpaceIds.length > 1 ? "s" : ""}`
+      : "Add Spaces";
 
   const handleSpaceCheckedChange = (spaceId: string, checked: boolean) => {
     if (!checked && !canDeselectSelectedSpaces) {
@@ -65,7 +66,7 @@ export function InputBarSpacesPicker({
       onSelectedSpaceIdsChange(
         selectedSpaceIdsSet.has(spaceId)
           ? selectedSpaceIds
-          : [...selectedSpaceIds, spaceId]
+          : [...selectedSpaceIds, spaceId],
       );
       return;
     }
@@ -109,6 +110,13 @@ export function InputBarSpacesPicker({
           </>
         }
       >
+        <DropdownMenuCheckboxItem
+          label="Agent's existing knowledge"
+          checked
+          disabled
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel label="Additional Spaces" />
         {isLoading ? (
           <DropdownMenuItem
             label="Loading"

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -110,11 +110,7 @@ export function InputBarSpacesPicker({
           </>
         }
       >
-        <DropdownMenuCheckboxItem
-          label="Agent's existing knowledge"
-          checked
-          disabled
-        />
+        <DropdownMenuCheckboxItem label="Agent's Spaces" checked disabled />
         <DropdownMenuSeparator />
         <DropdownMenuLabel label="Additional Spaces" />
         {isLoading ? (

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -38,7 +38,7 @@ export function InputBarSpacesPicker({
 }: InputBarSpacesPickerProps) {
   const selectedSpaceIdsSet = useMemo(
     () => new Set(selectedSpaceIds),
-    [selectedSpaceIds],
+    [selectedSpaceIds]
   );
   const [searchText, setSearchText] = useState("");
   const filteredSpaces = useMemo(() => {
@@ -48,7 +48,7 @@ export function InputBarSpacesPicker({
     }
 
     return spaces.filter((space) =>
-      space.name.toLowerCase().includes(normalizedSearchText),
+      space.name.toLowerCase().includes(normalizedSearchText)
     );
   }, [searchText, spaces]);
 
@@ -66,7 +66,7 @@ export function InputBarSpacesPicker({
       onSelectedSpaceIdsChange(
         selectedSpaceIdsSet.has(spaceId)
           ? selectedSpaceIds
-          : [...selectedSpaceIds, spaceId],
+          : [...selectedSpaceIds, spaceId]
       );
       return;
     }


### PR DESCRIPTION
## Description

Clarifies that Spaces selected from the input bar extend the agent's configured Spaces rather than replace them. The picker now shows Agent's Spaces separately from Additional Spaces, and its tooltip uses additive wording.


<img width="810" height="589" alt="Screenshot 2026-07-21 at 11 40 08" src="https://github.com/user-attachments/assets/08cda8e1-70e5-446e-8a2e-aec9b23166f7" />

## Tests

Tested locally in a seeded Hive with open and restricted Spaces. Verified selection, persistent dropdown behavior, filtering, icons, and selection count updates.

## Risk

Low. This only changes picker copy and menu structure.

## Deploy Plan

Standard deploy.