### PR TITLE
[zendesk] Add personal account support to Zendesk tool

### DIFF
--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -167,7 +167,7 @@ export const ZENDESK_SERVER = {
       "Access and manage support tickets, help center, and customer interactions.",
     authorization: {
       provider: "zendesk" as const,
-      supported_use_cases: ["platform_actions"] as const,
+      supported_use_cases: ["platform_actions", "personal_actions"] as const,
     },
     icon: "ZendeskLogo",
     documentationUrl: null,

--- a/front/lib/api/oauth/providers/zendesk.test.ts
+++ b/front/lib/api/oauth/providers/zendesk.test.ts
@@ -1,0 +1,149 @@
+import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { OAuthConnectionType } from "@app/types/oauth/lib";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConnectionMetadata: vi.fn(),
+  getWorkspaceOAuthConnectionIdForMCPServer: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/oauth/mcp_server_connection_auth", () => ({
+  getWorkspaceOAuthConnectionIdForMCPServer:
+    mocks.getWorkspaceOAuthConnectionIdForMCPServer,
+}));
+
+vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/types/oauth/oauth_api")>();
+
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function OAuthAPIMock() {
+      return {
+        getConnectionMetadata: mocks.getConnectionMetadata,
+      };
+    }),
+  };
+});
+
+function makeConnection(metadata: Record<string, string>): OAuthConnectionType {
+  return {
+    connection_id: "con_workspace",
+    created: Date.now(),
+    metadata,
+    provider: "zendesk",
+    status: "pending",
+  };
+}
+
+describe("ZendeskOAuthProvider.isExtraConfigValid", () => {
+  const provider = new ZendeskOAuthProvider();
+
+  it("accepts personal_actions with an mcp_server_id (subdomain inherited from admin)", () => {
+    expect(
+      provider.isExtraConfigValid(
+        { mcp_server_id: "srv_123" },
+        "personal_actions"
+      )
+    ).toBe(true);
+  });
+
+  it("requires a valid subdomain for personal_actions without an mcp_server_id", () => {
+    expect(
+      provider.isExtraConfigValid(
+        { zendesk_subdomain: "mycompany" },
+        "personal_actions"
+      )
+    ).toBe(true);
+    expect(
+      provider.isExtraConfigValid(
+        { zendesk_subdomain: "Invalid_Domain!" },
+        "personal_actions"
+      )
+    ).toBe(false);
+  });
+
+  it("requires a valid subdomain for platform_actions", () => {
+    expect(
+      provider.isExtraConfigValid(
+        { zendesk_subdomain: "mycompany" },
+        "platform_actions"
+      )
+    ).toBe(true);
+    expect(provider.isExtraConfigValid({}, "platform_actions")).toBe(false);
+  });
+
+  it("rejects extra config keys for platform_actions", () => {
+    expect(
+      provider.isExtraConfigValid(
+        { zendesk_subdomain: "mycompany", extra: "x" },
+        "platform_actions"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("ZendeskOAuthProvider.getUpdatedExtraConfig", () => {
+  beforeEach(() => {
+    mocks.getConnectionMetadata.mockReset();
+    mocks.getWorkspaceOAuthConnectionIdForMCPServer.mockReset();
+  });
+
+  it("inherits the subdomain from the workspace connection for personal actions", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const provider = new ZendeskOAuthProvider();
+
+    mocks.getWorkspaceOAuthConnectionIdForMCPServer.mockResolvedValue(
+      new Ok("con_workspace")
+    );
+    mocks.getConnectionMetadata.mockResolvedValue(
+      new Ok({
+        connection: makeConnection({ zendesk_subdomain: "admincompany" }),
+      })
+    );
+
+    const updated = await provider.getUpdatedExtraConfig(authenticator, {
+      useCase: "personal_actions",
+      extraConfig: { mcp_server_id: "srv_123" },
+    });
+
+    // The admin-configured subdomain is stamped in, and the transient
+    // mcp_server_id is dropped from the personal connection config.
+    expect(updated.zendesk_subdomain).toBe("admincompany");
+    expect(updated.mcp_server_id).toBeUndefined();
+  });
+
+  it("leaves config unchanged for personal actions without an mcp_server_id", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const provider = new ZendeskOAuthProvider();
+
+    const extraConfig = { zendesk_subdomain: "mycompany" };
+    const updated = await provider.getUpdatedExtraConfig(authenticator, {
+      useCase: "personal_actions",
+      extraConfig,
+    });
+
+    expect(updated).toEqual(extraConfig);
+    expect(
+      mocks.getWorkspaceOAuthConnectionIdForMCPServer
+    ).not.toHaveBeenCalled();
+  });
+
+  it("leaves config unchanged for platform actions", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const provider = new ZendeskOAuthProvider();
+
+    const extraConfig = { zendesk_subdomain: "mycompany" };
+    const updated = await provider.getUpdatedExtraConfig(authenticator, {
+      useCase: "platform_actions",
+      extraConfig,
+    });
+
+    expect(updated).toEqual(extraConfig);
+    expect(
+      mocks.getWorkspaceOAuthConnectionIdForMCPServer
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/oauth/providers/zendesk.test.ts
+++ b/front/lib/api/oauth/providers/zendesk.test.ts
@@ -115,6 +115,27 @@ describe("ZendeskOAuthProvider.getUpdatedExtraConfig", () => {
     expect(updated.mcp_server_id).toBeUndefined();
   });
 
+  it("throws when the workspace connection has no subdomain", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const provider = new ZendeskOAuthProvider();
+
+    mocks.getWorkspaceOAuthConnectionIdForMCPServer.mockResolvedValue(
+      new Ok("con_workspace")
+    );
+    mocks.getConnectionMetadata.mockResolvedValue(
+      new Ok({
+        connection: makeConnection({}),
+      })
+    );
+
+    await expect(
+      provider.getUpdatedExtraConfig(authenticator, {
+        useCase: "personal_actions",
+        extraConfig: { mcp_server_id: "srv_123" },
+      })
+    ).rejects.toThrow(/missing a subdomain/);
+  });
+
   it("leaves config unchanged for personal actions without an mcp_server_id", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const provider = new ZendeskOAuthProvider();

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -127,12 +127,18 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
           );
         }
         const connection = connectionRes.value.connection;
+        const { zendesk_subdomain } = connection.metadata;
+
+        if (!zendesk_subdomain) {
+          throw new Error(
+            "Zendesk workspace connection is missing a subdomain; " +
+              "cannot set up a personal connection."
+          );
+        }
 
         return {
           ...restConfig,
-          ...(connection.metadata.zendesk_subdomain && {
-            zendesk_subdomain: connection.metadata.zendesk_subdomain,
-          }),
+          zendesk_subdomain,
         };
       }
       case "connection":

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -1,18 +1,26 @@
 import { isValidZendeskSubdomain } from "@app/lib/api/actions/servers/zendesk/types";
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
 
 export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
+  // Personal connections inherit the Zendesk subdomain from the workspace
+  // connection set up by the admin, so that connection must exist first.
+  requiresWorkspaceConnectionForPersonalAuth = true;
+
   setupUri({
     connection,
     useCase,
@@ -55,10 +63,62 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
     return getStringFromQuery(query, "state");
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      // If we have an mcp_server_id it means the admin already set up the
+      // workspace connection, so we inherit the Zendesk subdomain from it.
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+    }
     if (Object.keys(extraConfig).length !== 1) {
       return false;
     }
     return isValidZendeskSubdomain(extraConfig.zendesk_subdomain);
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      // For personal actions we inherit the Zendesk subdomain from the existing
+      // workspace connection (set up by the admin) identified by mcp_server_id.
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: oauthConnectionIdRes.value,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+
+        return {
+          ...restConfig,
+          ...(connection.metadata.zendesk_subdomain && {
+            zendesk_subdomain: connection.metadata.zendesk_subdomain,
+          }),
+        };
+      }
+    }
+
+    return extraConfig;
   }
 }

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -14,6 +14,7 @@ import type {
   OAuthUseCase,
 } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ParsedUrlQuery } from "querystring";
 
 export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
@@ -64,13 +65,25 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
   }
 
   isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
-    if (useCase === "personal_actions") {
-      // If we have an mcp_server_id it means the admin already set up the
-      // workspace connection, so we inherit the Zendesk subdomain from it.
-      if (extraConfig.mcp_server_id) {
-        return true;
-      }
+    switch (useCase) {
+      case "personal_actions":
+        // If we have an mcp_server_id it means the admin already set up the
+        // workspace connection, so we inherit the Zendesk subdomain from it.
+        if (extraConfig.mcp_server_id) {
+          return true;
+        }
+        break;
+      case "connection":
+      case "labs_transcripts":
+      case "platform_actions":
+      case "bot":
+      case "webhooks":
+        break;
+      default:
+        assertNever(useCase);
     }
+
+    // Otherwise the config must be exactly a valid Zendesk subdomain.
     if (Object.keys(extraConfig).length !== 1) {
       return false;
     }
@@ -87,12 +100,17 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
       useCase: OAuthUseCase;
     }
   ): Promise<ExtraConfigType> {
-    if (useCase === "personal_actions") {
-      // For personal actions we inherit the Zendesk subdomain from the existing
-      // workspace connection (set up by the admin) identified by mcp_server_id.
-      const { mcp_server_id, ...restConfig } = extraConfig;
+    switch (useCase) {
+      case "personal_actions": {
+        // For personal actions we inherit the Zendesk subdomain from the
+        // existing workspace connection (set up by the admin) identified by
+        // mcp_server_id.
+        const { mcp_server_id, ...restConfig } = extraConfig;
 
-      if (mcp_server_id) {
+        if (!mcp_server_id) {
+          return extraConfig;
+        }
+
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
@@ -117,8 +135,14 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
           }),
         };
       }
+      case "connection":
+      case "labs_transcripts":
+      case "platform_actions":
+      case "bot":
+      case "webhooks":
+        return extraConfig;
+      default:
+        assertNever(useCase);
     }
-
-    return extraConfig;
   }
 }


### PR DESCRIPTION
Enable personal_actions for the Zendesk MCP server so each user can connect their own Zendesk account, alongside the existing workspace (platform_actions) connection.

Mirrors the Jira provider pattern: personal connections inherit the Zendesk subdomain from the admin's workspace connection via getUpdatedExtraConfig (keyed by mcp_server_id), so users never re-enter it. Sets requiresWorkspaceConnectionForPersonalAuth since the subdomain is mandatory. isExtraConfigValid accepts an mcp_server_id for personal setup. Adds unit tests covering config validation and subdomain inheritance.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Ask from EQT. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Added Unit tests for zendesk. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
