### PR TITLE
[front] enh: Flip MCPError tracked default to false

### DIFF
--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -20,14 +20,19 @@ export function isRemoteMCPServerError(
 }
 
 export class MCPError extends Error {
-  // Whether the error should be tracked and reported on our observability stack.
+  // Whether the error should be tracked and reported on our observability stack. Defaults to
+  // false: tool errors are overwhelmingly driven by user data or model-generated inputs and
+  // are not actionable on our side. Failures that ARE actionable alert through other
+  // channels regardless of this flag: provider 5xx (throw `ProviderError` from the API
+  // client) and uncaught exceptions (report + rethrow in `withToolLogging`). Set
+  // `tracked: true` only for failures we should investigate that neither channel can catch.
   public readonly tracked: boolean;
   public readonly code?: number;
 
   constructor(
     message: string,
     {
-      tracked = true,
+      tracked = false,
       code,
       cause,
     }: { tracked?: boolean; code?: number; cause?: Error | APIError } = {}


### PR DESCRIPTION
Stack 4/4 (on top of #29283) — flip `MCPError.tracked` default from `true` to `false`.

Tool errors are overwhelmingly user-data / model-input driven (~140k tracked error logs/week; salesforce alone ~40k/week of model-generated bad SOQL) and are not actionable. After this flip, what alerts is exactly:

1. **provider 5xx** — `ProviderError` thrown from API clients, converted centrally to a tracked MCPError (`error_type:provider_error`);
2. **uncaught exceptions** — reported (`Tool execution uncaught error` + `error_type:uncaught_error`, not gated on `enableAlerting`) then rethrown;
3. **explicit `tracked: true` opt-ins** — Dust-managed providers (previous PR) and the ~13 pre-existing opt-ins.

Not done here (deliberate):
- the ~380 now-redundant explicit `tracked: false` options are left in place — removing them is pure churn with zero behavior change; can be a mechanical follow-up if wanted;
- the Datadog "Tool execution errors" monitors keep working unchanged (they read `use_tools_error.count`, which now only receives tracked errors). Two follow-ups to consider on the Datadog side: an absolute-count monitor on `error_type:uncaught_error`, and updating the runbook text in the composite monitors (it still says "untrack the error via tracked: false", which is now the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
