### PR TITLE
Pricing: Add a feature flag to allow scim and bypass plan value

### DIFF
--- a/front-api/routes/w/[wId]/dsync.ts
+++ b/front-api/routes/w/[wId]/dsync.ts
@@ -8,6 +8,8 @@ import {
   generateWorkOSAdminPortalUrl,
   getWorkOSOrganizationDSyncDirectories,
 } from "@app/lib/api/workos/organization";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -33,7 +35,8 @@ async function checkAccess(ctx: Context) {
   }
 
   const plan = auth.getNonNullablePlan();
-  if (!plan.limits.users.isSCIMAllowed) {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!isSCIMEnabled(plan, featureFlags)) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -1,7 +1,8 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { GroupDialog } from "@app/components/groups/GroupDialog";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
 import { useDeleteGroup, useGroups } from "@app/lib/swr/groups";
 import {
@@ -137,7 +138,8 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
 
   const router = useAppRouter();
   const { subscription } = useAuth();
-  const isScimAllowed = subscription.plan.limits.users.isSCIMAllowed;
+  const { featureFlags } = useFeatureFlags();
+  const isScimAllowed = isSCIMEnabled(subscription.plan, featureFlags);
   const [searchTerm, setSearchTerm] = useState("");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editedGroupId, setEditedGroupId] = useState<string | null>(null);

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -6,6 +6,7 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
@@ -23,7 +24,7 @@ import {
 } from "@dust-tt/sparkle";
 
 export function MembersPage() {
-  const { hasFeature } = useFeatureFlags();
+  const { featureFlags, hasFeature } = useFeatureFlags();
   const isAdminGovernanceEnabled = hasFeature("admin_governance");
 
   const owner = useWorkspace();
@@ -43,7 +44,7 @@ export function MembersPage() {
 
   const hasVerifiedDomains = verifiedDomains.length > 0;
   const isProvisioningEnabled =
-    plan.limits.users.isSCIMAllowed && hasVerifiedDomains;
+    isSCIMEnabled(plan, featureFlags) && hasVerifiedDomains;
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -3,7 +3,8 @@ import type { SearchMemberType } from "@app/components/members/MemberSelectionTa
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
 import {
@@ -68,14 +69,15 @@ export function CreateOrEditSpaceModal({
     useState<MembersManagementType>("manual");
   const [isDirty, setIsDirty] = useState(false);
 
-  const planAllowsSCIM = plan.limits.users.isSCIMAllowed;
+  const { featureFlags } = useFeatureFlags();
+  const scimEnabled = isSCIMEnabled(plan, featureFlags);
   const { user } = useAuth();
 
   useEffect(() => {
-    if (!planAllowsSCIM) {
+    if (!scimEnabled) {
       setManagementType("manual");
     }
-  }, [planAllowsSCIM]);
+  }, [scimEnabled]);
 
   const doCreate = useCreateSpace({ owner });
   const doUpdate = useUpdateSpace({ owner });
@@ -92,7 +94,7 @@ export function CreateOrEditSpaceModal({
   const { groups } = useGroups({
     owner,
     kinds: ["provisioned"],
-    disabled: !planAllowsSCIM,
+    disabled: !scimEnabled,
   });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -109,7 +111,7 @@ export function CreateOrEditSpaceModal({
 
       // Initialize selected groups based on space's groupIds (only if workos feature is enabled)
       if (
-        planAllowsSCIM &&
+        scimEnabled &&
         spaceInfo?.groupIds &&
         spaceInfo.groupIds.length > 0 &&
         groups
@@ -147,7 +149,7 @@ export function CreateOrEditSpaceModal({
     defaultRestricted,
     groups,
     isOpen,
-    planAllowsSCIM,
+    scimEnabled,
     setSpaceName,
     spaceInfo,
     user,
@@ -196,7 +198,7 @@ export function CreateOrEditSpaceModal({
     setIsSaving(true);
 
     if (space) {
-      if (planAllowsSCIM && managementType === "group") {
+      if (scimEnabled && managementType === "group") {
         await doUpdate(space, {
           isRestricted,
           groupIds: selectedGroups.map((group) => group.sId),
@@ -219,7 +221,7 @@ export function CreateOrEditSpaceModal({
     } else if (!space) {
       let createdSpace;
 
-      if (planAllowsSCIM && managementType === "group") {
+      if (scimEnabled && managementType === "group") {
         createdSpace = await doCreate({
           name: trimmedName,
           isRestricted,
@@ -258,7 +260,7 @@ export function CreateOrEditSpaceModal({
     spaceName,
     managementType,
     selectedGroups,
-    planAllowsSCIM,
+    scimEnabled,
   ]);
 
   const onDelete = useCallback(async () => {
@@ -307,7 +309,7 @@ export function CreateOrEditSpaceModal({
     isDirty,
     spaceName,
   ]);
-  const isManual = !planAllowsSCIM || managementType === "manual";
+  const isManual = !scimEnabled || managementType === "manual";
 
   const handleNameChange = useCallback((value: string) => {
     setSpaceName(value);
@@ -359,7 +361,7 @@ export function CreateOrEditSpaceModal({
             {isRestricted && (
               <RestrictedAccessBody
                 isManual={isManual}
-                planAllowsSCIM={planAllowsSCIM}
+                scimEnabled={scimEnabled}
                 managementType={managementType}
                 owner={owner}
                 selectedMembers={selectedMembers}

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -25,7 +25,7 @@ function isMembersManagementType(
 
 interface RestrictedAccessBodyProps {
   isManual: boolean;
-  planAllowsSCIM: boolean;
+  scimEnabled: boolean;
   managementType: MembersManagementType;
   owner: LightWorkspaceType;
   selectedMembers: SearchMemberType[];
@@ -38,7 +38,7 @@ interface RestrictedAccessBodyProps {
 
 export function RestrictedAccessBody({
   isManual,
-  planAllowsSCIM,
+  scimEnabled,
   managementType,
   owner,
   selectedMembers,
@@ -75,7 +75,7 @@ export function RestrictedAccessBody({
   };
 
   const handleManagementTypeChange = async (newManagementType: string) => {
-    if (!isMembersManagementType(newManagementType) || !planAllowsSCIM) {
+    if (!isMembersManagementType(newManagementType) || !scimEnabled) {
       return;
     }
 
@@ -120,7 +120,7 @@ export function RestrictedAccessBody({
 
   return (
     <>
-      {planAllowsSCIM && (
+      {scimEnabled && (
         <div className="flex flex-row items-center justify-between">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -5,6 +5,7 @@ import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcp
 import SSOConnection from "@app/components/workspace/SSOConnection";
 import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import {
   useRemoveWorkspaceDomain,
   useWorkspaceDomains,
@@ -45,8 +46,9 @@ export default function WorkspaceAccessPanel({
   const { addDomainLink, domains, isDomainsLoading } = useWorkspaceDomains({
     owner,
   });
-  const { hasFeature } = useFeatureFlags();
+  const { featureFlags, hasFeature } = useFeatureFlags();
   const workspace = useWorkspace();
+  const scimEnabled = isSCIMEnabled(plan, featureFlags);
   const hasAuditLogsAccess =
     plan.isAuditLogsAllowed || hasFeature("audit_logs");
   const showAuditLogs =
@@ -72,10 +74,8 @@ export default function WorkspaceAccessPanel({
         owner={owner}
         plan={plan}
       />
-      {plan.limits.users.isSCIMAllowed && <Separator />}
-      {plan.limits.users.isSCIMAllowed && (
-        <UserProvisioning owner={owner} plan={plan} />
-      )}
+      {scimEnabled && <Separator />}
+      {scimEnabled && <UserProvisioning owner={owner} plan={plan} />}
       {showAuditLogs && <Separator />}
       {showAuditLogs && <AuditLogsSection owner={owner} />}
       {showExtensionMcpTools && (

--- a/front/lib/plans/scim.ts
+++ b/front/lib/plans/scim.ts
@@ -1,0 +1,9 @@
+import type { PlanType } from "@app/types/plan";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export function isSCIMEnabled(
+  plan: PlanType,
+  featureFlags: WhitelistableFeature[]
+): boolean {
+  return plan.limits.users.isSCIMAllowed || featureFlags.includes("allow_scim");
+}

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -22,7 +22,7 @@ import {
   getWorkspaceInfos,
   isWorkspaceRelocationDone,
 } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlagsForWorkspace } from "@app/lib/auth";
 import type { ExternalUser } from "@app/lib/iam/provider";
 import type { CustomAttributeKey } from "@app/lib/iam/users";
 import {
@@ -30,6 +30,7 @@ import {
   createOrUpdateUser,
   WORKOS_METADATA_KEY_PREFIX,
 } from "@app/lib/iam/users";
+import { isSCIMEnabled } from "@app/lib/plans/scim";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
@@ -113,7 +114,7 @@ async function verifyWorkOSWorkspace<E extends Event, R>(
     }
   }
 
-  // For dsync events, verify the plan allows SCIM and the directoryId matches
+  // For dsync events, verify SCIM is enabled and the directoryId matches
   // the current organization's active directory.
   const { data: eventData } = event;
   if (
@@ -123,10 +124,12 @@ async function verifyWorkOSWorkspace<E extends Event, R>(
   ) {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-    if (!subscription?.getPlan().limits.users.isSCIMAllowed) {
+    const featureFlags = await getFeatureFlagsForWorkspace(workspace);
+    const plan = subscription?.getPlan();
+    if (!plan || !isSCIMEnabled(plan, featureFlags)) {
       logger.warn(
         { workspaceId: workspace.sId, organizationId },
-        "SCIM event received but workspace plan does not allow SCIM, skipping"
+        "SCIM event received but neither the workspace plan nor a feature flag allows SCIM, skipping"
       );
       return;
     }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -4,6 +4,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",
     stage: "on_demand",
   },
+  allow_scim: {
+    description:
+      "Allow this workspace to configure SCIM user provisioning, independently of the plan's isSCIMAllowed flag. Enable on demand.",
+    stage: "on_demand",
+  },
   live_speech_to_text: {
     description:
       "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -723,6 +723,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "activation_scheduler"
   | "activation_skill"
   | "advanced_notion_management"
+  | "allow_scim"
   | "allow_sso"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"


### PR DESCRIPTION
## Description

Similar to how we have added `allow_sso` to bypass the plan value for SSO
This flag allows to bypass the plan value for SCIM.
This will allow to have SCIM in POC where plan would not normally allow it.

## Tests



## Risk

low

## Deploy Plan

deploy front
