### PR TITLE
Update hasWorkspacePermissions to take a verb

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -16,7 +16,8 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
-import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
+import type { ConcreteResourceType } from "@app/lib/resources/group_permission_registry";
+import { grantTypesForVerb } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
@@ -40,10 +41,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
-import type {
-  GrantType as GroupGrantType,
-  GroupPermissionResourceType,
-} from "@app/types/group_permissions";
+import type { GrantVerb } from "@app/types/group_permissions";
 import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
@@ -1102,24 +1100,25 @@ export class Authenticator {
   }
 
   /**
-   * Whether the caller holds a workspace-level capability. A capability is a
-   * (grantType, resourceType) pair whose grants live on the type-wide (-1) group_permissions
-   * rows. Admins bypass unconditionally (billing/security are admin-by-default). Otherwise we look
-   * for a -1 grant on any of the caller's groups; "*" grants match any grant type / resource type.
+   * Whether the caller holds a workspace-level capability. A capability is asked as a verb (e.g.
+   * "create"), expanded via the registry into the stored grant types (role names) that imply it, and
+   * checked against the type-wide (-1) group_permissions rows. Admins bypass unconditionally
+   * (billing/security are admin-by-default). Otherwise we look for a -1 grant on any of the caller's
+   * groups; "*" grants match any grant type / resource type.
    *
    * Cold path: a query per check is fine — no caching yet (pending auth-resolution decision).
    */
   async hasWorkspacePermission(
-    grantType: GroupGrantType,
-    resourceType: GroupPermissionResourceType
+    verb: GrantVerb,
+    resourceType: ConcreteResourceType
   ): Promise<boolean> {
-    // Reject invalid capability queries (e.g. write/billing) up front, so a "*" grant can't satisfy
+    // Reject invalid capability queries (e.g. create/billing) up front, so a "*" grant can't satisfy
     // a pair the registry forbids, and so callers fail fast on a programmer error.
-    assertValidGrant({
-      grantType,
-      resourceType,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
+    const grantTypes = grantTypesForVerb(resourceType, verb, "type");
+    assert(
+      grantTypes.length > 0,
+      `Verb "${verb}" is not allowed (no type-level role grants it) on resource type "${resourceType}".`
+    );
 
     if (this.isAdmin()) {
       return true;
@@ -1136,7 +1135,7 @@ export class Authenticator {
     return grants.some(
       (grant) =>
         (grant.resourceType === resourceType || grant.resourceType === "*") &&
-        (grant.grantType === grantType || grant.grantType === "*")
+        (grant.grantType === "*" || grantTypes.includes(grant.grantType))
     );
   }
 

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -8,6 +8,8 @@ import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { beforeEach, describe, expect, it } from "vitest";
 
 const CAPABILITY = { grantType: "create", resourceType: "agent" } as const;
+const RESOURCE_TYPE = "agent";
+const VERB = "create";
 
 describe("Authenticator.hasWorkspacePermission", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
@@ -39,23 +41,15 @@ describe("Authenticator.hasWorkspacePermission", () => {
 
   it("returns true for admins unconditionally (no grant needed)", async () => {
     expect(adminAuth.isAdmin()).toBe(true);
-    expect(
-      await adminAuth.hasWorkspacePermission(
-        CAPABILITY.grantType,
-        CAPABILITY.resourceType
-      )
-    ).toBe(true);
+    expect(await adminAuth.hasWorkspacePermission(VERB, RESOURCE_TYPE)).toBe(
+      true
+    );
   });
 
   it("returns false for a non-admin without any grant", async () => {
     const auth = await memberAuthInGroup();
     expect(auth.isAdmin()).toBe(false);
-    expect(
-      await auth.hasWorkspacePermission(
-        CAPABILITY.grantType,
-        CAPABILITY.resourceType
-      )
-    ).toBe(false);
+    expect(await auth.hasWorkspacePermission(VERB, RESOURCE_TYPE)).toBe(false);
   });
 
   it("returns true when one of the caller's groups holds the -1 grant", async () => {
@@ -66,12 +60,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
     });
     const auth = await memberAuthInGroup(group);
 
-    expect(
-      await auth.hasWorkspacePermission(
-        CAPABILITY.grantType,
-        CAPABILITY.resourceType
-      )
-    ).toBe(true);
+    expect(await auth.hasWorkspacePermission(VERB, RESOURCE_TYPE)).toBe(true);
     // A different verb on the same type is not granted.
     expect(await auth.hasWorkspacePermission("publish", "agent")).toBe(false);
   });
@@ -89,12 +78,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
     });
     const auth = await memberAuthInGroup();
 
-    expect(
-      await auth.hasWorkspacePermission(
-        CAPABILITY.grantType,
-        CAPABILITY.resourceType
-      )
-    ).toBe(true);
+    expect(await auth.hasWorkspacePermission(VERB, RESOURCE_TYPE)).toBe(true);
   });
 
   it("matches a wildcard grant against any capability", async () => {

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -25,11 +25,13 @@ import assert from "assert";
  */
 
 // Concrete (non-wildcard) vocabulary — the registry describes these.
-type ConcreteResourceType = Exclude<GroupPermissionResourceType, "*">;
+export type ConcreteResourceType = Exclude<GroupPermissionResourceType, "*">;
+
+export type ConcreteGrantType = Exclude<GrantType, "*">;
 
 // A grant applies either to a specific resource instance (resourceId > 0) or to the whole type
 // (resourceId = -1). A role declares the levels at which it can be granted.
-type GrantLevel = "instance" | "type";
+export type GrantLevel = "instance" | "type";
 
 interface RoleDefinition {
   verbs: GrantVerb[];
@@ -38,7 +40,7 @@ interface RoleDefinition {
 
 export const ROLE_REGISTRY: Record<
   ConcreteResourceType,
-  Record<string, RoleDefinition>
+  Partial<Record<ConcreteGrantType, RoleDefinition>>
 > = {
   space: {
     reader: { verbs: ["read"], levels: ["instance"] },
@@ -119,4 +121,20 @@ export function assertValidGrant({
     role.levels.includes("instance"),
     `Grant type "${grantType}" on "${resourceType}" is type-level and requires resourceId = ${WHOLE_TYPE_RESOURCE_ID}.`
   );
+}
+
+// Roles for `resourceType` whose verbs include `verb` at the given level — the verb→role expansion
+// `hasWorkspacePermission` needs to turn a capability question into stored grant types.
+export function grantTypesForVerb(
+  resourceType: ConcreteResourceType,
+  verb: GrantVerb,
+  level: GrantLevel
+): ConcreteGrantType[] {
+  const roles = ROLE_REGISTRY[resourceType];
+  // Object.keys() widens back to `string[]`; the cast is safe because ROLE_REGISTRY's declared
+  // type guarantees these keys are exactly ConcreteGrantType.
+  return (Object.keys(roles) as ConcreteGrantType[]).filter((grantType) => {
+    const role = roles[grantType];
+    return !!role && role.verbs.includes(verb) && role.levels.includes(level);
+  });
 }


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/9452

## Description

`Authenticator.hasWorkspacePermission` now takes a `GrantVerb` (a capability question, e.g. `"create"`) and a `ConcreteResourceType`, instead of taking a stored `GrantType` (role name) directly. Internally it expands the verb into the `ROLE_REGISTRY` roles that imply it, via a new `grantTypesForVerb(resourceType, verb, level)` helper in `group_permission_registry.ts`, then checks the caller's groups for a matching type-wide (`-1`) `group_permissions` row.

This is step 0 of the Admin Governance `create agent` capability rollout (dust-tt/tasks#9463, design doc: [Admin Governance](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)), landing on its own with **zero behavior change** — nothing outside its own test calls `hasWorkspacePermission` yet. Follow-ups will (1) enforce the `create agent` capability at the two agent-creation call sites, and (2) backfill `group_permissions` rows per workspace based on the legacy `disallow_agent_creation_to_users` feature flag.

## Tests

- `front/lib/auth.workspace_permission.test.ts` required no behavioral changes — verb and grant-type strings coincide for every case it exercises (`create`/`agent`, `publish`/`agent`, `admin`/`billing`, `read`/`audit_log`, plus the wildcard and rejection cases). Renamed the local reference used at call sites from `CAPABILITY.grantType` to `VERB` for clarity, since it's now passed as the verb parameter, not a stored grant type.
- `npx tsgo --noEmit` clean.

## Risk

Low. `hasWorkspacePermission` has no other callers yet, so this is an isolated signature change with no behavioral impact on any production code path.

## Deploy Plan

Standard deploy, no special considerations.