### PR TITLE
Add: profiling debug script for connectors.

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -32,6 +32,7 @@
     "migration:mark:post-deploy": "node ../scripts/db/run-migrate.cjs --command mark-post-deploy --execute",
     "teams:create-app": "tsx ./scripts/create-teams-app.ts",
     "discord:register-commands": "tsx ./scripts/register-discord-commands.ts",
+    "debug:profiler": "tsx ./scripts/debug/run_profiler.ts",
     "knip": "knip"
   },
   "dependencies": {

--- a/connectors/scripts/debug/run_profiler.ts
+++ b/connectors/scripts/debug/run_profiler.ts
@@ -1,0 +1,53 @@
+import type { GetProfilerResponse } from "@connectors/api/profiler";
+import { apiConfig } from "@connectors/lib/api/config";
+import { normalizeError } from "@connectors/types";
+import { makeScript } from "scripts/helpers";
+
+makeScript({}, async ({ execute }) => {
+  if (!execute) {
+    console.log("Use --execute to run the script");
+    return;
+  }
+
+  const debugProfilerSecret = apiConfig.getProfilerSecret();
+  if (!debugProfilerSecret) {
+    throw new Error("Profiler secret is not set");
+  }
+
+  try {
+    console.log("Starting profiling...");
+
+    // eslint-disable-next-line no-restricted-globals
+    const response = await fetch(
+      `http://localhost:3002/profiler?secret=${debugProfilerSecret}`
+    );
+
+    if (!response.ok) {
+      const error = await response.json();
+      console.error(error);
+      throw new Error(error.message);
+    }
+
+    const data: GetProfilerResponse = await response.json();
+    if ("cpu" in data) {
+      console.log("Profiling completed. Response:", JSON.stringify(data));
+
+      const { cpu: cpuPath, heap: heapPath } = data;
+
+      if (!cpuPath || !heapPath) {
+        throw new Error("Failed to parse profile paths from response");
+      }
+
+      console.log(`CPU profile: ${cpuPath}`);
+      console.log(`Heap profile: ${heapPath}`);
+
+      // Output paths for the local script to parse.
+      console.log("PROFILE_PATHS");
+      console.log(`cpu:${cpuPath}`);
+      console.log(`heap:${heapPath}`);
+    }
+  } catch (error) {
+    console.error("Error when running profiler", normalizeError(error).message);
+    process.exit(1);
+  }
+});

--- a/connectors/src/api/profiler.ts
+++ b/connectors/src/api/profiler.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import inspector from "node:inspector/promises";
+import os from "node:os";
+import path from "node:path";
+import { apiConfig } from "@connectors/lib/api/config";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
+import logger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import type { WithConnectorsAPIErrorReponse } from "@connectors/types/api";
+import { isString } from "@connectors/types/shared/utils/general";
+import type { Request, Response } from "express";
+
+const CPU_PROFILE_DURATION_MS = 30_000;
+const HEAP_PROFILE_DURATION_MS = 30_000;
+
+export type GetProfilerResponse = WithConnectorsAPIErrorReponse<{
+  cpu: string;
+  heap: string;
+}>;
+
+async function saveProfile({
+  extension,
+  filename,
+  profile,
+}: {
+  extension: string;
+  filename: string;
+  profile: unknown;
+}) {
+  const tmpdir = os.tmpdir();
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  const profilePath = path.join(
+    tmpdir,
+    `${filename}-${timestamp}.${extension}`
+  );
+  await fs.writeFile(profilePath, JSON.stringify(profile));
+
+  return profilePath;
+}
+
+async function profileCPU(): Promise<string> {
+  const session = new inspector.Session();
+
+  session.connect();
+  await session.post("Profiler.enable");
+  await session.post("Profiler.start");
+
+  await setTimeoutAsync(CPU_PROFILE_DURATION_MS);
+
+  const { profile } = await session.post("Profiler.stop");
+
+  const profilePath = await saveProfile({
+    extension: "cpuprofile",
+    filename: "cpu",
+    profile,
+  });
+
+  session.disconnect();
+
+  logger.info({ profilePath }, "CPU profile saved");
+
+  return profilePath;
+}
+
+async function profileHeap(): Promise<string> {
+  const session = new inspector.Session();
+
+  session.connect();
+  await session.post("HeapProfiler.enable");
+
+  // Start allocation timeline (tracks every allocation).
+  await session.post("HeapProfiler.startSampling", {
+    samplingInterval: 32768, // Bytes between samples.
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
+
+  await setTimeoutAsync(HEAP_PROFILE_DURATION_MS);
+
+  const { profile } = await session.post("HeapProfiler.stopSampling");
+  const profilePath = await saveProfile({
+    extension: "heapprofile",
+    filename: "heap-timeline",
+    profile,
+  });
+
+  session.disconnect();
+
+  logger.info({ profilePath }, "Heap timeline profile saved");
+
+  return profilePath;
+}
+
+const _profilerAPIHandler = async (
+  req: Request<never, GetProfilerResponse, { secret: string }>,
+  res: Response<GetProfilerResponse>
+) => {
+  const secret = req.query.secret;
+  const debugSecret = apiConfig.getProfilerSecret();
+
+  if (!debugSecret || !isString(secret) || secret !== debugSecret) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid secret.",
+      },
+    });
+  }
+
+  const cpuProfile = await profileCPU();
+  const heapProfile = await profileHeap();
+
+  return res.json({
+    cpu: cpuProfile,
+    heap: heapProfile,
+  });
+};
+
+export const profilerAPIHandler = withLogging(_profilerAPIHandler);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -39,6 +39,7 @@ import {
 } from "./api/connector_config";
 import { getNotionWorkspaceIdHandler } from "./api/get_notion_workspace_id";
 import { getWebhookRouterEntryHandler } from "./api/get_webhook_router_config";
+import { profilerAPIHandler } from "./api/profiler";
 import { syncWebhookRouterEntryHandler } from "./api/sync_webhook_router_config";
 import { webhookFirecrawlAPIHandler } from "./api/webhooks/webhook_firecrawl";
 
@@ -56,6 +57,9 @@ export function startServer(port: number) {
   app.get("/", (_req, res) => {
     res.status(200).send("OK");
   });
+
+  // for profiling -- doesn't go through auth middleware
+  app.get("/profiler", profilerAPIHandler);
 
   app.use(
     bodyParser.json({

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -65,4 +65,7 @@ export const apiConfig = {
   getDiscordApplicationId: (): string => {
     return EnvironmentConfig.getEnvVariable("DISCORD_APP_ID");
   },
+  getProfilerSecret: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DEBUG_PROFILER_SECRET");
+  },
 };


### PR DESCRIPTION
## Description

Adds a live profiling endpoint to the connectors API server for debugging performance issues in production. `GET /profiler?secret=<DEBUG_PROFILER_SECRET>` runs a 30-second CPU profile (`Profiler.*`) and a 30-second heap sampling profile (`HeapProfiler.*`) in parallel using Node.js `inspector`, writes both to tmpdir, and returns the file paths. The endpoint bypasses the normal auth middleware and is gated solely by the `DEBUG_PROFILER_SECRET` env var (absent by default). A companion debug script `run_profiler.ts` (runnable via `pnpm debug:profiler --execute`) calls the local endpoint and prints the output paths for further analysis.

## Tests

Tested manually — ran the script against a local connectors server with `DEBUG_PROFILER_SECRET` set, confirmed `.cpuprofile` and `.heapprofile` files were written to tmpdir and paths returned correctly.

## Risk

Low. The endpoint is inert unless `DEBUG_PROFILER_SECRET` is set in the environment (it is not set in production by default). When active, profiling adds CPU/memory overhead for ~60 seconds (30s CPU + 30s heap sequentially). Profiles are written server-side to tmpdir, nothing sensitive is returned over the wire. Rollback is safe — removing the env var disables it immediately.

## Deploy Plan

Deploy connectors. Set `DEBUG_PROFILER_SECRET` on the connectors server only when profiling is needed; unset after use.
