### PR TITLE
[LLM] Rely solely on dropTemperatureWhenReasoning for Claude models

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,7 +1,4 @@
-import {
-  dropTemperatureOfOneWhenReasoningIsNone,
-  dropTemperatureWhenReasoning,
-} from "@app/lib/llms/stream/types/configuration";
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeHaikuFourDotFive<
   TBase extends abstract new (
@@ -17,10 +14,7 @@ export function WithDustClaudeHaikuFourDotFive<
     // Anthropic rejects a non-default temperature while thinking is active (drop
     // it → schema re-applies the required 1), and rejects temperature=1 while
     // thinking is disabled.
-    static readonly configParsers = [
-      dropTemperatureWhenReasoning,
-      dropTemperatureOfOneWhenReasoningIsNone,
-    ];
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustClaudeHaikuFourDotFive;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,4 +1,4 @@
-import { dropTemperatureOfOneWhenReasoningIsNone } from "@app/lib/llms/stream/types/configuration";
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeOpusFourDotSixConfig<
   TBase extends abstract new (
@@ -17,7 +17,7 @@ export function WithDustClaudeOpusFourDotSixConfig<
     static readonly byok = true;
     // Opus 4.6 accepts a caller-supplied temperature, but Anthropic rejects
     // temperature=1 while thinking is disabled; drop it in that case only.
-    static readonly configParsers = [dropTemperatureOfOneWhenReasoningIsNone];
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustClaudeOpusFourDotSix;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,7 +1,4 @@
-import {
-  dropTemperatureOfOneWhenReasoningIsNone,
-  dropTemperatureWhenReasoning,
-} from "@app/lib/llms/stream/types/configuration";
+import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
@@ -21,10 +18,7 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     // Anthropic rejects a non-default temperature while thinking is active (drop
     // it → schema re-applies the required 1), and rejects temperature=1 while
     // thinking is disabled.
-    static readonly configParsers = [
-      dropTemperatureWhenReasoning,
-      dropTemperatureOfOneWhenReasoningIsNone,
-    ];
+    static readonly configParsers = [dropTemperatureWhenReasoning];
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -40,22 +40,6 @@ export function dropTemperatureWhenReasoning<C extends InputConfig>(
   return config;
 }
 
-// `configParsers` helper: Anthropic rejects an explicit temperature=1 while
-// thinking is disabled ("temperature may only be set to 1 when thinking is
-// enabled or in adaptive mode"). When reasoning is off, drop a temperature of
-// exactly 1 so we fall back to the provider default; other values pass through.
-// Used by Opus 4.6, which — unlike 4.7/4.8 — accepts a caller-supplied
-// temperature.
-export function dropTemperatureOfOneWhenReasoningIsNone<C extends InputConfig>(
-  config: C
-): C {
-  if (config.reasoning?.effort !== "none" || config.temperature !== 1) {
-    return config;
-  }
-
-  return { ...config, temperature: undefined };
-}
-
 // `configParsers` helper: some models reject an explicit temperature outright,
 // regardless of reasoning effort (e.g. the OpenAI gpt-5 / gpt-5-mini / gpt-5-nano
 // / gpt-5.1 Responses models). Always drop it.

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -23,6 +23,7 @@ const configSchema = z.union([
       })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
+    temperature: z.literal(1).optional().default(1),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),


### PR DESCRIPTION
## Description

Drop the `dropTemperatureOfOneWhenReasoningIsNone` parser entirely and have Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 rely only on `dropTemperatureWhenReasoning`, which drops a non-default temperature while thinking is active so the schema re-applies the required default.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`