### PR TITLE
feat(front): add Quick and Deep model stream routing

### DIFF
--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -55,6 +55,12 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   auto: {
     light: DustLogo,
   },
+  auto_quick: {
+    light: DustLogo,
+  },
+  auto_deep: {
+    light: DustLogo,
+  },
 };
 
 export const getModelProviderLogo = (

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -55,10 +55,10 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   auto: {
     light: DustLogo,
   },
-  auto_quick: {
+  auto_fast: {
     light: DustLogo,
   },
-  auto_deep: {
+  auto_complex: {
     light: DustLogo,
   },
 };

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -397,7 +397,7 @@ describe("resolveModel", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await FeatureFlagFactory.basic(auth, "models_picker");
 
-    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
@@ -407,7 +407,9 @@ describe("resolveModel", () => {
       featureFlags: ["models_picker"],
     });
 
-    expect(getAutoModelSpy).toHaveBeenCalledOnce();
+    // `auto` is a stream like `auto_fast` / `auto_complex`: it routes through
+    // getModelForStream and resolves to its first available candidate.
+    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
@@ -423,7 +425,7 @@ describe("resolveModel", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await FeatureFlagFactory.basic(auth, "models_picker");
 
-    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       selection: {
@@ -437,7 +439,7 @@ describe("resolveModel", () => {
       featureFlags: ["models_picker"],
     });
 
-    expect(getAutoModelSpy).toHaveBeenCalledOnce();
+    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({

--- a/front/lib/api/assistant/provider_whitelist.ts
+++ b/front/lib/api/assistant/provider_whitelist.ts
@@ -1,7 +1,4 @@
-import {
-  AUTO_MODEL_ID,
-  isModelStreamId,
-} from "@app/types/assistant/models/auto";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 // Canonical way to check if a provider is whitelisted.
@@ -11,9 +8,5 @@ export function isProviderWhitelisted(
   whitelistedProviders: Set<ModelProviderIdType>,
   providerId: ModelProviderIdType
 ): boolean {
-  return (
-    providerId === AUTO_MODEL_ID ||
-    isModelStreamId(providerId) ||
-    whitelistedProviders.has(providerId)
-  );
+  return isModelStreamId(providerId) || whitelistedProviders.has(providerId);
 }

--- a/front/lib/api/assistant/provider_whitelist.ts
+++ b/front/lib/api/assistant/provider_whitelist.ts
@@ -5,7 +5,7 @@ import {
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 // Canonical way to check if a provider is whitelisted.
-// Handle the special case of the routing sentinels (auto, auto_quick, auto_deep),
+// Handle the special case of the routing sentinels (auto, auto_fast, auto_complex),
 // which route to a concrete (whitelisted) model at message-send time.
 export function isProviderWhitelisted(
   whitelistedProviders: Set<ModelProviderIdType>,

--- a/front/lib/api/assistant/provider_whitelist.ts
+++ b/front/lib/api/assistant/provider_whitelist.ts
@@ -1,11 +1,19 @@
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import {
+  AUTO_MODEL_ID,
+  isModelStreamId,
+} from "@app/types/assistant/models/auto";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 // Canonical way to check if a provider is whitelisted.
-// Handle the special case of the auto model.
+// Handle the special case of the routing sentinels (auto and stream tiers),
+// which route to a concrete (whitelisted) model at message-send time.
 export function isProviderWhitelisted(
   whitelistedProviders: Set<ModelProviderIdType>,
   providerId: ModelProviderIdType
 ): boolean {
-  return providerId === AUTO_MODEL_ID || whitelistedProviders.has(providerId);
+  return (
+    providerId === AUTO_MODEL_ID ||
+    isModelStreamId(providerId) ||
+    whitelistedProviders.has(providerId)
+  );
 }

--- a/front/lib/api/assistant/provider_whitelist.ts
+++ b/front/lib/api/assistant/provider_whitelist.ts
@@ -5,7 +5,7 @@ import {
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 // Canonical way to check if a provider is whitelisted.
-// Handle the special case of the routing sentinels (auto and stream tiers),
+// Handle the special case of the routing sentinels (auto, auto_quick, auto_deep),
 // which route to a concrete (whitelisted) model at message-send time.
 export function isProviderWhitelisted(
   whitelistedProviders: Set<ModelProviderIdType>,

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,9 +1,15 @@
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import { getAutoModelForAuth } from "@app/lib/model_tiers/enabled_models";
+import {
+  getAutoModelForAuth,
+  getModelForStream,
+} from "@app/lib/model_tiers/enabled_models";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import {
+  AUTO_MODEL_ID,
+  isModelStreamId,
+} from "@app/types/assistant/models/auto";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
@@ -72,22 +78,38 @@ export async function resolveModel(
     }
   );
 
+  // Effort chosen by a stream tier (Quick/Deep) for its resolved model. When set,
+  // it takes precedence over any effort carried by the (sentinel) selection.
+  let streamEffort: ReasoningEffort | undefined;
+
   if (enabled?.modelId === AUTO_MODEL_ID) {
     // Alternatively, we could remove the agent config from the list of candidates and let the auto model fallback to a supported model by the workspace.
     // However, to be future-proof, we keep do it here to allow evolution on the way the auto model is selected.
     enabled = await getAutoModelForAuth(auth);
     modelResolutionMethod = "auto";
+  } else if (enabled && isModelStreamId(enabled.modelId)) {
+    const streamId = enabled.modelId;
+    const resolved = await getModelForStream(auth, streamId);
+    if (resolved) {
+      enabled = resolved.model;
+      streamEffort = resolved.reasoningEffort;
+    } else {
+      // None of the stream's candidates are available: fall back to auto.
+      enabled = await getAutoModelForAuth(auth);
+    }
+    modelResolutionMethod = streamId;
   }
 
   // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.
   assert(enabled, "No enabled model found");
 
-  const requestedReasoningEffort = selection
-    ? selection.reasoningEffort
-    : configuration.model.reasoningEffort;
+  // A stream tier dictates the effort of its resolved model. Otherwise honor the
+  // selected or agent-configured effort only if the resolved model supports it
+  // (raw API clients can send an unsupported effort); fall back to its default.
+  const requestedReasoningEffort =
+    streamEffort ??
+    (selection ? selection.reasoningEffort : configuration.model.reasoningEffort);
 
-  // Honor the selected or agent-configured effort only if the resolved model
-  // supports it. Raw API clients can send an unsupported effort.
   const effort =
     requestedReasoningEffort &&
     enabled.supportedReasoningEfforts[requestedReasoningEffort]

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -6,10 +6,7 @@ import {
   getModelForStream,
 } from "@app/lib/model_tiers/enabled_models";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import {
-  AUTO_MODEL_ID,
-  isModelStreamId,
-} from "@app/types/assistant/models/auto";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
@@ -82,19 +79,17 @@ export async function resolveModel(
   // it takes precedence over any effort carried by the (sentinel) selection.
   let streamEffort: ReasoningEffort | undefined;
 
-  if (enabled?.modelId === AUTO_MODEL_ID) {
-    // Alternatively, we could remove the agent config from the list of candidates and let the auto model fallback to a supported model by the workspace.
-    // However, to be future-proof, we keep do it here to allow evolution on the way the auto model is selected.
-    enabled = await getAutoModelForAuth(auth);
-    modelResolutionMethod = "auto";
-  } else if (enabled && isModelStreamId(enabled.modelId)) {
+  // `auto`, `auto_fast` and `auto_complex` are all streams: walk the stream's
+  // ordered candidate pool and pick the first one available to the workspace.
+  if (enabled && isModelStreamId(enabled.modelId)) {
     const streamId = enabled.modelId;
     const resolved = await getModelForStream(auth, streamId);
     if (resolved) {
       enabled = resolved.model;
       streamEffort = resolved.reasoningEffort;
     } else {
-      // None of the stream's candidates are available: fall back to auto.
+      // None of the stream's candidates are available: fall back to a preferred
+      // large model supported by the workspace.
       enabled = await getAutoModelForAuth(auth);
     }
     modelResolutionMethod = streamId;

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -108,7 +108,9 @@ export async function resolveModel(
   // (raw API clients can send an unsupported effort); fall back to its default.
   const requestedReasoningEffort =
     streamEffort ??
-    (selection ? selection.reasoningEffort : configuration.model.reasoningEffort);
+    (selection
+      ? selection.reasoningEffort
+      : configuration.model.reasoningEffort);
 
   const effort =
     requestedReasoningEffort &&

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -434,6 +434,16 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 0,
     cache_read_input_tokens: 0,
   },
+  auto_quick: {
+    input: 0,
+    output: 0,
+    cache_read_input_tokens: 0,
+  },
+  auto_deep: {
+    input: 0,
+    output: 0,
+    cache_read_input_tokens: 0,
+  },
 };
 
 const IMAGE_MODEL_PRICING: Record<string, PricingEntry> = {

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -434,12 +434,12 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 0,
     cache_read_input_tokens: 0,
   },
-  auto_quick: {
+  auto_fast: {
     input: 0,
     output: 0,
     cache_read_input_tokens: 0,
   },
-  auto_deep: {
+  auto_complex: {
     input: 0,
     output: 0,
     cache_read_input_tokens: 0,

--- a/front/lib/api/assistant/token_pricing/static_model_reasoning_efforts.ts
+++ b/front/lib/api/assistant/token_pricing/static_model_reasoning_efforts.ts
@@ -448,4 +448,16 @@ export const STATIC_MODEL_SUPPORTED_REASONING_EFFORTS = {
     medium: false,
     high: false,
   },
+  auto_quick: {
+    none: true,
+    light: false,
+    medium: false,
+    high: false,
+  },
+  auto_deep: {
+    none: true,
+    light: false,
+    medium: false,
+    high: false,
+  },
 } as const satisfies Record<StaticModelIdType, ReasoningEffortSupport>;

--- a/front/lib/api/assistant/token_pricing/static_model_reasoning_efforts.ts
+++ b/front/lib/api/assistant/token_pricing/static_model_reasoning_efforts.ts
@@ -448,13 +448,13 @@ export const STATIC_MODEL_SUPPORTED_REASONING_EFFORTS = {
     medium: false,
     high: false,
   },
-  auto_quick: {
+  auto_fast: {
     none: true,
     light: false,
     medium: false,
     high: false,
   },
-  auto_deep: {
+  auto_complex: {
     none: true,
     light: false,
     medium: false,

--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -392,10 +392,10 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   auto: {
     none: "balanced",
   },
-  auto_quick: {
+  auto_fast: {
     none: "balanced",
   },
-  auto_deep: {
+  auto_complex: {
     none: "balanced",
   },
 } satisfies StaticModelTiersMap;

--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -392,4 +392,10 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   auto: {
     none: "balanced",
   },
+  auto_quick: {
+    none: "balanced",
+  },
+  auto_deep: {
+    none: "balanced",
+  },
 } satisfies StaticModelTiersMap;

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -341,6 +341,8 @@ const PROVIDER_ID_TO_LAB: Record<ModelProviderIdType, Lab | null> = {
   xai: "xai",
   noop: "noop",
   auto: null,
+  auto_quick: null,
+  auto_deep: null,
 };
 
 const PROVIDER_ID_TO_HOST: Record<ModelProviderIdType, Host | null> = {
@@ -353,6 +355,8 @@ const PROVIDER_ID_TO_HOST: Record<ModelProviderIdType, Host | null> = {
   xai: null,
   noop: null,
   auto: null,
+  auto_quick: null,
+  auto_deep: null,
 };
 
 // Whitelisting is keyed on the legacy provider id, which conflates a model's

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -341,8 +341,8 @@ const PROVIDER_ID_TO_LAB: Record<ModelProviderIdType, Lab | null> = {
   xai: "xai",
   noop: "noop",
   auto: null,
-  auto_quick: null,
-  auto_deep: null,
+  auto_fast: null,
+  auto_complex: null,
 };
 
 const PROVIDER_ID_TO_HOST: Record<ModelProviderIdType, Host | null> = {
@@ -355,8 +355,8 @@ const PROVIDER_ID_TO_HOST: Record<ModelProviderIdType, Host | null> = {
   xai: null,
   noop: null,
   auto: null,
-  auto_quick: null,
-  auto_deep: null,
+  auto_fast: null,
+  auto_complex: null,
 };
 
 // Whitelisting is keyed on the legacy provider id, which conflates a model's

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -243,8 +243,8 @@ const USERFACING_CLIENT_ID: Record<ModelProviderIdType, string> = {
   google_ai_studio: "Google AI Studio",
   noop: "Noop",
   auto: "Auto",
-  auto_quick: "Quick",
-  auto_deep: "Deep",
+  auto_fast: "Fast",
+  auto_complex: "Complex",
 };
 
 /**

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -243,6 +243,8 @@ const USERFACING_CLIENT_ID: Record<ModelProviderIdType, string> = {
   google_ai_studio: "Google AI Studio",
   noop: "Noop",
   auto: "Auto",
+  auto_quick: "Quick",
+  auto_deep: "Deep",
 };
 
 /**

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -24,8 +24,8 @@ export function providerToProfile(
     case "fireworks":
     case "noop":
     case "auto":
-    case "auto_quick":
-    case "auto_deep":
+    case "auto_fast":
+    case "auto_complex":
       return "anthropic";
     default:
       assertNever(providerId);

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -24,6 +24,8 @@ export function providerToProfile(
     case "fireworks":
     case "noop":
     case "auto":
+    case "auto_quick":
+    case "auto_deep":
       return "anthropic";
     default:
       assertNever(providerId);

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -1,5 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
-import { withModelSelectability } from "@app/lib/model_tiers/enabled_models";
+import {
+  getModelForStream,
+  withModelSelectability,
+} from "@app/lib/model_tiers/enabled_models";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -7,8 +10,11 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+  CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { MODEL_STREAMS } from "@app/types/assistant/models/auto";
+import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -147,5 +153,45 @@ describe("withModelSelectability", () => {
     expect(model.supportedReasoningEfforts).toEqual(
       CUSTOM_MODEL_CONFIG.supportedReasoningEfforts
     );
+  });
+});
+
+describe("getModelForStream", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+  });
+
+  it("routes the Quick stream to its first available candidate + effort", async () => {
+    const resolved = await getModelForStream(adminAuth, "auto_quick");
+
+    expect(resolved).not.toBeNull();
+    // In a full workspace every candidate is available, so the first one wins.
+    expect(resolved?.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
+    expect(resolved?.reasoningEffort).toBe("light");
+  });
+
+  it("routes the Deep stream to its first available candidate + effort", async () => {
+    const resolved = await getModelForStream(adminAuth, "auto_deep");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_4_8_MODEL_ID);
+    expect(resolved?.reasoningEffort).toBe("high");
+  });
+
+  it("only ever resolves to a candidate declared in the stream", async () => {
+    for (const streamId of ["auto_quick", "auto_deep"] as const) {
+      const resolved = await getModelForStream(adminAuth, streamId);
+      const candidate = MODEL_STREAMS[streamId].find(
+        (c) =>
+          c.modelId === resolved?.model.modelId &&
+          c.reasoningEffort === resolved?.reasoningEffort
+      );
+      expect(candidate).toBeDefined();
+    }
   });
 });

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -166,6 +166,28 @@ describe("getModelForStream", () => {
     await FeatureFlagFactory.basic(adminAuth, "models_picker");
   });
 
+  async function userAuthForTierCap(tierName: "cost_efficient" | "balanced") {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await ModelsTierResource.setUserMaxAllowedTier(adminAuth, {
+      userId: user.sId,
+      tierName,
+    });
+
+    return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  }
+
+  it("routes the Auto stream to its first available candidate + effort", async () => {
+    const resolved = await getModelForStream(adminAuth, "auto");
+
+    expect(resolved).not.toBeNull();
+    // In a full workspace every candidate is available, so the first one wins.
+    expect(resolved?.model.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    expect(resolved?.reasoningEffort).toBe("medium");
+  });
+
   it("routes the Quick stream to its first available candidate + effort", async () => {
     const resolved = await getModelForStream(adminAuth, "auto_fast");
 
@@ -183,8 +205,23 @@ describe("getModelForStream", () => {
     expect(resolved?.reasoningEffort).toBe("high");
   });
 
+  it("keeps a cost-effective candidate in the Deep stream for cost_efficient-capped users", async () => {
+    const auth = await userAuthForTierCap("cost_efficient");
+
+    // Every premium/balanced candidate is unavailable under a cost_efficient
+    // cap, so the stream must still resolve to its cost-effective floor rather
+    // than returning null and dropping out of the Deep stream entirely.
+    const resolved = await getModelForStream(auth, "auto_complex");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.model.modelId).toBe(
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+    );
+    expect(resolved?.reasoningEffort).toBe("light");
+  });
+
   it("only ever resolves to a candidate declared in the stream", async () => {
-    for (const streamId of ["auto_fast", "auto_complex"] as const) {
+    for (const streamId of ["auto", "auto_fast", "auto_complex"] as const) {
       const resolved = await getModelForStream(adminAuth, streamId);
       const candidate = MODEL_STREAMS[streamId].find(
         (c) =>

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -188,7 +188,7 @@ describe("getModelForStream", () => {
     expect(resolved?.reasoningEffort).toBe("medium");
   });
 
-  it("routes the Quick stream to its first available candidate + effort", async () => {
+  it("routes the Fast stream to its first available candidate + effort", async () => {
     const resolved = await getModelForStream(adminAuth, "auto_fast");
 
     expect(resolved).not.toBeNull();
@@ -197,7 +197,7 @@ describe("getModelForStream", () => {
     expect(resolved?.reasoningEffort).toBe("light");
   });
 
-  it("routes the Deep stream to its first available candidate + effort", async () => {
+  it("routes the Complex stream to its first available candidate + effort", async () => {
     const resolved = await getModelForStream(adminAuth, "auto_complex");
 
     expect(resolved).not.toBeNull();
@@ -205,12 +205,12 @@ describe("getModelForStream", () => {
     expect(resolved?.reasoningEffort).toBe("high");
   });
 
-  it("keeps a cost-effective candidate in the Deep stream for cost_efficient-capped users", async () => {
+  it("keeps a cost-effective candidate in the Complex stream for cost_efficient-capped users", async () => {
     const auth = await userAuthForTierCap("cost_efficient");
 
     // Every premium/balanced candidate is unavailable under a cost_efficient
     // cap, so the stream must still resolve to its cost-effective floor rather
-    // than returning null and dropping out of the Deep stream entirely.
+    // than returning null and dropping out of the Complex stream entirely.
     const resolved = await getModelForStream(auth, "auto_complex");
 
     expect(resolved).not.toBeNull();

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -167,7 +167,7 @@ describe("getModelForStream", () => {
   });
 
   it("routes the Quick stream to its first available candidate + effort", async () => {
-    const resolved = await getModelForStream(adminAuth, "auto_quick");
+    const resolved = await getModelForStream(adminAuth, "auto_fast");
 
     expect(resolved).not.toBeNull();
     // In a full workspace every candidate is available, so the first one wins.
@@ -176,7 +176,7 @@ describe("getModelForStream", () => {
   });
 
   it("routes the Deep stream to its first available candidate + effort", async () => {
-    const resolved = await getModelForStream(adminAuth, "auto_deep");
+    const resolved = await getModelForStream(adminAuth, "auto_complex");
 
     expect(resolved).not.toBeNull();
     expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_4_8_MODEL_ID);
@@ -184,7 +184,7 @@ describe("getModelForStream", () => {
   });
 
   it("only ever resolves to a candidate declared in the stream", async () => {
-    for (const streamId of ["auto_quick", "auto_deep"] as const) {
+    for (const streamId of ["auto_fast", "auto_complex"] as const) {
       const resolved = await getModelForStream(adminAuth, streamId);
       const candidate = MODEL_STREAMS[streamId].find(
         (c) =>

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -8,10 +8,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import { AUTO_MODEL_ID, MODEL_STREAMS } from "@app/types/assistant/models/auto";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type {
   ModelConfigurationType,
+  ReasoningEffort,
   ReasoningEffortSupport,
 } from "@app/types/assistant/models/types";
 import { getMaximumReasoningEffort } from "@app/types/assistant/models/types";
@@ -120,6 +122,36 @@ export async function getAutoModelForAuth(
   return {
     ...pickPreferredLargeModel(availableModels.filter((m) => m.isSelectable)),
   };
+}
+
+// Resolve a stream tier (Quick/Deep) to a concrete model + reasoning effort.
+// Walks the stream's ordered candidate pool and picks the first one available
+// (selectable) to the workspace that supports the requested effort. Returns null
+// when none of the stream's candidates are available — the caller falls back to
+// the auto model.
+export async function getModelForStream(
+  auth: Authenticator,
+  streamId: ModelStreamIdType
+): Promise<{
+  model: EnabledModelConfigurationType;
+  reasoningEffort: ReasoningEffort;
+} | null> {
+  const availableModels = await getEnabledModelsForAuth(auth);
+
+  for (const candidate of MODEL_STREAMS[streamId]) {
+    const model = availableModels.find(
+      (m) =>
+        m.isSelectable &&
+        m.providerId === candidate.providerId &&
+        m.modelId === candidate.modelId &&
+        m.supportedReasoningEfforts[candidate.reasoningEffort]
+    );
+    if (model) {
+      return { model, reasoningEffort: candidate.reasoningEffort };
+    }
+  }
+
+  return null;
 }
 
 export async function getModelsForAuth(auth: Authenticator): Promise<{

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -53,7 +53,7 @@ export type AgentProviderPassthroughContentType = {
     // completed for other lab support.
     provider: Exclude<
       ModelProviderIdType,
-      "xai" | "fireworks" | "auto" | "auto_quick" | "auto_deep"
+      "xai" | "fireworks" | "auto" | "auto_fast" | "auto_complex"
     >;
     block: unknown;
   };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -51,7 +51,10 @@ export type AgentProviderPassthroughContentType = {
   value: {
     // Anthropic feature only for now. Need split between host and lab to be
     // completed for other lab support.
-    provider: Exclude<ModelProviderIdType, "xai" | "fireworks" | "auto">;
+    provider: Exclude<
+      ModelProviderIdType,
+      "xai" | "fireworks" | "auto" | "auto_quick" | "auto_deep"
+    >;
     block: unknown;
   };
 };

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -1,37 +1,163 @@
-import type { ModelConfigurationType } from "./types";
+import {
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "./anthropic";
+import {
+  GEMINI_3_1_FLASH_LITE_MODEL_ID,
+  GEMINI_3_1_PRO_MODEL_ID,
+} from "./google_ai_studio";
+import { MISTRAL_LARGE_MODEL_ID, MISTRAL_SMALL_MODEL_ID } from "./mistral";
+import { GPT_5_6_LUNA_MODEL_ID, GPT_5_6_SOL_MODEL_ID } from "./openai";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+  ReasoningEffort,
+} from "./types";
 
+// Auto-routing meta-models: sentinels that do not name a concrete model but are
+// resolved to one at message-send time. `auto` lets Dust pick any available
+// model; `auto_quick` / `auto_deep` route among a curated pool (a "stream").
+// Both the provider id and the model id of a meta-model are the sentinel string.
 export const AUTO_MODEL_ID = "auto" as const;
-export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
-  providerId: AUTO_MODEL_ID,
-  modelId: AUTO_MODEL_ID,
-  displayName: "Auto",
-  description: "Let's Dust select the best model for the task.",
-  shortDescription: "Select the best model for the task.",
+export const AUTO_QUICK_MODEL_ID = "auto_quick" as const;
+export const AUTO_DEEP_MODEL_ID = "auto_deep" as const;
 
-  // Everything below is just some value to make it compatible with the ModelConfigurationType.
-  // This model configuration will be dynamically routed to the best model for the task.
-  contextSize: 1_000_000,
-  recommendedTopK: 64,
-  recommendedExhaustiveTopK: 64,
-  largeModel: true,
-  isLegacy: false,
-  isLatest: true,
-  generationTokensCount: 64_000,
-  supportsVision: false,
-  supportedReasoningEfforts: {
-    none: true,
-    light: false,
-    medium: false,
-    high: false,
-  },
-  defaultReasoningEffort: "none",
-  supportsResponseFormat: false,
-  availableIfOneOf: {
-    featureFlag: "models_picker",
-  },
-  tokenizer: { type: "tiktoken", base: "o200k_base" },
-  regionalAvailability: {
-    "us-central1": true,
-    "europe-west1": true,
-  },
-};
+export const META_MODEL_IDS = [
+  AUTO_MODEL_ID,
+  AUTO_QUICK_MODEL_ID,
+  AUTO_DEEP_MODEL_ID,
+] as const;
+export type MetaModelIdType = (typeof META_MODEL_IDS)[number];
+
+export function isMetaModelId(modelId: string): modelId is MetaModelIdType {
+  return META_MODEL_IDS.includes(modelId as MetaModelIdType);
+}
+
+// The stream meta-models (everything except plain `auto`): they route among a
+// curated, ordered pool of concrete models rather than the whole catalog.
+export const MODEL_STREAM_IDS = [
+  AUTO_QUICK_MODEL_ID,
+  AUTO_DEEP_MODEL_ID,
+] as const;
+export type ModelStreamIdType = (typeof MODEL_STREAM_IDS)[number];
+
+export function isModelStreamId(modelId: string): modelId is ModelStreamIdType {
+  return MODEL_STREAM_IDS.includes(modelId as ModelStreamIdType);
+}
+
+// One candidate of a stream: a concrete model + the reasoning effort to run it
+// at. Ordered by preference — the router picks the first candidate available to
+// the workspace.
+export interface ModelStreamCandidate {
+  providerId: ModelProviderIdType;
+  modelId: string;
+  reasoningEffort: ReasoningEffort;
+}
+
+export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
+  {
+    [AUTO_QUICK_MODEL_ID]: [
+      {
+        providerId: "openai",
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        providerId: "google_ai_studio",
+        modelId: GEMINI_3_1_FLASH_LITE_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "mistral",
+        modelId: MISTRAL_SMALL_MODEL_ID,
+        reasoningEffort: "none",
+      },
+    ],
+    [AUTO_DEEP_MODEL_ID]: [
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_OPUS_4_8_MODEL_ID,
+        reasoningEffort: "high",
+      },
+      {
+        providerId: "openai",
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "google_ai_studio",
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "mistral",
+        modelId: MISTRAL_LARGE_MODEL_ID,
+        reasoningEffort: "none",
+      },
+    ],
+  };
+
+// All fields other than the ids are placeholders to satisfy
+// ModelConfigurationType: a meta-model is dynamically routed to a real model
+// before it is ever used to run a completion.
+function makeMetaModelConfig(
+  id: MetaModelIdType,
+  { displayName, description }: { displayName: string; description: string }
+): ModelConfigurationType {
+  return {
+    providerId: id,
+    modelId: id,
+    displayName,
+    description,
+    shortDescription: description,
+    contextSize: 1_000_000,
+    recommendedTopK: 64,
+    recommendedExhaustiveTopK: 64,
+    largeModel: true,
+    isLegacy: false,
+    isLatest: true,
+    generationTokensCount: 64_000,
+    supportsVision: false,
+    supportedReasoningEfforts: {
+      none: true,
+      light: false,
+      medium: false,
+      high: false,
+    },
+    defaultReasoningEffort: "none",
+    supportsResponseFormat: false,
+    availableIfOneOf: {
+      featureFlag: "models_picker",
+    },
+    tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": true,
+    },
+  };
+}
+
+export const AUTO_MODEL_CONFIG: ModelConfigurationType = makeMetaModelConfig(
+  AUTO_MODEL_ID,
+  {
+    displayName: "Auto",
+    description: "Let's Dust select the best model for the task.",
+  }
+);
+
+export const AUTO_QUICK_MODEL_CONFIG: ModelConfigurationType =
+  makeMetaModelConfig(AUTO_QUICK_MODEL_ID, {
+    displayName: "Quick",
+    description: "Fast models for simple tasks.",
+  });
+
+export const AUTO_DEEP_MODEL_CONFIG: ModelConfigurationType =
+  makeMetaModelConfig(AUTO_DEEP_MODEL_ID, {
+    displayName: "Deep",
+    description: "Powerful models for heavy tasks.",
+  });

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -16,16 +16,16 @@ import type {
 
 // Auto-routing meta-models: sentinels that do not name a concrete model but are
 // resolved to one at message-send time. `auto` lets Dust pick any available
-// model; `auto_quick` / `auto_deep` route among a curated pool (a "stream").
+// model; `auto_fast` / `auto_complex` route among a curated pool (a "stream").
 // Both the provider id and the model id of a meta-model are the sentinel string.
 export const AUTO_MODEL_ID = "auto" as const;
-export const AUTO_QUICK_MODEL_ID = "auto_quick" as const;
-export const AUTO_DEEP_MODEL_ID = "auto_deep" as const;
+export const AUTO_FAST_MODEL_ID = "auto_fast" as const;
+export const AUTO_COMPLEX_MODEL_ID = "auto_complex" as const;
 
 export const META_MODEL_IDS = [
   AUTO_MODEL_ID,
-  AUTO_QUICK_MODEL_ID,
-  AUTO_DEEP_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+  AUTO_COMPLEX_MODEL_ID,
 ] as const;
 export type MetaModelIdType = (typeof META_MODEL_IDS)[number];
 
@@ -36,8 +36,8 @@ export function isMetaModelId(modelId: string): modelId is MetaModelIdType {
 // The stream meta-models (everything except plain `auto`): they route among a
 // curated, ordered pool of concrete models rather than the whole catalog.
 export const MODEL_STREAM_IDS = [
-  AUTO_QUICK_MODEL_ID,
-  AUTO_DEEP_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+  AUTO_COMPLEX_MODEL_ID,
 ] as const;
 export type ModelStreamIdType = (typeof MODEL_STREAM_IDS)[number];
 
@@ -56,7 +56,7 @@ export interface ModelStreamCandidate {
 
 export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
   {
-    [AUTO_QUICK_MODEL_ID]: [
+    [AUTO_FAST_MODEL_ID]: [
       {
         providerId: "openai",
         modelId: GPT_5_6_LUNA_MODEL_ID,
@@ -78,7 +78,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
         reasoningEffort: "none",
       },
     ],
-    [AUTO_DEEP_MODEL_ID]: [
+    [AUTO_COMPLEX_MODEL_ID]: [
       {
         providerId: "anthropic",
         modelId: CLAUDE_OPUS_4_8_MODEL_ID,
@@ -150,14 +150,14 @@ export const AUTO_MODEL_CONFIG: ModelConfigurationType = makeMetaModelConfig(
   }
 );
 
-export const AUTO_QUICK_MODEL_CONFIG: ModelConfigurationType =
-  makeMetaModelConfig(AUTO_QUICK_MODEL_ID, {
-    displayName: "Quick",
+export const AUTO_FAST_MODEL_CONFIG: ModelConfigurationType =
+  makeMetaModelConfig(AUTO_FAST_MODEL_ID, {
+    displayName: "Fast",
     description: "Fast models for simple tasks.",
   });
 
-export const AUTO_DEEP_MODEL_CONFIG: ModelConfigurationType =
-  makeMetaModelConfig(AUTO_DEEP_MODEL_ID, {
-    displayName: "Deep",
+export const AUTO_COMPLEX_MODEL_CONFIG: ModelConfigurationType =
+  makeMetaModelConfig(AUTO_COMPLEX_MODEL_ID, {
+    displayName: "Complex",
     description: "Powerful models for heavy tasks.",
   });

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -6,36 +6,32 @@ import {
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 } from "./google_ai_studio";
-import { MISTRAL_LARGE_MODEL_ID, MISTRAL_SMALL_MODEL_ID } from "./mistral";
-import { GPT_5_6_LUNA_MODEL_ID, GPT_5_6_SOL_MODEL_ID } from "./openai";
+import {
+  MISTRAL_LARGE_MODEL_ID,
+  MISTRAL_MEDIUM_3_5_MODEL_ID,
+  MISTRAL_SMALL_MODEL_ID,
+} from "./mistral";
+import {
+  GPT_5_5_MODEL_ID,
+  GPT_5_6_LUNA_MODEL_ID,
+  GPT_5_6_SOL_MODEL_ID,
+} from "./openai";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
   ReasoningEffort,
 } from "./types";
+import { GROK_3_MINI_MODEL_ID, GROK_4_5_MODEL_ID } from "./xai";
 
-// Auto-routing meta-models: sentinels that do not name a concrete model but are
-// resolved to one at message-send time. `auto` lets Dust pick any available
-// model; `auto_fast` / `auto_complex` route among a curated pool (a "stream").
-// Both the provider id and the model id of a meta-model are the sentinel string.
+// Auto-routing meta-models: sentinels that never name a concrete model but are
+// resolved to one at message-send time by walking an ordered candidate pool (a
+// "stream") and picking the first candidate available to the workspace.
 export const AUTO_MODEL_ID = "auto" as const;
 export const AUTO_FAST_MODEL_ID = "auto_fast" as const;
 export const AUTO_COMPLEX_MODEL_ID = "auto_complex" as const;
 
-export const META_MODEL_IDS = [
-  AUTO_MODEL_ID,
-  AUTO_FAST_MODEL_ID,
-  AUTO_COMPLEX_MODEL_ID,
-] as const;
-export type MetaModelIdType = (typeof META_MODEL_IDS)[number];
-
-export function isMetaModelId(modelId: string): modelId is MetaModelIdType {
-  return META_MODEL_IDS.includes(modelId as MetaModelIdType);
-}
-
-// The stream meta-models (everything except plain `auto`): they route among a
-// curated, ordered pool of concrete models rather than the whole catalog.
 export const MODEL_STREAM_IDS = [
+  AUTO_MODEL_ID,
   AUTO_FAST_MODEL_ID,
   AUTO_COMPLEX_MODEL_ID,
 ] as const;
@@ -47,7 +43,9 @@ export function isModelStreamId(modelId: string): modelId is ModelStreamIdType {
 
 // One candidate of a stream: a concrete model + the reasoning effort to run it
 // at. Ordered by preference — the router picks the first candidate available to
-// the workspace.
+// the workspace. Efforts default to each model's own default; they are only
+// overridden when a stream deliberately wants a different effort (e.g. `light`
+// for the Fast stream, `high` for the Deep stream).
 export interface ModelStreamCandidate {
   providerId: ModelProviderIdType;
   modelId: string;
@@ -56,6 +54,61 @@ export interface ModelStreamCandidate {
 
 export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
   {
+    // Plain `auto` spans the whole preferred catalog at each model's default
+    // reasoning effort. The last candidate (Sonnet at `light`) is the
+    // cost-effective floor so tier-capped users still resolve within the stream.
+    [AUTO_MODEL_ID]: [
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "openai",
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "openai",
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      {
+        providerId: "google_ai_studio",
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        providerId: "google_ai_studio",
+        modelId: GEMINI_3_1_FLASH_LITE_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        providerId: "mistral",
+        modelId: MISTRAL_MEDIUM_3_5_MODEL_ID,
+        reasoningEffort: "none",
+      },
+      {
+        providerId: "mistral",
+        modelId: MISTRAL_SMALL_MODEL_ID,
+        reasoningEffort: "none",
+      },
+      {
+        providerId: "xai",
+        modelId: GROK_4_5_MODEL_ID,
+        reasoningEffort: "high",
+      },
+      {
+        providerId: "xai",
+        modelId: GROK_3_MINI_MODEL_ID,
+        reasoningEffort: "none",
+      },
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "light",
+      },
+    ],
     [AUTO_FAST_MODEL_ID]: [
       {
         providerId: "openai",
@@ -99,6 +152,12 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
         modelId: MISTRAL_LARGE_MODEL_ID,
         reasoningEffort: "none",
       },
+      // Cost-effective floor
+      {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "light",
+      },
     ],
   };
 
@@ -106,7 +165,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
 // ModelConfigurationType: a meta-model is dynamically routed to a real model
 // before it is ever used to run a completion.
 function makeMetaModelConfig(
-  id: MetaModelIdType,
+  id: ModelStreamIdType,
   { displayName, description }: { displayName: string; description: string }
 ): ModelConfigurationType {
   return {

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -39,12 +39,12 @@ import {
   CLAUDE_SONNET_5_MODEL_ID,
 } from "./anthropic";
 import {
-  AUTO_DEEP_MODEL_CONFIG,
-  AUTO_DEEP_MODEL_ID,
+  AUTO_COMPLEX_MODEL_CONFIG,
+  AUTO_COMPLEX_MODEL_ID,
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_FAST_MODEL_ID,
   AUTO_MODEL_CONFIG,
   AUTO_MODEL_ID,
-  AUTO_QUICK_MODEL_CONFIG,
-  AUTO_QUICK_MODEL_ID,
 } from "./auto";
 // Custom models (generated at build time from GCS, empty in dev).
 import {
@@ -252,8 +252,8 @@ export const STATIC_MODEL_IDS = [
   GROK_4_1_FAST_REASONING_MODEL_ID,
   NOOP_MODEL_ID,
   AUTO_MODEL_ID,
-  AUTO_QUICK_MODEL_ID,
-  AUTO_DEEP_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+  AUTO_COMPLEX_MODEL_ID,
 ] as const;
 
 // Type for static model IDs only (excludes custom models from GCS).
@@ -362,8 +362,8 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
   NOOP_MODEL_CONFIG,
   AUTO_MODEL_CONFIG,
-  AUTO_QUICK_MODEL_CONFIG,
-  AUTO_DEEP_MODEL_CONFIG,
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_COMPLEX_MODEL_CONFIG,
   // Custom models (generated at build time from GCS).
   ...CUSTOM_MODEL_CONFIGS,
 ];

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -38,7 +38,14 @@ import {
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "./anthropic";
-import { AUTO_MODEL_CONFIG, AUTO_MODEL_ID } from "./auto";
+import {
+  AUTO_DEEP_MODEL_CONFIG,
+  AUTO_DEEP_MODEL_ID,
+  AUTO_MODEL_CONFIG,
+  AUTO_MODEL_ID,
+  AUTO_QUICK_MODEL_CONFIG,
+  AUTO_QUICK_MODEL_ID,
+} from "./auto";
 // Custom models (generated at build time from GCS, empty in dev).
 import {
   CUSTOM_MODEL_CONFIGS,
@@ -245,6 +252,8 @@ export const STATIC_MODEL_IDS = [
   GROK_4_1_FAST_REASONING_MODEL_ID,
   NOOP_MODEL_ID,
   AUTO_MODEL_ID,
+  AUTO_QUICK_MODEL_ID,
+  AUTO_DEEP_MODEL_ID,
 ] as const;
 
 // Type for static model IDs only (excludes custom models from GCS).
@@ -353,6 +362,8 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
   NOOP_MODEL_CONFIG,
   AUTO_MODEL_CONFIG,
+  AUTO_QUICK_MODEL_CONFIG,
+  AUTO_DEEP_MODEL_CONFIG,
   // Custom models (generated at build time from GCS).
   ...CUSTOM_MODEL_CONFIGS,
 ];

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -20,8 +20,8 @@ export const MODEL_PROVIDER_IDS = [
   "xai",
   "noop",
   "auto",
-  "auto_quick",
-  "auto_deep",
+  "auto_fast",
+  "auto_complex",
 ] as const;
 
 export const BYOK_MODEL_PROVIDER_IDS = [
@@ -51,8 +51,8 @@ export function getProviderDisplayName(
     case "noop":
       return "noop";
     case "auto":
-    case "auto_quick":
-    case "auto_deep":
+    case "auto_fast":
+    case "auto_complex":
       return "Dust";
     default:
       return providerId;

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -20,6 +20,8 @@ export const MODEL_PROVIDER_IDS = [
   "xai",
   "noop",
   "auto",
+  "auto_quick",
+  "auto_deep",
 ] as const;
 
 export const BYOK_MODEL_PROVIDER_IDS = [
@@ -49,6 +51,8 @@ export function getProviderDisplayName(
     case "noop":
       return "noop";
     case "auto":
+    case "auto_quick":
+    case "auto_deep":
       return "Dust";
     default:
       return providerId;

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -40,13 +40,13 @@ export type ResolvedRequestedModel = {
 // How an agent message's model was resolved: "agent" (ran the agent's own
 // configured model, no override), "user" (ran a per-message model picked from
 // the input-bar picker), "auto" (resolved through the auto model), or
-// "auto_quick" / "auto_deep" (resolved through a curated stream tier).
+// "auto_fast" / "auto_complex" (resolved through a curated stream tier).
 export const MODEL_RESOLUTION_METHODS = [
   "agent",
   "user",
   "auto",
-  "auto_quick",
-  "auto_deep",
+  "auto_fast",
+  "auto_complex",
 ] as const;
 export type ModelResolutionMethodType =
   (typeof MODEL_RESOLUTION_METHODS)[number];

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -39,8 +39,15 @@ export type ResolvedRequestedModel = {
 
 // How an agent message's model was resolved: "agent" (ran the agent's own
 // configured model, no override), "user" (ran a per-message model picked from
-// the input-bar picker), or "auto" (resolved through the auto model).
-export const MODEL_RESOLUTION_METHODS = ["agent", "user", "auto"] as const;
+// the input-bar picker), "auto" (resolved through the auto model), or
+// "auto_quick" / "auto_deep" (resolved through a curated stream tier).
+export const MODEL_RESOLUTION_METHODS = [
+  "agent",
+  "user",
+  "auto",
+  "auto_quick",
+  "auto_deep",
+] as const;
 export type ModelResolutionMethodType =
   (typeof MODEL_RESOLUTION_METHODS)[number];
 

--- a/front/types/provider_selection.ts
+++ b/front/types/provider_selection.ts
@@ -12,6 +12,8 @@ export const ALL_PROVIDERS_SELECTED: ProvidersSelection = {
   xai: true,
   noop: true,
   auto: true,
+  auto_quick: true,
+  auto_deep: true,
 };
 
 export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
@@ -24,6 +26,8 @@ export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
   xai: false,
   noop: false,
   auto: true,
+  auto_quick: true,
+  auto_deep: true,
 };
 
 export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
@@ -36,4 +40,6 @@ export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
   xai: "xAI",
   noop: "noop",
   auto: "Auto",
+  auto_quick: "Quick",
+  auto_deep: "Deep",
 };

--- a/front/types/provider_selection.ts
+++ b/front/types/provider_selection.ts
@@ -12,8 +12,8 @@ export const ALL_PROVIDERS_SELECTED: ProvidersSelection = {
   xai: true,
   noop: true,
   auto: true,
-  auto_quick: true,
-  auto_deep: true,
+  auto_fast: true,
+  auto_complex: true,
 };
 
 export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
@@ -26,8 +26,8 @@ export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
   xai: false,
   noop: false,
   auto: true,
-  auto_quick: true,
-  auto_deep: true,
+  auto_fast: true,
+  auto_complex: true,
 };
 
 export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
@@ -40,6 +40,6 @@ export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
   xai: "xAI",
   noop: "noop",
   auto: "Auto",
-  auto_quick: "Quick",
-  auto_deep: "Deep",
+  auto_fast: "Fast",
+  auto_complex: "Complex",
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -24,6 +24,8 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "xai"
   | "noop"
   | "auto"
+  | "auto_quick"
+  | "auto_deep"
 >();
 
 export type KnownModelLLMId =
@@ -101,7 +103,9 @@ export type KnownModelLLMId =
   | "grok-4-1-fast-non-reasoning-latest"
   | "grok-4-1-fast-reasoning-latest"
   | "noop" // Noop
-  | "auto"; // Auto
+  | "auto" // Auto
+  | "auto_quick" // Quick stream tier
+  | "auto_deep"; // Deep stream tier
 
 // Cast to allow custom/unknown model IDs while preserving autocomplete.
 const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -24,8 +24,8 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "xai"
   | "noop"
   | "auto"
-  | "auto_quick"
-  | "auto_deep"
+  | "auto_fast"
+  | "auto_complex"
 >();
 
 export type KnownModelLLMId =
@@ -104,8 +104,8 @@ export type KnownModelLLMId =
   | "grok-4-1-fast-reasoning-latest"
   | "noop" // Noop
   | "auto" // Auto
-  | "auto_quick" // Quick stream tier
-  | "auto_deep"; // Deep stream tier
+  | "auto_fast" // Fast stream tier
+  | "auto_complex"; // Complex stream tier
 
 // Cast to allow custom/unknown model IDs while preserving autocomplete.
 const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<


### PR DESCRIPTION
## Description

Adds three auto-routing **meta-models**, centralised in `types/assistant/models/auto.ts`: the existing `auto` sentinel plus two new curated "stream" tiers, `auto_quick` and `auto_deep`.

Each stream is a sentinel model backed by an ordered pool of real models. At message-send time the backend routes the sentinel to the first candidate available to the workspace, at the effort declared for that candidate:

- **auto_quick**: GPT 5.6 Luna (light) → Sonnet 4.6 (light) → Gemini 3.1 Flash Lite (medium) → Mistral Small
- **auto_deep**: Opus 4.8 (high) → GPT 5.6 Sol (medium) → Gemini 3.1 Pro (medium) → Mistral Large

Core pieces:
- `auto.ts` — now the single home for all meta-models: `AUTO_MODEL_*`, `AUTO_QUICK_MODEL_*`, `AUTO_DEEP_MODEL_*`, plus `MODEL_STREAMS` (candidate pools), `isModelStreamId` / `isMetaModelId`, and a shared config factory.
- `getModelForStream` in `lib/model_tiers/enabled_models.ts` — walks the pool and picks the first selectable candidate that supports its effort.
- `resolveModel` routes the `auto_quick` / `auto_deep` sentinels (falling back to `auto` when no candidate is available) and records `modelResolutionMethod` accordingly.

The rest registers the two sentinels everywhere the `auto` sentinel already lives (provider ids, model ids, pricing/tier tables, provider whitelist, LLM lab/host maps, provider-selection records, resolution-method union) and adds the ids to the public SDK unions.

This is the backend/plumbing PR; the input-bar picker wiring is in the stacked frontend PR #29208.

## Tests

Added three cases to `lib/model_tiers/enabled_models.test.ts` covering stream resolution to the first available candidate + effort for both streams, and asserting resolution only ever returns a declared candidate. Full front + SDK typecheck pass.

## Risk

Adds `auto_quick` / `auto_deep` enum values to public SDK request/response unions, consistent with how `auto` is already exposed; the sentinels always resolve to a concrete model before appearing as a serving provider. No schema removals, no migration.
