### PR TITLE
[Forks] Signal branch preparation completion

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -12204,6 +12204,9 @@
             "$ref": "#/components/schemas/PrivateCompactionMessageDoneEvent"
           },
           {
+            "$ref": "#/components/schemas/PrivateConversationForkPreparedEvent"
+          },
+          {
             "$ref": "#/components/schemas/PrivateConversationTitleEvent"
           },
           {
@@ -12354,6 +12357,24 @@
           },
           "message": {
             "$ref": "#/components/schemas/PrivateCompactionMessage"
+          }
+        }
+      },
+      "PrivateConversationForkPreparedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "conversation_fork_prepared"
+            ]
+          },
+          "created": {
+            "type": "integer"
           }
         }
       },

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -60,6 +60,13 @@ function wakeUpUpdatedEvent(): ConversationEvent {
   };
 }
 
+function forkPreparedEvent(): ConversationEvent {
+  return {
+    eventId: "fork",
+    data: { type: "conversation_fork_prepared", created: 0 },
+  };
+}
+
 function getEvents(
   workspaceId: string,
   conversationId: string,
@@ -161,6 +168,7 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
         titleEvent("kept"),
         planUpdatedEvent(),
         wakeUpUpdatedEvent(),
+        forkPreparedEvent(),
       ])
     );
 
@@ -175,6 +183,7 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
     expect(body).not.toContain("plan_updated");
     // wake_up_updated is front-only; it must never reach the public API stream.
     expect(body).not.toContain("wake_up_updated");
+    expect(body).not.toContain("conversation_fork_prepared");
   });
 
   it("delivers events produced before an iterator error and ends the stream", async () => {

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -17,6 +17,7 @@ const transformForV1: ConversationEventsOptions["transformEvent"] = async (
   if (
     event.data.type === "compaction_message_new" ||
     event.data.type === "compaction_message_done" ||
+    event.data.type === "conversation_fork_prepared" ||
     event.data.type === "plan_updated" ||
     event.data.type === "wake_up_updated"
   ) {

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1322,6 +1322,7 @@
  *         - $ref: '#/components/schemas/PrivateAgentMessageDoneEvent'
  *         - $ref: '#/components/schemas/PrivateCompactionMessageNewEvent'
  *         - $ref: '#/components/schemas/PrivateCompactionMessageDoneEvent'
+ *         - $ref: '#/components/schemas/PrivateConversationForkPreparedEvent'
  *         - $ref: '#/components/schemas/PrivateConversationTitleEvent'
  *         - $ref: '#/components/schemas/PrivateWakeUpUpdatedEvent'
  *     PrivateUserMessageNewEvent:
@@ -1396,6 +1397,15 @@
  *           type: string
  *         message:
  *           $ref: '#/components/schemas/PrivateCompactionMessage'
+ *     PrivateConversationForkPreparedEvent:
+ *       type: object
+ *       required: [type, created]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [conversation_fork_prepared]
+ *         created:
+ *           type: integer
  *     PrivateConversationTitleEvent:
  *       type: object
  *       required: [type, created, title]

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -927,7 +927,12 @@ export const ConversationViewer = ({
 
             break;
           case "conversation_fork_prepared":
-            void mutateConversation();
+            if (
+              conversation?.forkingData?.forkedFrom?.fileCopyStatus ===
+              "pending"
+            ) {
+              void mutateConversation();
+            }
             break;
           case "agent_message_done":
             // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.
@@ -1099,6 +1104,7 @@ export const ConversationViewer = ({
       }
     },
     [
+      conversation?.forkingData?.forkedFrom?.fileCopyStatus,
       conversationId,
       debouncedMarkAsRead,
       mutateContextUsage,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -109,8 +109,6 @@ import { ConversationErrorDisplay } from "./ConversationError";
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
-const FORK_PREPARATION_POLL_INTERVAL_MS = 2_000;
-
 // A conversation must be unread and older than that to enable the suggestion of enabling notifications.
 const DELAY_BEFORE_SUGGESTING_PUSH_NOTIFICATION_ACTIVATION = 60 * 60 * 1000; // 1 hour
 
@@ -372,12 +370,6 @@ export const ConversationViewer = ({
   } = useConversation({
     conversationId,
     workspaceId: owner.sId,
-    options: {
-      refreshInterval: (data) =>
-        data?.conversation.forkingData?.forkedFrom?.fileCopyStatus === "pending"
-          ? FORK_PREPARATION_POLL_INTERVAL_MS
-          : 0,
-    },
   });
 
   const { spaceInfo } = useSpaceInfo({
@@ -924,6 +916,9 @@ export const ConversationViewer = ({
               { revalidate: false }
             );
 
+            break;
+          case "conversation_fork_prepared":
+            void mutateConversation();
             break;
           case "agent_message_done":
             // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -109,6 +109,9 @@ import { ConversationErrorDisplay } from "./ConversationError";
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
+// SSE is the fast path; poll slowly in case the completion event is missed before subscription.
+const FORK_PREPARATION_POLL_INTERVAL_MS = 60_000;
+
 // A conversation must be unread and older than that to enable the suggestion of enabling notifications.
 const DELAY_BEFORE_SUGGESTING_PUSH_NOTIFICATION_ACTIVATION = 60 * 60 * 1000; // 1 hour
 
@@ -370,6 +373,12 @@ export const ConversationViewer = ({
   } = useConversation({
     conversationId,
     workspaceId: owner.sId,
+    options: {
+      refreshInterval: (data) =>
+        data?.conversation.forkingData?.forkedFrom?.fileCopyStatus === "pending"
+          ? FORK_PREPARATION_POLL_INTERVAL_MS
+          : 0,
+    },
   });
 
   const { spaceInfo } = useSpaceInfo({

--- a/front/hooks/conversations/useConversation.ts
+++ b/front/hooks/conversations/useConversation.ts
@@ -5,7 +5,7 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { isAPIErrorResponse } from "@app/types/error";
-import type { Fetcher } from "swr";
+import type { Fetcher, SWRConfiguration } from "swr";
 
 export function useConversation({
   conversationId,
@@ -14,7 +14,10 @@ export function useConversation({
 }: {
   conversationId?: string | null;
   workspaceId: string;
-  options?: { disabled?: boolean };
+  options?: {
+    disabled?: boolean;
+    refreshInterval?: SWRConfiguration<GetConversationResponseBody>["refreshInterval"];
+  };
 }): {
   conversation?: ConversationWithoutContentType;
   isConversationLoading: boolean;

--- a/front/hooks/conversations/useConversation.ts
+++ b/front/hooks/conversations/useConversation.ts
@@ -5,7 +5,7 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { isAPIErrorResponse } from "@app/types/error";
-import type { Fetcher, SWRConfiguration } from "swr";
+import type { Fetcher } from "swr";
 
 export function useConversation({
   conversationId,
@@ -14,10 +14,7 @@ export function useConversation({
 }: {
   conversationId?: string | null;
   workspaceId: string;
-  options?: {
-    disabled?: boolean;
-    refreshInterval?: SWRConfiguration<GetConversationResponseBody>["refreshInterval"];
-  };
+  options?: { disabled?: boolean };
 }): {
   conversation?: ConversationWithoutContentType;
   isConversationLoading: boolean;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3076,6 +3076,7 @@ export async function isConversationEventAllowedForAuth(
     case "agent_message_done":
     case "compaction_message_new":
     case "compaction_message_done":
+    case "conversation_fork_prepared":
     case "conversation_title":
     case "user_message_promoted":
     case "plan_updated":

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -130,6 +130,7 @@ function isMessageEventParams(
     case "agent_message_done":
     case "compaction_message_new":
     case "compaction_message_done":
+    case "conversation_fork_prepared":
     case "conversation_title":
     case "plan_updated":
     case "wake_up_updated":

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -18,6 +18,8 @@ import type {
 } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
+const DEFAULT_CONVERSATION_EVENT_TTL_SECONDS = 5;
+
 /**
  * Generic event publication interface.
  */
@@ -40,8 +42,10 @@ export async function publishConversationEvent(
   event: ConversationEvents,
   {
     conversationId,
+    ttlSeconds = DEFAULT_CONVERSATION_EVENT_TTL_SECONDS,
   }: {
     conversationId: string;
+    ttlSeconds?: number;
   }
 ) {
   const redisHybridManager = getRedisHybridManager();
@@ -52,9 +56,7 @@ export async function publishConversationEvent(
     conversationChannel,
     JSON.stringify(event),
     "user_message_events",
-    // Conversation & message initial states are setup before starting to listen to events so we really care about getting new events.
-    // We are setting a low value to accommodate for reconnections to the event stream.
-    5
+    ttlSeconds
   );
 }
 

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -18,8 +18,6 @@ import type {
 } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-const DEFAULT_CONVERSATION_EVENT_TTL_SECONDS = 5;
-
 /**
  * Generic event publication interface.
  */
@@ -42,10 +40,8 @@ export async function publishConversationEvent(
   event: ConversationEvents,
   {
     conversationId,
-    ttlSeconds = DEFAULT_CONVERSATION_EVENT_TTL_SECONDS,
   }: {
     conversationId: string;
-    ttlSeconds?: number;
   }
 ) {
   const redisHybridManager = getRedisHybridManager();
@@ -56,7 +52,9 @@ export async function publishConversationEvent(
     conversationChannel,
     JSON.stringify(event),
     "user_message_events",
-    ttlSeconds
+    // Conversation & message initial states are setup before starting to listen to events so we really care about getting new events.
+    // We are setting a low value to accommodate for reconnections to the event stream.
+    5
   );
 }
 

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -19,6 +19,7 @@ import type {
   AgentMessageNewEvent,
   CompactionMessageDoneEvent,
   CompactionMessageNewEvent,
+  ConversationForkPreparedEvent,
   ConversationTitleEvent,
   PlanUpdatedEvent,
   UserMessageNewEvent,
@@ -50,6 +51,7 @@ export type ConversationEvents =
   | AgentMessageDoneEvent
   | CompactionMessageNewEvent
   | CompactionMessageDoneEvent
+  | ConversationForkPreparedEvent
   | PlanUpdatedEvent
   | WakeUpUpdatedEvent;
 

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -1,8 +1,22 @@
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { copyConversationGCSMount } from "@app/lib/api/files/gcs_mount/files";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
+
+async function markForkPrepared(
+  auth: Authenticator,
+  conversation: ConversationResource
+): Promise<void> {
+  await ConversationForkResource.markFileCopied(auth, {
+    childConversationModelId: conversation.id,
+  });
+  await publishConversationEvent(
+    { type: "conversation_fork_prepared", created: Date.now() },
+    { conversationId: conversation.sId }
+  );
+}
 
 export async function copyConversationGCSMountActivity({
   workspaceId,
@@ -36,9 +50,7 @@ export async function copyConversationGCSMountActivity({
 
     // Unblock the fork even if conversations are not found — nothing to copy.
     if (dest) {
-      await ConversationForkResource.markFileCopied(auth, {
-        childConversationModelId: dest.id,
-      });
+      await markForkPrepared(auth, dest);
     } else {
       await ConversationForkResource.markFileCopiedByDestSId(auth, {
         childConversationSId: destConversationId,
@@ -77,7 +89,5 @@ export async function copyConversationGCSMountActivity({
     );
   }
 
-  await ConversationForkResource.markFileCopied(auth, {
-    childConversationModelId: dest.id,
-  });
+  await markForkPrepared(auth, dest);
 }

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -5,6 +5,10 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 
+// The viewer delays its SSE connection until messages load, so retain this event
+// across slow initialization.
+const FORK_PREPARED_EVENT_TTL_SECONDS = 10 * 60;
+
 async function markForkPrepared(
   auth: Authenticator,
   conversation: ConversationResource
@@ -14,7 +18,10 @@ async function markForkPrepared(
   });
   await publishConversationEvent(
     { type: "conversation_fork_prepared", created: Date.now() },
-    { conversationId: conversation.sId }
+    {
+      conversationId: conversation.sId,
+      ttlSeconds: FORK_PREPARED_EVENT_TTL_SECONDS,
+    }
   );
 }
 

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -5,10 +5,6 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 
-// The viewer delays its SSE connection until messages load, so retain this event
-// across slow initialization.
-const FORK_PREPARED_EVENT_TTL_SECONDS = 10 * 60;
-
 async function markForkPrepared(
   auth: Authenticator,
   conversation: ConversationResource
@@ -18,10 +14,7 @@ async function markForkPrepared(
   });
   await publishConversationEvent(
     { type: "conversation_fork_prepared", created: Date.now() },
-    {
-      conversationId: conversation.sId,
-      ttlSeconds: FORK_PREPARED_EVENT_TTL_SECONDS,
-    }
+    { conversationId: conversation.sId }
   );
 }
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -798,6 +798,11 @@ export type ConversationTitleEvent = {
   title: string;
 };
 
+export type ConversationForkPreparedEvent = {
+  type: "conversation_fork_prepared";
+  created: number;
+};
+
 // Event sent when the conversation's plan.md is created, edited, or closed. A refetch signal: the
 // UI re-reads the plan content via the plan_mode GET endpoint on receipt. `isClosed` lets the UI
 // close the plan panel.


### PR DESCRIPTION
## Description

Follow-up to #29270 for https://github.com/dust-tt/tasks/issues/9719.

The initial fix polls the full conversation endpoint every two seconds while fork files are copied. That endpoint emits a conversation.accessed WorkOS audit event, so a long copy can create many duplicate audit records.

Publish a private conversation SSE event after the fork status is committed and refetch when the UI receives it while the fork remains pending. A 60-second poll remains as a safety net for missed events and rolling deploys. Normal copies complete through SSE before that fallback runs. The event is filtered out of the public v1 stream and documented in the private Swagger schema.

## Risks

Blast radius: completion signaling for newly forked conversations after background file copying.
Risk: low. Event publication happens after the idempotent status update; a publication failure retries the Temporal activity, and slow polling remains as a fallback. The existing activity name and signature are unchanged.

## Deploy Plan
- deploy front
- deploy front-sse
## Tests
- [x] ConversationViewer tests (7 tests)
- [x] Public conversation SSE filtering test