### PR TITLE
[front] enh: show system prompt in Poke conversation render

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -45,6 +45,7 @@ export type PostRenderConversationResponseBody = {
   modelConversation: unknown;
   modelContextSizeUsed: number;
   promptTokenCountApprox: number;
+  systemPrompt: string;
   toolsTokenCountApprox: number;
 };
 
@@ -291,6 +292,7 @@ app.post(
       modelConversation,
       modelContextSizeUsed: contextSize,
       promptTokenCountApprox,
+      systemPrompt: prompt,
       toolsTokenCountApprox,
     });
   }

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1071,6 +1071,13 @@ export function ConversationPage() {
               onClick={() => setUseMarkdown(!useMarkdown)}
             />
             <Button
+              label="Self-improving skills test"
+              variant="primary"
+              size="xs"
+              onClick={() => void copyTestCase()}
+              disabled={isTestCaseLoading}
+            />
+            <Button
               label="Render Conversation"
               variant="primary"
               size="xs"
@@ -1082,13 +1089,6 @@ export function ConversationPage() {
                 void handleRenderConversation();
               }}
               disabled={isRendering}
-            />
-            <Button
-              label="Self-improving skills test"
-              variant="primary"
-              size="xs"
-              onClick={() => void copyTestCase()}
-              disabled={isTestCaseLoading}
             />
             {isRendering && <Spinner size="xs" />}
             {showRenderControls && (

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1072,11 +1072,7 @@ export function ConversationPage() {
                 disabled={isTestCaseLoading}
               />
             </div>
-            <div
-              role="group"
-              aria-label="Render conversation controls"
-              className="inline-flex items-center gap-2 rounded-md border border-separator bg-muted-background p-1"
-            >
+            <div className="flex items-center gap-2">
               <Button
                 label="Render Conversation"
                 variant="primary"

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -29,6 +29,9 @@ import {
   Clipboard,
   ClipboardCheck,
   CodeBlock,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   ConversationMessage,
   cn,
   DropdownMenu,
@@ -1179,23 +1182,45 @@ export function ConversationPage() {
                       }}
                     />
                   </div>
-                  <div className="space-y-2">
-                    <div className="text-sm font-medium text-foreground">
-                      System prompt
-                    </div>
-                    <CodeBlock
-                      wrapLongLines
-                      className="language-text max-h-96 overflow-y-auto"
-                    >
-                      {renderResult.systemPrompt}
-                    </CodeBlock>
+                  <div className="rounded-md border border-separator p-3">
+                    <Collapsible defaultOpen={false}>
+                      <CollapsibleTrigger>
+                        <h3 className="text-sm font-medium text-foreground">
+                          System prompt
+                        </h3>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <div className="mt-2">
+                          <CodeBlock
+                            wrapLongLines
+                            className="language-text max-h-96 overflow-y-auto"
+                          >
+                            {renderResult.systemPrompt}
+                          </CodeBlock>
+                        </div>
+                      </CollapsibleContent>
+                    </Collapsible>
                   </div>
-                  <div className="text-sm font-medium text-foreground">
-                    Model conversation
+                  <div className="rounded-md border border-separator p-3">
+                    <Collapsible defaultOpen={true}>
+                      <CollapsibleTrigger>
+                        <h3 className="text-sm font-medium text-foreground">
+                          Model conversation
+                        </h3>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <div className="mt-2">
+                          <CodeBlock wrapLongLines className="language-json">
+                            {JSON.stringify(
+                              renderResult.modelConversation,
+                              null,
+                              2
+                            )}
+                          </CodeBlock>
+                        </div>
+                      </CollapsibleContent>
+                    </Collapsible>
                   </div>
-                  <CodeBlock wrapLongLines className="language-json">
-                    {JSON.stringify(renderResult.modelConversation, null, 2)}
-                  </CodeBlock>
                 </div>
               )}
             </div>

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -23,6 +23,7 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  ButtonGroup,
   Check,
   ChevronDown,
   Chip,
@@ -1070,26 +1071,28 @@ export function ConversationPage() {
               icon={useMarkdown ? DocumentTextIcon : CodeBracketIcon}
               onClick={() => setUseMarkdown(!useMarkdown)}
             />
-            <Button
-              label="Self-improving skills test"
-              variant="primary"
-              size="xs"
-              onClick={() => void copyTestCase()}
-              disabled={isTestCaseLoading}
-            />
-            <Button
-              label="Render Conversation"
-              variant="primary"
-              size="xs"
-              onClick={() => {
-                if (!showRenderControls) {
-                  setShowRenderControls(true);
-                  return;
-                }
-                void handleRenderConversation();
-              }}
-              disabled={isRendering}
-            />
+            <ButtonGroup>
+              <Button
+                label="Self-improving skills test"
+                variant="primary"
+                size="xs"
+                onClick={() => void copyTestCase()}
+                disabled={isTestCaseLoading}
+              />
+              <Button
+                label="Render Conversation"
+                variant="primary"
+                size="xs"
+                onClick={() => {
+                  if (!showRenderControls) {
+                    setShowRenderControls(true);
+                    return;
+                  }
+                  void handleRenderConversation();
+                }}
+                disabled={isRendering}
+              />
+            </ButtonGroup>
             {isRendering && <Spinner size="xs" />}
             {showRenderControls && (
               <div className="ml-2 flex items-center space-x-2">

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -23,7 +23,6 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  ButtonGroup,
   Check,
   ChevronDown,
   Chip,
@@ -1071,14 +1070,18 @@ export function ConversationPage() {
               icon={useMarkdown ? DocumentTextIcon : CodeBracketIcon}
               onClick={() => setUseMarkdown(!useMarkdown)}
             />
-            <ButtonGroup>
-              <Button
-                label="Self-improving skills test"
-                variant="primary"
-                size="xs"
-                onClick={() => void copyTestCase()}
-                disabled={isTestCaseLoading}
-              />
+            <Button
+              label="Self-improving skills test"
+              variant="primary"
+              size="xs"
+              onClick={() => void copyTestCase()}
+              disabled={isTestCaseLoading}
+            />
+            <div
+              role="group"
+              aria-label="Render conversation controls"
+              className="inline-flex items-center gap-2 rounded-md border border-separator bg-muted-background p-1"
+            >
               <Button
                 label="Render Conversation"
                 variant="primary"
@@ -1092,46 +1095,47 @@ export function ConversationPage() {
                 }}
                 disabled={isRendering}
               />
-            </ButtonGroup>
-            {isRendering && <Spinner size="xs" />}
-            {showRenderControls && (
-              <div className="ml-2 flex items-center space-x-2">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      label={
-                        selectedAgentId
-                          ? `Agent: ${
-                              agents.find((a) => a.sId === selectedAgentId)
-                                ?.name ?? selectedAgentId
-                            }`
-                          : "Select Agent"
-                      }
-                      variant="outline"
-                      size="xs"
-                    />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    {agents.map((a) => (
-                      <DropdownMenuItem
-                        key={a.sId}
-                        onClick={() => setSelectedAgentId(a.sId)}
-                      >
-                        {a.name} ({a.sId})
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-                <Input
-                  placeholder="Context size override"
-                  value={contextSizeOverride}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setContextSizeOverride(e.target.value)
-                  }
-                  className="h-7 w-44"
-                />
-              </div>
-            )}
+              {showRenderControls && (
+                <>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        label={
+                          selectedAgentId
+                            ? `Agent: ${
+                                agents.find((a) => a.sId === selectedAgentId)
+                                  ?.name ?? selectedAgentId
+                              }`
+                            : "Select Agent"
+                        }
+                        variant="outline"
+                        size="xs"
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start">
+                      {agents.map((a) => (
+                        <DropdownMenuItem
+                          key={a.sId}
+                          onClick={() => setSelectedAgentId(a.sId)}
+                        >
+                          {a.name} ({a.sId})
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <Input
+                    aria-label="Context size override"
+                    placeholder="Context size override"
+                    value={contextSizeOverride}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setContextSizeOverride(e.target.value)
+                    }
+                    className="h-7 w-44"
+                  />
+                </>
+              )}
+              {isRendering && <Spinner size="xs" />}
+            </div>
           </div>
           {(renderError !== null || renderResult !== null) && (
             <div className="mt-2 rounded-md border p-2">

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -47,12 +47,7 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
-import {
-  type ComponentProps,
-  type ReactNode,
-  useEffect,
-  useState,
-} from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 
 type ChipColor = NonNullable<ComponentProps<typeof Chip>["color"]>;
 
@@ -899,8 +894,14 @@ export function ConversationPage() {
     return lastAgentMessage?.configuration.sId ?? agents[0]?.sId ?? "";
   })();
 
-  const [selectedAgentId, setSelectedAgentId] =
-    useState<string>(defaultAgentId);
+  const [agentSelection, setAgentSelection] = useState<{
+    agentId: string;
+    conversationId: string;
+  } | null>(null);
+  const selectedAgentId =
+    agentSelection?.conversationId === conversationId
+      ? agentSelection.agentId
+      : defaultAgentId;
   const [contextSizeOverride, setContextSizeOverride] = useState<string>("");
   const [isRendering, setIsRendering] = useState(false);
   const [renderError, setRenderError] = useState<string | null>(null);
@@ -917,14 +918,6 @@ export function ConversationPage() {
 
   const { copyTestCase, isLoading: isTestCaseLoading } =
     useCopyReinforcementTestCase({ owner, conversationId });
-
-  useEffect(() => {
-    if (!selectedAgentId) {
-      if (defaultAgentId) {
-        setSelectedAgentId(defaultAgentId);
-      }
-    }
-  }, [defaultAgentId, selectedAgentId]);
 
   async function handleRenderConversation() {
     if (!selectedAgentId) {
@@ -1118,7 +1111,12 @@ export function ConversationPage() {
                       {agents.map((a) => (
                         <DropdownMenuItem
                           key={a.sId}
-                          onClick={() => setSelectedAgentId(a.sId)}
+                          onClick={() =>
+                            setAgentSelection({
+                              agentId: a.sId,
+                              conversationId,
+                            })
+                          }
                         >
                           {a.name} ({a.sId})
                         </DropdownMenuItem>

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1024,59 +1024,61 @@ export function ConversationPage() {
               workspace: owner,
             }}
           />
-          <div className="flex space-x-2">
-            {langfuseUiBaseUrl && (
+          <div className="flex flex-col items-start gap-2">
+            <div className="flex flex-wrap gap-2">
+              {langfuseUiBaseUrl && (
+                <Button
+                  href={`${langfuseUiBaseUrl}/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3B${conversationId}`}
+                  label="Langfuse Traces"
+                  variant="primary"
+                  size="xs"
+                  target="_blank"
+                />
+              )}
               <Button
-                href={`${langfuseUiBaseUrl}/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3B${conversationId}`}
-                label="Langfuse Traces"
+                href={`http://go/trace-conversation/${conversation.sId}`}
+                label="Trace Conversation"
                 variant="primary"
                 size="xs"
                 target="_blank"
               />
-            )}
-            <Button
-              href={`http://go/trace-conversation/${conversation.sId}`}
-              label="Trace Conversation"
-              variant="primary"
-              size="xs"
-              target="_blank"
-            />
-            <Button
-              href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=%60conversationId%60%3D"${conversationId}"`}
-              label="Temporal Workflows"
-              variant="primary"
-              size="xs"
-              target="_blank"
-            />
-            <Button
-              href={getDatadogSandboxLogsUrl(conversationId)}
-              label="Sandbox Logs"
-              variant="primary"
-              size="xs"
-              target="_blank"
-            />
-            <Button
-              href={`/poke/${owner.sId}/data_sources/${conversationDataSourceId}`}
-              label="Conversation DS"
-              variant="primary"
-              size="xs"
-              target="_blank"
-              disabled={!conversationDataSourceId}
-            />
-            <Button
-              label={useMarkdown ? "Plain Text" : "Preview Markdown"}
-              variant="outline"
-              size="xs"
-              icon={useMarkdown ? DocumentTextIcon : CodeBracketIcon}
-              onClick={() => setUseMarkdown(!useMarkdown)}
-            />
-            <Button
-              label="Self-improving skills test"
-              variant="primary"
-              size="xs"
-              onClick={() => void copyTestCase()}
-              disabled={isTestCaseLoading}
-            />
+              <Button
+                href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=%60conversationId%60%3D"${conversationId}"`}
+                label="Temporal Workflows"
+                variant="primary"
+                size="xs"
+                target="_blank"
+              />
+              <Button
+                href={getDatadogSandboxLogsUrl(conversationId)}
+                label="Sandbox Logs"
+                variant="primary"
+                size="xs"
+                target="_blank"
+              />
+              <Button
+                href={`/poke/${owner.sId}/data_sources/${conversationDataSourceId}`}
+                label="Conversation DS"
+                variant="primary"
+                size="xs"
+                target="_blank"
+                disabled={!conversationDataSourceId}
+              />
+              <Button
+                label={useMarkdown ? "Plain Text" : "Preview Markdown"}
+                variant="outline"
+                size="xs"
+                icon={useMarkdown ? DocumentTextIcon : CodeBracketIcon}
+                onClick={() => setUseMarkdown(!useMarkdown)}
+              />
+              <Button
+                label="Self-improving skills test"
+                variant="primary"
+                size="xs"
+                onClick={() => void copyTestCase()}
+                disabled={isTestCaseLoading}
+              />
+            </div>
             <div
               role="group"
               aria-label="Render conversation controls"

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -906,6 +906,7 @@ export function ConversationPage() {
     modelContextSizeUsed: number;
     modelConversation: unknown;
     promptTokenCountApprox: number;
+    systemPrompt: string;
     toolsTokenCountApprox: number;
   }>(null);
   const [showRenderControls, setShowRenderControls] = useState(false);
@@ -954,6 +955,7 @@ export function ConversationPage() {
         modelContextSizeUsed: data.modelContextSizeUsed,
         modelConversation: data.modelConversation,
         promptTokenCountApprox: data.promptTokenCountApprox,
+        systemPrompt: data.systemPrompt,
         toolsTokenCountApprox: data.toolsTokenCountApprox,
       });
     } catch (e) {
@@ -1176,6 +1178,20 @@ export function ConversationPage() {
                         setRenderResult(null);
                       }}
                     />
+                  </div>
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium text-foreground">
+                      System prompt
+                    </div>
+                    <CodeBlock
+                      wrapLongLines
+                      className="language-text max-h-96 overflow-y-auto"
+                    >
+                      {renderResult.systemPrompt}
+                    </CodeBlock>
+                  </div>
+                  <div className="text-sm font-medium text-foreground">
+                    Model conversation
                   </div>
                   <CodeBlock wrapLongLines className="language-json">
                     {JSON.stringify(renderResult.modelConversation, null, 2)}


### PR DESCRIPTION
## Description

The Poke conversation render view only exposes the rendered model conversation, which makes it harder to inspect the full input sent to the model.

This PR exposes the system prompt in the `render` endpoint (we already had it).

Also fixes the default agent selected.

<img width="1066" height="1164" alt="image" src="https://github.com/user-attachments/assets/99d9ae0e-1c74-4d0c-bd94-277b0b2fcb23" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front and front-api.
