### PR TITLE
[LLM] tag llm events with router in datadog

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -52,6 +52,8 @@ export abstract class LLM<TPayload = unknown> {
   protected responseFormat: string | null;
   protected bypassFeatureFlag: boolean;
   protected metadata: LLMClientMetadata;
+  // Temporary during the router migration; "new" is set by BaseTransition.
+  protected readonly router: "legacy" | "new" = "legacy";
 
   // Tracing fields.
   protected readonly authenticator: Authenticator;
@@ -270,6 +272,7 @@ export abstract class LLM<TPayload = unknown> {
           logger.error(
             {
               llmEventType: "error",
+              router: this.router,
               errorContent: currentEvent.content,
               modelId: this.modelId,
               inferenceProvider: this.metadata.inferenceProvider,
@@ -288,6 +291,7 @@ export abstract class LLM<TPayload = unknown> {
           logger.info(
             {
               llmEventType: "success",
+              router: this.router,
               modelId: this.modelId,
               inferenceProvider: this.metadata.inferenceProvider,
               region: this.metadata.region,

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -658,6 +658,8 @@ function legacyProviderIdForModel(modelId: ModelIdType): ModelProviderIdType {
  * `BatchEndpointTransition` for batch — mirroring `StreamEndpoint`/`BatchEndpoint`.
  */
 abstract class BaseTransition extends LLM {
+  protected override readonly router = "new" as const;
+
   // Builds the provider-agnostic conversation payload (system + messages) shared
   // by both the streaming and batch surfaces.
   //


### PR DESCRIPTION
## Description

Add a `router: "legacy" | "new"` field to the `llmEvent` success/error logs so Datadog can tell whether a model interaction was served by the legacy router or the new `model_constructors` router.

## Tests

Not needed. Type-checks clean; log-field-only change.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`