### PR TITLE
[front] perf: Exclude unbounded remote MCP server columns from base fetch

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
@@ -24,15 +24,40 @@ app.get(
 
     let mcpServerViews: MCPServerViewResource[];
     if (systemSpaceOnly === "true") {
-      mcpServerViews = await MCPServerViewResource.listForSystemSpace(auth);
+      mcpServerViews = await MCPServerViewResource.listForSystemSpace(auth, {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      });
     } else if (globalSpaceOnly === "true") {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
       mcpServerViews = await MCPServerViewResource.listBySpace(
         auth,
-        globalSpace
+        globalSpace,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
     } else {
-      mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
+      mcpServerViews = await MCPServerViewResource.listByWorkspace(auth, {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      });
     }
 
     return ctx.json({

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -21,7 +21,15 @@ app.get(
     const auth = ctx.get("auth");
     const { svId } = ctx.req.valid("param");
 
-    const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
+    const mcpServerView = await MCPServerViewResource.fetchById(auth, svId, {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    });
     if (!mcpServerView) {
       return apiError(ctx, {
         status_code: 404,
@@ -39,7 +47,16 @@ app.get(
 
     const allViews = await MCPServerViewResource.listByMCPServer(
       auth,
-      mcpServerView.mcpServerId
+      mcpServerView.mcpServerId,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
     const spaceViews = allViews
       .filter((view) => view.space.kind !== "system")

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -77,7 +77,16 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
     const views = await MCPServerViewResource.listBySpaceIds(
       auth,
       [claims.spaceId],
-      { includeGlobalSpace: true }
+      {
+        includeGlobalSpace: true,
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     const serverViews = views.map((view) => view.toJSON());
@@ -160,7 +169,15 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   }
 
   // Fetch the server views with their tools metadata.
-  const views = await MCPServerViewResource.fetchByIds(auth, [...viewIds]);
+  const views = await MCPServerViewResource.fetchByIds(auth, [...viewIds], {
+    includeHeavyAttributes: [
+      "authorization",
+      "cachedTools",
+      "customHeaders",
+      "lastError",
+      "sharedSecret",
+    ],
+  });
 
   return ctx.json(
     {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.ts
@@ -63,7 +63,15 @@ app.get(
     const { includeAuto } = ctx.req.valid("query");
 
     const mcpServerViews =
-      await MCPServerViewResource.listBySpaceEnsuringAutoViews(auth, space);
+      await MCPServerViewResource.listBySpaceEnsuringAutoViews(auth, space, {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      });
     return ctx.json({
       success: true,
       serverViews: mcpServerViews

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -51,7 +51,16 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   );
   const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
     auth,
-    mcpServerViewIds
+    mcpServerViewIds,
+    {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }
   );
 
   const tools = mcpServerViews.map((v) => v.toJSON());

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.test.ts
@@ -177,7 +177,18 @@ describe("DELETE /api/w/:wId/mcp/:serverId", () => {
 
     const stillExists = await RemoteMCPServerResource.fetchById(
       auth,
-      server.sId
+      server.sId,
+      // The factory returns the server with its heavy attributes — fetch it back the same way so the
+      // structural comparison holds.
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
     expect(stillExists).toStrictEqual(server);
   });

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
@@ -68,7 +68,15 @@ app.get(
         return ctx.json({ server: await enrichServer(auth, server.toJSON()) });
       }
       case "remote": {
-        const server = await RemoteMCPServerResource.fetchById(auth, serverId);
+        const server = await RemoteMCPServerResource.fetchById(auth, serverId, {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        });
 
         if (!server || server.id !== id) {
           return apiError(ctx, {
@@ -103,7 +111,16 @@ app.patch(
     if (serverType === "remote") {
       const remoteServer = await RemoteMCPServerResource.fetchById(
         auth,
-        serverId
+        serverId,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       if (!remoteServer) {
         return apiError(ctx, {
@@ -188,7 +205,15 @@ async function enrichServer(
   json: MCPServerType
 ): Promise<MCPServerTypeWithViews> {
   const [views, workspaceConnection] = await Promise.all([
-    MCPServerViewResource.listByMCPServer(auth, json.sId),
+    MCPServerViewResource.listByMCPServer(auth, json.sId, {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }),
     MCPServerConnectionResource.findByMCPServer(auth, {
       mcpServerId: json.sId,
       connectionType: "workspace",

--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
@@ -25,7 +25,15 @@ app.post(
     const auth = ctx.get("auth");
     const { serverId } = ctx.req.valid("param");
 
-    const server = await RemoteMCPServerResource.fetchById(auth, serverId);
+    const server = await RemoteMCPServerResource.fetchById(auth, serverId, {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    });
     if (!server) {
       return apiError(ctx, {
         status_code: 404,

--- a/front-api/routes/w/[wId]/mcp/request_access.ts
+++ b/front-api/routes/w/[wId]/mcp/request_access.ts
@@ -1,4 +1,3 @@
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import { PostRequestActionsAccessBodySchema } from "@app/lib/api/mcp_schemas";
@@ -74,7 +73,7 @@ app.post(
 
     const body =
       `${emailRequester} has sent you a request regarding access to ` +
-      `tools ${getMcpServerViewDisplayName(mcpServerView.toJSON())}: ` +
+      `tools ${mcpServerView.getDisplayName()}: ` +
       escape(emailMessage);
 
     const result = await sendEmailWithTemplate({

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
@@ -93,7 +93,16 @@ app.patch(
 
     const updatedSystemView = await MCPServerViewResource.fetchById(
       auth,
-      viewId
+      viewId,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     if (!updatedSystemView) {

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -67,7 +67,16 @@ app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
 
   const views = await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
     auth,
-    query.spaceIds
+    query.spaceIds,
+    {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }
   );
 
   const flattenedServerViews = views

--- a/front-api/routes/w/[wId]/me/approvals.ts
+++ b/front-api/routes/w/[wId]/me/approvals.ts
@@ -51,7 +51,7 @@ app.get("/", async (ctx): HandlerResult<GetUserApprovalsResponseBody> => {
           validation.mcpServerId
         );
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        serverName = server?.toJSON().name || "Unknown Remote Server";
+        serverName = server?.cachedName || "Unknown Remote Server";
       }
     } catch {
       // If we can't parse the server ID or fetch the server, use default name.

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -218,11 +218,21 @@ app.patch(
       }
     }
 
-    // Fetch MCP server views first to compute requestedSpaceIds.
+    // Fetch MCP server views first to compute requestedSpaceIds. The views end up on the
+    // updated skill, whose serialized response includes their tools — fetch the heavy attributes.
     const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
     const mcpServerViews = await MCPServerViewResource.fetchByIds(
       auth,
-      mcpServerViewIds
+      mcpServerViewIds,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     if (mcpServerViewIds.length !== mcpServerViews.length) {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -243,11 +243,21 @@ app.post(
       });
     }
 
-    // Validate all MCP server views exist before creating anything.
+    // Validate all MCP server views exist before creating anything. The views end up on the
+    // created skill, whose serialized response includes their tools — fetch the heavy attributes.
     const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
     const mcpServerViews = await MCPServerViewResource.fetchByIds(
       auth,
-      mcpServerViewIds
+      mcpServerViewIds,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     if (mcpServerViewIds.length !== mcpServerViews.length) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -249,7 +249,7 @@ app.get(
     const appsList = await AppResource.listBySpace(auth, space);
     const actions = await MCPServerViewResource.listBySpace(auth, space);
     const actionsCount = actions.filter(
-      (a) => a.toJSON().server.availability === "manual"
+      (a) => a.getServerDisplayMetadata().availability === "manual"
     ).length;
 
     const usages = await getDataSourceViewsUsageByModelIds({

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -32,18 +32,26 @@ app.get(
       workspaceServerViews,
     ] = await Promise.all([
       InternalMCPServerInMemoryResource.listByWorkspace(auth),
-      RemoteMCPServerResource.listByWorkspace(auth),
+      RemoteMCPServerResource.listByWorkspace(auth, {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }),
       MCPServerViewResource.listByWorkspaceEnsuringAutoViews(auth),
     ]);
 
     const globalServersId = workspaceServerViews
       .filter((s) => s.space.kind === "global")
-      .map((s) => s.toJSON().server.sId);
+      .map((s) => s.mcpServerId);
 
     const spaceServerViews = workspaceServerViews.filter(
       (s) => s.space.id === space.id
     );
-    const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.sId);
+    const spaceServersId = spaceServerViews.map((s) => s.mcpServerId);
 
     const availableServer: MCPServerType[] = [];
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -1,4 +1,3 @@
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
@@ -134,7 +133,15 @@ app.get(
     const { availability = "manual" } = r.data;
 
     const serverViews = (
-      await MCPServerViewResource.listBySpaceEnsuringAutoViews(auth, space)
+      await MCPServerViewResource.listBySpaceEnsuringAutoViews(auth, space, {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      })
     ).map((view) => view.toJSON());
 
     const filteredServerViews = serverViews.filter(
@@ -262,7 +269,7 @@ app.post(
     const affectedAgentNames = affectedAgents?.map((agent) => agent.name) ?? [];
 
     if (space.kind === "global" && affectedAgentNames.length > 0) {
-      const toolName = getMcpServerViewDisplayName(systemView.toJSON());
+      const toolName = systemView.getDisplayName();
 
       await notifyWorkspaceAdminsAboutAffectedAgents(auth, {
         toolName,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -40,6 +40,20 @@ app.get(
         (b.internalMCPServerId ?? b.remoteMCPServerId)
     );
 
+    // The lists above are fetched without the remote server heavy attributes (filtering only relies
+    // on view-level fields) — hydrate the activable subset before serializing it.
+    await MCPServerViewResource.hydrateRemoteServerHeavyAttributes(
+      auth,
+      activableMcpServerViews,
+      [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ]
+    );
+
     return ctx.json({
       success: true,
       serverViews: removeNulls(activableMcpServerViews.map((s) => s.toJSON())),

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -166,7 +166,8 @@ export async function fetchMCPServerActionConfigurations(
       serverName = "Missing";
       serverDescription = "Missing";
     } else {
-      const { name, description, icon, meta } = mcpServerView.toJSON().server;
+      const { name, description, icon, meta } =
+        mcpServerView.getServerDisplayMetadata();
 
       serverName = name;
       serverDescription = description;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -684,10 +684,11 @@ export async function* tryCallMCPTool(
     ) {
       const mcpServerView = await MCPServerViewResource.fetchById(
         auth,
-        toolConfiguration.mcpServerViewId
+        toolConfiguration.mcpServerViewId,
+        { includeHeavyAttributes: ["authorization"] }
       );
       if (mcpServerView) {
-        const authorization = mcpServerView.toJSON().server.authorization;
+        const authorization = mcpServerView.getAuthorization();
         if (authorization) {
           // Invalidate the cached access token so the next connection attempt
           // fetches a fresh token after the user re-authenticates.
@@ -1061,7 +1062,8 @@ export async function tryListMCPTools(
     isFromSkillServer: isSkillServerConfig[index],
   }));
 
-  // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries.
+  // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries. Only
+  // view-level fields are needed to build connection params: no heavy attributes.
   const serverSideViewIds = mcpServerActions
     .filter((config) => isServerSideMCPServerConfiguration(config))
     .map((config) => config.mcpServerViewId);
@@ -1429,14 +1431,18 @@ async function listMCPServerToolsAndServerInstructions(
         if (isRateLimited || isAuthError) {
           const remoteMCPServer = await RemoteMCPServerResource.fetchById(
             auth,
-            connectionParams.mcpServerId
+            connectionParams.mcpServerId,
+            { includeHeavyAttributes: ["cachedTools"] }
           );
-          if (remoteMCPServer?.cachedTools?.length) {
+          const cachedTools = remoteMCPServer
+            ? remoteMCPServer.getCachedTools()
+            : undefined;
+          if (cachedTools?.length) {
             logger.warn(
               {
                 workspaceId: owner.sId,
                 mcpServerId: connectionParams.mcpServerId,
-                cachedToolCount: remoteMCPServer.cachedTools.length,
+                cachedToolCount: cachedTools.length,
               },
               isRateLimited
                 ? "Remote MCP server rate limited, falling back to cached tools"
@@ -1446,7 +1452,7 @@ async function listMCPServerToolsAndServerInstructions(
               auth,
               connectionParams.mcpServerId,
               config,
-              remoteMCPServer.cachedTools
+              cachedTools
             );
             if (cachedToolsRes.isOk()) {
               return new Ok({

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -181,7 +181,10 @@ export function getMcpServerViewDescription(view: MCPServerViewType): string {
 }
 
 export function getMcpServerViewDisplayName(
-  view: MCPServerViewType,
+  view: {
+    name: string | null;
+    server: Pick<MCPServerType, "sId" | "name">;
+  },
   action?:
     | AgentBuilderMCPConfiguration
     | BuilderAction
@@ -194,7 +197,7 @@ export function getMcpServerViewDisplayName(
 }
 
 export function getMcpServerDisplayName(
-  server: MCPServerType,
+  server: Pick<MCPServerType, "sId" | "name">,
   action?:
     | AgentBuilderMCPConfiguration
     | BuilderAction

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -237,11 +237,14 @@ async function resolveRemoteServerOAuthToken(
     Error | MCPServerPersonalAuthenticationRequiredError
   >
 > {
+  const sharedSecret = remoteMCPServer.getSharedSecret();
+  const authorization = remoteMCPServer.getAuthorization();
+
   // Shared secret: no OAuth needed.
-  if (remoteMCPServer.sharedSecret) {
+  if (sharedSecret) {
     return new Ok({
       token: {
-        access_token: remoteMCPServer.sharedSecret,
+        access_token: sharedSecret,
         token_type: "bearer",
         expires_in: undefined,
         scope: "",
@@ -252,7 +255,7 @@ async function resolveRemoteServerOAuthToken(
   }
 
   // No authorization required.
-  if (!remoteMCPServer.authorization) {
+  if (!authorization) {
     return new Ok({
       token: undefined,
       oauthConnectionType: undefined,
@@ -307,7 +310,7 @@ async function resolveRemoteServerOAuthToken(
   }
 
   // Connection failed — return the appropriate error.
-  const { provider, scope } = remoteMCPServer.authorization;
+  const { provider, scope } = authorization;
 
   switch (connectionType) {
     case "personal": {
@@ -550,7 +553,16 @@ export async function connectToMCPServer(
         case "remote":
           const remoteMCPServer = await RemoteMCPServerResource.fetchById(
             auth,
-            params.mcpServerId
+            params.mcpServerId,
+            // Connecting only needs the auth material — skip `cachedTools`, the column
+            // whose detoasting this fetch is hot enough to care about.
+            {
+              includeHeavyAttributes: [
+                "authorization",
+                "customHeaders",
+                "sharedSecret",
+              ],
+            }
           );
 
           if (!remoteMCPServer) {
@@ -573,6 +585,9 @@ export async function connectToMCPServer(
           const { token, oauthConnectionType, oauthConnectionId } =
             tokenRes.value;
 
+          const authorization = remoteMCPServer.getAuthorization();
+          const customHeaders = remoteMCPServer.getCustomHeaders();
+
           const {
             dispatcher,
             fetch: proxyFetch,
@@ -583,7 +598,7 @@ export async function connectToMCPServer(
             const req = {
               requestInit: {
                 // Include stored custom headers
-                headers: remoteMCPServer.customHeaders ?? {},
+                headers: customHeaders ?? {},
                 dispatcher,
               },
               authProvider: new MCPOAuthProvider(token),
@@ -597,18 +612,18 @@ export async function connectToMCPServer(
             // MCPOAuthProviderError. This reliably indicates token rejection.
             if (
               e instanceof MCPOAuthProviderError &&
-              remoteMCPServer.authorization &&
+              authorization &&
               oauthConnectionType
             ) {
               if (oauthConnectionId) {
                 invalidateOAuthConnectionAccessTokenCache(oauthConnectionId);
               }
-              const scope = remoteMCPServer.authorization.scope;
+              const scope = authorization.scope;
               if (oauthConnectionType === "personal") {
                 return new Err(
                   new MCPServerPersonalAuthenticationRequiredError(
                     params.mcpServerId,
-                    remoteMCPServer.authorization.provider,
+                    authorization.provider,
                     scope
                   )
                 );
@@ -616,7 +631,7 @@ export async function connectToMCPServer(
               return new Err(
                 new MCPServerRequiresAdminAuthenticationError(
                   params.mcpServerId,
-                  remoteMCPServer.authorization.provider,
+                  authorization.provider,
                   scope,
                   "reconnect"
                 )

--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -51,7 +51,16 @@ export const getAccessibleSourcesAndAppsForActions = async (
       }),
       MCPServerViewResource.listBySpacesEnsuringAutoViews(
         auth,
-        accessibleSpaces
+        accessibleSpaces,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       ),
     ]);
 

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -270,11 +270,12 @@ export class AgentYAMLConverter {
       if (!mcpServerView) {
         return null;
       }
-      const json = mcpServerView.toJSON();
       // Match the precedence used to resolve names back on import
       // (see MCPServerViewResource.resolveAttachableByName): the view's
       // custom display name, if set, takes priority over the server's name.
-      return json.name ?? json.server.name;
+      return (
+        mcpServerView.name ?? mcpServerView.getServerDisplayMetadata().name
+      );
     } catch {
       return null;
     }

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -338,7 +338,19 @@ export async function createToolsSuggestions({
   }
 
   // Validate that all tool IDs exist and are accessible.
-  const tools = await MCPServerViewResource.fetchByIds(auth, suggestionToolIds);
+  const tools = await MCPServerViewResource.fetchByIds(
+    auth,
+    suggestionToolIds,
+    {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }
+  );
   const foundToolIds = new Set(tools.map((t) => t.sId));
   const missingToolIds = suggestionToolIds.filter(
     (id) => !foundToolIds.has(id)

--- a/front/lib/api/actions/servers/poke/tools/conversations.ts
+++ b/front/lib/api/actions/servers/poke/tools/conversations.ts
@@ -104,7 +104,16 @@ export const conversationHandlers: ConversationHandlers = {
     if (server_view_id) {
       const mcpServerView = await MCPServerViewResource.fetchById(
         targetAuthResult.value,
-        server_view_id
+        server_view_id,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       if (!mcpServerView) {
         return new Err(
@@ -122,7 +131,16 @@ export const conversationHandlers: ConversationHandlers = {
 
     // List all MCP server views for the workspace.
     const mcpServerViews = await MCPServerViewResource.listByWorkspace(
-      targetAuthResult.value
+      targetAuthResult.value,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     return jsonResponse({

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -129,7 +129,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
 
     const prefixHint = enabledView
       ? ` Their names share the \`${getToolNamePrefix(
-          enabledView.toJSON().name ?? enabledView.toJSON().server.name
+          enabledView.name ?? enabledView.getServerDisplayMetadata().name
         )}${TOOL_NAME_SEPARATOR}\` prefix.`
       : "";
 

--- a/front/lib/api/assistant/configuration/actions.ts
+++ b/front/lib/api/assistant/configuration/actions.ts
@@ -47,9 +47,8 @@ export async function createAgentActionConfiguration(
   if (!mcpServerView) {
     return new Err(new Error("MCP server view not found"));
   }
-  const {
-    server: { name: serverName, description: serverDescription },
-  } = mcpServerView.toJSON();
+  const { name: serverName, description: serverDescription } =
+    mcpServerView.getServerDisplayMetadata();
 
   return withTransaction(async (t) => {
     const mcpConfig = await AgentMCPServerConfigurationModel.create(

--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -33,16 +33,16 @@ export async function getConversationMCPServers(
     mcpServerViewIds
   );
 
-  return mcpServerViews.map((mcpServerViewResource) => {
-    const mcpServerView = mcpServerViewResource.toJSON();
+  return mcpServerViews.map((mcpServerView) => {
+    const serverDisplayMetadata = mcpServerView.getServerDisplayMetadata();
 
     return {
       id: -1,
       sId: generateRandomModelSId(),
       type: "mcp_server_configuration",
-      name: mcpServerView.name ?? mcpServerView.server.name,
+      name: mcpServerView.name ?? serverDisplayMetadata.name,
       description:
-        mcpServerView.description ?? mcpServerView.server.description,
+        mcpServerView.description ?? serverDisplayMetadata.description,
       dataSources: null,
       tables: null,
       childAgentId: null,
@@ -55,7 +55,7 @@ export async function getConversationMCPServers(
       dustAppConfiguration: null,
       internalMCPServerId:
         mcpServerView.serverType === "internal"
-          ? mcpServerView.server.sId
+          ? mcpServerView.mcpServerId
           : null,
     };
   });

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -106,7 +106,19 @@ export async function listAvailableTools(
 
   // Fetch all MCP server views from those spaces.
   const mcpServerViews =
-    await MCPServerViewResource.listBySpacesEnsuringAutoViews(auth, userSpaces);
+    await MCPServerViewResource.listBySpacesEnsuringAutoViews(
+      auth,
+      userSpaces,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
+    );
 
   return mcpServerViews
     .map((v) => v.toJSON())
@@ -154,6 +166,14 @@ export async function describeMcpServer(
   auth: Authenticator,
   mcpId: string
 ): Promise<MCPServerType | null> {
-  const [view] = await MCPServerViewResource.fetchByIds(auth, [mcpId]);
+  const [view] = await MCPServerViewResource.fetchByIds(auth, [mcpId], {
+    includeHeavyAttributes: [
+      "authorization",
+      "cachedTools",
+      "customHeaders",
+      "lastError",
+      "sharedSecret",
+    ],
+  });
   return view?.toJSON()?.server ?? null;
 }

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -38,7 +38,15 @@ export async function listMCPServersWithViews(
   auth: Authenticator
 ): Promise<MCPServerTypeWithViews[]> {
   const [remoteMCPs, internalMCPs] = await Promise.all([
-    RemoteMCPServerResource.listByWorkspace(auth),
+    RemoteMCPServerResource.listByWorkspace(auth, {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }),
     InternalMCPServerInMemoryResource.listByWorkspace(auth),
   ]);
 
@@ -49,7 +57,16 @@ export async function listMCPServersWithViews(
   // Batch-fetch all views in a single query instead of N+1.
   const allViews = await MCPServerViewResource.listByMCPServers(
     auth,
-    servers.map((s) => s.sId)
+    servers.map((s) => s.sId),
+    {
+      includeHeavyAttributes: [
+        "authorization",
+        "cachedTools",
+        "customHeaders",
+        "lastError",
+        "sharedSecret",
+      ],
+    }
   );
 
   const viewsByServerId = new Map<string, MCPServerViewType[]>();

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -109,8 +109,7 @@ export async function updateNameAndDescriptionForMCPServerViews(
         if (v.mcpServerId === mcpServerId) {
           return false;
         }
-        const viewJson = v.toJSON();
-        return (viewJson.name ?? viewJson.server.name) === name;
+        return (v.name ?? v.getServerDisplayMetadata().name) === name;
       });
 
       if (hasConflict) {

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -541,7 +541,8 @@ async function runOAuthDiscoveryCheck(
 
   const remoteServer = await RemoteMCPServerResource.fetchById(
     auth,
-    mcpServerId
+    mcpServerId,
+    { includeHeavyAttributes: ["customHeaders"] }
   );
 
   if (!remoteServer?.url) {
@@ -558,7 +559,7 @@ async function runOAuthDiscoveryCheck(
 
   const discoveryRes = await probeOAuthDiscovery({
     serverUrl: remoteServer.url,
-    customHeaders: remoteServer.customHeaders ?? undefined,
+    customHeaders: remoteServer.getCustomHeaders() ?? undefined,
   });
   const duration_ms = Date.now() - startedAt;
 

--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-credentials.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-credentials.ts
@@ -118,14 +118,16 @@ export const getMcpServerViewAccessTokenPlugin = createPlugin({
 
         const remoteServer = await RemoteMCPServerResource.findByPk(
           auth,
-          mcpServerView.remoteMCPServerId
+          mcpServerView.remoteMCPServerId,
+          { includeHeavyAttributes: ["sharedSecret"] }
         );
 
         if (!remoteServer) {
           return new Err(new Error("Remote MCP server not found."));
         }
 
-        if (!remoteServer.sharedSecret) {
+        const sharedSecret = remoteServer.getSharedSecret();
+        if (!sharedSecret) {
           return new Err(
             new Error(
               "No credentials found: this remote MCP server has no OAuth connection or API key configured."
@@ -135,7 +137,7 @@ export const getMcpServerViewAccessTokenPlugin = createPlugin({
 
         return new Ok({
           display: "text",
-          value: remoteServer.sharedSecret,
+          value: sharedSecret,
         });
       }
 

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -133,7 +133,15 @@ export async function createSandboxFunctionMCPAction(
     );
   }
 
-  const view = await MCPServerViewResource.fetchById(auth, serverViewId);
+  const view = await MCPServerViewResource.fetchById(auth, serverViewId, {
+    includeHeavyAttributes: [
+      "authorization",
+      "cachedTools",
+      "customHeaders",
+      "lastError",
+      "sharedSecret",
+    ],
+  });
   // `fetchById` is workspace-scoped, so reproduce the listing endpoint's confinement: the view
   // must be in the pod or global space (the spaces the listing queries) AND readable by the
   // caller. The permission check keeps this correct if pod access is revoked within the token

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1,5 +1,4 @@
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import {
   getInternalMCPServerNameFromSId,
   type InternalMCPServerNameType,
@@ -407,7 +406,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       getAgentConfigurationsWithVersion(auth, agentConfigVersionPairs, {
         variant: "extra_light",
       }),
-      MCPServerViewResource.fetchByIds(auth, mcpServerViewIds),
+      MCPServerViewResource.fetchByIds(auth, mcpServerViewIds, {
+        includeHeavyAttributes: ["authorization"],
+      }),
     ]);
 
     const agentConfigurationMap = new Map(
@@ -438,13 +439,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         ? mcpServerViewMap.get(action.toolConfiguration.mcpServerViewId)
         : null;
 
-      const authorizationInfo =
-        mcpServerView?.toJSON().server.authorization ?? null;
+      const authorizationInfo = mcpServerView?.getAuthorization() ?? null;
 
       const mcpServerId = mcpServerView?.mcpServerId;
-      const mcpServerDisplayName = mcpServerView
-        ? getMcpServerViewDisplayName(mcpServerView.toJSON())
-        : undefined;
+      const mcpServerDisplayName = mcpServerView?.getDisplayName();
 
       const parentUserMessage =
         parentUserMessageById[agentMessage.message.parentId!];

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -809,7 +809,16 @@ describe("MCPServerViewResource", () => {
       // Fetch the system view through baseFetch.
       const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
         adminAuth,
-        remoteServer.sId
+        remoteServer.sId,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       expect(view).not.toBeNull();
 
@@ -827,7 +836,16 @@ describe("MCPServerViewResource", () => {
 
       const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
         adminAuth,
-        remoteServer.sId
+        remoteServer.sId,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       expect(view).not.toBeNull();
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1,9 +1,18 @@
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
+import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import {
   autoInternalMCPServerNameToSId,
+  getMcpServerViewDisplayName,
   getServerTypeAndIdFromSId,
   remoteMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
-import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  AutoInternalMCPServerNameType,
+  MCPServerAvailability,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getAvailabilityOfInternalMCPServerById,
@@ -13,7 +22,7 @@ import {
   isValidInternalMCPServerId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
@@ -22,6 +31,7 @@ import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import type { RemoteMCPServerHeavyAttributeType } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -166,7 +176,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     if (blob.remoteMCPServerId) {
       const remoteServer = await RemoteMCPServerResource.findByPk(
         auth,
-        blob.remoteMCPServerId
+        blob.remoteMCPServerId,
+        {
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       if (!remoteServer) {
         throw new DustError(
@@ -203,8 +222,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     systemView: MCPServerViewResource,
     space: SpaceResource
   ): Promise<{ hasConflict: boolean; name: string }> {
-    const viewJson = systemView.toJSON();
-    const name = viewJson.name ?? viewJson.server.name;
+    const name = systemView.name ?? systemView.getServerDisplayMetadata().name;
 
     return this.hasNameConflictInSpaceByName(auth, name, space);
   }
@@ -219,10 +237,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     space: SpaceResource
   ): Promise<{ hasConflict: boolean; name: string }> {
     const existingViews = await this.listBySpace(auth, space);
-    const hasConflict = existingViews.some((v) => {
-      const view = v.toJSON();
-      return (view.name ?? view.server.name) === name;
-    });
+    const hasConflict = existingViews.some(
+      (v) => (v.name ?? v.getServerDisplayMetadata().name) === name
+    );
 
     return { hasConflict, name };
   }
@@ -393,8 +410,13 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     options: ResourceFindOptions<MCPServerViewModel> = {},
     {
       includeMetadata = true,
+      includeHeavyAttributes,
       transaction,
-    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
+    }: {
+      includeMetadata?: boolean;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+      transaction?: Transaction;
+    } = {}
   ) {
     const views = await this.baseFetchWithAuthorization(
       auth,
@@ -425,7 +447,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
         auth,
         removeNulls(views.map((v) => v.remoteMCPServerId)),
-        transaction
+        { transaction, includeHeavyAttributes }
       );
       const remoteServerMap = new Map(remoteServers.map((s) => [s.id, s]));
 
@@ -539,7 +561,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async fetchById(
     auth: Authenticator,
     id: string,
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource | null> {
     const [mcpServerView] = await this.fetchByIds(auth, [id], options);
 
@@ -549,19 +573,26 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     const viewModelIds = removeNulls(ids.map((id) => getResourceIdFromSId(id)));
+    const { includeHeavyAttributes, ...findOptions } = options ?? {};
 
-    const views = await this.baseFetch(auth, {
-      ...options,
-      where: {
-        ...options?.where,
-        id: {
-          [Op.in]: viewModelIds,
+    const views = await this.baseFetch(
+      auth,
+      {
+        ...findOptions,
+        where: {
+          ...findOptions.where,
+          id: {
+            [Op.in]: viewModelIds,
+          },
         },
       },
-    });
+      { includeHeavyAttributes }
+    );
 
     return views ?? [];
   }
@@ -581,8 +612,13 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     ids: ModelId[],
     {
       includeMetadata = true,
+      includeHeavyAttributes,
       transaction,
-    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
+    }: {
+      includeMetadata?: boolean;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+      transaction?: Transaction;
+    } = {}
   ) {
     const views = await this.baseFetch(
       auth,
@@ -593,7 +629,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeMetadata, transaction }
+      { includeMetadata, includeHeavyAttributes, transaction }
     );
 
     return views ?? [];
@@ -601,15 +637,20 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   static async listByWorkspace(
     auth: Authenticator,
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
-    return this.baseFetch(auth, options);
+    const { includeHeavyAttributes, ...findOptions } = options ?? {};
+    return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
   static async listBySpaces(
     auth: Authenticator,
     spaces: SpaceResource[],
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     // Filter out spaces that the user does not have read or administrate access to
     const accessibleSpaces = spaces.filter((s) =>
@@ -618,21 +659,32 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     if (accessibleSpaces.length === 0) {
       return [];
     }
-    return this.baseFetch(auth, {
-      ...options,
-      where: {
-        ...options?.where,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        vaultId: accessibleSpaces.map((s) => s.id),
+    const { includeHeavyAttributes, ...findOptions } = options ?? {};
+    return this.baseFetch(
+      auth,
+      {
+        ...findOptions,
+        where: {
+          ...findOptions.where,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          vaultId: accessibleSpaces.map((s) => s.id),
+        },
+        order: [["id", "ASC"]],
       },
-      order: [["id", "ASC"]],
-    });
+      { includeHeavyAttributes }
+    );
   }
 
   static async listBySpaceIds(
     auth: Authenticator,
     spaceIds: string[],
-    { includeGlobalSpace = false }: { includeGlobalSpace?: boolean } = {}
+    {
+      includeGlobalSpace = false,
+      includeHeavyAttributes,
+    }: {
+      includeGlobalSpace?: boolean;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<MCPServerViewResource[]> {
     const spaceModelIds = removeNulls(spaceIds.map(getResourceIdFromSId));
 
@@ -640,25 +692,29 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return [];
     }
 
-    const views = await this.baseFetch(auth, {
-      includes: [
-        {
-          model: SpaceResource.model,
-          as: "space",
-          attributes: [],
-          required: true,
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            deletedAt: null,
-            [Op.or]: [
-              { id: { [Op.in]: spaceModelIds } },
-              ...(includeGlobalSpace ? [{ kind: "global" }] : []),
-            ],
+    const views = await this.baseFetch(
+      auth,
+      {
+        includes: [
+          {
+            model: SpaceResource.model,
+            as: "space",
+            attributes: [],
+            required: true,
+            where: {
+              workspaceId: auth.getNonNullableWorkspace().id,
+              deletedAt: null,
+              [Op.or]: [
+                { id: { [Op.in]: spaceModelIds } },
+                ...(includeGlobalSpace ? [{ kind: "global" }] : []),
+              ],
+            },
           },
-        },
-      ],
-      order: [["id", "ASC"]],
-    });
+        ],
+        order: [["id", "ASC"]],
+      },
+      { includeHeavyAttributes }
+    );
 
     // Permission parity with listBySpaces: the canReadOrAdministrate pre-filter on fetched
     // spaces becomes a post-filter on the space hydrated by baseFetchWithAuthorization.
@@ -668,7 +724,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listBySpace(
     auth: Authenticator,
     space: SpaceResource,
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     return this.listBySpaces(auth, [space], options);
   }
@@ -690,7 +748,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listBySpacesEnsuringAutoViews(
     auth: Authenticator,
     spaces: SpaceResource[],
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     await this.unsafeEnsureAutoViewsForWorkspace(auth);
     return this.listBySpaces(auth, spaces, options);
@@ -699,7 +759,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listBySpaceEnsuringAutoViews(
     auth: Authenticator,
     space: SpaceResource,
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     return this.listBySpacesEnsuringAutoViews(auth, [space], options);
   }
@@ -707,15 +769,26 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listBySpaceIdsEnsuringAutoViews(
     auth: Authenticator,
     spaceIds: string[],
-    { includeGlobalSpace = false }: { includeGlobalSpace?: boolean } = {}
+    {
+      includeGlobalSpace = false,
+      includeHeavyAttributes,
+    }: {
+      includeGlobalSpace?: boolean;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<MCPServerViewResource[]> {
     await this.unsafeEnsureAutoViewsForWorkspace(auth);
-    return this.listBySpaceIds(auth, spaceIds, { includeGlobalSpace });
+    return this.listBySpaceIds(auth, spaceIds, {
+      includeGlobalSpace,
+      includeHeavyAttributes,
+    });
   }
 
   static async listForSystemSpace(
     auth: Authenticator,
-    options?: ResourceFindOptions<MCPServerViewModel>
+    options?: ResourceFindOptions<MCPServerViewModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<MCPServerViewResource[]> {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
@@ -725,7 +798,13 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listByMCPServers(
     auth: Authenticator,
     mcpServerIds: string[],
-    transaction?: Transaction
+    {
+      transaction,
+      includeHeavyAttributes,
+    }: {
+      transaction?: Transaction;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<MCPServerViewResource[]> {
     const serverTypesAndIds = mcpServerIds.map((mcpServerId) => ({
       ...getServerTypeAndIdFromSId(mcpServerId),
@@ -756,16 +835,19 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           ],
         },
       },
-      { transaction }
+      { transaction, includeHeavyAttributes }
     );
   }
 
   static async listByMCPServer(
     auth: Authenticator,
     mcpServerId: string,
-    transaction?: Transaction
+    options: {
+      transaction?: Transaction;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<MCPServerViewResource[]> {
-    return this.listByMCPServers(auth, [mcpServerId], transaction);
+    return this.listByMCPServers(auth, [mcpServerId], options);
   }
 
   static async getByMCPServerAndSpace(
@@ -870,8 +952,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ) {
         return false;
       }
-      const json = view.toJSON();
-      return (json.name ?? json.server.name) === name;
+      return (view.name ?? view.getServerDisplayMetadata().name) === name;
     });
 
     if (matches.length === 0) {
@@ -904,7 +985,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
       }),
-      transaction
+      { transaction }
     );
 
     // We include the global space, which is omitted from the requested space IDs of an agent.
@@ -948,7 +1029,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   static async getMCPServerViewForSystemSpace(
     auth: Authenticator,
-    mcpServerId: string
+    mcpServerId: string,
+    {
+      includeHeavyAttributes,
+    }: {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<MCPServerViewResource | null> {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
@@ -962,13 +1048,17 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       });
       return views[0] ?? null;
     } else {
-      const views = await this.baseFetch(auth, {
-        where: {
-          serverType: "remote",
-          remoteMCPServerId: id,
-          vaultId: systemSpace.id,
+      const views = await this.baseFetch(
+        auth,
+        {
+          where: {
+            serverType: "remote",
+            remoteMCPServerId: id,
+            vaultId: systemSpace.id,
+          },
         },
-      });
+        { includeHeavyAttributes }
+      );
       return views[0] ?? null;
     }
   }
@@ -1122,6 +1212,92 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
 
     return this.internalMCPServer;
+  }
+
+  /**
+   * Server display metadata that is available without the remote server payload (no tools,
+   * secrets or errors). Safe to use on views fetched without any heavy attributes.
+   */
+  getServerDisplayMetadata(): {
+    name: string;
+    description: string;
+    icon: CustomResourceIconType | InternalAllowedIconType;
+    meta: Record<string, string> | null;
+    availability: MCPServerAvailability;
+  } {
+    switch (this.serverType) {
+      case "remote": {
+        const server = this.getRemoteMCPServerResource();
+        return {
+          name: server.cachedName,
+          description:
+            server.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+          icon: server.icon,
+          meta: server.meta,
+          // Remote MCP servers are always manually installed (see
+          // RemoteMCPServerResource.toJSON).
+          availability: "manual",
+        };
+      }
+      case "internal": {
+        const server = this.getInternalMCPServerResource().toJSON();
+        return {
+          name: server.name,
+          description: server.description,
+          icon: server.icon,
+          meta: server.meta ?? null,
+          availability: server.availability,
+        };
+      }
+      default:
+        assertNever(this.serverType);
+    }
+  }
+
+  /**
+   * The server's authorization config with the view's admin-configured scope restriction
+   * applied. For remote servers this only needs the `authorization` heavy attribute.
+   */
+  getAuthorization(): MCPServerType["authorization"] {
+    const authorization =
+      this.serverType === "remote"
+        ? this.getRemoteMCPServerResource().getAuthorization()
+        : this.getInternalMCPServerResource().toJSON().authorization;
+    if (this.oauthScope !== null && authorization) {
+      return { ...authorization, scope: this.oauthScope };
+    }
+    return authorization;
+  }
+
+  /**
+   * Display name resolution, available without the remote server heavy attributes.
+   */
+  getDisplayName(): string {
+    return getMcpServerViewDisplayName({
+      name: this.name,
+      server: {
+        sId: this.mcpServerId,
+        name: this.getServerDisplayMetadata().name,
+      },
+    });
+  }
+
+  /**
+   * JIT-hydrate the requested heavy attributes on the views' remote servers, e.g. before
+   * serializing a filtered subset with `toJSON`.
+   */
+  static async hydrateRemoteServerHeavyAttributes(
+    auth: Authenticator,
+    views: MCPServerViewResource[],
+    attributes: readonly RemoteMCPServerHeavyAttributeType[],
+    transaction?: Transaction
+  ): Promise<void> {
+    await RemoteMCPServerResource.hydrateHeavyAttributes(
+      auth,
+      removeNulls(views.map((v) => v.remoteMCPServer ?? null)),
+      attributes,
+      transaction
+    );
   }
 
   get sId(): string {
@@ -1500,13 +1676,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     // Override the server's default authorization scope with the admin-configured
     // restriction if one has been set. This ensures personal connections and
     // platform OAuth setup both use the restricted scope.
-    const serverWithScope =
-      this.oauthScope !== null && server.authorization
-        ? {
-            ...server,
-            authorization: { ...server.authorization, scope: this.oauthScope },
-          }
-        : server;
+    const serverWithScope = {
+      ...server,
+      authorization: this.getAuthorization(),
+    };
 
     return {
       id: this.id,

--- a/front/lib/resources/remote_mcp_servers_resource.test.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.test.ts
@@ -104,13 +104,83 @@ describe("RemoteMCPServerResource.updateMetadata", () => {
     expect(remainingNames).toEqual(["tool_a", "tool_c"]);
 
     // Also ensure the server actually updated its cachedTools.
-    const refreshed = (await RemoteMCPServerResource.findByPk(
+    const refreshed = (await RemoteMCPServerResource.findByPk(auth, server.id, {
+      includeHeavyAttributes: ["cachedTools"],
+    }))!;
+    expect(
+      refreshed
+        .getCachedTools()
+        .map((t) => t.name)
+        .sort()
+    ).toEqual(["tool_a", "tool_c"]);
+  });
+});
+
+describe("RemoteMCPServerResource heavy attributes contract", () => {
+  async function setup() {
+    const workspace = await WorkspaceFactory.basic();
+    await SpaceFactory.system(workspace);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Contract Server",
+      tools: [{ name: "tool_a", description: "A", inputSchema: undefined }],
+    });
+
+    return { auth, server };
+  }
+
+  it("should throw on heavy attribute getters after a light fetch", async () => {
+    const { auth, server } = await setup();
+
+    const light = (await RemoteMCPServerResource.findByPk(auth, server.id))!;
+
+    expect(() => light.getCachedTools()).toThrow(/was not fetched/);
+    expect(() => light.getSharedSecret()).toThrow(/was not fetched/);
+    expect(() => light.getAuthorization()).toThrow(/was not fetched/);
+    expect(() => light.getCustomHeaders()).toThrow(/was not fetched/);
+    expect(() => light.getLastError()).toThrow(/was not fetched/);
+  });
+
+  it("should only expose the getters listed in includeHeavyAttributes", async () => {
+    const { auth, server } = await setup();
+
+    const partial = (await RemoteMCPServerResource.findByPk(auth, server.id, {
+      includeHeavyAttributes: ["sharedSecret"],
+    }))!;
+
+    expect(() => partial.getSharedSecret()).not.toThrow();
+    expect(() => partial.getCachedTools()).toThrow(/was not fetched/);
+    expect(() => partial.getAuthorization()).toThrow(/was not fetched/);
+  });
+
+  it("should hydrate only the requested heavy attributes", async () => {
+    const { auth, server } = await setup();
+
+    const light = (await RemoteMCPServerResource.findByPk(auth, server.id))!;
+    await RemoteMCPServerResource.hydrateHeavyAttributes(
       auth,
-      server.id
-    ))!;
-    expect(refreshed.cachedTools?.map((t) => t.name).sort()).toEqual([
-      "tool_a",
-      "tool_c",
-    ]);
+      [light],
+      ["cachedTools"]
+    );
+
+    expect(light.getCachedTools().map((t) => t.name)).toEqual(["tool_a"]);
+    expect(() => light.getSharedSecret()).toThrow(/was not fetched/);
+  });
+
+  it("should reflect updateMetadata writes on getters without a refetch", async () => {
+    const { auth, server } = await setup();
+
+    const light = (await RemoteMCPServerResource.findByPk(auth, server.id))!;
+    expect(() => light.getCachedTools()).toThrow(/was not fetched/);
+
+    await light.updateMetadata(auth, {
+      cachedTools: [
+        { name: "tool_new", description: "N", inputSchema: undefined },
+      ],
+      lastSyncAt: new Date(),
+    });
+
+    expect(light.getCachedTools().map((t) => t.name)).toEqual(["tool_new"]);
   });
 });

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -58,19 +58,161 @@ import { Op } from "sequelize";
 
 const SECRET_REDACTION_COOLDOWN_IN_MINUTES = 10;
 
+// Unbounded columns (large JSONB/TEXT values) excluded from the base fetch. Callers opt into
+// the ones they need via `includeHeavyAttributes`, or hydrate later via `hydrateHeavyAttributes`.
+const REMOTE_MCP_SERVER_HEAVY_ATTRIBUTES = [
+  "authorization",
+  "cachedTools",
+  "customHeaders",
+  "lastError",
+  "sharedSecret",
+] as const;
+
+export type RemoteMCPServerHeavyAttributeType =
+  (typeof REMOTE_MCP_SERVER_HEAVY_ATTRIBUTES)[number];
+
+type RemoteMCPServerHeavyAttributesType = Pick<
+  Attributes<RemoteMCPServerModel>,
+  RemoteMCPServerHeavyAttributeType
+>;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// Heavy attributes are not exposed directly: use their getters (`getCachedTools`, ...) after
+// listing them in `includeHeavyAttributes` at fetch time (none are fetched by default) or
+// after an explicit `hydrateHeavyAttributes`.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface RemoteMCPServerResource
-  extends ReadonlyAttributesType<RemoteMCPServerModel> {}
+  extends Omit<
+    ReadonlyAttributesType<RemoteMCPServerModel>,
+    RemoteMCPServerHeavyAttributeType
+  > {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> {
   static model: ModelStatic<RemoteMCPServerModel> = RemoteMCPServerModel;
+
+  // Only the keys fetched so far are present; a key mapped to `null` is a fetched NULL, an
+  // absent key was never fetched.
+  private heavyAttributes: Partial<RemoteMCPServerHeavyAttributesType>;
 
   constructor(
     model: ModelStatic<RemoteMCPServerModel>,
     blob: Attributes<RemoteMCPServerModel>
   ) {
     super(RemoteMCPServerModel, blob);
+    // Rows fetched without a heavy attribute do not carry its key at all.
+    this.heavyAttributes = {
+      ...("authorization" in blob ? { authorization: blob.authorization } : {}),
+      ...("cachedTools" in blob ? { cachedTools: blob.cachedTools } : {}),
+      ...("customHeaders" in blob ? { customHeaders: blob.customHeaders } : {}),
+      ...("lastError" in blob ? { lastError: blob.lastError } : {}),
+      ...("sharedSecret" in blob ? { sharedSecret: blob.sharedSecret } : {}),
+    };
+  }
+
+  private static missingHeavyAttributeMessage(
+    key: RemoteMCPServerHeavyAttributeType
+  ): string {
+    return (
+      `Remote MCP server \`${key}\` was not fetched — list it in ` +
+      "`includeHeavyAttributes` or call `hydrateHeavyAttributes` first"
+    );
+  }
+
+  getAuthorization(): RemoteMCPServerHeavyAttributesType["authorization"] {
+    const { authorization } = this.heavyAttributes;
+    assert(
+      authorization !== undefined,
+      RemoteMCPServerResource.missingHeavyAttributeMessage("authorization")
+    );
+    return authorization;
+  }
+
+  getCachedTools(): RemoteMCPServerHeavyAttributesType["cachedTools"] {
+    const { cachedTools } = this.heavyAttributes;
+    assert(
+      cachedTools !== undefined,
+      RemoteMCPServerResource.missingHeavyAttributeMessage("cachedTools")
+    );
+    return cachedTools;
+  }
+
+  getCustomHeaders(): RemoteMCPServerHeavyAttributesType["customHeaders"] {
+    const { customHeaders } = this.heavyAttributes;
+    assert(
+      customHeaders !== undefined,
+      RemoteMCPServerResource.missingHeavyAttributeMessage("customHeaders")
+    );
+    return customHeaders;
+  }
+
+  getLastError(): RemoteMCPServerHeavyAttributesType["lastError"] {
+    const { lastError } = this.heavyAttributes;
+    assert(
+      lastError !== undefined,
+      RemoteMCPServerResource.missingHeavyAttributeMessage("lastError")
+    );
+    return lastError;
+  }
+
+  getSharedSecret(): RemoteMCPServerHeavyAttributesType["sharedSecret"] {
+    const { sharedSecret } = this.heavyAttributes;
+    assert(
+      sharedSecret !== undefined,
+      RemoteMCPServerResource.missingHeavyAttributeMessage("sharedSecret")
+    );
+    return sharedSecret;
+  }
+
+  static async hydrateHeavyAttributes(
+    auth: Authenticator,
+    servers: RemoteMCPServerResource[],
+    attributes: readonly RemoteMCPServerHeavyAttributeType[],
+    transaction?: Transaction
+  ): Promise<void> {
+    const requested = new Set(attributes);
+    const missing = servers.filter((s) =>
+      attributes.some((key) => !(key in s.heavyAttributes))
+    );
+    if (missing.length === 0) {
+      return;
+    }
+    const rows = await RemoteMCPServerModel.findAll({
+      where: {
+        id: { [Op.in]: missing.map((s) => s.id) },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      attributes: ["id", ...attributes],
+      transaction,
+    });
+    const rowById = new Map(rows.map((r) => [r.id, r]));
+    for (const server of missing) {
+      const row = rowById.get(server.id);
+      if (!row) {
+        // The server can be deleted between the base fetch and this one — leave its heavy
+        // attributes unset rather than failing the whole batch.
+        logger.warn(
+          { remoteMCPServerId: server.id },
+          "Remote MCP server row missing when hydrating heavy attributes"
+        );
+        continue;
+      }
+      server.heavyAttributes = {
+        ...server.heavyAttributes,
+        ...(requested.has("authorization")
+          ? { authorization: row.authorization }
+          : {}),
+        ...(requested.has("cachedTools")
+          ? { cachedTools: row.cachedTools }
+          : {}),
+        ...(requested.has("customHeaders")
+          ? { customHeaders: row.customHeaders }
+          : {}),
+        ...(requested.has("lastError") ? { lastError: row.lastError } : {}),
+        ...(requested.has("sharedSecret")
+          ? { sharedSecret: row.sharedSecret }
+          : {}),
+      };
+    }
   }
 
   static async makeNew(
@@ -126,16 +268,30 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<RemoteMCPServerModel>,
+    options?: ResourceFindOptions<RemoteMCPServerModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    },
     transaction?: Transaction
   ) {
-    const { where, ...otherOptions } = options ?? {};
+    const {
+      where,
+      includeHeavyAttributes = [],
+      ...otherOptions
+    } = options ?? {};
+
+    const includedHeavyAttributes = new Set(includeHeavyAttributes);
+    const excludedHeavyAttributes = REMOTE_MCP_SERVER_HEAVY_ATTRIBUTES.filter(
+      (key) => !includedHeavyAttributes.has(key)
+    );
 
     const servers = await RemoteMCPServerModel.findAll({
       where: {
         ...where,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
+      ...(excludedHeavyAttributes.length > 0
+        ? { attributes: { exclude: excludedHeavyAttributes } }
+        : {}),
       ...otherOptions,
       transaction,
     });
@@ -147,27 +303,38 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   static async fetchByIds(
     auth: Authenticator,
-    ids: string[]
+    ids: string[],
+    {
+      includeHeavyAttributes,
+    }: {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<RemoteMCPServerResource[]> {
     return this.baseFetch(auth, {
       where: {
         id: removeNulls(ids.map(getResourceIdFromSId)),
       },
+      includeHeavyAttributes,
     });
   }
 
   static async fetchById(
     auth: Authenticator,
-    id: string
+    id: string,
+    options: {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<RemoteMCPServerResource | null> {
-    const [server] = await this.fetchByIds(auth, [id]);
+    const [server] = await this.fetchByIds(auth, [id], options);
     return server ?? null;
   }
 
   static async findByPk(
     auth: Authenticator,
     id: number,
-    options?: ResourceFindOptions<RemoteMCPServerModel>
+    options?: ResourceFindOptions<RemoteMCPServerModel> & {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    }
   ): Promise<RemoteMCPServerResource | null> {
     const servers = await this.baseFetch(auth, {
       where: {
@@ -181,7 +348,13 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    transaction?: Transaction
+    {
+      transaction,
+      includeHeavyAttributes,
+    }: {
+      transaction?: Transaction;
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
   ): Promise<RemoteMCPServerResource[]> {
     if (ids.length === 0) {
       return [];
@@ -190,6 +363,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       auth,
       {
         where: { id: { [Op.in]: ids } },
+        includeHeavyAttributes,
       },
       transaction
     );
@@ -216,8 +390,15 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return nameMap;
   }
 
-  static async listByWorkspace(auth: Authenticator) {
-    return this.baseFetch(auth);
+  static async listByWorkspace(
+    auth: Authenticator,
+    {
+      includeHeavyAttributes,
+    }: {
+      includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+    } = {}
+  ) {
+    return this.baseFetch(auth, { includeHeavyAttributes });
   }
 
   // Admin operations - don't use in non-temporal code.
@@ -369,8 +550,17 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       cachedDescription,
       cachedTools,
       lastSyncAt,
-      lastError: clearError ? null : this.lastError,
+      ...(clearError ? { lastError: null } : {}),
     });
+
+    // The written values are now known regardless of what the original fetch included.
+    this.heavyAttributes = {
+      ...this.heavyAttributes,
+      ...(sharedSecret !== undefined ? { sharedSecret } : {}),
+      ...(customHeaders !== undefined ? { customHeaders } : {}),
+      ...(cachedTools !== undefined ? { cachedTools } : {}),
+      ...(clearError ? { lastError: null } : {}),
+    };
 
     return new Ok(undefined);
   }
@@ -419,6 +609,8 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastError,
       lastSyncAt,
     });
+
+    this.heavyAttributes = { ...this.heavyAttributes, lastError };
   }
 
   static async discoverOAuthMetadata({
@@ -586,6 +778,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     customHeaders: Record<string, string> | null;
     meta: Record<string, string> | null;
   } {
+    const sharedSecretValue = this.getSharedSecret();
+    const customHeadersValue = this.getCustomHeaders();
+
     const currentTime = new Date();
     const createdAt = new Date(this.createdAt);
     const timeDifference = Math.abs(
@@ -595,23 +790,23 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     const shouldRedact =
       differenceInMinutes > SECRET_REDACTION_COOLDOWN_IN_MINUTES;
 
-    const secret = this.sharedSecret
+    const secret = sharedSecretValue
       ? shouldRedact
-        ? redactString(this.sharedSecret, 4)
-        : this.sharedSecret
+        ? redactString(sharedSecretValue, 4)
+        : sharedSecretValue
       : null;
 
     const headers =
-      this.customHeaders && shouldRedact
+      customHeadersValue && shouldRedact
         ? Object.fromEntries(
-            Object.entries(this.customHeaders).map(([key, value]) => [
+            Object.entries(customHeadersValue).map(([key, value]) => [
               key,
               value !== null && value !== undefined
                 ? redactString(String(value), 4)
                 : value,
             ])
           )
-        : this.customHeaders;
+        : customHeadersValue;
 
     return {
       sId: this.sId,
@@ -620,16 +815,16 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       description: this.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
       version: this.version,
       icon: this.icon,
-      tools: this.cachedTools,
+      tools: this.getCachedTools(),
 
-      authorization: this.authorization,
+      authorization: this.getAuthorization(),
       availability: "manual",
       allowMultipleInstances: true,
 
       // Remote MCP Server specifics
       url: this.url,
       lastSyncAt: this.lastSyncAt?.getTime() ?? null,
-      lastError: this.lastError,
+      lastError: this.getLastError(),
       sharedSecret: secret,
       customHeaders: headers,
       meta: this.meta,

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -307,7 +307,16 @@ async function buildActivationContext(
     await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
       auth,
       spaceIds,
-      { includeGlobalSpace: true }
+      {
+        includeGlobalSpace: true,
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
   const availableToolsets = allToolsets.filter((toolset) => {
     const mcpServerView = toolset.toJSON();

--- a/front/lib/resources/skill/code_defined/system/discover_tools.ts
+++ b/front/lib/resources/skill/code_defined/system/discover_tools.ts
@@ -21,7 +21,16 @@ export const discoverToolsSkill = {
       await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
         auth,
         spaceIds,
-        { includeGlobalSpace: true }
+        {
+          includeGlobalSpace: true,
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
 
     const availableToolsets = allToolsets.filter((toolset) => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -498,7 +498,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<Result<SkillResource, Error>> {
     const mcpServerViews = await MCPServerViewResource.fetchByIds(
       auth,
-      mcpServerViewIds
+      mcpServerViewIds,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
 
     if (mcpServerViews.length !== mcpServerViewIds.length) {
@@ -656,7 +665,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
           auth,
           removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
-          { includeMetadata: false }
+          {
+            includeMetadata: false,
+            includeHeavyAttributes: [
+              "authorization",
+              "cachedTools",
+              "customHeaders",
+              "lastError",
+              "sharedSecret",
+            ],
+          }
         );
       }
 
@@ -832,7 +850,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const allMCPServerViews = await MCPServerViewResource.listByMCPServers(
         auth,
         mcpServerIds,
-        transaction
+        {
+          transaction,
+          includeHeavyAttributes: [
+            "authorization",
+            "cachedTools",
+            "customHeaders",
+            "lastError",
+            "sharedSecret",
+          ],
+        }
       );
       mcpServerViews = allMCPServerViews.filter(
         (view) =>
@@ -2230,7 +2257,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
     const allMcpServerViews = await MCPServerViewResource.fetchByModelIds(
       auth,
-      allMcpServerViewIds
+      allMcpServerViewIds,
+      {
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
+      }
     );
     const mcpServerViewMap = new Map(
       allMcpServerViews.map((view) => [view.id, view])

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -571,6 +571,14 @@ export async function runModel(
     const allToolsets =
       await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(auth, [], {
         includeGlobalSpace: true,
+        // isJITMCPServerView inspects tool input schemas.
+        includeHeavyAttributes: [
+          "authorization",
+          "cachedTools",
+          "customHeaders",
+          "lastError",
+          "sharedSecret",
+        ],
       });
     const filteredToolsets = allToolsets.filter((toolset) => {
       const mcpServerView = toolset.toJSON();


### PR DESCRIPTION
## Description

Currently, we fetch remote_mcp_servers quite a lot, and have a nasty, unbounded JSONB column that makes 93% of the data (of course toasted).
Because of that, fetching a full row takes 3.6 pages on average, and while this is not a lot of data and the whole table fits 100% in shared buffers, detoasting thousands of times per minute is costly.

To stay lean, and because we really don't need this data in most cases, we don't return it anymore by default and codepath needing it now need to fetch it explicitly.

As a result, this query should drop drastically in usage: 


```
SELECT "createdAt", "updatedAt", "url", "icon", "version", "cachedName", "cachedDescription", "cachedTools", "lastSyncAt", "lastError", "sharedSecret", "authorization", "customHeaders", "meta", "workspaceId", "id" 
  FROM "remote_mcp_servers" AS "remote_mcp_server" 
 WHERE "remote_mcp_server"."id" IN ($0) AND "remote_mcp_server"."workspaceId" = $15
```

## Tests

Unit tests 

Will also front-edge it.


## Risk

Standard
Blast radius: remote mcp servers codepaths

## Deploy Plan

- Deploy front