### PR TITLE
Restric agent creation based on permission

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -136,7 +136,11 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - pending agent"
     });
     await SpaceFactory.defaults(auth);
 
-    const { sId: pendingId } = await createPendingAgentConfiguration(auth);
+    const pendingAgentRes = await createPendingAgentConfiguration(auth);
+    if (pendingAgentRes.isErr()) {
+      throw pendingAgentRes.error;
+    }
+    const { sId: pendingId } = pendingAgentRes.value;
 
     const response = await patch(workspace, pendingId, {
       assistant: {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/create-pending.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/create-pending.test.ts
@@ -13,6 +13,7 @@ function createPending(workspace: { sId: string }) {
 describe("POST /api/w/:wId/assistant/agent_configurations/create-pending", () => {
   it("creates a pending agent and returns sId; pending agent has correct status and placeholder values", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
+      role: "admin",
       method: "POST",
     });
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/create-pending.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/create-pending.ts
@@ -24,8 +24,18 @@ app.post("/", async (ctx): HandlerResult<PostPendingAgentResponseBody> => {
     });
   }
 
-  const { sId } = await createPendingAgentConfiguration(auth);
-  return ctx.json({ sId });
+  const pendingAgentRes = await createPendingAgentConfiguration(auth);
+  if (pendingAgentRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "assistant_saving_error",
+        message: `Error creating agent: ${pendingAgentRes.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ sId: pendingAgentRes.value.sId });
 });
 
 export default app;

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -12,6 +12,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -22,6 +23,7 @@ import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
@@ -37,8 +39,12 @@ describe("createAgentConfiguration with pending agent", () => {
     });
 
     // Create a pending agent using the helper function
-    const { sId: pendingId } =
+    const pendingAgentRes =
       await createPendingAgentConfiguration(authenticator);
+    if (pendingAgentRes.isErr()) {
+      throw pendingAgentRes.error;
+    }
+    const { sId: pendingId } = pendingAgentRes.value;
 
     // Convert the pending agent to active by passing its sId as agentConfigurationId
     const result = await createAgentConfiguration(authenticator, {
@@ -121,10 +127,12 @@ describe("createAgentConfiguration with pending agent", () => {
       role: "admin",
     });
 
-    // Create another user in the same workspace
+    // Create another user in the same workspace. Role is irrelevant to what this test asserts
+    // (ownership of the pending agent), so use "admin" to bypass the create-agent capability
+    // check in createPendingAgentConfiguration.
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, otherUser, {
-      role: "builder",
+      role: "admin",
     });
     const otherAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
       otherUser.sId,
@@ -132,8 +140,12 @@ describe("createAgentConfiguration with pending agent", () => {
     );
 
     // Create a pending agent owned by the other user using the helper function
-    const { sId: pendingId } =
+    const otherPendingAgentRes =
       await createPendingAgentConfiguration(otherAuthenticator);
+    if (otherPendingAgentRes.isErr()) {
+      throw otherPendingAgentRes.error;
+    }
+    const { sId: pendingId } = otherPendingAgentRes.value;
 
     // Should return an error because pending agents owned by other users cannot be updated
     const result = await createAgentConfiguration(authenticator, {
@@ -205,11 +217,17 @@ describe("createAgentConfiguration with pending agent", () => {
   });
 
   it("preserves suggestions when converting pending agent to active", async () => {
+    // Role is irrelevant to what this test asserts (suggestion preservation across the
+    // pending-to-active conversion), so use "admin" to bypass the create-agent capability check.
     const { authenticator, user } = await createResourceTest({
-      role: "builder",
+      role: "admin",
     });
-    const { sId: pendingId } =
+    const pendingAgentRes =
       await createPendingAgentConfiguration(authenticator);
+    if (pendingAgentRes.isErr()) {
+      throw pendingAgentRes.error;
+    }
+    const { sId: pendingId } = pendingAgentRes.value;
     const pendingAgent = await getAgentConfiguration(authenticator, {
       agentId: pendingId,
       variant: "light",
@@ -264,6 +282,195 @@ describe("createAgentConfiguration with pending agent", () => {
         );
       expect(suggestionsAfter).toHaveLength(1);
     }
+  });
+});
+
+describe("create agent capability", () => {
+  async function memberAuthInGroup(
+    workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"],
+    group?: Awaited<ReturnType<typeof GroupFactory.regularAuto>>
+  ) {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    if (group) {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await GroupFactory.withMembers(adminAuth, group, [user]);
+    }
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    return { authenticator, user };
+  }
+
+  it("rejects creating a brand-new agent for a user without the capability", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    const { authenticator, user } = await memberAuthInGroup(workspace);
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Unauthorized Agent",
+      description: "Test",
+      instructions: null,
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      authorId: user.id,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Creating agents is restricted.");
+    }
+  });
+
+  it("rejects a nonexistent agentConfigurationId used to bypass the capability check", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    const { authenticator, user } = await memberAuthInGroup(workspace);
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Unauthorized Agent",
+      description: "Test",
+      instructions: null,
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      // Doesn't match any real row, so this would otherwise take the "create new" branch.
+      agentConfigurationId: generateRandomModelSId(),
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      authorId: user.id,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Creating agents is restricted.");
+    }
+  });
+
+  it("allows creating a brand-new agent for a user granted via a group", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const group = await GroupFactory.regularAuto(workspace, "agent-creators");
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
+      group,
+      grantType: "create",
+      resourceType: "agent",
+    });
+    const { authenticator, user } = await memberAuthInGroup(workspace, group);
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Authorized Agent",
+      description: "Test",
+      instructions: null,
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      authorId: user.id,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("does not gate creating a new version of an existing agent", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const existingAgent =
+      await AgentConfigurationFactory.createTestAgent(adminAuth);
+    const { authenticator, user } = await memberAuthInGroup(workspace);
+    // No capability grant for this user; only editing rights on the existing agent matter here.
+    const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+      adminAuth,
+      existingAgent
+    );
+    if (editorGroupRes.isErr()) {
+      throw editorGroupRes.error;
+    }
+    await GroupFactory.withMembers(adminAuth, editorGroupRes.value, [user]);
+    await authenticator.refresh();
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Updated Agent",
+      description: "Test",
+      instructions: null,
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      agentConfigurationId: existingAgent.sId,
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      authorId: user.id,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects createPendingAgentConfiguration for a user without the capability", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await memberAuthInGroup(workspace);
+
+    const result = await createPendingAgentConfiguration(authenticator);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Creating agents is restricted.");
+    }
+  });
+
+  it("allows createPendingAgentConfiguration for a user granted via a group", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const group = await GroupFactory.regularAuto(workspace, "agent-creators");
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
+      group,
+      grantType: "create",
+      resourceType: "agent",
+    });
+    const { authenticator } = await memberAuthInGroup(workspace, group);
+
+    const result = await createPendingAgentConfiguration(authenticator);
+
+    expect(result.isOk()).toBe(true);
   });
 });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -109,7 +109,12 @@ const PENDING_AGENT_PLACEHOLDER_PICTURE_URL =
  */
 export async function createPendingAgentConfiguration(
   auth: Authenticator
-): Promise<{ sId: string }> {
+): Promise<Result<{ sId: string }, Error>> {
+  const canCreate = await auth.hasWorkspacePermission("create", "agent");
+  if (!canCreate) {
+    return new Err(new Error("Creating agents is restricted."));
+  }
+
   const owner = auth.getNonNullableWorkspace();
   const user = auth.getNonNullableUser();
 
@@ -158,7 +163,7 @@ export async function createPendingAgentConfiguration(
     });
   });
 
-  return { sId };
+  return new Ok({ sId });
 }
 
 export async function getAgentConfigurationsWithVersion<
@@ -675,6 +680,16 @@ export async function createAgentConfiguration(
         }
 
         userFavorite = userRelation?.favorite ?? false;
+      }
+
+      // `existingAgent` is null both when no `agentConfigurationId` was given and when one was
+      // given but didn't match a real row — the latter would otherwise let a caller bypass the
+      // capability check by passing a nonexistent id and taking the "create new" branch below.
+      if (!existingAgent) {
+        const canCreate = await auth.hasWorkspacePermission("create", "agent");
+        if (!canCreate) {
+          throw new Error("Creating agents is restricted.");
+        }
       }
 
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,4 +1,5 @@
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -39,6 +40,16 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+async function createPendingAgent(
+  authenticator: Authenticator
+): Promise<{ sId: string }> {
+  const res = await createPendingAgentConfiguration(authenticator);
+  if (res.isErr()) {
+    throw res.error;
+  }
+  return res.value;
+}
+
 async function getEditorGroupId(
   agentConfigurationId: number,
   workspaceId: number
@@ -56,7 +67,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
       role: "admin",
     });
 
-    const { sId } = await createPendingAgentConfiguration(authenticator);
+    const { sId } = await createPendingAgent(authenticator);
     const agent = await AgentConfigurationModel.findOne({
       where: { sId, workspaceId: workspace.id },
     });
@@ -85,7 +96,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
       role: "admin",
     });
 
-    const { sId } = await createPendingAgentConfiguration(authenticator);
+    const { sId } = await createPendingAgent(authenticator);
     const agent = await AgentConfigurationModel.findOne({
       where: { sId, workspaceId: workspace.id },
     });
@@ -114,7 +125,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
 
     const sIds: string[] = [];
     for (let i = 0; i < 3; i++) {
-      const { sId } = await createPendingAgentConfiguration(authenticator);
+      const { sId } = await createPendingAgent(authenticator);
       sIds.push(sId);
     }
 
@@ -166,8 +177,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     });
 
     // Create a pending agent that will expire.
-    const { sId: expiredId } =
-      await createPendingAgentConfiguration(authenticator);
+    const { sId: expiredId } = await createPendingAgent(authenticator);
     const expiredAgent = await AgentConfigurationModel.findOne({
       where: { sId: expiredId, workspaceId: workspace.id },
     });
@@ -180,8 +190,7 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     vi.advanceTimersByTime(PAST_THRESHOLD_MS);
 
     // Create a fresh pending agent (after time advance, so it's young).
-    const { sId: freshId } =
-      await createPendingAgentConfiguration(authenticator);
+    const { sId: freshId } = await createPendingAgent(authenticator);
     const freshAgent = await AgentConfigurationModel.findOne({
       where: { sId: freshId, workspaceId: workspace.id },
     });

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,5 +1,5 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ModelIdType,
@@ -34,7 +34,16 @@ export class AgentConfigurationFactory {
     const user = auth.user();
     assert(user, "User is required");
 
-    const result = await createAgentConfiguration(auth, {
+    // Test fixture, not a real workflow: many tests construct an Authenticator directly without
+    // ever creating a workspace membership, so `auth` may not hold the create-agent capability
+    // (or any capability at all). `authorId`/`editors` below are explicit, so using an internal
+    // admin authenticator for the actual write doesn't change who the created agent is
+    // attributed to — it only bypasses the capability check for this test fixture.
+    const internalAuth = await Authenticator.internalAdminForWorkspace(
+      auth.getNonNullableWorkspace().sId
+    );
+
+    const result = await createAgentConfiguration(internalAuth, {
       name,
       description,
       instructions: "Test Instructions",
@@ -57,6 +66,13 @@ export class AgentConfigurationFactory {
     if (result.isErr()) {
       throw result.error;
     }
+
+    // createAgentConfiguration refreshes its own `auth` argument's group memberships as a side
+    // effect of creating the new editor group. Since we called it with `internalAuth` above,
+    // mirror that refresh onto the caller's own `auth` so tests that rely on it seeing
+    // just-added group memberships (added earlier in the same test, before this call) keep
+    // working as if `auth` itself had been used.
+    await auth.refresh();
 
     return { ...result.value, instructionsHtml: null, actions: [] };
   }


### PR DESCRIPTION
## Description

Server-side enforcement of the `create agent` governance capability (dust-tt/tasks#9463, design doc: [Admin Governance](https://app.notion.com/p/dust-tt/Design-Doc-Admin-Governance-38a28599d941817292d0e94f8dfafe48)) at the two entry points that create brand-new agents:

- `createAgentConfiguration` (`front/lib/api/assistant/configuration/agent.ts`): the check runs once `existingAgent` is resolved to `null` — i.e. both when no `agentConfigurationId` was given, and when one was given but didn't match a real row (otherwise a caller could bypass the check by passing a nonexistent id and taking the "create new" branch). Creating a new version of an existing agent is unaffected.
- `createPendingAgentConfiguration` (same file): always creates a brand-new pending agent, so the check is unconditional. Its return type changed from a plain `{ sId }` to `Result<{ sId }, Error>` so the restriction is a normal `Err`, not a thrown exception that would 500 (per [ERR1]/[BACK18]). Its one route caller (`create-pending.ts`) now maps `Err` to `400`/`assistant_saving_error`, matching the sibling `POST /assistant/agent_configurations` route's existing handling of the publish restriction.

Both call `auth.hasWorkspacePermission("create", "agent")` (from the prior PR on `update-hasworkspacepermissions`). Admins bypass unconditionally; anyone else needs a `group_permissions` grant — none exist yet, so this lands as a no-op in practice until the follow-up backfill (step 2) seeds grants from the legacy `disallow_agent_creation_to_users` flag.

**UI is explicitly out of scope for this PR** — it will be done later, once the dedicated governance endpoints/hooks for this capability exist. Today's UI still only gates on `disallow_agent_creation_to_users` client-side; that's unchanged here.

## Tests

- New tests in `agent.test.ts` covering: a non-privileged user rejected on both entry points (including the nonexistent-`agentConfigurationId` bypass case), a user granted via group membership succeeding, and creating a new version of an existing agent being unaffected.
- Fixed the ripple from `createPendingAgentConfiguration`'s signature change across its existing call sites (`activities.test.ts`, `agent.test.ts`, `[aId]/index.test.ts`, `create-pending.test.ts`).
- `AgentConfigurationFactory.createTestAgent` (the shared test fixture used by ~60 other test files) now performs the actual creation via an internal admin authenticator, since many tests construct an `Authenticator` directly without a workspace membership — `authorId`/`editors` stay explicit params, so this doesn't change who the created agent is attributed to, only bypasses the capability check for the fixture. It also re-refreshes the caller's own `auth` afterward, since `createAgentConfiguration` refreshes its own `auth` argument as a side effect of creating the new editor group, and a few tests rely on that to pick up group memberships added earlier in the same test.
- Ran the full `front` test suite; only pre-existing, unrelated failures remain (a sandbox `grep` CLI exit-code test untouched by this change).
- `npx tsgo --noEmit` clean in `front` and `front-api`.

## Risk

Low today (no grants exist yet, so the check only ever passes for admins — matches current effective behavior for admins and is a no-op for everyone else until the backfill runs). The real risk window opens with the backfill PR: it must land and run before this restriction meaningfully changes behavior for non-admins, otherwise non-admins lose the ability to create agents until backfilled.

## Deploy Plan

Deploy after `update-hasworkspacepermissions`. Land and run the backfill script (follow-up PR) before or immediately after this deploys, so non-admin agent creation isn't interrupted for workspaces that currently allow it.