### PR TITLE
[front] enh: Track unexpected errors from Dust-managed tool providers explicitly

### DIFF
--- a/front/lib/api/actions/servers/exa/tools/index.ts
+++ b/front/lib/api/actions/servers/exa/tools/index.ts
@@ -23,7 +23,12 @@ async function exaSearch({
   category: "people" | "company";
 }) {
   if (!credentials.EXA_API_KEY) {
-    return new Err(new MCPError("EXA_API_KEY is required for Exa search."));
+    // Dust-managed credential: missing means a Dust misconfiguration, not a user error.
+    return new Err(
+      new MCPError("EXA_API_KEY is required for Exa search.", {
+        tracked: true,
+      })
+    );
   }
   const exa = new Exa(credentials.EXA_API_KEY);
 
@@ -44,7 +49,10 @@ async function exaSearch({
       );
     }
     logger.error({ error, category }, "Unexpected error on Exa search");
-    return new Err(new MCPError(normalizeError(error).message));
+    // Exa is a Dust-managed provider: unexpected failures are ours to know about.
+    return new Err(
+      new MCPError(normalizeError(error).message, { tracked: true })
+    );
   }
 
   return new Ok(

--- a/front/lib/api/actions/servers/sound_studio/tools/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/tools/index.ts
@@ -50,9 +50,8 @@ const handlers: ToolHandlers<typeof SOUND_STUDIO_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Error generating sound effect with ElevenLabs: ${cause.message}`,
-          {
-            cause,
-          }
+          // ElevenLabs is a Dust-managed provider: unexpected failures are ours to know about.
+          { tracked: true, cause }
         )
       );
     }

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -49,7 +49,8 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Error transcribing audio with ElevenLabs: ${cause.message}`,
-          { cause }
+          // ElevenLabs is a Dust-managed provider: unexpected failures are ours to know about.
+          { tracked: true, cause }
         )
       );
     }
@@ -99,9 +100,8 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Error generating speech audio with ElevenLabs: ${cause.message}`,
-          {
-            cause,
-          }
+          // ElevenLabs is a Dust-managed provider: unexpected failures are ours to know about.
+          { tracked: true, cause }
         )
       );
     }
@@ -151,9 +151,8 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Error generating dialogue audio with ElevenLabs: ${cause.message}`,
-          {
-            cause,
-          }
+          // ElevenLabs is a Dust-managed provider: unexpected failures are ours to know about.
+          { tracked: true, cause }
         )
       );
     }

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -80,8 +80,13 @@ async function handleWebsearch(
   });
 
   if (websearchRes.isErr()) {
+    // Search providers (Firecrawl, SerpAPI, Serper, Exa) are Dust-managed: any failure that
+    // is not a provider 5xx (those throw ProviderError from inside webSearch) is still ours
+    // to know about (bad request from our side, exhausted credits, unexpected response shape).
     return new Err(
-      new MCPError(`Failed to search: ${websearchRes.error.message}`)
+      new MCPError(`Failed to search: ${websearchRes.error.message}`, {
+        tracked: true,
+      })
     );
   }
 


### PR DESCRIPTION
Stack 3/4 (on top of #29282) — explicit `tracked: true` opt-ins for Dust-managed providers, ahead of the default flip in the next PR.

For servers whose provider is a Dust-managed dependency (Dust credentials, no customer data in the failure path), ANY unexpected failure is ours to know about — not just the 5xx that PR 2 captures at the funnel (e.g. Firecrawl being down can also look like bad requests, exhausted credits, or unexpected response shapes):

- web_search_browse: search-provider failures (Firecrawl/SerpAPI/Serper/Exa) → `tracked: true`;
- speech_generator / sound_studio: ElevenLabs catch-all fallbacks → `tracked: true`;
- exa: catch-all fallback + missing Dust-managed `EXA_API_KEY` → `tracked: true`.

image_generation needed nothing: it already computes `tracked` explicitly (`safety_blocked` untracked, the rest tracked).

These are no-ops until the next PR flips the default; they exist so the signal survives the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
