### PR TITLE
feat: check create skill permission frontend

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -1,13 +1,13 @@
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
   getAgentBuilderRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -39,6 +39,9 @@ export const CreateDropdown = ({
   const { isUploading: isUploadingYAML, triggerYAMLUpload } = useYAMLUpload({
     owner,
   });
+  const { hasPermission } = useWorkspacePermissions(owner);
+
+  const canCreateSkill = hasPermission("create", "skill");
 
   return (
     <DropdownMenu>
@@ -57,7 +60,7 @@ export const CreateDropdown = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {isBuilder(owner) && <DropdownMenuLabel label="Agents" />}
+        {canCreateSkill && <DropdownMenuLabel label="Agents" />}
         <DropdownMenuItem
           label="agent from scratch"
           icon={File02}
@@ -88,7 +91,7 @@ export const CreateDropdown = ({
           disabled={isUploadingYAML}
           onClick={triggerYAMLUpload}
         />
-        {isBuilder(owner) && (
+        {canCreateSkill && (
           <>
             <DropdownMenuLabel label="Skills" />
             <DropdownMenuItem

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -43,6 +43,16 @@ vi.mock("@app/lib/utils/router", () => ({
   setQueryParam: (...args: any[]) => setQueryParamMock(...args),
 }));
 
+// Mock workspace permissions so skill chips can be rendered without a
+// FetcherProvider / live permissions endpoint. Tests toggle the return value to
+// simulate whether the current user can create skills.
+const hasPermissionMock = vi.fn(() => false);
+vi.mock("@app/lib/swr/permissions", () => ({
+  useWorkspacePermissions: () => ({
+    hasPermission: hasPermissionMock,
+  }),
+}));
+
 const mockOwner = {
   id: 1,
   sId: "test-workspace",
@@ -219,6 +229,7 @@ Quote text
     });
 
     it("renders inline skill tags as chips", () => {
+      hasPermissionMock.mockReturnValue(false);
       const content =
         'Please use <skill id="skill_123" name="commit" icon="book_open" />';
       const message = { ...mockMessage, content };
@@ -235,14 +246,14 @@ Quote text
       expect(container.textContent).not.toContain("<skill");
     });
 
-    it("links inline skill tags for builders", () => {
+    it("links inline skill tags when the user can create skills", () => {
+      hasPermissionMock.mockReturnValue(true);
       const content =
         'Please use <skill id="skill_123" name="commit" icon="book_open" />';
       const message = { ...mockMessage, content };
-      const builderOwner = { ...mockOwner, role: "builder" } as const;
       const { container } = render(
         <UserMessageMarkdown
-          owner={builderOwner}
+          owner={mockOwner}
           message={message}
           isLastMessage={false}
         />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -61,7 +61,6 @@ import {
 } from "@app/types/assistant/conversation";
 import type { PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   ArrowRight,
   Avatar,
@@ -498,6 +497,7 @@ export function AgentSidebarMenu({
     useStarredPodsSectionCollapsed();
 
   const canCreateAgent = hasPermission("create", "agent");
+  const canCreateSkill = hasPermission("create", "skill");
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -1102,7 +1102,7 @@ export function AgentSidebarMenu({
                             />
                           </>
                         )}
-                        {isBuilder(owner) && (
+                        {canCreateSkill && (
                           <>
                             <DropdownMenuLabel>Skills</DropdownMenuLabel>
                             <DropdownMenuSub>

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -2,10 +2,14 @@ import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { useAppRouter } from "@app/lib/platform";
+import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import { getAgentBuilderRoute, setQueryParam } from "@app/lib/utils/router";
-import { isBuilder } from "@app/types/user";
+import {
+  getAgentBuilderRoute,
+  getSkillBuilderRoute,
+  setQueryParam,
+} from "@app/lib/utils/router";
 import {
   Button,
   ContactsRobot,
@@ -54,6 +58,7 @@ export function WebAgentBrowser({
   const { hasPermission } = useWorkspacePermissions(owner);
 
   const canCreateAgent = hasPermission("create", "agent");
+  const canCreateSkill = hasPermission("create", "skill");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {
@@ -103,25 +108,28 @@ export function WebAgentBrowser({
                 <CreateDropdown owner={owner} dataGtmLocation="homepage" />
               </div>
             )}
-            {isBuilder(owner) ? (
+            {canCreateAgent && canCreateSkill ? (
               <ManageDropdownMenu owner={owner} />
-            ) : (
-              canCreateAgent && (
-                <Button
-                  href={getAgentBuilderRoute(owner.sId, "manage")}
-                  variant="primary"
-                  icon={ContactsRobot}
-                  label="Manage agents"
-                  data-gtm-label="assistantManagementButton"
-                  data-gtm-location="homepage"
-                  size="sm"
-                  onClick={withTracking(
-                    TRACKING_AREAS.BUILDER,
-                    "manage_agents"
-                  )}
-                />
-              )
-            )}
+            ) : canCreateAgent ? (
+              <Button
+                href={getAgentBuilderRoute(owner.sId, "manage")}
+                variant="primary"
+                icon={ContactsRobot}
+                label="Manage agents"
+                data-gtm-label="assistantManagementButton"
+                data-gtm-location="homepage"
+                size="sm"
+                onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
+              />
+            ) : canCreateSkill ? (
+              <Button
+                href={getSkillBuilderRoute(owner.sId, "manage")}
+                variant="primary"
+                icon={SKILL_ICON}
+                label="Manage skills"
+                size="sm"
+              />
+            ) : null}
           </div>
         </div>
       </div>

--- a/front/components/markdown/SkillBlock.tsx
+++ b/front/components/markdown/SkillBlock.tsx
@@ -1,7 +1,7 @@
 import { getSkillIcon } from "@app/lib/skill";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import { AttachmentChip } from "@dust-tt/sparkle";
 import { visit } from "unist-util-visit";
 
@@ -21,7 +21,10 @@ export function SkillBlock({
   skillIcon,
   skillName,
 }: SkillBlockProps) {
-  const href = isBuilder(owner)
+  const { hasPermission } = useWorkspacePermissions(owner);
+  const canCreateSkill = hasPermission("create", "skill");
+
+  const href = canCreateSkill
     ? getManageSkillsRoute(owner.sId, skillId)
     : undefined;
 


### PR DESCRIPTION
## Description

This PR replaces `isBuilder` role checks with `hasPermission("create", "skill")` permission checks in the frontend to gate skill-related UI elements.

## Tests

Manually.

## Risks

If the backfill in https://github.com/dust-tt/dust/pull/29224 did not complete properly some people may be unable to create skills.

## Deploy Plan

Wait for the backfill in https://github.com/dust-tt/dust/pull/29224 to be completed.