### PR TITLE
Self-improving skills: mark notification as read when suggestion are handled

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -62,7 +62,9 @@ async function buildConnectedServerIdsByType(
       auth,
       { connectionType: "personal" }
     );
-    connectedByType["personal"] = new Set(connections.map((c) => c.mcpServerId));
+    connectedByType["personal"] = new Set(
+      connections.map((c) => c.mcpServerId)
+    );
   }
   if (neededTypes.has("workspace")) {
     const connections = await MCPServerConnectionResource.listByWorkspace(
@@ -84,9 +86,9 @@ function isServerConnected(
   if (!view.oAuthUseCase) {
     return true;
   }
-  return connectedByType[
-    connectionTypeForOAuthUseCase(view.oAuthUseCase)
-  ].has(view.mcpServerId);
+  return connectedByType[connectionTypeForOAuthUseCase(view.oAuthUseCase)].has(
+    view.mcpServerId
+  );
 }
 
 async function resolveToolExecutionMode(

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -513,9 +513,28 @@ export async function postSkillSuggestionStatusUpdate(
     // as unread for the acting editor. Push `lastReadAt` a minute into the
     // future so the ack holds through the imminent agent completion — the
     // NOOP reply lands within milliseconds.
-    await ConversationResource.markAsReadForAuthUser(auth, {
-      conversation: conversationResource,
-      lastReadAt: new Date(Date.now() + 60_000),
-    });
+    const lastReadAt = new Date(Date.now() + 60_000);
+
+    // When the last pending suggestion of this notification conversation has
+    // been handled, mark the conversation as read for every participant: the
+    // other editors have nothing left to act on and should not be notified
+    // about an already-handled suggestion list.
+    const hasPending =
+      await SkillSuggestionResource.hasPendingForNotificationConversation(
+        auth,
+        conversationResource.id
+      );
+
+    if (hasPending) {
+      await ConversationResource.markAsReadForAuthUser(auth, {
+        conversation: conversationResource,
+        lastReadAt,
+      });
+    } else {
+      await ConversationResource.markAsReadForAllParticipants(auth, {
+        conversation: conversationResource,
+        lastReadAt,
+      });
+    }
   }
 }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -8,6 +8,7 @@ import {
   ConversationModel,
   ConversationParticipantModel,
   MessageModel,
+  UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
@@ -6424,6 +6425,89 @@ describe("markAsReadForAuthUser", () => {
     });
     assert(row);
     expect(row.lastReadAt.getTime()).toBe(explicit.getTime());
+  });
+});
+
+describe("markAsReadForAllParticipants", () => {
+  let workspace: LightWorkspaceType;
+  let auth: Authenticator;
+  let otherAuth: Authenticator;
+  let conversation: ConversationWithoutContentType;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    const [agent] = await setupTestAgents(workspace, user);
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+      lastReadAt: null,
+    });
+    await ConversationResource.upsertParticipation(otherAuth, {
+      conversation,
+      action: "posted",
+      user: otherAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null,
+    });
+  });
+
+  it("marks the conversation as read for every participant", async () => {
+    const lastReadAt = new Date(Date.now() + 60_000);
+    await ConversationResource.markAsReadForAllParticipants(auth, {
+      conversation,
+      lastReadAt,
+    });
+
+    const rows = await UserConversationReadsModel.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    expect(rows).toHaveLength(2);
+    expect(
+      rows.every((row) => row.lastReadAt.getTime() === lastReadAt.getTime())
+    ).toBe(true);
+  });
+
+  it("overwrites existing read entries", async () => {
+    const earlier = new Date(Date.now() - 60_000);
+    await ConversationResource.markAsReadForAuthUser(otherAuth, {
+      conversation,
+      lastReadAt: earlier,
+    });
+
+    const lastReadAt = new Date(Date.now() + 60_000);
+    await ConversationResource.markAsReadForAllParticipants(auth, {
+      conversation,
+      lastReadAt,
+    });
+
+    const row = await UserConversationReadsModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        userId: otherAuth.getNonNullableUser().id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    assert(row);
+    expect(row.lastReadAt.getTime()).toBe(lastReadAt.getTime());
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2708,6 +2708,47 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(updated);
   }
 
+  /**
+   * Marks the conversation as read for every participant. Used for
+   * notification-style conversations once their purpose is fulfilled (e.g. all
+   * skill suggestions handled), so the remaining participants are not notified
+   * about an already-handled conversation.
+   */
+  static async markAsReadForAllParticipants(
+    auth: Authenticator,
+    {
+      conversation,
+      lastReadAt,
+    }: {
+      conversation: ConversationWithoutContentType | ConversationResource;
+      lastReadAt?: Date;
+    }
+  ): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const participants = await ConversationParticipantModel.findAll({
+      where: {
+        workspaceId,
+        conversationId: conversation.id,
+      },
+      attributes: ["userId"],
+    });
+
+    if (participants.length === 0) {
+      return;
+    }
+
+    await UserConversationReadsModel.bulkCreate(
+      participants.map((p) => ({
+        conversationId: conversation.id,
+        userId: p.userId,
+        workspaceId,
+        lastReadAt: lastReadAt ?? new Date(),
+      })),
+      { updateOnDuplicate: ["lastReadAt"] }
+    );
+  }
+
   static async markAsUnreadForAuthUser(
     auth: Authenticator,
     {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1705,7 +1705,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         this.internalMCPServerId
       );
       if (nameResult.isOk()) {
-        const tools = INTERNAL_MCP_SERVERS[nameResult.value.name].metadata.tools;
+        const tools =
+          INTERNAL_MCP_SERVERS[nameResult.value.name].metadata.tools;
         const overrides = new Map(
           this.allToolsMetadata.map((m) => [m.toolName, m])
         );

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -607,6 +607,81 @@ describe("SkillSuggestionResource", () => {
     });
   });
 
+  describe("hasPendingForNotificationConversation", () => {
+    it("returns true while some linked suggestions are pending", async () => {
+      const s1 = await SkillSuggestionFactory.create(authenticator, skill);
+      const s2 = await SkillSuggestionFactory.create(authenticator, skill);
+
+      const conversation = await createConversation(authenticator, {
+        title: "Notification",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      await SkillSuggestionResource.bulkSetNotificationConversation(
+        authenticator,
+        [s1, s2],
+        conversation.id
+      );
+
+      await SkillSuggestionResource.bulkUpdateState(
+        authenticator,
+        [s1],
+        "approved"
+      );
+
+      expect(
+        await SkillSuggestionResource.hasPendingForNotificationConversation(
+          authenticator,
+          conversation.id
+        )
+      ).toBe(true);
+    });
+
+    it("returns false once all linked suggestions are handled", async () => {
+      const s1 = await SkillSuggestionFactory.create(authenticator, skill);
+      const s2 = await SkillSuggestionFactory.create(authenticator, skill);
+      // Pending suggestion not linked to the conversation: must not count.
+      await SkillSuggestionFactory.create(authenticator, skill);
+
+      const conversation = await createConversation(authenticator, {
+        title: "Notification",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      await SkillSuggestionResource.bulkSetNotificationConversation(
+        authenticator,
+        [s1, s2],
+        conversation.id
+      );
+      expect(
+        await SkillSuggestionResource.hasPendingForNotificationConversation(
+          authenticator,
+          conversation.id
+        )
+      ).toBe(true);
+
+      await SkillSuggestionResource.bulkUpdateState(
+        authenticator,
+        [s1],
+        "approved"
+      );
+      await SkillSuggestionResource.bulkUpdateState(
+        authenticator,
+        [s2],
+        "rejected"
+      );
+
+      expect(
+        await SkillSuggestionResource.hasPendingForNotificationConversation(
+          authenticator,
+          conversation.id
+        )
+      ).toBe(false);
+    });
+  });
+
   describe("sourceConversationIds", () => {
     it("should store and retrieve sourceConversationIds", async () => {
       const suggestion = await SkillSuggestionFactory.create(

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -371,6 +371,25 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
     );
   }
 
+  /**
+   * Returns whether any pending suggestions remain linked to the given
+   * notification conversation.
+   */
+  static async hasPendingForNotificationConversation(
+    auth: Authenticator,
+    notificationConversationModelId: ModelId
+  ): Promise<boolean> {
+    const count = await SkillSuggestionModel.count({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        notificationConversationModelId,
+        state: "pending",
+      },
+    });
+
+    return count > 0;
+  }
+
   static async bulkUpdateState(
     auth: Authenticator,
     suggestions: SkillSuggestionResource[],


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8768

The purpose is to avoid being notified by some suggestion another user has already handled.
When the last suggestion of the conversation has been handled, mark the conversation as read for everybody so 

## Tests

Added unit tests for the new resources methods

## Risk

low: just about notifications + easy to revert

## Deploy Plan

deploy front
