### PR TITLE
Report OpenAI 5.6 cache writes correctly

### DIFF
--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -13,7 +13,7 @@ const metadata = {
 type ChunkDelta = ChatCompletionChunk["choices"][number]["delta"];
 type ChunkFinishReason =
   ChatCompletionChunk["choices"][number]["finish_reason"];
-type ChunkUsage = ChatCompletionChunk["usage"];
+type ChunkUsage = NonNullable<ChatCompletionChunk["usage"]>;
 
 function makeChunk({
   delta,
@@ -394,6 +394,39 @@ describe("streamLLMEvents", () => {
         outputTokens: 4,
         totalTokens: 7,
         cachedTokens: undefined,
+      },
+      metadata,
+    });
+  });
+
+  it("splits standard input, cache reads, and cache writes", async () => {
+    const result = [];
+    const usage: ChunkUsage = {
+      prompt_tokens: 2006,
+      completion_tokens: 300,
+      total_tokens: 2306,
+      prompt_tokens_details: {
+        cached_tokens: 1200,
+        cache_write_tokens: 720,
+      },
+    };
+
+    for await (const event of streamLLMEvents(
+      createAsyncGenerator([makeUsageChunk(usage)]),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    expect(result.find((event) => event.type === "token_usage")).toEqual({
+      type: "token_usage",
+      content: {
+        inputTokens: 2006,
+        outputTokens: 300,
+        totalTokens: 2306,
+        cachedTokens: 1200,
+        cacheCreationTokens: 720,
+        uncachedInputTokens: 86,
       },
       metadata,
     });

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -43,13 +43,27 @@ export async function* streamLLMEvents(
     }
 
     if (chunk.usage && !hasYieldedTokenUsage) {
+      const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
+      const cacheCreationTokens =
+        chunk.usage.prompt_tokens_details?.cache_write_tokens;
+      const hasCacheDetails =
+        cachedTokens !== undefined || cacheCreationTokens !== undefined;
       const tokenUsageEvent: LLMEvent = {
         type: "token_usage",
         content: {
           inputTokens: chunk.usage.prompt_tokens,
           outputTokens: chunk.usage.completion_tokens,
           totalTokens: chunk.usage.total_tokens,
-          cachedTokens: chunk.usage.prompt_tokens_details?.cached_tokens,
+          cachedTokens,
+          cacheCreationTokens,
+          uncachedInputTokens: hasCacheDetails
+            ? Math.max(
+                0,
+                chunk.usage.prompt_tokens -
+                  (cachedTokens ?? 0) -
+                  (cacheCreationTokens ?? 0)
+              )
+            : undefined,
         },
         metadata,
       };

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -196,8 +196,17 @@ function responseCompleted(
   } = response.usage;
   // even if in the types `input_tokens_details` and `output_tokens_details` are NOT optional,
   // some providers (e.g. Fireworks) return them as null
-  // NB: OpenAI API does not return the number of cache writes
   const cachedTokens = response.usage.input_tokens_details?.cached_tokens;
+  const cacheCreationTokens =
+    response.usage.input_tokens_details?.cache_write_tokens;
+  const hasCacheDetails =
+    cachedTokens !== undefined || cacheCreationTokens !== undefined;
+  const uncachedInputTokens = hasCacheDetails
+    ? Math.max(
+        0,
+        inputTokens - (cachedTokens ?? 0) - (cacheCreationTokens ?? 0)
+      )
+    : undefined;
   const reasoningTokens =
     response.usage.output_tokens_details?.reasoning_tokens;
 
@@ -206,6 +215,8 @@ function responseCompleted(
     content: {
       inputTokens,
       cachedTokens,
+      cacheCreationTokens,
+      uncachedInputTokens,
       reasoningTokens,
       outputTokens,
       totalTokens,

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -98,6 +98,8 @@ export const functionCallLLMEvents: LLMEvent[] = [
     content: {
       inputTokens: 1391,
       cachedTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 1391,
       reasoningTokens: 0,
       outputTokens: 74,
       totalTokens: 1465,

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
@@ -114,6 +114,8 @@ export const reasoningLLMEvents = [
     content: {
       inputTokens: 6853,
       cachedTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 6853,
       reasoningTokens: 320,
       outputTokens: 414,
       totalTokens: 7267,

--- a/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
@@ -4,6 +4,10 @@ import { functionCallLLMEvents } from "@app/lib/api/llm/utils/openai_like/respon
 import { reasoningLLMEvents } from "@app/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning";
 import { functionCallModelEvents } from "@app/lib/api/llm/utils/openai_like/responses/test/fixtures/model_output/function_call";
 import { reasoningModelOutput } from "@app/lib/api/llm/utils/openai_like/responses/test/fixtures/model_output/reasoning";
+import type {
+  ResponseCompletedEvent,
+  ResponseUsage,
+} from "openai/resources/responses/responses";
 import { describe, expect, it } from "vitest";
 
 const metadata = {
@@ -39,5 +43,57 @@ describe("streamLLMEvents", () => {
     }
 
     expect(result).toEqual(reasoningLLMEvents);
+  });
+
+  it("splits standard input, cache reads, and cache writes", async () => {
+    const completedEvent = functionCallModelEvents.find(
+      (event): event is ResponseCompletedEvent =>
+        event.type === "response.completed"
+    );
+    expect(completedEvent).toBeDefined();
+    if (!completedEvent) {
+      return;
+    }
+
+    const usage: ResponseUsage = {
+      input_tokens: 2006,
+      input_tokens_details: {
+        cached_tokens: 1200,
+        cache_write_tokens: 720,
+      },
+      output_tokens: 300,
+      output_tokens_details: { reasoning_tokens: 50 },
+      total_tokens: 2306,
+    };
+    const responseCompletedEvent: ResponseCompletedEvent = {
+      ...completedEvent,
+      response: {
+        ...completedEvent.response,
+        usage,
+      },
+    };
+    const responseStreamEvents = createAsyncGenerator([responseCompletedEvent]);
+    const result = [];
+
+    for await (const event of openai_to_events.streamLLMEvents(
+      responseStreamEvents,
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    expect(result.find((event) => event.type === "token_usage")).toEqual({
+      type: "token_usage",
+      content: {
+        inputTokens: 2006,
+        cachedTokens: 1200,
+        cacheCreationTokens: 720,
+        uncachedInputTokens: 86,
+        reasoningTokens: 50,
+        outputTokens: 300,
+        totalTokens: 2306,
+      },
+      metadata,
+    });
   });
 });

--- a/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
@@ -39,17 +39,22 @@ function usageToTokenUsageEvent(
   usage: ChatCompletionChunk["usage"]
 ): TokenUsageEvent {
   const cacheHit = usage?.prompt_tokens_details?.cached_tokens ?? 0;
+  const cacheCreated = usage?.prompt_tokens_details?.cache_write_tokens ?? 0;
   const reasoning = usage?.completion_tokens_details?.reasoning_tokens ?? 0;
   return {
     type: "token_usage",
     content: {
-      // OpenAI-style prompt caching has no separate creation cost or TTL buckets.
-      cacheCreated: 0,
+      // OpenAI usage reports a flat cache write total without TTL buckets.
+      cacheCreated,
       longCacheCreated: 0,
       shortCacheCreated: 0,
       cacheHit,
-      // prompt_tokens includes cached; subtract to get the uncached portion.
-      standardInput: (usage?.prompt_tokens ?? 0) - cacheHit,
+      // prompt_tokens includes cache reads and writes. Subtract both to get
+      // standard input.
+      standardInput: Math.max(
+        0,
+        (usage?.prompt_tokens ?? 0) - cacheHit - cacheCreated
+      ),
       standardOutput: (usage?.completion_tokens ?? 0) - reasoning,
       reasoning,
     },

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
@@ -1,0 +1,39 @@
+import { usageToTokenUsageEvent } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import type { ResponseUsage } from "openai/resources/responses/responses";
+import { describe, expect, it } from "vitest";
+
+const metadata = {
+  lab: "openai",
+  host: "openai-responses",
+  model: "gpt-5.4",
+  region: "global",
+} as const;
+
+describe("usageToTokenUsageEvent", () => {
+  it("splits standard input, cache reads, and cache writes", () => {
+    const usage: ResponseUsage = {
+      input_tokens: 2006,
+      input_tokens_details: {
+        cached_tokens: 1200,
+        cache_write_tokens: 720,
+      },
+      output_tokens: 300,
+      output_tokens_details: { reasoning_tokens: 50 },
+      total_tokens: 2306,
+    };
+
+    expect(usageToTokenUsageEvent(metadata, usage)).toEqual({
+      type: "token_usage",
+      content: {
+        cacheCreated: 720,
+        longCacheCreated: 0,
+        shortCacheCreated: 0,
+        cacheHit: 1200,
+        standardInput: 86,
+        standardOutput: 250,
+        reasoning: 50,
+      },
+      metadata,
+    });
+  });
+});

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -196,18 +196,19 @@ export function usageToTokenUsageEvent(
   usage: ResponseUsage
 ): TokenUsageEvent {
   const cacheHit = usage.input_tokens_details?.cached_tokens ?? 0;
+  const cacheCreated = usage.input_tokens_details?.cache_write_tokens ?? 0;
   const reasoning = usage.output_tokens_details?.reasoning_tokens ?? 0;
   return {
     type: "token_usage",
     content: {
-      // OpenAI prompt caching has no separate creation cost, nor per-TTL
-      // buckets.
-      cacheCreated: 0,
+      // OpenAI reports a flat cache write total without TTL buckets.
+      cacheCreated,
       longCacheCreated: 0,
       shortCacheCreated: 0,
       cacheHit,
-      // input_tokens includes cached; subtract to get the uncached portion.
-      standardInput: usage.input_tokens - cacheHit,
+      // input_tokens includes cache reads and writes. Subtract both to get
+      // standard input.
+      standardInput: Math.max(0, usage.input_tokens - cacheHit - cacheCreated),
       standardOutput: usage.output_tokens - reasoning,
       reasoning,
     },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since OpenAI 5.6 we now need to pay a premium for cache write. Our token reports was not accounting for it. This PR changes so that it reports cache reads and writes separately in both routers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
