### PR TITLE
[front] perf: avoid global space fetches in the agent loop

### DIFF
--- a/front/lib/resources/data_source_view_resource.test.ts
+++ b/front/lib/resources/data_source_view_resource.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -7,7 +8,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 describe("DataSourceViewResource", () => {
   describe("listByWorkspace", () => {
@@ -142,6 +143,90 @@ describe("DataSourceViewResource", () => {
       expect(viewsWithConversations.map((v) => v.space.id).sort()).toEqual(
         [regularSpace.id, conversationSpace.id].sort()
       );
+    });
+  });
+
+  describe("listBySpaceIds", () => {
+    it("includes global space views without fetching spaces", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      const globalDsv = await DataSourceViewFactory.folder(
+        workspace,
+        globalSpace
+      );
+      const regularDsv = await DataSourceViewFactory.folder(
+        workspace,
+        regularSpace
+      );
+
+      const globalSpaceFetch = vi.spyOn(
+        SpaceResource,
+        "fetchWorkspaceGlobalSpace"
+      );
+      const spacesFetch = vi.spyOn(SpaceResource, "fetchByIds");
+
+      try {
+        const views = await DataSourceViewResource.listBySpaceIds(
+          adminAuth,
+          [regularSpace.sId],
+          { includeGlobalSpace: true }
+        );
+
+        expect(views.map((v) => v.sId).sort()).toEqual(
+          [globalDsv.sId, regularDsv.sId].sort()
+        );
+        expect(globalSpaceFetch).not.toHaveBeenCalled();
+        expect(spacesFetch).not.toHaveBeenCalled();
+      } finally {
+        globalSpaceFetch.mockRestore();
+        spacesFetch.mockRestore();
+      }
+    });
+
+    it("returns only global views for empty space ids with includeGlobalSpace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      const globalDsv = await DataSourceViewFactory.folder(
+        workspace,
+        globalSpace
+      );
+      await DataSourceViewFactory.folder(workspace, regularSpace);
+
+      const globalOnly = await DataSourceViewResource.listBySpaceIds(
+        adminAuth,
+        [],
+        { includeGlobalSpace: true }
+      );
+      expect(globalOnly.map((v) => v.sId)).toEqual([globalDsv.sId]);
+
+      const none = await DataSourceViewResource.listBySpaceIds(adminAuth, []);
+      expect(none).toHaveLength(0);
+    });
+
+    it("ignores spaces from other workspaces", async () => {
+      const workspace1 = await WorkspaceFactory.basic();
+      const workspace2 = await WorkspaceFactory.basic();
+      const adminAuth1 = await Authenticator.internalAdminForWorkspace(
+        workspace1.sId
+      );
+      await SpaceFactory.defaults(adminAuth1);
+      const foreignSpace = await SpaceFactory.regular(workspace2);
+      await DataSourceViewFactory.folder(workspace2, foreignSpace);
+
+      const views = await DataSourceViewResource.listBySpaceIds(adminAuth1, [
+        foreignSpace.sId,
+      ]);
+      expect(views).toHaveLength(0);
     });
   });
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -335,14 +335,33 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     spaceIds: string[],
     { includeGlobalSpace = false }: { includeGlobalSpace?: boolean } = {}
   ) {
-    const requestedSpaces = await SpaceResource.fetchByIds(auth, spaceIds);
+    const spaceModelIds = removeNulls(spaceIds.map(getResourceIdFromSId));
 
-    if (includeGlobalSpace) {
-      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      requestedSpaces.push(globalSpace);
+    if (spaceModelIds.length === 0 && !includeGlobalSpace) {
+      return [];
     }
 
-    return this.listBySpaces(auth, requestedSpaces);
+    return this.baseFetch(auth, undefined, {
+      includes: [
+        {
+          model: SpaceResource.model,
+          as: "space",
+          attributes: [],
+          required: true,
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            deletedAt: null,
+            [Op.or]: [
+              { id: { [Op.in]: spaceModelIds } },
+              ...(includeGlobalSpace ? [{ kind: "global" }] : []),
+            ],
+          },
+        },
+      ],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
   }
 
   static async listAssistantDefaultSelected(auth: Authenticator) {

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -376,6 +376,171 @@ describe("MCPServerViewResource", () => {
     });
   });
 
+  describe("listBySpaceIds", () => {
+    it("includes global space views without fetching spaces", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "image_generation",
+          useCase: null,
+        }
+      );
+      const globalView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        globalSpace
+      );
+      const regularView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        regularSpace
+      );
+
+      const globalSpaceFetch = vi.spyOn(
+        SpaceResource,
+        "fetchWorkspaceGlobalSpace"
+      );
+      const spacesFetch = vi.spyOn(SpaceResource, "fetchByIds");
+
+      try {
+        const views = await MCPServerViewResource.listBySpaceIds(
+          adminAuth,
+          [regularSpace.sId],
+          { includeGlobalSpace: true }
+        );
+
+        expect(views.map((v) => v.sId).sort()).toEqual(
+          [globalView.sId, regularView.sId].sort()
+        );
+        expect(globalSpaceFetch).not.toHaveBeenCalled();
+        expect(spacesFetch).not.toHaveBeenCalled();
+      } finally {
+        globalSpaceFetch.mockRestore();
+        spacesFetch.mockRestore();
+      }
+    });
+
+    it("returns only global views for empty space ids with includeGlobalSpace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "image_generation",
+          useCase: null,
+        }
+      );
+      const globalView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        globalSpace
+      );
+      await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        regularSpace
+      );
+
+      // The run_model.ts shape: list the global space views only.
+      const globalOnly = await MCPServerViewResource.listBySpaceIds(
+        adminAuth,
+        [],
+        { includeGlobalSpace: true }
+      );
+      expect(globalOnly.map((v) => v.sId)).toEqual([globalView.sId]);
+
+      const none = await MCPServerViewResource.listBySpaceIds(adminAuth, []);
+      expect(none).toHaveLength(0);
+    });
+
+    it("filters out views from spaces the user cannot read", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "image_generation",
+          useCase: null,
+        }
+      );
+      const globalView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        globalSpace
+      );
+      const restrictedView = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        restrictedSpace
+      );
+
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const views = await MCPServerViewResource.listBySpaceIds(
+        userAuth,
+        [restrictedSpace.sId],
+        { includeGlobalSpace: true }
+      );
+
+      expect(views.map((v) => v.sId)).toEqual([globalView.sId]);
+      expect(views.map((v) => v.sId)).not.toContain(restrictedView.sId);
+    });
+
+    it("ignores spaces from other workspaces", async () => {
+      const workspace1 = await WorkspaceFactory.basic();
+      const workspace2 = await WorkspaceFactory.basic();
+      const adminAuth1 = await Authenticator.internalAdminForWorkspace(
+        workspace1.sId
+      );
+      const adminAuth2 = await Authenticator.internalAdminForWorkspace(
+        workspace2.sId
+      );
+      await SpaceFactory.defaults(adminAuth1);
+      await SpaceFactory.defaults(adminAuth2);
+      const foreignSpace = await SpaceFactory.regular(workspace2);
+
+      const internalServer2 = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth2,
+        {
+          name: "image_generation",
+          useCase: null,
+        }
+      );
+      await MCPServerViewFactory.create(
+        workspace2,
+        internalServer2.id,
+        foreignSpace
+      );
+
+      const views = await MCPServerViewResource.listBySpaceIds(adminAuth1, [
+        foreignSpace.sId,
+      ]);
+      expect(views).toHaveLength(0);
+    });
+  });
+
   describe("internal MCP server resolution", () => {
     it("resolves auto server views without fetching the system space", async () => {
       const workspace = await WorkspaceFactory.basic();

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -634,14 +634,35 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     spaceIds: string[],
     { includeGlobalSpace = false }: { includeGlobalSpace?: boolean } = {}
   ): Promise<MCPServerViewResource[]> {
-    const requestedSpaces = await SpaceResource.fetchByIds(auth, spaceIds);
+    const spaceModelIds = removeNulls(spaceIds.map(getResourceIdFromSId));
 
-    if (includeGlobalSpace) {
-      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      requestedSpaces.push(globalSpace);
+    if (spaceModelIds.length === 0 && !includeGlobalSpace) {
+      return [];
     }
 
-    return this.listBySpaces(auth, requestedSpaces);
+    const views = await this.baseFetch(auth, {
+      includes: [
+        {
+          model: SpaceResource.model,
+          as: "space",
+          attributes: [],
+          required: true,
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            deletedAt: null,
+            [Op.or]: [
+              { id: { [Op.in]: spaceModelIds } },
+              ...(includeGlobalSpace ? [{ kind: "global" }] : []),
+            ],
+          },
+        },
+      ],
+      order: [["id", "ASC"]],
+    });
+
+    // Permission parity with listBySpaces: the canReadOrAdministrate pre-filter on fetched
+    // spaces becomes a post-filter on the space hydrated by baseFetchWithAuthorization.
+    return views.filter((view) => view.canReadOrAdministrate(auth));
   }
 
   static async listBySpace(

--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -48,6 +48,7 @@ export type TypedIncludeable<M> = {
   [K in NonAttributeKeys<M>]: {
     model: ModelStatic<InferIncludeTypeForInclude<M>[K]>;
     as: K;
+    attributes?: FindOptions<InferIncludeTypeForInclude<M>[K]>["attributes"];
     required?: boolean;
     where?: WhereOptions<InferIncludeTypeForInclude<M>[K]>;
     include?: Includeable[];

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -65,7 +65,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { constructProjectContext } from "@app/lib/resources/skill/code_defined/global/projects";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
@@ -566,12 +565,10 @@ export async function runModel(
     isServerSideMCPServerConfigurationWithName(action, "toolsets")
   );
   if (globalAgentInjectsToolsets(agentConfiguration.sId) && hasToolsetsAction) {
-    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     const allToolsets =
-      await MCPServerViewResource.listBySpaceEnsuringAutoViews(
-        auth,
-        globalSpace
-      );
+      await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(auth, [], {
+        includeGlobalSpace: true,
+      });
     const filteredToolsets = allToolsets.filter((toolset) => {
       const mcpServerView = toolset.toJSON();
       return (


### PR DESCRIPTION
## Description

We query a lot spaces x group vault x group just to get the global space id.
This code remove entirely the lookup mcp server view (which is a hot code path) and datasource (side-drive)

Left untouched (genuinely need the resource, LLM-frequency only): the `toolsets` and `pod_manager` tool handlers.

## Tests

Unit tests

## Risk

Standard
Blast radius: agent loop mostly

## Plan

deploy front