### PR TITLE
[front] fix: improve Jira update issue tool search recall

### DIFF
--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -239,6 +239,10 @@ const QUERIES: LabeledQuery[] = [
     expected: "jira.update_issue",
   },
   {
+    query: "jira update issue description",
+    expected: "jira.update_issue",
+  },
+  {
     query: "change the priority on jira issue PROJ-9",
     expected: "jira.update_issue",
     maxRank: 3,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -350,7 +350,7 @@ export const JIRA_TOOLS_METADATA = [
   {
     name: "update_issue",
     description:
-      "Update or change field values on an existing Jira issue, such as its summary, description, priority, or assignee. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
+      "Update or change field values on an existing Jira issue, such as its summary, description, priority, or assignee. Use this tool to update, edit, or replace a Jira issue description. Description accepts plain text or rich ADF. Issue links and attachments are not changed here.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       updateData: JiraCreateIssueRequestSchema.partial().describe(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9698

When someone searches for `jira update issue description`, the Jira `update_issue` tool sometimes is not surfaced by the BM25 tool search.

The tool description now clearly says that it can update, edit, or replace a Jira issue description. This helps search find the right tool.

## Tests

- Added a BM25 test for this search.

## Risk

- Low.

## Deploy Plan

- Deploy front.
