### PR TITLE
[LLM] Fix Anthropic temperature=1 rejection when thinking is off

### DIFF
--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -729,11 +729,13 @@ abstract class BaseTransition extends LLM {
   protected buildConfig(
     streamParameters: LLMStreamParameters,
     configSchema: BaseEndpointConfiguration["configSchema"],
-    // Per-endpoint adjustment applied before schema validation (defaults to
-    // identity). Some schemas reject provider-invalid combinations (e.g.
-    // Anthropic requires temperature=1 with thinking), so the fix must land
+    // Per-endpoint adjustments applied in order before schema validation
+    // (defaults to identity). Some schemas reject provider-invalid combinations
+    // (e.g. Anthropic requires temperature=1 with thinking), so the fix must land
     // before `parse`, not after.
-    parseConfig: (config: InputConfig) => InputConfig = (config) => config,
+    configParsers: Array<(config: InputConfig) => InputConfig> = [
+      (config) => config,
+    ],
     // Prompt cache key, forwarded only by surfaces whose config schema accepts
     // it (OpenAI Responses). Left undefined elsewhere so the provider schemas
     // that guard `cacheKey` to `undefined` still parse.
@@ -766,8 +768,13 @@ abstract class BaseTransition extends LLM {
       cacheKey,
     };
 
+    const parsedConfig = configParsers.reduce(
+      (acc, parser) => parser(acc),
+      config
+    );
+
     return configSchema.parse({
-      ...parseConfig(config),
+      ...parsedConfig,
       // Prompt-cache diagnostics opt-in. Kept only by the Anthropic (direct)
       // config schema; other surfaces' schemas strip this unknown key.
       previousMessageId,
@@ -818,7 +825,7 @@ export class StreamEndpointTransition extends BaseTransition {
       this.buildConfig(
         streamParameters,
         this.model.constructor.configSchema,
-        this.endpointConstructor.parseConfig,
+        this.endpointConstructor.configParsers,
         cacheKey
       )
     );

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -16,7 +16,7 @@ export function WithDustClaudeFableFiveConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustClaudeFableFive;

--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,4 +1,7 @@
-import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import {
+  dropTemperatureOfOneWhenReasoningIsNone,
+  dropTemperatureWhenReasoning,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeHaikuFourDotFive<
   TBase extends abstract new (
@@ -11,8 +14,13 @@ export function WithDustClaudeHaikuFourDotFive<
       "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).";
     static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
-    // Anthropic rejects a non-default temperature while thinking is active.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    // Anthropic rejects a non-default temperature while thinking is active (drop
+    // it → schema re-applies the required 1), and rejects temperature=1 while
+    // thinking is disabled.
+    static readonly configParsers = [
+      dropTemperatureWhenReasoning,
+      dropTemperatureOfOneWhenReasoningIsNone,
+    ];
   }
 
   return DustClaudeHaikuFourDotFive;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -16,7 +16,7 @@ export function WithDustClaudeOpusFourDotEightConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustClaudeOpusFourDotEight;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -16,7 +16,7 @@ export function WithDustClaudeOpusFourDotSevenConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustClaudeOpusFourDotSeven;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,3 +1,5 @@
+import { dropTemperatureOfOneWhenReasoningIsNone } from "@app/lib/llms/stream/types/configuration";
+
 export function WithDustClaudeOpusFourDotSixConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -13,6 +15,9 @@ export function WithDustClaudeOpusFourDotSixConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
+    // Opus 4.6 accepts a caller-supplied temperature, but Anthropic rejects
+    // temperature=1 while thinking is disabled; drop it in that case only.
+    static readonly configParsers = [dropTemperatureOfOneWhenReasoningIsNone];
   }
 
   return DustClaudeOpusFourDotSix;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -16,7 +16,7 @@ export function WithDustClaudeSonnetFiveConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustClaudeSonnetFive;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,4 +1,7 @@
-import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import {
+  dropTemperatureOfOneWhenReasoningIsNone,
+  dropTemperatureWhenReasoning,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
@@ -15,8 +18,13 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     // Dust caps output at 64k; the model itself supports 128k.
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
-    // Anthropic rejects a non-default temperature while thinking is active.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    // Anthropic rejects a non-default temperature while thinking is active (drop
+    // it → schema re-applies the required 1), and rejects temperature=1 while
+    // thinking is disabled.
+    static readonly configParsers = [
+      dropTemperatureWhenReasoning,
+      dropTemperatureOfOneWhenReasoningIsNone,
+    ];
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -15,7 +15,7 @@ export function WithDustMistralCodestralConfig<
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
     // Non-reasoning model: drop the reasoning effort the schema rejects.
-    static readonly parseConfig = dropReasoning;
+    static readonly configParsers = [dropReasoning];
   }
 
   return DustMistralCodestral;

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -14,7 +14,7 @@ export function WithDustMistralLargeConfig<
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
     // Non-reasoning model: drop the reasoning effort the schema rejects.
-    static readonly parseConfig = dropReasoning;
+    static readonly configParsers = [dropReasoning];
   }
 
   return DustMistralLarge;

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -15,7 +15,7 @@ export function WithDustMistralMedium35Config<
     static readonly byok = true;
     // Mistral rejects an explicit temperature on this model; drop it (matches
     // the legacy client's REASONING_OVERWRITES and the schema's undefined temp).
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustMistralMedium35;

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -14,7 +14,7 @@ export function WithDustMistralSmallConfig<
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;
     // Non-reasoning model: drop the reasoning effort the schema rejects.
-    static readonly parseConfig = dropReasoning;
+    static readonly configParsers = [dropReasoning];
   }
 
   return DustMistralSmall;

--- a/front/lib/llms/providers/openai/models/gpt_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustGptFive;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotFiveConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotFive;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotFourConfig<
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotFour;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotFourMiniConfig<
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotFourMini;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotFourNanoConfig<
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotFourNano;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotOneConfig<
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustGptFiveDotOne;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotSixLunaConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotSixLuna;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotSixSolConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotSixSol;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotSixTerraConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotSixTerra;

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveDotTwoConfig<
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
-    static readonly parseConfig = dropTemperatureWhenReasoning;
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustGptFiveDotTwo;

--- a/front/lib/llms/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_mini.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveMiniConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustGptFiveMini;

--- a/front/lib/llms/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_nano.ts
@@ -12,7 +12,7 @@ export function WithDustGptFiveNanoConfig<
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
-    static readonly parseConfig = dropTemperature;
+    static readonly configParsers = [dropTemperature];
   }
 
   return DustGptFiveNano;

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -15,17 +15,18 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
     // Behavior
     defaultReasoningEffort: ReasoningEffortOf<C>;
 
-    // Adjusts the config before it is validated by the endpoint's schema.
-    // Omitted means identity; override per endpoint for provider quirks — e.g.
-    // dropping a non-default temperature when reasoning is active, which some
-    // schemas reject outright (Anthropic requires temperature=1 with thinking).
-    parseConfig?: (config: InputConfig) => InputConfig;
+    // Parsers applied in order to the config before it is validated by the
+    // endpoint's schema. Omitted means identity; override per endpoint for
+    // provider quirks — e.g. dropping a non-default temperature when reasoning is
+    // active, which some schemas reject outright (Anthropic requires
+    // temperature=1 with thinking).
+    configParsers?: Array<(config: InputConfig) => InputConfig>;
 
     // Filter
     endpointFilter: Where<WorkspaceConfig>;
   };
 
-// `parseConfig` helper: some providers reject any explicit temperature while
+// `configParsers` helper: some providers reject any explicit temperature while
 // reasoning is active, so drop it when reasoning is on. Providers that require a
 // specific value (e.g. Anthropic's temperature=1) re-apply it via their schema
 // default. Temperature is preserved when reasoning is off.
@@ -39,14 +40,30 @@ export function dropTemperatureWhenReasoning<C extends InputConfig>(
   return config;
 }
 
-// `parseConfig` helper: some models reject an explicit temperature outright,
+// `configParsers` helper: Anthropic rejects an explicit temperature=1 while
+// thinking is disabled ("temperature may only be set to 1 when thinking is
+// enabled or in adaptive mode"). When reasoning is off, drop a temperature of
+// exactly 1 so we fall back to the provider default; other values pass through.
+// Used by Opus 4.6, which — unlike 4.7/4.8 — accepts a caller-supplied
+// temperature.
+export function dropTemperatureOfOneWhenReasoningIsNone<C extends InputConfig>(
+  config: C
+): C {
+  if (config.reasoning?.effort !== "none" || config.temperature !== 1) {
+    return config;
+  }
+
+  return { ...config, temperature: undefined };
+}
+
+// `configParsers` helper: some models reject an explicit temperature outright,
 // regardless of reasoning effort (e.g. the OpenAI gpt-5 / gpt-5-mini / gpt-5-nano
 // / gpt-5.1 Responses models). Always drop it.
 export function dropTemperature<C extends InputConfig>(config: C): C {
   return { ...config, temperature: undefined };
 }
 
-// `parseConfig` helper: non-reasoning models reject `reasoning_effort`, so drop
+// `configParsers` helper: non-reasoning models reject `reasoning_effort`, so drop
 // the reasoning field before validation (their schemas require it undefined).
 export function dropReasoning<C extends InputConfig>(config: C): C {
   return { ...config, reasoning: undefined };

--- a/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -25,7 +25,7 @@ const configSchema = z.union([
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
-    temperature: temperatureSchema.optional().default(1),
+    temperature: temperatureSchema.optional(),
   }),
 ]);
 

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -25,7 +25,7 @@ const configSchema = z.union([
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
-    temperature: temperatureSchema.optional().default(1),
+    temperature: temperatureSchema.optional(),
   }),
 ]);
 


### PR DESCRIPTION
## Description

Anthropic rejects an explicit `temperature=1` unless thinking is enabled/adaptive, so drop that value when reasoning is off (Opus 4.6, Sonnet 4.6, Haiku 4.5) and refactor endpoint `parseConfig` into an ordered `configParsers` array applied before schema validation.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`