### PR TITLE
feat: publish agent permission frontend

### DIFF
--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -114,7 +114,7 @@ export function AccessSection({
               disabled={!canPublishAgent}
               tooltip={
                 !canPublishAgent
-                  ? "You don't have permission to publish agents."
+                  ? "You don’t have permission to publish agents."
                   : undefined
               }
             />

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -111,6 +111,12 @@ export function AccessSection({
               label={getDisplayValue()}
               isSelect
               type="button"
+              disabled={!canPublishAgent}
+              tooltip={
+                !canPublishAgent
+                  ? "You don't have permission to publish agents."
+                  : undefined
+              }
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
@@ -120,17 +126,13 @@ export function AccessSection({
               icon={Eye}
               onClick={() => scope.onChange("visible")}
               disabled={!canPublishAgent}
-              tooltip={
-                !canPublishAgent
-                  ? "You don't have permission to publish agents."
-                  : undefined
-              }
             />
             <DropdownMenuItem
               label="Unpublished"
               description="Visible & usable by editors only."
               icon={EyeOff}
               onClick={() => scope.onChange("hidden")}
+              disabled={!canPublishAgent}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -5,8 +5,6 @@ import { SlackSettingsSheet } from "@app/components/agent_builder/settings/Slack
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { BecomeEditorButton } from "@app/components/shared/BecomeEditorButton";
-import { getPublishingRestrictionForOwner } from "@app/lib/api/assistant/publishing_restrictions";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   Button,
@@ -58,14 +56,9 @@ export function AccessSection({
 
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { owner } = useAgentBuilderContext();
-  const { featureFlags } = useFeatureFlags();
   const { hasPermission } = useWorkspacePermissions(owner);
-  const canPublishAgent = hasPermission("publish", "agent");
 
-  const {
-    disabled: publishingToggleDisabled,
-    tooltip: publishingToggleTooltip,
-  } = getPublishingRestrictionForOwner(featureFlags, owner);
+  const canPublishAgent = hasPermission("publish", "agent");
 
   const getDisplayValue = () => {
     return scope.value === "visible" ? "Published" : "Unpublished";
@@ -118,8 +111,6 @@ export function AccessSection({
               label={getDisplayValue()}
               isSelect
               type="button"
-              disabled={publishingToggleDisabled}
-              tooltip={publishingToggleTooltip}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
@@ -128,14 +119,18 @@ export function AccessSection({
               description="Visible & usable by all members of the workspace."
               icon={Eye}
               onClick={() => scope.onChange("visible")}
-              disabled={publishingToggleDisabled}
+              disabled={!canPublishAgent}
+              tooltip={
+                !canPublishAgent
+                  ? "You don't have permission to publish agents."
+                  : undefined
+              }
             />
             <DropdownMenuItem
               label="Unpublished"
               description="Visible & usable by editors only."
               icon={EyeOff}
               onClick={() => scope.onChange("hidden")}
-              disabled={publishingToggleDisabled}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/front/lib/api/assistant/publishing_restrictions.ts
+++ b/front/lib/api/assistant/publishing_restrictions.ts
@@ -1,6 +1,4 @@
 import type { Authenticator } from "@app/lib/auth";
-import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder } from "@app/types/user";
 
 export const PUBLISHING_RESTRICTIONS = {
   builders_and_admins: {
@@ -41,16 +39,6 @@ function canPublishForRole(
   return role === "admin" ? check.isAdmin : check.isBuilder;
 }
 
-export function canPublishForOwner(
-  owner: WorkspaceType | null,
-  level: PublishingRestriction
-): boolean {
-  return canPublishForRole(PUBLISHING_RESTRICTIONS[level].requiredRole, {
-    isAdmin: isAdmin(owner),
-    isBuilder: isBuilder(owner),
-  });
-}
-
 export function canPublishForAuth(
   auth: Authenticator,
   level: PublishingRestriction
@@ -59,20 +47,4 @@ export function canPublishForAuth(
     isAdmin: auth.isAdmin(),
     isBuilder: auth.isBuilder(),
   });
-}
-
-export function getPublishingRestrictionForOwner(
-  featureFlags: readonly string[],
-  owner: WorkspaceType | null
-): { disabled: boolean; tooltip: string | undefined } {
-  const level = getPublishingRestrictionLevel(featureFlags);
-  if (!level) {
-    return { disabled: false, tooltip: undefined };
-  }
-  const restriction = PUBLISHING_RESTRICTIONS[level];
-  const disabled = !canPublishForOwner(owner, level);
-  return {
-    disabled,
-    tooltip: disabled ? restriction.message : undefined,
-  };
 }


### PR DESCRIPTION
## Description

This PR updates the agent builder to check for the permission to publish agents rather then relying on the publishing restriction feature flags.

## Tests

Manually.

## Risks

Low. The behaviour should be equivalent as long as the backend `publish`/`agent` permission is correctly set, but any misconfiguration there could affect who can publish agents.

## Deploy Plan

Wait for the backfill to be completed before merging.