### PR TITLE
feat: check create agent permission frontend

### DIFF
--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -160,7 +160,7 @@ export function WelcomeTourGuide({
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
+  const canCreateAgent = hasPermission("create", "agent");
 
   const connections = useMemo(() => {
     return Object.values(CONNECTOR_CONFIGURATIONS)
@@ -199,8 +199,7 @@ export function WelcomeTourGuide({
             workspace.
           </div>
           <div className="copy-base px-3 text-muted-foreground">
-            Discover the basics of Dust in{" "}
-            {!isRestrictedFromAgentCreation ? "3" : "2"} steps.
+            Discover the basics of Dust in {canCreateAgent ? "3" : "2"} steps.
           </div>
         </>
       ),
@@ -311,7 +310,7 @@ export function WelcomeTourGuide({
         </>
       ),
     },
-    ...(!isRestrictedFromAgentCreation
+    ...(canCreateAgent
       ? [
           {
             anchorRef: createAgentButtonRef,

--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -1,9 +1,8 @@
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   AnchoredPopover,
   Avatar,
@@ -159,11 +158,9 @@ export function WelcomeTourGuide({
   const centeredRef = useRef<HTMLDivElement>(null);
   const [currentStep, setCurrentStep] = useState(0);
 
-  const { featureFlags } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner);
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
 
   const connections = useMemo(() => {
     return Object.values(CONNECTOR_CONFIGURATIONS)

--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -160,7 +160,7 @@ export function WelcomeTourGuide({
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
 
   const connections = useMemo(() => {
     return Object.values(CONNECTOR_CONFIGURATIONS)

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -175,7 +175,7 @@ export function ConversationMenu({
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
   const canTurnIntoAgent =
     !!conversation &&
     !!user &&

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -18,10 +18,11 @@ import { useMoveConversationToPod } from "@app/hooks/useMoveConversationToPod";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -38,7 +39,6 @@ import {
   isPodConversation,
 } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   ArrowRight,
   Avatar,
@@ -166,7 +166,6 @@ export function ConversationMenu({
   openDetailsInNewTab,
 }: ConversationMenuProps) {
   const { user, providersHealth } = useAuth();
-  const { featureFlags } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
 
   const clientType = useClientType();
@@ -174,9 +173,9 @@ export function ConversationMenu({
 
   const router = useAppRouter();
 
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner);
+  const { hasPermission } = useWorkspacePermissions(owner);
+
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
   const canTurnIntoAgent =
     !!conversation &&
     !!user &&

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -175,11 +175,11 @@ export function ConversationMenu({
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
+  const canCreateAgent = hasPermission("create", "agent");
   const canTurnIntoAgent =
     !!conversation &&
     !!user &&
-    !isRestrictedFromAgentCreation &&
+    canCreateAgent &&
     !isMobile &&
     clientType !== "extension";
   const sendNotification = useSendNotification();

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -497,7 +497,7 @@ export function AgentSidebarMenu({
   const { isStarredPodsSectionCollapsed, setStarredPodsSectionCollapsed } =
     useStarredPodsSectionCollapsed();
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
+  const canCreateAgent = hasPermission("create", "agent");
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -990,7 +990,7 @@ export function AgentSidebarMenu({
                         />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {!isRestrictedFromAgentCreation && (
+                        {canCreateAgent && (
                           <>
                             <DropdownMenuLabel>Agents</DropdownMenuLabel>
                             <DropdownMenuSub>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -497,7 +497,7 @@ export function AgentSidebarMenu({
   const { isStarredPodsSectionCollapsed, setStarredPodsSectionCollapsed } =
     useStarredPodsSectionCollapsed();
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -37,12 +37,13 @@ import { usePodsSectionCollapsed } from "@app/hooks/usePodsSectionCollapsed";
 import { useSearchPods } from "@app/hooks/useSearchPods";
 import { useStarredPodsSectionCollapsed } from "@app/hooks/useStarredPodsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -419,7 +420,7 @@ export function AgentSidebarMenu({
   const router = useAppRouter();
   const activeConversationId = useActiveConversationId();
   const activePodId = useActivePodId();
-  const { hasFeature } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions(owner);
   const moveConversationToPod = useMoveConversationToPod(owner);
   const bulkMoveConversationsToPod = useBulkMoveConversationsToPod(owner);
 
@@ -496,8 +497,7 @@ export function AgentSidebarMenu({
   const { isStarredPodsSectionCollapsed, setStarredPodsSectionCollapsed } =
     useStarredPodsSectionCollapsed();
 
-  const isRestrictedFromAgentCreation =
-    hasFeature("disallow_agent_creation_to_users") && !isBuilder(owner);
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -1,8 +1,8 @@
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getAgentBuilderRoute, setQueryParam } from "@app/lib/utils/router";
 import { isBuilder } from "@app/types/user";
@@ -21,7 +21,6 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
-
 import {
   AGENTS_TABS,
   AgentBrowserSearchDropdown,
@@ -52,11 +51,9 @@ export function WebAgentBrowser({
 }: WebAgentBrowserProps) {
   const router = useAppRouter();
   const { createAgentButtonRef } = useWelcomeTourGuide();
-  const { featureFlags } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner);
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -53,7 +53,7 @@ export function WebAgentBrowser({
   const { createAgentButtonRef } = useWelcomeTourGuide();
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -53,7 +53,7 @@ export function WebAgentBrowser({
   const { createAgentButtonRef } = useWelcomeTourGuide();
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
+  const canCreateAgent = hasPermission("create", "agent");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {
@@ -98,7 +98,7 @@ export function WebAgentBrowser({
 
         <div className="hidden sm:block">
           <div className="flex gap-2">
-            {!isRestrictedFromAgentCreation && (
+            {canCreateAgent && (
               <div ref={createAgentButtonRef}>
                 <CreateDropdown owner={owner} dataGtmLocation="homepage" />
               </div>
@@ -106,7 +106,7 @@ export function WebAgentBrowser({
             {isBuilder(owner) ? (
               <ManageDropdownMenu owner={owner} />
             ) : (
-              !isRestrictedFromAgentCreation && (
+              canCreateAgent && (
                 <Button
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   variant="primary"

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -82,7 +82,7 @@ export function ManageAgentsPage() {
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
   const shouldDisableAgentFetching = isRestrictedFromAgentCreation;
   const isSearchActive = assistantSearch.trim() !== "";
 

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -11,13 +11,10 @@ import {
   useSetNavChildren,
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   compareForFuzzySort,
   getAgentSearchString,
@@ -74,7 +71,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
 
 export function ManageAgentsPage() {
   const owner = useWorkspace();
-  const { user, isBuilder } = useAuth();
+  const { user } = useAuth();
   const [assistantSearch, setAssistantSearch] = useState("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
     useState<string | null>(null);
@@ -83,10 +80,9 @@ export function ManageAgentsPage() {
   const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
 
-  const { featureFlags } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder;
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
   const shouldDisableAgentFetching = isRestrictedFromAgentCreation;
   const isSearchActive = assistantSearch.trim() !== "";
 

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -82,8 +82,8 @@ export function ManageAgentsPage() {
 
   const { hasPermission } = useWorkspacePermissions(owner);
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
-  const shouldDisableAgentFetching = isRestrictedFromAgentCreation;
+  const canCreateAgent = hasPermission("create", "agent");
+  const shouldDisableAgentFetching = !canCreateAgent;
   const isSearchActive = assistantSearch.trim() !== "";
 
   const activeTab = useMemo(() => {
@@ -215,7 +215,7 @@ export function ManageAgentsPage() {
   }, []);
 
   useEffect(() => {
-    if (isRestrictedFromAgentCreation) {
+    if (!canCreateAgent) {
       return;
     }
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -229,7 +229,7 @@ export function ManageAgentsPage() {
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [isRestrictedFromAgentCreation]);
+  }, [canCreateAgent]);
 
   const navChildren = useMemo(
     () => <AgentSidebarMenu owner={owner} />,
@@ -241,7 +241,7 @@ export function ManageAgentsPage() {
 
   return (
     <>
-      {isRestrictedFromAgentCreation ? (
+      {!canCreateAgent ? (
         <Custom404 />
       ) : (
         <>
@@ -284,7 +284,7 @@ export function ManageAgentsPage() {
                       setSelectedTags={setSelectedTags}
                       owner={owner}
                     />
-                    {!isRestrictedFromAgentCreation && (
+                    {canCreateAgent && (
                       <CreateDropdown
                         owner={owner}
                         dataGtmLocation="assistantsWorkspace"
@@ -366,7 +366,7 @@ export function ManageAgentsPage() {
                   />
                 ) : (
                   !assistantSearch &&
-                  !isRestrictedFromAgentCreation && (
+                  canCreateAgent && (
                     <div className="pt-2">
                       <EmptyCallToAction
                         href={`/w/${owner.sId}/builder/agents/create`}

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -5,16 +5,13 @@ import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
 import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
 import Custom404 from "@app/components/pages/Custom404";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSearchParam } from "@app/lib/platform";
 import {
   useAgentConfiguration,
   useAssistantTemplate,
 } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import type {
   AgentConfigurationScope,
@@ -28,8 +25,8 @@ function isBuilderFlow(value: string): value is BuilderFlow {
 
 export function NewAgentPage() {
   const owner = useWorkspace();
-  const { user, isAdmin, isBuilder, providersHealth } = useAuth();
-  const { featureFlags } = useFeatureFlags();
+  const { user, isAdmin, providersHealth } = useAuth();
+  const { hasPermission } = useWorkspacePermissions(owner);
 
   const flowParam = useSearchParam("flow");
   const flow: BuilderFlow =
@@ -39,8 +36,7 @@ export function NewAgentPage() {
   const templateId = useSearchParam("templateId");
   const conversationId = useSearchParam("conversationId");
 
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder;
+  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
 
   const {
     agentConfiguration,

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -36,7 +36,7 @@ export function NewAgentPage() {
   const templateId = useSearchParam("templateId");
   const conversationId = useSearchParam("conversationId");
 
-  const isRestrictedFromAgentCreation = !hasPermission("agent", "create");
+  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
 
   const {
     agentConfiguration,

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -36,7 +36,7 @@ export function NewAgentPage() {
   const templateId = useSearchParam("templateId");
   const conversationId = useSearchParam("conversationId");
 
-  const isRestrictedFromAgentCreation = !hasPermission("create", "agent");
+  const canCreateAgent = hasPermission("create", "agent");
 
   const {
     agentConfiguration,
@@ -68,7 +68,7 @@ export function NewAgentPage() {
 
   const isDuplicateLoading = !!duplicateAgentId && isAgentConfigurationLoading;
 
-  if (isRestrictedFromAgentCreation) {
+  if (!canCreateAgent) {
     return <Custom404 />;
   }
 

--- a/front/lib/swr/permissions.ts
+++ b/front/lib/swr/permissions.ts
@@ -1,0 +1,51 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPermissionsResponseBody } from "@app/types/api/governance";
+import type {
+  ConcreteResourceType,
+  GrantVerb,
+} from "@app/types/group_permissions";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useMemo } from "react";
+import type { Fetcher, SWRConfiguration } from "swr";
+
+// Workspace permissions rarely change within a session, so we keep the query cheap: dedupe
+// identical requests within a minute and throttle focus-triggered revalidations to five minutes.
+// This mirrors the low-churn strategy we use for other capability lookups.
+const WORKSPACE_PERMISSIONS_SWR_OPTIONS: SWRConfiguration = {
+  dedupingInterval: 60 * 1000,
+  focusThrottleInterval: 5 * 60 * 1000,
+};
+
+export function useWorkspacePermissions(
+  owner: LightWorkspaceType,
+  { disabled }: { disabled?: boolean } = {}
+) {
+  const { fetcher } = useFetcher();
+
+  const permissionsFetcher: Fetcher<GetPermissionsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/permissions`,
+    permissionsFetcher,
+    { ...WORKSPACE_PERMISSIONS_SWR_OPTIONS, disabled }
+  );
+
+  const workspacePermissions = useMemo(
+    () => data?.workspacePermissions,
+    [data]
+  );
+
+  const hasPermission = useCallback(
+    (resourceType: ConcreteResourceType, verb: GrantVerb): boolean =>
+      workspacePermissions?.[resourceType]?.includes(verb) ?? false,
+    [workspacePermissions]
+  );
+
+  return {
+    workspacePermissions,
+    hasPermission,
+    isWorkspacePermissionsLoading: !error && !data && !disabled,
+    isWorkspacePermissionsError: !!error,
+    mutateWorkspacePermissions: mutate,
+  };
+}

--- a/front/lib/swr/permissions.ts
+++ b/front/lib/swr/permissions.ts
@@ -36,7 +36,7 @@ export function useWorkspacePermissions(
   );
 
   const hasPermission = useCallback(
-    (resourceType: ConcreteResourceType, verb: GrantVerb): boolean =>
+    (verb: GrantVerb, resourceType: ConcreteResourceType): boolean =>
       workspacePermissions?.[resourceType]?.includes(verb) ?? false,
     [workspacePermissions]
   );


### PR DESCRIPTION
## Description

This PR replaces the frontend agent creation permission check — previously based on the `disallow_agent_creation_to_users` feature flag and the `isBuilder` role — with a unified `hasPermission("agent", "create")` call backed by the workspace permissions API.

- Introduces a new `useWorkspacePermissions` SWR hook (`front/lib/swr/permissions.ts`) that fetches workspace-level permissions.
- Replaces the `featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder(owner)` pattern with `!hasPermission("agent", "create")` across all relevant frontend components: `WelcomeTourGuide`, `ConversationMenu`, `SidebarMenu`, `WebAgentBrowser`, `ManageAgentsPage`, and `NewAgentPage`.

## Tests

Manually.

## Risks

If the backfill in https://github.com/dust-tt/dust/pull/29224 did not complete properly some people may be unable to create agents.

## Deploy Plan
Wait for the backfill in https://github.com/dust-tt/dust/pull/29224 to be completed.
