### PR TITLE
[front] perf: Add partial index on agent_configurations (workspaceId, scope, id)

### DIFF
--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -194,6 +194,13 @@ AgentConfigurationModel.init(
           status: "active",
         },
       },
+      {
+        fields: ["workspaceId", "scope", "id"],
+        name: "partial_agent_config_active_scope_id",
+        where: {
+          status: "active",
+        },
+      },
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
       { fields: ["workspaceId", "authorId", "sId"] },

--- a/front/migrations/pre-deploy/20260721164750_add_partial_index_agent_config_active_scope_id.sql
+++ b/front/migrations/pre-deploy/20260721164750_add_partial_index_agent_config_active_scope_id.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY partial_agent_config_active_scope_id ON public.agent_configurations USING btree ("workspaceId", scope, id) WHERE ((status)::text = 'active'::text);


### PR DESCRIPTION
## Description

The agent configuration listing query ([views.ts](https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/configuration/views.ts)) filters with a three-branch OR:

- `scope IN ('workspace', 'published', 'visible')`
- `authorId = :user AND scope = 'private'`
- `id IN (:agentIdsForUserAsEditor) AND scope = 'hidden'`

all under `workspaceId = :w AND status = 'active'`.

The first two branches are served by `partial_agent_config_active (workspaceId, scope, authorId) WHERE status = 'active'`, but the third one can only use the `(workspaceId, scope)` prefix. The planner compensates with a `BitmapAnd` between that prefix scan and per-id primary-key descents — [in this pganalyze plan](https://app.pganalyze.com/databases/-642267629/queries/12470698034/explains/ydsdcmed4rdy7pvv5lnszynfqe), 112 editor agent ids cost 417 buffer hits and ~86% of the plan cost. The query runs ~92 times/min at ~42ms avg (~4.2% of total front DB time).

This adds `partial_agent_config_active_scope_id (workspaceId, scope, id) WHERE status = 'active'` so the editor-visibility branch gets a direct index condition on all three columns.

Migration is pre-deploy, `CREATE INDEX CONCURRENTLY`, generated with `npm run migration:generate:pre-deploy` against a pristine baseline.

## Risk

Low: additive index, built concurrently. Small write overhead on agent_configurations (index is partial on active rows only).

## Deploy Plan

1. Run `./scripts/run-migrations.sh pre-deploy front` from prodbox (both regions).
2. Deploy front.
3. Verify the new plan on query [12470698034](https://app.pganalyze.com/databases/-642267629/queries/12470698034) in pganalyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)