### PR TITLE
[LLM] Document leaf/composite converter pattern in SDK input converters

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -70,9 +70,37 @@ const IMAGE_LOAD_FAILED_TEXT = "Attachment: image could not be loaded.";
 const UNSUPPORTED_MEDIA_TYPE_TEXT =
   "Attachement: an unsupported media type was provided.";
 
-// The per-message leaf converters. Composites below take an object satisfying
-// this interface (`this`), so overriding one leaf on an endpoint changes how
-// every composite uses it.
+// This SDK client is shared across hosts and labs (direct Anthropic, Vertex,
+// Bedrock, ...). The goal is to let a specific endpoint override one small
+// conversion step (e.g. how a user text message becomes a text block) without
+// reimplementing the whole `buildRequestPayload`.
+//
+// To make that possible, conversions are split into two kinds:
+//
+//   - "leaf" converters (this interface): the smallest units, each turning one
+//     Base* message into one Anthropic block. E.g. `userTextMessageToTextBlock`,
+//     `imageUrlToImageBlock`. These are the override points.
+//
+//   - "composite" converters (defined below): higher-level converters that
+//     assemble blocks by delegating to leaves rather than doing the leaf work
+//     themselves. E.g. `userMessageToContentBlocks` switches on message type and
+//     calls `userTextMessageToTextBlock` / `imageUrlToImageBlock`.
+//
+// The link between them is that composites receive an object satisfying this
+// interface (`this` on the endpoint class — see `WithAnthropicAIInputConverter`)
+// and route every child call through it. So overriding a single leaf field on an
+// endpoint (e.g. Vertex swaps `imageUrlToImageBlock` for a base64 variant)
+// changes how every composite depending on it behaves — no need to touch the
+// composites or `buildRequestPayload`.
+//
+// This composes both ways: a composite is itself an override point. An endpoint
+// can override a composite method and still reach its children through
+// `this.<child>` (e.g. a custom `userMessageToContentBlocks` that calls
+// `this.userTextMessageToTextBlock`), so it picks up any leaf overrides too and
+// only the reassembly logic changes.
+//
+// "leaf" / "composite" naming lives only in comments; it's just a mental model
+// for how the pieces compose.
 export interface MessageBlockConverters {
   systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -65,9 +65,35 @@ async function imageUrlToPart(url: string): Promise<Part> {
   return { inlineData: { mimeType: mediaType, data } };
 }
 
-// The per-message leaf converters. Composites below take an object satisfying
-// this interface (`this`), so overriding one leaf on an endpoint changes how
-// every composite uses it.
+// This SDK client is shared across hosts and labs. The goal is to let a
+// specific endpoint override one small conversion step (e.g. how a user text
+// message becomes a part) without reimplementing the whole `buildRequestPayload`.
+//
+// To make that possible, conversions are split into two kinds:
+//
+//   - "leaf" converters (this interface): the smallest units, each turning one
+//     Base* message into one Gemini part/content. E.g. `userTextMessageToPart`,
+//     `userImageMessageToPart`. These are the override points.
+//
+//   - "composite" converters (defined below): higher-level converters that
+//     assemble parts by delegating to leaves rather than doing the leaf work
+//     themselves. E.g. `userMessageToContent` switches on message type and calls
+//     `userTextMessageToPart` / `userImageMessageToPart`.
+//
+// The link between them is that composites receive an object satisfying this
+// interface (`this` on the endpoint class — see `WithGoogleGenAIInputConverter`)
+// and route every child call through it. So overriding a single leaf field on an
+// endpoint changes how every composite depending on it behaves — no need to
+// touch the composites or `buildRequestPayload`.
+//
+// This composes both ways: a composite is itself an override point. An endpoint
+// can override a composite method and still reach its children through
+// `this.<child>` (e.g. a custom `userMessageToContent` that calls
+// `this.userTextMessageToPart`), so it picks up any leaf overrides too and only
+// the reassembly logic changes.
+//
+// "leaf" / "composite" naming lives only in comments; it's just a mental model
+// for how the pieces compose.
 export interface ContentBlockConverters {
   systemMessageToPart(message: SystemTextMessage): Part;
   userTextMessageToPart(message: BaseUserTextMessage): Part;

--- a/front/lib/model_constructors/sdk/mistralai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/mistralai/converters/input/utils.ts
@@ -41,9 +41,36 @@ export function sanitizeToolCallId(id: string): string {
   return s;
 }
 
-// The per-message leaf converters. The composite below takes an object
-// satisfying this interface (`this`), so overriding one leaf on an endpoint
-// changes how the composite uses it.
+// This SDK client is shared across hosts and labs. The goal is to let a
+// specific endpoint override one small conversion step (e.g. how a user text
+// message becomes a Mistral message) without reimplementing the whole
+// `buildRequestPayload`.
+//
+// To make that possible, conversions are split into two kinds:
+//
+//   - "leaf" converters (this interface): the smallest units, each turning one
+//     Base* message into one Mistral message. E.g. `userTextMessageToMessage`,
+//     `userImageMessageToMessage`. These are the override points.
+//
+//   - "composite" converters (defined below): higher-level converters that
+//     assemble messages by delegating to leaves rather than doing the leaf work
+//     themselves. E.g. `userMessageToMessage` switches on message type and calls
+//     `userTextMessageToMessage` / `userImageMessageToMessage`.
+//
+// The link between them is that composites receive an object satisfying this
+// interface (`this` on the endpoint class — see `WithMistralAIInputConverter`)
+// and route every child call through it. So overriding a single leaf field on an
+// endpoint changes how every composite depending on it behaves — no need to
+// touch the composites or `buildRequestPayload`.
+//
+// This composes both ways: a composite is itself an override point. An endpoint
+// can override a composite method and still reach its children through
+// `this.<child>` (e.g. a custom `userMessageToMessage` that calls
+// `this.userTextMessageToMessage`), so it picks up any leaf overrides too and
+// only the reassembly logic changes.
+//
+// "leaf" / "composite" naming lives only in comments; it's just a mental model
+// for how the pieces compose.
 export interface MistralMessageConverters {
   systemMessageToMessage(message: SystemTextMessage): MistralMessage;
   userTextMessageToMessage(message: BaseUserTextMessage): MistralMessage;

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
@@ -28,9 +28,38 @@ import type {
   ResponseFormatJSONSchema,
 } from "openai/resources/shared";
 
-// The per-message leaf converters. The composite below routes through an object
-// satisfying this interface (`this`), so overriding one leaf on an endpoint
-// changes how the composite uses it.
+// This SDK client is shared across hosts and labs (OpenAI, Fireworks, ...). The
+// goal is to let a specific endpoint override one small conversion step (e.g.
+// how a user text message becomes a chat-completions message) without
+// reimplementing the whole `buildRequestPayload`.
+//
+// To make that possible, conversions are split into two kinds:
+//
+//   - "leaf" converters (this interface): the smallest units, each turning one
+//     Base* message into one chat-completions message. E.g.
+//     `userTextMessageToMessage`, `userImageMessageToMessage`. These are the
+//     override points.
+//
+//   - "composite" converters (defined below): higher-level converters that
+//     assemble messages by delegating to leaves rather than doing the leaf work
+//     themselves. E.g. `userMessageToMessage` switches on message type and calls
+//     `userTextMessageToMessage` / `userImageMessageToMessage`.
+//
+// The link between them is that composites receive an object satisfying this
+// interface (`this` on the endpoint class — see
+// `WithOpenAICompletionsInputConverter`) and route every child call through it.
+// So overriding a single leaf field on an endpoint changes how every composite
+// depending on it behaves — no need to touch the composites or
+// `buildRequestPayload`.
+//
+// This composes both ways: a composite is itself an override point. An endpoint
+// can override a composite method and still reach its children through
+// `this.<child>` (e.g. a custom `userMessageToMessage` that calls
+// `this.userTextMessageToMessage`), so it picks up any leaf overrides too and
+// only the reassembly logic changes.
+//
+// "leaf" / "composite" naming lives only in comments; it's just a mental model
+// for how the pieces compose.
 export interface OpenAICompletionsMessageConverters {
   systemMessageToMessage(
     message: SystemTextMessage

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -41,9 +41,38 @@ type PromptCacheBreakpoint =
     }
   | Record<string, never>;
 
-// The per-message leaf converters. Composites below take an object satisfying
-// this interface (`this`), so overriding one leaf on an endpoint changes how
-// every composite uses it.
+// This SDK client is shared across hosts and labs. The goal is to let a
+// specific endpoint override one small conversion step (e.g. how a user image
+// message becomes an input item) without reimplementing the whole
+// `buildRequestPayload`.
+//
+// To make that possible, conversions are split into two kinds:
+//
+//   - "leaf" converters (this interface): the smallest units, each turning one
+//     Base* message into one (or a few) Responses input item(s). E.g.
+//     `userImageMessageToInputItem`, `assistantTextMessageToInputItem`. These
+//     are the override points.
+//
+//   - "composite" converters (defined below): higher-level converters that
+//     assemble input items by delegating to leaves rather than doing the leaf
+//     work themselves. E.g. `userMessageToInputItems` switches on message type
+//     and calls `userImageMessageToInputItem` / `toolCallResultMessageToInputItem`.
+//
+// The link between them is that composites receive an object satisfying this
+// interface (`this` on the endpoint class — see
+// `WithOpenAIResponsesInputConverter`) and route every child call through it. So
+// overriding a single leaf field on an endpoint changes how every composite
+// depending on it behaves — no need to touch the composites or
+// `buildRequestPayload`.
+//
+// This composes both ways: a composite is itself an override point. An endpoint
+// can override a composite method and still reach its children through
+// `this.<child>` (e.g. a custom `userMessageToInputItems` that calls
+// `this.userImageMessageToInputItem`), so it picks up any leaf overrides too and
+// only the reassembly logic changes.
+//
+// "leaf" / "composite" naming lives only in comments; it's just a mental model
+// for how the pieces compose.
 export interface MessageItemConverters {
   systemMessageToInputItem(message: SystemTextMessage): ResponseInputItem;
   userImageMessageToInputItem(message: BaseUserImageMessage): ResponseInputItem;


### PR DESCRIPTION
## Description

Expand the leaf/composite comment in all five SDK input converters (anthropic_ai, google_genai, mistralai, openai_completions, openai_responses) to explain why converters split into leaves and composites, how endpoints override a single step via `this`, and that composites are override points too.

## Tests

Not needed.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`