### PR TITLE
[front] enh: Add ProviderError with central catch in tool execution wrapper

### DIFF
--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -36,3 +36,33 @@ export class MCPError extends Error {
     this.code = code;
   }
 }
+
+export function isMCPError(error: unknown): error is MCPError {
+  return error instanceof MCPError;
+}
+
+/**
+ * Thrown by tool API clients when the service a tool depends on fails unexpectedly: HTTP
+ * 5xx-class responses, provider SDK internal errors, unreachable Dust infra. Caught in
+ * `withToolLogging` and surfaced as a tracked `MCPError`, so it reaches our observability
+ * stack regardless of the tool's error-tracking defaults.
+ *
+ * Must not be used for failures driven by user input or configuration (4xx-class responses,
+ * invalid queries, permission errors) nor for arbitrary user-provided endpoints (e.g.
+ * http_client URLs): those are not actionable on our side.
+ */
+export class ProviderError extends Error {
+  public readonly status?: number;
+
+  constructor(
+    message: string,
+    { status, cause }: { status?: number; cause?: Error } = {}
+  ) {
+    super(message, { cause });
+    this.status = status;
+  }
+}
+
+export function isProviderError(error: unknown): error is ProviderError {
+  return error instanceof ProviderError;
+}

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,4 +1,8 @@
-import type { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   ToolDefinition,
   ToolHandlerResult,
@@ -13,8 +17,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
-import { errorToString } from "@app/types/shared/utils/error_utils";
+import { Err, Ok } from "@app/types/shared/result";
+import {
+  errorToString,
+  normalizeError,
+} from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
@@ -186,7 +193,43 @@ function withToolLogging<T>(
     }
     const startTime = performance.now();
 
-    const result = await toolCallback(params, extra);
+    let result: Result<CallToolResult["content"], MCPError>;
+    try {
+      result = await toolCallback(params, extra);
+    } catch (error) {
+      if (isProviderError(error)) {
+        // Unexpected failure of the service the tool depends on, thrown from the lowest
+        // level of the tool's API client: always tracked, regardless of the tool's
+        // error-tracking defaults.
+        result = new Err(
+          new MCPError(error.message, {
+            tracked: true,
+            code: error.status,
+            cause: error,
+          })
+        );
+      } else if (isMCPError(error)) {
+        // Thrown from call stacks where plumbing a Result back is impractical; honor the
+        // error as if it had been returned.
+        result = new Err(error);
+      } else {
+        // Any other throw is a bug: report it, then rethrow (the MCP SDK turns the throw
+        // into a generic isError result for the model).
+        getStatsDClient().increment("use_tools_error.count", 1, [
+          "error_type:uncaught_error",
+          ...tags,
+        ]);
+        logger.error(
+          {
+            ...loggerArgs,
+            duration: performance.now() - startTime,
+            error: normalizeError(error),
+          },
+          "Tool execution uncaught error"
+        );
+        throw error;
+      }
+    }
 
     const elapsed = performance.now() - startTime;
 
@@ -194,7 +237,9 @@ function withToolLogging<T>(
     if (result.isErr()) {
       if (enableAlerting && result.error.tracked) {
         getStatsDClient().increment("use_tools_error.count", 1, [
-          "error_type:run_error",
+          isProviderError(result.error.cause)
+            ? "error_type:provider_error"
+            : "error_type:run_error",
           ...tags,
         ]);
       }


### PR DESCRIPTION
Stack 1/4 — reduce MCP tool-error alert noise to the failures we actually care about.

## Problem

`MCPError.tracked` defaults to `true` and requires opt-out; almost nobody opts out. Result: ~140k tracked `Tool execution error` logs/week feeding the "Tool execution errors" monitors — salesforce alone is ~40k/week and is virtually all model-generated bad SOQL (`No such column`, `unexpected token`). None of it is actionable.

Meanwhile the two failure modes we DO want to alert on are invisible:
- an uncaught `throw` inside a tool handler is swallowed by the MCP SDK into an `isError` text result before `withToolLogging` sees it — no metric, no log;
- provider-side 5xx errors are indistinguishable from user/model input errors in the `tracked` stream.

## This PR

Ships the mechanism, used nowhere yet (call sites come in the next PR of the stack):

- **`ProviderError`** (`mcp_errors.ts`): thrown by tool API clients at the lowest level when the service a tool depends on fails unexpectedly (HTTP 5xx-class, provider SDK internal failures, unreachable Dust infra). Explicitly NOT for user/config-driven failures (4xx, invalid queries) nor arbitrary user endpoints (http_client and co).
- **Central catch in `withToolLogging`** around the tool callback:
  - thrown `ProviderError` → converted to a **tracked** `MCPError` (alerts regardless of the tool's tracking defaults), metric tagged `error_type:provider_error`;
  - thrown `MCPError` → honored as if returned (its `tracked` flag is respected) — gives deep call stacks an intentional abort channel instead of Result-plumbing through every layer;
  - anything else → **bug**: `logger.error("Tool execution uncaught error")` + `use_tools_error.count` with `error_type:uncaught_error`, then rethrown (model-visible behavior unchanged: the SDK still turns it into a generic `isError` result). The uncaught metric is deliberately NOT gated on `enableAlerting`, so an absolute-count monitor on `error_type:uncaught_error` can alert "no questions asked".

## Stack plan

1. **this PR** — mechanism only;
2. throw `ProviderError` from every server API client on provider 5xx (per-server funnels; CoreAPI/DustAPI `internal_server_error` for infra-backed tools);
3. explicit `tracked: true` opt-ins where low-level 5xx capture is not possible (e.g. providers whose SDK hides status; network-level failures for Dust-managed providers like firecrawl);
4. flip the `MCPError.tracked` default to `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
