### PR TITLE
Seed capabilities + migration script

### DIFF
--- a/front/lib/api/permissions/governance_seeding.test.ts
+++ b/front/lib/api/permissions/governance_seeding.test.ts
@@ -1,16 +1,70 @@
 import { seedWorkspaceCapabilities } from "@app/lib/api/permissions/governance_seeding";
 import { Authenticator } from "@app/lib/auth";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it } from "vitest";
 
 describe("seedWorkspaceCapabilities", () => {
-  it("is a safe no-op with the empty Phase 0 seeder list", async () => {
+  it("grants create-agent to everybody by default for a fresh workspace", async () => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    // Empty registry: resolves without touching the database.
-    await expect(seedWorkspaceCapabilities(auth)).resolves.toBeUndefined();
+    await seedWorkspaceCapabilities(auth);
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(await userAuth.hasWorkspacePermission("create", "agent")).toBe(true);
+  });
+
+  it("creates the Builders group and grants it when disallow_agent_creation_to_users is already set", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    await FeatureFlagResource.enable(
+      workspace,
+      "disallow_agent_creation_to_users"
+    );
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Freshly created workspace: no Builders group has ever been synced yet, so seeding must
+    // create it (empty) rather than leaving the capability unconfigured.
+    await seedWorkspaceCapabilities(auth);
+
+    const buildersGroup = await GroupResource.fetchByName(auth, "Builders");
+    expect(buildersGroup).not.toBeNull();
+    expect(buildersGroup?.kind).toBe("regular_manual");
+
+    const plainUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, plainUser, { role: "user" });
+    const plainAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      plainUser.sId,
+      workspace.sId
+    );
+    expect(await plainAuth.hasWorkspacePermission("create", "agent")).toBe(
+      false
+    );
+
+    const builder = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, builder, { role: "builder" });
+    await GroupResource.syncBuilderGroupMembership({
+      workspace,
+      user: builder,
+      isBuilder: true,
+    });
+    const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      builder.sId,
+      workspace.sId
+    );
+    expect(await builderAuth.hasWorkspacePermission("create", "agent")).toBe(
+      true
+    );
   });
 });

--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -1,27 +1,99 @@
 import type { Authenticator } from "@app/lib/auth";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { CapabilitySpec } from "@app/types/group_permissions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
- * Workspace-creation entry point for governance capability seeding.
+ * Governance capability seeders: the single source of truth for where each capability's default
+ * grant should land, shared by two call sites:
  *
- * A capability seeder sets up the default state of a workspace-level governance capability (which
- * groups get it, or "everybody"/"disabled") for a freshly created workspace. Phase 2 capabilities
- * register their seeder here; Phase 0 ships the hook with an empty list, so it is a no-op.
+ * - `seedWorkspaceCapabilities`, called once from workspace provisioning (dust-tt/tasks#9454), to
+ *   set a fresh workspace's default state.
+ * - `migrations/20260721_backfill_create_agent_capability.ts`, which backfills existing
+ *   workspaces from their current legacy state (feature flags, roles, etc).
+ *
+ * A capability seeder is defined once here; both call sites drive it identically — a fresh
+ * workspace simply has no legacy flag set yet, so `resolveTarget` naturally resolves to the same
+ * default a backfill would apply (e.g. no `disallow_agent_creation_to_users` flag => "everyone").
+ *
+ * To register a new capability, add an entry to CAPABILITY_SEEDERS below; nothing else needs to
+ * change at either call site.
  */
 
+// Where a capability's grant should land for a workspace.
+export type CapabilityTarget = "everyone" | "builders" | "admins_only";
+
 export interface CapabilitySeeder {
-  // Stable identifier for logs / debugging (e.g. "create:agent").
-  name: string;
-  seed: (auth: Authenticator) => Promise<void>;
+  capability: CapabilitySpec;
+  // Decides the target for the workspace behind `auth`.
+  resolveTarget: (auth: Authenticator) => Promise<CapabilityTarget>;
 }
 
-const CAPABILITY_SEEDERS: CapabilitySeeder[] = [];
+export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
+  {
+    // dust-tt/tasks#9463 — replaces the isBuilder()-gated create-agent check.
+    capability: { grantType: "create", resourceType: "agent" },
+    resolveTarget: async (auth) => {
+      const disallowsUserCreation =
+        await FeatureFlagResource.isEnabledForWorkspace(
+          auth.getNonNullableWorkspace(),
+          "disallow_agent_creation_to_users"
+        );
+      return disallowsUserCreation ? "builders" : "everyone";
+    },
+  },
+];
+
+export type ApplyCapabilityOutcome =
+  | "seeded_everybody"
+  | "seeded_builders"
+  | "skipped_admins_only";
+
+// Applies an already-resolved target for one capability on the workspace behind `auth`. Shared
+// write path for both call sites listed above. The "builders" target creates the workspace's
+// Builders group if it doesn't exist yet (e.g. no builder-role member has ever been synced into
+// it), so this never leaves the capability unconfigured. With `dryRun: true`, resolves and
+// returns the outcome without writing — used by the backfill script's default dry-run mode.
+export async function applyCapabilityTarget(
+  auth: Authenticator,
+  capability: CapabilitySpec,
+  target: CapabilityTarget,
+  { dryRun = false }: { dryRun?: boolean } = {}
+): Promise<ApplyCapabilityOutcome> {
+  switch (target) {
+    case "admins_only":
+      return "skipped_admins_only";
+    case "everyone":
+      if (!dryRun) {
+        await GroupPermissionResource.setForEverybody(auth, capability);
+      }
+      return "seeded_everybody";
+    case "builders": {
+      if (!dryRun) {
+        const buildersGroup =
+          await GroupResource.fetchOrCreateManualBuildersGroup(
+            auth.getNonNullableWorkspace()
+          );
+        await GroupPermissionResource.setGroups(auth, capability, [
+          buildersGroup,
+        ]);
+      }
+      return "seeded_builders";
+    }
+    default:
+      assertNever(target);
+  }
+}
 
 // Seed default governance state for a newly created workspace. Called once from workspace
-// provisioning. Runs seeders sequentially — the list is a small, static registry, not user data.
+// provisioning. Runs seeders sequentially and unconditionally.
 export async function seedWorkspaceCapabilities(
   auth: Authenticator
 ): Promise<void> {
   for (const seeder of CAPABILITY_SEEDERS) {
-    await seeder.seed(auth);
+    const target = await seeder.resolveTarget(auth);
+    await applyCapabilityTarget(auth, seeder.capability, target);
   }
 }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2613,45 +2613,23 @@ export class GroupResource extends BaseResource<GroupModel> {
     user: UserResource;
     isBuilder: boolean;
   }): Promise<void> {
-    let group = await GroupModel.findOne({
+    const existingGroup = await GroupModel.findOne({
       where: { workspaceId: workspace.id, name: MANUAL_BUILDERS_GROUP_NAME },
     });
 
-    if (!group) {
-      if (!isBuilder) {
-        return;
-      }
-      try {
-        await GroupResource.makeNew(
-          {
-            name: MANUAL_BUILDERS_GROUP_NAME,
-            kind: "regular_manual",
-            workspaceId: workspace.id,
-          },
-          { memberIds: [user.id] }
-        );
-        return;
-      } catch (err) {
-        // Two concurrent membership writes can race on the group creation; the
-        // (workspaceId, name) unique index makes the loser land here. Fall through to the
-        // membership sync against the winner's group.
-        if (!(err instanceof UniqueConstraintError)) {
-          throw err;
-        }
-        group = await GroupModel.findOne({
-          where: {
-            workspaceId: workspace.id,
-            name: MANUAL_BUILDERS_GROUP_NAME,
-          },
-        });
-        assert(group, "Builders group missing after unique constraint error");
-      }
+    if (!existingGroup && !isBuilder) {
+      // Nothing to revoke from a group that doesn't exist yet.
+      return;
     }
+
+    const groupId = existingGroup
+      ? existingGroup.id
+      : (await GroupResource.fetchOrCreateManualBuildersGroup(workspace)).id;
 
     const now = new Date();
     // Served by the (userId, groupId) index.
     const activeMembershipWhere = {
-      groupId: group.id,
+      groupId,
       userId: user.id,
       workspaceId: workspace.id,
       status: "active",
@@ -2667,7 +2645,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         return;
       }
       await GroupMembershipModel.create({
-        groupId: group.id,
+        groupId,
         userId: user.id,
         workspaceId: workspace.id,
         startAt: now,
@@ -2688,6 +2666,43 @@ export class GroupResource extends BaseResource<GroupModel> {
     await GroupResource.batchInvalidateGroupIdsCacheForUsers([
       [{ user: { id: user.id }, workspace: { id: workspace.id } }],
     ]);
+  }
+
+  /**
+   * Fetches the workspace's manual "Builders" group (MANUAL_BUILDERS_GROUP_NAME), creating it
+   * empty if it doesn't exist yet. Governance capability seeding may need to grant a capability
+   * to this group before any builder-role member has ever been synced into it — normally the
+   * group is created lazily by `syncBuilderGroupMembership` on the first such sync.
+   */
+  static async fetchOrCreateManualBuildersGroup(
+    workspace: LightWorkspaceType
+  ): Promise<GroupResource> {
+    const existing = await GroupModel.findOne({
+      where: { workspaceId: workspace.id, name: MANUAL_BUILDERS_GROUP_NAME },
+    });
+    if (existing) {
+      return new this(GroupModel, existing.get());
+    }
+
+    try {
+      return await GroupResource.makeNew({
+        name: MANUAL_BUILDERS_GROUP_NAME,
+        kind: "regular_manual",
+        workspaceId: workspace.id,
+      });
+    } catch (err) {
+      // Two concurrent callers can race on the group creation (this method, or a concurrent
+      // syncBuilderGroupMembership call); the (workspaceId, name) unique index makes the loser
+      // land here. Fall through to the winner's group.
+      if (!(err instanceof UniqueConstraintError)) {
+        throw err;
+      }
+      const winner = await GroupModel.findOne({
+        where: { workspaceId: workspace.id, name: MANUAL_BUILDERS_GROUP_NAME },
+      });
+      assert(winner, "Builders group missing after unique constraint error");
+      return new this(GroupModel, winner.get());
+    }
   }
 
   /**

--- a/front/migrations/20260721_backfill_create_agent_capability.ts
+++ b/front/migrations/20260721_backfill_create_agent_capability.ts
@@ -1,0 +1,121 @@
+import {
+  applyCapabilityTarget,
+  CAPABILITY_SEEDERS,
+} from "@app/lib/api/permissions/governance_seeding";
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { CapabilityKey } from "@app/types/group_permissions";
+import { capabilityKey } from "@app/types/group_permissions";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+
+interface SeederCounts {
+  seededEverybody: number;
+  seededBuilders: number;
+  alreadySet: number;
+  skippedAdminsOnly: number;
+}
+
+function newCounts(): SeederCounts {
+  return {
+    seededEverybody: 0,
+    seededBuilders: 0,
+    alreadySet: 0,
+    skippedAdminsOnly: 0,
+  };
+}
+
+/**
+ * Backfill governance capabilities (`group_permissions`) for every seeder registered in
+ * `CAPABILITY_SEEDERS` (`@app/lib/api/permissions/governance_seeding`), from each existing
+ * workspace's current legacy configuration, so that once a capability's
+ * `auth.hasWorkspacePermission(verb, resourceType)` check is enforced server-side, every
+ * workspace preserves its effective access as of today. First capability: `create agent`
+ * (dust-tt/tasks#9463).
+ *
+ * The seeders themselves — which capability, and what target (everyone / builders / admins_only)
+ * a workspace resolves to — are shared with `seedWorkspaceCapabilities`, which applies the same
+ * registry to brand-new workspaces at creation time (dust-tt/tasks#9454). This script is only
+ * responsible for existing workspaces: it adds the idempotency check (skip if already configured)
+ * and the dry-run/--execute gating that a one-time backfill needs but workspace creation doesn't.
+ *
+ * Pass `--wId <workspaceId>` to run on a single workspace.
+ */
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    const countsByCapability = new Map<CapabilityKey, SeederCounts>(
+      CAPABILITY_SEEDERS.map((seeder) => [
+        capabilityKey(seeder.capability),
+        newCounts(),
+      ])
+    );
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+
+        const states = await GroupPermissionResource.getCapabilitiesState(
+          auth,
+          CAPABILITY_SEEDERS.map((seeder) => seeder.capability)
+        );
+
+        for (const seeder of CAPABILITY_SEEDERS) {
+          const key = capabilityKey(seeder.capability);
+          const counts = countsByCapability.get(key);
+          if (!counts) {
+            throw new Error(`Missing counters for capability ${key}.`);
+          }
+
+          const current = states.get(key);
+          if (current && current.scope !== "admins_only") {
+            counts.alreadySet++;
+            continue;
+          }
+
+          const target = await seeder.resolveTarget(auth);
+          const outcome = await applyCapabilityTarget(
+            auth,
+            seeder.capability,
+            target,
+            { dryRun: !execute }
+          );
+
+          logger.info(
+            { workspaceId: workspace.sId, capability: key, target, outcome },
+            execute ? "Applied." : "Would apply."
+          );
+
+          switch (outcome) {
+            case "seeded_everybody":
+              counts.seededEverybody++;
+              break;
+            case "seeded_builders":
+              counts.seededBuilders++;
+              break;
+            case "skipped_admins_only":
+              counts.skippedAdminsOnly++;
+              break;
+            default:
+              assertNeverAndIgnore(outcome);
+          }
+        }
+      },
+      { wId }
+    );
+
+    logger.info(
+      Object.fromEntries(countsByCapability),
+      execute ? "Backfill completed." : "Dry run completed."
+    );
+  }
+);


### PR DESCRIPTION
## Description

Implements the `create agent` capability backfill (dust-tt/tasks#9463) and the workspace-creation lifecycle hook for governance capability seeding (dust-tt/tasks#9454), sharing one registry between the two.

**`front/lib/api/permissions/governance_seeding.ts`** — was a stub (`CAPABILITY_SEEDERS = []`, no-op `seedWorkspaceCapabilities`). Now the single source of truth for governance capability defaults:
- `CAPABILITY_SEEDERS`: a list of `{ capability, resolveTarget(auth) }` entries. `resolveTarget` decides, per workspace, whether a capability should go to `"everyone"`, `"builders"`, or `"admins_only"`. Adding a new capability later is just adding an entry here — nothing else needs to change. Currently seeds `create agent`, resolved from the legacy `disallow_agent_creation_to_users` flag.
- `applyCapabilityTarget(auth, capability, target, { dryRun? })`: the shared write path for a resolved target (`setForEverybody` / grant the workspace's "Builders" group / no-op for admins-only). Supports `dryRun` so a caller can predict the outcome without writing.
- `seedWorkspaceCapabilities(auth)`: applies every registered seeder unconditionally — called once from `createWorkspaceInternal` (already wired up from #9454's initial empty-list version, so no call-site changes needed). A brand-new workspace naturally has no legacy flag set, so `resolveTarget` resolves to the same default a backfill would apply — one resolver serves both a fresh workspace and an existing one.

**`front/lib/resources/group_resource.ts`** — added `GroupResource.fetchOrCreateManualBuildersGroup(workspace)`, so a "builders" target never leaves a capability unconfigured just because no builder has been synced into the group yet (it creates the group empty). `syncBuilderGroupMembership` now delegates to this same helper instead of duplicating the find-or-create-with-race-handling logic, so there's exactly one place that creates the Builders group.

**`front/migrations/20260721_backfill_create_agent_capability.ts`** — backfills existing workspaces from the same `CAPABILITY_SEEDERS` registry. Adds only what a one-time backfill needs on top of the shared seeders: an idempotency check (skip a workspace/capability pair that's already configured, so re-running after a manual override is a no-op) and dry-run-by-default / `--execute` gating. Pass `--wId <workspaceId>` for a single workspace.

## Tests

- New/updated tests in `governance_seeding.test.ts`: a fresh workspace defaults `create agent` to everyone; a workspace with the legacy flag already set gets the Builders group created and granted (verified a plain user is still blocked, and a synced builder gets access).
- `group_resource.test.ts`'s existing `syncBuilderGroupMembership` suite (34 tests) passes unchanged against the refactored implementation — it asserts final DB state, not internal call patterns, so behavior is provably unchanged there.
- `lib/api/membership.test.ts` (the main production caller of `syncBuilderGroupMembership`) passes unchanged.
- Verified the migration script end-to-end against the test DB with a throwaway smoke test (not committed — this repo has no test convention for migration scripts): everybody-grant, builders-grant (including creating the group from scratch), dry-run (no writes), and idempotent re-run.
- `npx tsgo --noEmit` and `biome check` clean.

## Risk

Low. `seedWorkspaceCapabilities` only affects brand-new workspaces going forward (adds a `create`/`agent` grant that didn't exist before — harmless, since step 1's enforcement PR is what actually starts checking it). The backfill script only writes when re-run with `--execute`; nothing here changes behavior for existing workspaces until that flag is passed.

## Deploy Plan

Deploy after `restric-agent-creation-based-on`. Run the backfill script (`--execute`, no `--wId` for all workspaces) before or immediately after this deploys, so non-admin agent creation isn't interrupted for workspaces that currently allow it.