### PR TITLE
Add list loading skeleton to skill import dialog

### DIFF
--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -9,10 +9,10 @@ import {
   ContentMessage,
   createSelectionColumn,
   DataTable,
+  DataTableLoadingSkeleton,
   InfoCircle,
   PuzzlePiece01,
   ScrollableDataTable,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useEffect, useMemo } from "react";
@@ -141,11 +141,7 @@ export function DetectedSkillsList({
           {detectError}
         </ContentMessage>
       )}
-      {isDetecting && (
-        <div className="flex items-center justify-center py-4">
-          <Spinner size="md" />
-        </div>
-      )}
+      {isDetecting && <DataTableLoadingSkeleton rows={3} />}
       {rows.length > 0 && (
         <ScrollableDataTable<SkillRowData>
           data={rows}

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -10,7 +10,7 @@ import { useWorkspaceGitHubConnection } from "@app/lib/swr/github_connection";
 import { useDetectSkillsFromRepo } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { ContentMessage, InfoCircle, Input } from "@dust-tt/sparkle";
+import { ContentMessage, cn, InfoCircle, Input } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
@@ -73,6 +73,12 @@ export function ImportFromRepositoryTab({
 
   const showRepositoryNotFound = repositoryNotFound && !isConnectionLoading;
 
+  const hasRepositoryContent =
+    isDetecting ||
+    !!detectError ||
+    showRepositoryNotFound ||
+    detectedSkills.length > 0;
+
   let repositoryContent = (
     <DetectedSkillsList
       detectedSkills={detectedSkills}
@@ -90,8 +96,8 @@ export function ImportFromRepositoryTab({
       >
         The currently connected GitHub account can't access this repository.{" "}
         {isAdmin(owner)
-          ? "Reconnect with an account that has access."
-          : "Ask an admin to reconnect with an account that has access."}
+          ? "Check the URL or reconnect with an account that has access."
+          : "Check the URL or ask an admin to reconnect with an account that has access."}
       </ContentMessage>
     );
   } else if (showRepositoryNotFound && isAdmin(owner)) {
@@ -139,7 +145,11 @@ export function ImportFromRepositoryTab({
         className="bg-muted-background"
       />
 
-      {repositoryContent}
+      <div
+        className={cn("flex flex-col", hasRepositoryContent && "min-h-[160px]")}
+      >
+        {repositoryContent}
+      </div>
 
       {connection && (
         <GitHubConnectionRow

--- a/sparkle/src/components/DataTableLoadingSkeleton.tsx
+++ b/sparkle/src/components/DataTableLoadingSkeleton.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@sparkle/lib/utils";
+import * as React from "react";
+
+import { LoadingBlock } from "./LoadingBlock";
+
+const LABEL_WIDTHS = ["w-32", "w-48", "w-28", "w-40", "w-36"];
+
+interface DataTableLoadingSkeletonProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  rows?: number;
+  showSelectionColumn?: boolean;
+  showTrailingCell?: boolean;
+}
+
+function DataTableLoadingSkeleton({
+  rows = 5,
+  showSelectionColumn = true,
+  showTrailingCell = false,
+  className,
+  ...props
+}: DataTableLoadingSkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("flex w-full flex-col", className)}
+      {...props}
+    >
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          className="flex h-12 items-center gap-3 border-b border-separator px-2"
+        >
+          {showSelectionColumn && (
+            <LoadingBlock className="h-5 w-5 shrink-0 rounded-md" />
+          )}
+          <LoadingBlock
+            className={cn("h-4", LABEL_WIDTHS[i % LABEL_WIDTHS.length])}
+          />
+          {showTrailingCell && (
+            <LoadingBlock className="ml-auto h-5 w-24 rounded-full" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export { DataTableLoadingSkeleton };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -92,6 +92,7 @@ export {
   DataTable,
   ScrollableDataTable,
 } from "./DataTable";
+export { DataTableLoadingSkeleton } from "./DataTableLoadingSkeleton";
 export {
   Dialog,
   DialogClose,

--- a/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { DataTableLoadingSkeleton } from "@sparkle/components";
+
+const meta = {
+  title: "Feedback & Status/DataTableLoadingSkeleton",
+  component: DataTableLoadingSkeleton,
+  parameters: {
+    docs: {
+      description: {
+        component: `A skeleton placeholder that mirrors the layout of a **DataTable** / **ScrollableDataTable** list (rows with an optional selection checkbox, a label, and an optional trailing cell). Built on **LoadingBlock**, it reserves the list's shape while rows are being fetched, so the swap to real content feels seamless.
+
+**When to use**
+- While loading rows whose shape is known ahead of time (selectable lists, tables).
+
+**Guidelines**
+- Toggle \`showSelectionColumn\` and \`showTrailingCell\` to match the real table's columns.
+- For an indeterminate load with no known layout, use a **Spinner** instead.`,
+      },
+    },
+  },
+  argTypes: {
+    rows: { control: { type: "number" } },
+    showSelectionColumn: { control: "boolean" },
+    showTrailingCell: { control: "boolean" },
+  },
+} satisfies Meta<typeof DataTableLoadingSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Demo: Story = {
+  args: {
+    rows: 5,
+    showSelectionColumn: true,
+    showTrailingCell: false,
+  },
+};
+
+export const PlainList: Story = {
+  args: {
+    rows: 6,
+    showSelectionColumn: false,
+    showTrailingCell: false,
+  },
+};


### PR DESCRIPTION
## Description

Added skeleton instead of spinner to skills import from repo 
Standardized the size of the popup when URL is not empty so that there isn't a blink during the skills detection

Skeleton in storybook:
<img width="329" height="252" alt="Screenshot 2026-07-21 at 15 55 02" src="https://github.com/user-attachments/assets/f912a46c-4ae7-4a74-8570-874e658b9d2e" />

## Tests

Tested locally 

## Risk

Low

## Deploy Plan

Deploy front and sparkle