### PR TITLE
feat(activation): add admin CLI for the workspace schedule lifecycle

### DIFF
--- a/front/temporal/activation_scheduler/admin/cli.ts
+++ b/front/temporal/activation_scheduler/admin/cli.ts
@@ -1,0 +1,89 @@
+import {
+  deleteActivationWorkspaceSchedule,
+  ensureActivationWorkspaceSchedules,
+  launchEnsureActivationSchedulesWorkflow,
+  startActivationWorkspaceSchedule,
+  stopAllActivationWorkspaceSchedules,
+  stopEnsureActivationSchedulesWorkflow,
+  triggerActivationWorkspaceWorkflow,
+} from "@app/temporal/activation_scheduler/client";
+import parseArgs from "minimist";
+
+function usage() {
+  console.error(`Usage:
+  start                                        Ensure all workspace schedules (start missing, stop extra)
+  stop                                         Stop all running schedules
+  start-ensure                                 Start the nightly ensure-schedules workflow (11pm local)
+  stop-ensure                                  Stop the nightly ensure-schedules workflow
+  start-workspace --workspace-id <sId>         Start the schedule for a specific workspace
+  stop-workspace --workspace-id <sId>          Stop the schedule for a specific workspace
+  trigger-workspace --workspace-id <sId>       Trigger an activation cycle for a specific workspace on demand`);
+}
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2), {
+    string: ["workspace-id"],
+  });
+
+  const [command] = argv._;
+
+  switch (command) {
+    case "start":
+      await ensureActivationWorkspaceSchedules();
+      return;
+    case "stop":
+      await stopAllActivationWorkspaceSchedules();
+      return;
+    case "start-ensure":
+      await launchEnsureActivationSchedulesWorkflow();
+      return;
+    case "stop-ensure":
+      await stopEnsureActivationSchedulesWorkflow();
+      return;
+    case "start-workspace": {
+      const workspaceId = argv["workspace-id"];
+      if (!workspaceId) {
+        console.error("Error: --workspace-id is required");
+        usage();
+        process.exit(1);
+      }
+      await startActivationWorkspaceSchedule({ workspaceId });
+      return;
+    }
+    case "stop-workspace": {
+      const workspaceId = argv["workspace-id"];
+      if (!workspaceId) {
+        console.error("Error: --workspace-id is required");
+        usage();
+        process.exit(1);
+      }
+      await deleteActivationWorkspaceSchedule({ workspaceId });
+      return;
+    }
+    case "trigger-workspace": {
+      const workspaceId = argv["workspace-id"];
+      if (!workspaceId) {
+        console.error("Error: --workspace-id is required");
+        usage();
+        process.exit(1);
+      }
+      await triggerActivationWorkspaceWorkflow({ workspaceId });
+      return;
+    }
+    default:
+      console.error(`Error: Unknown command "${command}"`);
+      usage();
+      process.exit(1);
+  }
+};
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description

Adds `front/temporal/activation_scheduler/admin/cli.ts`, a command-line entry point for the ensure-schedules lifecycle introduced in #29244, mirroring `front/temporal/reinforcement/admin/cli.ts`:

- `start` / `stop`: run the ensure-schedules reconcile once, or delete all workspace schedules.
- `start-ensure` / `stop-ensure`: bootstrap or tear down the nightly recurring cron workflow (a one-time operation since the workflow is a singleton kept alive by Temporal's `cronSchedule`).
- `start-workspace` / `stop-workspace` / `trigger-workspace`: manage or force-run a single workspace's schedule.

Without this, `launchEnsureActivationSchedulesWorkflow` (and friends) had no caller and the nightly reconcile job could never actually be started.

## Tests

No behavioral logic changed — this only wires up existing, already-tested `client.ts` functions to a CLI. Verified `tsgo --noEmit` passes.
