### PR TITLE
[Forks] Block sending while branch prepares

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -133,6 +133,10 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         CONTEXT_USAGE_PERCENT_THRESHOLDS["force_compaction"]
       ? "Context is full, compact to continue."
       : null;
+  const forkBlockMessage =
+    context.conversation?.forkingData?.forkedFrom?.fileCopyStatus === "pending"
+      ? "Wait for the branch to finish preparing."
+      : null;
   const showContextUsageBanner =
     contextUsage &&
     !!contextUsagePercentage &&
@@ -525,6 +529,15 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           )}
         </ContentMessageInline>
       )}
+      {forkBlockMessage && (
+        <ContentMessageInline
+          icon={InfoCircle}
+          variant="primary"
+          className="mb-5 flex max-h-dvh w-full"
+        >
+          Preparing branch… You can draft a message while its files are copied.
+        </ContentMessageInline>
+      )}
       {showContextUsageBanner && (
         <ContextUsageWarningBanner
           owner={context.owner}
@@ -559,7 +572,9 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           actions={agentBuilderContext?.actionsToShow}
           isSubmitting={agentBuilderContext?.isSubmitting === true}
           isAgentBuilder={!!agentBuilderContext}
-          submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
+          submitBlockMessage={
+            forkBlockMessage ?? wakeUpBlockMessage ?? compactionBlockMessage
+          }
           effectiveIsCompact={effectiveIsCompact}
           onExpandInputBar={expandInputBar}
           onEditorFocusChange={onEditorFocusChange}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -109,6 +109,7 @@ import { ConversationErrorDisplay } from "./ConversationError";
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
+const FORK_PREPARATION_POLL_INTERVAL_MS = 2_000;
 
 // A conversation must be unread and older than that to enable the suggestion of enabling notifications.
 const DELAY_BEFORE_SUGGESTING_PUSH_NOTIFICATION_ACTIVATION = 60 * 60 * 1000; // 1 hour
@@ -371,6 +372,12 @@ export const ConversationViewer = ({
   } = useConversation({
     conversationId,
     workspaceId: owner.sId,
+    options: {
+      refreshInterval: (data) =>
+        data?.conversation.forkingData?.forkedFrom?.fileCopyStatus === "pending"
+          ? FORK_PREPARATION_POLL_INTERVAL_MS
+          : 0,
+    },
   });
 
   const { spaceInfo } = useSpaceInfo({

--- a/front/hooks/conversations/useConversation.ts
+++ b/front/hooks/conversations/useConversation.ts
@@ -5,7 +5,7 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { isAPIErrorResponse } from "@app/types/error";
-import type { Fetcher } from "swr";
+import type { Fetcher, SWRConfiguration } from "swr";
 
 export function useConversation({
   conversationId,
@@ -14,7 +14,10 @@ export function useConversation({
 }: {
   conversationId?: string | null;
   workspaceId: string;
-  options?: { disabled: boolean };
+  options?: {
+    disabled?: boolean;
+    refreshInterval?: SWRConfiguration<GetConversationResponseBody>["refreshInterval"];
+  };
 }): {
   conversation?: ConversationWithoutContentType;
   isConversationLoading: boolean;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9719

Context: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1784649803525579

Large conversations can remain in file-copy preparation after the user reaches the branched conversation. The composer previously allowed sending during this window, even though the backend rejects the message.

Polls conversation readiness only while file copying is pending, shows a preparation banner, and disables Send while keeping the editor available for drafting.

## Risks

Blast radius: Message composition in newly branched conversations while background file copying runs.
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] ConversationViewer tests (7 tests)