### PR TITLE
Admin governance: add availibility to skill model

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -10,6 +10,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
+  SkillAvailability,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -74,6 +75,13 @@ const SKILL_MODEL_ATTRIBUTES = {
     allowNull: false,
     defaultValue: false,
   },
+  // Transition (isDefault -> availability): nullable with no default on purpose. NULL means
+  // "written by code predating the column, derive from isDefault". Will become NOT NULL once
+  // the backfill has run and isDefault is dropped.
+  availability: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
 } as const satisfies ModelAttributes;
 
 /**
@@ -112,6 +120,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
   declare isDefault: boolean;
+  declare availability: SkillAvailability | null;
   declare favoriteCount: CreationOptional<number>;
 
   declare reinforcement: CreationOptional<SkillReinforcementMode>;

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -563,6 +563,54 @@ describe("SkillResource", () => {
   });
 
   describe("updateSkill", () => {
+    it("keeps availability in sync when updating isDefault", async () => {
+      const skillResource = await SkillFactory.create(
+        testContext.authenticator,
+        { name: "Test Skill For Availability Sync" }
+      );
+
+      expect(skillResource.isDefault).toBe(false);
+      expect(skillResource.availability).toBe("workspace_users");
+
+      await skillResource.updateSkill(testContext.authenticator, {
+        name: skillResource.name,
+        agentFacingDescription: skillResource.agentFacingDescription,
+        userFacingDescription: skillResource.userFacingDescription,
+        instructions: skillResource.instructions,
+        icon: skillResource.icon,
+        isDefault: true,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: [],
+      });
+
+      const updatedSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        skillResource.sId
+      );
+      expect(updatedSkill?.isDefault).toBe(true);
+      expect(updatedSkill?.availability).toBe("users_and_agents");
+
+      await skillResource.updateSkill(testContext.authenticator, {
+        name: skillResource.name,
+        agentFacingDescription: skillResource.agentFacingDescription,
+        userFacingDescription: skillResource.userFacingDescription,
+        instructions: skillResource.instructions,
+        icon: skillResource.icon,
+        isDefault: false,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: [],
+      });
+
+      const revertedSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        skillResource.sId
+      );
+      expect(revertedSkill?.isDefault).toBe(false);
+      expect(revertedSkill?.availability).toBe("workspace_users");
+    });
+
     it("should add skill space requirements to agents using the skill", async () => {
       const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -78,12 +78,17 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
+  SkillAvailability,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
   SkillStatus,
   SkillType,
   UsedBySkillType,
+} from "@app/types/assistant/skill_configuration";
+import {
+  availabilityFromIsDefault,
+  isDefaultFromAvailability,
 } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
@@ -417,11 +422,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
 
+    // Transition (isDefault -> availability): dual-write both columns from whichever one the
+    // caller provided, so old code reading isDefault stays correct during the rollout.
+    const availability =
+      blob.availability ?? availabilityFromIsDefault(blob.isDefault ?? false);
+
     // Use a transaction to ensure all creations succeed or all are rolled back.
     return withTransaction(async (transaction) => {
       const skill = await this.model.create(
         {
           ...blob,
+          availability,
+          isDefault: isDefaultFromAvailability(availability),
           instructionsHtml: blob.instructionsHtml ?? null,
           workspaceId: owner.id,
         },
@@ -1987,6 +1999,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         source: null,
         sourceMetadata: null,
         isDefault: !SystemSkillsRegistry.isSystemSkill(def.sId),
+        availability: SystemSkillsRegistry.isSystemSkill(def.sId)
+          ? "workspace_users"
+          : "users_and_agents",
         favoriteCount: 0,
         reinforcement: "auto",
         lastReinforcementAnalysisAt: null,
@@ -2274,6 +2289,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           source: versionModel.source,
           sourceMetadata: versionModel.sourceMetadata,
           isDefault: versionModel.isDefault,
+          availability: versionModel.availability,
           favoriteCount: this.favoriteCount,
           reinforcement: "auto",
           lastReinforcementAnalysisAt: null,
@@ -2832,7 +2848,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
-          ...(isDefault !== undefined ? { isDefault } : {}),
+          // Transition (isDefault -> availability): dual-write both columns until all code
+          // relies on availability and isDefault is dropped.
+          ...(isDefault !== undefined
+            ? { isDefault, availability: availabilityFromIsDefault(isDefault) }
+            : {}),
           ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
         transaction
@@ -3987,8 +4007,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       })),
       canWrite: this.canWrite(auth),
       canAdministrate: this.canAdministrate(auth),
-      isDefault: this.isDefault,
+      isDefault: isDefaultFromAvailability(this.getAvailability()),
     };
+  }
+
+  getAvailability(): SkillAvailability {
+    // Transition (isDefault -> availability): NULL means the row predates the availability column
+    // and isDefault is authoritative.
+    return this.availability ?? availabilityFromIsDefault(this.isDefault);
   }
 
   private async saveVersion(
@@ -4055,6 +4081,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
       isDefault: this.isDefault,
+      availability: this.availability,
     };
 
     await SkillVersionModel.create(versionData, {

--- a/front/migrations/20260722_backfill_skill_availability.ts
+++ b/front/migrations/20260722_backfill_skill_availability.ts
@@ -1,0 +1,74 @@
+import {
+  SkillConfigurationModel,
+  SkillVersionModel,
+} from "@app/lib/models/skill";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { availabilityFromIsDefault } from "@app/types/assistant/skill_configuration";
+import type { ModelStatic } from "sequelize";
+
+const WORKSPACE_CONCURRENCY = 16;
+
+// Transition (isDefault -> availability): rows written by code predating the availability column
+// have a NULL availability and an authoritative isDefault. Run this once all pods write the
+// availability column (post-deploy), so no row can be updated by old code afterwards.
+const MODELS: {
+  table: string;
+  model: ModelStatic<SkillConfigurationModel>;
+}[] = [
+  { table: "skill_configurations", model: SkillConfigurationModel },
+  { table: "skill_versions", model: SkillVersionModel },
+];
+
+makeScript({}, async ({ execute }, logger) => {
+  let totalUpdated = 0;
+
+  await runOnAllWorkspaces(
+    async (workspace) => {
+      for (const { table, model } of MODELS) {
+        if (!execute) {
+          const wouldUpdateCount = await model.count({
+            where: { workspaceId: workspace.id, availability: null },
+          });
+
+          if (wouldUpdateCount > 0) {
+            logger.info(
+              { workspaceId: workspace.sId, table, wouldUpdateCount },
+              "Dry run: would backfill availability from isDefault"
+            );
+          }
+          continue;
+        }
+
+        let updated = 0;
+        for (const isDefault of [true, false]) {
+          // The `availability: null` guard makes the script safe to re-run and keeps rows
+          // already written by new code untouched. `silent` leaves updatedAt untouched.
+          const [count] = await model.update(
+            { availability: availabilityFromIsDefault(isDefault) },
+            {
+              where: {
+                workspaceId: workspace.id,
+                availability: null,
+                isDefault,
+              },
+              silent: true,
+            }
+          );
+          updated += count;
+        }
+
+        if (updated > 0) {
+          totalUpdated += updated;
+          logger.info(
+            { workspaceId: workspace.sId, table, updated },
+            "Backfilled skill availability"
+          );
+        }
+      }
+    },
+    { concurrency: WORKSPACE_CONCURRENCY }
+  );
+
+  logger.info({ totalUpdated }, "Completed skill availability backfill");
+});

--- a/front/migrations/pre-deploy/20260722103940_add_availability_to_skill_configurations.sql
+++ b/front/migrations/pre-deploy/20260722103940_add_availability_to_skill_configurations.sql
@@ -1,0 +1,13 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "availability" character varying(255) COLLATE "pg_catalog"."default";
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ADD COLUMN "availability" character varying(255) COLLATE "pg_catalog"."default";

--- a/front/scripts/create_hard_coded_suggested_skills.ts
+++ b/front/scripts/create_hard_coded_suggested_skills.ts
@@ -272,6 +272,7 @@ async function createSuggestedSkills(
               requestedSpaceIds: [],
               icon: skill.icon,
               isDefault: false,
+              availability: "workspace_users",
             },
             { transaction }
           );

--- a/front/scripts/create_meeting_prep_skill.ts
+++ b/front/scripts/create_meeting_prep_skill.ts
@@ -354,6 +354,7 @@ async function createMeetingPrepSkill(
         requestedSpaceIds: [],
         icon: SKILL_ICON,
         isDefault: false,
+        availability: "workspace_users",
       },
       { transaction }
     );

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,5 +1,6 @@
 import { MCPServerViewSchema } from "@app/lib/api/mcp_schemas";
 import type { AgentsUsageType } from "@app/types/data_source";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
@@ -8,6 +9,35 @@ export type SkillStatus = (typeof SKILL_STATUSES)[number];
 
 export const SKILL_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
 export type SkillReinforcementMode = (typeof SKILL_REINFORCEMENT_MODES)[number];
+
+export const SKILL_AVAILABILITIES = [
+  "editors",
+  "workspace_users",
+  "users_and_agents",
+] as const;
+export type SkillAvailability = (typeof SKILL_AVAILABILITIES)[number];
+
+// Transition (isDefault -> availability): rows written before the availability column existed only
+// carry isDefault. Remove these mappings once the backfill has run and isDefault is dropped.
+export function availabilityFromIsDefault(
+  isDefault: boolean
+): SkillAvailability {
+  return isDefault ? "users_and_agents" : "workspace_users";
+}
+
+export function isDefaultFromAvailability(
+  availability: SkillAvailability
+): boolean {
+  switch (availability) {
+    case "users_and_agents":
+      return true;
+    case "workspace_users":
+    case "editors":
+      return false;
+    default:
+      return assertNever(availability);
+  }
+}
 
 export const SKILL_VIEWS = ["full", "summary"] as const;
 export type SkillViewType = (typeof SKILL_VIEWS)[number];


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9725

Skill configurations currently have a boolean isDefault flag. We are replacing it with a 3-state availability column:

  ```
┌──────────────────┬─────────────────────────────────────────────────────────────────────┐
  │   availability   │                               Meaning                               │
  ├──────────────────┼─────────────────────────────────────────────────────────────────────┤
  │ editors          │ Only skill editors (new state, not yet writable)                    │
  ├──────────────────┼─────────────────────────────────────────────────────────────────────┤
  │ workspace_users  │ All workspace users (maps to isDefault: false, default)             │
  ├──────────────────┼─────────────────────────────────────────────────────────────────────┤
  │ users_and_agents │ Users and agents — discoverable by agents (maps to isDefault: true) │
  └──────────────────┴─────────────────────────────────────────────────────────────────────┘
```

### Migration plan 

A pre-deploy backfill alone would lose data: during the deploy window, pods running old code still write isDefault without touching availability, so any row updated between the backfill and the last old pod dying would carry a stale availability. Instead:

**PR 1 (this PR):**
  1. Pre-deploy migration adds a nullable availability column with no DB default to `skill_configurations` and `skill_versions`. `NULL` unambiguously means "row written by code predating the column; `isDefault` is
  authoritative".
  2. New code dual-writes both columns on every create/update, keeping them consistent.
  3. Reads go through a fallback: `availability ?? (isDefault ? "users_and_agents" : "workspace_users")`.
  4. After this deploy completes (no old pods left), run the backfill script to fill remaining NULLs from
  `isDefault`.

**PR 2:**
Drop isDefault and rely on availability only


## Tests

added unit test

## Risk

PR can be reverted if needed without data loss

## Deploy Plan

lock front
run pre deploy migration
deploy front
unlock front
run post-deploy migration
