### PR TITLE
Add sortable People member columns

### DIFF
--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -24,6 +24,8 @@ const SearchMembersQuerySchema = z.object({
     .string()
     .transform((v) => v === "true")
     .optional(),
+  sortBy: z.enum(["name", "email", "role", "status", "groups"]).optional(),
+  sortDirection: z.enum(["asc", "desc"]).optional(),
 });
 
 // Mounted at /api/w/:wId/members/search.

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -14,7 +14,11 @@ import {
   LoadingBlock,
   XClose,
 } from "@dust-tt/sparkle";
-import type { CellContext, PaginationState } from "@tanstack/react-table";
+import type {
+  CellContext,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import capitalize from "lodash/capitalize";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, { useMemo } from "react";
@@ -78,6 +82,7 @@ const memberColumns = [
   {
     id: "name" as const,
     header: "Name",
+    accessorFn: (row: RowData) => row.name,
     cell: (info: Info) => (
       <DataTable.CellContent avatarUrl={info.row.original.icon} roundedAvatar>
         {info.row.original.name}
@@ -86,7 +91,7 @@ const memberColumns = [
         )}
       </DataTable.CellContent>
     ),
-    enableSorting: false,
+    enableSorting: true,
   },
   {
     id: "email" as const,
@@ -139,6 +144,8 @@ const memberColumns = [
   {
     id: "status" as const,
     header: "Status",
+    accessorFn: (row: RowData) =>
+      row.status + (row.origin ? ` (${capitalize(row.origin)})` : ""),
     cell: (info: Info) => {
       return (
         <DataTable.CellContent>
@@ -153,6 +160,7 @@ const memberColumns = [
   {
     id: "groups" as const,
     header: "Groups",
+    accessorFn: (row: RowData) => row.groups.join(", "),
     cell: (info: Info) => (
       <DataTable.CellContent className="max-w-40 truncate capitalize">
         {info.row.original.groups.join(", ")}
@@ -169,6 +177,8 @@ interface MembersListProps {
   showColumns: ("name" | "email" | "role" | "remove" | "status" | "groups")[];
   pagination?: PaginationState;
   setPagination?: (pagination: PaginationState) => void;
+  sorting?: SortingState;
+  setSorting?: (sorting: SortingState) => void;
 }
 
 export function MembersList({
@@ -179,6 +189,8 @@ export function MembersList({
   showColumns,
   pagination,
   setPagination,
+  sorting,
+  setSorting,
 }: MembersListProps) {
   assert(
     !showColumns.includes("remove") || onRemoveMemberClick,
@@ -214,6 +226,9 @@ export function MembersList({
           pagination={pagination}
           setPagination={setPagination}
           totalRowCount={totalMembersCount}
+          sorting={sorting}
+          setSorting={setSorting}
+          isServerSideSorting={!!sorting && !!setSorting}
         />
       )}
     </>

--- a/front/components/members/WorkspaceMembersSection.tsx
+++ b/front/components/members/WorkspaceMembersSection.tsx
@@ -25,7 +25,7 @@ import {
   ButtonsSwitchList,
   SearchInput,
 } from "@dust-tt/sparkle";
-import type { PaginationState } from "@tanstack/react-table";
+import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -153,6 +153,7 @@ function WorkspaceMembersList({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
+  const [sorting, setSorting] = useState<SortingState>([]);
   const [prevSearchTerm, setPrevSearchTerm] = useState(searchTerm);
 
   const [selectedMember, setSelectedMember] =
@@ -164,7 +165,13 @@ function WorkspaceMembersList({
     pageIndex: pagination.pageIndex,
     pageSize: DEFAULT_PAGE_SIZE,
     groupKind: isProvisioningEnabled ? "provisioned" : undefined,
+    sorting,
   });
+
+  const handleSetSorting = useCallback((next: SortingState) => {
+    setSorting(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
 
   if (searchTerm !== prevSearchTerm) {
     setPrevSearchTerm(searchTerm);
@@ -196,6 +203,8 @@ function WorkspaceMembersList({
         }
         pagination={pagination}
         setPagination={setPagination}
+        sorting={sorting}
+        setSorting={handleSetSorting}
       />
       <ChangeMemberModal
         onClose={resetSelectedMember}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -314,6 +314,14 @@ export async function searchMembers(
 
   let users: UserResource[];
   let total: number;
+  const shouldSortInMemory =
+    paginationParams.sortBy !== undefined &&
+    paginationParams.sortBy !== "name" &&
+    paginationParams.sortBy !== "email";
+  const searchSortBy =
+    paginationParams.sortBy === "name" || paginationParams.sortBy === "email"
+      ? paginationParams.sortBy
+      : undefined;
 
   if (options.searchEmails) {
     if (options.searchEmails.length > MAX_SEARCH_EMAILS) {
@@ -326,11 +334,29 @@ export async function searchMembers(
       options.searchEmails
     );
     total = users.length;
+  } else if (shouldSortInMemory) {
+    const results = await UserResource.searchAllUsers(auth, {
+      searchTerm: options.searchTerm ?? "",
+    });
+
+    if (results.isErr()) {
+      logger.error({ err: results.error }, "Error searching users");
+      return { members: [], total: 0 };
+    }
+
+    users = results.value.users;
+    total = results.value.total;
   } else {
     const results = await UserResource.searchUsers(auth, {
       searchTerm: options.searchTerm ?? "",
       offset: paginationParams.offset,
       limit: paginationParams.limit,
+      ...(searchSortBy && {
+        orderBy: {
+          field: searchSortBy,
+          direction: paginationParams.sortDirection ?? "asc",
+        },
+      }),
     });
 
     if (results.isErr()) {
@@ -389,8 +415,51 @@ export async function searchMembers(
     filteredUsers = usersWithWorkspace.filter((u) => isBuilder(u.workspace));
   }
 
+  if (options.searchEmails || shouldSortInMemory) {
+    const sortBy = paginationParams.sortBy ?? "name";
+    const sortDirection = paginationParams.sortDirection ?? "asc";
+
+    filteredUsers.sort((a, b) => {
+      const getSortValue = (user: UserTypeWithWorkspace) => {
+        switch (sortBy) {
+          case "email":
+            return user.email ?? "";
+          case "role":
+            return user.workspace.role ?? "";
+          case "status":
+            return `${
+              user.lastLoginAt === null ? "Unregistered" : "Active"
+            }${user.origin ? ` (${user.origin})` : ""}`;
+          case "groups":
+            return user.workspace.groups?.join(", ") ?? "";
+          case "name":
+            return user.fullName ?? "";
+        }
+      };
+
+      const comparison = getSortValue(a).localeCompare(
+        getSortValue(b),
+        undefined,
+        { sensitivity: "base" }
+      );
+      return comparison === 0
+        ? a.sId.localeCompare(b.sId)
+        : sortDirection === "desc"
+          ? -comparison
+          : comparison;
+    });
+  }
+
+  const paginatedUsers =
+    options.searchEmails || shouldSortInMemory
+      ? filteredUsers.slice(
+          paginationParams.offset,
+          paginationParams.offset + paginationParams.limit
+        )
+      : filteredUsers;
+
   return {
-    members: filteredUsers,
+    members: paginatedUsers,
     total: options.buildersOnly ? filteredUsers.length : total,
   };
 }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -49,6 +49,8 @@ import { Op } from "sequelize";
 export interface SearchMembersPaginationParams {
   offset: number;
   limit: number;
+  sortBy?: "name" | "email" | "role" | "status" | "groups";
+  sortDirection?: "asc" | "desc";
 }
 
 export interface GetUserApprovalsResponseBody {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -24,6 +24,7 @@ import type {
   LightWorkspaceType,
 } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SortingState } from "@tanstack/react-table";
 import type { Fetcher } from "swr";
 import { mutate } from "swr";
 import { z } from "zod";
@@ -129,6 +130,7 @@ export function useSearchMembers<
   pageSize,
   groupKind,
   buildersOnly,
+  sorting,
   disabled,
 }: {
   workspaceId: string;
@@ -137,6 +139,7 @@ export function useSearchMembers<
   pageSize: number;
   groupKind?: Exclude<GroupKind, "system">;
   buildersOnly?: boolean;
+  sorting?: SortingState;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -167,6 +170,12 @@ export function useSearchMembers<
 
   if (buildersOnly) {
     searchParams.set("buildersOnly", "true");
+  }
+
+  const sort = sorting?.[0];
+  if (sort) {
+    searchParams.set("sortBy", sort.id);
+    searchParams.set("sortDirection", sort.desc ? "desc" : "asc");
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =


### PR DESCRIPTION
## Description

Fixes [dust-tt/tasks#9718](https://github.com/dust-tt/tasks/issues/9718).

Adds ascending and descending sorting to the People > Members table for Name, Email, Role, Status, and Groups. Sorting is kept server-side so it applies across paginated results. Name and Email use the user search ordering, while Role, Status, and Groups are sorted after member data is hydrated. Changing the sort resets the table to the first page.

## Tests

- `git diff --check`
- Local automated tests and formatting were not run in the Computer because repository dependencies are not installed.
- Full validation is delegated to PR CI.

## Risk

No schema or data changes. Sorting Role, Status, and Groups requires hydrating the full matching member set before pagination, so large workspaces may see additional work on those sort requests. The change is isolated to the member search path and is straightforward to roll back.

## Deploy Plan

No special deployment steps or migrations. Deploy through the normal release process and monitor the People member search endpoint for regressions.
