### PR TITLE
feat(front): default @dust agent to Auto when models_picker is enabled

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -48,6 +48,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import {
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
@@ -467,18 +468,25 @@ export function _getDustGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs
 ): AgentConfigurationType | null {
+  let preferredModelConfiguration: ModelConfigurationType =
+    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+  let preferredReasoningEffort: ReasoningEffort = "medium";
+
+  if (args.preferSonnet5DefaultModel) {
+    preferredModelConfiguration = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;
+    preferredReasoningEffort = "medium";
+  } else if (args.preferGpt56LunaDefaultModel) {
+    preferredModelConfiguration = GPT_5_6_LUNA_MODEL_CONFIG;
+    preferredReasoningEffort = "high";
+  } else if (args.featureFlags.includes("models_picker")) {
+    preferredModelConfiguration = AUTO_MODEL_CONFIG;
+    preferredReasoningEffort = "none";
+  }
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: args.preferSonnet5DefaultModel
-      ? CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG
-      : args.preferGpt56LunaDefaultModel
-        ? GPT_5_6_LUNA_MODEL_CONFIG
-        : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort:
-      args.preferGpt56LunaDefaultModel && !args.preferSonnet5DefaultModel
-        ? "high"
-        : "medium",
+    preferredModelConfiguration,
+    preferredReasoningEffort,
   });
 }
 


### PR DESCRIPTION
## Description

Defaults the `@dust` global agent to **Auto** (Dust selects the model per request) when the `models_picker` feature flag is enabled and no explicit model override is set.

The model resolution in `_getDustGlobalAgent` is now a plain if/else covering the four cases in priority order:
- `preferSonnet5DefaultModel` override → Claude Sonnet 5 (medium)
- `preferGpt56LunaDefaultModel` override → GPT 5.6 Luna (high)
- `models_picker` enabled, no override → Auto (none)
- otherwise → Claude Sonnet 4.6 (medium)

`AUTO_MODEL_CONFIG` is already gated behind the `models_picker` flag via `availableIfOneOf`, so it only resolves as available in the branch that checks for the flag.

## Tests

## Risk

## Deploy Plan
