### PR TITLE
[front] fix: unbreak main — pass userId to emitActivationEvent in send-activation-nudge

### DIFF
--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -2,7 +2,8 @@ import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -29,9 +30,9 @@ export const sendActivationNudgePlugin = createPlugin({
     id: "send-activation-nudge",
     name: "Send Activation Nudge",
     description:
-      "Nudge all members of this Activation Pod. Emits a single activation " +
-      "event; the pod's per-member triggers each start a @dust conversation " +
-      "running the activation workflow.",
+      "Nudge all members of this Activation Pod. Emits one activation event " +
+      "per member; each member's activation trigger starts a @dust " +
+      "conversation running the activation workflow.",
     resourceTypes: ["spaces"],
     args: {},
     requiredRoles: ["support"],
@@ -46,20 +47,46 @@ export const sendActivationNudgePlugin = createPlugin({
     }
 
     const workspace = auth.getNonNullableWorkspace();
-
-    // Emit a single activation event for the pod which creates individual
-    // conversations for all pod members.
     const adminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
     );
 
-    const emitResult = await emitActivationEvent(adminAuth, pod);
-    if (emitResult.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to emit activation event for pod ${pod.sId}: ${emitResult.error.message}`
-        )
+    const podWithGroups = await SpaceResource.fetchById(adminAuth, pod.sId);
+    if (!podWithGroups) {
+      return new Err(new Error(`Pod ${pod.sId} not found.`));
+    }
+
+    // The activation event is per-user (its trigger filter matches both the pod
+    // and the target user), so we emit one event per pod member.
+    const membersBySpaceModelId =
+      await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
+        adminAuth,
+        [podWithGroups]
       );
+    const members = membersBySpaceModelId.get(podWithGroups.id) ?? [];
+
+    if (members.length === 0) {
+      return new Ok({
+        display: "text",
+        value: `Activation Pod ${pod.sId} has no members to nudge.`,
+      });
+    }
+
+    const emitResults = await concurrentExecutor(
+      members,
+      async (member) => {
+        const result = await emitActivationEvent(adminAuth, pod, member.sId);
+        return { name: member.fullName() || member.email, result };
+      },
+      { concurrency: 3 }
+    );
+
+    const errorMessages: string[] = [];
+    for (const { name, result } of emitResults) {
+      if (result.isErr()) {
+        errorMessages.push(`${name}: ${result.error.message}`);
+      }
     }
 
     sendActivationNudgeLogger.info(
@@ -67,15 +94,25 @@ export const sendActivationNudgePlugin = createPlugin({
         action: "send_activation_nudge",
         spaceId: pod.sId,
         workspaceId: workspace.sId,
+        memberCount: members.length,
+        failedCount: errorMessages.length,
       },
-      "Emitted activation nudge event via poke"
+      "Emitted activation nudge events via poke"
     );
+
+    if (errorMessages.length > 0) {
+      return new Err(
+        new Error(
+          `Failed to emit activation events for ${errorMessages.length}/` +
+            `${members.length} member(s) of pod ${pod.sId}: ` +
+            errorMessages.join("; ")
+        )
+      );
+    }
 
     return new Ok({
       display: "text",
-      value:
-        "Activation nudge event emitted. Each pod member with an activation " +
-        "trigger will receive a @dust conversation.",
+      value: `Activation nudge emitted for ${members.length} pod member(s).`,
     });
   },
   isApplicableTo: (auth, pod) => (pod ? isActivationPod(auth, pod) : false),


### PR DESCRIPTION
## Description
`emitActivationEvent` gained a required `userId` param (#29123, per-user activation model), but send_activation_nudge.ts (#29092) still called it with 2 args and landed on main after the signature change, so main's front-spa type-check (TS2554) is currently red.

Fix the call by emitting one event per pod member: enumerate the pod's members (re-fetching under an admin auth with all groups, since pods are restricted spaces) and emit a per-user activation event for each, matching how the activation orchestrator drives nudges.

The actual design update --> making the nudge plugin create a conversation for a select subset of users, will be added in a stacked PR for a long-term change, this is the more immediate fix.

## Tests
Tested locally, all checks pass now.

## Risk


## Deploy Plan