### PR TITLE
[Admin Gov] Backfill the Builders group from builder roles

### DIFF
--- a/front/migrations/20260721_backfill_builders_group.ts
+++ b/front/migrations/20260721_backfill_builders_group.ts
@@ -1,0 +1,187 @@
+import { Op, QueryTypes } from "sequelize";
+
+import {
+  GroupResource,
+  MANUAL_BUILDERS_GROUP_NAME,
+} from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
+const WORKSPACE_CONCURRENCY = 4;
+
+/**
+ * Backfill of the "Builders" group (builder role deprecation, PR 2 of
+ * https://github.com/dust-tt/tasks/issues/9459).
+ *
+ * The sync shipped in PR 1 only fires on membership writes, so builders whose role never
+ * changes after the deploy would never enter the group. This one-shot reconciles every
+ * workspace from the roles (the source of truth): active builders are added to the group,
+ * group members who are not active builders are removed.
+ */
+
+async function reconcileWorkspace(
+  workspaceModelId: number,
+  execute: boolean,
+  logger: Logger
+): Promise<{ added: number; removed: number }> {
+  const [workspace] = await WorkspaceResource.fetchByModelIds([
+    workspaceModelId,
+  ]);
+  if (!workspace) {
+    logger.warn({ workspaceModelId }, "Workspace not found, skipping");
+    return { added: 0, removed: 0 };
+  }
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+  const now = new Date();
+  const activeWindow = {
+    startAt: { [Op.lte]: now },
+    [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+  };
+
+  const builderMemberships = await MembershipModel.findAll({
+    attributes: ["userId"],
+    where: { workspaceId: workspaceModelId, role: "builder", ...activeWindow },
+  });
+  const builderUserIds = new Set(builderMemberships.map((m) => m.userId));
+
+  const group = await GroupModel.findOne({
+    where: {
+      workspaceId: workspaceModelId,
+      name: MANUAL_BUILDERS_GROUP_NAME,
+    },
+  });
+  if (group && group.kind === "provisioned") {
+    // Same guard as the sync: never mutate IdP-owned membership.
+    logger.warn(
+      { workspaceId: workspace.sId, groupId: group.id },
+      "Builders group name taken by a provisioned group, skipping workspace"
+    );
+    return { added: 0, removed: 0 };
+  }
+
+  let currentMemberIds = new Set<number>();
+  if (group) {
+    const memberRows = await GroupMembershipModel.findAll({
+      attributes: ["userId"],
+      where: {
+        groupId: group.id,
+        workspaceId: workspaceModelId,
+        status: "active",
+        ...activeWindow,
+      },
+    });
+    currentMemberIds = new Set(memberRows.map((r) => r.userId));
+  }
+
+  const toAdd = [...builderUserIds].filter((id) => !currentMemberIds.has(id));
+  const toRemove = [...currentMemberIds].filter(
+    (id) => !builderUserIds.has(id)
+  );
+  if (toAdd.length === 0 && toRemove.length === 0) {
+    return { added: 0, removed: 0 };
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      toAdd: toAdd.length,
+      toRemove: toRemove.length,
+      execute,
+    },
+    execute
+      ? "Reconciling Builders group"
+      : "Would reconcile Builders group (dry run)"
+  );
+  if (!execute) {
+    return { added: toAdd.length, removed: toRemove.length };
+  }
+
+  const users = await UserResource.fetchByModelIds([...toAdd, ...toRemove]);
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
+
+  // Per-user sync inside the loop is a deliberate reuse of the PR 1 code path (idempotent,
+  // race-safe): one-shot migration, a few queries per out-of-sync user only.
+  let added = 0;
+  let removed = 0;
+  for (const userModelId of toAdd) {
+    const user = userByModelId.get(userModelId);
+    if (!user) {
+      logger.warn(
+        { workspaceId: workspace.sId, userModelId },
+        "User not found, skipping"
+      );
+      continue;
+    }
+    await GroupResource.syncBuilderGroupMembership({
+      workspace: lightWorkspace,
+      user,
+      isBuilder: true,
+    });
+    added++;
+  }
+  for (const userModelId of toRemove) {
+    const user = userByModelId.get(userModelId);
+    if (!user) {
+      logger.warn(
+        { workspaceId: workspace.sId, userModelId },
+        "User not found, skipping"
+      );
+      continue;
+    }
+    await GroupResource.syncBuilderGroupMembership({
+      workspace: lightWorkspace,
+      user,
+      isBuilder: false,
+    });
+    removed++;
+  }
+
+  return { added, removed };
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  // One-shot full scans: workspaces with at least one active builder, plus workspaces
+  // already holding a non-provisioned Builders group (to reconcile removals).
+  const candidates = await frontSequelize.query<{ workspaceId: number }>(
+    `SELECT DISTINCT "workspaceId" FROM memberships
+     WHERE role = 'builder' AND "startAt" <= NOW()
+       AND ("endAt" IS NULL OR "endAt" > NOW())
+     UNION
+     SELECT DISTINCT "workspaceId" FROM groups
+     WHERE name = :groupName AND kind != 'provisioned'`,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { groupName: MANUAL_BUILDERS_GROUP_NAME },
+    }
+  );
+
+  logger.info({ count: candidates.length }, "Found candidate workspaces");
+
+  const results = await concurrentExecutor(
+    candidates,
+    (candidate) => reconcileWorkspace(candidate.workspaceId, execute, logger),
+    { concurrency: WORKSPACE_CONCURRENCY }
+  );
+
+  const added = results.reduce((sum, r) => sum + r.added, 0);
+  const removed = results.reduce((sum, r) => sum + r.removed, 0);
+  const touchedWorkspaces = results.filter(
+    (r) => r.added > 0 || r.removed > 0
+  ).length;
+
+  logger.info(
+    { workspaces: touchedWorkspaces, added, removed, execute },
+    execute
+      ? "Builders group backfill complete"
+      : "Builders group backfill dry run complete"
+  );
+});

--- a/front/migrations/20260721_backfill_builders_group.ts
+++ b/front/migrations/20260721_backfill_builders_group.ts
@@ -15,7 +15,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
-const WORKSPACE_CONCURRENCY = 4;
+const WORKSPACE_CONCURRENCY = 8;
 
 /**
  * Backfill of the "Builders" group (builder role deprecation, PR 2 of
@@ -59,14 +59,6 @@ async function reconcileWorkspace(
       name: MANUAL_BUILDERS_GROUP_NAME,
     },
   });
-  if (group && group.kind === "provisioned") {
-    // Same guard as the sync: never mutate IdP-owned membership.
-    logger.warn(
-      { workspaceId: workspace.sId, groupId: group.id },
-      "Builders group name taken by a provisioned group, skipping workspace"
-    );
-    return { added: 0, removed: 0 };
-  }
 
   let currentMemberIds = new Set<number>();
   if (group) {
@@ -109,7 +101,8 @@ async function reconcileWorkspace(
   const userByModelId = new Map(users.map((u) => [u.id, u]));
 
   // Per-user sync inside the loop is a deliberate reuse of the PR 1 code path (idempotent,
-  // race-safe): one-shot migration, a few queries per out-of-sync user only.
+  // race-safe): one-shot migration, a few queries per out-of-sync user only — and only
+  // builders are synced, a small fraction of users.
   let added = 0;
   let removed = 0;
   for (const userModelId of toAdd) {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9459 — PR 2 of the builder role deprecation series. **Stacked on #29192** (uses `syncBuilderGroupMembership` and `MANUAL_BUILDERS_GROUP_NAME`); merge that one first.

The sync from PR 1 only fires on membership writes, so builders whose role never changes after the deploy would never enter the Builders group. This one-shot migration reconciles every workspace from the roles (the source of truth):
- candidate workspaces: those with at least one active builder, plus those already holding a non-provisioned Builders group (to reconcile removals);
- per workspace: active builders missing from the group are added, group members who are not active builders are removed — reusing the PR 1 per-user sync (idempotent, race-safe, provisioned-name-squat guard included).

Safe to re-run at any time: a second pass finds nothing to reconcile.

## Tests
- [x] Local run against a seeded database: dry run reports correct add/remove counts, `--execute` produces the expected group state (builder added, stale member removed), re-run is a no-op.

## Risks
Blast radius: one-shot writes to Builders group memberships across workspaces with builders.
Risk: low

## Deploy Plan
- merge and deploy #29192 (front) first
- run `npx tsx front/migrations/20260721_backfill_builders_group.ts` (dry run, review counts)
- re-run with `--execute`
- optionally re-run `--execute` once more: a second pass is nearly free (only out-of-sync users cost writes) and catches role changes that raced the first pass

**Note on per-user queries**: the reconcile deliberately reuses the PR 1 per-user sync instead of bulk inserts — a bulk path would duplicate the sync's semantics (provisioned-name guard, active-window logic, cache invalidation) into a second implementation. Cost is ~4 indexed point-queries per out-of-sync user, throttled at 4 concurrent workspaces: acceptable for a supervised one-shot, and re-runs only pay for the remaining drift.
