### PR TITLE
[LLM] Force DeepSeek V4 Pro reasoning effort to high

### DIFF
--- a/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
@@ -8,10 +8,16 @@ const MAX_OUTPUT_TOKENS = 64_000;
 // DeepSeek V4 Pro only supports none/high/maximal reasoning; `none` drops
 // reasoning_effort, high/maximal reach the model. Defaults to high.
 const configSchema = fireworksConfigSchema.extend({
+  // TODO(new-llm-router): force reasoning effort to `high` regardless of input.
+  // In the legacy model the only configurable effort is `none`, and when set we
+  // omit reasoning_effort from the payload, which makes Fireworks fall back to
+  // its `high` default. So legacy DeepSeek V4 Pro effectively always runs `high`.
+  // We force `high` here to match that behavior. Once the router supports all
+  // reasoning efforts, migrate the legacy `none` values to `high` and remove this.
   reasoning: z
     .object({ effort: z.enum(["none", "high", "maximal"]) })
     .optional()
-    .default({ effort: "high" }),
+    .transform(() => ({ effort: "high" as const })),
 });
 
 export function WithDeepSeekDeepSeekV4ProConfig<


### PR DESCRIPTION
## Description

Force DeepSeek V4 Pro's reasoning effort to `high` in the new router, matching the legacy model's effective behavior (where the only configurable effort is `none`, which we omit from the payload, causing Fireworks to fall back to its `high` default).

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`