### PR TITLE
Remove group join from space fetches

### DIFF
--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -148,9 +148,12 @@ describe("GET /api/poke/search - data source", () => {
     });
 
     const dustAPIProjectId = faker.string.numeric(9);
-    await DataSourceViewFactory.folder(workspace, globalSpace, null, {
-      dustAPIProjectId,
-    });
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      null,
+      { dustAPIProjectId }
+    );
 
     const response = await searchRequest(dustAPIProjectId);
 
@@ -158,10 +161,12 @@ describe("GET /api/poke/search - data source", () => {
     const data = await response.json();
     expect(data.results).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          dustAPIProjectId,
+        {
+          id: dataSourceView.dataSource.id,
+          link: expect.stringContaining(dataSourceView.dataSource.sId),
+          name: `${workspace.name}'s folder (${dataSourceView.dataSource.name})`,
           type: "Data Source",
-        }),
+        },
       ])
     );
   });

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -35,7 +35,10 @@ app.get(
       });
     }
 
-    const dataSourceViewJSON = await dataSourceViewToPokeJSON(dataSourceView);
+    const dataSourceViewJSON = await dataSourceViewToPokeJSON(
+      auth,
+      dataSourceView
+    );
 
     return ctx.json({ dataSourceView: dataSourceViewJSON });
   }

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -37,16 +37,17 @@ app.get(
 
     const members: Record<string, UserTypeWithWorkspaces[]> = {};
 
-    const allGroups = space.groups.filter((g) =>
+    const groupReferences = space.groups.filter((group) =>
       space.managementMode === "manual"
-        ? g.isRegularAuto() || g.kind === "space_editors"
-        : g.kind === "provisioned"
+        ? group.isRegularAuto() || group.groupKind === "space_editors"
+        : group.isProvisioned()
     );
+    const groups = await space.fetchGroupResources(auth, { groupReferences });
 
     const memberships = await getMembers(auth);
     const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
 
-    for (const group of allGroups) {
+    for (const group of groups) {
       const groupMembers = await group.getActiveMembers(auth);
       members[group.name] = groupMembers.flatMap((user) => {
         const member = memberById.get(user.sId);
@@ -61,7 +62,7 @@ app.get(
     return ctx.json({
       members,
       metadata: metadata ? metadata.toJSON() : null,
-      space: spaceToPokeJSON(space),
+      space: await spaceToPokeJSON(auth, space),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -43,7 +43,7 @@ app.delete(
 
     if (
       space.managementMode === "group" ||
-      space.groups.some((g) => g.kind === "global")
+      space.groups.some((group) => group.isGlobal())
     ) {
       return apiError(ctx, {
         status_code: 404,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -60,7 +60,7 @@ const withEditableSpace = createMiddleware<
 
   if (
     space.managementMode === "group" ||
-    space.groups.some((g) => g.kind === "global")
+    space.groups.some((group) => group.isGlobal())
   ) {
     return apiError(ctx, {
       status_code: 404,
@@ -93,11 +93,12 @@ app.get(
   async (ctx): HandlerResult<GetSpaceMembersResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
+    const groups = await space.fetchGroupResources(auth);
 
     const currentMembers = uniqBy(
       (
         await concurrentExecutor(
-          space.groups,
+          groups,
           (group) => group.getActiveMembers(auth),
           { concurrency: 1 }
         )

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -147,7 +147,12 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     const member2 = await UserFactory.basic();
     await MembershipFactory.associate(workspace, member2, { role: "user" });
 
-    const projectGroup = space.groups[0];
+    const [projectGroup] = await space.fetchGroupResources(adminAuth, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
+    if (!projectGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
     await projectGroup.dangerouslyAddMember(adminAuth, {
       user: member1.toJSON(),
     });

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -69,10 +69,11 @@ app.get(
     }
 
     // Fetch current members of the project
+    const groups = await space.fetchGroupResources(auth);
     const memberUsers = uniqBy(
       (
         await concurrentExecutor(
-          space.groups,
+          groups,
           (group) => group.getActiveMembers(auth),
           { concurrency: 2 }
         )

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -224,7 +224,9 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.isRegularAuto());
+    const [memberGroup] = await space.fetchGroupResources(auth, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
     await memberGroup?.dangerouslyAddMembers(auth, { users: [user.toJSON()] });
 
     const file = await FileFactory.create(auth, user, {
@@ -288,7 +290,9 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
 
     const otherUser = await UserFactory.basic();
     const space = await SpaceFactory.regular(workspace);
-    const memberGroup = space.groups.find((g) => g.isRegularAuto());
+    const [memberGroup] = await space.fetchGroupResources(auth, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
     await memberGroup?.dangerouslyAddMembers(auth, {
       users: [otherUser.toJSON()],
     });

--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
@@ -51,7 +51,12 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const [spaceGroup] = project.groups.filter((g) => !g.isGlobal());
+    const [spaceGroup] = await project.fetchGroupResources(adminAuth, {
+      groupReferences: project.groups.filter((group) => group.isRegularAuto()),
+    });
+    if (!spaceGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
     await spaceGroup.dangerouslyAddMembers(adminAuth, {
       users: [user.toJSON()],
     });
@@ -71,7 +76,11 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
+    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
+      groupReferences: regularSpace.groups.filter((group) =>
+        group.isRegularAuto()
+      ),
+    });
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -122,12 +122,15 @@ async function setupSandboxFunction({
     workspace,
   });
   if (addCallerToSpace) {
-    const addMemberResult = await space.groups[0].dangerouslyAddMember(
-      adminAuth,
-      {
-        user: user.toJSON(),
-      }
-    );
+    const [memberGroup] = await space.fetchGroupResources(adminAuth, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
+    if (!memberGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
+    const addMemberResult = await memberGroup.dangerouslyAddMember(adminAuth, {
+      user: user.toJSON(),
+    });
     expect(addMemberResult.isOk()).toBe(true);
   }
   const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -20,8 +20,13 @@ async function addUserToProject(
   user: UserResource,
   options: { asEditor?: boolean } = {}
 ) {
-  const memberGroup = project.groups.find((g) => g.isRegularAuto());
-  const editorGroup = project.groups.find((g) => g.kind === "space_editors");
+  const groups = await project.fetchGroupResources(adminAuth, {
+    groupReferences: project.groups.filter(
+      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
+    ),
+  });
+  const memberGroup = groups.find((group) => group.kind === "regular_auto");
+  const editorGroup = groups.find((group) => group.kind === "space_editors");
 
   if (memberGroup) {
     await memberGroup.dangerouslyAddMembers(adminAuth, {
@@ -46,7 +51,11 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       );
 
       const regularSpace = await SpaceFactory.regular(workspace);
-      const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
+      const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
+        groupReferences: regularSpace.groups.filter((group) =>
+          group.isRegularAuto()
+        ),
+      });
       if (memberGroup) {
         await memberGroup.dangerouslyAddMembers(adminAuth, {
           users: [user.toJSON()],
@@ -122,7 +131,11 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       expect(response.status).toBe(200);
       expect((await response.json()).success).toBe(true);
 
-      const memberGroup = project.groups.find((g) => g.isRegularAuto());
+      const [memberGroup] = await project.fetchGroupResources(adminAuth, {
+        groupReferences: project.groups.filter((group) =>
+          group.isRegularAuto()
+        ),
+      });
       if (memberGroup) {
         const isMember = await memberGroup.isMember(user);
         expect(isMember).toBe(false);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -40,8 +40,15 @@ app.post(
 
     const user = auth.getNonNullableUser();
 
-    const memberGroup = space.groups.find((g) => g.isRegularAuto());
-    const editorGroup = space.groups.find((g) => g.kind === "space_editors");
+    const groupReferencesToLeave = space.groups.filter(
+      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
+    );
+    const groupsToLeave = await space.fetchGroupResources(auth, {
+      groupReferences: groupReferencesToLeave,
+    });
+    const editorGroup = groupsToLeave.find(
+      (group) => group.kind === "space_editors"
+    );
 
     if (editorGroup) {
       const activeEditors = await editorGroup.getActiveMembers(auth);
@@ -57,10 +64,6 @@ app.post(
         });
       }
     }
-
-    const groupsToLeave = [memberGroup, editorGroup].filter(
-      (g): g is NonNullable<typeof g> => g !== undefined
-    );
 
     for (const group of groupsToLeave) {
       const result = await group.leaveGroup(auth);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -95,7 +95,15 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/mcp_views/:svId", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].dangerouslyAddMember(adminAuth, {
+    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
+      groupReferences: regularSpace.groups.filter((group) =>
+        group.isRegularAuto()
+      ),
+    });
+    if (!memberGroup) {
+      throw new Error("Expected the space member group to exist.");
+    }
+    await memberGroup.dangerouslyAddMember(adminAuth, {
       user: user.toJSON(),
     });
     await FeatureFlagFactory.basic(adminAuth, "dev_mcp_actions");

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -106,7 +106,14 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const [spaceGroup] = projectSpace.groups.filter((g) => !g.isGlobal());
+    const [spaceGroup] = await projectSpace.fetchGroupResources(adminAuth, {
+      groupReferences: projectSpace.groups.filter((group) =>
+        group.isRegularAuto()
+      ),
+    });
+    if (!spaceGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
     await spaceGroup.dangerouslyAddMembers(adminAuth, {
       users: [user.toJSON()],
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
@@ -159,8 +159,12 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_tasks/:taskId", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const memberGroup =
-      project.groups.find((g) => g.isRegularAuto()) ?? project.groups[0]!;
+    const [memberGroup] = await project.fetchGroupResources(adminAuth, {
+      groupReferences: project.groups.filter((group) => group.isRegularAuto()),
+    });
+    if (!memberGroup) {
+      throw new Error("Expected the project member group to exist.");
+    }
     await GroupFactory.withMembers(adminAuth, memberGroup, [otherUser]);
 
     const todo = await ProjectTaskFactory.create(workspace, project, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -91,7 +91,11 @@ describe("POST /api/w/:wId/spaces/:spaceId/project_tasks/mark_read", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = regularSpace.groups.find((g) => g.isRegularAuto());
+    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
+      groupReferences: regularSpace.groups.filter((group) =>
+        group.isRegularAuto()
+      ),
+    });
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -239,7 +239,15 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/webhook_source_views/:webhookSource
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].dangerouslyAddMember(adminAuth, {
+    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
+      groupReferences: regularSpace.groups.filter((group) =>
+        group.isRegularAuto()
+      ),
+    });
+    if (!memberGroup) {
+      throw new Error("Expected the space member group to exist.");
+    }
+    await memberGroup.dangerouslyAddMember(adminAuth, {
       user: user.toJSON(),
     });
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -2174,7 +2174,7 @@ describe("agent_sidekick_context tools", () => {
         restrictedSpace.sId
       );
       if (fetchedSpace) {
-        const [group] = await fetchedSpace.fetchGroups(internalAuth);
+        const [group] = await fetchedSpace.fetchGroupResources(internalAuth);
         await group.dangerouslyAddMember(internalAuth, {
           user: user1.toJSON(),
         });

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -2174,7 +2174,15 @@ describe("agent_sidekick_context tools", () => {
         restrictedSpace.sId
       );
       if (fetchedSpace) {
-        const [group] = await fetchedSpace.fetchGroupResources(internalAuth);
+        const groupReference = fetchedSpace.groups.find((group) =>
+          group.isRegularAuto()
+        );
+        if (!groupReference) {
+          throw new Error("Expected a regular group on the restricted space");
+        }
+        const [group] = await fetchedSpace.fetchGroupResources(internalAuth, {
+          groupReferences: [groupReference],
+        });
         await group.dangerouslyAddMember(internalAuth, {
           user: user1.toJSON(),
         });

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -2173,8 +2173,9 @@ describe("agent_sidekick_context tools", () => {
         internalAuth,
         restrictedSpace.sId
       );
-      if (fetchedSpace?.groups[0]) {
-        await fetchedSpace.groups[0].dangerouslyAddMember(internalAuth, {
+      if (fetchedSpace) {
+        const [group] = await fetchedSpace.fetchGroups(internalAuth);
+        await group.dangerouslyAddMember(internalAuth, {
           user: user1.toJSON(),
         });
       }

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -652,10 +652,14 @@ describe("retryAgentMessage", () => {
       const user = auth.getNonNullableUser();
       const userJson = user.toJSON();
 
-      const projectSpaceGroup = projectSpace.groups.find((g) =>
+      const projectSpaceGroups =
+        await projectSpace.fetchGroups(internalAdminAuth);
+      const anotherProjectSpaceGroups =
+        await anotherProjectSpace.fetchGroups(internalAdminAuth);
+      const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
-      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+      const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
 
@@ -2357,7 +2361,9 @@ describe("postUserMessage", () => {
       );
 
       // Add member user to the project space group
-      const projectSpaceGroup = projectSpace.groups.find((g) =>
+      const projectSpaceGroups =
+        await projectSpace.fetchGroups(internalAdminAuth);
+      const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
       if (projectSpaceGroup) {
@@ -2731,10 +2737,14 @@ describe("postUserMessage", () => {
       );
       const user = auth.getNonNullableUser();
 
-      const projectSpaceGroup = projectSpace.groups.find((g) =>
+      const projectSpaceGroups =
+        await projectSpace.fetchGroups(internalAdminAuth);
+      const anotherProjectSpaceGroups =
+        await anotherProjectSpace.fetchGroups(internalAdminAuth);
+      const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
-      const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+      const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
 
@@ -3690,11 +3700,12 @@ describe("postNewContentFragment", () => {
 
     // SpaceFactory.project creates a group and associates it with the space
     // We need to add the user to those groups
-    // The groups are available on space.groups
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
-    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+    const projectSpaceGroups =
+      await projectSpace.fetchGroups(internalAdminAuth);
+    const anotherProjectSpaceGroups =
+      await anotherProjectSpace.fetchGroups(internalAdminAuth);
+    const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
+    const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
       g.isRegularAuto()
     );
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -106,6 +106,20 @@ const TEST_CREDIT_EXPIRATION_DELAY_MS =
   TEST_CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
 const TEST_DAILY_USAGE_TTL_SECONDS = 60 * 60;
 
+async function fetchRegularAutoGroup(
+  space: SpaceResource,
+  auth: Authenticator
+) {
+  const groupReference = space.groups.find((group) => group.isRegularAuto());
+  if (!groupReference) {
+    return null;
+  }
+  const [group] = await space.fetchGroupResources(auth, {
+    groupReferences: [groupReference],
+  });
+  return group;
+}
+
 async function createActiveProgrammaticCredit(
   auth: Authenticator
 ): Promise<void> {
@@ -652,15 +666,13 @@ describe("retryAgentMessage", () => {
       const user = auth.getNonNullableUser();
       const userJson = user.toJSON();
 
-      const projectSpaceGroups =
-        await projectSpace.fetchGroupResources(internalAdminAuth);
-      const anotherProjectSpaceGroups =
-        await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
-      const projectSpaceGroup = projectSpaceGroups.find((g) =>
-        g.isRegularAuto()
+      const projectSpaceGroup = await fetchRegularAutoGroup(
+        projectSpace,
+        internalAdminAuth
       );
-      const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
-        g.isRegularAuto()
+      const anotherProjectSpaceGroup = await fetchRegularAutoGroup(
+        anotherProjectSpace,
+        internalAdminAuth
       );
 
       if (projectSpaceGroup) {
@@ -2361,10 +2373,9 @@ describe("postUserMessage", () => {
       );
 
       // Add member user to the project space group
-      const projectSpaceGroups =
-        await projectSpace.fetchGroupResources(internalAdminAuth);
-      const projectSpaceGroup = projectSpaceGroups.find((g) =>
-        g.isRegularAuto()
+      const projectSpaceGroup = await fetchRegularAutoGroup(
+        projectSpace,
+        internalAdminAuth
       );
       if (projectSpaceGroup) {
         const addRes = await projectSpaceGroup.dangerouslyAddMember(
@@ -2737,15 +2748,13 @@ describe("postUserMessage", () => {
       );
       const user = auth.getNonNullableUser();
 
-      const projectSpaceGroups =
-        await projectSpace.fetchGroupResources(internalAdminAuth);
-      const anotherProjectSpaceGroups =
-        await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
-      const projectSpaceGroup = projectSpaceGroups.find((g) =>
-        g.isRegularAuto()
+      const projectSpaceGroup = await fetchRegularAutoGroup(
+        projectSpace,
+        internalAdminAuth
       );
-      const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
-        g.isRegularAuto()
+      const anotherProjectSpaceGroup = await fetchRegularAutoGroup(
+        anotherProjectSpace,
+        internalAdminAuth
       );
 
       if (projectSpaceGroup) {
@@ -3700,13 +3709,13 @@ describe("postNewContentFragment", () => {
 
     // SpaceFactory.project creates a group and associates it with the space
     // We need to add the user to those groups
-    const projectSpaceGroups =
-      await projectSpace.fetchGroupResources(internalAdminAuth);
-    const anotherProjectSpaceGroups =
-      await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
-    const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
-    const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
-      g.isRegularAuto()
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
+    const anotherProjectSpaceGroup = await fetchRegularAutoGroup(
+      anotherProjectSpace,
+      internalAdminAuth
     );
 
     if (projectSpaceGroup) {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -653,9 +653,9 @@ describe("retryAgentMessage", () => {
       const userJson = user.toJSON();
 
       const projectSpaceGroups =
-        await projectSpace.fetchGroups(internalAdminAuth);
+        await projectSpace.fetchGroupResources(internalAdminAuth);
       const anotherProjectSpaceGroups =
-        await anotherProjectSpace.fetchGroups(internalAdminAuth);
+        await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
       const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
@@ -2362,7 +2362,7 @@ describe("postUserMessage", () => {
 
       // Add member user to the project space group
       const projectSpaceGroups =
-        await projectSpace.fetchGroups(internalAdminAuth);
+        await projectSpace.fetchGroupResources(internalAdminAuth);
       const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
@@ -2738,9 +2738,9 @@ describe("postUserMessage", () => {
       const user = auth.getNonNullableUser();
 
       const projectSpaceGroups =
-        await projectSpace.fetchGroups(internalAdminAuth);
+        await projectSpace.fetchGroupResources(internalAdminAuth);
       const anotherProjectSpaceGroups =
-        await anotherProjectSpace.fetchGroups(internalAdminAuth);
+        await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
       const projectSpaceGroup = projectSpaceGroups.find((g) =>
         g.isRegularAuto()
       );
@@ -3701,9 +3701,9 @@ describe("postNewContentFragment", () => {
     // SpaceFactory.project creates a group and associates it with the space
     // We need to add the user to those groups
     const projectSpaceGroups =
-      await projectSpace.fetchGroups(internalAdminAuth);
+      await projectSpace.fetchGroupResources(internalAdminAuth);
     const anotherProjectSpaceGroups =
-      await anotherProjectSpace.fetchGroups(internalAdminAuth);
+      await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
     const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
     const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
       g.isRegularAuto()

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -49,11 +49,16 @@ describe("mergeConversationBranch", () => {
       workspace.sId
     );
 
-    const projectGroups = await projectSpace.fetchGroups(internalAdminAuth);
-    const projectGroup = projectGroups.find((g) => g.isRegularAuto());
-    if (!projectGroup) {
+    const projectGroupReference = projectSpace.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!projectGroupReference) {
       throw new Error("Project group should exist.");
     }
+    const [projectGroup] = await projectSpace.fetchGroupResources(
+      internalAdminAuth,
+      { groupReferences: [projectGroupReference] }
+    );
 
     const addMergerToProjectRes = await projectGroup.dangerouslyAddMember(
       internalAdminAuth,
@@ -73,12 +78,16 @@ describe("mergeConversationBranch", () => {
       throw new Error(addProjectMemberToProjectRes.error.message);
     }
 
-    const restrictedGroups =
-      await restrictedSpace.fetchGroups(internalAdminAuth);
-    const restrictedGroup = restrictedGroups.find((g) => g.isRegularAuto());
-    if (!restrictedGroup) {
+    const restrictedGroupReference = restrictedSpace.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!restrictedGroupReference) {
       throw new Error("Restricted space group should exist.");
     }
+    const [restrictedGroup] = await restrictedSpace.fetchGroupResources(
+      internalAdminAuth,
+      { groupReferences: [restrictedGroupReference] }
+    );
 
     const addMergerToRestrictedRes = await restrictedGroup.dangerouslyAddMember(
       internalAdminAuth,

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -49,7 +49,8 @@ describe("mergeConversationBranch", () => {
       workspace.sId
     );
 
-    const projectGroup = projectSpace.groups.find((g) => g.isRegularAuto());
+    const projectGroups = await projectSpace.fetchGroups(internalAdminAuth);
+    const projectGroup = projectGroups.find((g) => g.isRegularAuto());
     if (!projectGroup) {
       throw new Error("Project group should exist.");
     }
@@ -72,9 +73,9 @@ describe("mergeConversationBranch", () => {
       throw new Error(addProjectMemberToProjectRes.error.message);
     }
 
-    const restrictedGroup = restrictedSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const restrictedGroups =
+      await restrictedSpace.fetchGroups(internalAdminAuth);
+    const restrictedGroup = restrictedGroups.find((g) => g.isRegularAuto());
     if (!restrictedGroup) {
       throw new Error("Restricted space group should exist.");
     }

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -272,7 +272,7 @@ export const suggestionsOfMentions = async (
     const allMembers = await concurrentExecutor(
       conversationGroups,
       (group) => group.getActiveMembers(auth),
-      { concurrency: 8 }
+      { concurrency: 4 }
     );
 
     allMembers.flat().forEach((m) => projectMemberIds.add(m.sId));

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -264,7 +264,7 @@ export const suggestionsOfMentions = async (
   if (spaceId) {
     const conversationSpace = await SpaceResource.fetchById(auth, spaceId);
     const conversationGroups = conversationSpace
-      ? await conversationSpace.fetchGroups(auth)
+      ? await conversationSpace.fetchGroupResources(auth)
       : [];
 
     const allMembers = await concurrentExecutor(

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -263,12 +263,14 @@ export const suggestionsOfMentions = async (
   // This aims to prioritize them in the suggestions
   if (spaceId) {
     const conversationSpace = await SpaceResource.fetchById(auth, spaceId);
+    const groupReferences =
+      conversationSpace?.groups.filter((group) => !group.isGlobal()) ?? [];
     const conversationGroups = conversationSpace
-      ? await conversationSpace.fetchGroupResources(auth)
+      ? await conversationSpace.fetchGroupResources(auth, { groupReferences })
       : [];
 
     const allMembers = await concurrentExecutor(
-      conversationGroups.filter((g) => g.kind !== "global"),
+      conversationGroups,
       (group) => group.getActiveMembers(auth),
       { concurrency: 8 }
     );

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -263,9 +263,12 @@ export const suggestionsOfMentions = async (
   // This aims to prioritize them in the suggestions
   if (spaceId) {
     const conversationSpace = await SpaceResource.fetchById(auth, spaceId);
+    const conversationGroups = conversationSpace
+      ? await conversationSpace.fetchGroups(auth)
+      : [];
 
     const allMembers = await concurrentExecutor(
-      conversationSpace?.groups.filter((g) => g.kind !== "global") ?? [],
+      conversationGroups.filter((g) => g.kind !== "global"),
       (group) => group.getActiveMembers(auth),
       { concurrency: 8 }
     );

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -923,7 +923,7 @@ describe("createAgentMessages", () => {
       const globalGroup = globalGroupRes.value;
 
       // Add global group directly to make it open (if not already there)
-      const existingGroupIds = openSpace.groups.map((g) => g.sId);
+      const existingGroupIds = openSpace.groups.map((g) => g.groupSId);
       const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
 
       // If global group is not already there, associate it directly

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1500,7 +1500,7 @@ describe("createAgentMessages", () => {
       const globalGroup = globalGroupRes.value;
 
       // Add global group directly to make it open (if not already there)
-      const existingGroupIds = openSpace.groups.map((g) => g.sId);
+      const existingGroupIds = openSpace.groups.map((g) => g.groupSId);
       const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
 
       // If global group is not already there, associate it directly

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -46,7 +46,8 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const regularGroup = space.groups.find((g) => g.isRegularAuto());
+    const groups = await space.fetchGroups(internalAdminAuth);
+    const regularGroup = groups.find((g) => g.isRegularAuto());
     if (!regularGroup) {
       throw new Error("Expected a regular group on the space");
     }
@@ -724,10 +725,12 @@ describe("updateConversationRequirements", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
-    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find((g) =>
+    const projectSpaceGroups =
+      await projectSpace.fetchGroups(internalAdminAuth);
+    const anotherProjectSpaceGroups =
+      await anotherProjectSpace.fetchGroups(internalAdminAuth);
+    const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
+    const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
       g.isRegularAuto()
     );
 
@@ -1356,7 +1359,8 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const group = space.groups.find((g) => g.isRegularAuto());
+      const groups = await space.fetchGroups(internalAdminAuth);
+      const group = groups.find((g) => g.isRegularAuto());
       if (!group) {
         continue;
       }

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -46,11 +46,15 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const groups = await space.fetchGroupResources(internalAdminAuth);
-    const regularGroup = groups.find((g) => g.isRegularAuto());
-    if (!regularGroup) {
+    const regularGroupReference = space.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!regularGroupReference) {
       throw new Error("Expected a regular group on the space");
     }
+    const [regularGroup] = await space.fetchGroupResources(internalAdminAuth, {
+      groupReferences: [regularGroupReference],
+    });
     const addRes = await regularGroup.dangerouslyAddMember(internalAdminAuth, {
       user: userJson,
     });
@@ -725,14 +729,26 @@ describe("updateConversationRequirements", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroups =
-      await projectSpace.fetchGroupResources(internalAdminAuth);
-    const anotherProjectSpaceGroups =
-      await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
-    const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
-    const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
-      g.isRegularAuto()
+    const projectSpaceGroupReference = projectSpace.groups.find((group) =>
+      group.isRegularAuto()
     );
+    const anotherProjectSpaceGroupReference = anotherProjectSpace.groups.find(
+      (group) => group.isRegularAuto()
+    );
+    const [projectSpaceGroup] = await projectSpace.fetchGroupResources(
+      internalAdminAuth,
+      {
+        groupReferences: projectSpaceGroupReference
+          ? [projectSpaceGroupReference]
+          : [],
+      }
+    );
+    const [anotherProjectSpaceGroup] =
+      await anotherProjectSpace.fetchGroupResources(internalAdminAuth, {
+        groupReferences: anotherProjectSpaceGroupReference
+          ? [anotherProjectSpaceGroupReference]
+          : [],
+      });
 
     if (projectSpaceGroup) {
       const addRes = await projectSpaceGroup.dangerouslyAddMember(
@@ -1359,11 +1375,15 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const groups = await space.fetchGroupResources(internalAdminAuth);
-      const group = groups.find((g) => g.isRegularAuto());
-      if (!group) {
+      const groupReference = space.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      if (!groupReference) {
         continue;
       }
+      const [group] = await space.fetchGroupResources(internalAdminAuth, {
+        groupReferences: [groupReference],
+      });
       const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
         user: userJson,
       });

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -46,7 +46,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const groups = await space.fetchGroups(internalAdminAuth);
+    const groups = await space.fetchGroupResources(internalAdminAuth);
     const regularGroup = groups.find((g) => g.isRegularAuto());
     if (!regularGroup) {
       throw new Error("Expected a regular group on the space");
@@ -726,9 +726,9 @@ describe("updateConversationRequirements", () => {
     const userJson = user.toJSON();
 
     const projectSpaceGroups =
-      await projectSpace.fetchGroups(internalAdminAuth);
+      await projectSpace.fetchGroupResources(internalAdminAuth);
     const anotherProjectSpaceGroups =
-      await anotherProjectSpace.fetchGroups(internalAdminAuth);
+      await anotherProjectSpace.fetchGroupResources(internalAdminAuth);
     const projectSpaceGroup = projectSpaceGroups.find((g) => g.isRegularAuto());
     const anotherProjectSpaceGroup = anotherProjectSpaceGroups.find((g) =>
       g.isRegularAuto()
@@ -1359,7 +1359,7 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const groups = await space.fetchGroups(internalAdminAuth);
+      const groups = await space.fetchGroupResources(internalAdminAuth);
       const group = groups.find((g) => g.isRegularAuto());
       if (!group) {
         continue;

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -73,11 +73,13 @@ describe("selected conversation Spaces", () => {
   }
 
   async function regularGroup(space: SpaceResource, auth: Authenticator) {
-    const groups = await space.fetchGroupResources(auth);
-    const group = groups.find((g) => g.isRegularAuto());
-    if (!group) {
+    const groupReference = space.groups.find((group) => group.isRegularAuto());
+    if (!groupReference) {
       throw new Error("Expected regular member group on Space");
     }
+    const [group] = await space.fetchGroupResources(auth, {
+      groupReferences: [groupReference],
+    });
     return group;
   }
 

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -72,8 +72,9 @@ describe("selected conversation Spaces", () => {
     await FeatureFlagFactory.basic(auth, "restricted_spaces_in_input_bar");
   }
 
-  function regularGroup(space: SpaceResource) {
-    const group = space.groups.find((g) => g.isRegularAuto());
+  async function regularGroup(space: SpaceResource, auth: Authenticator) {
+    const groups = await space.fetchGroups(auth);
+    const group = groups.find((g) => g.isRegularAuto());
     if (!group) {
       throw new Error("Expected regular member group on Space");
     }
@@ -84,7 +85,8 @@ describe("selected conversation Spaces", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    await regularGroup(space).dangerouslyAddMembers(internalAdminAuth, {
+    const group = await regularGroup(space, internalAdminAuth);
+    await group.dangerouslyAddMembers(internalAdminAuth, {
       users: [user],
     });
     await auth.refresh();
@@ -94,7 +96,8 @@ describe("selected conversation Spaces", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    await regularGroup(space).dangerouslyRemoveMembers(internalAdminAuth, {
+    const group = await regularGroup(space, internalAdminAuth);
+    await group.dangerouslyRemoveMembers(internalAdminAuth, {
       users: [user],
     });
     await auth.refresh();

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -73,7 +73,7 @@ describe("selected conversation Spaces", () => {
   }
 
   async function regularGroup(space: SpaceResource, auth: Authenticator) {
-    const groups = await space.fetchGroups(auth);
+    const groups = await space.fetchGroupResources(auth);
     const group = groups.find((g) => g.isRegularAuto());
     if (!group) {
       throw new Error("Expected regular member group on Space");

--- a/front/lib/api/assistant/conversation/skill_permissions.test.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.test.ts
@@ -31,7 +31,8 @@ describe("updateConversationRequirementsForSkills", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, anotherProjectSpace]) {
-      const group = space.groups.find((g) => g.isRegularAuto());
+      const groups = await space.fetchGroups(internalAdminAuth);
+      const group = groups.find((g) => g.isRegularAuto());
       if (group) {
         const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
           user: userJson,

--- a/front/lib/api/assistant/conversation/skill_permissions.test.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.test.ts
@@ -31,9 +31,13 @@ describe("updateConversationRequirementsForSkills", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, anotherProjectSpace]) {
-      const groups = await space.fetchGroupResources(internalAdminAuth);
-      const group = groups.find((g) => g.isRegularAuto());
-      if (group) {
+      const groupReference = space.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      if (groupReference) {
+        const [group] = await space.fetchGroupResources(internalAdminAuth, {
+          groupReferences: [groupReference],
+        });
         const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
           user: userJson,
         });

--- a/front/lib/api/assistant/conversation/skill_permissions.test.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.test.ts
@@ -31,7 +31,7 @@ describe("updateConversationRequirementsForSkills", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, anotherProjectSpace]) {
-      const groups = await space.fetchGroups(internalAdminAuth);
+      const groups = await space.fetchGroupResources(internalAdminAuth);
       const group = groups.find((g) => g.isRegularAuto());
       if (group) {
         const addRes = await group.dangerouslyAddMember(internalAdminAuth, {

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -80,9 +80,9 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -143,9 +143,9 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -305,9 +305,9 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -503,9 +503,9 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -607,9 +607,9 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = destinationProject.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const destinationProjectGroup = (
+      await destinationProject.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
     }
@@ -673,9 +673,9 @@ describe("moveConversationToProject", () => {
     );
 
     // Add current user as member (but not editor) of source project
-    const sourceProjectGroup = sourceProject.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const sourceProjectGroup = (
+      await sourceProject.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!sourceProjectGroup) {
       throw new Error("Source project regular group not found");
     }
@@ -685,9 +685,9 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = destinationProject.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const destinationProjectGroup = (
+      await destinationProject.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
     }
@@ -735,9 +735,9 @@ describe("moveConversationToProject", () => {
     );
 
     // Add user as member of the project
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -794,9 +794,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -875,9 +875,9 @@ describe("moveConversationOutOfProject", () => {
     );
 
     // Add current user as member (but not editor) of project.
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -938,9 +938,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -1096,9 +1096,9 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = projectSpace.groups.find((g) =>
-      g.isRegularAuto()
-    );
+    const projectSpaceGroup = (
+      await projectSpace.fetchGroups(internalAdminAuth)
+    ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -81,7 +81,7 @@ describe("moveConversationToProject", () => {
     const userJson = user.toJSON();
 
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -144,7 +144,7 @@ describe("moveConversationToProject", () => {
     const userJson = user.toJSON();
 
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -306,7 +306,7 @@ describe("moveConversationToProject", () => {
       workspace.sId
     );
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -504,7 +504,7 @@ describe("moveConversationToProject", () => {
       workspace.sId
     );
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -608,7 +608,7 @@ describe("moveConversationToProject", () => {
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
     const destinationProjectGroup = (
-      await destinationProject.fetchGroups(internalAdminAuth)
+      await destinationProject.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -674,7 +674,7 @@ describe("moveConversationToProject", () => {
 
     // Add current user as member (but not editor) of source project
     const sourceProjectGroup = (
-      await sourceProject.fetchGroups(internalAdminAuth)
+      await sourceProject.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!sourceProjectGroup) {
       throw new Error("Source project regular group not found");
@@ -686,7 +686,7 @@ describe("moveConversationToProject", () => {
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
     const destinationProjectGroup = (
-      await destinationProject.fetchGroups(internalAdminAuth)
+      await destinationProject.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
@@ -736,7 +736,7 @@ describe("moveConversationToProject", () => {
 
     // Add user as member of the project
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -795,7 +795,7 @@ describe("moveConversationOutOfProject", () => {
       workspace.sId
     );
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -876,7 +876,7 @@ describe("moveConversationOutOfProject", () => {
 
     // Add current user as member (but not editor) of project.
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -939,7 +939,7 @@ describe("moveConversationOutOfProject", () => {
       workspace.sId
     );
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
@@ -1097,7 +1097,7 @@ describe("moveConversationOutOfProject", () => {
       workspace.sId
     );
     const projectSpaceGroup = (
-      await projectSpace.fetchGroups(internalAdminAuth)
+      await projectSpace.fetchGroupResources(internalAdminAuth)
     ).find((g) => g.isRegularAuto());
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -11,6 +11,7 @@ import {
   UserConversationReadsModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -23,6 +24,20 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 import { Op } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
+
+async function fetchRegularAutoGroup(
+  space: SpaceResource,
+  auth: Authenticator
+) {
+  const groupReference = space.groups.find((group) => group.isRegularAuto());
+  if (!groupReference) {
+    return null;
+  }
+  const [group] = await space.fetchGroupResources(auth, {
+    groupReferences: [groupReference],
+  });
+  return group;
+}
 
 async function markConversationAgentMessagesAsSucceeded(
   workspace: WorkspaceType,
@@ -80,9 +95,10 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -143,9 +159,10 @@ describe("moveConversationToProject", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -305,9 +322,10 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -503,9 +521,10 @@ describe("moveConversationToProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -607,9 +626,10 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = (
-      await destinationProject.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const destinationProjectGroup = await fetchRegularAutoGroup(
+      destinationProject,
+      internalAdminAuth
+    );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
     }
@@ -673,9 +693,10 @@ describe("moveConversationToProject", () => {
     );
 
     // Add current user as member (but not editor) of source project
-    const sourceProjectGroup = (
-      await sourceProject.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const sourceProjectGroup = await fetchRegularAutoGroup(
+      sourceProject,
+      internalAdminAuth
+    );
     if (!sourceProjectGroup) {
       throw new Error("Source project regular group not found");
     }
@@ -685,9 +706,10 @@ describe("moveConversationToProject", () => {
 
     // Create destination project and add user as member
     const destinationProject = await SpaceFactory.project(workspace);
-    const destinationProjectGroup = (
-      await destinationProject.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const destinationProjectGroup = await fetchRegularAutoGroup(
+      destinationProject,
+      internalAdminAuth
+    );
     if (!destinationProjectGroup) {
       throw new Error("Destination project regular group not found");
     }
@@ -735,9 +757,10 @@ describe("moveConversationToProject", () => {
     );
 
     // Add user as member of the project
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -794,9 +817,10 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -875,9 +899,10 @@ describe("moveConversationOutOfProject", () => {
     );
 
     // Add current user as member (but not editor) of project.
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -938,9 +963,10 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }
@@ -1096,9 +1122,10 @@ describe("moveConversationOutOfProject", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const projectSpaceGroup = (
-      await projectSpace.fetchGroupResources(internalAdminAuth)
-    ).find((g) => g.isRegularAuto());
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
     if (!projectSpaceGroup) {
       throw new Error("Project space regular group not found");
     }

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -28,6 +28,17 @@ import { Err, Ok } from "@app/types/shared/result";
 import { SPACE_KINDS } from "@app/types/space";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+async function fetchNonGlobalGroup(space: SpaceResource, auth: Authenticator) {
+  const groupReference = space.groups.find((group) => !group.isGlobal());
+  if (!groupReference) {
+    return null;
+  }
+  const [group] = await space.fetchGroupResources(auth, {
+    groupReferences: [groupReference],
+  });
+  return group;
+}
+
 describe("createSpaceAndGroup", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
   let adminAuth: Authenticator;
@@ -1029,8 +1040,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroupResources(adminAuth);
-        const spaceGroup = groups.find((g) => !g.isGlobal());
+        const spaceGroup = await fetchNonGlobalGroup(space, adminAuth);
         expect(spaceGroup).toBeDefined();
 
         // Create an active API key for the space group
@@ -1065,8 +1075,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroupResources(adminAuth);
-        const spaceGroup = groups.find((g) => !g.isGlobal());
+        const spaceGroup = await fetchNonGlobalGroup(space, adminAuth);
         expect(spaceGroup).toBeDefined();
 
         // Create an active API key for the space group
@@ -1096,8 +1105,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroupResources(adminAuth);
-        const spaceGroup = groups.find((g) => !g.isGlobal());
+        const spaceGroup = await fetchNonGlobalGroup(space, adminAuth);
         expect(spaceGroup).toBeDefined();
 
         // Create a disabled API key for the space group

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -90,7 +90,7 @@ describe("createSpaceAndGroup", () => {
         expect(space.isRegularAndRestricted()).toBe(true);
 
         // Verify the space has a group
-        const groups = await space.fetchGroups(adminAuth);
+        const groups = await space.fetchGroupResources(adminAuth);
         expect(groups.length).toBeGreaterThan(0);
         const spaceGroup = groups.find((g) =>
           g.name.startsWith("Group for space Test Regular Space")
@@ -118,7 +118,7 @@ describe("createSpaceAndGroup", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        const groups = await result.value.fetchGroups(adminAuth);
+        const groups = await result.value.fetchGroupResources(adminAuth);
         const memberGroup = groups.find((g) =>
           g.name.startsWith("Group for space Kind Check Space")
         );
@@ -1029,7 +1029,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroups(adminAuth);
+        const groups = await space.fetchGroupResources(adminAuth);
         const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 
@@ -1065,7 +1065,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroups(adminAuth);
+        const groups = await space.fetchGroupResources(adminAuth);
         const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 
@@ -1096,7 +1096,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const groups = await space.fetchGroups(adminAuth);
+        const groups = await space.fetchGroupResources(adminAuth);
         const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -90,8 +90,9 @@ describe("createSpaceAndGroup", () => {
         expect(space.isRegularAndRestricted()).toBe(true);
 
         // Verify the space has a group
-        expect(space.groups.length).toBeGreaterThan(0);
-        const spaceGroup = space.groups.find((g) =>
+        const groups = await space.fetchGroups(adminAuth);
+        expect(groups.length).toBeGreaterThan(0);
+        const spaceGroup = groups.find((g) =>
           g.name.startsWith("Group for space Test Regular Space")
         );
         expect(spaceGroup).toBeDefined();
@@ -117,7 +118,8 @@ describe("createSpaceAndGroup", () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        const memberGroup = result.value.groups.find((g) =>
+        const groups = await result.value.fetchGroups(adminAuth);
+        const memberGroup = groups.find((g) =>
           g.name.startsWith("Group for space Kind Check Space")
         );
         expect(memberGroup).toBeDefined();
@@ -1027,7 +1029,8 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        const groups = await space.fetchGroups(adminAuth);
+        const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 
         // Create an active API key for the space group
@@ -1062,7 +1065,8 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        const groups = await space.fetchGroups(adminAuth);
+        const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 
         // Create an active API key for the space group
@@ -1092,7 +1096,8 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       if (result.isOk()) {
         const space = result.value;
         // Get the space's non-global group
-        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        const groups = await space.fetchGroups(adminAuth);
+        const spaceGroup = groups.find((g) => !g.isGlobal());
         expect(spaceGroup).toBeDefined();
 
         // Create a disabled API key for the space group

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -404,7 +404,7 @@ export async function hardDeleteSpace(
 
   await withTransaction(async (t) => {
     // Delete all spaces groups.
-    const groups = await space.fetchGroups(auth, { transaction: t });
+    const groups = await space.fetchGroupResources(auth, { transaction: t });
     for (const group of groups) {
       // Skip deleting global groups for regular spaces.
       if (space.isRegular() && group.isGlobal()) {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -404,13 +404,14 @@ export async function hardDeleteSpace(
 
   await withTransaction(async (t) => {
     // Delete all spaces groups.
-    const groups = await space.fetchGroupResources(auth, { transaction: t });
+    const groupReferences = space.groups.filter(
+      (group) => !space.isRegular() || !group.isGlobal()
+    );
+    const groups = await space.fetchGroupResources(auth, {
+      groupReferences,
+      transaction: t,
+    });
     for (const group of groups) {
-      // Skip deleting global groups for regular spaces.
-      if (space.isRegular() && group.isGlobal()) {
-        continue;
-      }
-
       const res = await group.delete(auth, { transaction: t });
       if (res.isErr()) {
         throw res.error;

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -404,7 +404,8 @@ export async function hardDeleteSpace(
 
   await withTransaction(async (t) => {
     // Delete all spaces groups.
-    for (const group of space.groups) {
+    const groups = await space.fetchGroups(auth, { transaction: t });
+    for (const group of groups) {
       // Skip deleting global groups for regular spaces.
       if (space.isRegular() && group.isGlobal()) {
         continue;

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -169,7 +169,7 @@ async function setupPodTestContext() {
     user,
   } = await createResourceTest({ role: "admin" });
   const space = await SpaceFactory.project(workspace, user.id);
-  const [group] = await space.fetchGroups(workspaceAdminAuth);
+  const [group] = await space.fetchGroupResources(workspaceAdminAuth);
   const addMemberResult = await group.dangerouslyAddMember(workspaceAdminAuth, {
     user: user.toJSON(),
   });

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -169,10 +169,10 @@ async function setupPodTestContext() {
     user,
   } = await createResourceTest({ role: "admin" });
   const space = await SpaceFactory.project(workspace, user.id);
-  const addMemberResult = await space.groups[0].dangerouslyAddMember(
-    workspaceAdminAuth,
-    { user: user.toJSON() }
-  );
+  const [group] = await space.fetchGroups(workspaceAdminAuth);
+  const addMemberResult = await group.dangerouslyAddMember(workspaceAdminAuth, {
+    user: user.toJSON(),
+  });
   assert(addMemberResult.isOk());
 
   return {

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -169,7 +169,11 @@ async function setupPodTestContext() {
     user,
   } = await createResourceTest({ role: "admin" });
   const space = await SpaceFactory.project(workspace, user.id);
-  const [group] = await space.fetchGroupResources(workspaceAdminAuth);
+  const groupReference = space.groups.find((group) => group.isRegularAuto());
+  assert(groupReference);
+  const [group] = await space.fetchGroupResources(workspaceAdminAuth, {
+    groupReferences: [groupReference],
+  });
   const addMemberResult = await group.dangerouslyAddMember(workspaceAdminAuth, {
     user: user.toJSON(),
   });

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -145,7 +145,7 @@ describe("Authenticator.fromJSON", () => {
 
     const pod = await SpaceFactory.project(workspace, user.id);
     const editorGroup = pod.groups.find(
-      (group) => group.kind === "space_editors"
+      (group) => group.groupKind === "space_editors"
     );
     expect(editorGroup).toBeDefined();
 

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -150,10 +150,10 @@ describe("Authenticator.fromJSON", () => {
     expect(editorGroup).toBeDefined();
 
     const staleAuth = await Authenticator.fromJSON(staleAuthJson);
-    expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
+    expect(staleAuth.hasGroupByModelId(editorGroup!.groupId)).toBe(false);
 
     const freshAuth =
       await Authenticator.fromJsonWithRefrehedGroups(staleAuthJson);
-    expect(freshAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
+    expect(freshAuth.hasGroupByModelId(editorGroup!.groupId)).toBe(true);
   });
 });

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -7,8 +7,8 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import {
-  dataSourceToPokeJSON,
-  dataSourceViewToPokeJSON,
+  dataSourceToPokeItem,
+  dataSourceViewToPokeItem,
 } from "@app/lib/poke/utils";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -207,7 +207,7 @@ async function searchPokeDataSourcesByDustAPIProjectId(
     return [];
   }
 
-  return [await dataSourceToPokeJSON(auth, dataSource)];
+  return [await dataSourceToPokeItem(dataSource)];
 }
 
 async function searchByPhoneNumber(
@@ -285,7 +285,7 @@ async function searchPokeResourcesBySId(
         return [];
       }
 
-      return [await dataSourceViewToPokeJSON(auth, dataSourceView)];
+      return [await dataSourceViewToPokeItem(dataSourceView)];
 
     case "data_source":
       const dataSource = await DataSourceResource.fetchByNameOrId(auth, sId);
@@ -293,7 +293,7 @@ async function searchPokeResourcesBySId(
         return [];
       }
 
-      return [await dataSourceToPokeJSON(auth, dataSource)];
+      return [await dataSourceToPokeItem(dataSource)];
 
     default:
       return [];

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -207,7 +207,7 @@ async function searchPokeDataSourcesByDustAPIProjectId(
     return [];
   }
 
-  return [await dataSourceToPokeJSON(dataSource)];
+  return [await dataSourceToPokeJSON(auth, dataSource)];
 }
 
 async function searchByPhoneNumber(
@@ -285,7 +285,7 @@ async function searchPokeResourcesBySId(
         return [];
       }
 
-      return [await dataSourceViewToPokeJSON(dataSourceView)];
+      return [await dataSourceViewToPokeJSON(auth, dataSourceView)];
 
     case "data_source":
       const dataSource = await DataSourceResource.fetchByNameOrId(auth, sId);
@@ -293,7 +293,7 @@ async function searchPokeResourcesBySId(
         return [];
       }
 
-      return [await dataSourceToPokeJSON(dataSource)];
+      return [await dataSourceToPokeJSON(auth, dataSource)];
 
     default:
       return [];

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -14,15 +14,20 @@ import type {
   PokeSpaceType,
 } from "@app/types/poke";
 
-export function spaceToPokeJSON(space: SpaceResource): PokeSpaceType {
+export async function spaceToPokeJSON(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<PokeSpaceType> {
+  const groups = await space.fetchGroups(auth);
   return {
     id: space.id,
     ...space.toJSON(),
-    groups: space.groups.map((group) => group.toJSON()),
+    groups: groups.map((group) => group.toJSON()),
   };
 }
 
 export async function dataSourceToPokeJSON(
+  auth: Authenticator,
   dataSource: DataSourceResource
 ): Promise<PokeDataSourceType> {
   const workspace = await WorkspaceResource.fetchByModelId(
@@ -40,11 +45,12 @@ export async function dataSourceToPokeJSON(
         ? getDisplayNameForDataSource(dataSource.toJSON())
         : `folder (${dataSource.name})`),
     type: "Data Source",
-    space: spaceToPokeJSON(dataSource.space),
+    space: await spaceToPokeJSON(auth, dataSource.space),
   };
 }
 
 export async function dataSourceViewToPokeJSON(
+  auth: Authenticator,
   dataSourceView: DataSourceViewResource
 ): Promise<PokeDataSourceViewType> {
   const workspace = await WorkspaceResource.fetchByModelId(
@@ -53,7 +59,7 @@ export async function dataSourceViewToPokeJSON(
 
   return {
     ...dataSourceView.toJSON(),
-    dataSource: await dataSourceToPokeJSON(dataSourceView.dataSource),
+    dataSource: await dataSourceToPokeJSON(auth, dataSourceView.dataSource),
     link: workspace
       ? `${config.getPokeAppUrl()}/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
@@ -63,7 +69,7 @@ export async function dataSourceViewToPokeJSON(
         ? getDisplayNameForDataSource(dataSourceView.dataSource.toJSON())
         : `folder (${dataSourceView.dataSource.name})`),
     type: "Data Source View",
-    space: spaceToPokeJSON(dataSourceView.space),
+    space: await spaceToPokeJSON(auth, dataSourceView.space),
   };
 }
 
@@ -111,7 +117,7 @@ export async function mcpServerViewToPokeJSON(
     name: json.name ?? json.server.name,
     customName: json.name,
     type: "MCP Server View",
-    space: spaceToPokeJSON(mcpServerView.space),
+    space: await spaceToPokeJSON(auth, mcpServerView.space),
     connections: connections,
   };
 }

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -18,7 +18,7 @@ export async function spaceToPokeJSON(
   auth: Authenticator,
   space: SpaceResource
 ): Promise<PokeSpaceType> {
-  const groups = await space.fetchGroups(auth);
+  const groups = await space.fetchGroupResources(auth);
   return {
     id: space.id,
     ...space.toJSON(),

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -10,6 +10,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type {
   PokeDataSourceType,
   PokeDataSourceViewType,
+  PokeItemBase,
   PokeMCPServerViewType,
   PokeSpaceType,
 } from "@app/types/poke";
@@ -26,16 +27,15 @@ export async function spaceToPokeJSON(
   };
 }
 
-export async function dataSourceToPokeJSON(
-  auth: Authenticator,
+export async function dataSourceToPokeItem(
   dataSource: DataSourceResource
-): Promise<PokeDataSourceType> {
+): Promise<PokeItemBase> {
   const workspace = await WorkspaceResource.fetchByModelId(
     dataSource.workspaceId
   );
 
   return {
-    ...dataSource.toJSON(),
+    id: dataSource.id,
     link: workspace
       ? `${config.getPokeAppUrl()}/${workspace.sId}/data_sources/${dataSource.sId}`
       : null,
@@ -45,21 +45,29 @@ export async function dataSourceToPokeJSON(
         ? getDisplayNameForDataSource(dataSource.toJSON())
         : `folder (${dataSource.name})`),
     type: "Data Source",
+  };
+}
+
+export async function dataSourceToPokeJSON(
+  auth: Authenticator,
+  dataSource: DataSourceResource
+): Promise<PokeDataSourceType> {
+  return {
+    ...dataSource.toJSON(),
+    ...(await dataSourceToPokeItem(dataSource)),
     space: await spaceToPokeJSON(auth, dataSource.space),
   };
 }
 
-export async function dataSourceViewToPokeJSON(
-  auth: Authenticator,
+export async function dataSourceViewToPokeItem(
   dataSourceView: DataSourceViewResource
-): Promise<PokeDataSourceViewType> {
+): Promise<PokeItemBase> {
   const workspace = await WorkspaceResource.fetchByModelId(
     dataSourceView.workspaceId
   );
 
   return {
-    ...dataSourceView.toJSON(),
-    dataSource: await dataSourceToPokeJSON(auth, dataSourceView.dataSource),
+    id: dataSourceView.id,
     link: workspace
       ? `${config.getPokeAppUrl()}/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
@@ -69,6 +77,17 @@ export async function dataSourceViewToPokeJSON(
         ? getDisplayNameForDataSource(dataSourceView.dataSource.toJSON())
         : `folder (${dataSourceView.dataSource.name})`),
     type: "Data Source View",
+  };
+}
+
+export async function dataSourceViewToPokeJSON(
+  auth: Authenticator,
+  dataSourceView: DataSourceViewResource
+): Promise<PokeDataSourceViewType> {
+  return {
+    ...dataSourceView.toJSON(),
+    dataSource: await dataSourceToPokeJSON(auth, dataSourceView.dataSource),
+    ...(await dataSourceViewToPokeItem(dataSourceView)),
     space: await spaceToPokeJSON(auth, dataSourceView.space),
   };
 }

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -26,7 +26,8 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const memberGroup = space.groups.find((group) => group.isRegularAuto());
+    const groups = await space.fetchGroups(internalAdminAuth);
+    const memberGroup = groups.find((group) => group.isRegularAuto());
     if (!memberGroup) {
       throw new Error("Expected regular member group on Space");
     }

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -26,7 +26,7 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const groups = await space.fetchGroups(internalAdminAuth);
+    const groups = await space.fetchGroupResources(internalAdminAuth);
     const memberGroup = groups.find((group) => group.isRegularAuto());
     if (!memberGroup) {
       throw new Error("Expected regular member group on Space");

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -26,11 +26,15 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const groups = await space.fetchGroupResources(internalAdminAuth);
-    const memberGroup = groups.find((group) => group.isRegularAuto());
-    if (!memberGroup) {
+    const memberGroupReference = space.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!memberGroupReference) {
       throw new Error("Expected regular member group on Space");
     }
+    const [memberGroup] = await space.fetchGroupResources(internalAdminAuth, {
+      groupReferences: [memberGroupReference],
+    });
 
     await memberGroup.dangerouslyAddMembers(internalAdminAuth, {
       users: [user],

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -194,7 +194,8 @@ describe("MCPServerViewResource", () => {
       // - User is NOT in any group for restrictedSpace
 
       // Add user to the group that accesses accessibleSpace
-      const [accessibleGroup] = await accessibleSpace.fetchGroups(adminAuth);
+      const [accessibleGroup] =
+        await accessibleSpace.fetchGroupResources(adminAuth);
       const addMemberResult = await accessibleGroup.dangerouslyAddMember(
         adminAuth,
         {
@@ -352,8 +353,8 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      const [group1] = await space1.fetchGroups(adminAuth);
-      const [group2] = await space2.fetchGroups(adminAuth);
+      const [group1] = await space1.fetchGroupResources(adminAuth);
+      const [group2] = await space2.fetchGroupResources(adminAuth);
       await group1.dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
       });

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -194,8 +194,16 @@ describe("MCPServerViewResource", () => {
       // - User is NOT in any group for restrictedSpace
 
       // Add user to the group that accesses accessibleSpace
-      const [accessibleGroup] =
-        await accessibleSpace.fetchGroupResources(adminAuth);
+      const accessibleGroupReference = accessibleSpace.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      if (!accessibleGroupReference) {
+        throw new Error("Expected a regular group on the accessible space");
+      }
+      const [accessibleGroup] = await accessibleSpace.fetchGroupResources(
+        adminAuth,
+        { groupReferences: [accessibleGroupReference] }
+      );
       const addMemberResult = await accessibleGroup.dangerouslyAddMember(
         adminAuth,
         {
@@ -353,8 +361,21 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      const [group1] = await space1.fetchGroupResources(adminAuth);
-      const [group2] = await space2.fetchGroupResources(adminAuth);
+      const group1Reference = space1.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      const group2Reference = space2.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      if (!group1Reference || !group2Reference) {
+        throw new Error("Expected regular groups on both spaces");
+      }
+      const [group1] = await space1.fetchGroupResources(adminAuth, {
+        groupReferences: [group1Reference],
+      });
+      const [group2] = await space2.fetchGroupResources(adminAuth, {
+        groupReferences: [group2Reference],
+      });
       await group1.dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
       });

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -194,10 +194,13 @@ describe("MCPServerViewResource", () => {
       // - User is NOT in any group for restrictedSpace
 
       // Add user to the group that accesses accessibleSpace
-      const addMemberResult =
-        await accessibleSpace.groups[0].dangerouslyAddMember(adminAuth, {
+      const [accessibleGroup] = await accessibleSpace.fetchGroups(adminAuth);
+      const addMemberResult = await accessibleGroup.dangerouslyAddMember(
+        adminAuth,
+        {
           user: user.toJSON(),
-        });
+        }
+      );
       expect(addMemberResult.isOk()).toBe(true);
 
       // Create auth for the regular user
@@ -349,10 +352,12 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      await space1.groups[0].dangerouslyAddMember(adminAuth, {
+      const [group1] = await space1.fetchGroups(adminAuth);
+      const [group2] = await space2.fetchGroups(adminAuth);
+      await group1.dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
       });
-      await space2.groups[0].dangerouslyAddMember(adminAuth, {
+      await group2.dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
       });
 

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -1,8 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { ResourceWithId } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type {
@@ -96,7 +96,8 @@ export abstract class ResourceWithSpace<
       },
       include: [
         {
-          model: GroupResource.model,
+          as: "groupSpaces",
+          model: GroupSpaceModel,
         },
       ],
       includeDeleted,

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -137,7 +137,8 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const [accessibleGroup] = await accessibleSpace.fetchGroups(adminAuth);
+    const [accessibleGroup] =
+      await accessibleSpace.fetchGroupResources(adminAuth);
     const addMemberResult = await accessibleGroup.dangerouslyAddMember(
       adminAuth,
       {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -137,10 +137,13 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const addMemberResult =
-      await accessibleSpace.groups[0].dangerouslyAddMember(adminAuth, {
+    const [accessibleGroup] = await accessibleSpace.fetchGroups(adminAuth);
+    const addMemberResult = await accessibleGroup.dangerouslyAddMember(
+      adminAuth,
+      {
         user: user.toJSON(),
-      });
+      }
+    );
     expect(addMemberResult.isOk()).toBe(true);
 
     const userAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -137,8 +137,16 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const [accessibleGroup] =
-      await accessibleSpace.fetchGroupResources(adminAuth);
+    const accessibleGroupReference = accessibleSpace.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!accessibleGroupReference) {
+      throw new Error("Expected a regular group on the accessible space");
+    }
+    const [accessibleGroup] = await accessibleSpace.fetchGroupResources(
+      adminAuth,
+      { groupReferences: [accessibleGroupReference] }
+    );
     const addMemberResult = await accessibleGroup.dangerouslyAddMember(
       adminAuth,
       {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1411,8 +1411,12 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroups = await projectSpace.fetchGroupResources(adminAuth);
-      const projectGroup = projectGroups.find((g) => g.isRegularAuto());
+      const projectGroupReference = projectSpace.groups.find((group) =>
+        group.isRegularAuto()
+      );
+      const [projectGroup] = await projectSpace.fetchGroupResources(adminAuth, {
+        groupReferences: projectGroupReference ? [projectGroupReference] : [],
+      });
 
       // User is not a member, should not see it
       const userSpaces =

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1188,9 +1188,9 @@ describe("SpaceResource", () => {
       );
       expect(fetchedSpace?.groups).toEqual([
         expect.objectContaining({
-          id: groupReference.id,
+          groupId: groupReference.groupId,
           groupKind: "regular_auto",
-          kind: "member",
+          groupSpaceKind: "member",
           workspaceId: workspace.id,
         }),
       ]);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -19,7 +19,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {
@@ -1158,6 +1158,47 @@ describe("SpaceResource", () => {
       expect(spaces.some((s) => s.id === regularSpace.id)).toBe(true);
     });
 
+    it("hydrates group references directly from group vaults", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+      const [groupReference] = regularSpace.groups;
+      const findAllSpy = vi.spyOn(SpaceModel, "findAll");
+
+      const fetchedSpace = await SpaceResource.fetchById(
+        adminAuth,
+        regularSpace.sId
+      );
+
+      expect(fetchedSpace).not.toBeNull();
+      expect(findAllSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.arrayContaining([
+            expect.objectContaining({
+              as: "groupSpaces",
+              model: GroupSpaceModel,
+            }),
+          ]),
+        })
+      );
+      expect(findAllSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.arrayContaining([
+            expect.objectContaining({ model: GroupResource.model }),
+          ]),
+        })
+      );
+      expect(fetchedSpace?.groups).toEqual([
+        expect.objectContaining({
+          id: groupReference.id,
+          kind: "regular_auto",
+          relationshipKind: "member",
+          workspaceId: workspace.id,
+        }),
+      ]);
+      expect(fetchedSpace?.toJSON().groupIds).toEqual([groupReference.sId]);
+
+      findAllSpy.mockRestore();
+    });
+
     it("should include conversations space when includeConversationsSpace is true", async () => {
       const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth, {
         includeConversationsSpace: true,
@@ -1368,7 +1409,8 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroup = projectSpace.groups.find((g) => g.isRegularAuto());
+      const projectGroups = await projectSpace.fetchGroups(adminAuth);
+      const projectGroup = projectGroups.find((g) => g.isRegularAuto());
 
       // User is not a member, should not see it
       const userSpaces =

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1194,7 +1194,9 @@ describe("SpaceResource", () => {
           workspaceId: workspace.id,
         }),
       ]);
-      expect(fetchedSpace?.toJSON().groupIds).toEqual([groupReference.sId]);
+      expect(fetchedSpace?.toJSON().groupIds).toEqual([
+        groupReference.groupSId,
+      ]);
 
       findAllSpy.mockRestore();
     });
@@ -1409,7 +1411,7 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroups = await projectSpace.fetchGroups(adminAuth);
+      const projectGroups = await projectSpace.fetchGroupResources(adminAuth);
       const projectGroup = projectGroups.find((g) => g.isRegularAuto());
 
       // User is not a member, should not see it

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1189,8 +1189,8 @@ describe("SpaceResource", () => {
       expect(fetchedSpace?.groups).toEqual([
         expect.objectContaining({
           id: groupReference.id,
-          kind: "regular_auto",
-          relationshipKind: "member",
+          groupKind: "regular_auto",
+          kind: "member",
           workspaceId: workspace.id,
         }),
       ]);

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -663,11 +663,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
     // Provisioned groups are not tied to any space, we don't delete them.
-    const groupReferences = this.groups.filter(
+    const groupReferencesToMaybeDelete = this.groups.filter(
       (group) => !group.isProvisioned()
     );
-    const groups = await this.fetchGroupResources(auth, {
-      groupReferences,
+    const groupsToMaybeDelete = await this.fetchGroupResources(auth, {
+      groupReferences: groupReferencesToMaybeDelete,
       transaction,
     });
 
@@ -683,7 +683,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // When deleting a space, we delete the dangling groups as it won't be available in the UI anymore.
     // This should be changed when we separate the management of groups and spaces
     await concurrentExecutor(
-      groups,
+      groupsToMaybeDelete,
       async (group) => {
         // As the model allows it, ensure the group is not associated with any other space.
         const count = await GroupSpaceModel.count({
@@ -892,7 +892,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       // If the space should be restricted and was not restricted before, remove the global group.
       if (!wasRestricted && isRestricted) {
-        await this.removeGroup(auth, globalGroup.id, t);
+        const globalGroupReference = this.groups.find((group) =>
+          group.isGlobal()
+        );
+        assert(
+          globalGroupReference,
+          "An unrestricted space must have a global group."
+        );
+        await this.removeGroup(auth, globalGroupReference, t);
       }
 
       // If the space should not be restricted and was restricted before, add the global group.
@@ -1018,7 +1025,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           (g) => g.groupKind === "provisioned"
         );
         for (const group of existingExternalGroups) {
-          await this.removeGroup(auth, group.id, t);
+          await this.removeGroup(auth, group, t);
         }
 
         // Add the new groups
@@ -1072,12 +1079,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private async removeGroup(
     auth: Authenticator,
-    groupModelId: ModelId,
+    groupReference: SpaceGroupReference,
     transaction?: Transaction
   ) {
     await GroupSpaceModel.destroy({
       where: {
-        groupId: groupModelId,
+        groupId: groupReference.id,
         vaultId: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -656,7 +656,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
-    const groups = await this.fetchGroupResources(auth, { transaction });
+    const groupReferences = this.groups.filter(
+      (group) => !group.isProvisioned()
+    );
+    const groups = await this.fetchGroupResources(auth, {
+      groupReferences,
+      transaction,
+    });
 
     await GroupSpaceModel.destroy({
       where: {
@@ -672,10 +678,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     await concurrentExecutor(
       groups,
       async (group) => {
-        // Provisioned groups are not tied to any space, we don't delete them.
-        if (group.kind === "provisioned") {
-          return;
-        }
         // As the model allows it, ensure the group is not associated with any other space.
         const count = await GroupSpaceModel.count({
           where: {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1834,22 +1834,27 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     // Manual group references (regular + editor) per space.
-    const manualGroupIdsBySpaceModelId = new Map<ModelId, ModelId[]>();
-    const allGroupIds = new Set<ModelId>();
+    const manualGroupReferencesBySpaceModelId = new Map<
+      ModelId,
+      SpaceGroupReference[]
+    >();
+    const allGroupReferences = new Map<ModelId, SpaceGroupReference>();
     for (const space of spaces) {
-      const groupIds = space.groups
-        .filter(
-          (g) =>
-            g.groupKind === "regular_auto" || g.groupKind === "space_editors"
-        )
-        .map((group) => group.id);
-      manualGroupIdsBySpaceModelId.set(space.id, groupIds);
-      groupIds.forEach((groupId) => allGroupIds.add(groupId));
+      const groupReferences = space.groups.filter(
+        (group) =>
+          group.groupKind === "regular_auto" ||
+          group.groupKind === "space_editors"
+      );
+      manualGroupReferencesBySpaceModelId.set(space.id, groupReferences);
+      groupReferences.forEach((group) =>
+        allGroupReferences.set(group.id, group)
+      );
     }
 
-    const allGroups = await GroupResource.fetchByModelIds(auth, [
-      ...allGroupIds,
-    ]);
+    const allGroups = await GroupResource.fetchByModelIds(
+      auth,
+      [...allGroupReferences.values()].map((group) => group.id)
+    );
 
     // Single query for the active memberships across every group.
     const userModelIdsByGroupModelId =
@@ -1867,10 +1872,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Reassemble the distinct member set for each space.
     for (const space of spaces) {
-      const groupIds = manualGroupIdsBySpaceModelId.get(space.id) ?? [];
+      const groups = manualGroupReferencesBySpaceModelId.get(space.id) ?? [];
       const byId = new Map<ModelId, UserResource>();
-      for (const groupId of groupIds) {
-        for (const userModelId of userModelIdsByGroupModelId[groupId] ?? []) {
+      for (const group of groups) {
+        for (const userModelId of userModelIdsByGroupModelId[group.id] ?? []) {
           const user = usersByModelId.get(userModelId);
           if (user && !byId.has(user.id)) {
             byId.set(user.id, user);

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -52,11 +52,17 @@ import { Op, Sequelize } from "sequelize";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SpaceResource extends ReadonlyAttributesType<SpaceModel> {}
 
+/**
+ * Lightweight representation of a group_vaults join row. It carries enough
+ * data to enforce space permissions without fetching the full group and adding
+ * a second join. This is slated to be superseded by the upcoming
+ * GroupPermission model.
+ */
 export class SpaceGroupReference {
   constructor(
     readonly id: ModelId,
-    readonly kind: GroupKind,
-    readonly relationshipKind: GroupSpaceKind,
+    readonly groupKind: GroupKind,
+    readonly kind: GroupSpaceKind,
     readonly workspaceId: ModelId
   ) {}
 
@@ -77,15 +83,15 @@ export class SpaceGroupReference {
   }
 
   isGlobal(): boolean {
-    return this.kind === "global";
+    return this.groupKind === "global";
   }
 
   isRegularAuto(): boolean {
-    return this.kind === "regular_auto";
+    return this.groupKind === "regular_auto";
   }
 
   isProvisioned(): boolean {
-    return this.kind === "provisioned";
+    return this.groupKind === "provisioned";
   }
 }
 
@@ -656,6 +662,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
+    // Provisioned groups are not tied to any space, we don't delete them.
     const groupReferences = this.groups.filter(
       (group) => !group.isProvisioned()
     );
@@ -790,8 +797,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     if (this.isRegular() || this.isProject()) {
       // For regular spaces that only have a single group, update
       // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
-      const regularGroupReference = this.getSpaceManualMemberGroup();
-      const spaceEditorGroupReference = this.getSpaceManualEditorGroup();
+      const regularGroupReference = this.getSpaceManualMemberGroupReference();
+      const spaceEditorGroupReference =
+        this.getSpaceManualEditorGroupReference();
       const [regularGroup, spaceEditorGroup] = await this.fetchGroupResources(
         auth,
         {
@@ -1007,7 +1015,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         // Remove existing external groups
         const existingExternalGroups = this.groups.filter(
-          (g) => g.kind === "provisioned"
+          (g) => g.groupKind === "provisioned"
         );
         for (const group of existingExternalGroups) {
           await this.removeGroup(auth, group.id, t);
@@ -1064,12 +1072,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private async removeGroup(
     auth: Authenticator,
-    groupId: ModelId,
+    groupModelId: ModelId,
     transaction?: Transaction
   ) {
     await GroupSpaceModel.destroy({
       where: {
-        groupId,
+        groupId: groupModelId,
         vaultId: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
@@ -1391,7 +1399,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new Ok(users);
   }
 
-  private getSpaceManualMemberGroup(): SpaceGroupReference {
+  private getSpaceManualMemberGroupReference(): SpaceGroupReference {
     const regularGroups = this.groups.filter((group) => group.isRegularAuto());
     assert(
       regularGroups.length === 1,
@@ -1400,9 +1408,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return regularGroups[0];
   }
 
-  private getSpaceManualEditorGroup(): SpaceGroupReference | null {
+  private getSpaceManualEditorGroupReference(): SpaceGroupReference | null {
     const editorGroups = this.groups.filter(
-      (group) => group.kind === "space_editors"
+      (group) => group.groupKind === "space_editors"
     );
     if (editorGroups.length === 0) {
       return null;
@@ -1551,7 +1559,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           ],
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
-              if (group.relationshipKind === "project_editor") {
+              if (group.kind === "project_editor") {
                 // Project editors get admin permissions
                 acc.push({
                   id: group.id,
@@ -1686,10 +1694,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroup = this.getSpaceManualMemberGroup();
-    const editorGroup = this.getSpaceManualEditorGroup();
+    const memberGroupReference = this.getSpaceManualMemberGroupReference();
+    const editorGroupReference = this.getSpaceManualEditorGroupReference();
     const groups = await this.fetchGroupResources(auth, {
-      groupReferences: [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      groupReferences: [
+        memberGroupReference,
+        ...(editorGroupReference ? [editorGroupReference] : []),
+      ],
       transaction,
     });
 
@@ -1705,10 +1716,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroup = this.getSpaceManualMemberGroup();
-    const editorGroup = this.getSpaceManualEditorGroup();
+    const memberGroupReference = this.getSpaceManualMemberGroupReference();
+    const editorGroupReference = this.getSpaceManualEditorGroupReference();
     const groups = await this.fetchGroupResources(auth, {
-      groupReferences: [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      groupReferences: [
+        memberGroupReference,
+        ...(editorGroupReference ? [editorGroupReference] : []),
+      ],
       transaction,
     });
 
@@ -1735,7 +1749,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     allGroupMemberships: GroupMembershipModel[];
   }> {
     const groupReferences = this.groups.filter(
-      (group) => group.isRegularAuto() || group.kind === "space_editors"
+      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
     );
     const groupsToProcess = await this.fetchGroupResources(auth, {
       groupReferences,
@@ -1817,7 +1831,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const allGroupIds = new Set<ModelId>();
     for (const space of spaces) {
       const groupIds = space.groups
-        .filter((g) => g.kind === "regular_auto" || g.kind === "space_editors")
+        .filter(
+          (g) =>
+            g.groupKind === "regular_auto" || g.groupKind === "space_editors"
+        )
         .map((group) => group.id);
       manualGroupIdsBySpaceModelId.set(space.id, groupIds);
       groupIds.forEach((groupId) => allGroupIds.add(groupId));

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -62,7 +62,7 @@ export class SpaceGroupReference {
   constructor(
     readonly id: ModelId,
     readonly groupKind: GroupKind,
-    readonly kind: GroupSpaceKind,
+    readonly referenceKind: GroupSpaceKind,
     readonly workspaceId: ModelId
   ) {}
 
@@ -1566,7 +1566,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           ],
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
-              if (group.kind === "project_editor") {
+              if (group.referenceKind === "project_editor") {
                 // Project editors get admin permissions
                 acc.push({
                   id: group.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -62,7 +62,7 @@ export class SpaceGroupReference {
   constructor(
     readonly id: ModelId,
     readonly groupKind: GroupKind,
-    readonly referenceKind: GroupSpaceKind,
+    readonly groupSpaceKind: GroupSpaceKind,
     readonly workspaceId: ModelId
   ) {}
 
@@ -1566,7 +1566,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           ],
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
-              if (group.referenceKind === "project_editor") {
+              if (group.groupSpaceKind === "project_editor") {
                 // Project editors get admin permissions
                 acc.push({
                   id: group.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -60,7 +60,7 @@ export class SpaceGroupReference {
     readonly workspaceId: ModelId
   ) {}
 
-  static fromModel(groupSpace: GroupSpaceModel) {
+  static fromGroupSpaceModel(groupSpace: GroupSpaceModel) {
     return new SpaceGroupReference(
       groupSpace.groupId,
       groupSpace.groupKind,
@@ -69,7 +69,7 @@ export class SpaceGroupReference {
     );
   }
 
-  get sId(): string {
+  get groupSId(): string {
     return GroupResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
@@ -105,7 +105,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new SpaceResource(
       SpaceModel,
       space.get(),
-      space.groupSpaces.map(SpaceGroupReference.fromModel)
+      space.groupSpaces.map(SpaceGroupReference.fromGroupSpaceModel)
     );
   }
 
@@ -157,7 +157,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new this(
         SpaceModel,
         space.get(),
-        groupSpaces.map(SpaceGroupReference.fromModel)
+        groupSpaces.map(SpaceGroupReference.fromGroupSpaceModel)
       );
     }, transaction);
   }
@@ -244,17 +244,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
-  async fetchGroups(
+  async fetchGroupResources(
     auth: Authenticator,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<GroupResource[]> {
-    return this.fetchGroupResources(auth, this.groups, { transaction });
-  }
-
-  private async fetchGroupResources(
-    auth: Authenticator,
-    groupReferences: SpaceGroupReference[],
-    { transaction }: { transaction?: Transaction } = {}
+    {
+      groupReferences = this.groups,
+      transaction,
+    }: {
+      groupReferences?: SpaceGroupReference[];
+      transaction?: Transaction;
+    } = {}
   ): Promise<GroupResource[]> {
     if (groupReferences.length === 0) {
       return [];
@@ -269,7 +267,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     return groupReferences.map((group) => {
       const resource = groupsById.get(group.id);
-      assert(resource, `Group ${group.sId} not found.`);
+      assert(resource, `Group ${group.groupSId} not found.`);
       return resource;
     });
   }
@@ -658,7 +656,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
-    const groups = await this.fetchGroups(auth, { transaction });
+    const groups = await this.fetchGroupResources(auth, { transaction });
 
     await GroupSpaceModel.destroy({
       where: {
@@ -794,12 +792,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       const spaceEditorGroupReference = this.getSpaceManualEditorGroup();
       const [regularGroup, spaceEditorGroup] = await this.fetchGroupResources(
         auth,
-        [
-          regularGroupReference,
-          ...(spaceEditorGroupReference && this.isProject()
-            ? [spaceEditorGroupReference]
-            : []),
-        ]
+        {
+          groupReferences: [
+            regularGroupReference,
+            ...(spaceEditorGroupReference && this.isProject()
+              ? [spaceEditorGroupReference]
+              : []),
+          ],
+        }
       );
       await regularGroup.updateName(
         auth,
@@ -1686,11 +1686,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ): Promise<void> {
     const memberGroup = this.getSpaceManualMemberGroup();
     const editorGroup = this.getSpaceManualEditorGroup();
-    const groups = await this.fetchGroupResources(
-      auth,
-      [memberGroup, ...(editorGroup ? [editorGroup] : [])],
-      { transaction }
-    );
+    const groups = await this.fetchGroupResources(auth, {
+      groupReferences: [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      transaction,
+    });
 
     for (const group of groups) {
       await group.suspendMembers(auth, { transaction });
@@ -1706,11 +1705,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ): Promise<void> {
     const memberGroup = this.getSpaceManualMemberGroup();
     const editorGroup = this.getSpaceManualEditorGroup();
-    const groups = await this.fetchGroupResources(
-      auth,
-      [memberGroup, ...(editorGroup ? [editorGroup] : [])],
-      { transaction }
-    );
+    const groups = await this.fetchGroupResources(auth, {
+      groupReferences: [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      transaction,
+    });
 
     for (const group of groups) {
       await group.restoreMembers(auth, { transaction });
@@ -1737,10 +1735,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const groupReferences = this.groups.filter(
       (group) => group.isRegularAuto() || group.kind === "space_editors"
     );
-    const groupsToProcess = await this.fetchGroupResources(
-      auth,
-      groupReferences
-    );
+    const groupsToProcess = await this.fetchGroupResources(auth, {
+      groupReferences,
+    });
 
     // Fetch all group memberships to get the startAt date (will be the joinedAt date returned for each member)
     const allGroupMemberships = await GroupMembershipModel.findAll({
@@ -1863,12 +1860,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),
-      groupIds: this.groups.map((group) =>
-        GroupResource.modelIdToSId({
-          id: group.id,
-          workspaceId: this.workspaceId,
-        })
-      ),
+      groupIds: this.groups.map((group) => group.groupSId),
       isRestricted:
         this.isRegularAndRestricted() || this.isProjectAndRestricted(),
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -10,7 +10,6 @@ import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -21,7 +20,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
-import type { GroupType } from "@app/types/groups";
+import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
   PROJECT_EDITOR_GROUP_PREFIX,
@@ -37,7 +36,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { SpaceKind, SpaceType } from "@app/types/space";
+import type { GroupSpaceKind, SpaceKind, SpaceType } from "@app/types/space";
 import assert from "assert";
 import type {
   Attributes,
@@ -52,6 +51,44 @@ import { Op, Sequelize } from "sequelize";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SpaceResource extends ReadonlyAttributesType<SpaceModel> {}
+
+export class SpaceGroupReference {
+  constructor(
+    readonly id: ModelId,
+    readonly kind: GroupKind,
+    readonly relationshipKind: GroupSpaceKind,
+    readonly workspaceId: ModelId
+  ) {}
+
+  static fromModel(groupSpace: GroupSpaceModel) {
+    return new SpaceGroupReference(
+      groupSpace.groupId,
+      groupSpace.groupKind,
+      groupSpace.kind,
+      groupSpace.workspaceId
+    );
+  }
+
+  get sId(): string {
+    return GroupResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  isGlobal(): boolean {
+    return this.kind === "global";
+  }
+
+  isRegularAuto(): boolean {
+    return this.kind === "regular_auto";
+  }
+
+  isProvisioned(): boolean {
+    return this.kind === "provisioned";
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SpaceResource extends BaseResource<SpaceModel> {
   static model: ModelStaticSoftDeletable<SpaceModel> = SpaceModel;
@@ -59,7 +96,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   constructor(
     model: ModelStaticSoftDeletable<SpaceModel>,
     blob: Attributes<SpaceModel>,
-    readonly groups: GroupResource[]
+    readonly groups: SpaceGroupReference[]
   ) {
     super(SpaceModel, blob);
   }
@@ -68,7 +105,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new SpaceResource(
       SpaceModel,
       space.get(),
-      space.groups.map((group) => new GroupResource(GroupModel, group.get()))
+      space.groupSpaces.map(SpaceGroupReference.fromModel)
     );
   }
 
@@ -80,17 +117,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return withTransaction(async (t: Transaction) => {
       const space = await SpaceModel.create(blob, { transaction: t });
       const { members, editors = [] } = groups;
+      const groupSpaces: GroupSpaceModel[] = [];
 
       for (const memberGroup of members) {
-        await GroupSpaceModel.create(
-          {
-            groupId: memberGroup.id,
-            groupKind: memberGroup.kind,
-            vaultId: space.id,
-            workspaceId: space.workspaceId,
-            kind: "member",
-          },
-          { transaction: t }
+        groupSpaces.push(
+          await GroupSpaceModel.create(
+            {
+              groupId: memberGroup.id,
+              groupKind: memberGroup.kind,
+              vaultId: space.id,
+              workspaceId: space.workspaceId,
+              kind: "member",
+            },
+            { transaction: t }
+          )
         );
       }
       if (editors.length > 0) {
@@ -99,23 +139,26 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           "Only projects can have editor groups."
         );
         for (const editorGroup of editors) {
-          await GroupSpaceModel.create(
-            {
-              groupId: editorGroup.id,
-              groupKind: editorGroup.kind,
-              vaultId: space.id,
-              workspaceId: space.workspaceId,
-              kind: "project_editor",
-            },
-            { transaction: t }
+          groupSpaces.push(
+            await GroupSpaceModel.create(
+              {
+                groupId: editorGroup.id,
+                groupKind: editorGroup.kind,
+                vaultId: space.id,
+                workspaceId: space.workspaceId,
+                kind: "project_editor",
+              },
+              { transaction: t }
+            )
           );
         }
       }
 
-      return new this(SpaceModel, space.get(), [
-        ...groups.members,
-        ...(groups.editors ?? []),
-      ]);
+      return new this(
+        SpaceModel,
+        space.get(),
+        groupSpaces.map(SpaceGroupReference.fromModel)
+      );
     }, transaction);
   }
 
@@ -201,6 +244,36 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
+  async fetchGroups(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<GroupResource[]> {
+    return this.fetchGroupResources(auth, this.groups, { transaction });
+  }
+
+  private async fetchGroupResources(
+    auth: Authenticator,
+    groupReferences: SpaceGroupReference[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<GroupResource[]> {
+    if (groupReferences.length === 0) {
+      return [];
+    }
+
+    const groups = await GroupResource.fetchByModelIds(
+      auth,
+      groupReferences.map((group) => group.id),
+      { transaction }
+    );
+    const groupsById = new Map(groups.map((group) => [group.id, group]));
+
+    return groupReferences.map((group) => {
+      const resource = groupsById.get(group.id);
+      assert(resource, `Group ${group.sId} not found.`);
+      return resource;
+    });
+  }
+
   private static async baseFetch(
     auth: Authenticator,
     {
@@ -214,7 +287,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ) {
     const includeClauses: Includeable[] = [
       {
-        model: GroupResource.model,
+        as: "groupSpaces",
+        model: GroupSpaceModel,
       },
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(includes || []),
@@ -546,7 +620,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       include: [
         {
-          model: GroupResource.model,
+          as: "groupSpaces",
+          model: GroupSpaceModel,
         },
       ],
       includeDeleted: true,
@@ -583,6 +658,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
+    const groups = await this.fetchGroups(auth, { transaction });
 
     await GroupSpaceModel.destroy({
       where: {
@@ -596,7 +672,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // When deleting a space, we delete the dangling groups as it won't be available in the UI anymore.
     // This should be changed when we separate the management of groups and spaces
     await concurrentExecutor(
-      this.groups,
+      groups,
       async (group) => {
         // Provisioned groups are not tied to any space, we don't delete them.
         if (group.kind === "provisioned") {
@@ -711,21 +787,31 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     await this.update({ name: trimmedName });
-    // For regular spaces that only have a single group, update
-    // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
-    const regularGroup = this.getSpaceManualMemberGroup();
     if (this.isRegular() || this.isProject()) {
+      // For regular spaces that only have a single group, update
+      // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
+      const regularGroupReference = this.getSpaceManualMemberGroup();
+      const spaceEditorGroupReference = this.getSpaceManualEditorGroup();
+      const [regularGroup, spaceEditorGroup] = await this.fetchGroupResources(
+        auth,
+        [
+          regularGroupReference,
+          ...(spaceEditorGroupReference && this.isProject()
+            ? [spaceEditorGroupReference]
+            : []),
+        ]
+      );
       await regularGroup.updateName(
         auth,
         `${this.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${this.name}`
       );
-    }
-    const spaceEditorGroup = this.getSpaceManualEditorGroup();
-    if (spaceEditorGroup && this.isProject()) {
-      await spaceEditorGroup.updateName(
-        auth,
-        `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`
-      );
+
+      if (spaceEditorGroup && this.isProject()) {
+        await spaceEditorGroup.updateName(
+          auth,
+          `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`
+        );
+      }
     }
 
     return new Ok(undefined);
@@ -781,7 +867,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const { isRestricted } = params;
 
-    const wasRestricted = this.groups.every((g) => !g.isGlobal());
+    const wasRestricted = !this.isOpen();
 
     const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
     if (groupRes.isErr()) {
@@ -796,7 +882,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       // If the space should be restricted and was not restricted before, remove the global group.
       if (!wasRestricted && isRestricted) {
-        await this.removeGroup(auth, globalGroup, t);
+        await this.removeGroup(auth, globalGroup.id, t);
       }
 
       // If the space should not be restricted and was restricted before, add the global group.
@@ -922,7 +1008,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           (g) => g.kind === "provisioned"
         );
         for (const group of existingExternalGroups) {
-          await this.removeGroup(auth, group, t);
+          await this.removeGroup(auth, group.id, t);
         }
 
         // Add the new groups
@@ -976,12 +1062,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private async removeGroup(
     auth: Authenticator,
-    group: GroupResource,
+    groupId: ModelId,
     transaction?: Transaction
   ) {
     await GroupSpaceModel.destroy({
       where: {
-        groupId: group.id,
+        groupId,
         vaultId: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
@@ -1303,7 +1389,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new Ok(users);
   }
 
-  private getSpaceManualMemberGroup(): GroupResource {
+  private getSpaceManualMemberGroup(): SpaceGroupReference {
     const regularGroups = this.groups.filter((group) => group.isRegularAuto());
     assert(
       regularGroups.length === 1,
@@ -1312,7 +1398,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return regularGroups[0];
   }
 
-  private getSpaceManualEditorGroup(): GroupResource | null {
+  private getSpaceManualEditorGroup(): SpaceGroupReference | null {
     const editorGroups = this.groups.filter(
       (group) => group.kind === "space_editors"
     );
@@ -1423,7 +1509,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const groupFilter =
       this.managementMode === "manual"
-        ? (group: GroupResource) => !group.isProvisioned()
+        ? (group: SpaceGroupReference) => !group.isProvisioned()
         : () => true;
 
     // Open space.
@@ -1463,8 +1549,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           ],
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
-              const groupKind = group.group_vaults?.kind;
-              if (groupKind === "project_editor") {
+              if (group.relationshipKind === "project_editor") {
                 // Project editors get admin permissions
                 acc.push({
                   id: group.id,
@@ -1599,11 +1684,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const groups = [this.getSpaceManualMemberGroup()];
+    const memberGroup = this.getSpaceManualMemberGroup();
     const editorGroup = this.getSpaceManualEditorGroup();
-    if (editorGroup) {
-      groups.push(editorGroup);
-    }
+    const groups = await this.fetchGroupResources(
+      auth,
+      [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      { transaction }
+    );
 
     for (const group of groups) {
       await group.suspendMembers(auth, { transaction });
@@ -1617,11 +1704,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const groups = [this.getSpaceManualMemberGroup()];
+    const memberGroup = this.getSpaceManualMemberGroup();
     const editorGroup = this.getSpaceManualEditorGroup();
-    if (editorGroup) {
-      groups.push(editorGroup);
-    }
+    const groups = await this.fetchGroupResources(
+      auth,
+      [memberGroup, ...(editorGroup ? [editorGroup] : [])],
+      { transaction }
+    );
 
     for (const group of groups) {
       await group.restoreMembers(auth, { transaction });
@@ -1645,9 +1734,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     groupsToProcess: GroupResource[];
     allGroupMemberships: GroupMembershipModel[];
   }> {
-    const groupsToProcess = this.groups.filter((g) => {
-      return g.isRegularAuto() || g.kind === "space_editors";
-    });
+    const groupReferences = this.groups.filter(
+      (group) => group.isRegularAuto() || group.kind === "space_editors"
+    );
+    const groupsToProcess = await this.fetchGroupResources(
+      auth,
+      groupReferences
+    );
 
     // Fetch all group memberships to get the startAt date (will be the joinedAt date returned for each member)
     const allGroupMemberships = await GroupMembershipModel.findAll({
@@ -1720,16 +1813,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return result;
     }
 
-    // Manual groups (regular + editor) per space, plus the flat set of them all.
-    const manualGroupsBySpaceModelId = new Map<ModelId, GroupResource[]>();
-    const allGroups: GroupResource[] = [];
+    // Manual group references (regular + editor) per space.
+    const manualGroupIdsBySpaceModelId = new Map<ModelId, ModelId[]>();
+    const allGroupIds = new Set<ModelId>();
     for (const space of spaces) {
-      const groups = space.groups.filter(
-        (g) => g.kind === "regular_auto" || g.kind === "space_editors"
-      );
-      manualGroupsBySpaceModelId.set(space.id, groups);
-      allGroups.push(...groups);
+      const groupIds = space.groups
+        .filter((g) => g.kind === "regular_auto" || g.kind === "space_editors")
+        .map((group) => group.id);
+      manualGroupIdsBySpaceModelId.set(space.id, groupIds);
+      groupIds.forEach((groupId) => allGroupIds.add(groupId));
     }
+
+    const allGroups = await GroupResource.fetchByModelIds(auth, [
+      ...allGroupIds,
+    ]);
 
     // Single query for the active memberships across every group.
     const userModelIdsByGroupModelId =
@@ -1747,10 +1844,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Reassemble the distinct member set for each space.
     for (const space of spaces) {
-      const groups = manualGroupsBySpaceModelId.get(space.id) ?? [];
+      const groupIds = manualGroupIdsBySpaceModelId.get(space.id) ?? [];
       const byId = new Map<ModelId, UserResource>();
-      for (const group of groups) {
-        for (const userModelId of userModelIdsByGroupModelId[group.id] ?? []) {
+      for (const groupId of groupIds) {
+        for (const userModelId of userModelIdsByGroupModelId[groupId] ?? []) {
           const user = usersByModelId.get(userModelId);
           if (user && !byId.has(user.id)) {
             byId.set(user.id, user);
@@ -1766,7 +1863,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),
-      groupIds: this.groups.map((group) => group.sId),
+      groupIds: this.groups.map((group) =>
+        GroupResource.modelIdToSId({
+          id: group.id,
+          workspaceId: this.workspaceId,
+        })
+      ),
       isRestricted:
         this.isRegularAndRestricted() || this.isProjectAndRestricted(),
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -60,7 +60,7 @@ export interface SpaceResource extends ReadonlyAttributesType<SpaceModel> {}
  */
 export class SpaceGroupReference {
   constructor(
-    readonly id: ModelId,
+    readonly groupId: ModelId,
     readonly groupKind: GroupKind,
     readonly groupSpaceKind: GroupSpaceKind,
     readonly workspaceId: ModelId
@@ -77,7 +77,7 @@ export class SpaceGroupReference {
 
   get groupSId(): string {
     return GroupResource.modelIdToSId({
-      id: this.id,
+      id: this.groupId,
       workspaceId: this.workspaceId,
     });
   }
@@ -266,13 +266,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const groups = await GroupResource.fetchByModelIds(
       auth,
-      groupReferences.map((group) => group.id),
+      groupReferences.map((group) => group.groupId),
       { transaction }
     );
     const groupsById = new Map(groups.map((group) => [group.id, group]));
 
     return groupReferences.map((group) => {
-      const resource = groupsById.get(group.id);
+      const resource = groupsById.get(group.groupId);
       assert(resource, `Group ${group.groupSId} not found.`);
       return resource;
     });
@@ -1084,7 +1084,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ) {
     await GroupSpaceModel.destroy({
       where: {
-        groupId: groupReference.id,
+        groupId: groupReference.groupId,
         vaultId: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
@@ -1443,7 +1443,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           if (group.isGlobal()) {
             return true;
           }
-          if (auth.hasGroupByModelId(group.id)) {
+          if (auth.hasGroupByModelId(group.groupId)) {
             return true;
           }
         }
@@ -1454,7 +1454,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           if (group.isGlobal()) {
             continue;
           }
-          if (auth.hasGroupByModelId(group.id)) {
+          if (auth.hasGroupByModelId(group.groupId)) {
             return true;
           }
         }
@@ -1500,7 +1500,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [{ role: "admin", permissions: ["admin", "write"] }],
           groups: this.groups.map((group) => ({
-            id: group.id,
+            id: group.groupId,
             permissions: ["read", "write"],
           })),
         },
@@ -1517,7 +1517,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             { role: "builder", permissions: ["read", "write"] },
           ],
           groups: this.groups.map((group) => ({
-            id: group.id,
+            id: group.groupId,
             permissions: ["read"],
           })),
         },
@@ -1546,7 +1546,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
               acc.push({
-                id: group.id,
+                id: group.groupId,
                 permissions: ["read"],
               });
             }
@@ -1569,13 +1569,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               if (group.groupSpaceKind === "project_editor") {
                 // Project editors get admin permissions
                 acc.push({
-                  id: group.id,
+                  id: group.groupId,
                   permissions: ["admin", "read", "write"],
                 });
               } else {
                 // Members get read permissions in restricted projects (the unrestricted case is handled by the roles above)
                 acc.push({
-                  id: group.id,
+                  id: group.groupId,
                   permissions: ["read", "write"],
                 });
               }
@@ -1594,7 +1594,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         groups: this.groups.reduce((acc, group) => {
           if (groupFilter(group)) {
             acc.push({
-              id: group.id,
+              id: group.groupId,
               permissions: ["read", "write"],
             });
           }
@@ -1847,13 +1847,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
       manualGroupReferencesBySpaceModelId.set(space.id, groupReferences);
       groupReferences.forEach((group) =>
-        allGroupReferences.set(group.id, group)
+        allGroupReferences.set(group.groupId, group)
       );
     }
 
     const allGroups = await GroupResource.fetchByModelIds(
       auth,
-      [...allGroupReferences.values()].map((group) => group.id)
+      [...allGroupReferences.values()].map((group) => group.groupId)
     );
 
     // Single query for the active memberships across every group.
@@ -1875,7 +1875,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       const groups = manualGroupReferencesBySpaceModelId.get(space.id) ?? [];
       const byId = new Map<ModelId, UserResource>();
       for (const group of groups) {
-        for (const userModelId of userModelIdsByGroupModelId[group.id] ?? []) {
+        for (const userModelId of userModelIdsByGroupModelId[group.groupId] ??
+          []) {
           const user = usersByModelId.get(userModelId);
           if (user && !byId.has(user.id)) {
             byId.set(user.id, user);

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -58,3 +58,12 @@ GroupModel.belongsToMany(SpaceModel, {
   through: GroupSpaceModel,
   foreignKey: "groupId",
 });
+
+SpaceModel.hasMany(GroupSpaceModel, {
+  as: "groupSpaces",
+  foreignKey: "vaultId",
+});
+GroupSpaceModel.belongsTo(SpaceModel, {
+  as: "space",
+  foreignKey: "vaultId",
+});

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,5 +1,6 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
+import type { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import type { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SpaceKind } from "@app/types/space";
@@ -22,6 +23,7 @@ export class SpaceModel extends SoftDeletableWorkspaceAwareModel<SpaceModel> {
   declare managementMode: CreationOptional<"manual" | "group">;
 
   declare groups: NonAttribute<GroupModel[]>;
+  declare groupSpaces: NonAttribute<GroupSpaceModel[]>;
 }
 SpaceModel.init(
   {

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,7 +1,6 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import type { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
-import type { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SpaceKind } from "@app/types/space";
 import { isUniqueSpaceKind } from "@app/types/space";
@@ -22,7 +21,6 @@ export class SpaceModel extends SoftDeletableWorkspaceAwareModel<SpaceModel> {
   // But in both modes we have "groups" associated to the space to hold the members.
   declare managementMode: CreationOptional<"manual" | "group">;
 
-  declare groups: NonAttribute<GroupModel[]>;
   declare groupSpaces: NonAttribute<GroupSpaceModel[]>;
 }
 SpaceModel.init(

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -29,7 +29,8 @@ makeScript(
           const auth = await Authenticator.internalAdminForWorkspace(w.sId);
           const pods = await SpaceResource.listProjectSpaces(auth);
           for (const pod of pods) {
-            const regularGroups = pod.groups.filter((g) => g.isRegularAuto());
+            const groups = await pod.fetchGroups(auth);
+            const regularGroups = groups.filter((g) => g.isRegularAuto());
             if (regularGroups.length === 1) {
               const group = regularGroups[0];
               const newName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;
@@ -42,7 +43,7 @@ makeScript(
               }
             }
 
-            const spaceEditorsGroups = pod.groups.filter(
+            const spaceEditorsGroups = groups.filter(
               (g) => g.kind === "space_editors"
             );
             if (spaceEditorsGroups.length === 1) {

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -29,10 +29,28 @@ makeScript(
           const auth = await Authenticator.internalAdminForWorkspace(w.sId);
           const pods = await SpaceResource.listProjectSpaces(auth);
           for (const pod of pods) {
-            const groups = await pod.fetchGroupResources(auth);
-            const regularGroups = groups.filter((g) => g.isRegularAuto());
-            if (regularGroups.length === 1) {
-              const group = regularGroups[0];
+            const regularGroupReferences = pod.groups.filter((group) =>
+              group.isRegularAuto()
+            );
+            const spaceEditorGroupReferences = pod.groups.filter(
+              (group) => group.kind === "space_editors"
+            );
+            const groups = await pod.fetchGroupResources(auth, {
+              groupReferences: [
+                ...regularGroupReferences,
+                ...spaceEditorGroupReferences,
+              ],
+            });
+            const regularGroups = groups.slice(
+              0,
+              regularGroupReferences.length
+            );
+            const spaceEditorGroups = groups.slice(
+              regularGroupReferences.length
+            );
+
+            if (regularGroupReferences.length === 1) {
+              const [group] = regularGroups;
               const newName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;
               if (execute) {
                 await group.updateName(auth, newName);
@@ -43,11 +61,8 @@ makeScript(
               }
             }
 
-            const spaceEditorsGroups = groups.filter(
-              (g) => g.kind === "space_editors"
-            );
-            if (spaceEditorsGroups.length === 1) {
-              const group = spaceEditorsGroups[0];
+            if (spaceEditorGroupReferences.length === 1) {
+              const [group] = spaceEditorGroups;
               const newName = `${PROJECT_EDITOR_GROUP_PREFIX} ${pod.name}`;
               if (execute) {
                 await group.updateName(auth, newName);

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -29,7 +29,7 @@ makeScript(
           const auth = await Authenticator.internalAdminForWorkspace(w.sId);
           const pods = await SpaceResource.listProjectSpaces(auth);
           for (const pod of pods) {
-            const groups = await pod.fetchGroups(auth);
+            const groups = await pod.fetchGroupResources(auth);
             const regularGroups = groups.filter((g) => g.isRegularAuto());
             if (regularGroups.length === 1) {
               const group = regularGroups[0];

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -33,7 +33,7 @@ makeScript(
               group.isRegularAuto()
             );
             const spaceEditorGroupReferences = pod.groups.filter(
-              (group) => group.kind === "space_editors"
+              (group) => group.groupKind === "space_editors"
             );
             const groups = await pod.fetchGroupResources(auth, {
               groupReferences: [


### PR DESCRIPTION
## Description

- replace the `GroupResource.model` include in space fetches with a direct `GroupSpaceModel` include
- represent `SpaceResource.groups` as lightweight `SpaceGroupReference` records hydrated from `group_vaults.groupId`, `groupKind`, and relationship `kind`
- compute serialized group sIds with `GroupResource.modelIdToSId`
- use group references directly for openness, membership, and permission checks
- fetch full `GroupResource` instances on demand for mutations, member management, and serializers that need complete group data
- update nested resource hydration and affected call sites to use the same direct group-vault association
- return lightweight `PokeItemBase` results for data source searches instead of serializing their spaces and groups
- add regression coverage for the space query shape and workspace-less superuser Poke search

Space reads only need the group id, intrinsic group kind, and group-space relationship kind for openness, membership, and permission checks. The previous belongs-to-many include joined both `group_vaults` and `groups` on every base fetch. The preceding rollout populated and enforced `group_vaults.groupKind`, so these reads can now avoid the extra join while preserving full group loading where it is actually required.

## Tests

- `nvm use && NODE_ENV=test npm test -- lib/resources/space_resource.test.ts lib/api/spaces.test.ts lib/resources/mcp_server_view_resource.test.ts lib/resources/sandbox_function_resource.test.ts lib/resources/conversation_selected_space_resource.test.ts lib/api/assistant/conversation/permissions.test.ts lib/api/assistant/conversation/selected_spaces.test.ts lib/api/projects/conversations.test.ts lib/api/assistant/conversation/branches.test.ts lib/api/assistant/conversation/skill_permissions.test.ts lib/api/viz/publish_frame.test.ts` (206 tests)
- `nvm use && NODE_ENV=test npm test -- routes/poke/search.test.ts` from `front-api` (7 tests)

## Risk

- High. This changes the hot `ResourceWithSpace` fetch path and the group representation used by general `SpaceResource` permissioning.

Can be reverted at any time.

## Deploy Plan

- deploy `front`
- deploy `front-sse`