### PR TITLE
[Tables] Keep exponent-like text values (e.g. 32E0134) as text in CSV parsing

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1332,10 +1332,7 @@ mod tests {
         let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::String("32E0134".to_string()));
         assert_eq!(row.content()["b"], Value::String("14e0050".to_string()));
-        assert_eq!(
-            row.content()["c"],
-            Value::Number(serde_json::Number::from_f64(320000.0).unwrap())
-        );
+        assert_eq!(row.content()["c"], Value::from(320000.0));
 
         let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["true", "false"];

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -945,6 +945,13 @@ impl Row {
         let mut values = Vec::<serde_json::Value>::new();
 
         fn try_parse_float(s: &str) -> Result<serde_json::Number> {
+            // Rust's float parser accepts exponent notation without a decimal separator,
+            // coercing product references like "32E0134" into numbers. Only treat exponent
+            // notation as numeric when a decimal separator is present (e.g. "3.2E5").
+            // Round-trip safe: to_csv_record writes floats via Display, never as exponents.
+            if !s.contains('.') && (s.contains('e') || s.contains('E')) {
+                return Err(anyhow!("Exponent notation without decimal separator"));
+            }
             if let Ok(float) = s.parse::<f64>() {
                 match serde_json::Number::from_f64(float) {
                     Some(num) => Ok(num),
@@ -1317,6 +1324,19 @@ mod tests {
             Value::Number(serde_json::Number::from_f64(0.1).unwrap())
         );
 
+        // Exponent notation without a decimal separator is kept as text (product
+        // references such as "32E0134" must not be coerced to numbers), while genuine
+        // scientific notation with a decimal separator is parsed as a float.
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        let record = vec!["32E0134", "14e0050", "3.2E5"];
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
+        assert_eq!(row.content()["a"], Value::String("32E0134".to_string()));
+        assert_eq!(row.content()["b"], Value::String("14e0050".to_string()));
+        assert_eq!(
+            row.content()["c"],
+            Value::Number(serde_json::Number::from_f64(320000.0).unwrap())
+        );
+
         let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["true", "false"];
         let row = Row::from_csv_record(headers, record, "0".to_string())?;
@@ -1351,6 +1371,7 @@ mod tests {
             ("integer_col".to_string(), 42.into()),
             ("float_col".to_string(), 3.14.into()),
             ("string_col".to_string(), "hello world".into()),
+            ("exponent_like_col".to_string(), "32E0134".into()),
             ("bool_col".to_string(), true.into()),
             ("null_col".to_string(), Value::Null),
         ]);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9285

Table rows are persisted as a CSV file in GCS, and every read re-infers each value's type in `Row::from_csv_record`. Rust's float parser accepts exponent notation without a decimal separator, so TEXT values shaped like `[digits]E[digits]` (e.g. a product reference `32E0134`) were silently parsed as floats (`3.2e135`) — even when upserted as proper JSON strings through the rows API, since those are also serialized to CSV before the background worker re-parses them. When rows were re-written to storage (background consolidation, non-truncate merge, row deletion), the float was serialized via Rust's `Display`, which never emits exponent notation, so the stored CSV ended up with the 136-digit numeral. Query results are served straight from that CSV (SQLite csvtab), hence the corrupted output and `WHERE reference = '32E0134'` matching nothing.

Fix: in CSV value type inference, only treat exponent notation as numeric when a decimal separator is present. `3.2E5` still parses as a float; `32E0134` (and `1e5`) now stay text. This is round-trip safe because our own CSV serialization never emits exponent notation.

Note: already-corrupted stored values cannot be recovered (the original string is lost); affected tables need a truncate re-upsert to be repaired.

## Risks

Blast radius: type inference of table values (CSV uploads and rows-API upserts) for structured data queries.
Risk: low

Behavior change edge case: a column containing genuine scientific notation without a decimal separator (e.g. `1e5`) is now inferred as Text instead of Float. Preserving user strings is the safer default there.

## Deploy Plan

- deploy core (front-edge/core-edge first is fine, no migration)