### PR TITLE
feat: update capability seeders for publish agent

### DIFF
--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -1,3 +1,4 @@
+import { getPublishingRestrictionLevel } from "@app/lib/api/assistant/publishing_restrictions";
 import type { Authenticator } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -47,6 +48,27 @@ export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
   {
     capability: { grantType: "create", resourceType: "skill" },
     resolveTarget: async (_auth) => "builders",
+  },
+  {
+    capability: { grantType: "publish", resourceType: "agent" },
+    resolveTarget: async (auth) => {
+      const featureFlags = (
+        await FeatureFlagResource.listForWorkspace(
+          auth.getNonNullableWorkspace()
+        )
+      ).map((flag) => flag.name);
+      const level = getPublishingRestrictionLevel(featureFlags);
+      switch (level) {
+        case "admins_only":
+          return "admins_only";
+        case "builders_and_admins":
+          return "builders";
+        case null:
+          return "everyone";
+        default:
+          assertNever(level);
+      }
+    },
   },
 ];
 


### PR DESCRIPTION
## Description

This PR adds a capability seeder for the `publish agent` capability, ensuring that the default permission target is correctly resolved based on the workspace's publishing restriction level when permissions are initialized or backfilled.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Run the backfill script before merging the related publish agent changes.