### PR TITLE
feat(activation): refine skill prompt and compact BannerView

### DIFF
--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -32,7 +32,7 @@ The purpose is to increasingly personalize the recommendations and experience in
 3. Every recommendation must stand alone. Each suggested action must show clear, immediate value as if nothing else existed: a real artifact, from the user's real work, produced in this conversation. Streamlining what they already do beats introducing what they've never done. Usage evidence is heavily weighted: the strongest recommendation automates a task they demonstrably repeat.
 4. Reuse before create. Existing workspace skills and agents beat creating anything new — always. A recommendation that lights up something that already exists is a better outcome than one that adds to the pile.
 5. In a Pod, every win is also a brick. Behind each standalone win you assemble the larger system: win → Skill → schedule → reflected in the Overview Frame → sharper next recommendation. The Frame is the visible face of that assembly. The ideal end result is a mature system running the user's day from their Pod, with the Frame as its front page.
-6. At the start of any conversation, ALWAYS open the pinned frame in the side panel by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
+6. For every message, ALWAYS open the pinned frame by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
 
 # Voice & brevity rules
 
@@ -89,9 +89,10 @@ The frame has 4 sections:
   * If there is not enough data to return results for either of those calls, populate the data by calling \'search_agent_templates'\ with the user's job type.
   * For each item, ensure you label it as a skill/agent and include a clear, concise description of what it does.
   * This should be the default tab when the frame is opened. For all future interactions, "Recommendations" should be changed to the default tab.
+  * Update the 'Open the last recommendation' link to open this conversation.
 - Your Work + Your Setup
   * You will not yet have data to populate this section. You can include a placeholder message that explains that the user needs to execute a recommendation first to see their work here.
-  * Include example placeholders to ensure that the Frame section keeps the format we want.
+  * Include an obvious placeholders to ensure that the Frame section keeps the format we want (do not just include the example test from the Frame template).
 - Recommendations
   * You will produce 3 recommendations using the philosophy described below. The first recommendation we want the user to consider should be under the "current recommendation" heading (with the others being "upcoming"). Ensure you are fully educating users on the Dust concepts behind the recommendations.
 
@@ -108,7 +109,7 @@ The turn arrives with zero context on the user's side — they did not ask for t
 5. Generate one action card with the first recommendation.
 6. Use the quick reply format (":quickReply[Label]{message="message to send"}") to provide the following options: 
    - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
-   - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
+   - [If sources are connected] :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
 
 # Stage 2 — Recommend
 
@@ -158,11 +159,11 @@ Workspaces will vary wildly in terms of available skills/agents and usage data. 
 If a user is an admin or builder, these options will require the user to create a skill. This should be avoided otherwise in cases 1 & 2.
 
 3. CURATED TEMPLATES matching the user's job type — call \`search_agent_templates\` with the user's job type.
-4. LAST RESORT FALLBACK: See "Scan Sources Recommendation" section below.
+4. LAST RESORT FALLBACK: See "Scan Sources Recommendation" section.
 
 ## Presenting the Recommendation
 
-- In this stage, always surface a new recommendation as a card immediately. Never open the conversation with a question. If you need more context after this first message, use \`ask_user_question\` tool. Always include a title and an array of options that are specific/meaningful and attempt to minimize turns.
+- In this stage, always surface a new recommendation as a card immediately. If you need more context ONLY after presenting the recommendation, use \`ask_user_question\` tool. Always include a title and an array of options that are specific/meaningful and attempt to minimize turns.
 - Every card body follows a pattern:
     1. The evidence, one sentence stating what you noticed about their work — specific and natural. The user must be able to clearly answer "why am I seeing this?" from the card alone.
     2. the suggestion, one sentence naming the concrete artifact they'll see

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -30,7 +30,7 @@ import {
 
 /* ---------------- TEMPLATE DATA ---------------- */
 
-const USER = { name: "Alex", role: "Marketing", company: "Acme" };
+const USER = { name: "User", role: "Marketing", company: "Acme" };
 
 const CONVERSATION_URL = "https://app.dust.tt/w/[workspace-id]/assistant/[conversation-id]";
 
@@ -183,46 +183,96 @@ function CuratedRow({ name, type, desc }: { name: string; type: string; desc: st
   );
 }
 
+/* ---------------- How this works (shared) ---------------- */
+
+function HowThisWorks({ compact = false }: { compact?: boolean }) {
+  if (compact) {
+    return (
+      <div className="flex h-full flex-col justify-center gap-1.5 overflow-hidden">
+        <SectionLabel icon={<Sparkles className="h-3 w-3 text-blue-500" />}>
+          How this works
+        </SectionLabel>
+        <p className="truncate text-xs text-foreground">
+          <span className="font-medium">{POD_INTRO.lead}</span>
+        </p>
+        <div className="flex min-h-0 flex-1 items-stretch gap-1.5">
+          {LOOP.map((step, i) => (
+            <div key={step.title} className="flex min-w-0 flex-1 items-center gap-1">
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center rounded-lg border border-border px-2 py-1.5">
+                <span
+                  className="flex h-4 w-4 items-center justify-center rounded-full bg-blue-500 font-semibold text-white"
+                  style={{ fontSize: 9 }}
+                >
+                  {i + 1}
+                </span>
+                <p className="mt-1 truncate text-xs font-medium text-foreground">{step.title}</p>
+                <p className="truncate text-xs text-muted-foreground" style={{ fontSize: 10 }}>
+                  {step.sub}
+                </p>
+              </div>
+              {i < LOOP.length - 1 && (
+                <ArrowRight className="h-3 w-3 shrink-0 text-stone-400" />
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="h-px flex-1 bg-border" />
+          <p className="flex items-center gap-1 text-xs text-muted-foreground" style={{ fontSize: 10 }}>
+            <RotateCcw className="h-2.5 w-2.5" />
+            what it finds shapes the next suggestion
+          </p>
+          <span className="h-px flex-1 bg-border" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionLabel icon={<Sparkles className="h-3.5 w-3.5 text-blue-500" />}>
+        How this works
+      </SectionLabel>
+      <p className="mt-2 text-sm text-foreground">
+        <span className="font-medium">{POD_INTRO.lead}</span>{" "}
+        <span className="text-muted-foreground">{POD_INTRO.body}</span>
+      </p>
+
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-stretch">
+        {LOOP.map((step, i) => (
+          <div key={step.title} className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="min-w-0 flex-1 rounded-xl border border-border px-3 py-2.5">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
+                {i + 1}
+              </span>
+              <p className="mt-1.5 text-sm font-medium text-foreground">{step.title}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">{step.sub}</p>
+            </div>
+            {i < LOOP.length - 1 && (
+              <ArrowRight className="hidden h-3.5 w-3.5 shrink-0 text-stone-400 sm:block" />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <span className="h-px flex-1 bg-border" />
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RotateCcw className="h-3 w-3" />
+          what it finds shapes the next suggestion
+        </p>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+    </div>
+  );
+}
+
 /* ---------------- Tab 1: Overview ---------------- */
 
 function OverviewTab() {
   return (
     <div className="space-y-6">
 
-      <div>
-        <SectionLabel icon={<Sparkles className="h-3.5 w-3.5 text-blue-500" />}>
-          How this works
-        </SectionLabel>
-        <p className="mt-2 text-sm text-foreground">
-          <span className="font-medium">{POD_INTRO.lead}</span>{" "}
-          <span className="text-muted-foreground">{POD_INTRO.body}</span>
-        </p>
-
-        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-stretch">
-          {LOOP.map((step, i) => (
-            <div key={step.title} className="flex min-w-0 flex-1 items-center gap-2">
-              <div className="min-w-0 flex-1 rounded-xl border border-border px-3 py-2.5">
-                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
-                  {i + 1}
-                </span>
-                <p className="mt-1.5 text-sm font-medium text-foreground">{step.title}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{step.sub}</p>
-              </div>
-              {i < LOOP.length - 1 && (
-                <ArrowRight className="hidden h-3.5 w-3.5 shrink-0 text-stone-400 sm:block" />
-              )}
-            </div>
-          ))}
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          <span className="h-px flex-1 bg-border" />
-          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <RotateCcw className="h-3 w-3" />
-            what it finds shapes the next suggestion
-          </p>
-          <span className="h-px flex-1 bg-border" />
-        </div>
-      </div>
+      <HowThisWorks />
 
       <div>
         <SectionLabel icon={<Users className="h-3.5 w-3.5 text-blue-500" />}>
@@ -625,28 +675,17 @@ function FullView() {
 
       <div className="mx-auto w-full max-w-4xl flex-1 px-8 py-6">
         {active === 0 ? <OverviewTab /> : active === 1 ? <YourWorkTab /> : active === 2 ? <YourSetupTab /> : <RecommendationsTab />}
-
-        <div className="mt-6 flex justify-center">
-          <a
-            href={CONVERSATION_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-xl bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600"
-          >
-            Open the last recommendation <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
       </div>
     </div>
   );
 }
 
-/* ---------------- Condensed banner view (~280px) ---------------- */
+/* ---------------- Condensed banner view (pinned, ~280px) ---------------- */
 
 function BannerView() {
   return (
-    <div className="flex h-full flex-col bg-background text-foreground">
-      <div className="flex shrink-0 items-center gap-2 border-b border-blue-100 bg-blue-50 px-4 py-2.5 dark:border-blue-900 dark:bg-blue-950/40">
+    <div className="flex h-full flex-col overflow-hidden bg-background text-foreground">
+      <div className="flex shrink-0 items-center gap-2 border-b border-blue-100 bg-blue-50 px-4 py-2 dark:border-blue-900 dark:bg-blue-950/40">
         <Sparkles className="h-4 w-4 shrink-0 text-blue-500" />
         <span className="truncate text-sm font-semibold text-foreground">{USER.name}'s pod</span>
         <a
@@ -658,25 +697,8 @@ function BannerView() {
           Open the last recommendation <ArrowRight className="h-3.5 w-3.5" />
         </a>
       </div>
-      <div className="min-h-0 flex-1 px-4 py-3">
-        <p className="text-sm text-foreground" style={{ overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>
-          <span className="font-medium">{POD_INTRO.lead}</span>{" "}
-          <span className="text-muted-foreground">{POD_INTRO.body}</span>
-        </p>
-        <div className="mt-3 flex items-center gap-2 overflow-x-auto">
-          {LOOP.map((step, i) => (
-            <div key={step.title} className="flex shrink-0 items-center gap-2">
-              <div className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5">
-                <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-blue-500 font-semibold text-white" style={{ fontSize: 10 }}>
-                  {i + 1}
-                </span>
-                <span className="text-xs font-medium text-foreground">{step.title}</span>
-              </div>
-              {i < LOOP.length - 1 && <ArrowRight className="h-3 w-3 shrink-0 text-stone-400" />}
-            </div>
-          ))}
-          <RotateCcw className="h-3 w-3 shrink-0 text-stone-400" />
-        </div>
+      <div className="min-h-0 flex-1 overflow-hidden px-4 py-2">
+        <HowThisWorks compact />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Tighten Stage 1/2 rules: frame directive now fires every message (not just the first)
- Add instruction to update the 'Open last recommendation' link during first-session flow
- Make the source-scan quick reply conditional (only shown when sources are connected)
- Extract `HowThisWorks` into a shared component with compact/full variants; `BannerView` uses the compact layout
- Remove the standalone 'Open last recommendation' button from `FullView` footer (it's now in the header)
- Reset template `USER.name` to generic `'User'` placeholder (was `'Alex'`)
- Minor prose/copy nits throughout

## Testing
- [ ] Manually verify BannerView compact layout renders correctly in a ~280px panel
- [ ] Verify full OverviewTab still renders HowThisWorks correctly
- [ ] Confirm frame-preview directive fires on all messages in a pod conversation

## Risk
Low — prompt text changes and a UI-only React component refactor inside the static pod frame template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)