### PR TITLE
feat(activation): schedule pod nudges across the workday

### DIFF
--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,21 +1,184 @@
-import { runActivationForWorkspace } from "@app/lib/api/activation/orchestrator";
+import { isEligibleForNudge } from "@app/lib/api/activation/nudge";
+import { determineEligibleActivationUsers } from "@app/lib/api/activation/orchestrator";
+import { emitActivationEvent } from "@app/lib/api/activation/trigger";
+import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import {
+  ACTIVATION_WORKDAY_WINDOW_MINUTES,
+  ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
+} from "@app/temporal/activation_scheduler/config";
+import { getNudgeSlotAtMs } from "@app/temporal/activation_scheduler/slots";
+
+const ACTIVATION_PODS_CONCURRENCY = 4;
+
+export type EligiblePodNudge = {
+  podId: string;
+  targetUserId: string;
+  slotAtMs: number;
+};
 
 /**
- * Runs the activation orchestration for a workspace: skips already-activated pod
- * members and re-fires the activation trigger
- * for every pod that still has an eligible member, nudging them back into the
- * pod's activation conversation.
+ * Enumerates every (pod, target user) still eligible for activation in the
+ * workspace, gates each on `isEligibleForNudge`, and assigns the eligible
+ * ones a deterministic slot within the regional workday window. This is the
+ * planning step: it does not send anything, since state can go stale between
+ * this pass (run once at the start of the workday) and a pod's actual slot
+ * later in the day.
  */
-export async function runActivationForWorkspaceActivity({
+export async function enumerateEligiblePodsForNudgeActivity({
   workspaceId,
 }: {
   workspaceId: string;
-}): Promise<void> {
-  const result = await runActivationForWorkspace({
-    workspaceId,
-    dryRun: false,
+}): Promise<EligiblePodNudge[]> {
+  // Activation conversations live in Pods, which are restricted spaces: request
+  // all groups so admin auth can read/write them.
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
   });
-  if (result.isErr()) {
-    throw result.error;
+
+  const planResult = await determineEligibleActivationUsers(auth, {
+    userId: null,
+  });
+  if (planResult.isErr()) {
+    throw planResult.error;
   }
+  const { eligible } = planResult.value;
+  if (eligible.length === 0) {
+    return [];
+  }
+
+  const uniqueSpaceIds = [...new Set(eligible.map((c) => c.spaceId))];
+  const pods = await SpaceResource.fetchByIds(auth, uniqueSpaceIds);
+  const podBySId = new Map(pods.map((pod) => [pod.sId, pod]));
+
+  const users = await UserResource.fetchByIds([
+    ...new Set(eligible.map((c) => c.targetUserId)),
+  ]);
+  const userBySId = new Map(users.map((user) => [user.sId, user]));
+
+  const timezone = REGION_TIMEZONES[config.getCurrentRegion()];
+  const now = new Date();
+
+  const eligiblePods: EligiblePodNudge[] = [];
+
+  await concurrentExecutor(
+    eligible,
+    async (candidate) => {
+      const pod = podBySId.get(candidate.spaceId);
+      if (!pod) {
+        logger.error(
+          { workspaceId, spaceId: candidate.spaceId },
+          "[ActivationScheduler] Pod space not found, skipping."
+        );
+        return;
+      }
+
+      const user = userBySId.get(candidate.targetUserId) ?? null;
+      if (!(await isEligibleForNudge(auth, pod, { user }))) {
+        logger.info(
+          { workspaceId, spaceId: pod.sId, userId: candidate.targetUserId },
+          "[ActivationScheduler] Pod is not eligible for a nudge, skipping."
+        );
+        return;
+      }
+
+      eligiblePods.push({
+        podId: pod.sId,
+        targetUserId: candidate.targetUserId,
+        slotAtMs: getNudgeSlotAtMs({
+          podModelId: pod.id,
+          timezone,
+          windowStartMinutes: ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
+          windowMinutes: ACTIVATION_WORKDAY_WINDOW_MINUTES,
+          now,
+        }),
+      });
+    },
+    { concurrency: ACTIVATION_PODS_CONCURRENCY }
+  );
+
+  return eligiblePods.sort((a, b) => a.slotAtMs - b.slotAtMs);
+}
+
+/**
+ * Re-fires the activation trigger for a single (pod, target user), at its
+ * assigned slot. Re-runs `isEligibleForNudge` right before sending: state can
+ * go stale between the morning enumeration and this pod's slot, and this
+ * re-check doubles as the idempotency guard against activity retries or
+ * workflow replays (a nudge already recorded for the pod makes the frequency
+ * cap reject a duplicate call).
+ */
+export async function reGateAndNudgePodActivity({
+  workspaceId,
+  podId,
+  targetUserId,
+}: {
+  workspaceId: string;
+  podId: string;
+  targetUserId: string;
+}): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
+
+  const pod = await SpaceResource.fetchById(auth, podId, {
+    includeDeleted: true,
+  });
+  if (!pod) {
+    logger.error(
+      { workspaceId, spaceId: podId },
+      "[ActivationScheduler] Pod not found at nudge time, skipping."
+    );
+    return;
+  }
+
+  const [user] = await UserResource.fetchByIds([targetUserId]);
+
+  if (!(await isEligibleForNudge(auth, pod, { user: user ?? null }))) {
+    logger.info(
+      { workspaceId, spaceId: pod.sId, userId: targetUserId },
+      "[ActivationScheduler] Pod no longer eligible for a nudge at slot time, skipping."
+    );
+    return;
+  }
+
+  const result = await emitActivationEvent(auth, pod, targetUserId);
+  if (result.isErr()) {
+    logger.error(
+      {
+        workspaceId,
+        spaceId: pod.sId,
+        userId: targetUserId,
+        error: result.error,
+      },
+      "[ActivationScheduler] Failed to emit activation event for pod."
+    );
+    return;
+  }
+
+  const { triggerId } = result.value;
+  if (!triggerId) {
+    logger.warn(
+      { workspaceId, spaceId: pod.sId, userId: targetUserId },
+      "[ActivationScheduler] Activation event did not fire the pod's trigger."
+    );
+    return;
+  }
+
+  const [trigger] = await TriggerResource.fetchByIds(auth, [triggerId]);
+  if (!trigger) {
+    logger.error(
+      { workspaceId, spaceId: pod.sId, triggerId },
+      "[ActivationScheduler] Activation trigger not found after firing."
+    );
+    return;
+  }
+
+  await ActivationNudgeResource.makeNew(auth, { pod, trigger });
 }

--- a/front/temporal/activation_scheduler/client.ts
+++ b/front/temporal/activation_scheduler/client.ts
@@ -10,6 +10,7 @@ import {
 } from "@temporalio/client";
 
 import { QUEUE_NAME } from "./config";
+import { runActivationSignal } from "./signals";
 import { activationWorkspaceWorkflow } from "./workflows";
 
 const WORKSPACE_WORKFLOW_ID_PREFIX = "activation-workspace-";
@@ -47,6 +48,10 @@ export async function startActivationWorkspaceSchedule({
         workflowType: activationWorkspaceWorkflow,
         args: [{ workspaceId }],
         taskQueue: QUEUE_NAME,
+        // Pinned to the same deterministic id used by the on-demand
+        // signalWithStart trigger below, so a poke/admin-forced cycle joins
+        // the day's scheduled run instead of starting a second one.
+        workflowId: scheduleId,
       },
       scheduleId,
       policies: {
@@ -107,26 +112,35 @@ export async function deleteActivationWorkspaceSchedule({
 }
 
 // ---------------------------------------------------------------------------
-// Manual one-off runs
+// On-demand runs (poke/admin-forced cycles)
 // ---------------------------------------------------------------------------
 
-export async function startActivationWorkspaceWorkflow({
+/**
+ * Triggers an activation cycle for a workspace on demand, through the same
+ * code path as the scheduled run: `signalWithStart` against the workspace's
+ * deterministic workflow id starts a fresh run if none is active today, or
+ * simply signals the one already in flight (started by the schedule) if one
+ * is running.
+ */
+export async function triggerActivationWorkspaceWorkflow({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
-  const workflowId = `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}-manual-${Date.now()}`;
+  const workflowId = makeWorkspaceWorkflowId(workspaceId);
 
-  await client.workflow.start(activationWorkspaceWorkflow, {
+  await client.workflow.signalWithStart(activationWorkspaceWorkflow, {
     args: [{ workspaceId }],
     taskQueue: QUEUE_NAME,
     workflowId,
+    signal: runActivationSignal,
+    signalArgs: undefined,
   });
 
   logger.info(
     { workflowId, workspaceId },
-    "[ActivationScheduler] Started workspace workflow."
+    "[ActivationScheduler] Triggered workspace workflow."
   );
   return new Ok(workflowId);
 }

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -1,6 +1,12 @@
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `activation-scheduler-queue-v${QUEUE_VERSION}`;
 
+// Pods are nudged at a deterministic slot within this window of the regional
+// workday (9:30 - 16:30), spreading nudges out instead of firing them all at
+// once when the workspace schedule triggers.
+export const ACTIVATION_WORKDAY_WINDOW_START_MINUTES = 9 * 60 + 30;
+export const ACTIVATION_WORKDAY_WINDOW_MINUTES = 7 * 60;
+
 // Default number of days to wait before nudging the same pod again. Workspaces
 // can override this via the `activationNudgeFrequencyCapDays` metadata key.
 export const DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS = 2;

--- a/front/temporal/activation_scheduler/signals.ts
+++ b/front/temporal/activation_scheduler/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const runActivationSignal = defineSignal<[void]>(
+  "run_activation_signal"
+);

--- a/front/temporal/activation_scheduler/slots.test.ts
+++ b/front/temporal/activation_scheduler/slots.test.ts
@@ -1,0 +1,80 @@
+import {
+  getNudgeSlotAtMs,
+  getPodNudgeSlotMinutes,
+} from "@app/temporal/activation_scheduler/slots";
+import { describe, expect, it } from "vitest";
+
+const WINDOW_MINUTES = 420; // 9:30 - 16:30.
+
+describe("getPodNudgeSlotMinutes", () => {
+  it("is deterministic", () => {
+    expect(getPodNudgeSlotMinutes(123, WINDOW_MINUTES)).toBe(
+      getPodNudgeSlotMinutes(123, WINDOW_MINUTES)
+    );
+  });
+
+  it("returns an offset within the configured window", () => {
+    for (const podModelId of [1, 123, 987_654]) {
+      const slotMinutes = getPodNudgeSlotMinutes(podModelId, WINDOW_MINUTES);
+
+      expect(slotMinutes).toBeGreaterThanOrEqual(0);
+      expect(slotMinutes).toBeLessThan(WINDOW_MINUTES);
+    }
+  });
+
+  it("spreads nearby pod model ids", () => {
+    const slots = new Set(
+      Array.from({ length: 10 }, (_, index) =>
+        getPodNudgeSlotMinutes(index, WINDOW_MINUTES)
+      )
+    );
+
+    expect(slots.size).toBeGreaterThan(1);
+  });
+});
+
+describe("getNudgeSlotAtMs", () => {
+  const timezone = "America/New_York";
+  const windowStartMinutes = 9 * 60 + 30;
+  const now = new Date("2026-07-21T18:00:00.000Z");
+
+  it("is deterministic for the same day", () => {
+    const first = getNudgeSlotAtMs({
+      podModelId: 123,
+      timezone,
+      windowStartMinutes,
+      windowMinutes: WINDOW_MINUTES,
+      now,
+    });
+    const second = getNudgeSlotAtMs({
+      podModelId: 123,
+      timezone,
+      windowStartMinutes,
+      windowMinutes: WINDOW_MINUTES,
+      now,
+    });
+
+    expect(first).toBe(second);
+  });
+
+  it("falls within the window on the given day", () => {
+    const slotAtMs = getNudgeSlotAtMs({
+      podModelId: 123,
+      timezone,
+      windowStartMinutes,
+      windowMinutes: WINDOW_MINUTES,
+      now,
+    });
+
+    const windowStartMs = getNudgeSlotAtMs({
+      podModelId: 123,
+      timezone,
+      windowStartMinutes,
+      windowMinutes: 1,
+      now,
+    });
+
+    expect(slotAtMs).toBeGreaterThanOrEqual(windowStartMs);
+    expect(slotAtMs).toBeLessThan(windowStartMs + WINDOW_MINUTES * 60 * 1000);
+  });
+});

--- a/front/temporal/activation_scheduler/slots.ts
+++ b/front/temporal/activation_scheduler/slots.ts
@@ -1,0 +1,39 @@
+import type { ModelId } from "@app/types/shared/model_id";
+import moment from "moment-timezone";
+
+// Mirrors the `scheduleOffsetMinutes = spaceModelId % 60` pattern in
+// front/temporal/project_task/client.ts: a pod's numeric model id is already
+// a well-distributed, stable integer, so taking it modulo the window size
+// gives a deterministic per-pod offset without hashing anything.
+export function getPodNudgeSlotMinutes(
+  podModelId: ModelId,
+  windowMinutes: number
+): number {
+  return podModelId % windowMinutes;
+}
+
+// Computes the absolute epoch ms of a pod's nudge slot: `windowStartMinutes`
+// (minutes from midnight) on `now`'s calendar day in `timezone`, plus the
+// pod's deterministic offset within `windowMinutes`.
+export function getNudgeSlotAtMs({
+  podModelId,
+  timezone,
+  windowStartMinutes,
+  windowMinutes,
+  now,
+}: {
+  podModelId: ModelId;
+  timezone: string;
+  windowStartMinutes: number;
+  windowMinutes: number;
+  now: Date;
+}): number {
+  const windowStart = moment
+    .tz(now, timezone)
+    .startOf("day")
+    .add(windowStartMinutes, "minutes");
+
+  const slotMinutes = getPodNudgeSlotMinutes(podModelId, windowMinutes);
+
+  return windowStart.add(slotMinutes, "minutes").valueOf();
+}

--- a/front/temporal/activation_scheduler/workflows.ts
+++ b/front/temporal/activation_scheduler/workflows.ts
@@ -1,21 +1,47 @@
 import type * as activities from "@app/temporal/activation_scheduler/activities";
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
-const { runActivationForWorkspaceActivity } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "5 minutes",
-});
+import { runActivationSignal } from "./signals";
+
+const { enumerateEligiblePodsForNudgeActivity, reGateAndNudgePodActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "5 minutes",
+  });
 
 /**
- * Workspace-level workflow (one per workspace, schedule-triggered).
- * The Temporal schedule applies jitter to spread load across the region's
- * workday start.
+ * Workspace-level workflow: one per workspace, triggered by the workspace's
+ * Temporal Schedule at the start of the regional workday, and restartable
+ * on demand via `signalWithStart` against the same deterministic workflow id
+ * (see client.ts) so poke/admin-forced cycles go through this same code path.
+ *
+ * Enumerates and gates every Activation Pod once, then visits each eligible
+ * pod at its deterministic slot within the regional workday window,
+ * re-gating right before sending since state (opt-out, credit, frequency cap)
+ * can go stale between the morning enumeration and the pod's slot later in
+ * the day.
  */
 export async function activationWorkspaceWorkflow({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<void> {
-  await runActivationForWorkspaceActivity({ workspaceId });
+  setHandler(runActivationSignal, () => {
+    // Empty handler: signalWithStart only needs this to (re)start the
+    // workflow when it isn't already running for this workspace.
+  });
+
+  const pods = await enumerateEligiblePodsForNudgeActivity({ workspaceId });
+
+  for (const pod of pods) {
+    const sleepMs = pod.slotAtMs - Date.now();
+    if (sleepMs > 0) {
+      await sleep(sleepMs);
+    }
+
+    await reGateAndNudgePodActivity({
+      workspaceId,
+      podId: pod.podId,
+      targetUserId: pod.targetUserId,
+    });
+  }
 }


### PR DESCRIPTION
## Description

Builds the Temporal orchestration layer for pod activation nudges. The
`activation_scheduler` workflow now enumerates and gates every pod once per
day, then visits each eligible pod at a deterministic slot spread across the
regional workday window (9:30 - 16:30) instead of nudging them all at once.
Slot assignment reuses the `spaceModelId % windowMinutes` pattern already
used in `project_task`.

Each pod is re-gated right before sending, since state can go stale between
the morning pass and the pod's slot later in the day; this re-check doubles
as the idempotency guard against activity retries or workflow replays. Also
adds an on-demand `signalWithStart` trigger (`triggerActivationWorkspaceWorkflow`)
so poke/admin-forced cycles run through the same code path as the scheduled
run, targeting the same deterministic workflow id.

## Tests

Added `slots.test.ts` for the deterministic slot assignment (determinism,
bounds, spread). Ran the full `activation_scheduler` test suite plus
`npx tsgo --noEmit`.
