### PR TITLE
Skills: Fix similar skills detection for more than 100 skills

### DIFF
--- a/front-api/routes/w/[wId]/skills/similar.test.ts
+++ b/front-api/routes/w/[wId]/skills/similar.test.ts
@@ -1,6 +1,9 @@
+import { SKILLS_PER_LLM_CALL } from "@app/lib/api/skills/existing_skill_checker";
+import { Authenticator } from "@app/lib/auth";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { Ok } from "@app/types/shared/result";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/assistant/call_llm", () => ({
   runMultiActionsAgent: vi.fn(),
@@ -11,8 +14,21 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { honoApp } from "@front-api/app";
 
 async function setup(role: "builder" | "user" | "admin" = "builder") {
-  const { workspace } = await createPrivateApiMockRequest({ role });
-  return { workspace };
+  const { workspace, user } = await createPrivateApiMockRequest({ role });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  return { workspace, auth };
+}
+
+async function createSkills(auth: Authenticator, count: number) {
+  for (let i = 0; i < count; i++) {
+    await SkillFactory.create(auth, {
+      name: `Test Skill ${i}`,
+      agentFacingDescription: `Test skill description ${i}`,
+    });
+  }
 }
 
 function post(workspace: { sId: string }, body: unknown) {
@@ -23,20 +39,29 @@ function post(workspace: { sId: string }, body: unknown) {
   });
 }
 
+function mockSimilarSkillsResponse(similarSkillIds: string[]) {
+  return new Ok({
+    actions: [
+      {
+        name: "set_similar_skills",
+        arguments: { similar_skills_array: similarSkillIds },
+      },
+    ],
+    generation: "",
+  });
+}
+
 describe("POST /api/w/:wId/skills/similar", () => {
+  beforeEach(() => {
+    vi.mocked(runMultiActionsAgent).mockClear();
+  });
+
   it("returns similar skills when runMultiActionsAgent succeeds", async () => {
-    const { workspace } = await setup();
+    const { workspace, auth } = await setup();
+    await createSkills(auth, 3);
 
     vi.mocked(runMultiActionsAgent).mockResolvedValue(
-      new Ok({
-        actions: [
-          {
-            name: "set_similar_skills",
-            arguments: { similar_skills_array: ["abc12", "20zer", "35xyz"] },
-          },
-        ],
-        generation: "",
-      })
+      mockSimilarSkillsResponse(["abc12", "20zer", "35xyz"])
     );
 
     const response = await post(workspace, {
@@ -47,21 +72,15 @@ describe("POST /api/w/:wId/skills/similar", () => {
     expect(await response.json()).toEqual({
       similar_skills: ["abc12", "20zer", "35xyz"],
     });
+    expect(runMultiActionsAgent).toHaveBeenCalledTimes(1);
   });
 
   it("returns empty similar skills when runMultiActionsAgent succeeds with empty array", async () => {
-    const { workspace } = await setup();
+    const { workspace, auth } = await setup();
+    await createSkills(auth, 1);
 
     vi.mocked(runMultiActionsAgent).mockResolvedValue(
-      new Ok({
-        actions: [
-          {
-            name: "set_similar_skills",
-            arguments: { similar_skills_array: [] },
-          },
-        ],
-        generation: "",
-      })
+      mockSimilarSkillsResponse([])
     );
 
     const response = await post(workspace, {
@@ -70,6 +89,37 @@ describe("POST /api/w/:wId/skills/similar", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ similar_skills: [] });
+  });
+
+  it("returns empty similar skills without calling the LLM when the workspace has no custom skills", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ similar_skills: [] });
+    expect(runMultiActionsAgent).not.toHaveBeenCalled();
+  });
+
+  it("batches skills into multiple LLM calls and merges deduplicated results", async () => {
+    const { workspace, auth } = await setup();
+    await createSkills(auth, SKILLS_PER_LLM_CALL + 1);
+
+    vi.mocked(runMultiActionsAgent)
+      .mockResolvedValueOnce(mockSimilarSkillsResponse(["abc12", "20zer"]))
+      .mockResolvedValueOnce(mockSimilarSkillsResponse(["20zer", "35xyz"]));
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      similar_skills: ["abc12", "20zer", "35xyz"],
+    });
+    expect(runMultiActionsAgent).toHaveBeenCalledTimes(2);
   });
 
   it("returns 400 when naturalDescription is missing", async () => {

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -3,12 +3,17 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import logger from "@app/logger/logger";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import chunk from "lodash/chunk";
+import uniq from "lodash/uniq";
 
-// Safeguards to avoid sending a huge number of skills to the LLM
-const MAX_SKILLS_SENT_TO_LLM = 100;
+// Safeguards to avoid sending a huge number of skills to a single LLM call:
+// skills are checked in batches of this size, one LLM call per batch.
+export const SKILLS_PER_LLM_CALL = 100;
+const MAX_CONCURRENT_LLM_CALLS = 4;
 const MAX_DESCRIPTION_LENGTH = 500;
 
 const SET_SIMILAR_SKILLS_FUNCTION_NAME = "set_similar_skills";
@@ -99,37 +104,19 @@ function truncateDescription(description: string): string {
   return description;
 }
 
-export async function getSimilarSkills(
+async function findSimilarSkillsInBatch(
   auth: Authenticator,
-  inputs: {
+  {
+    model,
+    naturalDescription,
+    skills,
+  }: {
+    model: ModelConfigurationType;
     naturalDescription: string;
-    excludeSkillId: string | null;
+    skills: SkillResource[];
   }
-): Promise<Result<{ similar_skills: string[] }, Error>> {
+): Promise<Result<string[], Error>> {
   const owner = auth.getNonNullableWorkspace();
-
-  const model = await getSmallWhitelistedModel(auth);
-  if (!model) {
-    return new Err(
-      new Error("Failed to find a whitelisted model to generate cron rule")
-    );
-  }
-
-  // Retrieve existing skills
-  const allSkills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
-    limit: MAX_SKILLS_SENT_TO_LLM,
-    onlyCustom: true,
-  });
-  if (allSkills.length === MAX_SKILLS_SENT_TO_LLM) {
-    logger.warn(
-      { workspaceId: owner.sId },
-      "The number of skills fetched reached the limit. Some skills might not be considered in the similarity check."
-    );
-  }
-
-  const skills = inputs.excludeSkillId
-    ? allSkills.filter((s) => s.sId !== inputs.excludeSkillId)
-    : allSkills;
 
   const existingSkills = skills
     .map(
@@ -137,7 +124,7 @@ export async function getSimilarSkills(
 "${truncateDescription(s.agentFacingDescription)}"`
     )
     .join("\n---\n");
-  const inputText = `Input description:"${inputs.naturalDescription}"
+  const inputText = `Input description:"${naturalDescription}"
 Existing skills:
 ${existingSkills}
 `;
@@ -191,5 +178,57 @@ ${existingSkills}
     return new Err(new Error("No similar skills generated"));
   }
 
-  return new Ok({ similar_skills: similar_skills });
+  return new Ok(similar_skills);
+}
+
+export async function getSimilarSkills(
+  auth: Authenticator,
+  inputs: {
+    naturalDescription: string;
+    excludeSkillId: string | null;
+  }
+): Promise<Result<{ similar_skills: string[] }, Error>> {
+  const model = await getSmallWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate cron rule")
+    );
+  }
+
+  // Retrieve all existing custom skills.
+  const allSkills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
+    onlyCustom: true,
+  });
+
+  const skills = inputs.excludeSkillId
+    ? allSkills.filter((s) => s.sId !== inputs.excludeSkillId)
+    : allSkills;
+
+  if (skills.length === 0) {
+    return new Ok({ similar_skills: [] });
+  }
+
+  // Check skills in batches, one LLM call per batch, so all skills are
+  // considered regardless of how many the workspace has.
+  const batches = chunk(skills, SKILLS_PER_LLM_CALL);
+  const results = await concurrentExecutor(
+    batches,
+    async (batch) =>
+      findSimilarSkillsInBatch(auth, {
+        model,
+        naturalDescription: inputs.naturalDescription,
+        skills: batch,
+      }),
+    { concurrency: MAX_CONCURRENT_LLM_CALLS }
+  );
+
+  const similarSkillIds: string[] = [];
+  for (const res of results) {
+    if (res.isErr()) {
+      return new Err(res.error);
+    }
+    similarSkillIds.push(...res.value);
+  }
+
+  return new Ok({ similar_skills: uniq(similarSkillIds) });
 }


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9714

the similar skill detection was limited to only 100 oldest skills so not very good for workspaces with 500+ skills like the dust workspace.
This run the similar skills detection by batch of 100 skills, with several parallel LLM calls.

We can tweak the value later, but 100 skills seems reasonable:
100 skills * 500 characters / 4 char per token ~= 12.5K tokens 

## Tests

tested locally but not with 100+ skills
Added unit test to make sure 101 skills do trigger 2 calls

## Risk

low, easy to revert
we increase cost of the feature as the number of LLM calls is now proportional to number of skills.
this should stay reasonable and hopefully, the number of skills to search will be lower when we have unpublished skills

## Deploy Plan

deploy front 
