### PR TITLE
Handle skill creation capability backend checks

### DIFF
--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
 import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -157,9 +158,17 @@ describe("GET /api/v1/w/[wId]/skills", () => {
 describe("POST /api/v1/w/[wId]/skills", () => {
   it("adds provided editors to new and existing imported skills", async () => {
     const { auth, workspace } = await createPublicApiMockRequest();
-    await SpaceFactory.defaults(
-      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
     );
+    await SpaceFactory.defaults(adminAuth);
+    // The mock key's role ("builder") doesn't grant create/skill by itself anymore — it
+    // requires a group grant. The key is scoped to the workspace's global group, so granting
+    // the capability to everybody satisfies it.
+    await GroupPermissionResource.setForEverybody(adminAuth, {
+      grantType: "create",
+      resourceType: "skill",
+    });
     const firstEditor = await UserFactory.basic();
     const secondEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, firstEditor, {
@@ -244,9 +253,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toBe(
-        "Importing skills requires a builder user."
-      );
+      expect(result.error.message).toBe("Creating skills is restricted.");
     }
   });
 });

--- a/front-api/routes/w/[wId]/skills/import/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/index.ts
@@ -5,7 +5,6 @@ import type { ImportSkillsRequestBody } from "@app/types/api/skills/detection/gi
 import { ImportSkillsRequestBodySchema } from "@app/types/api/skills/detection/github/import_skills";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -24,7 +23,6 @@ app.route("/upload", upload);
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsBuilder(),
   validate("json", ImportSkillsRequestBodySchema),
   async (ctx): HandlerResult<ImportSkillsResponseBody> => {
     const auth = ctx.get("auth");
@@ -77,6 +75,14 @@ app.post(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "app_auth_error",
               message: error.message,
             },
           });

--- a/front-api/routes/w/[wId]/skills/import/upload.ts
+++ b/front-api/routes/w/[wId]/skills/import/upload.ts
@@ -3,7 +3,6 @@ import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_ski
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
@@ -16,7 +15,7 @@ import formidable from "formidable";
 const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 /** @ignoreswagger */
-app.post("/", ensureIsBuilder(), async (ctx) => {
+app.post("/", async (ctx) => {
   const auth = ctx.get("auth");
   const incoming = ctx.env?.incoming;
   if (!incoming) {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -3,6 +3,7 @@ import {
   SkillFileAttachmentModel,
   SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -26,6 +27,29 @@ import { describe, expect, it, vi } from "vitest";
 
 async function setupTest(role: MembershipRoleType = "builder") {
   return createPrivateApiMockRequest({ role });
+}
+
+// The test's own "builder" membership role doesn't grant create/skill by itself anymore — it
+// requires a group grant. Used by tests that specifically need a non-admin caller (e.g. to
+// exercise space-access checks admins would otherwise bypass) while still being allowed to
+// create a skill.
+async function grantCreateSkillCapability(
+  workspace: Awaited<ReturnType<typeof setupTest>>["workspace"],
+  user: Awaited<ReturnType<typeof setupTest>>["user"]
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    workspace,
+    `skill-creator-${user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType: "create",
+    resourceType: "skill",
+  });
 }
 
 function getSkills(
@@ -770,7 +794,8 @@ describe("POST /api/w/:wId/skills", () => {
   });
 
   it("rejects additional requested spaces the user cannot access", async () => {
-    const { workspace } = await setupTest("builder");
+    const { workspace, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
 
     const restrictedSpace = await SpaceFactory.regular(workspace);
 
@@ -796,7 +821,8 @@ describe("POST /api/w/:wId/skills", () => {
   });
 
   it("allows restricting a skill to an open Pod the user can access", async () => {
-    const { workspace, globalGroup } = await setupTest("builder");
+    const { workspace, globalGroup, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
 
     const openPod = await SpaceFactory.project(workspace);
     await GroupSpaceFactory.associate(openPod, globalGroup);
@@ -1055,6 +1081,7 @@ describe("POST /api/w/:wId/skills", () => {
 describe("POST /api/w/:wId/skills - file attachments", () => {
   it("creates a skill with file attachments", async () => {
     const { auth, workspace, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
 
     const file1 = await FileFactory.create(auth, user, {
       contentType: "text/plain",

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -18,7 +18,6 @@ import {
   SKILL_REINFORCEMENT_MODES,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
-import { isBuilder } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -204,14 +203,13 @@ app.post(
   validate("json", PostSkillRequestBodySchema),
   async (ctx): HandlerResult<PostSkillResponseBody> => {
     const auth = ctx.get("auth");
-    const owner = auth.getNonNullableWorkspace();
 
-    if (!isBuilder(owner)) {
+    if (!(await auth.hasWorkspacePermission("create", "skill"))) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "app_auth_error",
-          message: "User is not a builder.",
+          message: "Creating skills is restricted.",
         },
       });
     }

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -8,7 +8,9 @@ import {
 } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { isSkillAuthoringResultOutput } from "@app/lib/api/actions/servers/skill_authoring/rendering";
 import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -63,6 +65,28 @@ function makeExtra(auth: Authenticator) {
   return extra as ToolHandlerExtra;
 }
 
+// A "builder" role membership no longer grants create/skill by itself — it requires a group
+// grant. Drop-in replacement for createResourceTest({ role: "builder" }) for tests that create a
+// skill via the CREATE_SKILL_TOOL_NAME tool.
+async function createBuilderTestContext() {
+  const result = await createResourceTest({ role: "builder" });
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    result.workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    result.workspace,
+    `skill-creator-${result.user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [result.user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType: "create",
+    resourceType: "skill",
+  });
+  await result.authenticator.refresh();
+  return result;
+}
+
 // Seed a skill directly and refresh the authenticator so it picks up the editor
 // group membership created during makeNew (create_skill does the same refresh).
 async function seedSkill(
@@ -81,9 +105,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("creates, lists, reads, and updates a skill", async () => {
-    const { authenticator, workspace } = await createResourceTest({
-      role: "builder",
-    });
+    const { authenticator, workspace } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -230,7 +252,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("returns an MCPError without an interactive user", async () => {
-    const { workspace } = await createResourceTest({ role: "builder" });
+    const { workspace } = await createBuilderTestContext();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const result = await getTool(CREATE_SKILL_TOOL_NAME).handler(
@@ -249,10 +271,10 @@ describe("skill_authoring tools", () => {
       throw new Error("Expected missing user to fail.");
     }
     expect(result.error).toBeInstanceOf(MCPError);
-    expect(result.error.message).toContain("interactive builder user context");
+    expect(result.error.message).toContain("interactive user context");
   });
 
-  it("returns an MCPError for non-builders", async () => {
+  it("returns an MCPError for users without the create-skill capability", async () => {
     const { authenticator } = await createResourceTest({ role: "user" });
 
     const result = await getTool(CREATE_SKILL_TOOL_NAME).handler(
@@ -268,13 +290,13 @@ describe("skill_authoring tools", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isOk()) {
-      throw new Error("Expected non-builder to fail.");
+      throw new Error("Expected unauthorized user to fail.");
     }
-    expect(result.error.message).toContain("builder");
+    expect(result.error.message).toContain("restricted");
   });
 
   it("ignores an invalid icon on create and falls back to a valid one", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -306,7 +328,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an invalid icon on update", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -351,7 +373,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("applies a targeted instructions edit with old_string/new_string", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -393,7 +415,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an edit when old_string is not found", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -438,7 +460,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects an edit when the replacement count does not match", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -494,7 +516,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that drops a knowledge tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       'Summarize the runbook. <knowledge id="data_xyz" title="Runbook" />';
     const skill = await seedSkill(authenticator, {
@@ -534,7 +556,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that drops a knowledge tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       'Summarize the runbook. <knowledge id="data_xyz" title="Runbook" />';
     const skill = await seedSkill(authenticator, {
@@ -562,7 +584,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that drops a nested skill tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -608,7 +630,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that strips knowledge tag attributes", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       'Use <knowledge id="n1" title="Runbook" space="sp1" dsv="dsv1" hasChildren="true" /> for context.';
     const skill = await seedSkill(authenticator, {
@@ -635,7 +657,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("allows a full replace that reorders knowledge tag attributes", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       'Use <knowledge id="n1" title="Runbook" space="sp1" dsv="dsv1" hasChildren="true" /> for context.';
     const reorderedInstructions =
@@ -659,7 +681,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that strips tool tag attributes", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       'Use <tool id="tool_1" name="Search" icon="ActionListIcon" /> for research.';
     const skill = await seedSkill(authenticator, {
@@ -686,7 +708,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("keeps nested skill references in sync when editing instructions", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -724,7 +746,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a knowledge tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -747,7 +769,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a tool tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {
@@ -770,7 +792,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects creating a skill that embeds a nested skill reference", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -798,7 +820,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a full replace that adds a knowledge tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions =
       "Summarize the runbook in three bullet points.";
     const skill = await seedSkill(authenticator, {
@@ -826,7 +848,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects a targeted edit that adds a tool tag", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
     const originalInstructions = "Use the search step for research.";
     const skill = await seedSkill(authenticator, {
       name: "Plain Tool Skill",
@@ -853,7 +875,7 @@ describe("skill_authoring tools", () => {
   });
 
   it("rejects combining a full instructions replace with a targeted edit", async () => {
-    const { authenticator } = await createResourceTest({ role: "builder" });
+    const { authenticator } = await createBuilderTestContext();
 
     const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
       {

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -29,7 +29,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-function requireInteractiveBuilder(
+function requireInteractiveUser(
   auth: Authenticator
 ): Result<UserResource, MCPError> {
   const user = auth.user();
@@ -41,8 +41,21 @@ function requireInteractiveBuilder(
     );
   }
 
-  if (!auth.isBuilder()) {
-    return new Err(new MCPError("Skill authoring requires a builder user."));
+  return new Ok(user);
+}
+
+async function requireCreateSkillPermission(
+  auth: Authenticator
+): Promise<Result<UserResource, MCPError>> {
+  const user = auth.user();
+  if (!user) {
+    return new Err(
+      new MCPError("Skill authoring requires an interactive user context.")
+    );
+  }
+
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return new Err(new MCPError("Creating skills is restricted."));
   }
 
   return new Ok(user);
@@ -219,7 +232,7 @@ function findDisallowedSpecialTagChanges(
 
 const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
   [LIST_SKILLS_TOOL_NAME]: async ({ filter, cursor, limit }, { auth }) => {
-    const user = requireInteractiveBuilder(auth);
+    const user = requireInteractiveUser(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }
@@ -271,7 +284,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
   },
 
   [GET_SKILL_TOOL_NAME]: async ({ sId }, { auth }) => {
-    const user = requireInteractiveBuilder(auth);
+    const user = requireInteractiveUser(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }
@@ -322,7 +335,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const user = requireInteractiveBuilder(auth);
+    const user = await requireCreateSkillPermission(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }
@@ -442,7 +455,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const user = requireInteractiveBuilder(auth);
+    const user = requireInteractiveUser(auth);
     if (user.isErr()) {
       return new Err(user.error);
     }

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -71,8 +71,8 @@ export async function importSkillsFromFiles(
     onConflict?: ImportConflictStrategyType;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
-  if (!auth.isBuilder()) {
-    return new Err(new Error("Importing skills requires a builder user."));
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return new Err(new Error("Creating skills is restricted."));
   }
 
   const allSkills: ZipDetectedSkill[] = [];

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -42,6 +42,12 @@ type ImportSkillsResult = {
   skipped: { name: string; message: string }[];
 };
 
+// Wider than GitHubSkillDetectionError (shared with the read-only detect endpoint, which never
+// produces this variant): only the actual import/creation path checks the create/skill capability.
+export type ImportSkillsFromGitHubError =
+  | GitHubSkillDetectionError
+  | { type: "unauthorized"; message: string };
+
 /**
  * Imports skills from a GitHub repository. Detects skills, fetches their
  * attachments, and creates or updates SkillResource objects.
@@ -57,7 +63,14 @@ export async function importSkillsFromGitHub(
     names: string[];
     onConflict?: "error" | "skip";
   }
-): Promise<Result<ImportSkillsResult, GitHubSkillDetectionError>> {
+): Promise<Result<ImportSkillsResult, ImportSkillsFromGitHubError>> {
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return new Err({
+      type: "unauthorized",
+      message: "Creating skills is restricted.",
+    });
+  }
+
   const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
   const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
   if (clientResult.isErr()) {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -48,23 +48,17 @@ describe("SkillResource", () => {
   });
 
   describe("permissions", () => {
-    it("allows builder API keys to administrate skills", async () => {
+    it("allows any API key to write and administrate skills, regardless of role", async () => {
       const skill = await SkillFactory.create(testContext.authenticator);
-      const builderKey = await KeyFactory.regular(testContext.globalGroup);
-      const readOnlyKey = await KeyFactory.readOnly(testContext.globalGroup);
+      // Keys have no editor-group assignment mechanism, so even the least-privileged key
+      // role ("user") must be allowed here — there is no role distinction left to gate on.
+      const key = await KeyFactory.readOnly(testContext.globalGroup);
 
-      const builderAuth = (
-        await Authenticator.fromKey(builderKey, testContext.workspace.sId)
-      ).workspaceAuth;
-      const readOnlyAuth = (
-        await Authenticator.fromKey(readOnlyKey, testContext.workspace.sId)
-      ).workspaceAuth;
+      const auth = (await Authenticator.fromKey(key, testContext.workspace.sId))
+        .workspaceAuth;
 
-      expect(skill.canWrite(builderAuth)).toBe(true);
-      expect(skill.canAdministrate(builderAuth)).toBe(true);
-
-      expect(skill.canWrite(readOnlyAuth)).toBe(false);
-      expect(skill.canAdministrate(readOnlyAuth)).toBe(false);
+      expect(skill.canWrite(auth)).toBe(true);
+      expect(skill.canAdministrate(auth)).toBe(true);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2034,8 +2034,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canWrite(auth: Authenticator): boolean {
-    // API keys with at least builder role can write to any skill.
-    if (auth.isKey() && auth.isBuilder()) {
+    // TODO(governance): cleanup we we'll be able to assign API key to editor groups.
+    // API keys cannot be added to a skill's editor group (no such assignment mechanism exists),
+    // so any key is allowed to write to any skill. Skill *creation* is separately gated by
+    // `auth.hasWorkspacePermission("create", "skill")`; this only governs already-existing skills.
+    if (auth.isKey()) {
       return true;
     }
 
@@ -2047,8 +2050,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canAdministrate(auth: Authenticator): boolean {
-    // API keys with at least builder role can administrate any skill.
-    if (auth.isKey() && auth.isBuilder()) {
+    // See canWrite: API keys have no editor-group assignment mechanism, so any key can
+    // administrate any skill.
+    if (auth.isKey()) {
       return true;
     }
 


### PR DESCRIPTION
## Description

Part of the Admin Governance initiative (`create skill` capability, dust-tt/tasks#9464) — replaces the hardcoded builder-role check on every skill-creation entry point with the new group-permissions-backed `auth.hasWorkspacePermission("create", "skill")` check, so skill creation is governed the same way as agent creation.

- **`front-api/routes/w/[wId]/skills/index.ts`** (POST, create skill): replaced `isBuilder(owner)` with `auth.hasWorkspacePermission("create", "skill")`. Error message changed from `"User is not a builder."` to the generic `"Creating skills is restricted."`.
- **`front-api/routes/w/[wId]/skills/import/index.ts`** and **`.../import/upload.ts`**: dropped the `ensureIsBuilder()` middleware (the underlying `import_skills.ts` functions now do their own capability check instead of relying on route-level role gating). Added handling for a new `"unauthorized"` error variant, mapped to a 403.
- **`front/lib/api/skills/detection/files/import_skills.ts`**: replaced `auth.isBuilder()` with the capability check; same error message change.
- **`front/lib/api/skills/detection/github/import_skills.ts`**: added the same capability check at the top of `importSkillsFromGitHub`. Widened its error union with `ImportSkillsFromGitHubError = GitHubSkillDetectionError | { type: "unauthorized"; message: string }` — the read-only detect endpoint shares `GitHubSkillDetectionError` but never hits this new branch, only the actual import/creation path does.
- **`front/lib/api/actions/servers/skill_authoring/tools/index.ts`**: the skill-authoring MCP tool's `create_skill` handler now calls a new `requireCreateSkillPermission` (checks `auth.hasWorkspacePermission("create", "skill")`) instead of `requireInteractiveBuilder`.
- Fixed a stale test assertion in `front-api/routes/v1/w/[wId]/skills/index.test.ts` still expecting the old message `"Importing skills requires a builder user."` instead of the current `"Creating skills is restricted."`.

## Tests

- `front-api/routes/v1/w/[wId]/skills/index.test.ts` (4 tests) and `front-api/routes/w/[wId]/skills/index.test.ts` (31 tests) — all green.
- `front/lib/api/actions/servers/skill_authoring/tools/index.test.ts` — updated for the new permission check, green.
- `npx tsgo --noEmit` clean on `front` and `front-api`.

## Risk

- Skill creation access now depends on the `create skill` governance capability's configured scope (`GroupPermissionResource`), which defaults to `"builders"` via `CAPABILITY_SEEDERS` (`governance_seeding.ts`) — i.e. members of the workspace's Builders group, same effective population as the old `isBuilder()` check, as long as the Builders group has been seeded/backfilled for that workspace. Workspaces without a seeded grant yet will deny non-admins by default (fails closed), matching the "admins_only" fallback used elsewhere in the governance rollout.
- The GitHub-import error union widening (`ImportSkillsFromGitHubError`) is additive; existing callers exhaustively switching on `GitHubSkillDetectionError` need to handle the new `"unauthorized"` variant (done in `skills/import/index.ts`), otherwise `assertNever` will catch it at compile time.

## Deploy Plan

- Merge and deploy as usual. No new migration in this PR — relies on the `create skill` capability already being seeded via the shared Admin Governance seeding/backfill infrastructure.