### PR TITLE
Denormalize group kind on group vaults (take #1)

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -584,6 +584,7 @@ export async function createSpaceAndGroup(
         {
           kind: space.isProject() ? "project_viewer" : "member",
           groupId: globalGroup.id,
+          groupKind: globalGroup.kind,
           vaultId: space.id,
           workspaceId: owner.id,
         },

--- a/front/lib/dev/byok_seed.sql
+++ b/front/lib/dev/byok_seed.sql
@@ -124,8 +124,8 @@ inserted_conversations_space AS (
 
 -- Step 6a: Link system group → system space
 link_system AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT sg."workspaceId", sg.id, ss.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT sg."workspaceId", sg.id, 'system', ss.id, NOW(), NOW()
   FROM inserted_system_group sg
   CROSS JOIN inserted_system_space ss
   RETURNING "vaultId"
@@ -133,8 +133,8 @@ link_system AS (
 
 -- Step 6b: Link global group → global space
 link_global AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT gg."workspaceId", gg.id, gs.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT gg."workspaceId", gg.id, 'global', gs.id, NOW(), NOW()
   FROM inserted_global_group gg
   CROSS JOIN inserted_global_space gs
   RETURNING "vaultId"
@@ -142,8 +142,8 @@ link_global AS (
 
 -- Step 6c: Link global group → conversations space
 link_conversations AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT gg."workspaceId", gg.id, cs.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT gg."workspaceId", gg.id, 'global', cs.id, NOW(), NOW()
   FROM inserted_global_group gg
   CROSS JOIN inserted_conversations_space cs
   RETURNING "vaultId"

--- a/front/lib/dev/dust_hive_seed.sql
+++ b/front/lib/dev/dust_hive_seed.sql
@@ -115,8 +115,8 @@ inserted_conversations_space AS (
 
 -- Step 5a: Link system group to system space
 link_system AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT sg."workspaceId", sg.id, ss.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT sg."workspaceId", sg.id, 'system', ss.id, NOW(), NOW()
   FROM inserted_system_group sg
   CROSS JOIN inserted_system_space ss
   RETURNING "vaultId"
@@ -124,8 +124,8 @@ link_system AS (
 
 -- Step 5b: Link global group to global space
 link_global AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT gg."workspaceId", gg.id, gs.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT gg."workspaceId", gg.id, 'global', gs.id, NOW(), NOW()
   FROM inserted_global_group gg
   CROSS JOIN inserted_global_space gs
   RETURNING "vaultId"
@@ -133,8 +133,8 @@ link_global AS (
 
 -- Step 5c: Link global group to conversations space
 link_conversations AS (
-  INSERT INTO group_vaults ("workspaceId", "groupId", "vaultId", "createdAt", "updatedAt")
-  SELECT gg."workspaceId", gg.id, cs.id, NOW(), NOW()
+  INSERT INTO group_vaults ("workspaceId", "groupId", "groupKind", "vaultId", "createdAt", "updatedAt")
+  SELECT gg."workspaceId", gg.id, 'global', cs.id, NOW(), NOW()
   FROM inserted_global_group gg
   CROSS JOIN inserted_conversations_space cs
   RETURNING "vaultId"

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -48,6 +48,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
+        groupKind: group.kind,
         vaultId: space.id,
         workspaceId: auth.getNonNullableWorkspace().id,
         kind: "project_editor",

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -46,6 +46,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
+        groupKind: group.kind,
         vaultId: space.id,
         workspaceId: auth.getNonNullableWorkspace().id,
         kind: "member",

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -52,6 +52,7 @@ describe("GroupSpaceMemberResource", () => {
       expect(groupSpaceMember.vaultId).toBe(regularSpace.id);
       expect(groupSpaceMember.workspaceId).toBe(workspace.id);
       expect(groupSpaceMember.kind).toBe("member");
+      expect(groupSpaceMember.groupKind).toBe("regular_auto");
     });
   });
 
@@ -171,6 +172,7 @@ describe("GroupSpaceEditorResource", () => {
 
       expect(groupSpaceEditor).toBeInstanceOf(GroupSpaceEditorResource);
       expect(groupSpaceEditor.kind).toBe("project_editor");
+      expect(groupSpaceEditor.groupKind).toBe("provisioned");
     });
   });
 
@@ -235,6 +237,7 @@ describe("GroupSpaceEditorResource", () => {
       // Create a GroupSpaceModel with a non-editor group
       await GroupSpaceModel.create({
         groupId: regularGroup.id,
+        groupKind: regularGroup.kind,
         vaultId: projectSpace.id,
         workspaceId: workspace.id,
         kind: "project_editor",
@@ -328,6 +331,7 @@ describe("GroupSpaceViewerResource", () => {
       expect(result?.groupId).toBe(globalGroup.id);
       expect(result?.vaultId).toBe(projectSpace.id);
       expect(result?.kind).toBe("project_viewer");
+      expect(result?.groupKind).toBe("global");
     });
 
     it("should throw an assertion error when space is not a project space", async () => {
@@ -355,6 +359,7 @@ describe("GroupSpaceViewerResource", () => {
       // Create a GroupSpaceModel with a non-global group
       await GroupSpaceModel.create({
         groupId: regularGroup.id,
+        groupKind: regularGroup.kind,
         vaultId: projectSpace.id,
         workspaceId: workspace.id,
         kind: "project_viewer",

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -45,6 +45,7 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
+        groupKind: group.kind,
         vaultId: space.id,
         workspaceId: auth.getNonNullableWorkspace().id,
         kind: "project_viewer",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -85,6 +85,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         await GroupSpaceModel.create(
           {
             groupId: memberGroup.id,
+            groupKind: memberGroup.kind,
             vaultId: space.id,
             workspaceId: space.workspaceId,
             kind: "member",
@@ -101,6 +102,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           await GroupSpaceModel.create(
             {
               groupId: editorGroup.id,
+              groupKind: editorGroup.kind,
               vaultId: space.id,
               workspaceId: space.workspaceId,
               kind: "project_editor",

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -3,12 +3,15 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { GroupKind } from "@app/types/groups";
 import type { GroupSpaceKind } from "@app/types/space";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
 export class GroupSpaceModel extends WorkspaceAwareModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare groupId: ForeignKey<GroupModel["id"]>;
+  // Denormalized from groups.kind. Keep in sync if group kinds ever become mutable.
+  declare groupKind: GroupKind | null;
   declare vaultId: ForeignKey<SpaceModel["id"]>;
   declare kind: GroupSpaceKind;
 }
@@ -26,6 +29,10 @@ GroupSpaceModel.init(
       validate: {
         isIn: [["member", "project_editor", "project_viewer"]],
       },
+    },
+    groupKind: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -70,6 +70,8 @@ async function backfillAgentEditorsGroup(
       const groupModel = await GroupModel.findByPk(editorGroup.id);
       assert(groupModel, "Group model not found");
       if (execute) {
+        // If reusing this group-kind update, also update the denormalized
+        // group_vaults.groupKind. See https://github.com/dust-tt/dust/pull/29239.
         await groupModel.update({
           kind: "agent_editors",
         });

--- a/front/migrations/20260112_migrate_skill_editor_groups.ts
+++ b/front/migrations/20260112_migrate_skill_editor_groups.ts
@@ -86,6 +86,8 @@ async function migrateSkillEditorGroups(
       );
 
       if (execute) {
+        // If reusing this group-kind update, also update the denormalized
+        // group_vaults.groupKind. See https://github.com/dust-tt/dust/pull/29239.
         await group.update({
           kind: "skill_editors",
           name: newName,

--- a/front/migrations/pre-deploy/20260721155534_add_group_kind_to_group_vaults.sql
+++ b/front/migrations/pre-deploy/20260721155534_add_group_kind_to_group_vaults.sql
@@ -1,0 +1,8 @@
+/*
+Add the nullable groupKind column to group_vaults. Existing rows can be backfilled after all
+writers populate the column.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_vaults"
+  ADD COLUMN "groupKind" character varying(255) COLLATE "pg_catalog"."default";

--- a/front/scripts/move_company_space_to_restricted.ts
+++ b/front/scripts/move_company_space_to_restricted.ts
@@ -175,6 +175,7 @@ makeScript(
       await GroupSpaceModel.create(
         {
           groupId: memberGroup.id,
+          groupKind: memberGroup.kind,
           vaultId: globalSpace.id,
           workspaceId: workspace.id,
           kind: "member",
@@ -197,6 +198,7 @@ makeScript(
           await GroupSpaceModel.create(
             {
               groupId: group.id,
+              groupKind: group.kind,
               vaultId: globalSpace.id,
               workspaceId: workspace.id,
               kind: "member",

--- a/front/tests/utils/GroupSpaceFactory.ts
+++ b/front/tests/utils/GroupSpaceFactory.ts
@@ -10,6 +10,7 @@ export class GroupSpaceFactory {
   ): Promise<GroupSpaceModel> {
     return GroupSpaceModel.create({
       groupId: group.id,
+      groupKind: group.kind,
       vaultId: space.id,
       workspaceId: space.workspaceId,
       kind,


### PR DESCRIPTION
## Description

- add a nullable `groupKind` column to `group_vaults`
- populate it from `groups.kind` in every group-vault creation path and development seed
- document the denormalization contract beside historical group-kind migrations
- add focused assertions for member, editor, and viewer relationships

Space reads currently need the intrinsic group kind but should not need an additional join through `groups`. Storing the immutable group kind on the group-vault relationship prepares that query simplification while keeping the rollout backwards-compatible for existing rows.

`groups.kind` has no active runtime mutation path. Historical migrations that changed it are documented so future changes synchronize the denormalized value.

While this is unsatisfying to have such a denormalization, the `group_vaults` table will be soon removed by the admin governance initiative in favour of a new `group_permissions` table. Interestingly the kinds (on groups) needed for permission checking are already slated by this initiative to be moved to `group_permissions`. It was a hack to have the `agent_editors`, `skill_editors`, ... kinds on `groups` which is also the root cause for needing `group.kind` in `SpaceResource`.

## Tests

- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`
- `NODE_ENV=test npm test -- lib/resources/group_space_resource.test.ts lib/dev/dust_hive_seed_schema.test.ts`
- `NODE_ENV=test npm test -- lib/resources/space_resource.test.ts lib/api/spaces.test.ts`

## Risks

- Low simple column addition and new writes to it.

## Deploy Plan

- `npm run migration:apply:pre-deploy`
- deploy `front`