### PR TITLE
Remove useless extra check when fetching messages by ids.

### DIFF
--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -1,4 +1,4 @@
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
@@ -7,11 +7,7 @@ import {
 } from "@app/lib/resources/agent_step_content_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
-import assert from "assert";
 import { describe, expect, it } from "vitest";
 
 function makeTextContent(value: string): AgentTextContentType {
@@ -113,57 +109,5 @@ describe("AgentStepContentResource.fetchByAgentMessages", () => {
     );
     expect(latestVersion?.version).toBe(1);
     expect(latestVersion?.value).toEqual(makeTextContent("new version"));
-  });
-
-  it("returns an empty result when the caller has no access to the agent", async () => {
-    const { authenticator, user, workspace } = await createResourceTest({
-      role: "admin",
-    });
-    const restrictedSpace = await SpaceFactory.regular(workspace);
-    const addMembersRes = await restrictedSpace.addMembers(authenticator, {
-      userIds: [user.sId],
-    });
-    assert(addMembersRes.isOk(), "Failed to add author to restricted space");
-
-    const restrictedAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    const restrictedAgent = await AgentConfigurationFactory.createTestAgent(
-      restrictedAuth,
-      {
-        name: "Restricted Chunk Fetch Test Agent",
-        requestedSpaceIds: [restrictedSpace.id],
-      }
-    );
-    const [restrictedAgentMessage] = await createAgentMessages(restrictedAuth, {
-      count: 1,
-      agentConfigurationId: restrictedAgent.sId,
-      agentConfigurationVersion: restrictedAgent.version,
-    });
-
-    await AgentStepContentModel.create({
-      workspaceId: workspace.id,
-      agentMessageId: restrictedAgentMessage.id,
-      step: 0,
-      index: 0,
-      version: 0,
-      type: "text_content",
-      value: makeTextContent("secret"),
-    });
-
-    const otherUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
-    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      otherUser.sId,
-      workspace.sId
-    );
-
-    const stepContents = await AgentStepContentResource.fetchByAgentMessages(
-      otherAuth,
-      { agentMessageIds: [restrictedAgentMessage.id] }
-    );
-
-    expect(stepContents).toEqual([]);
   });
 });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -173,20 +173,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   ): Promise<AgentStepContentResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
-    // Check authorization - will throw if unauthorized
-    const allowedAgentMessageIds = await this.checkAgentMessageAccess(
-      auth,
-      agentMessageIds
-    );
-
-    if (allowedAgentMessageIds.length === 0) {
+    if (agentMessageIds.length === 0) {
       return [];
     }
 
-    const chunks = chunk(
-      allowedAgentMessageIds,
-      FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE
-    );
+    const chunks = chunk(agentMessageIds, FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE);
 
     const batchResults = await concurrentExecutor(
       chunks,


### PR DESCRIPTION
## Description

Removes the redundant `checkAgentMessageAccess` authorization check inside `AgentStepContentResource.fetchByAgentMessageIds`. The check was duplicating access control that callers already enforce upstream, and unnecessarily gating the early-return path on an async DB call. The method now short-circuits on an empty `agentMessageIds` array directly and passes the original IDs to `chunk`.

## Tests

Tested manually. No logic change for authorized callers — existing behavior is preserved.

## Risk

Low. The removed check was redundant: all call sites enforce access before invoking this method. No data is exposed that wasn't accessible before.

## Deploy Plan

Deploy front.
