### PR TITLE
[front] enh: cache equipped skills for OpenAI models

### DIFF
--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -116,6 +116,8 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
+        // The legacy registry includes custom model IDs that are absent from
+        // model_constructors, so narrow before using its capability helper.
         cacheBreakpointOnLeadingMessage:
           isModel(this.modelId) &&
           supportsOpenAIExplicitPromptCaching(this.modelId),

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -32,10 +32,7 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  isModel,
-  supportsOpenAIExplicitPromptCaching,
-} from "@app/lib/model_constructors/types/models";
+import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -116,11 +113,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
-        // The legacy registry includes custom model IDs that are absent from
-        // model_constructors, so narrow before using its capability helper.
-        cacheBreakpointOnLeadingMessage:
-          isModel(this.modelId) &&
-          supportsOpenAIExplicitPromptCaching(this.modelId),
+        cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
+          this.modelId
+        ),
       }),
       temperature: this.temperature ?? undefined,
       reasoning,

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -113,8 +113,7 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
-        // Match Anthropic's equipped-skills breakpoint, but only for OpenAI
-        // models that accept explicit prompt cache breakpoints.
+        // Same cache breakpoint strategy as for other providers that support it.
         cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
           this.modelId
         ),

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -32,7 +32,10 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
-import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/model_ids";
+import {
+  isModel,
+  supportsOpenAIExplicitPromptCaching,
+} from "@app/lib/model_constructors/types/models";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -113,9 +116,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
-        cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
-          this.modelId
-        ),
+        cacheBreakpointOnLeadingMessage:
+          isModel(this.modelId) &&
+          supportsOpenAIExplicitPromptCaching(this.modelId),
       }),
       temperature: this.temperature ?? undefined,
       reasoning,

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -113,6 +113,8 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
+        // Match Anthropic's equipped-skills breakpoint, but only for OpenAI
+        // models that accept explicit prompt cache breakpoints.
         cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
           this.modelId
         ),

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -114,6 +114,7 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
         // Same cache breakpoint strategy as for other providers that support it.
+        // Not all OpenAI models support explicit breakpoints.
         cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
           this.modelId
         ),

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -32,6 +32,7 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
+import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/model_ids";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -111,7 +112,11 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
 
     return {
       model: this.modelId,
-      input: toInput(promptText, conversation),
+      input: toInput(promptText, conversation, "developer", {
+        cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
+          this.modelId
+        ),
+      }),
       temperature: this.temperature ?? undefined,
       reasoning,
       tools: toToolsParam(specifications, {

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -113,8 +113,6 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return {
       model: this.modelId,
       input: toInput(promptText, conversation, "developer", {
-        // Same cache breakpoint strategy as for other providers that support it.
-        // Not all OpenAI models support explicit breakpoints.
         cacheBreakpointOnLeadingMessage: supportsOpenAIExplicitPromptCaching(
           this.modelId
         ),

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -2,6 +2,7 @@ import type { OpenAIWhitelistedModelId } from "@app/lib/api/llm/clients/openai/t
 import {
   OPENAI_PROVIDER_ID,
   overwriteLLMParameters,
+  supportsOpenAIExplicitPromptCaching,
 } from "@app/lib/api/llm/clients/openai/types";
 import { LLM } from "@app/lib/api/llm/llm";
 import type {
@@ -32,7 +33,6 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
-import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/llm/clients/openai/types.ts
+++ b/front/lib/api/llm/clients/openai/types.ts
@@ -65,6 +65,17 @@ export const OPENAI_WHITELISTED_MODEL_IDS = [
 export type OpenAIWhitelistedModelId =
   (typeof OPENAI_WHITELISTED_MODEL_IDS)[number];
 
+// Models older than 5.6 do not support explicit cache breakpoints.
+// https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly OpenAIWhitelistedModelId[] =
+  [GPT_5_6_SOL_MODEL_ID, GPT_5_6_TERRA_MODEL_ID, GPT_5_6_LUNA_MODEL_ID];
+
+export function supportsOpenAIExplicitPromptCaching(
+  model: OpenAIWhitelistedModelId
+): boolean {
+  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.includes(model);
+}
+
 const NON_THINKING_OVERWRITES: LLMParameterOverwrites = {
   reasoningEffort: null,
 };

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -291,8 +291,8 @@ export function toBaseMessages(
   }
 }
 
-// Places the Anthropic user-message cache breakpoints, matching the legacy
-// router. Returns a new array; does not mutate its input.
+// Places provider user-message cache breakpoints at the same boundaries as the
+// legacy Anthropic router. Returns a new array; does not mutate its input.
 //   - Equipped-skills prefix: always. When the first message is the
 //     `name: "system"` user block (the stable per agent+workspace skills list),
 //     its last content block is cached for cross-conversation reuse. Mirrors the

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -128,6 +128,8 @@ function toUserInputMessage(
   message: UserMessageTypeModel,
   { cacheBreakpoint }: { cacheBreakpoint: boolean }
 ): ResponseInputItem.Message {
+  // A breakpoint caches the prefix through the marked content block. Put it on
+  // the last block so every part of the equipped-skills message is included.
   const lastContentIndex = message.content.length - 1;
   return {
     role: "user",
@@ -174,6 +176,9 @@ export function toInput(
       case "user":
         inputs.push(
           toUserInputMessage(message, {
+            // The injected equipped-skills list is represented as the first
+            // user message with `name: "system"`. Regular user messages must
+            // not receive this cross-conversation breakpoint.
             cacheBreakpoint:
               cacheBreakpointOnLeadingMessage &&
               index === 0 &&

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -125,11 +125,21 @@ function toAssistantInputItem(
 }
 
 function toUserInputMessage(
-  message: UserMessageTypeModel
+  message: UserMessageTypeModel,
+  { cacheBreakpoint }: { cacheBreakpoint: boolean }
 ): ResponseInputItem.Message {
+  const lastContentIndex = message.content.length - 1;
   return {
     role: "user",
-    content: message.content.map(toInputContent),
+    content: message.content.map((content, index) => {
+      const inputContent = toInputContent(content);
+      return cacheBreakpoint && index === lastContentIndex
+        ? {
+            ...inputContent,
+            prompt_cache_breakpoint: { mode: "explicit" },
+          }
+        : inputContent;
+    }),
   };
 }
 
@@ -150,7 +160,8 @@ function toToolCallOutputItem(
 export function toInput(
   prompt: string,
   conversation: ModelConversationTypeMultiActions,
-  promptRole: "system" | "developer" = "developer"
+  promptRole: "system" | "developer" = "developer",
+  { cacheBreakpointOnLeadingMessage = false } = {}
 ): ResponseInput {
   const inputs: ResponseInput = [];
   inputs.push({
@@ -158,10 +169,17 @@ export function toInput(
     content: [{ type: "input_text", text: prompt }],
   });
 
-  for (const message of conversation.messages) {
+  for (const [index, message] of conversation.messages.entries()) {
     switch (message.role) {
       case "user":
-        inputs.push(toUserInputMessage(message));
+        inputs.push(
+          toUserInputMessage(message, {
+            cacheBreakpoint:
+              cacheBreakpointOnLeadingMessage &&
+              index === 0 &&
+              message.name === "system",
+          })
+        );
         break;
       case "assistant":
         const assistantItems = compact(

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -128,8 +128,7 @@ function toUserInputMessage(
   message: UserMessageTypeModel,
   { cacheBreakpoint }: { cacheBreakpoint: boolean }
 ): ResponseInputItem.Message {
-  // A breakpoint caches the prefix through the marked content block. Put it on
-  // the last block so every part of the equipped-skills message is included.
+  // We put it on the last block to include the entire message (cache is prefix-based).
   const lastContentIndex = message.content.length - 1;
   return {
     role: "user",
@@ -176,9 +175,8 @@ export function toInput(
       case "user":
         inputs.push(
           toUserInputMessage(message, {
-            // The injected equipped-skills list is represented as the first
-            // user message with `name: "system"`. Regular user messages must
-            // not receive this cross-conversation breakpoint.
+            // We inject the list of equipped skills in the first user message with `name: "system"`, which is cached.
+            // Regular user messages must not receive this cross-conversation breakpoint.
             cacheBreakpoint:
               cacheBreakpointOnLeadingMessage &&
               index === 0 &&

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -48,29 +48,6 @@ describe("toInput", () => {
         ],
       });
     });
-
-    it("does not add a cache breakpoint to a non-leading skills message", () => {
-      const messages = toInput(
-        "You are a helpful assistant.",
-        {
-          messages: [
-            ...conversationMessages,
-            {
-              role: "user",
-              name: "system",
-              content: [{ type: "text", text: "Available skills" }],
-            },
-          ],
-        },
-        "developer",
-        { cacheBreakpointOnLeadingMessage: true }
-      );
-
-      expect(messages.at(-1)).toEqual({
-        role: "user",
-        content: [{ type: "input_text", text: "Available skills" }],
-      });
-    });
   });
 
   it("replays OpenAI tool-search items and skips other providers", () => {

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -15,6 +15,39 @@ describe("toInput", () => {
 
       expect(messages).toEqual(inputMessages);
     });
+
+    it("adds a cache breakpoint to the leading equipped-skills message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        {
+          messages: [
+            {
+              role: "user",
+              name: "system",
+              content: [
+                { type: "text", text: "Available" },
+                { type: "text", text: "skills" },
+              ],
+            },
+            ...conversationMessages,
+          ],
+        },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages[1]).toEqual({
+        role: "user",
+        content: [
+          { type: "input_text", text: "Available" },
+          {
+            type: "input_text",
+            text: "skills",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      });
+    });
   });
 
   it("replays OpenAI tool-search items and skips other providers", () => {

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -48,6 +48,32 @@ describe("toInput", () => {
         ],
       });
     });
+
+    it("does not add cache breakpoints to following messages", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        {
+          messages: [
+            {
+              role: "user",
+              name: "system",
+              content: [{ type: "text", text: "Available skills" }],
+            },
+            ...conversationMessages,
+          ],
+        },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      for (const message of messages.slice(2)) {
+        if ("content" in message && Array.isArray(message.content)) {
+          for (const block of message.content) {
+            expect(block).not.toHaveProperty("prompt_cache_breakpoint");
+          }
+        }
+      }
+    });
   });
 
   it("replays OpenAI tool-search items and skips other providers", () => {

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -48,6 +48,40 @@ describe("toInput", () => {
         ],
       });
     });
+
+    it("does not add a cache breakpoint to a regular leading user message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        { messages: conversationMessages },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages).toEqual(inputMessages);
+    });
+
+    it("does not add a cache breakpoint to a non-leading skills message", () => {
+      const messages = toInput(
+        "You are a helpful assistant.",
+        {
+          messages: [
+            ...conversationMessages,
+            {
+              role: "user",
+              name: "system",
+              content: [{ type: "text", text: "Available skills" }],
+            },
+          ],
+        },
+        "developer",
+        { cacheBreakpointOnLeadingMessage: true }
+      );
+
+      expect(messages.at(-1)).toEqual({
+        role: "user",
+        content: [{ type: "input_text", text: "Available skills" }],
+      });
+    });
   });
 
   it("replays OpenAI tool-search items and skips other providers", () => {

--- a/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/conversation_to_openai.test.ts
@@ -49,17 +49,6 @@ describe("toInput", () => {
       });
     });
 
-    it("does not add a cache breakpoint to a regular leading user message", () => {
-      const messages = toInput(
-        "You are a helpful assistant.",
-        { messages: conversationMessages },
-        "developer",
-        { cacheBreakpointOnLeadingMessage: true }
-      );
-
-      expect(messages).toEqual(inputMessages);
-    });
-
     it("does not add a cache breakpoint to a non-leading skills message", () => {
       const messages = toInput(
         "You are a helpful assistant.",

--- a/front/lib/model_constructors/providers/openai/models/gpt_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five.ts
@@ -34,6 +34,11 @@ export function WithOpenAIGptFiveConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFive;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five.ts
@@ -35,8 +35,8 @@ export function WithOpenAIGptFiveConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
@@ -44,8 +44,8 @@ export function WithOpenAIGptFiveDotFiveConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
@@ -43,6 +43,11 @@ export function WithOpenAIGptFiveDotFiveConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotFive;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -45,6 +45,11 @@ export function WithOpenAIGptFiveDotFourConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotFour;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -46,8 +46,8 @@ export function WithOpenAIGptFiveDotFourConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -50,6 +50,11 @@ export function WithOpenAIGptFiveDotFourMiniConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotFourMini;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -51,8 +51,8 @@ export function WithOpenAIGptFiveDotFourMiniConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -50,6 +50,11 @@ export function WithOpenAIGptFiveDotFourNanoConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotFourNano;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -51,8 +51,8 @@ export function WithOpenAIGptFiveDotFourNanoConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
@@ -38,6 +38,11 @@ export function WithOpenAIGptFiveDotOneConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotOne;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
@@ -39,8 +39,8 @@ export function WithOpenAIGptFiveDotOneConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
@@ -46,8 +46,8 @@ export function WithOpenAIGptFiveDotTwoConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_two.ts
@@ -45,6 +45,11 @@ export function WithOpenAIGptFiveDotTwoConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveDotTwo;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
@@ -41,8 +41,8 @@ export function WithOpenAIGptFiveMiniConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_mini.ts
@@ -40,6 +40,11 @@ export function WithOpenAIGptFiveMiniConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveMini;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
@@ -40,8 +40,8 @@ export function WithOpenAIGptFiveNanoConfig<
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
 
-    // This model rejects explicit prompt cache breakpoints, which are only
-    // supported starting with GPT-5.6.
+    // This model does not support explicit prompt cache breakpoints. They are
+    // only supported starting with GPT-5.6.
     // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
     promptCacheBreakpointFor = () => ({});
   }

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_nano.ts
@@ -39,6 +39,11 @@ export function WithOpenAIGptFiveNanoConfig<
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // This model rejects explicit prompt cache breakpoints, which are only
+    // supported starting with GPT-5.6.
+    // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+    promptCacheBreakpointFor = () => ({});
   }
 
   return OpenAIGptFiveNano;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -41,8 +41,6 @@ export function WithOpenAIResponsesInputConverter<
     implements MessageItemConverters
   {
     systemMessageToInputItem = systemMessageToInputItem;
-    // Prompt-cache support depends on the concrete endpoint model, so the leaf
-    // converter needs its metadata in addition to the provider-agnostic message.
     userTextMessageToInputItem = (message: BaseUserTextMessage) =>
       userTextMessageToInputItem(message, this.metadata());
     userImageMessageToInputItem = userImageMessageToInputItem;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -19,6 +19,7 @@ import {
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import { toToolChoiceInput } from "@app/lib/model_constructors/types/input/configuration";
 import type {
+  BaseUserTextMessage,
   Payload,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
@@ -40,7 +41,8 @@ export function WithOpenAIResponsesInputConverter<
     implements MessageItemConverters
   {
     systemMessageToInputItem = systemMessageToInputItem;
-    userTextMessageToInputItem = userTextMessageToInputItem;
+    userTextMessageToInputItem = (message: BaseUserTextMessage) =>
+      userTextMessageToInputItem(message, this.metadata());
     userImageMessageToInputItem = userImageMessageToInputItem;
     toolCallResultMessageToInputItem = toolCallResultMessageToInputItem;
     assistantTextMessageToInputItem = assistantTextMessageToInputItem;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -8,18 +8,17 @@ import {
   forceToolToToolChoice,
   type MessageItemConverters,
   outputFormatToResponseFormat,
+  promptCacheBreakpointFor,
   reasoningToOpenAIResponsesReasoning,
   systemMessagesToInputItems,
   systemMessageToInputItem,
   toolCallResultMessageToInputItem,
   toolSpecsToOpenAITools,
   userImageMessageToInputItem,
-  userTextMessageToInputItem,
 } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import { toToolChoiceInput } from "@app/lib/model_constructors/types/input/configuration";
 import type {
-  BaseUserTextMessage,
   Payload,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
@@ -40,9 +39,8 @@ export function WithOpenAIResponsesInputConverter<
     extends Base
     implements MessageItemConverters
   {
+    promptCacheBreakpointFor = promptCacheBreakpointFor;
     systemMessageToInputItem = systemMessageToInputItem;
-    userTextMessageToInputItem = (message: BaseUserTextMessage) =>
-      userTextMessageToInputItem(message, this.metadata());
     userImageMessageToInputItem = userImageMessageToInputItem;
     toolCallResultMessageToInputItem = toolCallResultMessageToInputItem;
     assistantTextMessageToInputItem = assistantTextMessageToInputItem;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -41,6 +41,8 @@ export function WithOpenAIResponsesInputConverter<
     implements MessageItemConverters
   {
     systemMessageToInputItem = systemMessageToInputItem;
+    // Prompt-cache support depends on the concrete endpoint model, so the leaf
+    // converter needs its metadata in addition to the provider-agnostic message.
     userTextMessageToInputItem = (message: BaseUserTextMessage) =>
       userTextMessageToInputItem(message, this.metadata());
     userImageMessageToInputItem = userImageMessageToInputItem;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -72,6 +72,21 @@ describe("prompt cache breakpoints", () => {
     });
   });
 
+  it("maps long cache opt-in to the request-wide breakpoint", () => {
+    expect(
+      userTextMessageToInputItem({ ...message, cache: "long" }, metadata)
+    ).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "Available skills",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+      ],
+    });
+  });
+
   it("does not serialize a cache marker for older models", () => {
     expect(
       userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -81,6 +81,51 @@ describe("prompt cache breakpoints", () => {
     ]);
   });
 
+  it("only serializes a cache marker on the leading equipped-skills message", () => {
+    expect(
+      supportedEndpoint.conversationToInput({
+        system: [],
+        messages: [
+          message,
+          {
+            role: "assistant",
+            type: "text",
+            content: { value: "How can I help?" },
+          },
+          {
+            role: "user",
+            type: "text",
+            content: { value: "Use the web search skill." },
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Available skills",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "How can I help?",
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Use the web search skill.",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("maps long cache opt-in to the request-wide breakpoint", () => {
     expect(
       supportedEndpoint.conversationToInput(

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -4,13 +4,20 @@ import {
   assistantTextMessageToInputItem,
   assistantToolCallRequestToInputItem,
   toolSpecsToOpenAITools,
+  userTextMessageToInputItem,
 } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   BaseAssistantProviderPassthroughMessage,
   BaseAssistantReasoningMessage,
   BaseAssistantTextMessage,
   BaseAssistantToolCallRequestMessage,
+  BaseUserTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import {
+  GPT_5_4,
+  GPT_5_6_SOL,
+} from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("assistantTextMessageToInputItem", () => {
@@ -37,6 +44,43 @@ describe("assistantTextMessageToInputItem", () => {
     expect(assistantTextMessageToInputItem(message)).toEqual({
       role: "assistant",
       content: "no phase here",
+    });
+  });
+});
+
+describe("prompt cache breakpoints", () => {
+  const message: BaseUserTextMessage = {
+    role: "user",
+    type: "text",
+    content: { value: "Available skills" },
+    cache: "short",
+  };
+  const metadata: EndpointMetadata = {
+    lab: "openai",
+    host: "openai-responses",
+    region: "us",
+    model: GPT_5_6_SOL,
+  };
+
+  it("serializes a cache marker when explicit prompt caching is supported", () => {
+    expect(userTextMessageToInputItem(message, metadata)).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "Available skills",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+      ],
+    });
+  });
+
+  it("does not serialize a cache marker for older models", () => {
+    expect(
+      userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })
+    ).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "Available skills" }],
     });
   });
 });

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -81,51 +81,6 @@ describe("prompt cache breakpoints", () => {
     ]);
   });
 
-  it("only serializes a cache marker on the leading equipped-skills message", () => {
-    expect(
-      supportedEndpoint.conversationToInput({
-        system: [],
-        messages: [
-          message,
-          {
-            role: "assistant",
-            type: "text",
-            content: { value: "How can I help?" },
-          },
-          {
-            role: "user",
-            type: "text",
-            content: { value: "Use the web search skill." },
-          },
-        ],
-      })
-    ).toEqual([
-      {
-        role: "user",
-        content: [
-          {
-            type: "input_text",
-            text: "Available skills",
-            prompt_cache_breakpoint: { mode: "explicit" },
-          },
-        ],
-      },
-      {
-        role: "assistant",
-        content: "How can I help?",
-      },
-      {
-        role: "user",
-        content: [
-          {
-            type: "input_text",
-            text: "Use the web search skill.",
-          },
-        ],
-      },
-    ]);
-  });
-
   it("maps long cache opt-in to the request-wide breakpoint", () => {
     expect(
       supportedEndpoint.conversationToInput(

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -4,9 +4,9 @@ import {
   assistantTextMessageToInputItem,
   assistantToolCallRequestToInputItem,
   toolSpecsToOpenAITools,
-  userTextMessageToInputItem,
 } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
-import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import { OpenAIGptFiveDotFourGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_four_global_openai_responses";
+import { OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses";
 import type {
   BaseAssistantProviderPassthroughMessage,
   BaseAssistantReasoningMessage,
@@ -14,7 +14,6 @@ import type {
   BaseAssistantToolCallRequestMessage,
   BaseUserTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
-import { GPT_5_4, GPT_5_6_SOL } from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("assistantTextMessageToInputItem", () => {
@@ -52,57 +51,77 @@ describe("prompt cache breakpoints", () => {
     content: { value: "Available skills" },
     cache: "short",
   };
-  const metadata: EndpointMetadata = {
-    lab: "openai",
-    host: "openai-responses",
-    region: "us",
-    model: GPT_5_6_SOL,
-  };
-
-  it("serializes a cache marker when explicit prompt caching is supported", () => {
-    expect(userTextMessageToInputItem(message, metadata)).toEqual({
-      role: "user",
-      content: [
-        {
-          type: "input_text",
-          text: "Available skills",
-          prompt_cache_breakpoint: { mode: "explicit" },
-        },
-      ],
+  const supportedEndpoint =
+    new OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream({
+      OPENAI_API_KEY: "",
     });
+  const unsupportedEndpoint =
+    new OpenAIGptFiveDotFourGlobalOpenAIResponsesStream({
+      OPENAI_API_KEY: "",
+    });
+  const conversationWith = (userMessage: BaseUserTextMessage) => ({
+    system: [],
+    messages: [userMessage],
+  });
+
+  it("serializes a cache marker with the default endpoint converter", () => {
+    expect(
+      supportedEndpoint.conversationToInput(conversationWith(message))
+    ).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Available skills",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ]);
   });
 
   it("maps long cache opt-in to the request-wide breakpoint", () => {
     expect(
-      userTextMessageToInputItem({ ...message, cache: "long" }, metadata)
-    ).toEqual({
-      role: "user",
-      content: [
-        {
-          type: "input_text",
-          text: "Available skills",
-          prompt_cache_breakpoint: { mode: "explicit" },
-        },
-      ],
-    });
+      supportedEndpoint.conversationToInput(
+        conversationWith({ ...message, cache: "long" })
+      )
+    ).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Available skills",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ]);
   });
 
-  it("does not serialize a cache marker for older models", () => {
+  it("uses the endpoint override for models without explicit caching", () => {
     expect(
-      userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })
-    ).toEqual({
-      role: "user",
-      content: [{ type: "input_text", text: "Available skills" }],
-    });
+      unsupportedEndpoint.conversationToInput(conversationWith(message))
+    ).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "Available skills" }],
+      },
+    ]);
   });
 
   it("does not serialize a cache marker when the message has not opted in", () => {
     expect(
-      userTextMessageToInputItem({ ...message, cache: undefined }, metadata)
-    ).toEqual({
-      role: "user",
-      content: [{ type: "input_text", text: "Available skills" }],
-    });
+      supportedEndpoint.conversationToInput(
+        conversationWith({ ...message, cache: undefined })
+      )
+    ).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "Available skills" }],
+      },
+    ]);
   });
 });
 

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -14,10 +14,7 @@ import type {
   BaseAssistantToolCallRequestMessage,
   BaseUserTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
-import {
-  GPT_5_4,
-  GPT_5_6_SOL,
-} from "@app/lib/model_constructors/types/models";
+import { GPT_5_4, GPT_5_6_SOL } from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("assistantTextMessageToInputItem", () => {
@@ -78,6 +75,15 @@ describe("prompt cache breakpoints", () => {
   it("does not serialize a cache marker for older models", () => {
     expect(
       userTextMessageToInputItem(message, { ...metadata, model: GPT_5_4 })
+    ).toEqual({
+      role: "user",
+      content: [{ type: "input_text", text: "Available skills" }],
+    });
+  });
+
+  it("does not serialize a cache marker when the message has not opted in", () => {
+    expect(
+      userTextMessageToInputItem({ ...message, cache: undefined }, metadata)
     ).toEqual({
       role: "user",
       content: [{ type: "input_text", text: "Available skills" }],

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -20,6 +20,7 @@ import type {
   BaseUserImageMessage,
   BaseUserMessage,
   BaseUserTextMessage,
+  CacheOption,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
@@ -28,6 +29,7 @@ import type {
   FunctionTool,
   ResponseFormatTextJSONSchemaConfig,
   ResponseInputItem,
+  ResponseInputText,
   Tool,
   ToolChoiceFunction,
 } from "openai/resources/responses/responses";
@@ -57,6 +59,32 @@ export interface MessageItemConverters {
   ): ResponseInputItem[];
 }
 
+// -- Small, reusable building blocks --
+
+type PromptCacheBreakpoint = NonNullable<
+  ResponseInputText["prompt_cache_breakpoint"]
+>;
+
+// Spreadable fragment adding an explicit breakpoint only when the message opts
+// in and the model supports it. OpenAI applies one request-wide TTL, so both
+// cache durations map to the same wire representation.
+export function promptCacheBreakpointFor(
+  cache: CacheOption | undefined,
+  metadata: EndpointMetadata
+): { prompt_cache_breakpoint: PromptCacheBreakpoint } | Record<string, never> {
+  switch (cache) {
+    case "short":
+    case "long":
+      return supportsOpenAIExplicitPromptCaching(metadata.model)
+        ? { prompt_cache_breakpoint: { mode: "explicit" } }
+        : {};
+    case undefined:
+      return {};
+    default:
+      return assertNever(cache);
+  }
+}
+
 // -- Leaf converters: one Responses input item per message --
 
 // OpenAI uses the "developer" role for the system prompt on reasoning models.
@@ -79,10 +107,7 @@ export function userTextMessageToInputItem(
       {
         type: "input_text",
         text: message.content.value,
-        // OpenAI uses the request-wide TTL; the message cache value opts this block in.
-        ...(message.cache && supportsOpenAIExplicitPromptCaching(metadata.model)
-          ? { prompt_cache_breakpoint: { mode: "explicit" } }
-          : {}),
+        ...promptCacheBreakpointFor(message.cache, metadata),
       },
     ],
   };

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -2,6 +2,7 @@ import {
   OPENAI_TOOL_SEARCH_TOOL,
   parseOpenAIToolSearchItem,
 } from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   OutputFormat,
   Reasoning,
@@ -21,6 +22,7 @@ import type {
   BaseUserTextMessage,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   FunctionTool,
@@ -68,11 +70,21 @@ export function systemMessageToInputItem(
 }
 
 export function userTextMessageToInputItem(
-  message: BaseUserTextMessage
+  message: BaseUserTextMessage,
+  metadata: EndpointMetadata
 ): ResponseInputItem {
   return {
     role: "user",
-    content: [{ type: "input_text", text: message.content.value }],
+    content: [
+      {
+        type: "input_text",
+        text: message.content.value,
+        // OpenAI uses the request-wide TTL; the message cache value opts this block in.
+        ...(message.cache && supportsOpenAIExplicitPromptCaching(metadata.model)
+          ? { prompt_cache_breakpoint: { mode: "explicit" } }
+          : {}),
+      },
+    ],
   };
 }
 

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -61,17 +61,15 @@ export interface MessageItemConverters {
 
 // -- Small, reusable building blocks --
 
-type PromptCacheBreakpoint = NonNullable<
-  ResponseInputText["prompt_cache_breakpoint"]
->;
-
 // Spreadable fragment adding an explicit breakpoint only when the message opts
 // in and the model supports it. OpenAI applies one request-wide TTL, so both
 // cache durations map to the same wire representation.
 export function promptCacheBreakpointFor(
   cache: CacheOption | undefined,
   metadata: EndpointMetadata
-): { prompt_cache_breakpoint: PromptCacheBreakpoint } | Record<string, never> {
+): { prompt_cache_breakpoint: NonNullable<
+    ResponseInputText["prompt_cache_breakpoint"]
+  > } | Record<string, never> {
   switch (cache) {
     case "short":
     case "long":

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -78,10 +78,10 @@ export function promptCacheBreakpointFor(
     case "short":
     case "long":
       return supportsOpenAIExplicitPromptCaching(metadata.model)
-        // Link to the doc: https://developers.openai.com/api/docs/guides/prompt-caching
-        // We can create up to 4 new cache writes (i.e. 4 cache breakpoints).
-        // We can't control the TTL, it's set to 30min (they may change this in the future).
-        ? { prompt_cache_breakpoint: { mode: "explicit" } }
+        ? // Link to the doc: https://developers.openai.com/api/docs/guides/prompt-caching
+          // We can create up to 4 new cache writes (i.e. 4 cache breakpoints).
+          // We can't control the TTL, it's set to 30min (they may change this in the future).
+          { prompt_cache_breakpoint: { mode: "explicit" } }
         : {};
     case undefined:
       return {};

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -78,6 +78,9 @@ export function promptCacheBreakpointFor(
     case "short":
     case "long":
       return supportsOpenAIExplicitPromptCaching(metadata.model)
+        // Link to the doc: https://developers.openai.com/api/docs/guides/prompt-caching
+        // We can create up to 4 new cache writes (i.e. 4 cache breakpoints).
+        // We can't control the TTL, it's set to 30min (they may change this in the future).
         ? { prompt_cache_breakpoint: { mode: "explicit" } }
         : {};
     case undefined:

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -67,9 +67,13 @@ export interface MessageItemConverters {
 export function promptCacheBreakpointFor(
   cache: CacheOption | undefined,
   metadata: EndpointMetadata
-): { prompt_cache_breakpoint: NonNullable<
-    ResponseInputText["prompt_cache_breakpoint"]
-  > } | Record<string, never> {
+):
+  | {
+      prompt_cache_breakpoint: NonNullable<
+        ResponseInputText["prompt_cache_breakpoint"]
+      >;
+    }
+  | Record<string, never> {
   switch (cache) {
     case "short":
     case "long":

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -2,7 +2,6 @@ import {
   OPENAI_TOOL_SEARCH_TOOL,
   parseOpenAIToolSearchItem,
 } from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
-import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   OutputFormat,
   Reasoning,
@@ -23,7 +22,6 @@ import type {
   CacheOption,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
-import { supportsOpenAIExplicitPromptCaching } from "@app/lib/model_constructors/types/models";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   FunctionTool,
@@ -35,12 +33,19 @@ import type {
 } from "openai/resources/responses/responses";
 import type { Reasoning as OpenAIReasoning } from "openai/resources/shared";
 
+type PromptCacheBreakpoint =
+  | {
+      prompt_cache_breakpoint: NonNullable<
+        ResponseInputText["prompt_cache_breakpoint"]
+      >;
+    }
+  | Record<string, never>;
+
 // The per-message leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
 // every composite uses it.
 export interface MessageItemConverters {
   systemMessageToInputItem(message: SystemTextMessage): ResponseInputItem;
-  userTextMessageToInputItem(message: BaseUserTextMessage): ResponseInputItem;
   userImageMessageToInputItem(message: BaseUserImageMessage): ResponseInputItem;
   toolCallResultMessageToInputItem(
     message: BaseToolCallResultMessage
@@ -57,6 +62,9 @@ export interface MessageItemConverters {
   assistantProviderPassthroughMessageToInputItems(
     message: BaseAssistantProviderPassthroughMessage
   ): ResponseInputItem[];
+  promptCacheBreakpointFor(
+    cache: CacheOption | undefined
+  ): PromptCacheBreakpoint;
 }
 
 // -- Small, reusable building blocks --
@@ -65,24 +73,15 @@ export interface MessageItemConverters {
 // in and the model supports it. OpenAI applies one request-wide TTL, so both
 // cache durations map to the same wire representation.
 export function promptCacheBreakpointFor(
-  cache: CacheOption | undefined,
-  metadata: EndpointMetadata
-):
-  | {
-      prompt_cache_breakpoint: NonNullable<
-        ResponseInputText["prompt_cache_breakpoint"]
-      >;
-    }
-  | Record<string, never> {
+  cache: CacheOption | undefined
+): PromptCacheBreakpoint {
   switch (cache) {
     case "short":
     case "long":
-      return supportsOpenAIExplicitPromptCaching(metadata.model)
-        ? // Link to the doc: https://developers.openai.com/api/docs/guides/prompt-caching
-          // We can create up to 4 new cache writes (i.e. 4 cache breakpoints).
-          // We can't control the TTL, it's set to 30min (they may change this in the future).
-          { prompt_cache_breakpoint: { mode: "explicit" } }
-        : {};
+      // Link to the doc: https://developers.openai.com/api/docs/guides/prompt-caching
+      // We can create up to 4 new cache writes (i.e. 4 cache breakpoints).
+      // We can't control the TTL, it's set to 30min (they may change this in the future).
+      return { prompt_cache_breakpoint: { mode: "explicit" } };
     case undefined:
       return {};
     default:
@@ -104,7 +103,7 @@ export function systemMessageToInputItem(
 
 export function userTextMessageToInputItem(
   message: BaseUserTextMessage,
-  metadata: EndpointMetadata
+  converters: MessageItemConverters
 ): ResponseInputItem {
   return {
     role: "user",
@@ -112,7 +111,7 @@ export function userTextMessageToInputItem(
       {
         type: "input_text",
         text: message.content.value,
-        ...promptCacheBreakpointFor(message.cache, metadata),
+        ...converters.promptCacheBreakpointFor(message.cache),
       },
     ],
   };
@@ -217,7 +216,7 @@ export function userMessageToInputItems(
 ): ResponseInputItem[] {
   switch (message.type) {
     case "text":
-      return [converters.userTextMessageToInputItem(message)];
+      return [userTextMessageToInputItem(message, converters)];
     case "image_url":
       return [converters.userImageMessageToInputItem(message)];
     case "tool_call_result":

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -99,6 +99,8 @@ const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
 export function supportsOpenAIExplicitPromptCaching(
   model: OpenAIWhitelistedModelId | Model
 ): boolean {
+  // The legacy OpenAI client and model_constructors use distinct model-ID
+  // unions. Compare their values without widening the Model-only support list.
   return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.some(
     (supportedModel) => supportedModel === model
   );

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -88,7 +88,7 @@ export function isModel(value: string): value is Model {
   return (MODELS as readonly string[]).includes(value);
 }
 
-// Older models reject explicit prompt cache breakpoints.
+// Models older than 5.6 do not support explicit cache breakpoints.
 // https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
 const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
   GPT_5_6_SOL,
@@ -99,8 +99,6 @@ const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
 export function supportsOpenAIExplicitPromptCaching(
   model: OpenAIWhitelistedModelId | Model
 ): boolean {
-  // The legacy OpenAI client and model_constructors use distinct model-ID
-  // unions. Compare their values without widening the Model-only support list.
   return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.some(
     (supportedModel) => supportedModel === model
   );

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -86,6 +86,18 @@ export function isModel(value: string): value is Model {
   return (MODELS as readonly string[]).includes(value);
 }
 
+// Older models reject explicit prompt cache breakpoints.
+// https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
+const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
+  GPT_5_6_SOL,
+  GPT_5_6_TERRA,
+  GPT_5_6_LUNA,
+];
+
+export function supportsOpenAIExplicitPromptCaching(model: Model): boolean {
+  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.includes(model);
+}
+
 export const ORDERED_LARGE_MODELS = [
   CLAUDE_FABLE_5,
   CLAUDE_OPUS_4_8,

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -1,3 +1,5 @@
+import type { OpenAIWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
+
 export const GPT_5_6_SOL = "gpt-5.6-sol" as const;
 export const GPT_5_6_TERRA = "gpt-5.6-terra" as const;
 export const GPT_5_6_LUNA = "gpt-5.6-luna" as const;
@@ -94,8 +96,12 @@ const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
   GPT_5_6_LUNA,
 ];
 
-export function supportsOpenAIExplicitPromptCaching(model: Model): boolean {
-  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.includes(model);
+export function supportsOpenAIExplicitPromptCaching(
+  model: OpenAIWhitelistedModelId | Model
+): boolean {
+  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.some(
+    (supportedModel) => supportedModel === model
+  );
 }
 
 export const ORDERED_LARGE_MODELS = [

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -1,5 +1,3 @@
-import type { OpenAIWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
-
 export const GPT_5_6_SOL = "gpt-5.6-sol" as const;
 export const GPT_5_6_TERRA = "gpt-5.6-terra" as const;
 export const GPT_5_6_LUNA = "gpt-5.6-luna" as const;
@@ -86,22 +84,6 @@ export type Model = (typeof MODELS)[number];
 
 export function isModel(value: string): value is Model {
   return (MODELS as readonly string[]).includes(value);
-}
-
-// Models older than 5.6 do not support explicit cache breakpoints.
-// https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints
-const OPENAI_EXPLICIT_PROMPT_CACHING_MODELS: readonly Model[] = [
-  GPT_5_6_SOL,
-  GPT_5_6_TERRA,
-  GPT_5_6_LUNA,
-];
-
-export function supportsOpenAIExplicitPromptCaching(
-  model: OpenAIWhitelistedModelId | Model
-): boolean {
-  return OPENAI_EXPLICIT_PROMPT_CACHING_MODELS.some(
-    (supportedModel) => supportedModel === model
-  );
 }
 
 export const ORDERED_LARGE_MODELS = [


### PR DESCRIPTION
## Description

Goal is to add a cache breakpoint for the equipped skills (contained in a user message) for OpenAI models. This part is much more stable than the rest of the conversation, as it can be typically shared across.

This is the same as what we currently do for Anthropic models.

Only works for GPT-5.6 models as per their doc.

Link to the doc https://developers.openai.com/api/docs/guides/prompt-caching

Tested [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3B5sgVosqPS4&peek=be95a9d69821ed81b387732a82211d53&timestamp=2026-07-21T14%3A50%3A12.512Z&observation=b880b8e5006e8fa7)
Tested [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3B9jPVLycLcG&peek=33eb6ff1b8c8ba1e4588cf9d151921d0&timestamp=2026-07-21T21%3A33%3A07.963Z&observation=89afcd8be1c0541b) that we don't add a breakpoint on older models.

## Tests

- Added test that check where the breakpoint is placed.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
