### PR TITLE
[Analytics] Prevent user exports from exceeding bucket limit

### DIFF
--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -75,6 +75,7 @@ export async function fetchUserExportRows({
               date_histogram: {
                 field: "timestamp",
                 calendar_interval: "day",
+                min_doc_count: 1,
                 time_zone: timezone,
               },
             },


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9387

The users export created an empty daily Elasticsearch bucket for every inactive day between each user's first and last message. Large workspaces could therefore exceed Elasticsearch's bucket limit even though those empty buckets were discarded when building the export.

Only return days that contain messages. This preserves `activeDaysCount` while preventing empty buckets from exhausting the query limit.

## Risks

Blast radius: users analytics exports
Risk: low

## Deploy Plan

- deploy front