### PR TITLE
[front] fix: keep model ID out of system prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -162,6 +162,36 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(prompt1).toEqual(prompt2);
   });
 
+  it("should generate identical system prompts when only the model ID changes", () => {
+    const model = agentLoopModel(agentConfig1, modelConfig);
+    const alternativeModel = getSupportedModelConfigs().find(
+      (candidate) =>
+        candidate.providerId === model.providerId &&
+        candidate.modelId !== model.modelId
+    );
+    if (!alternativeModel) {
+      throw new Error("Expected another model from the same provider.");
+    }
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: withoutModel(agentConfig1),
+      model,
+      hasAvailableActions: true,
+      systemSkills: [],
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    const prompt1 = constructPromptMultiActions(authenticator1, params);
+    const prompt2 = constructPromptMultiActions(authenticator1, {
+      ...params,
+      model: { ...model, modelId: alternativeModel.modelId },
+    });
+
+    expect(prompt1).toEqual(prompt2);
+  });
+
   it("should generate identical prompts with different conversation metadata from the same workspace", () => {
     // Same workspace, same agent, but different conversation metadata
     const baseParams = {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -67,7 +67,6 @@ function constructContextSection({
   let context = "# CONTEXT\n\n";
   context += `assistant: @${agentConfiguration.name}\n`;
   context += `current_date: ${d.format("YYYY-MM-DD (ddd)")}\n`;
-  context += `model_id: ${model.modelId}\n`;
   if (owner) {
     context += `workspace: ${owner.name}\n`;
   }


### PR DESCRIPTION
## Description

We've seen occurrences where switching models mid-convo is diagnosed as a `system_changed` rather than a `model_changed` prompt because `constructContextSection` includes the model ID.

This PR removes the model ID from the context section of the prompt.

## Tests

- Added regression coverage that check that the system prompt is stable when only the `modelId` changes.

## Risk

- Low.

## Deploy Plan

- Deploy front.
