### PR TITLE
Don't set capability to 'builders' group if it does not exist yet

### DIFF
--- a/front/lib/api/permissions/governance_seeding.test.ts
+++ b/front/lib/api/permissions/governance_seeding.test.ts
@@ -25,7 +25,7 @@ describe("seedWorkspaceCapabilities", () => {
     expect(await userAuth.hasWorkspacePermission("create", "agent")).toBe(true);
   });
 
-  it("creates the Builders group and grants it when disallow_agent_creation_to_users is already set", async () => {
+  it("leaves create-agent as admins_only when disallow_agent_creation_to_users is set and no Builders group exists yet", async () => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     await FeatureFlagResource.enable(
@@ -34,13 +34,11 @@ describe("seedWorkspaceCapabilities", () => {
     );
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    // Freshly created workspace: no Builders group has ever been synced yet, so seeding must
-    // create it (empty) rather than leaving the capability unconfigured.
+    // Freshly created workspace: no Builders group has ever been synced yet. Seeding must not
+    // fabricate one — it leaves the capability admins_only rather than granting an empty group.
     await seedWorkspaceCapabilities(auth);
 
-    const buildersGroup = await GroupResource.fetchByName(auth, "Builders");
-    expect(buildersGroup).not.toBeNull();
-    expect(buildersGroup?.kind).toBe("regular_manual");
+    expect(await GroupResource.fetchByName(auth, "Builders")).toBeNull();
 
     const plainUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, plainUser, { role: "user" });
@@ -52,6 +50,9 @@ describe("seedWorkspaceCapabilities", () => {
       false
     );
 
+    // Even a builder added afterward has no access: seeding never wrote a grant, and the
+    // Builders group created later by syncBuilderGroupMembership isn't retroactively wired to
+    // any existing grant.
     const builder = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builder, { role: "builder" });
     await GroupResource.syncBuilderGroupMembership({
@@ -64,16 +65,18 @@ describe("seedWorkspaceCapabilities", () => {
       workspace.sId
     );
     expect(await builderAuth.hasWorkspacePermission("create", "agent")).toBe(
-      true
+      false
     );
   });
 
-  it("always grants create-skill to the Builders group, regardless of any flag", async () => {
+  it("leaves create-skill as admins_only when no Builders group exists yet", async () => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     await seedWorkspaceCapabilities(auth);
+
+    expect(await GroupResource.fetchByName(auth, "Builders")).toBeNull();
 
     const plainUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, plainUser, { role: "user" });
@@ -84,7 +87,11 @@ describe("seedWorkspaceCapabilities", () => {
     expect(await plainAuth.hasWorkspacePermission("create", "skill")).toBe(
       false
     );
+  });
 
+  it("grants create-skill to the Builders group when it already exists", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
     const builder = await UserFactory.basic();
     await MembershipFactory.associate(workspace, builder, { role: "builder" });
     await GroupResource.syncBuilderGroupMembership({
@@ -92,12 +99,26 @@ describe("seedWorkspaceCapabilities", () => {
       user: builder,
       isBuilder: true,
     });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await seedWorkspaceCapabilities(auth);
+
     const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
       builder.sId,
       workspace.sId
     );
     expect(await builderAuth.hasWorkspacePermission("create", "skill")).toBe(
       true
+    );
+
+    const plainUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, plainUser, { role: "user" });
+    const plainAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      plainUser.sId,
+      workspace.sId
+    );
+    expect(await plainAuth.hasWorkspacePermission("create", "skill")).toBe(
+      false
     );
   });
 });

--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -1,9 +1,13 @@
 import type { Authenticator } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupResource,
+  MANUAL_BUILDERS_GROUP_NAME,
+} from "@app/lib/resources/group_resource";
 import type { CapabilitySpec } from "@app/types/group_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
 
 /**
  * Governance capability seeders: the single source of truth for where each capability's default
@@ -52,22 +56,45 @@ export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
 export type ApplyCapabilityOutcome =
   | "seeded_everybody"
   | "seeded_builders"
-  | "skipped_admins_only";
+  | "skipped_admins_only"
+  | "skipped_no_builders_group";
+
+// Resolves a seeder's raw target down to what will actually happen: "builders" degrades to
+// "admins_only" if the workspace has no Builders group yet (no builder-role member has ever been
+// synced into it — see `syncBuilderGroupMembership`). Deliberately never creates the group here;
+// a capability grant with no members behind it isn't a meaningful default for either call site.
+// Exposed so a caller that needs to know the effective target before deciding whether to write
+// (the backfill script's idempotency check) doesn't have to duplicate the group lookup.
+export async function resolveEffectiveTarget(
+  auth: Authenticator,
+  target: CapabilityTarget
+): Promise<CapabilityTarget> {
+  if (target !== "builders") {
+    return target;
+  }
+  const buildersGroup = await GroupResource.fetchByName(
+    auth,
+    MANUAL_BUILDERS_GROUP_NAME
+  );
+  return buildersGroup ? "builders" : "admins_only";
+}
 
 // Applies an already-resolved target for one capability on the workspace behind `auth`. Shared
-// write path for both call sites listed above. The "builders" target creates the workspace's
-// Builders group if it doesn't exist yet (e.g. no builder-role member has ever been synced into
-// it), so this never leaves the capability unconfigured. With `dryRun: true`, resolves and
-// returns the outcome without writing — used by the backfill script's default dry-run mode.
+// write path for both call sites listed above. With `dryRun: true`, resolves and returns the
+// outcome without writing — used by the backfill script's default dry-run mode.
 export async function applyCapabilityTarget(
   auth: Authenticator,
   capability: CapabilitySpec,
   target: CapabilityTarget,
   { dryRun = false }: { dryRun?: boolean } = {}
 ): Promise<ApplyCapabilityOutcome> {
-  switch (target) {
+  const effectiveTarget = await resolveEffectiveTarget(auth, target);
+
+  switch (effectiveTarget) {
     case "admins_only":
-      return "skipped_admins_only";
+      return target === "builders"
+        ? "skipped_no_builders_group"
+        : "skipped_admins_only";
     case "everyone":
       if (!dryRun) {
         await GroupPermissionResource.setForEverybody(auth, capability);
@@ -75,10 +102,14 @@ export async function applyCapabilityTarget(
       return "seeded_everybody";
     case "builders": {
       if (!dryRun) {
-        const buildersGroup =
-          await GroupResource.fetchOrCreateManualBuildersGroup(
-            auth.getNonNullableWorkspace()
-          );
+        const buildersGroup = await GroupResource.fetchByName(
+          auth,
+          MANUAL_BUILDERS_GROUP_NAME
+        );
+        assert(
+          buildersGroup,
+          "Builders group disappeared between resolve and apply."
+        );
         await GroupPermissionResource.setGroups(auth, capability, [
           buildersGroup,
         ]);
@@ -86,7 +117,7 @@ export async function applyCapabilityTarget(
       return "seeded_builders";
     }
     default:
-      assertNever(target);
+      assertNever(effectiveTarget);
   }
 }
 

--- a/front/migrations/20260721_backfill_governance_capabilities.ts
+++ b/front/migrations/20260721_backfill_governance_capabilities.ts
@@ -1,6 +1,7 @@
 import {
   applyCapabilityTarget,
   CAPABILITY_SEEDERS,
+  resolveEffectiveTarget,
 } from "@app/lib/api/permissions/governance_seeding";
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -15,6 +16,7 @@ interface SeederCounts {
   seededBuilders: number;
   alreadySet: number;
   skippedAdminsOnly: number;
+  revertedToAdminsOnly: number;
 }
 
 function newCounts(): SeederCounts {
@@ -23,6 +25,7 @@ function newCounts(): SeederCounts {
     seededBuilders: 0,
     alreadySet: 0,
     skippedAdminsOnly: 0,
+    revertedToAdminsOnly: 0,
   };
 }
 
@@ -38,9 +41,11 @@ function newCounts(): SeederCounts {
  *
  * The seeders themselves — which capability, and what target (everyone / builders / admins_only)
  * a workspace resolves to — are shared with `seedWorkspaceCapabilities`, which applies the same
- * registry to brand-new workspaces at creation time (dust-tt/tasks#9454). This script is only
- * responsible for existing workspaces: it adds the idempotency check (skip if already configured)
- * and the dry-run/--execute gating that a one-time backfill needs but workspace creation doesn't.
+ * registry to brand-new workspaces at creation time (dust-tt/tasks#9454). This script adds what a
+ * one-time backfill needs on top: it resolves the effective target up front (via
+ * `resolveEffectiveTarget`) so it can decide, per workspace, whether to preserve an existing
+ * manual configuration, actively revert to admins_only, or apply a fresh grant — plus the
+ * dry-run/--execute gating.
  *
  * Pass `--wId <workspaceId>` to run on a single workspace.
  */
@@ -78,13 +83,47 @@ makeScript(
             throw new Error(`Missing counters for capability ${key}.`);
           }
 
+          const target = await seeder.resolveTarget(auth);
+          const effectiveTarget = await resolveEffectiveTarget(auth, target);
+
           const current = states.get(key);
-          if (current && current.scope !== "admins_only") {
+          const currentlyConfigured =
+            !!current && current.scope !== "admins_only";
+
+          if (effectiveTarget === "admins_only") {
+            if (!currentlyConfigured) {
+              // Already the default state; nothing to do.
+              counts.skippedAdminsOnly++;
+              continue;
+            }
+
+            // Legacy state no longer grants this capability (e.g. the flag got enabled, or the
+            // Builders group disappeared, since an earlier run) — actively revert, unlike the
+            // "everyone"/"builders" branch below, which preserves any existing configuration.
+            logger.info(
+              {
+                workspaceId: workspace.sId,
+                capability: key,
+                previousScope: current?.scope,
+              },
+              execute
+                ? "Reverting to admins_only."
+                : "Would revert to admins_only."
+            );
+            if (execute) {
+              await GroupPermissionResource.disable(auth, seeder.capability);
+            }
+            counts.revertedToAdminsOnly++;
+            continue;
+          }
+
+          // effectiveTarget is "everyone" or "builders": preserve any existing configuration
+          // (e.g. a manual admin override) rather than overwriting it.
+          if (currentlyConfigured) {
             counts.alreadySet++;
             continue;
           }
 
-          const target = await seeder.resolveTarget(auth);
           const outcome = await applyCapabilityTarget(
             auth,
             seeder.capability,
@@ -105,6 +144,7 @@ makeScript(
               counts.seededBuilders++;
               break;
             case "skipped_admins_only":
+            case "skipped_no_builders_group":
               counts.skippedAdminsOnly++;
               break;
             default:


### PR DESCRIPTION
## Description

Two related fixes to the governance capability seeding introduced in the Admin Governance stack (dust-tt/tasks#9463, #9464):

**1. Never fabricate the Builders group.** Previously, a `"builders"` target with no existing `MANUAL_BUILDERS_GROUP_NAME` group (no builder-role member ever synced into it) would create the group empty just to grant it. That's now centralized in a new `resolveEffectiveTarget(auth, target)` in `governance_seeding.ts`: it degrades `"builders"` down to `"admins_only"` when the group doesn't exist, and `applyCapabilityTarget` uses it internally — so this applies uniformly to **every** caller (`seedWorkspaceCapabilities` at workspace creation, and the backfill script), not just the backfill. `ApplyCapabilityOutcome` gains `"skipped_no_builders_group"` to distinguish this case from a target that resolved to `admins_only` directly.

**2. The backfill script now actively reverts stale grants.** Previously it only ever skipped a workspace/capability pair that was already configured (protecting a manual override), even if the *newly resolved* target was `admins_only` — e.g. a stale `"everyone"` grant from an earlier run would never be corrected. Now, when the resolved effective target is `admins_only` and the capability is currently configured to something else, the script calls `GroupPermissionResource.disable(...)` to revert it. The "preserve existing configuration" idempotency guard still applies for `"everyone"`/`"builders"` targets — only the `admins_only` case is now actively enforced. New counter: `revertedToAdminsOnly`.

## Tests

- `governance_seeding.test.ts`: updated the two tests that previously asserted the Builders group got created during seeding — they now assert the capability stays `admins_only` and no group is created; added a case confirming seeding still grants correctly when the group *already* exists.
- Verified end-to-end against the test DB with a throwaway smoke test (not committed — no test convention for migration scripts in this repo): everybody-grant, builders-grant, skip-when-no-group, revert-when-previously-configured (including dry-run not writing), and idempotent re-run.
- `npx tsgo --noEmit` and `biome check` clean.

## Risk

Low. Tightens existing behavior toward "don't fabricate state" and "keep the backfill's output in sync with resolved targets" — no new capabilities or call sites introduced.

## Deploy Plan

Standard deploy. Safe to re-run the backfill script after this deploys; it will now revert any workspace whose earlier backfill run granted `"builders"` via a group that has since disappeared (or never should have been created).