### PR TITLE
feat(activation): automate workspace schedule lifecycle from pod provisioning

### DIFF
--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.test.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.test.ts
@@ -1,0 +1,129 @@
+import { joinActivationPodPlugin } from "@app/lib/api/poke/plugins/spaces/join_activation_pod";
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+//
+// The pod's trigger/webhook wiring is unrelated to the schedule-lifecycle
+// behavior under test here, and exercising it for real would require setting
+// up webhook sources and firing an actual agent conversation. Mock it so the
+// plugin's `execute` can be driven end to end against the real test DB for
+// everything else (space/membership/skills creation).
+
+const {
+  mockGetOrCreateActivationWebhookSourceView,
+  mockCreateActivationTrigger,
+  mockEmitActivationEvent,
+  mockStartActivationWorkspaceSchedule,
+} = vi.hoisted(() => ({
+  mockGetOrCreateActivationWebhookSourceView: vi.fn(),
+  mockCreateActivationTrigger: vi.fn(),
+  mockEmitActivationEvent: vi.fn(),
+  mockStartActivationWorkspaceSchedule: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/activation/trigger", () => ({
+  getOrCreateActivationWebhookSourceView:
+    mockGetOrCreateActivationWebhookSourceView,
+  createActivationTrigger: mockCreateActivationTrigger,
+  emitActivationEvent: mockEmitActivationEvent,
+}));
+
+vi.mock("@app/temporal/activation_scheduler/client", () => ({
+  startActivationWorkspaceSchedule: mockStartActivationWorkspaceSchedule,
+}));
+
+beforeEach(async () => {
+  mockGetOrCreateActivationWebhookSourceView.mockReset();
+  mockCreateActivationTrigger.mockReset();
+  mockEmitActivationEvent.mockReset();
+  mockStartActivationWorkspaceSchedule.mockReset();
+
+  mockGetOrCreateActivationWebhookSourceView.mockResolvedValue(
+    new Ok({ sId: "wsv_test" })
+  );
+  // A syntactically valid but non-existent trigger sId: TriggerResource.fetchById
+  // (called with this value in the plugin) resolves it to no row, so the pod is
+  // created with a null trigger -- fine here since the trigger/webhook wiring is
+  // mocked out and not under test.
+  mockCreateActivationTrigger.mockResolvedValue(
+    new Ok({ triggerId: makeSId("trigger", { id: 1, workspaceId: 1 }) })
+  );
+  mockEmitActivationEvent.mockResolvedValue(new Ok({ triggerId: null }));
+  mockStartActivationWorkspaceSchedule.mockResolvedValue(new Ok(undefined));
+
+  // Pod creation kicks off a real (external) dust_project connector; stub it
+  // out the same way lib/api/spaces.test.ts does for "project" space tests.
+  vi.spyOn(
+    await import("@app/lib/api/projects/connector"),
+    "createDataSourceAndConnectorForProject"
+  ).mockResolvedValue(new Ok(undefined));
+});
+
+async function makeWorkspaceWithEditor() {
+  const workspace = await WorkspaceFactory.basic();
+  const editor = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, editor, { role: "admin" });
+
+  // Bootstrap the workspace's default groups/spaces, mirroring what
+  // `createWorkspaceInternal` does in production before any pod can be
+  // provisioned.
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await SpaceResource.makeDefaultsForWorkspace(adminAuth, {
+    globalGroup,
+    systemGroup,
+  });
+
+  return { workspace, adminAuth, editor };
+}
+
+describe("joinActivationPodPlugin.execute", () => {
+  it("starts the workspace's Activation schedule once provisioning succeeds", async () => {
+    const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor();
+
+    const result = await joinActivationPodPlugin.execute(adminAuth, null, {
+      editorUserId: [editor.sId],
+      memberUserIds: [],
+      podName: "",
+      defaultSkillIds: [],
+      agentsMdInstructions: "",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockStartActivationWorkspaceSchedule).toHaveBeenCalledWith({
+      workspaceId: workspace.sId,
+    });
+  });
+
+  it("returns Err and does not report success when starting the schedule fails", async () => {
+    const { adminAuth, editor } = await makeWorkspaceWithEditor();
+    mockStartActivationWorkspaceSchedule.mockResolvedValue(
+      new Err(new Error("temporal unavailable"))
+    );
+
+    const result = await joinActivationPodPlugin.execute(adminAuth, null, {
+      editorUserId: [editor.sId],
+      memberUserIds: [],
+      podName: "",
+      defaultSkillIds: [],
+      agentsMdInstructions: "",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("temporal unavailable");
+    }
+  });
+});

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -22,6 +22,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
+import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -385,6 +386,20 @@ export const joinActivationPodPlugin = createPlugin({
       return new Err(
         new Error(
           `Failed to emit Activation Pod event: ${emitResult.error.message}`
+        )
+      );
+    }
+
+    // Ensure the workspace has a running Activation schedule now that it has
+    // a pod to nudge: idempotent (a no-op if one already exists), so this
+    // runs unconditionally rather than only on the workspace's first pod.
+    const scheduleResult = await startActivationWorkspaceSchedule({
+      workspaceId: workspace.sId,
+    });
+    if (scheduleResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to start the Activation Pod schedule: ${scheduleResult.error.message}`
         )
       );
     }

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,7 +1,7 @@
 import { seedWorkspaceCapabilities } from "@app/lib/api/permissions/governance_seeding";
 import { activateCreditPricedFreePlanForWorkspace } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -18,7 +18,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { UTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 
 export async function createWorkspace(
   session: SessionWithUser,
@@ -103,18 +102,6 @@ export async function createWorkspaceInternal({
 
   // Ensure all auto MCP server views are created for the workspace
   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-  if (await hasFeatureFlag(auth, "activation_scheduler")) {
-    const scheduleRes = await startActivationWorkspaceSchedule({
-      workspaceId: workspace.sId,
-    });
-    if (scheduleRes.isErr()) {
-      logger.error(
-        { workspaceId: workspace.sId, error: scheduleRes.error },
-        "Failed to start activation schedule for new workspace"
-      );
-    }
-  }
 
   if (planCode) {
     if (isCreditPricedFreePlan(planCode)) {

--- a/front/lib/resources/activation_pod_resource.test.ts
+++ b/front/lib/resources/activation_pod_resource.test.ts
@@ -1,0 +1,85 @@
+import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ActivationPodResource", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    projectSpace = await SpaceFactory.project(workspace);
+  });
+
+  describe("listWorkspaceModelIdsWithActivationPods", () => {
+    it("returns the workspace of an activation pod", async () => {
+      const user = await UserFactory.basic();
+      await ActivationPodResource.makeNew(auth, { pod: projectSpace, user });
+
+      const workspaceIds =
+        await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+
+      expect(workspaceIds).toContain(workspace.id);
+    });
+
+    it("dedupes workspaces with multiple activation pods", async () => {
+      const secondProjectSpace = await SpaceFactory.project(workspace);
+      const userA = await UserFactory.basic();
+      const userB = await UserFactory.basic();
+
+      await ActivationPodResource.makeNew(auth, {
+        pod: projectSpace,
+        user: userA,
+      });
+      await ActivationPodResource.makeNew(auth, {
+        pod: secondProjectSpace,
+        user: userB,
+      });
+
+      const workspaceIds =
+        await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+
+      expect(workspaceIds.filter((id) => id === workspace.id)).toHaveLength(1);
+    });
+
+    it("excludes workspaces without an activation pod", async () => {
+      const workspaceIds =
+        await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+
+      expect(workspaceIds).not.toContain(workspace.id);
+    });
+
+    it("excludes workspaces whose only pod has been deleted", async () => {
+      const user = await UserFactory.basic();
+      const pod = await ActivationPodResource.makeNew(auth, {
+        pod: projectSpace,
+        user,
+      });
+      await pod.delete(auth, {});
+
+      const otherWorkspace = await WorkspaceFactory.basic();
+      const otherAuth = await Authenticator.internalAdminForWorkspace(
+        otherWorkspace.sId
+      );
+      const otherProjectSpace = await SpaceFactory.project(otherWorkspace);
+      const otherUser = await UserFactory.basic();
+      await ActivationPodResource.makeNew(otherAuth, {
+        pod: otherProjectSpace,
+        user: otherUser,
+      });
+
+      const workspaceIds =
+        await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+
+      expect(workspaceIds).not.toContain(workspace.id);
+      expect(workspaceIds).toContain(otherWorkspace.id);
+    });
+  });
+});

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -3,6 +3,7 @@ import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -11,13 +12,15 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { col, fn } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationPodResource
   extends ReadonlyAttributesType<ActivationPodModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ActivationPodResource extends BaseResource<ActivationPodModel> {
-  static model: ModelStatic<ActivationPodModel> = ActivationPodModel;
+  static model: ModelStaticWorkspaceAware<ActivationPodModel> =
+    ActivationPodModel;
 
   constructor(
     _: ModelStatic<ActivationPodModel>,
@@ -104,6 +107,25 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     });
 
     return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
+  // Cross-tenant scan for the nightly activation-schedule reconcile job: the
+  // distinct workspaces that currently have at least one Activation Pod
+  // (row existence is the "live" signal; provisioning deletes the row when a
+  // pod is torn down), i.e. the workspaces that should have a running
+  // schedule.
+  static async listWorkspaceModelIdsWithActivationPods(): Promise<ModelId[]> {
+    const rows = await this.model.findAll({
+      attributes: [[fn("DISTINCT", col("workspaceId")), "workspaceId"]],
+      raw: true,
+      // WORKSPACE_ISOLATION_BYPASS: nightly reconcile scan across all workspaces
+      // to find which ones have a live activation pod (see
+      // front/temporal/activation_scheduler/client.ts).
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return rows.map((row) => row.workspaceId);
   }
 
   // Sets the Pod's activation trigger once it has been provisioned.

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -9,6 +9,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import { ensureActivationWorkspaceSchedules } from "@app/temporal/activation_scheduler/client";
 import {
   ACTIVATION_WORKDAY_WINDOW_MINUTES,
   ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
@@ -181,4 +182,15 @@ export async function reGateAndNudgePodActivity({
   }
 
   await ActivationNudgeResource.makeNew(auth, { pod, trigger });
+}
+
+// ---------------------------------------------------------------------------
+// Ensure schedules activity
+// ---------------------------------------------------------------------------
+
+export async function ensureActivationWorkspaceSchedulesActivity(): Promise<{
+  started: string[];
+  stopped: string[];
+}> {
+  return ensureActivationWorkspaceSchedules();
 }

--- a/front/temporal/activation_scheduler/client.ts
+++ b/front/temporal/activation_scheduler/client.ts
@@ -1,5 +1,8 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -7,11 +10,17 @@ import {
   ScheduleAlreadyRunning,
   ScheduleNotFoundError,
   ScheduleOverlapPolicy,
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowNotFoundError,
 } from "@temporalio/client";
+import moment from "moment-timezone";
 
 import { QUEUE_NAME } from "./config";
 import { runActivationSignal } from "./signals";
-import { activationWorkspaceWorkflow } from "./workflows";
+import {
+  activationWorkspaceWorkflow,
+  ensureActivationWorkspaceSchedulesWorkflow,
+} from "./workflows";
 
 const WORKSPACE_WORKFLOW_ID_PREFIX = "activation-workspace-";
 
@@ -143,4 +152,205 @@ export async function triggerActivationWorkspaceWorkflow({
     "[ActivationScheduler] Triggered workspace workflow."
   );
   return new Ok(workflowId);
+}
+
+// ---------------------------------------------------------------------------
+// Ensure schedules (start missing, stop extra)
+// ---------------------------------------------------------------------------
+
+/**
+ * Workspaces that currently have at least one live Activation Pod, i.e. the
+ * workspaces that should have a running schedule. Provisioning a workspace's
+ * first pod (see the `join-activation-pod` poke plugin) defines scope going
+ * forward; this reconcile pass is the safety net that keeps schedules in
+ * sync as pods are provisioned/removed outside that hook.
+ */
+async function getActivationWorkspaceIds(): Promise<string[]> {
+  const workspaceModelIds =
+    await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+  if (workspaceModelIds.length === 0) {
+    return [];
+  }
+
+  const workspaces = await WorkspaceResource.fetchByModelIds(workspaceModelIds);
+  return workspaces.map((workspace) => workspace.sId);
+}
+
+/**
+ * Ensure every workspace with a live Activation Pod has a running schedule,
+ * and delete schedules for workspaces that no longer have any pod left. This
+ * is the only place schedules are deleted for that reason; a stale schedule
+ * firing for an emptied-out workspace is a no-op (the workflow enumerates
+ * zero eligible pods).
+ */
+export async function ensureActivationWorkspaceSchedules(): Promise<{
+  started: string[];
+  stopped: string[];
+}> {
+  const client = await getTemporalClientForFrontNamespace();
+  const inScopeWorkspaceIds = new Set(await getActivationWorkspaceIds());
+  logger.info(
+    { inScopeWorkspaceCount: inScopeWorkspaceIds.size },
+    "[ActivationScheduler] Ensuring workspace schedules."
+  );
+
+  // Find existing schedules by ID prefix.
+  const runningWorkspaceIds = new Set<string>();
+  for await (const schedule of client.schedule.list()) {
+    if (schedule.scheduleId.startsWith(WORKSPACE_WORKFLOW_ID_PREFIX)) {
+      runningWorkspaceIds.add(
+        schedule.scheduleId.slice(WORKSPACE_WORKFLOW_ID_PREFIX.length)
+      );
+    }
+  }
+  logger.info(
+    { runningWorkspaceCount: runningWorkspaceIds.size },
+    "[ActivationScheduler] Found existing workspace schedules."
+  );
+
+  // Workspaces that need a schedule started / stopped.
+  const toStart = [...inScopeWorkspaceIds].filter(
+    (id) => !runningWorkspaceIds.has(id)
+  );
+  const toStop = [...runningWorkspaceIds].filter(
+    (id) => !inScopeWorkspaceIds.has(id)
+  );
+  logger.info(
+    { toStartCount: toStart.length, toStopCount: toStop.length },
+    "[ActivationScheduler] Schedules to start/stop."
+  );
+
+  const CONCURRENCY = 5;
+
+  // Create schedules for in-scope workspaces that don't have one.
+  const started = await concurrentExecutor(
+    toStart,
+    async (workspaceId) => {
+      logger.info(
+        { workspaceId },
+        "[ActivationScheduler] Creating schedule for workspace."
+      );
+      await startActivationWorkspaceSchedule({ workspaceId });
+      return workspaceId;
+    },
+    { concurrency: CONCURRENCY }
+  );
+
+  // Delete schedules for workspaces that no longer have a live pod.
+  const stopped = await concurrentExecutor(
+    toStop,
+    async (workspaceId) => {
+      logger.info(
+        { workspaceId },
+        "[ActivationScheduler] Deleting schedule for workspace."
+      );
+      await deleteActivationWorkspaceSchedule({ workspaceId });
+      return workspaceId;
+    },
+    { concurrency: CONCURRENCY }
+  );
+
+  logger.info(
+    { startedCount: started.length, stoppedCount: stopped.length },
+    "[ActivationScheduler] Ensured activation workspace schedules."
+  );
+
+  return { started, stopped };
+}
+
+// ---------------------------------------------------------------------------
+// Bulk stop (all workspaces)
+// ---------------------------------------------------------------------------
+
+export async function stopAllActivationWorkspaceSchedules(): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workspaceIds: string[] = [];
+  for await (const schedule of client.schedule.list()) {
+    if (schedule.scheduleId.startsWith(WORKSPACE_WORKFLOW_ID_PREFIX)) {
+      workspaceIds.push(
+        schedule.scheduleId.slice(WORKSPACE_WORKFLOW_ID_PREFIX.length)
+      );
+    }
+  }
+
+  for (const workspaceId of workspaceIds) {
+    await deleteActivationWorkspaceSchedule({ workspaceId });
+  }
+
+  logger.info(
+    { workspaceCount: workspaceIds.length },
+    "[ActivationScheduler] Deleted schedules for all workspaces."
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Nightly reconcile cron
+// ---------------------------------------------------------------------------
+
+export const ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID = `ensure-${WORKSPACE_WORKFLOW_ID_PREFIX}schedules`;
+
+const ELEVEN_PM = "23:00";
+
+export async function launchEnsureActivationSchedulesWorkflow(): Promise<
+  Result<string, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const region = config.getCurrentRegion();
+  const timezone = REGION_TIMEZONES[region];
+  const elevenPmInTz = moment.tz(ELEVEN_PM, "HH:mm", timezone);
+  const utcHour = elevenPmInTz.utc().hour();
+
+  try {
+    await client.workflow.start(ensureActivationWorkspaceSchedulesWorkflow, {
+      args: [],
+      taskQueue: QUEUE_NAME,
+      workflowId: ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID,
+      cronSchedule: `0 ${utcHour} * * *`,
+    });
+
+    logger.info(
+      {
+        region,
+        timezone,
+        utcHour,
+        workflowId: ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID,
+      },
+      "[ActivationScheduler] Launched ensure-schedules workflow."
+    );
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId: ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID },
+        "[ActivationScheduler] Ensure-schedules workflow already running, skipping."
+      );
+    } else {
+      throw e;
+    }
+  }
+
+  return new Ok(ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID);
+}
+
+export async function stopEnsureActivationSchedulesWorkflow(): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    const handle = client.workflow.getHandle(
+      ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID
+    );
+    await handle.terminate("Stopped via CLI");
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      logger.info(
+        { workflowId: ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID },
+        "[ActivationScheduler] Ensure-schedules workflow not running, skipping."
+      );
+    } else {
+      logger.error(
+        { error: e, workflowId: ENSURE_ACTIVATION_SCHEDULES_WORKFLOW_ID },
+        "[ActivationScheduler] Failed stopping ensure-schedules workflow."
+      );
+    }
+  }
 }

--- a/front/temporal/activation_scheduler/workflows.ts
+++ b/front/temporal/activation_scheduler/workflows.ts
@@ -3,10 +3,13 @@ import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
 import { runActivationSignal } from "./signals";
 
-const { enumerateEligiblePodsForNudgeActivity, reGateAndNudgePodActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "5 minutes",
-  });
+const {
+  enumerateEligiblePodsForNudgeActivity,
+  reGateAndNudgePodActivity,
+  ensureActivationWorkspaceSchedulesActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
 
 /**
  * Workspace-level workflow: one per workspace, triggered by the workspace's
@@ -44,4 +47,13 @@ export async function activationWorkspaceWorkflow({
       targetUserId: pod.targetUserId,
     });
   }
+}
+
+/**
+ * Cron workflow that ensures every workspace with a live Activation Pod has a
+ * running schedule, and stops schedules for workspaces whose pods have all
+ * gone terminal (archived).
+ */
+export async function ensureActivationWorkspaceSchedulesWorkflow(): Promise<void> {
+  await ensureActivationWorkspaceSchedulesActivity();
 }


### PR DESCRIPTION
## Description

Replaces the hand-created pilot schedule with an automated lifecycle for the per-workspace Activation nudge schedule:

- Provisioning a workspace's first Activation Pod (via the `join-activation-pod` poke plugin) now starts that workspace's schedule directly.
- A nightly reconcile job (`ensureActivationWorkspaceSchedules`, mirroring reinforcement's ensure-schedules pattern) creates schedules for any workspace with a live pod that's missing one, and deletes schedules for workspaces with no live pods left.
- Removes the old feature-flag-gated schedule creation at workspace-creation time (`activation_scheduler` flag in `lib/iam/workspaces.ts`), since provisioning a pod now defines scope instead.

The partial index on `project_metadata.provisioningSource` needed for the reconcile query already shipped separately, so no migration is included here.

## Tests

Added coverage for the new reconcile query (`ProjectMetadataResource.listWorkspaceModelIdsWithLiveActivationPods`) and for the pod-provisioning hook (`join_activation_pod.test.ts`), including the schedule-creation failure path.
