### PR TITLE
Make group vault group kind not null

### DIFF
--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -11,7 +11,7 @@ export class GroupSpaceModel extends WorkspaceAwareModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare groupId: ForeignKey<GroupModel["id"]>;
   // Denormalized from groups.kind. Keep in sync if group kinds ever become mutable.
-  declare groupKind: GroupKind | null;
+  declare groupKind: GroupKind;
   declare vaultId: ForeignKey<SpaceModel["id"]>;
   declare kind: GroupSpaceKind;
 }
@@ -32,7 +32,7 @@ GroupSpaceModel.init(
     },
     groupKind: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
   },
   {

--- a/front/migrations/post-deploy/20260721185104_make_group_vault_group_kind_not_null.sql
+++ b/front/migrations/post-deploy/20260721185104_make_group_vault_group_kind_not_null.sql
@@ -1,0 +1,33 @@
+/*
+Post-deploy: make group_vaults.groupKind NOT NULL after the TypeScript backfill has run in every
+region.
+
+Validate a temporary CHECK constraint before taking the brief ACCESS EXCLUSIVE lock required by
+SET NOT NULL. PostgreSQL can then use the validated constraint instead of scanning the million-row
+table while holding that stronger lock.
+*/
+
+/* Statement 0: add the temporary constraint without scanning existing rows. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_vaults"
+  ADD CONSTRAINT "group_vaults_group_kind_not_null_check"
+  CHECK ("groupKind" IS NOT NULL) NOT VALID;
+
+/* Statement 1: validate existing rows without blocking normal reads and writes. */
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_vaults"
+  VALIDATE CONSTRAINT "group_vaults_group_kind_not_null_check";
+
+/* Statement 2: use the validated constraint to make the column NOT NULL without another scan. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_vaults"
+  ALTER COLUMN "groupKind" SET NOT NULL;
+
+/* Statement 3: remove the now-redundant temporary constraint. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."group_vaults"
+  DROP CONSTRAINT "group_vaults_group_kind_not_null_check";


### PR DESCRIPTION
## Description

- make `GroupSpaceModel.groupKind` non-nullable in TypeScript
- set `allowNull: false` in the Sequelize model
- add a post-deploy migration that makes `group_vaults.groupKind` `NOT NULL`
- validate a temporary `CHECK` constraint before setting `NOT NULL`, then remove it

This completes the rollout started by [#29239](https://github.com/dust-tt/dust/pull/29239), which added the nullable denormalized column and populated it in all writers, and [#29248](https://github.com/dust-tt/dust/pull/29248), which added the batched regional backfill.

The temporary `CHECK NOT VALID` pattern lets PostgreSQL scan the roughly one-million-row table without holding an access-exclusive lock. Once validated, PostgreSQL can set `NOT NULL` with only a brief metadata lock instead of rescanning the table under that stronger lock.

## Tests

- `npx biome check lib/resources/storage/models/group_spaces.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`
- `NODE_ENV=test npm test -- lib/resources/group_space_resource.test.ts lib/resources/space_resource.test.ts lib/api/spaces.test.ts lib/dev/dust_hive_seed_schema.test.ts`
- tested locally

## Risks

- Low. DB looks good so this should be a breeze

## Deploy Plan

- apply the post-deploy migration: `npm run migration:apply:post-deploy`
