### PR TITLE
[front] enh: Throw ProviderError from tool API clients on provider 5xx

### DIFF
--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -1,3 +1,4 @@
+import type { CoreAPIError } from "@app/types/core/core_api";
 import type { APIError } from "@app/types/error";
 
 export class MCPServerNotFoundError extends Error {
@@ -65,4 +66,35 @@ export class ProviderError extends Error {
 
 export function isProviderError(error: unknown): error is ProviderError {
   return error instanceof ProviderError;
+}
+
+/**
+ * Throws a `ProviderError` when a `CoreAPIError` is an unexpected core failure (core uses the
+ * `internal_server_error` code for its 500s). All other codes are request/data-driven and must
+ * keep their local handling: call this before converting the error at the call site.
+ */
+export function throwOnCoreAPIInternalError(error: CoreAPIError): void {
+  if (error.code === "internal_server_error") {
+    throw new ProviderError("CoreAPI returned an unexpected error.", {
+      cause: new Error(error.message),
+    });
+  }
+}
+
+/**
+ * Throws a `ProviderError` when a Dust API error is an unexpected front failure (front uses the
+ * `internal_server_error` type for its 500s). All other types are request/user/config-driven and
+ * must keep their local handling: call this before converting the error at the call site.
+ *
+ * Accepts both the `@dust-tt/client` and the front `APIError` shapes structurally.
+ */
+export function throwOnDustAPIInternalError(error: {
+  type: string;
+  message: string;
+}): void {
+  if (error.type === "internal_server_error") {
+    throw new ProviderError("Dust API returned an unexpected error.", {
+      cause: new Error(error.message),
+    });
+  }
 }

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_ROUTER_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_router/metadata";
@@ -40,6 +43,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       view: user ? "list" : "all",
     });
     if (res.isErr()) {
+      throwOnDustAPIInternalError(res.error);
       return new Err(new MCPError("Error fetching agent configurations"));
     }
 
@@ -86,6 +90,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       view: user ? "list" : "all",
     });
     if (getAgentsRes.isErr()) {
+      throwOnDustAPIInternalError(getAgentsRes.error);
       logger.error(
         { err: getAgentsRes.error },
         "suggest_agents_for_content: error fetching agent configurations"

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -1,5 +1,8 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import { isToolWithKnowledge } from "@app/lib/actions/mcp_helper";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -1291,6 +1294,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     );
 
     if (searchResults.isErr()) {
+      throwOnCoreAPIInternalError(searchResults.error);
       return new Err(
         new MCPError(
           `Failed to search knowledge: ${searchResults.error.message}`

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
   AshbyAPIErrorInfo,
@@ -144,6 +144,12 @@ export class AshbyClient {
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Ashby API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorText = await response.text();
       return new Err(
         new Error(

--- a/front/lib/api/actions/servers/clari_copilot/client.ts
+++ b/front/lib/api/actions/servers/clari_copilot/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
   ClariCallDetails,
@@ -101,6 +101,12 @@ export class ClariCopilotClient {
       );
 
       if (!response.ok) {
+        if (response.status >= 500) {
+          throw new ProviderError(
+            `Clari API returned an unexpected error (HTTP ${response.status}).`,
+            { status: response.status }
+          );
+        }
         const errorText = await response.text();
         return new Err(
           new ClariHttpError(
@@ -125,6 +131,10 @@ export class ClariCopilotClient {
 
       return new Ok(parseResult.data);
     } catch (err) {
+      // Let provider 5xx errors escape to the tool-execution wrapper.
+      if (err instanceof ProviderError) {
+        throw err;
+      }
       return new Err(normalizeError(err));
     }
   }

--- a/front/lib/api/actions/servers/confluence/helpers.ts
+++ b/front/lib/api/actions/servers/confluence/helpers.ts
@@ -1,3 +1,4 @@
+import { isProviderError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type {
   ConfluenceCreatePageRequest,
@@ -56,6 +57,12 @@ async function confluenceApiCall<T extends z.ZodTypeAny>(
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Confluence API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorBody = await response.text();
       const msg = `Confluence API error: ${response.status} ${response.statusText} - ${errorBody}`;
       logger.error(`[Confluence MCP Server] ${msg}`);
@@ -81,6 +88,9 @@ async function confluenceApiCall<T extends z.ZodTypeAny>(
 
     return new Ok(parseResult.data);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     logger.error(
       `[Confluence MCP Server] Confluence API call failed for ${endpoint}:`,
       {
@@ -181,6 +191,11 @@ export async function withAuth<T>(
     const result = await action(baseUrl, accessToken);
     return { success: true, result };
   } catch (error) {
+    if (isProviderError(error)) {
+      // Let provider 5xx failures escape to the tool-execution wrapper, which converts
+      // them to tracked MCPErrors.
+      throw error;
+    }
     logger.error("Error in withAuth", { error });
     return {
       success: false,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { renderNode } from "@app/lib/actions/mcp_internal_actions/rendering";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
@@ -110,6 +113,10 @@ export async function cat(
     },
   });
 
+  if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
+  }
+
   if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
     return new Err(
       new MCPError(
@@ -159,6 +166,7 @@ export async function cat(
   });
 
   if (readResult.isErr()) {
+    throwOnCoreAPIInternalError(readResult.error);
     return new Err(
       new MCPError(
         `Could not read node: ${nodeId} (error: ${readResult.error.message})`,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
@@ -91,6 +94,7 @@ export async function find(
       },
     });
     if (rootNodeSearchResult.isErr()) {
+      throwOnCoreAPIInternalError(rootNodeSearchResult.error);
       return new Err(
         new MCPError(
           `Failed to search content: ${rootNodeSearchResult.error.message}`
@@ -128,6 +132,7 @@ export async function find(
   });
 
   if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
     return new Err(
       new MCPError(`Failed to search content: ${searchResult.error.message}`)
     );

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
@@ -151,6 +154,8 @@ export async function list(
   }
 
   if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
+
     if (searchResult.error.code === "cursor_sort_mismatch") {
       return new Err(
         new MCPError(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { FilesystemPathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
@@ -92,6 +95,10 @@ export const locateTree = async (
     },
   });
 
+  if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
+  }
+
   if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
     return new Err(
       new MCPError(`Could not find node: ${nodeId}`, { tracked: false })
@@ -121,6 +128,7 @@ export const locateTree = async (
     });
 
     if (pathSearchResult.isErr()) {
+      throwOnCoreAPIInternalError(pathSearchResult.error);
       return new Err(new MCPError("Failed to fetch nodes in the path"));
     }
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
@@ -127,6 +130,7 @@ export async function search(
   );
 
   if (searchResults.isErr()) {
+    throwOnCoreAPIInternalError(searchResults.error);
     return new Err(
       new MCPError(`Failed to search content: ${searchResults.error.message}`)
     );
@@ -193,6 +197,7 @@ export async function search(
     });
 
     if (searchResult.isErr()) {
+      throwOnCoreAPIInternalError(searchResult.error);
       return new Err(
         new MCPError(`Failed to search content: ${searchResult.error.message}`)
       );

--- a/front/lib/api/actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/api/actions/servers/data_warehouses/helpers.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   RenderedWarehouseNodeType,
   WarehousesBrowseType,
@@ -47,6 +50,7 @@ export async function getAvailableWarehouses(
     },
   });
   if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
     return new Err(new MCPError(searchResult.error.message));
   }
 
@@ -174,6 +178,7 @@ export async function getWarehouseNodes(
   });
 
   if (result.isErr()) {
+    throwOnCoreAPIInternalError(result.error);
     return new Err(new MCPError(result.error.message));
   }
 
@@ -340,6 +345,7 @@ export async function validateTables(
   });
 
   if (searchResult.isErr()) {
+    throwOnCoreAPIInternalError(searchResult.error);
     return new Err(new MCPError(searchResult.error.message));
   }
 

--- a/front/lib/api/actions/servers/databricks/helpers.ts
+++ b/front/lib/api/actions/servers/databricks/helpers.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -57,6 +57,13 @@ async function databricksApiCall<T extends z.ZodTypeAny>(
     },
     ...(options.body && { body: JSON.stringify(options.body) }),
   });
+
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `Databricks API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
 
   if (!response.ok) {
     const errorBody = await response.text();

--- a/front/lib/api/actions/servers/elevenlabs/utils.ts
+++ b/front/lib/api/actions/servers/elevenlabs/utils.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import {
   VOICE_LANGUAGES,
   type VoiceGender,
@@ -7,7 +8,7 @@ import {
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import logger from "@app/logger/logger";
 import { dustManagedServiceCredentials } from "@app/types/api/credentials";
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { ElevenLabsClient, ElevenLabsError } from "@elevenlabs/elevenlabs-js";
 import type { Voice } from "@elevenlabs/elevenlabs-js/api/types";
 import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
 
@@ -255,6 +256,24 @@ export async function resolveDefaultVoiceId({
 
   // 5) Final safety fallback.
   return DEFAULT_GENDER_FALLBACK[gender];
+}
+
+/**
+ * Rethrows a caught error as `ProviderError` when the ElevenLabs API failed unexpectedly
+ * (HTTP 5xx), so it escapes the tool handlers' catch-all blocks and reaches the central
+ * tool wrapper, which always tracks it. No-op for anything else.
+ */
+export function throwIfElevenLabsProviderError(error: unknown): void {
+  if (
+    error instanceof ElevenLabsError &&
+    error.statusCode !== undefined &&
+    error.statusCode >= 500
+  ) {
+    throw new ProviderError(
+      `ElevenLabs API returned an unexpected error (HTTP ${error.statusCode}).`,
+      { status: error.statusCode, cause: error }
+    );
+  }
 }
 
 export function getElevenLabsClient() {

--- a/front/lib/api/actions/servers/exa/tools/index.ts
+++ b/front/lib/api/actions/servers/exa/tools/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { EXA_TOOLS_METADATA } from "@app/lib/api/actions/servers/exa/metadata";
@@ -7,7 +7,7 @@ import { dustManagedServiceCredentials } from "@app/types/api/credentials";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import Exa from "exa-js";
+import Exa, { ExaError } from "exa-js";
 
 const credentials = dustManagedServiceCredentials();
 
@@ -36,6 +36,13 @@ async function exaSearch({
       contents: { highlights: true },
     });
   } catch (error) {
+    // EXA_API_KEY is Dust-managed: an Exa 5xx means our provider is down.
+    if (error instanceof ExaError && error.statusCode >= 500) {
+      throw new ProviderError(
+        `Exa API returned an unexpected error (HTTP ${error.statusCode}).`,
+        { status: error.statusCode, cause: error }
+      );
+    }
     logger.error({ error, category }, "Unexpected error on Exa search");
     return new Err(new MCPError(normalizeError(error).message));
   }

--- a/front/lib/api/actions/servers/fathom/client.ts
+++ b/front/lib/api/actions/servers/fathom/client.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -86,6 +87,12 @@ export class FathomMCPClient {
       return new Ok({ meetings: [], nextCursor: null });
     } catch (error) {
       if (error instanceof FathomError) {
+        if (error.statusCode >= 500) {
+          throw new ProviderError(
+            `Fathom API returned an unexpected error (HTTP ${error.statusCode}).`,
+            { status: error.statusCode, cause: error }
+          );
+        }
         return new Err(new Error(`Fathom API error: ${error.message}`));
       }
       return new Err(normalizeError(error));
@@ -106,6 +113,12 @@ export class FathomMCPClient {
       return new Ok(null);
     } catch (error) {
       if (error instanceof FathomError) {
+        if (error.statusCode >= 500) {
+          throw new ProviderError(
+            `Fathom API returned an unexpected error (HTTP ${error.statusCode}).`,
+            { status: error.statusCode, cause: error }
+          );
+        }
         return new Err(new Error(`Fathom API error: ${error.message}`));
       }
       return new Err(normalizeError(error));
@@ -126,6 +139,12 @@ export class FathomMCPClient {
       return new Ok(response.transcript);
     } catch (error) {
       if (error instanceof FathomError) {
+        if (error.statusCode >= 500) {
+          throw new ProviderError(
+            `Fathom API returned an unexpected error (HTTP ${error.statusCode}).`,
+            { status: error.statusCode, cause: error }
+          );
+        }
         return new Err(new Error(`Fathom API error: ${error.message}`));
       }
       return new Err(normalizeError(error));

--- a/front/lib/api/actions/servers/freshservice/client.ts
+++ b/front/lib/api/actions/servers/freshservice/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -15,7 +15,9 @@ export function normalizeApiDomain(freshserviceDomainRaw: string): string {
     .replace(/\/$/, "");
 
   if (!domain) {
-    throw new Error("Invalid Freshservice domain format");
+    throw new MCPError("Invalid Freshservice domain format", {
+      tracked: false,
+    });
   }
 
   // If it already contains a dot (likely a full domain), use as-is
@@ -60,8 +62,16 @@ export class FreshserviceClient {
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Freshservice API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorText = await response.text();
-      throw new Error(`API error: ${response.status} - ${errorText}`);
+      throw new MCPError(`API error: ${response.status} - ${errorText}`, {
+        tracked: false,
+      });
     }
 
     const contentType = response.headers.get("content-type");

--- a/front/lib/api/actions/servers/freshservice/tools/index.ts
+++ b/front/lib/api/actions/servers/freshservice/tools/index.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+} from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createFreshserviceClient } from "@app/lib/api/actions/servers/freshservice/client";
@@ -15,6 +19,22 @@ import {
   FreshserviceTicketSchema,
 } from "@app/lib/api/actions/servers/freshservice/types";
 import { Err, Ok } from "@app/types/shared/result";
+
+function handleRequestError(error: unknown): Err<MCPError> {
+  // Let provider 5xx errors escape to the tool-execution wrapper, which tracks them.
+  if (isProviderError(error)) {
+    throw error;
+  }
+  // MCPErrors thrown by the client carry their own tracking flag; honor them as-is.
+  if (isMCPError(error)) {
+    return new Err(error);
+  }
+  return new Err(
+    new MCPError(
+      `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
+    )
+  );
+}
 
 const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
   list_tickets: async ({ filter, fields, page, per_page }, { authInfo }) => {
@@ -69,11 +89,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -120,11 +136,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -190,11 +202,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -281,11 +289,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -337,11 +341,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -375,11 +375,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -407,11 +403,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -441,11 +433,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -474,11 +462,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -502,11 +486,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -567,11 +547,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -636,11 +612,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -664,11 +636,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -695,11 +663,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -736,11 +700,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -804,11 +764,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -842,11 +798,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -880,11 +832,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -918,11 +866,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -956,11 +900,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -998,11 +938,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1047,11 +983,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1078,11 +1010,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1118,11 +1046,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1209,11 +1133,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1247,11 +1167,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1292,11 +1208,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1358,11 +1270,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1389,11 +1297,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1438,11 +1342,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1489,11 +1389,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1520,11 +1416,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1558,11 +1450,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1591,11 +1479,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1645,11 +1529,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 
@@ -1676,11 +1556,7 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
         },
       ]);
     } catch (error) {
-      return new Err(
-        new MCPError(
-          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
-        )
-      );
+      return handleRequestError(error);
     }
   },
 };

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -84,6 +84,12 @@ export const makeFrontAPIRequest = async (
   }
 
   if (!response.ok) {
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `Front API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
     const errorBody = await response.text();
     if (response.status === 401) {
       throw new MCPError(

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   ToolDefinition,
   ToolHandlers,
@@ -12,6 +16,7 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Octokit } from "@octokit/core";
+import { RequestError } from "@octokit/request-error";
 import type {
   RequestInfo as UndiciRequestInfo,
   RequestInit as UndiciRequestInit,
@@ -58,6 +63,23 @@ export const createOctokit = async (
   });
 };
 
+/**
+ * Rethrows GitHub API server-side failures (HTTP 5xx) as ProviderError so they are tracked
+ * upstream. Passes through ProviderErrors surfaced by nested catch blocks; leaves every other
+ * error untouched.
+ */
+function throwIfGithubServerError(e: unknown): void {
+  if (isProviderError(e)) {
+    throw e;
+  }
+  if (e instanceof RequestError && e.status >= 500) {
+    throw new ProviderError(
+      `GitHub API returned an unexpected error (HTTP ${e.status}).`,
+      { status: e.status, cause: e }
+    );
+  }
+}
+
 export function createGithubTools(auth: Authenticator): ToolDefinition[] {
   const handlers: ToolHandlers<typeof GITHUB_TOOLS_METADATA> = {
     create_issue: async (
@@ -85,6 +107,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           { type: "text" as const, text: `Issue created: #${issue.number}` },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error creating GitHub issue: ${normalizeError(e).message}`
@@ -362,6 +385,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           { type: "text" as const, text: JSON.stringify(content, null, 2) },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error retrieving GitHub pull request: ${normalizeError(e).message}`
@@ -410,6 +434,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           { type: "text" as const, text: `Issue #${issue.number} updated` },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error updating GitHub issue: ${normalizeError(e).message}`
@@ -446,6 +471,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error reviewing GitHub pull request: ${normalizeError(e).message}`
@@ -550,6 +576,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           { type: "text" as const, text: JSON.stringify(content, null, 2) },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error retrieving GitHub repository projects: ${normalizeError(e).message}`
@@ -643,6 +670,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error adding GitHub issue to project: ${normalizeError(e).message}`
@@ -677,6 +705,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error commenting on GitHub issue: ${normalizeError(e).message}`
@@ -769,6 +798,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error listing GitHub discussion categories: ${normalizeError(e).message}`
@@ -851,6 +881,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error creating GitHub discussion: ${normalizeError(e).message}`
@@ -938,6 +969,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error commenting on GitHub discussion: ${normalizeError(e).message}`
@@ -1052,6 +1084,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error retrieving GitHub discussion: ${normalizeError(e).message}`
@@ -1207,6 +1240,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error retrieving GitHub discussion comments: ${normalizeError(e).message}`
@@ -1358,6 +1392,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error listing GitHub discussions: ${normalizeError(e).message}`
@@ -1477,6 +1512,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error retrieving GitHub issue: ${normalizeError(e).message}`
@@ -1705,7 +1741,8 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                   text: JSON.stringify({ customFields: [] }, null, 2),
                 },
               ]);
-            } catch {
+            } catch (e) {
+              throwIfGithubServerError(e);
               return new Err(
                 new MCPError(
                   `Issue #${issueNumber} is not in the specified project, or project not found`
@@ -1765,6 +1802,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         const error = normalizeError(e);
         // Handle case where projectItems field might not be available
         if (
@@ -1960,6 +1998,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                 },
               ]);
             } catch (fallbackError) {
+              throwIfGithubServerError(fallbackError);
               return new Err(
                 new MCPError(
                   `Error retrieving GitHub issue custom fields: ${normalizeError(fallbackError).message}. Note: Querying all projects requires the projectItems field which may not be available on all GitHub plans.`
@@ -2122,6 +2161,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error listing GitHub issues: ${normalizeError(e).message}`
@@ -2418,6 +2458,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error searching GitHub issues and pull requests: ${normalizeError(e).message}`
@@ -2628,6 +2669,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           },
         ]);
       } catch (e) {
+        throwIfGithubServerError(e);
         return new Err(
           new MCPError(
             `Error listing GitHub pull requests: ${normalizeError(e).message}`

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { escape } from "html-escaper";
 import sanitizeHtml from "sanitize-html";
@@ -309,13 +310,22 @@ export async function fetchFromGmail(
   options?: RequestInit
 ): Promise<Response> {
   // eslint-disable-next-line no-restricted-globals
-  return fetch(`https://gmail.googleapis.com${endpoint}`, {
+  const response = await fetch(`https://gmail.googleapis.com${endpoint}`, {
     ...options,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       ...options?.headers,
     },
   });
+
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `Gmail API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
+
+  return response;
 }
 
 /**

--- a/front/lib/api/actions/servers/gong/client.ts
+++ b/front/lib/api/actions/servers/gong/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   GongCall,
   GongCallTranscript,
@@ -75,6 +75,12 @@ export class GongClient {
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Gong API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorText = await response.text();
       return new Err(
         new GongApiError(

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -18,8 +18,25 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import { randomUUID } from "crypto";
-import { google } from "googleapis";
+import { Common, google } from "googleapis";
 import { DateTime, Interval } from "luxon";
+
+/**
+ * Rethrows Google 5xx responses as ProviderError so the tool-execution
+ * wrapper reports them as tracked provider failures; other errors are left
+ * untouched for the per-tool handling below.
+ */
+function throwIfGoogleServerError(err: unknown): void {
+  if (err instanceof Common.GaxiosError) {
+    const status = err.response?.status;
+    if (status !== undefined && status >= 500) {
+      throw new ProviderError(
+        `Google Calendar API returned an unexpected error (HTTP ${status}).`,
+        { status, cause: err }
+      );
+    }
+  }
+}
 
 const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
   list_calendars: async ({ pageToken, maxResults }, { authInfo }) => {
@@ -40,6 +57,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list calendars")
       );
@@ -82,6 +100,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: formattedText }]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to list/search events"
@@ -119,6 +138,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: formattedText }]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to get event")
       );
@@ -210,6 +230,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to create event")
       );
@@ -289,6 +310,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to update event")
       );
@@ -311,6 +333,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         { type: "text" as const, text: "Event deleted successfully" },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to delete event")
       );
@@ -419,6 +442,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: formattedText }]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to check calendar availability"
@@ -445,6 +469,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
           calendarAccessible: true,
         });
       } catch (err) {
+        throwIfGoogleServerError(err);
         results.push({
           email,
           timeZone: null,

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -371,7 +371,9 @@ describe("handleFileAccessError", () => {
   });
 
   it("should return generic message for GaxiosError without message", async () => {
-    const error = createGaxiosError(500, "Internal Server Error");
+    // 5xx statuses now throw ProviderError, so use a 4xx to exercise the
+    // generic message fallback.
+    const error = createGaxiosError(400, "Bad Request");
     // Simulate an error without a message
     error.message = undefined as any;
 

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -135,6 +135,23 @@ async function extractTextAndBuildResource({
  */
 function normalizeCode(code: string | number | undefined): string | undefined {
   return code !== undefined ? String(code) : undefined;
+}
+
+/**
+ * Rethrows Google 5xx responses as ProviderError so the tool-execution
+ * wrapper reports them as tracked provider failures; other errors are left
+ * untouched for the local handling below.
+ */
+function throwIfGoogleServerError(err: unknown): void {
+  if (err instanceof Common.GaxiosError) {
+    const status = err.response?.status;
+    if (status !== undefined && status >= 500) {
+      throw new ProviderError(
+        `Google Drive API returned an unexpected error (HTTP ${status}).`,
+        { status, cause: err }
+      );
+    }
+  }
 }
 
 // 403 reasons that are authentication problems: the token lacks the required
@@ -298,6 +315,8 @@ export async function handleFileAccessError(
   { authInfo, runContext }: Pick<ToolHandlerExtra, "authInfo" | "runContext">,
   fileMeta?: { name?: string; mimeType?: string }
 ): Promise<ToolHandlerResult> {
+  throwIfGoogleServerError(err);
+
   if (err instanceof Common.GaxiosError) {
     const status = normalizeCode(err.code);
     const message = err.message?.toLowerCase() ?? "";
@@ -403,6 +422,8 @@ async function handleDriveAccessError(
   err: unknown,
   authInfo?: Pick<ToolHandlerExtra, "authInfo">["authInfo"]
 ): Promise<ToolHandlerResult> {
+  throwIfGoogleServerError(err);
+
   if (err instanceof Common.GaxiosError) {
     const status = normalizeCode(err.code);
 
@@ -540,6 +561,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       return new Err(
         new MCPError(normalizeError(err).message ?? "Failed to list drives")
       );
@@ -595,6 +617,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
+      throwIfGoogleServerError(err);
       const error = normalizeError(err);
       return new Err(
         new MCPError(error.message ?? "Failed to search files", {

--- a/front/lib/api/actions/servers/google_sheets/helpers.ts
+++ b/front/lib/api/actions/servers/google_sheets/helpers.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -11,12 +15,30 @@ import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { drive_v3, sheets_v4 } from "googleapis";
+import { Common } from "googleapis";
 
 export const ERROR_MESSAGES = {
   NO_ACCESS_TOKEN: "Failed to authenticate with Google",
   DRIVE_AUTH_FAILED: "Failed to authenticate with Google Drive",
   SHEETS_AUTH_FAILED: "Failed to authenticate with Google Sheets",
 } as const;
+
+/**
+ * Rethrows Google 5xx responses as ProviderError so the tool-execution
+ * wrapper reports them as tracked provider failures; other errors are left
+ * untouched for the caller's local handling.
+ */
+export function throwIfGoogleServerError(err: unknown): void {
+  if (err instanceof Common.GaxiosError) {
+    const status = err.response?.status;
+    if (status !== undefined && status >= 500) {
+      throw new ProviderError(
+        `Google Sheets API returned an unexpected error (HTTP ${status}).`,
+        { status, cause: err }
+      );
+    }
+  }
+}
 
 /**
  * Wrapper to handle authentication and error logging for Google Sheets operations.
@@ -41,6 +63,12 @@ export async function withAuth(
   try {
     return await action({ drive, sheets, accessToken });
   } catch (error: unknown) {
+    // Let ProviderError reach the tool-execution wrapper instead of being
+    // converted to a plain MCPError here.
+    if (isProviderError(error)) {
+      throw error;
+    }
+    throwIfGoogleServerError(error);
     return logAndReturnError({ error, message: "Operation failed" });
   }
 }
@@ -62,6 +90,12 @@ export async function withSheetsAuth(
   try {
     return await action(sheets);
   } catch (error: unknown) {
+    // Let ProviderError reach the tool-execution wrapper instead of being
+    // converted to a plain MCPError here.
+    if (isProviderError(error)) {
+      throw error;
+    }
+    throwIfGoogleServerError(error);
     return logAndReturnError({ error, message: "Operation failed" });
   }
 }
@@ -83,6 +117,12 @@ export async function withDriveAuth(
   try {
     return await action(drive);
   } catch (error: unknown) {
+    // Let ProviderError reach the tool-execution wrapper instead of being
+    // converted to a plain MCPError here.
+    if (isProviderError(error)) {
+      throw error;
+    }
+    throwIfGoogleServerError(error);
     return logAndReturnError({ error, message: "Operation failed" });
   }
 }

--- a/front/lib/api/actions/servers/google_sheets/tools/index.ts
+++ b/front/lib/api/actions/servers/google_sheets/tools/index.ts
@@ -2,6 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  throwIfGoogleServerError,
   withDriveAuth,
   withSheetsAuth,
 } from "@app/lib/api/actions/servers/google_sheets/helpers";
@@ -32,6 +33,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to list spreadsheets"
@@ -52,6 +54,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to get spreadsheet"
@@ -78,6 +81,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to get worksheet data"
@@ -107,6 +111,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to update cells")
         );
@@ -142,6 +147,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to append data")
         );
@@ -161,6 +167,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to clear range")
         );
@@ -187,6 +194,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to create spreadsheet"
@@ -225,6 +233,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to add worksheet")
         );
@@ -252,6 +261,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to delete worksheet"
@@ -302,6 +312,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to format cells")
         );
@@ -327,6 +338,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(normalizeError(err).message || "Failed to copy sheet")
         );
@@ -358,6 +370,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to rename worksheet"
@@ -391,6 +404,7 @@ const handlers: ToolHandlers<typeof GOOGLE_SHEETS_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
         ]);
       } catch (err) {
+        throwIfGoogleServerError(err);
         return new Err(
           new MCPError(
             normalizeError(err).message || "Failed to move worksheet"

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1,3 +1,4 @@
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Client } from "@hubspot/api-client";
@@ -42,11 +43,40 @@ async function hubspotApiFetch<T>({
   });
 
   if (!response.ok) {
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `HubSpot API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
     const body = await response.text().catch(() => "");
-    throw new Error(`HubSpot API error ${response.status} on ${path}: ${body}`);
+    throw new MCPError(
+      `HubSpot API error ${response.status} on ${path}: ${body}`,
+      { tracked: false }
+    );
   }
 
   return response.json() as Promise<T>;
+}
+
+/**
+ * Converts a HubSpot SDK error into a ProviderError when the underlying HTTP status is >= 500.
+ * The SDK generates one `ApiException` class per codegen namespace, so the HTTP status is
+ * detected structurally through the numeric `code` field rather than with `instanceof`.
+ */
+export function toHubspotProviderError(error: unknown): ProviderError | null {
+  if (
+    error instanceof Error &&
+    "code" in error &&
+    typeof error.code === "number" &&
+    error.code >= 500
+  ) {
+    return new ProviderError(
+      `HubSpot API returned an unexpected error (HTTP ${error.code}).`,
+      { status: error.code, cause: error }
+    );
+  }
+  return null;
 }
 
 const MAX_ENUM_OPTIONS_DISPLAYED = 50;
@@ -144,8 +174,9 @@ function buildHubspotFilters(
   return filters.map(({ propertyName, operator, value, values }) => {
     // Validate operator is supported
     if (!supportedOperators.includes(operator)) {
-      throw new Error(
-        `Unsupported filter operator: ${operator}. Supported operators: ${supportedOperators.join(", ")}`
+      throw new MCPError(
+        `Unsupported filter operator: ${operator}. Supported operators: ${supportedOperators.join(", ")}`,
+        { tracked: false }
       );
     }
 
@@ -182,7 +213,10 @@ function buildHubspotFilters(
               ? cleanValues
               : cleanValues.map((v) => v.toLowerCase());
         } else {
-          throw new Error(`Values array is required for ${operator} operator`);
+          throw new MCPError(
+            `Values array is required for ${operator} operator`,
+            { tracked: false }
+          );
         }
       } else if (operator === FilterOperatorEnum.Between) {
         // Date properties need to be converted to Unix timestamps in milliseconds
@@ -203,8 +237,9 @@ function buildHubspotFilters(
               // Convert ISO date string to timestamp
               const timestamp = new Date(dateStr).getTime();
               if (isNaN(timestamp)) {
-                throw new Error(
-                  `Invalid date format for BETWEEN operator: ${dateStr}`
+                throw new MCPError(
+                  `Invalid date format for BETWEEN operator: ${dateStr}`,
+                  { tracked: false }
                 );
               }
               return String(timestamp);
@@ -224,8 +259,9 @@ function buildHubspotFilters(
               if (!/^\d+$/.test(lowValue)) {
                 const timestamp = new Date(lowValue).getTime();
                 if (isNaN(timestamp)) {
-                  throw new Error(
-                    `Invalid date format for BETWEEN operator: ${lowValue}`
+                  throw new MCPError(
+                    `Invalid date format for BETWEEN operator: ${lowValue}`,
+                    { tracked: false }
                   );
                 }
                 lowValue = String(timestamp);
@@ -233,8 +269,9 @@ function buildHubspotFilters(
               if (!/^\d+$/.test(highValue)) {
                 const timestamp = new Date(highValue).getTime();
                 if (isNaN(timestamp)) {
-                  throw new Error(
-                    `Invalid date format for BETWEEN operator: ${highValue}`
+                  throw new MCPError(
+                    `Invalid date format for BETWEEN operator: ${highValue}`,
+                    { tracked: false }
                   );
                 }
                 highValue = String(timestamp);
@@ -244,13 +281,15 @@ function buildHubspotFilters(
             filter.value = lowValue;
             filter.highValue = highValue;
           } else {
-            throw new Error(
-              `BETWEEN operator with single value requires semicolon-separated format (e.g., "100;200")`
+            throw new MCPError(
+              `BETWEEN operator with single value requires semicolon-separated format (e.g., "100;200")`,
+              { tracked: false }
             );
           }
         } else {
-          throw new Error(
-            `BETWEEN operator requires either a values array with 2 elements or a semicolon-separated value string`
+          throw new MCPError(
+            `BETWEEN operator requires either a values array with 2 elements or a semicolon-separated value string`,
+            { tracked: false }
           );
         }
       } else {
@@ -278,7 +317,9 @@ function buildHubspotFilters(
             filter.value = stringValue;
           }
         } else {
-          throw new Error(`Value is required for ${operator} operator`);
+          throw new MCPError(`Value is required for ${operator} operator`, {
+            tracked: false,
+          });
         }
       }
     }
@@ -516,19 +557,25 @@ const getAssociationTypeId = async (
   );
 
   if (!response.ok) {
-    const e = new Error(
-      `Failed to fetch association types for ${fromObjectType} to ${toObjectType}: ${response.status} ${response.statusText}`
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `HubSpot API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
+    throw new MCPError(
+      `Failed to fetch association types for ${fromObjectType} to ${toObjectType}: ${response.status} ${response.statusText}`,
+      { tracked: false }
     );
-    throw normalizeError(e);
   }
 
   const data = await response.json();
 
   if (!data.results || data.results.length === 0) {
-    const e = new Error(
-      `No association types found for ${fromObjectType} to ${toObjectType}`
+    throw new MCPError(
+      `No association types found for ${fromObjectType} to ${toObjectType}`,
+      { tracked: false }
     );
-    throw normalizeError(e);
   }
 
   // Assuming the first result is the one needed for standard associations.
@@ -739,9 +786,9 @@ export const createNote = async ({
   const propertiesForApi = { ...properties };
 
   if (!propertiesForApi.hs_note_body) {
-    throw normalizeError(
-      new Error("hs_note_body is required to create a note.")
-    );
+    throw new MCPError("hs_note_body is required to create a note.", {
+      tracked: false,
+    });
   }
 
   // Use Unix milliseconds for hs_timestamp to ensure proper timeline placement.
@@ -806,7 +853,7 @@ export const createNote = async ({
       { error, noteInput, function: "createNote" },
       `Error creating note.`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -912,10 +959,9 @@ export const createCommunication = async ({
   const hubspotClient = new Client({ accessToken });
 
   if (!properties.hs_communication_channel_type) {
-    throw normalizeError(
-      new Error(
-        "hs_communication_channel_type is required in properties for createCommunication."
-      )
+    throw new MCPError(
+      "hs_communication_channel_type is required in properties for createCommunication.",
+      { tracked: false }
     );
   }
 
@@ -966,7 +1012,7 @@ export const createCommunication = async ({
       { error, communicationData, function: "createCommunication" },
       `Error creating communication (channel: ${properties.hs_communication_channel_type}).`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1032,7 +1078,7 @@ export const createMeeting = async ({
       { error, meetingInput, function: "createMeeting" },
       `Error creating meeting.`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1071,7 +1117,7 @@ export const getMeeting = async (
       { error, meetingId },
       `Error fetching meeting ${meetingId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1115,7 +1161,7 @@ export const getFilePublicUrl = async (
       { error, fileId },
       `Error fetching file ${fileId} public URL:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1167,7 +1213,7 @@ export const getAssociatedMeetings = async (
       { error, fromObjectType, fromObjectId },
       `Error fetching associated meetings for ${fromObjectType}/${fromObjectId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1338,7 +1384,7 @@ export const searchCrmObjects = async ({
       return { results: [], paging: undefined };
     }
     localLogger.error({ error }, `Error searching ${objectType}:`);
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1479,7 +1525,7 @@ export const getUserActivity = async ({
       { error, ownerId, startDate, endDate },
       `Error getting user activity for owner ${ownerId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1493,7 +1539,7 @@ export const getCurrentUserId = async (accessToken: string) => {
     };
   } catch (error) {
     localLogger.error({ error }, "Error getting current user ID:");
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1524,7 +1570,7 @@ export const updateContact = async ({
       { error, contactId },
       `Error updating contact with ID ${contactId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1555,7 +1601,7 @@ export const updateCompany = async ({
       { error, companyId },
       `Error updating company with ID ${companyId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1586,7 +1632,7 @@ export const updateDeal = async ({
       { error, dealId },
       `Error updating deal with ID ${dealId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1618,7 +1664,7 @@ export const updateTask = async ({
       { error, taskId },
       `Error updating task with ID ${taskId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1638,7 +1684,7 @@ export const deleteTask = async ({
       { error, taskId },
       `Error deleting task with ID ${taskId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1738,7 +1784,7 @@ export const updateCustomObject = async ({
       { error, objectType, objectId },
       `Error updating custom object ${objectType} with ID ${objectId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1757,7 +1803,15 @@ export const getUserDetails = async (accessToken: string) => {
     );
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `HubSpot API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
+      throw new MCPError(`HTTP error! status: ${response.status}`, {
+        tracked: false,
+      });
     }
 
     const data = await response.json();
@@ -1769,7 +1823,7 @@ export const getUserDetails = async (accessToken: string) => {
     };
   } catch (error) {
     localLogger.error({ error }, "Error getting user details:");
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1814,7 +1868,7 @@ export const createAssociation = async ({
       { error, fromObjectType, fromObjectId, toObjectType, toObjectId },
       `Error creating association between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1902,7 +1956,7 @@ export const listAssociations = async ({
       { error, objectType, objectId, toObjectType },
       `Error listing associations for ${objectType}:${objectId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 
@@ -1935,7 +1989,7 @@ export const removeAssociation = async ({
       { error, fromObjectType, fromObjectId, toObjectType, toObjectId },
       `Error removing association between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}:`
     );
-    throw normalizeError(error);
+    throw toHubspotProviderError(error) ?? normalizeError(error);
   }
 };
 

--- a/front/lib/api/actions/servers/hubspot/helpers.ts
+++ b/front/lib/api/actions/servers/hubspot/helpers.ts
@@ -1,8 +1,13 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { toHubspotProviderError } from "@app/lib/api/actions/servers/hubspot/client";
 import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
 
@@ -76,6 +81,21 @@ export const withAuth = async (
   try {
     return await action(accessToken);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      // Unexpected provider failure: rethrow for the central tool wrapper to track.
+      throw error;
+    }
+    if (isMCPError(error)) {
+      // Thrown from call stacks where returning a Result is impractical; honor it as if
+      // it had been returned (its tracked flag is respected by the tool wrapper).
+      return new Err(error);
+    }
+    // HubSpot SDK calls without a local catch site propagate here: surface HTTP 5xx
+    // responses as ProviderError.
+    const providerError = toHubspotProviderError(error);
+    if (providerError) {
+      throw providerError;
+    }
     return logAndReturnError({ error, message: "Operation failed" });
   }
 };

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+} from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -289,6 +293,13 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
         }
       }
     } catch (err) {
+      if (isProviderError(err)) {
+        // Unexpected provider failure: rethrow for the central tool wrapper to track.
+        throw err;
+      }
+      if (isMCPError(err)) {
+        return new Err(err);
+      }
       return new Err(
         new MCPError(
           `Failed to fetch objects from HubSpot: ${err instanceof Error ? err.message : String(err)}`

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   MCPProgressNotificationType,
   ToolGeneratedFileType,
@@ -29,7 +29,9 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { ApiError as GoogleGenAIApiError } from "@google/genai";
 import assert from "assert";
+import { APIError as OpenAIAPIError } from "openai";
 
 export type ImageGenerationErrorCode =
   | "api_error"
@@ -44,6 +46,34 @@ export class ImageGenerationError extends Error {
   ) {
     super(message, { cause: options?.cause });
     this.name = "ImageGenerationError";
+  }
+}
+
+/**
+ * Rethrows an `ImageGenerationError` as `ProviderError` when the underlying image
+ * generation provider call failed unexpectedly (HTTP 5xx), so it escapes the tool
+ * handler and reaches the central tool wrapper, which always tracks it. The provider
+ * SDK error is carried on `cause` by the LLM layer. No-op for anything else.
+ */
+export function throwIfImageGenerationProviderError(
+  error: ImageGenerationError
+): void {
+  const { cause } = error;
+  if (
+    cause instanceof OpenAIAPIError &&
+    typeof cause.status === "number" &&
+    cause.status >= 500
+  ) {
+    throw new ProviderError(
+      `OpenAI API returned an unexpected error (HTTP ${cause.status}).`,
+      { status: cause.status, cause }
+    );
+  }
+  if (cause instanceof GoogleGenAIApiError && cause.status >= 500) {
+    throw new ProviderError(
+      `Google AI Studio API returned an unexpected error (HTTP ${cause.status}).`,
+      { status: cause.status, cause }
+    );
   }
 }
 

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -10,6 +10,7 @@ import {
   computeImageGenerationCostDetails,
   processImageFileIds,
   sendImageProgressNotification,
+  throwIfImageGenerationProviderError,
   trackTokenUsage,
   uploadAndFormatImageResponse,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
@@ -142,6 +143,8 @@ export function createImageGenerationTools(
           },
         });
         generation.end();
+
+        throwIfImageGenerationProviderError(genError);
 
         return new Err(
           new MCPError(genError.message, { tracked, cause: genError })

--- a/front/lib/api/actions/servers/include_data/include_function.ts
+++ b/front/lib/api/actions/servers/include_data/include_function.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   IncludeResultResourceType,
@@ -116,6 +119,7 @@ export async function runIncludeDataRetrieval(
   );
 
   if (searchResults.isErr()) {
+    throwOnCoreAPIInternalError(searchResults.error);
     return new Err(new MCPError(searchResults.error.message));
   }
 

--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
@@ -97,6 +101,12 @@ async function jiraApiCall<T extends z.ZodTypeAny>(
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Jira API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorBody = await response.text();
       const msg = `JIRA API error: ${response.status} ${response.statusText} - ${errorBody}`;
       logger.error(`[JIRA MCP Server] ${msg}`);
@@ -119,6 +129,9 @@ async function jiraApiCall<T extends z.ZodTypeAny>(
 
     return new Ok(parseResult.data);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     logger.error(`[JIRA MCP Server] JIRA API call failed for ${endpoint}:`);
     return new Err(normalizeError(error).message);
   }
@@ -1109,6 +1122,11 @@ export const withAuth = async ({
 
     return await action(baseUrl, resourceInfo, accessToken);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      // Let provider 5xx failures escape to the tool-execution wrapper, which converts
+      // them to tracked MCPErrors.
+      throw error;
+    }
     return logAndReturnError({
       error,
       message: "Operation failed",
@@ -1203,6 +1221,12 @@ export async function uploadAttachmentsToJira(
     );
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Jira API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorBody = await response.text();
       const msg = `JIRA API error: ${response.status} ${response.statusText} - ${errorBody}`;
       return logAndReturnApiError({
@@ -1232,6 +1256,9 @@ export async function uploadAttachmentsToJira(
 
     return new Ok(parseResult.data);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     return logAndReturnApiError({
       error,
       message: "JIRA API call failed for attachment upload",
@@ -1290,6 +1317,12 @@ async function downloadAttachmentContent({
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Jira API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorBody = await response.text();
       const msg = `JIRA API error: ${response.status} ${response.statusText} - ${errorBody}`;
       logger.warn(`${msg}`);
@@ -1302,6 +1335,9 @@ async function downloadAttachmentContent({
     const buffer = Buffer.from(await response.arrayBuffer());
     return new Ok(buffer);
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     logger.warn(`Attachment download failed:`, {
       error: error instanceof Error ? error.message : String(error),
       attachmentId,

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { isProviderError, MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
@@ -320,6 +320,9 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
             },
           ]);
         } catch (error) {
+          if (isProviderError(error)) {
+            throw error;
+          }
           return new Err(
             new MCPError(
               `Error retrieving issue types: ${normalizeError(error).message}`
@@ -360,6 +363,9 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
             },
           ]);
         } catch (error) {
+          if (isProviderError(error)) {
+            throw error;
+          }
           return new Err(
             new MCPError(
               `Error retrieving issue fields: ${normalizeError(error).message}`
@@ -604,6 +610,9 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
             },
           });
         } catch (error) {
+          if (isProviderError(error)) {
+            throw error;
+          }
           logger.error(`Error in read_attachment:`, {
             error: error,
             issueKey,

--- a/front/lib/api/actions/servers/luma/client.ts
+++ b/front/lib/api/actions/servers/luma/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
   CreateEventParams,
@@ -101,6 +101,12 @@ export class LumaClient {
     }
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Luma API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorText = await response.text();
       return new Err(
         new Error(

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -1,3 +1,4 @@
+import { isProviderError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import config from "@app/lib/api/config";
@@ -14,6 +15,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import {
   Client as GraphClient,
+  GraphError,
   ResponseType,
 } from "@microsoft/microsoft-graph-client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -168,6 +170,24 @@ export async function getGraphClient(
   return GraphClient.init({
     authProvider: (done) => done(null, accessToken),
   });
+}
+
+/**
+ * Rethrows a caught error as `ProviderError` when Microsoft Graph failed unexpectedly
+ * (HTTP 5xx), so it escapes the tool handlers' catch-all blocks and reaches the central
+ * tool wrapper, which always tracks it. Rethrows an existing `ProviderError` as-is so
+ * nested catch sites do not swallow it. No-op for anything else.
+ */
+export function throwIfGraphProviderError(error: unknown): void {
+  if (isProviderError(error)) {
+    throw error;
+  }
+  if (error instanceof GraphError && error.statusCode >= 500) {
+    throw new ProviderError(
+      `Microsoft Graph API returned an unexpected error (HTTP ${error.statusCode}).`,
+      { status: error.statusCode, cause: error }
+    );
+  }
 }
 
 export async function getDriveItemEndpoint(
@@ -464,6 +484,12 @@ export async function downloadDriveItemAsBuffer(
 ): Promise<Buffer> {
   if (downloadUrl) {
     const response = await untrustedFetch(downloadUrl);
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `Microsoft Graph API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
     if (!response.ok) {
       throw new Error(
         `Failed to download file: ${response.status} ${response.statusText}`
@@ -515,6 +541,12 @@ export async function downloadAndProcessMicrosoftFile({
     buffer = await downloadDriveItemAsBuffer(client, endpoint, downloadUrl);
   } else if (downloadUrl) {
     const docResponse = await untrustedFetch(downloadUrl);
+    if (docResponse.status >= 500) {
+      throw new ProviderError(
+        `Microsoft Graph API returned an unexpected error (HTTP ${docResponse.status}).`,
+        { status: docResponse.status }
+      );
+    }
     if (!docResponse.ok) {
       throw new Error(
         `Failed to download file: ${docResponse.status} ${docResponse.statusText}`

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -16,6 +16,7 @@ import {
   getDriveItemEndpoint,
   getGraphClient,
   searchMicrosoftDriveItems,
+  throwIfGraphProviderError,
   validateDocumentXml,
   validateZipFile,
 } from "@app/lib/api/actions/servers/microsoft/utils";
@@ -76,6 +77,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to search files")
       );
@@ -108,6 +110,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to search drive items"
@@ -209,6 +212,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to list drive items"
@@ -258,6 +262,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to resolve URL to a drive item"
@@ -348,6 +353,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       const originalError =
         normalizeError(err).message || "Failed to update document";
       let errorMessage = originalError;
@@ -424,6 +430,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
             extractAsXml: true,
           });
         } catch (error) {
+          throwIfGraphProviderError(error);
           return new Err(
             new MCPError(
               `Failed to process file: ${normalizeError(error).message}`
@@ -468,6 +475,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       try {
         buffer = await downloadDriveItemAsBuffer(client, endpoint, downloadUrl);
       } catch (err) {
+        throwIfGraphProviderError(err);
         return new Err(
           new MCPError(
             `Failed to download file: ${normalizeError(err).message}`
@@ -502,6 +510,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
       return new Ok(result.value);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to retrieve file content"
@@ -549,6 +558,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       const error = normalizeError(err);
       if (error.message.toLowerCase().includes("namealreadyexists")) {
         return new Err(
@@ -634,6 +644,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       const error = normalizeError(err);
 
       const errorMessage = error.message || "Failed to upload file";
@@ -676,6 +687,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to rename item")
       );
@@ -737,6 +749,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to copy file or folder"

--- a/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
@@ -5,6 +5,7 @@ import {
   getDriveItemEndpoint,
   getGraphClient,
   parseCellRef,
+  throwIfGraphProviderError,
 } from "@app/lib/api/actions/servers/microsoft/utils";
 import { makeExcelRequest } from "@app/lib/api/actions/servers/microsoft_excel/helpers";
 import { MICROSOFT_EXCEL_TOOLS_METADATA } from "@app/lib/api/actions/servers/microsoft_excel/metadata";
@@ -38,6 +39,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(response, null, 2) },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to list Excel files"
@@ -69,6 +71,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(response, null, 2) },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to get worksheets")
       );
@@ -160,6 +163,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: csv }]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to read worksheet data"
@@ -265,6 +269,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(response, null, 2) },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to write worksheet data"
@@ -302,6 +307,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(response, null, 2) },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to create worksheet"
@@ -346,6 +352,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to clear range")
       );

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -9,7 +9,10 @@ import type {
   TeamsMessage,
   TeamsUser,
 } from "@app/lib/api/actions/servers/microsoft/utils";
-import { getGraphClient } from "@app/lib/api/actions/servers/microsoft/utils";
+import {
+  getGraphClient,
+  throwIfGraphProviderError,
+} from "@app/lib/api/actions/servers/microsoft/utils";
 import { MICROSOFT_TEAMS_TOOLS_METADATA } from "@app/lib/api/actions/servers/microsoft_teams/metadata";
 import {
   renderChannels,
@@ -63,6 +66,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to search Teams messages"
@@ -89,6 +93,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list teams")
       );
@@ -128,6 +133,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list users")
       );
@@ -161,6 +167,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to list public channels"
@@ -210,6 +217,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list chats")
       );
@@ -378,6 +386,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       return new Ok(content);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list threads")
       );
@@ -513,6 +522,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
               }
             }
           } catch (err) {
+            throwIfGraphProviderError(err);
             return new Err(
               new MCPError(
                 `Failed to create or find chat with users: ${normalizeError(err).message}`
@@ -593,6 +603,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to post message")
       );
@@ -659,6 +670,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to list meetings")
       );
@@ -759,6 +771,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      throwIfGraphProviderError(err);
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to get transcript content"

--- a/front/lib/api/actions/servers/monday/helpers.ts
+++ b/front/lib/api/actions/servers/monday/helpers.ts
@@ -1,3 +1,9 @@
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -96,8 +102,16 @@ const makeGraphQLRequest = async (
 
       // Special handling for authentication errors
       if (response.status === 401 || response.status === 403) {
-        throw new Error(
-          `Authentication failed: ${response.status} - Token may be expired or invalid`
+        throw new MCPError(
+          `Authentication failed: ${response.status} - Token may be expired or invalid`,
+          { tracked: false }
+        );
+      }
+
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Monday API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
         );
       }
 
@@ -117,8 +131,7 @@ const makeGraphQLRequest = async (
         }
       }
 
-      const error = new Error(errorMessage);
-      throw normalizeError(error);
+      throw new MCPError(errorMessage, { tracked: false });
     }
 
     let result;
@@ -147,12 +160,18 @@ const makeGraphQLRequest = async (
         )
         .join(", ");
 
-      const error = new Error(`Monday GraphQL error: ${errorDetails}`);
-      throw normalizeError(error);
+      // GraphQL-level errors are driven by the query/user input, not a provider outage.
+      throw new MCPError(`Monday GraphQL error: ${errorDetails}`, {
+        tracked: false,
+      });
     }
 
     return result.data;
   } catch (error) {
+    // Let typed tool errors escape to the tool-execution wrapper.
+    if (isMCPError(error) || isProviderError(error)) {
+      throw error;
+    }
     localLogger.error("Error making Monday API request:", {
       error,
       query: query.substring(0, 200),
@@ -191,7 +210,7 @@ export const getBoardItems = async (
   // Convert boardId to integer to ensure proper format
   const boardIdInt = parseInt(boardId, 10);
   if (isNaN(boardIdInt)) {
-    throw new Error(`Invalid board ID: ${boardId}`);
+    throw new MCPError(`Invalid board ID: ${boardId}`, { tracked: false });
   }
 
   const query = `
@@ -310,7 +329,9 @@ export const searchItems = async (
     // Convert boardId to integer
     const boardIdInt = parseInt(filters.boardId, 10);
     if (isNaN(boardIdInt)) {
-      throw new Error(`Invalid board ID: ${filters.boardId}`);
+      throw new MCPError(`Invalid board ID: ${filters.boardId}`, {
+        tracked: false,
+      });
     }
 
     query = `
@@ -578,7 +599,7 @@ export const updateItem = async (
   // First get the item to find its board ID (required by Monday API)
   const itemDetails = await getItemDetails(accessToken, itemId);
   if (!itemDetails) {
-    throw new Error("Item not found");
+    throw new MCPError("Item not found", { tracked: false });
   }
 
   const query = `
@@ -672,7 +693,7 @@ export const updateItemName = async (
   // First get the item to find its board ID
   const itemDetails = await getItemDetails(accessToken, itemId);
   if (!itemDetails) {
-    throw new Error("Item not found");
+    throw new MCPError("Item not found", { tracked: false });
   }
 
   const query = `
@@ -929,7 +950,7 @@ export const updateSubitem = async (
   // First get the subitem to find its board ID (required by Monday API)
   const itemDetails = await getItemDetails(accessToken, subitemId);
   if (!itemDetails) {
-    throw new Error("Subitem not found");
+    throw new MCPError("Subitem not found", { tracked: false });
   }
 
   const query = `
@@ -1028,23 +1049,34 @@ export const uploadFileToColumn = async (
     });
 
     if (!response.ok) {
-      const error = new Error(
-        `Monday API file upload failed: ${response.status} ${response.statusText}`
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Monday API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
+      throw new MCPError(
+        `Monday API file upload failed: ${response.status} ${response.statusText}`,
+        { tracked: false }
       );
-      throw normalizeError(error);
     }
 
     const result = await response.json();
 
     if (result.errors) {
-      const error = new Error(
-        `Monday GraphQL error: ${result.errors.map((e: any) => e.message).join(", ")}`
+      // GraphQL-level errors are driven by the query/user input, not a provider outage.
+      throw new MCPError(
+        `Monday GraphQL error: ${result.errors.map((e: any) => e.message).join(", ")}`,
+        { tracked: false }
       );
-      throw normalizeError(error);
     }
 
     return result.data.add_file_to_column;
   } catch (error) {
+    // Let typed tool errors escape to the tool-execution wrapper.
+    if (isMCPError(error) || isProviderError(error)) {
+      throw error;
+    }
     localLogger.error("Error uploading file to Monday:", error);
     throw normalizeError(error);
   }
@@ -1141,7 +1173,7 @@ export const getBoardValues = async (
   // Convert boardId to integer
   const boardIdInt = parseInt(boardId, 10);
   if (isNaN(boardIdInt)) {
-    throw new Error(`Invalid board ID: ${boardId}`);
+    throw new MCPError(`Invalid board ID: ${boardId}`, { tracked: false });
   }
 
   const query = `
@@ -1266,7 +1298,7 @@ export const getGroupDetails = async (
   // Convert boardId to integer
   const boardIdInt = parseInt(boardId, 10);
   if (isNaN(boardIdInt)) {
-    throw new Error(`Invalid board ID: ${boardId}`);
+    throw new MCPError(`Invalid board ID: ${boardId}`, { tracked: false });
   }
 
   const query = `
@@ -1579,7 +1611,7 @@ export const getBoardAnalytics = async (
   const board = data.boards?.[0];
 
   if (!board) {
-    throw new Error("Board not found");
+    throw new MCPError("Board not found", { tracked: false });
   }
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isMCPError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
@@ -23,14 +27,56 @@ import {
 } from "@app/types/shared/utils/time_frame";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { Client, isFullDataSource, isFullPage } from "@notionhq/client";
+import {
+  APIErrorCode,
+  APIResponseError,
+  Client,
+  isFullDataSource,
+  isFullPage,
+  isHTTPResponseError,
+} from "@notionhq/client";
 import type {
   CreateCommentParameters,
   QueryDataSourceParameters,
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
-import { APIResponseError } from "@notionhq/client/build/src/errors";
 import { parseISO } from "date-fns";
+
+/**
+ * Converts an error caught around a Notion SDK call into an MCPError. Notion server-side
+ * failures (HTTP 5xx) are rethrown as ProviderError so they are tracked upstream.
+ */
+function notionErrorToMCPError(e: unknown): MCPError {
+  if (isMCPError(e)) {
+    return e;
+  }
+  if (
+    isHTTPResponseError(e) &&
+    (e.status >= 500 ||
+      e.code === APIErrorCode.InternalServerError ||
+      e.code === APIErrorCode.ServiceUnavailable)
+  ) {
+    throw new ProviderError(
+      `Notion API returned an unexpected error (HTTP ${e.status}).`,
+      { status: e.status, cause: e }
+    );
+  }
+  if (
+    APIResponseError.isAPIResponseError(e) &&
+    [
+      // Errors due to a malformed input passed by the model (e.g. invalid ID) are not tracked.
+      APIErrorCode.RestrictedResource,
+      APIErrorCode.ObjectNotFound,
+      APIErrorCode.InvalidRequest,
+      APIErrorCode.ValidationError,
+    ].includes(e.code)
+  ) {
+    return new MCPError(e.message, { tracked: false, cause: e });
+  }
+  return new MCPError(normalizeError(e).message, {
+    cause: normalizeError(e),
+  });
+}
 
 async function withNotionClient<T>(
   fn: (notion: Client) => Promise<T>,
@@ -51,21 +97,7 @@ async function withNotionClient<T>(
       { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ]);
   } catch (e) {
-    const tracked =
-      APIResponseError.isAPIResponseError(e) &&
-      [
-        // Ignoring errors due to a malformed input passed by the model (e.g. invalid ID).
-        "restricted_resource",
-        "object_not_found",
-        "invalid_request",
-        "validation_error",
-      ].includes(e.code);
-    return new Err(
-      new MCPError(normalizeError(e).message, {
-        tracked,
-        cause: normalizeError(e),
-      })
-    );
+    return new Err(notionErrorToMCPError(e));
   }
 }
 
@@ -81,14 +113,19 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
       }
       const notion = new Client({ auth: accessToken });
 
-      const rawResults = await notion.search({
-        query,
-        filter: {
-          property: "object",
-          value: type === "database" ? "data_source" : type,
-        },
-        page_size: NOTION_SEARCH_ACTION_NUM_RESULTS,
-      });
+      let rawResults;
+      try {
+        rawResults = await notion.search({
+          query,
+          filter: {
+            property: "object",
+            value: type === "database" ? "data_source" : type,
+          },
+          page_size: NOTION_SEARCH_ACTION_NUM_RESULTS,
+        });
+      } catch (e) {
+        return new Err(notionErrorToMCPError(e));
+      }
 
       const timeFrame = parseTimeFrame(relativeTimeFrame);
 
@@ -346,8 +383,9 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
     ) => {
       return withNotionClient((notion) => {
         if (!parent_page_id && !discussion_id) {
-          throw new Error(
-            "Either parent_page_id or discussion_id must be provided."
+          throw new MCPError(
+            "Either parent_page_id or discussion_id must be provided.",
+            { tracked: false }
           );
         }
         let params: CreateCommentParameters;

--- a/front/lib/api/actions/servers/openai_usage/client.ts
+++ b/front/lib/api/actions/servers/openai_usage/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -67,6 +67,12 @@ export class OpenAIUsageClient {
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `OpenAI API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorBody = await response.text();
       if (response.status === 401) {
         return new Err(

--- a/front/lib/api/actions/servers/outlook/outlook_api_helper.ts
+++ b/front/lib/api/actions/servers/outlook/outlook_api_helper.ts
@@ -1,3 +1,4 @@
+import { isProviderError, ProviderError } from "@app/lib/actions/mcp_errors";
 import logger from "@app/logger/logger";
 import { z } from "zod";
 
@@ -171,10 +172,19 @@ const fetchFromOutlook = async (
   }
 
   // eslint-disable-next-line no-restricted-globals
-  return fetch(`https://graph.microsoft.com/v1.0${endpoint}`, {
+  const response = await fetch(`https://graph.microsoft.com/v1.0${endpoint}`, {
     ...options,
     headers,
   });
+
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `Microsoft Graph API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
+
+  return response;
 };
 
 const getErrorText = async (response: Response): Promise<string> => {
@@ -208,6 +218,9 @@ export async function getUserTimezone(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return result.timeZone || "UTC";
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error getting user timezone");
     return { error: `Error getting user timezone: ${error}` };
   }
@@ -261,6 +274,9 @@ export async function listCalendars(
       nextLink: result["@odata.nextLink"],
     };
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error listing calendars");
     return { error: `Error listing calendars: ${error}` };
   }
@@ -329,6 +345,9 @@ export async function listEvents(
         nextLink: result["@odata.nextLink"],
       };
     } catch (error) {
+      if (isProviderError(error)) {
+        throw error;
+      }
       localLogger.error({ error }, "Error listing events");
       return { error: `Error listing events: ${error}` };
     }
@@ -397,6 +416,9 @@ export async function listEvents(
         nextLink: result["@odata.nextLink"],
       };
     } catch (error) {
+      if (isProviderError(error)) {
+        throw error;
+      }
       localLogger.error({ error }, "Error listing events");
       return { error: `Error listing events: ${error}` };
     }
@@ -446,6 +468,9 @@ export async function getEvent(
 
     return eventResult.data;
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error getting event");
     return { error: `Error getting event: ${error}` };
   }
@@ -550,6 +575,9 @@ export async function createEvent(
 
     return eventResult.data;
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error creating event");
     return { error: `Error creating event: ${error}` };
   }
@@ -664,6 +692,9 @@ export async function updateEvent(
 
     return eventResult.data;
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error updating event");
     return { error: `Error updating event: ${error}` };
   }
@@ -699,6 +730,9 @@ export async function deleteEvent(
 
     return { success: true };
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error deleting event");
     return { error: `Error deleting event: ${error}` };
   }
@@ -773,6 +807,9 @@ export async function checkAvailability(
       timeSlot: { start: startTime, end: endTime },
     };
   } catch (error) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     localLogger.error({ error }, "Error checking availability");
     return { error: `Error checking availability: ${error}` };
   }

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolHandlerExtra,
@@ -100,13 +100,29 @@ const fetchFromOutlook = async (
   options?: RequestInit
 ): Promise<Response> => {
   // eslint-disable-next-line no-restricted-globals
-  return fetch(`https://graph.microsoft.com/v1.0${endpoint}`, {
+  const response = await fetch(`https://graph.microsoft.com/v1.0${endpoint}`, {
     ...options,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       ...options?.headers,
     },
   });
+
+  // Microsoft Graph signals throttling with 429/503 + Retry-After. A 503
+  // carrying Retry-After is expected throttling, not an unexpected provider
+  // failure: let callers handle it (move_messages surfaces the retry delay to
+  // the model).
+  if (
+    response.status >= 500 &&
+    !(response.status === 503 && response.headers.has("Retry-After"))
+  ) {
+    throw new ProviderError(
+      `Microsoft Graph API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
+
+  return response;
 };
 
 const getMailboxBasePath = (sharedMailboxAddress?: string): string => {
@@ -518,11 +534,13 @@ async function createOutlookDraft({
     );
 
     if (!updateDraftResponse.ok) {
+      // Best-effort draft cleanup: swallow failures (including the funnel's
+      // ProviderError on 5xx) so they don't surface as unhandled rejections.
       void fetchFromOutlook(
         `${basePath}/messages/${encodedDraftId}`,
         accessToken,
         { method: "DELETE" }
-      );
+      ).catch(() => {});
       const errorText = await getErrorText(updateDraftResponse);
       return new Err(
         new MCPError(`Failed to update reply draft: ${errorText}`)
@@ -591,11 +609,13 @@ async function createOutlookDraft({
     );
 
     if (!attachmentResponse.ok) {
+      // Best-effort draft cleanup: swallow failures (including the funnel's
+      // ProviderError on 5xx) so they don't surface as unhandled rejections.
       void fetchFromOutlook(
         `${basePath}/messages/${encodedDraftId}`,
         accessToken,
         { method: "DELETE" }
-      );
+      ).catch(() => {});
       const errorText = await getErrorText(attachmentResponse);
       return new Err(new MCPError(`Failed to add attachment: ${errorText}`));
     }
@@ -1677,11 +1697,13 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       );
 
       if (!sendResponse.ok) {
+        // Best-effort draft cleanup: swallow failures (including the funnel's
+        // ProviderError on 5xx) so they don't surface as unhandled rejections.
         void fetchFromOutlook(
           `${basePath}/messages/${encodedDraftId}`,
           accessToken,
           { method: "DELETE" }
-        );
+        ).catch(() => {});
         const errorText = await getErrorText(sendResponse);
         return new Err(
           new MCPError(

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { isProviderError, MCPError } from "@app/lib/actions/mcp_errors";
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type {
   DataSourcesToolConfigurationType,
@@ -350,6 +350,11 @@ export async function withErrorHandling<T>(
   try {
     return await operation();
   } catch (error) {
+    if (isProviderError(error)) {
+      // Unexpected upstream failures must reach the tool-execution wrapper, which
+      // converts them to tracked MCPErrors that always alert.
+      throw error;
+    }
     return new Err(
       new MCPError(errorMessage, {
         cause: normalizeError(error),

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
 import type {
   ToolDefinition,
@@ -1221,6 +1224,7 @@ export function createProjectManagerTools(
         });
 
         if (messageRes.isErr()) {
+          throwOnDustAPIInternalError(messageRes.error.api_error);
           return new Err(
             new MCPError(
               `Failed to post message: ${messageRes.error.api_error.message}`,
@@ -1510,6 +1514,7 @@ export function createProjectManagerTools(
         });
 
         if (messageRes.isErr()) {
+          throwOnDustAPIInternalError(messageRes.error.api_error);
           return new Err(
             new MCPError(
               `Failed to post message: ${messageRes.error.api_error.message}`,

--- a/front/lib/api/actions/servers/productboard/client.ts
+++ b/front/lib/api/actions/servers/productboard/client.ts
@@ -1,4 +1,5 @@
 import type { MCPError } from "@app/lib/actions/mcp_errors";
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   ProductboardConfiguration,
   ProductboardEntity,
@@ -83,6 +84,12 @@ export class ProductboardClient {
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Productboard API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const isInvalidInput = response.status === 400 || response.status === 422;
       const errorText = await response.text();
 

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -3,7 +3,10 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   SqlQueryOutputType,
   ThinkingOutputType,
@@ -118,6 +121,7 @@ export async function executeQuery(
     query,
   });
   if (queryResult.isErr()) {
+    throwOnCoreAPIInternalError(queryResult.error);
     return new Err(
       // Certain errors we don't track as they can occur in the context of a normal execution.
       new MCPError(

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { TablesConfigurationToolType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { GET_DATABASE_SCHEMA_MARKER } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -122,6 +125,7 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
         });
 
         if (tableResult.isErr()) {
+          throwOnCoreAPIInternalError(tableResult.error);
           return {
             uri,
             tableId: tableConfiguration.tableId,
@@ -202,6 +206,7 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
     });
 
     if (schemaResult.isErr()) {
+      throwOnCoreAPIInternalError(schemaResult.error);
       return new Err(
         new MCPError(
           `Error retrieving database schema: ${schemaResult.error.message}`,
@@ -270,8 +275,10 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
       tables: tableConfigurations.map((t) => {
         const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
         if (!dataSourceView || !dataSourceView.dataSource.dustAPIDataSourceId) {
-          throw new Error(
-            `Missing data source ID for view ${t.dataSourceViewId}`
+          // Outdated or inaccessible table configuration: not actionable on our side.
+          throw new MCPError(
+            `Missing data source ID for view ${t.dataSourceViewId}`,
+            { tracked: false }
           );
         }
         return {

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import {
   appendFilePathsHintToQuery,
@@ -95,6 +98,10 @@ async function postMessageAndFetchConversation(
   if (messageRes.isErr()) {
     const isUserSide = isUserSideError(messageRes.error);
     const isTransient = isTransientNetworkError(messageRes.error);
+    if (!isTransient) {
+      // Transient network failures keep their untracked handling below.
+      throwOnDustAPIInternalError(messageRes.error);
+    }
     if (isUserSide) {
       await onPostMessageError?.();
     }
@@ -180,6 +187,10 @@ export async function getOrCreateConversation(
     if (convRes.isErr()) {
       const isUserSide = isUserSideError(convRes.error);
       const isTransient = isTransientNetworkError(convRes.error);
+      if (!isTransient) {
+        // Transient network failures keep their untracked handling below.
+        throwOnDustAPIInternalError(convRes.error);
+      }
       const message = isUserSide
         ? convRes.error.message
         : "Failed to get conversation";
@@ -334,6 +345,11 @@ export async function getOrCreateConversation(
       },
       "Failed to create conversation"
     );
+
+    if (!isTransient) {
+      // Transient network failures keep their untracked handling below.
+      throwOnDustAPIInternalError(convRes.error);
+    }
 
     const message = isUserSide
       ? convRes.error.message

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import { AGENT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   MCPProgressNotificationType,
@@ -586,6 +589,14 @@ const runAgent = async (
     const abortClassification = classifyToolAbortSignal(abortSignal);
     if (abortClassification !== "none") {
       return handleAbortedSignal(abortClassification);
+    }
+
+    if (
+      !(streamRes.error instanceof Error) &&
+      !isTransientStreamError(streamRes.error)
+    ) {
+      // Transient network failures keep their existing handling below.
+      throwOnDustAPIInternalError(streamRes.error);
     }
 
     const errorMessage = `Failed to stream agent answer: ${streamRes.error.message}`;

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolGeneratedFilePathType,
@@ -180,6 +180,17 @@ export default async function createServer(
         );
 
         if (runRes.isErr()) {
+          // `runAppStreamed` only exposes the upstream HTTP status inside the error
+          // message (`status_code=<n>`), so parse it to detect unexpected Dust API
+          // failures (HTTP >= 500).
+          const statusMatch = runRes.error.message.match(/status_code=(\d{3})/);
+          const statusCode = statusMatch ? parseInt(statusMatch[1], 10) : null;
+          if (statusCode !== null && statusCode >= 500) {
+            throw new ProviderError(
+              `Dust API returned an unexpected error (HTTP ${statusCode}).`,
+              { status: statusCode, cause: new Error(runRes.error.message) }
+            );
+          }
           return new Err(
             new MCPError(`Error running Dust app: ${runRes.error.message}`)
           );

--- a/front/lib/api/actions/servers/salesforce/api_helper.ts
+++ b/front/lib/api/actions/servers/salesforce/api_helper.ts
@@ -1,4 +1,8 @@
-import { SF_API_VERSION } from "@app/lib/api/actions/servers/salesforce/helpers";
+import { isProviderError, ProviderError } from "@app/lib/actions/mcp_errors";
+import {
+  SF_API_VERSION,
+  toSalesforceProviderError,
+} from "@app/lib/api/actions/servers/salesforce/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -63,6 +67,10 @@ async function getSalesforceAttachments(
 
     return new Ok(attachments);
   } catch (error) {
+    const providerError = toSalesforceProviderError(error);
+    if (providerError) {
+      throw providerError;
+    }
     return new Err(
       `Failed to get attachments: ${normalizeError(error).message}`
     );
@@ -123,6 +131,10 @@ async function getSalesforceFiles(
 
     return new Ok(files);
   } catch (error) {
+    const providerError = toSalesforceProviderError(error);
+    if (providerError) {
+      throw providerError;
+    }
     return new Err(`Failed to get files: ${normalizeError(error).message}`);
   }
 }
@@ -144,11 +156,21 @@ async function downloadSalesforceAttachment(
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Salesforce API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       return new Err(`Salesforce API error: ${response.status}`);
     }
 
     return new Ok(Buffer.from(await response.arrayBuffer()));
   } catch (error) {
+    // Salesforce-side failures must reach the tool wrapper, not be swallowed here.
+    if (isProviderError(error)) {
+      throw error;
+    }
     return new Err(
       `Failed to download attachment: ${normalizeError(error).message}`
     );
@@ -172,11 +194,21 @@ async function downloadSalesforceFile(
     });
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Salesforce API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       return new Err(`Salesforce API error: ${response.status}`);
     }
 
     return new Ok(Buffer.from(await response.arrayBuffer()));
   } catch (error) {
+    // Salesforce-side failures must reach the tool wrapper, not be swallowed here.
+    if (isProviderError(error)) {
+      throw error;
+    }
     return new Err(`Failed to download file: ${normalizeError(error).message}`);
   }
 }

--- a/front/lib/api/actions/servers/salesforce/helpers.ts
+++ b/front/lib/api/actions/servers/salesforce/helpers.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -10,6 +10,40 @@ import type { Connection } from "jsforce";
 import jsforce from "jsforce";
 
 export const SF_API_VERSION = "57.0";
+
+const SALESFORCE_HTTP_ERROR_CODE_PATTERN = /^ERROR_HTTP_(\d{3})$/;
+
+/**
+ * Converts a jsforce error into a ProviderError when the underlying HTTP status is >= 500.
+ * jsforce surfaces HTTP-level failures without a parseable Salesforce error body as
+ * `HttpApiError` with `errorCode` set to `ERROR_HTTP_<status>` (see jsforce lib/http-api.js).
+ * User-driven failures (bad SOQL, unknown fields, permissions) carry Salesforce error codes
+ * such as `MALFORMED_QUERY` instead and must not be treated as provider failures. jsforce
+ * does not export its error class, so detection is structural on `errorCode`.
+ */
+export function toSalesforceProviderError(
+  error: unknown
+): ProviderError | null {
+  if (!(error instanceof Error) || !("errorCode" in error)) {
+    return null;
+  }
+  const { errorCode } = error;
+  if (typeof errorCode !== "string") {
+    return null;
+  }
+  const match = SALESFORCE_HTTP_ERROR_CODE_PATTERN.exec(errorCode);
+  if (!match) {
+    return null;
+  }
+  const status = parseInt(match[1], 10);
+  if (status < 500) {
+    return null;
+  }
+  return new ProviderError(
+    `Salesforce API returned an unexpected error (HTTP ${status}).`,
+    { status, cause: error }
+  );
+}
 
 export async function withAuth(
   { authInfo }: ToolHandlerExtra,
@@ -31,6 +65,10 @@ export async function withAuth(
   try {
     await conn.identity();
   } catch (error) {
+    const providerError = toSalesforceProviderError(error);
+    if (providerError) {
+      throw providerError;
+    }
     return new Err(
       new MCPError(
         `Failed to authenticate with Salesforce: ${normalizeError(error).message}`
@@ -50,6 +88,12 @@ export function logAndReturnError({
   params: Record<string, unknown>;
   message: string;
 }): ToolHandlerResult {
+  // Salesforce-side failures (HTTP >= 500) are thrown so they reach the tool wrapper and
+  // alert, instead of being returned as a plain tool error.
+  const providerError = toSalesforceProviderError(error);
+  if (providerError) {
+    throw providerError;
+  }
   const normalizedError = normalizeError(error);
   logger.error(
     { params, error: normalizedError.message },

--- a/front/lib/api/actions/servers/salesloft/client.ts
+++ b/front/lib/api/actions/servers/salesloft/client.ts
@@ -1,3 +1,4 @@
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   SalesloftApiResponse,
   SalesloftSingleItemResponse,
@@ -10,6 +11,13 @@ async function handleSalesloftError(
   response: Response,
   errorText: string
 ): Promise<never> {
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `Salesloft API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
+
   let errorMessage = `Salesloft API error: ${response.status} ${response.statusText}`;
 
   if (errorText) {
@@ -37,12 +45,13 @@ async function handleSalesloftError(
   }
 
   if (response.status === 401 || response.status === 403) {
-    throw new Error(
-      `Authentication failed: ${errorMessage}. Please verify your bearer token is valid.`
+    throw new MCPError(
+      `Authentication failed: ${errorMessage}. Please verify your bearer token is valid.`,
+      { tracked: false }
     );
   }
 
-  throw new Error(errorMessage);
+  throw new MCPError(errorMessage, { tracked: false });
 }
 
 export async function makeSalesloftRequest<T>(

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -142,6 +145,7 @@ export async function searchFunction(
   );
 
   if (searchResults.isErr()) {
+    throwOnCoreAPIInternalError(searchResults.error);
     return new Err(new MCPError(searchResults.error.message));
   }
 

--- a/front/lib/api/actions/servers/servicenow/client.ts
+++ b/front/lib/api/actions/servers/servicenow/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { untrustedFetch } from "@app/lib/egress/server";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -51,6 +51,13 @@ async function servicenowApiCall<T extends z.ZodTypeAny>(
     },
   });
 
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `ServiceNow API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
+
   if (!response.ok) {
     const errorBody = await response.text();
     let errorMessage = `ServiceNow API error: ${response.status} ${response.statusText}`;
@@ -60,9 +67,7 @@ async function servicenowApiCall<T extends z.ZodTypeAny>(
     } catch {
       errorMessage = `${errorMessage} - ${errorBody}`;
     }
-    return new Err(
-      new MCPError(errorMessage, { tracked: response.status >= 500 })
-    );
+    return new Err(new MCPError(errorMessage, { tracked: false }));
   }
 
   const responseText = await response.text();

--- a/front/lib/api/actions/servers/slab/client.ts
+++ b/front/lib/api/actions/servers/slab/client.ts
@@ -1,3 +1,9 @@
+import {
+  isMCPError,
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -76,19 +82,33 @@ async function makeGraphQLRequest<T>(
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Slab API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
+      throw new MCPError(`HTTP ${response.status}: ${await response.text()}`, {
+        tracked: false,
+      });
     }
 
     const json = (await response.json()) as GraphQLResponse<T>;
 
     if (json.errors?.length) {
-      throw new Error(
-        `GraphQL errors: ${json.errors.map((e) => e.message).join(", ")}`
+      // GraphQL-level errors are driven by the query/user input, not a provider outage.
+      throw new MCPError(
+        `GraphQL errors: ${json.errors.map((e) => e.message).join(", ")}`,
+        { tracked: false }
       );
     }
 
     return json.data;
   } catch (error) {
+    // Let typed tool errors escape to the tool-execution wrapper.
+    if (isMCPError(error) || isProviderError(error)) {
+      throw error;
+    }
     const normalizedError = normalizeError(error);
     logger.error({ error: normalizedError }, "GraphQL request failed");
     throw normalizedError;

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   isAgentLoopRunContext,
@@ -17,8 +21,12 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { WebAPICallResult } from "@slack/web-api";
-import { WebClient } from "@slack/web-api";
+import type {
+  WebAPICallResult,
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+} from "@slack/web-api";
+import { ErrorCode, WebClient } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse";
 import type { Usergroup } from "@slack/web-api/dist/types/response/UsergroupsListResponse";
 import type { Member } from "@slack/web-api/dist/types/response/UsersListResponse";
@@ -54,9 +62,60 @@ export function isSlackMissingScope(error: unknown): boolean {
   );
 }
 
+// Slack platform error codes indicating a Slack-side failure rather than a user or
+// configuration issue (see the common errors table in Slack's Web API method docs).
+const SLACK_SERVER_SIDE_PLATFORM_ERRORS = [
+  "internal_error",
+  "fatal_error",
+  "service_unavailable",
+];
+
+function isSlackWebAPIHTTPError(error: unknown): error is WebAPIHTTPError {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === ErrorCode.HTTPError
+  );
+}
+
+function isSlackWebAPIPlatformError(
+  error: unknown
+): error is WebAPIPlatformError {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === ErrorCode.PlatformError
+  );
+}
+
+// Rethrow errors caught around Slack SDK calls as ProviderError when the failure is on
+// Slack's side: HTTP 5xx responses or server-side platform errors. User/config-driven
+// platform errors (channel_not_found, missing_scope, ...) pass through untouched.
+// ProviderError instances thrown from deeper call sites are rethrown as-is.
+export function throwIfSlackProviderError(error: unknown): void {
+  if (isProviderError(error)) {
+    throw error;
+  }
+  if (isSlackWebAPIHTTPError(error) && error.statusCode >= 500) {
+    throw new ProviderError(
+      `Slack API returned an unexpected error (HTTP ${error.statusCode}).`,
+      { status: error.statusCode, cause: error }
+    );
+  }
+  if (
+    isSlackWebAPIPlatformError(error) &&
+    SLACK_SERVER_SIDE_PLATFORM_ERRORS.includes(error.data.error)
+  ) {
+    throw new ProviderError(
+      `Slack API returned an unexpected error (${error.data.error}).`,
+      { cause: error }
+    );
+  }
+}
+
 export const getSlackClient = async (accessToken?: string) => {
   if (!accessToken) {
-    throw new Error("No access token provided");
+    throw new MCPError("No access token provided", { tracked: false });
   }
 
   return new WebClient(accessToken, {
@@ -233,7 +292,9 @@ export const getChannels = async (
           });
 
     if (!response.ok) {
-      throw new Error(`Failed to list ${scope} channels`);
+      throw new MCPError(`Failed to list ${scope} channels`, {
+        tracked: false,
+      });
     }
 
     channels.push(...(response.channels ?? []));
@@ -291,7 +352,7 @@ const getAllUsers = async ({
     });
 
     if (!response.ok) {
-      throw new Error("Failed to list users");
+      throw new MCPError("Failed to list users", { tracked: false });
     }
 
     users.push(
@@ -359,7 +420,8 @@ export async function resolveChannelId({
       if (openResp.ok && openResp.channel?.id) {
         return openResp.channel.id;
       }
-    } catch {
+    } catch (error) {
+      throwIfSlackProviderError(error);
       // conversations.open failed, user ID cannot be resolved.
     }
     return null;
@@ -374,9 +436,8 @@ export async function resolveChannelId({
       if (infoResp.ok && infoResp.channel?.id) {
         return infoResp.channel.id;
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
     } catch (error) {
+      throwIfSlackProviderError(error);
       // Fall through to name-based search.
     }
   }
@@ -1100,7 +1161,8 @@ async function searchUserById(
       const user = cleanUserPayload(response.user);
       return new Ok(user);
     }
-  } catch (_error) {
+  } catch (error) {
+    throwIfSlackProviderError(error);
     return new Err(new MCPError(`User not found: ${originalQuery}`));
   }
   return new Err(new MCPError(`User not found: ${originalQuery}`));
@@ -1118,7 +1180,8 @@ async function searchUserByEmail(
       const user = cleanUserPayload(response.user);
       return new Ok(user);
     }
-  } catch (_error) {
+  } catch (error) {
+    throwIfSlackProviderError(error);
     return new Err(new MCPError(`User not found for email: ${originalQuery}`));
   }
   return new Err(new MCPError(`User not found for email: ${originalQuery}`));

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -11,6 +11,7 @@ import {
   executeSearchUser,
   executeUpdateMessage,
   getSlackClient,
+  throwIfSlackProviderError,
 } from "@app/lib/api/actions/servers/slack/helpers";
 import { SLACK_BOT_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import type { Authenticator } from "@app/lib/auth";
@@ -47,6 +48,7 @@ export function createSlackBotTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error posting message: ${normalizeError(error)}`)
         );
@@ -66,6 +68,7 @@ export function createSlackBotTools(
           message,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error editing message: ${normalizeError(error)}`)
         );
@@ -84,6 +87,7 @@ export function createSlackBotTools(
           mcpServerId,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error searching user: ${normalizeError(error)}`)
         );
@@ -103,6 +107,7 @@ export function createSlackBotTools(
           mcpServerId
         );
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error listing channels: ${normalizeError(error)}`)
         );
@@ -151,6 +156,7 @@ export function createSlackBotTools(
           },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(
             `Error reading channel history: ${normalizeError(error)}`
@@ -214,6 +220,7 @@ export function createSlackBotTools(
           },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(
             `Error reading thread messages: ${normalizeError(error)}`
@@ -251,6 +258,7 @@ export function createSlackBotTools(
           { type: "text" as const, text: JSON.stringify(response, null, 2) },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error adding reaction: ${normalizeError(error)}`)
         );
@@ -286,6 +294,7 @@ export function createSlackBotTools(
           { type: "text" as const, text: JSON.stringify(response, null, 2) },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         return new Err(
           new MCPError(`Error removing reaction: ${normalizeError(error)}`)
         );

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -1,5 +1,5 @@
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
@@ -32,6 +32,7 @@ import {
   resolveChannelId,
   resolveUserDisplayName,
   SLACK_THREAD_LISTING_LIMIT,
+  throwIfSlackProviderError,
 } from "@app/lib/api/actions/servers/slack/helpers";
 import {
   formatSlackMessageForLLM,
@@ -158,14 +159,20 @@ const slackSearch = async (
     );
 
     if (!resp.ok) {
-      throw new Error(`HTTP ${resp.status}`);
+      if (resp.status >= 500) {
+        throw new ProviderError(
+          `Slack API returned an unexpected error (HTTP ${resp.status}).`,
+          { status: resp.status }
+        );
+      }
+      throw new MCPError(`HTTP ${resp.status}`, { tracked: false });
     }
 
     const data: SlackSearchResponse =
       (await resp.json()) as SlackSearchResponse;
     if (!data.ok) {
       // If invalid_action_token or other errors, throw to trigger fallback.
-      throw new Error(data.error ?? "unknown_error");
+      throw new MCPError(data.error ?? "unknown_error", { tracked: false });
     }
 
     // Transform API response to match SlackSearchMatch format.
@@ -204,7 +211,7 @@ const slackSearch = async (
     });
 
     if (!response.ok) {
-      throw new Error("Failed to search messages");
+      throw new MCPError("Failed to search messages", { tracked: false });
     }
 
     const rawMatches = response.messages?.matches ?? [];
@@ -479,6 +486,7 @@ export function createSlackPersonalTools(
           }))
         );
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -559,6 +567,7 @@ export function createSlackPersonalTools(
           }))
         );
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -604,6 +613,7 @@ export function createSlackPersonalTools(
           showSentByFooter: show_sent_by_footer ?? true,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -649,6 +659,7 @@ export function createSlackPersonalTools(
           showSentByFooter: show_sent_by_footer ?? true,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -671,6 +682,7 @@ export function createSlackPersonalTools(
           mcpServerId,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -690,6 +702,7 @@ export function createSlackPersonalTools(
       try {
         return await executeListUserGroups({ accessToken });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -712,6 +725,7 @@ export function createSlackPersonalTools(
           mcpServerId,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -745,6 +759,7 @@ export function createSlackPersonalTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -776,6 +791,7 @@ export function createSlackPersonalTools(
           limit: SLACK_THREAD_LISTING_LIMIT,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -882,15 +898,28 @@ export function createSlackPersonalTools(
         return new Err(new MCPError("Access token not found"));
       }
 
-      return executeReadThreadMessages({
-        channel,
-        threadTs,
-        limit,
-        cursor,
-        oldest,
-        latest,
-        accessToken,
-      });
+      try {
+        return await executeReadThreadMessages({
+          channel,
+          threadTs,
+          limit,
+          cursor,
+          oldest,
+          latest,
+          accessToken,
+        });
+      } catch (error) {
+        throwIfSlackProviderError(error);
+        const authError = handleSlackAuthError(error);
+        if (authError) {
+          return authError;
+        }
+        return new Err(
+          new MCPError(
+            `Error reading thread messages: ${normalizeError(error)}`
+          )
+        );
+      }
     },
 
     get_channel_canvases: async ({ channel_id }, { authInfo }) => {
@@ -905,6 +934,7 @@ export function createSlackPersonalTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -934,6 +964,7 @@ export function createSlackPersonalTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -964,6 +995,7 @@ export function createSlackPersonalTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -991,6 +1023,7 @@ export function createSlackPersonalTools(
           accessToken,
         });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1010,6 +1043,7 @@ export function createSlackPersonalTools(
       try {
         return await executeInviteToChannel({ channel, users, accessToken });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1031,6 +1065,7 @@ export function createSlackPersonalTools(
       try {
         return await executeArchiveChannel({ channel, accessToken });
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1072,6 +1107,7 @@ export function createSlackPersonalTools(
             : "Status cleared";
         return new Ok([{ type: "text" as const, text: displayText }]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1110,6 +1146,7 @@ export function createSlackPersonalTools(
           },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1148,6 +1185,7 @@ export function createSlackPersonalTools(
           },
         ]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;
@@ -1196,6 +1234,7 @@ export function createSlackPersonalTools(
 
         return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
       } catch (error) {
+        throwIfSlackProviderError(error);
         const authError = handleSlackAuthError(error);
         if (authError) {
           return authError;

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -1,4 +1,5 @@
 import { createPrivateKey } from "node:crypto";
+import { isProviderError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { parseOptionalInt } from "@app/lib/utils/parseOptionalInt";
 import { escapeSnowflakeIdentifier } from "@app/lib/utils/snowflake";
 import logger from "@app/logger/logger";
@@ -63,6 +64,38 @@ function getRowStringMultiKey(
     }
   }
   return undefined;
+}
+
+/**
+ * Converts a snowflake-sdk error into a ProviderError when the Snowflake service itself
+ * failed. The SDK surfaces non-200 HTTP responses from Snowflake as errors named
+ * "RequestFailedError" carrying the HTTP response, while user-driven failures (SQL
+ * compilation/execution errors, invalid identifiers, permissions) surface as
+ * "OperationFailedError" on an HTTP 200 response and must not be treated as provider
+ * failures. The SDK does not export its error classes, so detection is structural,
+ * mirroring the SDK's own `isRequestFailedError` predicate. Only HTTP >= 500 is converted.
+ */
+function toSnowflakeProviderError(error: unknown): ProviderError | null {
+  if (!(error instanceof Error) || error.name !== "RequestFailedError") {
+    return null;
+  }
+  if (!("response" in error)) {
+    return null;
+  }
+  const { response } = error;
+  if (
+    typeof response !== "object" ||
+    response === null ||
+    !("statusCode" in response) ||
+    typeof response.statusCode !== "number" ||
+    response.statusCode < 500
+  ) {
+    return null;
+  }
+  return new ProviderError(
+    `Snowflake API returned an unexpected error (HTTP ${response.statusCode}).`,
+    { status: response.statusCode, cause: error }
+  );
 }
 
 export class SnowflakeClient {
@@ -188,6 +221,10 @@ export class SnowflakeClient {
       } catch (error) {
         // Clean up connection on USE WAREHOUSE failure
         await this.closeConnection(connection);
+        const providerError = toSnowflakeProviderError(error);
+        if (providerError) {
+          throw providerError;
+        }
         return new Err(normalizeError(error));
       }
 
@@ -199,11 +236,23 @@ export class SnowflakeClient {
         );
       } catch (error) {
         await this.closeConnection(connection);
+        const providerError = toSnowflakeProviderError(error);
+        if (providerError) {
+          throw providerError;
+        }
         return new Err(normalizeError(error));
       }
 
       return new Ok(connection);
     } catch (error) {
+      // ProviderErrors thrown by the inner catch blocks above must reach the tool wrapper.
+      if (isProviderError(error)) {
+        throw error;
+      }
+      const providerError = toSnowflakeProviderError(error);
+      if (providerError) {
+        throw providerError;
+      }
       return new Err(normalizeError(error));
     }
   }
@@ -285,6 +334,10 @@ export class SnowflakeClient {
         rowCount: rows.length,
       });
     } catch (error) {
+      const providerError = toSnowflakeProviderError(error);
+      if (providerError) {
+        throw providerError;
+      }
       return new Err(normalizeError(error));
     }
   }

--- a/front/lib/api/actions/servers/sound_studio/tools/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/tools/index.ts
@@ -4,6 +4,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import {
   getElevenLabsClient,
   streamToBase64,
+  throwIfElevenLabsProviderError,
 } from "@app/lib/api/actions/servers/elevenlabs/utils";
 import { SOUND_STUDIO_TOOLS_METADATA } from "@app/lib/api/actions/servers/sound_studio/metadata";
 import { Err, Ok } from "@app/types/shared/result";
@@ -44,6 +45,7 @@ const handlers: ToolHandlers<typeof SOUND_STUDIO_TOOLS_METADATA> = {
         },
       ]);
     } catch (e) {
+      throwIfElevenLabsProviderError(e);
       const cause = normalizeError(e);
       return new Err(
         new MCPError(

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -5,6 +5,7 @@ import {
   getElevenLabsClient,
   resolveDefaultVoiceId,
   streamToBase64,
+  throwIfElevenLabsProviderError,
 } from "@app/lib/api/actions/servers/elevenlabs/utils";
 import {
   isAllowedAudioUrl,
@@ -43,6 +44,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: result.text }]);
     } catch (e) {
+      throwIfElevenLabsProviderError(e);
       const cause = normalizeError(e);
       return new Err(
         new MCPError(
@@ -92,6 +94,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
         },
       ]);
     } catch (e) {
+      throwIfElevenLabsProviderError(e);
       const cause = normalizeError(e);
       return new Err(
         new MCPError(
@@ -143,6 +146,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
         },
       ]);
     } catch (e) {
+      throwIfElevenLabsProviderError(e);
       const cause = normalizeError(e);
       return new Err(
         new MCPError(

--- a/front/lib/api/actions/servers/statuspage/client.ts
+++ b/front/lib/api/actions/servers/statuspage/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
   CreateIncidentRequest,
@@ -69,6 +69,12 @@ export class StatuspageClient {
     );
 
     if (!response.ok) {
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Statuspage API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
       const errorText = await response.text();
       return new Err(
         new Error(

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -1,5 +1,8 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -51,7 +54,12 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     const r = await api.getMCPServerViews(globalSpace.sId, true);
     if (r.isErr()) {
-      throw new Error(r.error.message);
+      throwOnDustAPIInternalError(r.error);
+      return new Err(
+        new MCPError(`Failed to list toolsets: ${r.error.message}`, {
+          tracked: false,
+        })
+      );
     }
 
     const mcpServerViews = r.value
@@ -116,6 +124,10 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       mcpServerViewId: toolsetId,
       agentConfigurationId,
     });
+
+    if (res.isErr()) {
+      throwOnDustAPIInternalError(res.error);
+    }
 
     if (res.isErr() || !res.value.success) {
       return new Err(

--- a/front/lib/api/actions/servers/ukg_ready/helpers.ts
+++ b/front/lib/api/actions/servers/ukg_ready/helpers.ts
@@ -1,4 +1,8 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  isProviderError,
+  MCPError,
+  ProviderError,
+} from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -103,6 +107,13 @@ async function ukgReadyApiCall<T extends z.ZodTypeAny>(
       body: body ? JSON.stringify(body) : undefined,
     });
 
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `UKG Ready API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
+
     if (!response.ok) {
       const errorBody = await response.text();
       const msg = `UKG Ready API error: ${response.status} ${response.statusText} - ${errorBody}`;
@@ -126,6 +137,9 @@ async function ukgReadyApiCall<T extends z.ZodTypeAny>(
 
     return new Ok(parseResult.data);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     const errorMsg = `UKG Ready API call failed for ${endpoint}: ${normalizeError(error).message}`;
     logger.error(errorMsg);
     return new Err(normalizeError(error).message);
@@ -328,6 +342,13 @@ export async function deletePTORequest(
       },
     });
 
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `UKG Ready API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
+
     if (!response.ok) {
       const errorBody = await response.text();
       const msg = `UKG Ready API error: ${response.status} ${response.statusText} - ${errorBody}`;
@@ -337,6 +358,9 @@ export async function deletePTORequest(
 
     return new Ok(undefined);
   } catch (error: unknown) {
+    if (isProviderError(error)) {
+      throw error;
+    }
     const errorMsg = `Failed to delete PTO request(s) ${requestIds.join(", ")}: ${normalizeError(error).message}`;
     logger.error(errorMsg);
     return new Err(normalizeError(error).message);

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnDustAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
@@ -48,6 +51,7 @@ const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
     });
 
     if (r.isErr()) {
+      throwOnDustAPIInternalError(r.error);
       return new Err(
         new MCPError(`Error getting mentions suggestions: ${r.error.message}`, {
           cause: r.error,

--- a/front/lib/api/actions/servers/val_town/helpers.ts
+++ b/front/lib/api/actions/servers/val_town/helpers.ts
@@ -1,9 +1,10 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt } from "@app/types/shared/utils/encryption";
-import ValTown from "@valtown/sdk";
+import ValTown, { APIError } from "@valtown/sdk";
 
 interface ValTownError {
   status?: number;
@@ -16,6 +17,22 @@ export function isValTownError(error: unknown): error is ValTownError {
     error !== null &&
     ("status" in error || "message" in error)
   );
+}
+
+// Rethrows Val Town SDK errors carrying a 5xx status as ProviderError: the provider failing
+// unexpectedly is tracked by the tool-execution wrapper. 4xx and network errors are left for
+// the caller to surface as untracked tool errors.
+export function throwIfValTownServerError(error: unknown): void {
+  if (
+    error instanceof APIError &&
+    typeof error.status === "number" &&
+    error.status >= 500
+  ) {
+    throw new ProviderError(
+      `Val Town API returned an unexpected error (HTTP ${error.status}).`,
+      { status: error.status, cause: error }
+    );
+  }
 }
 
 export async function getValTownClient(

--- a/front/lib/api/actions/servers/val_town/tools/index.ts
+++ b/front/lib/api/actions/servers/val_town/tools/index.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from "@app/lib/actions/types";
 import {
   getValTownClient,
   isValTownError,
+  throwIfValTownServerError,
 } from "@app/lib/api/actions/servers/val_town/helpers";
 import { VAL_TOWN_TOOLS_METADATA } from "@app/lib/api/actions/servers/val_town/metadata";
 import type { Authenticator } from "@app/lib/auth";
@@ -46,6 +47,7 @@ export function createValTownTools(
           },
         ]);
       } catch (error: unknown) {
+        throwIfValTownServerError(error);
         if (isValTownError(error) && error.status === 409) {
           return new Err(
             new MCPError(
@@ -95,6 +97,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error getting val: ${normalizeError(err).message}`)
         );
@@ -158,6 +161,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error listing vals: ${normalizeError(err).message}`)
         );
@@ -215,6 +219,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error searching vals: ${normalizeError(err).message}`)
         );
@@ -276,6 +281,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(
             `Error listing val files: ${normalizeError(err).message}`
@@ -308,6 +314,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(
             `Error getting file content: ${normalizeError(err).message}`
@@ -337,6 +344,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error deleting file: ${normalizeError(err).message}`)
         );
@@ -364,6 +372,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(
             `Error updating file content: ${normalizeError(err).message}`
@@ -405,6 +414,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error updating file: ${normalizeError(err).message}`)
         );
@@ -433,6 +443,7 @@ export function createValTownTools(
           },
         ]);
       } catch (err) {
+        throwIfValTownServerError(err);
         return new Err(
           new MCPError(`Error creating file: ${normalizeError(err).message}`)
         );

--- a/front/lib/api/actions/servers/vanta/api.ts
+++ b/front/lib/api/actions/servers/vanta/api.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import { untrustedFetch } from "@app/lib/egress/server";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -39,6 +39,13 @@ export async function vantaGet<T extends z.ZodTypeAny>({
       "Content-Type": "application/json",
     },
   });
+
+  if (response.status >= 500) {
+    throw new ProviderError(
+      `Vanta API returned an unexpected error (HTTP ${response.status}).`,
+      { status: response.status }
+    );
+  }
 
   if (!response.ok) {
     return new Err(

--- a/front/lib/api/actions/servers/workday/tools/index.ts
+++ b/front/lib/api/actions/servers/workday/tools/index.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { withAuth } from "@app/lib/api/actions/servers/workday/helpers";
@@ -30,6 +30,13 @@ const handlers: ToolHandlers<typeof WORKDAY_TOOLS_METADATA> = {
           "Content-Type": "application/json",
         },
       });
+
+      if (response.status >= 500) {
+        throw new ProviderError(
+          `Workday API returned an unexpected error (HTTP ${response.status}).`,
+          { status: response.status }
+        );
+      }
 
       if (!response.ok) {
         return new Err(

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -1,4 +1,4 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MCPError, ProviderError } from "@app/lib/actions/mcp_errors";
 import type {
   ZendeskSearchResponse,
   ZendeskTicket,
@@ -115,6 +115,13 @@ class ZendeskClient {
       },
       body: body ? JSON.stringify(body) : undefined,
     });
+
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `Zendesk API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -368,6 +375,13 @@ class ZendeskClient {
       method: "GET",
       headers,
     });
+
+    if (response.status >= 500) {
+      throw new ProviderError(
+        `Zendesk API returned an unexpected error (HTTP ${response.status}).`,
+        { status: response.status }
+      );
+    }
 
     if (!response.ok) {
       return new Err(

--- a/front/lib/api/actions/tools/find_tags/index.ts
+++ b/front/lib/api/actions/tools/find_tags/index.ts
@@ -1,4 +1,7 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPError,
+  throwOnCoreAPIInternalError,
+} from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import config from "@app/lib/api/config";
@@ -51,6 +54,7 @@ export async function executeFindTags(
   });
 
   if (result.isErr()) {
+    throwOnCoreAPIInternalError(result.error);
     return new Err(new MCPError("Error searching for labels"));
   }
 
@@ -64,6 +68,7 @@ export async function executeFindTags(
     });
 
     if (result.isErr()) {
+      throwOnCoreAPIInternalError(result.error);
       return new Err(new MCPError("Error searching for labels"));
     }
   }

--- a/front/lib/utils/webbrowse.ts
+++ b/front/lib/utils/webbrowse.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { clientFetch } from "@app/lib/egress/client";
 import { untrustedFetch } from "@app/lib/egress/server";
@@ -11,7 +12,7 @@ import type {
   ScrapeResponse,
 } from "@mendable/firecrawl-js";
 import FirecrawlApp, { FirecrawlError } from "@mendable/firecrawl-js";
-import Exa from "exa-js";
+import Exa, { ExaError } from "exa-js";
 
 const credentials = dustManagedServiceCredentials();
 
@@ -332,6 +333,16 @@ const browseUrlFirecrawl = async (
       };
     }
 
+    // FIRECRAWL_API_KEY is Dust-managed: a 5xx returned by the Firecrawl API itself is
+    // treated as a provider failure. Other scrape failures (driven by the target
+    // website) keep surfacing as per-URL error responses.
+    if (error instanceof FirecrawlError && error.statusCode >= 500) {
+      throw new ProviderError(
+        `Firecrawl API returned an unexpected error (HTTP ${error.statusCode}).`,
+        { status: error.statusCode, cause: error }
+      );
+    }
+
     logger.error(
       {
         error,
@@ -496,6 +507,16 @@ const browseUrlSpider = async (
     };
   }
 
+  // SPIDER_API_KEY is Dust-managed: a 5xx returned by the Spider API itself is treated
+  // as a provider failure. Per-page scrape failures (driven by the target website) are
+  // reported in the response body and keep surfacing as per-URL error responses.
+  if (res.status >= 500) {
+    throw new ProviderError(
+      `Spider API returned an unexpected error (HTTP ${res.status}).`,
+      { status: res.status }
+    );
+  }
+
   let json: unknown;
   try {
     json = await res.json();
@@ -625,6 +646,13 @@ const browseUrlExa = async (
       extras: { links: options?.links ? 10 : 0 },
     });
   } catch (error) {
+    // EXA_API_KEY is Dust-managed: an Exa 5xx means our provider is down.
+    if (error instanceof ExaError && error.statusCode >= 500) {
+      throw new ProviderError(
+        `Exa API returned an unexpected error (HTTP ${error.statusCode}).`,
+        { status: error.statusCode, cause: error }
+      );
+    }
     logger.error(
       { error, url },
       "[Exa] Network or fetch error while scraping URL"

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@app/lib/actions/mcp_errors";
 import logger from "@app/logger/logger";
 import { dustManagedServiceCredentials } from "@app/types/api/credentials";
 import type { Result } from "@app/types/shared/result";
@@ -5,8 +6,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
-import FirecrawlApp from "@mendable/firecrawl-js";
-import Exa from "exa-js";
+import FirecrawlApp, { FirecrawlError } from "@mendable/firecrawl-js";
+import Exa, { ExaError } from "exa-js";
 import isNil from "lodash/isNil";
 import omitBy from "lodash/omitBy";
 
@@ -123,6 +124,14 @@ const serpapiSearch = async (
     return new Ok([]);
   }
 
+  // SERP_API_KEY is Dust-managed: a SerpAPI 5xx means our provider is down.
+  if (res.status >= 500) {
+    throw new ProviderError(
+      `SerpAPI returned an unexpected error (HTTP ${res.status}).`,
+      { status: res.status }
+    );
+  }
+
   // TODO: Remove once we have a proper error handling.
   logger.error(
     { status: res.status, statusText: res.statusText },
@@ -152,6 +161,14 @@ const serperSearch = async (
     const json = await res.json();
     // WARN: need to format Serper results before using
     return new Ok(json);
+  }
+
+  // The Serper API key is Dust-managed: a Serper 5xx means our provider is down.
+  if (res.status >= 500) {
+    throw new ProviderError(
+      `Serper API returned an unexpected error (HTTP ${res.status}).`,
+      { status: res.status }
+    );
   }
 
   // TODO: Remove once we have a proper error handling.
@@ -192,7 +209,14 @@ const firecrawlSearch = async ({
       country: "us",
       scrapeOptions: { formats: [] },
     });
-  } catch (error: any) {
+  } catch (error) {
+    // FIRECRAWL_API_KEY is Dust-managed: a Firecrawl 5xx means our provider is down.
+    if (error instanceof FirecrawlError && error.statusCode >= 500) {
+      throw new ProviderError(
+        `Firecrawl API returned an unexpected error (HTTP ${error.statusCode}).`,
+        { status: error.statusCode, cause: error }
+      );
+    }
     logger.error({ error }, "Unexpected error on Firecrawl search");
     return new Err(normalizeError(error));
   }
@@ -248,6 +272,13 @@ const exaSearch = async ({
       },
     });
   } catch (error) {
+    // EXA_API_KEY is Dust-managed: an Exa 5xx means our provider is down.
+    if (error instanceof ExaError && error.statusCode >= 500) {
+      throw new ProviderError(
+        `Exa API returned an unexpected error (HTTP ${error.statusCode}).`,
+        { status: error.statusCode, cause: error }
+      );
+    }
     logger.error({ error }, "Unexpected error on Exa search");
     return new Err(normalizeError(error));
   }


### PR DESCRIPTION
Stack 2/4 (on top of #29279) — every tool API client now throws `ProviderError` when the upstream service fails unexpectedly, at the lowest level possible.

## What "unexpected provider failure" means here

- HTTP >= 500 from the provider (raw-fetch funnels and SDK errors carrying a status);
- `internal_server_error` from our own infra (CoreAPI code, Dust API error type) via two small shared guards in `mcp_errors.ts` (`throwOnCoreAPIInternalError`, `throwOnDustAPIInternalError`).

Deliberately NOT converted in this pass: 4xx, 429, network/timeout failures (PR 3/4 of the stack decides per-provider tracking for those), and anything hitting **user-controlled endpoints** (http_client URLs, val_town trigger-val, user file URLs) — a 5xx there is the user's endpoint's fault.

## Shape of the change, per client type

- **Raw-fetch funnels** (ashby, gong, clari_copilot, luma, productboard, statuspage, zendesk, vanta, databricks, servicenow, ukg_ready, workday, freshservice, salesloft, slab, monday, jira, confluence, front, openai_usage, gmail, outlook, hubspot raw paths): `status >= 500` → throw at the funnel; `< 500` behavior unchanged (funnels that used to throw bare `Error` on non-ok now throw `MCPError { tracked: false }` so they don't count as uncaught bugs).
- **SDK clients** (notion, github/octokit, slack family, googleapis, microsoft graph, hubspot, fathom, exa, val_town, elevenlabs, firecrawl/serpapi/serper/spider, snowflake, salesforce/jsforce, openai/gemini image gen): one small `throwIf<Provider>ProviderError`-style guard per server (or shared dir), using the SDK's own error classes — verified against the installed packages (e.g. jsforce only exposes 5xx as `ERROR_HTTP_<status>` codes when the body is unparseable; snowflake's `RequestFailedError` is disjoint from user-SQL `OperationFailedError`).
- **Swallowing wrappers** made ProviderError-aware (rethrow before their catch-all conversion): hubspot/salesforce/google_sheets `withAuth`, jira/confluence `withAuth`, pod_manager `withErrorHandling`, freshservice's 36 per-tool catches, outlook's 9 `{ error }`-returning catches, github's 20 catches, etc.

## Notable behavior fixes along the way

- **notion**: the old catch computed `tracked` INVERTED vs its own comment — it tracked exactly the model-input errors (`object_not_found`, `validation_error`, …) it claimed to ignore (~5k errors/week of pure noise). Now: model-input codes → `tracked: false`, Notion 5xx → `ProviderError`.
- **outlook mail**: 503 + `Retry-After` (Graph throttling) is exempt from the 5xx throw — the existing per-message throttle handling and its model-visible "retry after N seconds" flow is preserved.
- **run_agent**: transient-network classification (`network_errors.ts`) keeps priority; only non-transient `internal_server_error` escalates.
- **query_tables_v2 / snowflake / salesforce**: model-generated SQL/SOQL failures are structurally excluded from ProviderError.
- google_drive test: one fixture used a 500 to exercise a message-fallback path; switched to 400 to preserve the test's intent (new behavior throws on 500, as designed).

Checks: biome clean, `tsgo --noEmit` clean, 142 tests green across the 11 suites in touched areas (mcp_actions, mcp_execution, gmail, google_drive, microsoft_teams, pod_manager, run_agent x2, slack x3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
