### PR TITLE
Enable native light reasoning for Opus 4.8

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.test.ts
@@ -85,6 +85,15 @@ describe("toAutoThinkingConfig", () => {
     });
   });
 
+  it('returns adaptive thinking for "light" when native light reasoning is true', () => {
+    expect(toAutoThinkingConfig("light", true)).toEqual({
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: {
+        effort: ANTHROPIC_THINKING_EFFORT_MAPPING.light,
+      },
+    });
+  });
+
   it('returns adaptive thinking with output_config for "medium"', () => {
     expect(toAutoThinkingConfig("medium")).toEqual({
       thinking: { type: "adaptive", display: "summarized" },

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -356,6 +356,7 @@ export const CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     high: true,
   },
   defaultReasoningEffort: "medium",
+  useNativeLightReasoning: true,
   // Opus 4.8 shares Opus 4.7's tokenizer (~555k words/1M tokens vs ~750k for
   // anthropic_base). Ratio: 750/555 ≈ 1.35, applied on top of the base 1.3
   // adjustment → 1.3 × 1.35 ≈ 1.75.


### PR DESCRIPTION
## Description

Set `useNativeLightReasoning` for Opus 4.8 so configured `light` effort maps to adaptive low reasoning instead of disabled thinking.

This restores valid signed reasoning blocks after the effort resolver began honoring the configured light effort.

## Tests

Added unit coverage for native light mapping to adaptive thinking with low output effort. The focused run was blocked because the cold Hive environment has no test database.

## Risk

Low. Only Opus 4.8 calls configured with `light` effort change, from disabled thinking to adaptive low reasoning.

## Deploy Plan

Standard deploy.