### PR TITLE
[LLM] Add xAI Grok 4.5 support

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -338,7 +338,7 @@ const PROVIDER_ID_TO_LAB: Record<ModelProviderIdType, Lab | null> = {
   google_ai_studio: "google",
   deepseek: "deepseek",
   fireworks: null,
-  xai: "z_ai",
+  xai: "xai",
   noop: "noop",
   auto: null,
 };

--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -6,6 +6,8 @@ import { GoogleLLM } from "@app/lib/api/llm/clients/google";
 import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
 import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
+import { XaiLLM } from "@app/lib/api/llm/clients/xai";
+import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
@@ -16,6 +18,7 @@ import {
   GOOGLE_AI_STUDIO_HOST,
   type Host,
   OPENAI_RESPONSES_HOST,
+  XAI_HOST,
 } from "@app/lib/model_constructors/types/hosts";
 import type { Region } from "@app/lib/model_constructors/types/regions";
 import { isModelId } from "@app/types/assistant/models/models";
@@ -32,6 +35,7 @@ export const PARITY_CREDENTIALS: LLMCredentialsType = {
   GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
   OPENAI_API_KEY: "test-openai-key",
   FIREWORKS_API_KEY: "test-fireworks-key",
+  XAI_API_KEY: "test-xai-key",
 };
 
 /** Per-call parameters shared by both routers for one parity case. */
@@ -261,11 +265,45 @@ const fireworksProvider: ParityProvider = {
   },
 };
 
+const xaiProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isXaiWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted xAI model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, _endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isXaiWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(`${params.modelId} is not a whitelisted xAI model.`);
+    }
+    return new XaiLLM(auth, {
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  // xAI uses the OpenAI Responses SDK (`responses.create`), so calls land in the
+  // shared `openai` bucket: legacy stream drains first, new one last.
+  selectOldRequest(_endpoint, captures) {
+    return first(captures.openai);
+  },
+  selectNewRequest(_endpoint, captures) {
+    return last(captures.openai);
+  },
+};
+
 const PARITY_PROVIDERS: Partial<Record<Host, ParityProvider>> = {
   [ANTHROPIC_HOST]: anthropicProvider,
   [GOOGLE_AI_STUDIO_HOST]: googleProvider,
   [OPENAI_RESPONSES_HOST]: openaiProvider,
   [FIREWORKS_HOST]: fireworksProvider,
+  [XAI_HOST]: xaiProvider,
 };
 
 export function getParityProvider(host: Host): ParityProvider {

--- a/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
+++ b/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
@@ -1,0 +1,15 @@
+export function WithDustGrok45Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGrok45 extends Base {
+    static readonly displayName = "Grok 4.5";
+    static readonly description =
+      "xAI's Grok 4.5 flagship model (500k context, reasoning, vision).";
+    static readonly defaultReasoningEffort = "high";
+    static readonly byok = false;
+  }
+
+  return DustGrok45;
+}

--- a/front/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
+++ b/front/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
@@ -1,0 +1,13 @@
+import { WithDustGrok45Config } from "@app/lib/llms/providers/xai/models/grok_four_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { XaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai";
+
+export class DustXaiGrokFourDotFiveGlobalXaiStream extends WithDustGrok45Config(
+  XaiGrokFourDotFiveGlobalXaiStream
+) {
+  static readonly endpointFilter = {
+    featureFlags: { contains: "xai_feature" as const },
+  };
+}
+
+defineDustStreamEndpoint(DustXaiGrokFourDotFiveGlobalXaiStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -52,6 +52,7 @@ import { DustOpenAIGptFiveMiniEuropeOpenAIResponsesStream } from "@app/lib/llms/
 import { DustOpenAIGptFiveMiniGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_mini_global_openai_responses";
 import { DustOpenAIGptFiveNanoEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_nano_eu_openai_responses";
 import { DustOpenAIGptFiveNanoGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_nano_global_openai_responses";
+import { DustXaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/llms/stream/endpoints/xai_grok_four_dot_five_global_xai";
 import { DustZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/llms/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
@@ -169,6 +170,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustOpenAIGptFiveNanoGlobalOpenAIResponsesStream,
   [DustOpenAIGptFiveGlobalOpenAIResponsesStream.id]:
     DustOpenAIGptFiveGlobalOpenAIResponsesStream,
+  [DustXaiGrokFourDotFiveGlobalXaiStream.id]:
+    DustXaiGrokFourDotFiveGlobalXaiStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/stream/clients/xai.ts
+++ b/front/lib/model_constructors/stream/clients/xai.ts
@@ -1,0 +1,74 @@
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { XAI_HOST } from "@app/lib/model_constructors/types/hosts";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import { XAI_LAB } from "@app/lib/model_constructors/types/labs";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import type { z } from "zod";
+
+// xAI exposes an OpenAI-compatible Responses API, so we reuse the OpenAI
+// Responses converters and SDK client, only swapping the base URL and key.
+const XAI_BASE_URL = "https://api.x.ai/v1";
+
+export abstract class XaiStream extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    StreamEndpoint<ResponseCreateParamsNonStreaming, ResponseStreamEvent>
+  )
+) {
+  static readonly lab = XAI_LAB;
+  static readonly host = XAI_HOST;
+
+  static readonly configSchema: z.ZodType<InputConfig> = inputConfigSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ XAI_API_KEY }: Credentials) {
+    super();
+    this.client = new OpenAI({ apiKey: XAI_API_KEY, baseURL: XAI_BASE_URL });
+  }
+
+  buildRequestPayload(
+    payload: Payload,
+    config: InputConfig
+  ): ResponseCreateParamsNonStreaming {
+    const request = super.buildRequestPayload(payload, config);
+    if (request.tools && request.tools.length > 0) {
+      return request;
+    }
+    // Unlike OpenAI, x.ai rejects `tool_choice` when the request has no tools.
+    const { tool_choice: _toolChoice, ...withoutToolChoice } = request;
+    return withoutToolChoice;
+  }
+
+  async *streamRaw(
+    input: ResponseCreateParamsNonStreaming
+  ): AsyncGenerator<ResponseStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ResponseCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = await this.client.responses.create(streamingInput);
+
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ResponseStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
+++ b/front/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai.ts
@@ -1,0 +1,38 @@
+import { XaiStream } from "@app/lib/model_constructors/stream/clients/xai";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { GROK_4_5 } from "@app/lib/model_constructors/types/models";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+import { z } from "zod";
+
+// grok-4.5 reasoning is always on: only low/medium/high are accepted (it rejects
+// none/minimal/xhigh/maximal) and it defaults to high. A temperature is allowed.
+// https://docs.x.ai/docs/guides/reasoning (2026-07-21)
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(["low", "medium", "high"]) })
+    .default({ effort: "high" }),
+});
+
+export class XaiGrokFourDotFiveGlobalXaiStream extends XaiStream {
+  static readonly model = GROK_4_5;
+
+  static readonly configSchema = configSchema;
+
+  // https://docs.x.ai/developers/models/grok-4.5 (2026-07-21)
+  static readonly contextSize = 500_000;
+  static readonly maxOutputTokens = 64_000;
+
+  // https://docs.x.ai/docs/models (2026-07-21)
+  static readonly tokenPricing = {
+    cacheHit: 0.3,
+    standardInput: 2.0,
+    standardOutput: 6.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+XaiGrokFourDotFiveGlobalXaiStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -52,6 +52,7 @@ import { OpenAIGptFiveMiniEuropeOpenAIResponsesStream } from "@app/lib/model_con
 import { OpenAIGptFiveMiniGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_mini_global_openai_responses";
 import { OpenAIGptFiveNanoEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_eu_openai_responses";
 import { OpenAIGptFiveNanoGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_global_openai_responses";
+import { XaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai";
 import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
 
 export const STREAM_ENDPOINTS = {
@@ -161,6 +162,7 @@ export const STREAM_ENDPOINTS = {
     OpenAIGptFiveNanoGlobalOpenAIResponsesStream,
   [OpenAIGptFiveGlobalOpenAIResponsesStream.id]:
     OpenAIGptFiveGlobalOpenAIResponsesStream,
+  [XaiGrokFourDotFiveGlobalXaiStream.id]: XaiGrokFourDotFiveGlobalXaiStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -56,6 +56,7 @@ import { OpenAIGptFiveMiniEuropeOpenAIResponsesStream } from "@app/lib/model_con
 import { OpenAIGptFiveMiniGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_mini_global_openai_responses";
 import { OpenAIGptFiveNanoEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_eu_openai_responses";
 import { OpenAIGptFiveNanoGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_global_openai_responses";
+import { XaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai";
 import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
 import { AnthropicClaudeFableFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_global_anthropic.test";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform.test";
@@ -110,6 +111,7 @@ import { OpenAIGptFiveMiniEuropeOpenAIResponsesStreamSetup } from "@app/lib/mode
 import { OpenAIGptFiveMiniGlobalOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_mini_global_openai_responses.test";
 import { OpenAIGptFiveNanoEuropeOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_nano_eu_openai_responses.test";
 import { OpenAIGptFiveNanoGlobalOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_nano_global_openai_responses.test";
+import { XaiGrokFourDotFiveGlobalXaiStreamSetup } from "@app/lib/model_constructors/test/endpoints/xai_grok_four_dot_five_global_xai.test";
 import { ZAiGlmFiveDotTwoGlobalFireworksStreamSetup } from "@app/lib/model_constructors/test/endpoints/z_ai_glm_five_dot_two_global_fireworks.test";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -221,4 +223,6 @@ export const STREAM_ENDPOINT_SETUPS = {
     OpenAIGptFiveNanoGlobalOpenAIResponsesStreamSetup,
   [OpenAIGptFiveGlobalOpenAIResponsesStream.id]:
     OpenAIGptFiveGlobalOpenAIResponsesStreamSetup,
+  [XaiGrokFourDotFiveGlobalXaiStream.id]:
+    XaiGrokFourDotFiveGlobalXaiStreamSetup,
 } satisfies Record<StreamEndpointId, StreamSetup>;

--- a/front/lib/model_constructors/test/endpoints/xai_grok_four_dot_five_global_xai.test.ts
+++ b/front/lib/model_constructors/test/endpoints/xai_grok_four_dot_five_global_xai.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { XaiGrokFourDotFiveGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_five_global_xai";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const XaiGrokFourDotFiveGlobalXaiStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new XaiGrokFourDotFiveGlobalXaiStream({
+      XAI_API_KEY: process.env.DUST_MANAGED_XAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // grok-4.5 reasoning is always on and only accepts low/medium/high;
+    // none/minimal/maximal are rejected by the config schema.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/xai_grok_four_dot_five_global_xai.test.ts
+runStreamEndpointTests(
+  XaiGrokFourDotFiveGlobalXaiStream,
+  XaiGrokFourDotFiveGlobalXaiStreamSetup
+);

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -6,4 +6,5 @@ export type Credentials = {
   AGENT_PLATFORM_PROJECT_ID?: string;
   MISTRAL_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
+  XAI_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/hosts.ts
+++ b/front/lib/model_constructors/types/hosts.ts
@@ -4,6 +4,7 @@ export const GOOGLE_AI_STUDIO_HOST = "google-ai-studio" as const;
 export const AGENT_PLATFORM_HOST = "agent-platform" as const;
 export const MISTRAL_HOST = "mistral" as const;
 export const FIREWORKS_HOST = "fireworks" as const;
+export const XAI_HOST = "xai" as const;
 export const NOOP_HOST = "noop" as const;
 
 const HOSTS = [
@@ -13,6 +14,7 @@ const HOSTS = [
   AGENT_PLATFORM_HOST,
   MISTRAL_HOST,
   FIREWORKS_HOST,
+  XAI_HOST,
   NOOP_HOST,
 ] as const;
 export type Host = (typeof HOSTS)[number];

--- a/front/lib/model_constructors/types/labs.ts
+++ b/front/lib/model_constructors/types/labs.ts
@@ -6,6 +6,7 @@ export const DEEPSEEK_LAB = "deepseek" as const;
 export const FIREWORKS_LAB = "fireworks" as const;
 export const MOONSHOT_AI_LAB = "moonshot_ai" as const;
 export const Z_AI_LAB = "z_ai" as const;
+export const XAI_LAB = "xai" as const;
 export const NOOP_LAB = "noop" as const;
 
 export const LABS = [
@@ -16,6 +17,7 @@ export const LABS = [
   DEEPSEEK_LAB,
   MOONSHOT_AI_LAB,
   Z_AI_LAB,
+  XAI_LAB,
   NOOP_LAB,
 ] as const;
 export type Lab = (typeof LABS)[number];

--- a/front/lib/model_constructors/types/models.ts
+++ b/front/lib/model_constructors/types/models.ts
@@ -37,6 +37,8 @@ export const MINIMAX_M2P5 = "minimax-m2p5" as const;
 export const GLM_5 = "glm-5" as const;
 export const GLM_5P2 = "glm-5p2" as const;
 
+export const GROK_4_5 = "grok-4.5" as const;
+
 // Dummy model used for local/dev testing (static replies, simulated credit
 // consumption). Served by the in-process noop endpoint, not an external API.
 export const NOOP_MODEL = "noop" as const;
@@ -77,6 +79,7 @@ export const MODELS = [
   MINIMAX_M2P5,
   GLM_5,
   GLM_5P2,
+  GROK_4_5,
   NOOP_MODEL,
 ] as const;
 
@@ -100,4 +103,5 @@ export const ORDERED_LARGE_MODELS = [
   GPT_5,
   GPT_5_1,
   GEMINI_3_1_PRO,
+  GROK_4_5,
 ];

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -69,9 +69,11 @@ export interface ReasoningEvent {
 // for verbatim replay. The block stays opaque to the generic pipeline.
 // Passthrough blocks only originate from labs Dust talks to directly (Anthropic
 // only today). Fireworks-hosted labs (moonshot_ai, z_ai) and the noop lab never
-// produce one, so they are excluded to keep the value mappable to the persisted
-// provider vocabulary.
-export type PassthroughLab = Exclude<Lab, "moonshot_ai" | "z_ai">;
+// produce one. xai reuses the OpenAI Responses converter, which tags its
+// passthrough blocks under the "openai" provider, so "xai" never appears as a
+// passthrough value either. All are excluded to keep the value mappable to the
+// persisted provider vocabulary.
+export type PassthroughLab = Exclude<Lab, "moonshot_ai" | "z_ai" | "xai">;
 
 export type ProviderPassthroughContent = {
   provider: PassthroughLab;


### PR DESCRIPTION
## Description

Adds the xAI Grok 4.5 (global) stream endpoint to the `model_constructors` router and wires it into the Dust LLM stream layer.

## Tests

Added an integration test for the new stream endpoint (`xai_grok_four_dot_five_global_xai.test.ts`).

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`