### PR TITLE
[Activation] Nudge conversation is per-user

### DIFF
--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -1,15 +1,27 @@
-import { emitActivationEvent } from "@app/lib/api/activation/trigger";
+import {
+  createActivationTrigger,
+  emitActivationEvent,
+  getOrCreateActivationWebhookSourceView,
+} from "@app/lib/api/activation/trigger";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 const sendActivationNudgeLogger = logger.child({
   activity: "send-activation-nudge",
 });
+
+function formatMemberLabel(member: UserResource): string {
+  const name = member.fullName();
+  return name ? `${name} (${member.email})` : member.email;
+}
 
 // Whether the pod was provisioned through the activation flow. Gates both
 // visibility (isApplicableTo) and execution.
@@ -30,20 +42,28 @@ export const sendActivationNudgePlugin = createPlugin({
     id: "send-activation-nudge",
     name: "Send Activation Nudge",
     description:
-      "Nudge all members of this Activation Pod. Emits one activation event " +
-      "per member; each member's activation trigger starts a @dust " +
-      "conversation running the activation workflow.",
+      "Nudge selected members members of this Activation Pod, " +
+      "starting a @dust conversation running the activation " +
+      "workflow. All members are selected by default: deselect to nudge only " +
+      "a subset.",
     resourceTypes: ["spaces"],
-    args: {},
+    args: {
+      members: {
+        type: "enum",
+        label: "Members to nudge",
+        description:
+          "Members who will receive an activation nudge. All are selected by " +
+          "default; deselect to nudge only some.",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+    },
     requiredRoles: ["support"],
   },
-  execute: async (auth, pod) => {
+  populateAsyncArgs: async (auth, pod) => {
     if (!pod) {
-      return new Err(new Error("Pod not found."));
-    }
-
-    if (!(await isActivationPod(auth, pod))) {
-      return new Err(new Error("This plugin only applies to Activation Pods."));
+      return new Ok({ members: [] });
     }
 
     const workspace = auth.getNonNullableWorkspace();
@@ -52,40 +72,117 @@ export const sendActivationNudgePlugin = createPlugin({
       { dangerouslyRequestAllGroups: true }
     );
 
-    const podWithGroups = await SpaceResource.fetchById(adminAuth, pod.sId);
-    if (!podWithGroups) {
-      return new Err(new Error(`Pod ${pod.sId} not found.`));
-    }
-
-    // The activation event is per-user (its trigger filter matches both the pod
-    // and the target user), so we emit one event per pod member.
     const membersBySpaceModelId =
       await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
         adminAuth,
-        [podWithGroups]
+        [pod]
       );
-    const members = membersBySpaceModelId.get(podWithGroups.id) ?? [];
+    const members = membersBySpaceModelId.get(pod.id) ?? [];
 
-    if (members.length === 0) {
-      return new Ok({
-        display: "text",
-        value: `Activation Pod ${pod.sId} has no members to nudge.`,
-      });
+    return new Ok({
+      members: members.map((member) => ({
+        label: formatMemberLabel(member),
+        value: member.sId,
+        // Default to nudging everyone; support can deselect to target a subset.
+        checked: true,
+      })),
+    });
+  },
+  execute: async (auth, pod, args) => {
+    if (!pod) {
+      return new Err(new Error("Pod not found."));
     }
 
-    const emitResults = await concurrentExecutor(
-      members,
+    if (!(await isActivationPod(auth, pod))) {
+      return new Err(new Error("This plugin only applies to Activation Pods."));
+    }
+
+    const selectedMemberIds = args.members ?? [];
+    if (selectedMemberIds.length === 0) {
+      return new Err(new Error("Select at least one member to nudge."));
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
+    );
+
+    // The activation conversation is created by a per-user trigger.
+    // So to nudge a member we ensure that member has an activation trigger,
+    // (provisioning one on their behalf if missing) then emit the event that fires it.
+    const podViewResult = await getOrCreateActivationWebhookSourceView(
+      adminAuth,
+      pod
+    );
+    if (podViewResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to get or create Activation Pod webhook view: ${podViewResult.error.message}`
+        )
+      );
+    }
+    const podView = podViewResult.value;
+
+    const existingTriggers = await TriggerResource.listByWebhookSourceViewId(
+      adminAuth,
+      podView.id
+    );
+    const memberModelIdsWithTrigger = new Set(
+      removeNulls(existingTriggers.map((trigger) => trigger.editor))
+    );
+
+    const users = await UserResource.fetchByIds(selectedMemberIds);
+
+    const outcomes = await concurrentExecutor(
+      users,
       async (member) => {
-        const result = await emitActivationEvent(adminAuth, pod, member.sId);
-        return { name: member.fullName() || member.email, result };
+        const name = member.fullName() || member.email;
+
+        if (!memberModelIdsWithTrigger.has(member.id)) {
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            member.sId,
+            workspace.sId
+          );
+          const triggerResult = await createActivationTrigger(memberAuth, {
+            pod,
+            creator: member,
+            podView,
+          });
+          if (triggerResult.isErr()) {
+            return {
+              name,
+              status: "failed" as const,
+              message: `trigger provisioning failed: ${triggerResult.error.message}`,
+            };
+          }
+        }
+
+        const emitResult = await emitActivationEvent(
+          adminAuth,
+          pod,
+          member.sId
+        );
+        if (emitResult.isErr()) {
+          return {
+            name,
+            status: "failed" as const,
+            message: emitResult.error.message,
+          };
+        }
+
+        return { name, status: "nudged" as const };
       },
       { concurrency: 3 }
     );
 
-    const errorMessages: string[] = [];
-    for (const { name, result } of emitResults) {
-      if (result.isErr()) {
-        errorMessages.push(`${name}: ${result.error.message}`);
+    const nudged: string[] = [];
+    const failed: string[] = [];
+    for (const outcome of outcomes) {
+      if (outcome.status === "failed") {
+        failed.push(`${outcome.name}: ${outcome.message}`);
+      } else {
+        nudged.push(outcome.name);
       }
     }
 
@@ -94,25 +191,27 @@ export const sendActivationNudgePlugin = createPlugin({
         action: "send_activation_nudge",
         spaceId: pod.sId,
         workspaceId: workspace.sId,
-        memberCount: members.length,
-        failedCount: errorMessages.length,
+        selectedCount: selectedMemberIds.length,
+        nudgedCount: nudged.length,
+        failedCount: failed.length,
       },
       "Emitted activation nudge events via poke"
     );
 
-    if (errorMessages.length > 0) {
+    if (failed.length > 0) {
       return new Err(
         new Error(
-          `Failed to emit activation events for ${errorMessages.length}/` +
-            `${members.length} member(s) of pod ${pod.sId}: ` +
-            errorMessages.join("; ")
+          `Failed to nudge ${failed.length}/${selectedMemberIds.length} ` +
+            `member(s) of pod ${pod.sId}: ${failed.join("; ")}`
         )
       );
     }
 
     return new Ok({
       display: "text",
-      value: `Activation nudge emitted for ${members.length} pod member(s).`,
+      value:
+        `Activation nudge emitted for ${nudged.length} member(s): ` +
+        `${nudged.join(", ")}.`,
     });
   },
   isApplicableTo: (auth, pod) => (pod ? isActivationPod(auth, pod) : false),

--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -42,10 +42,9 @@ export const sendActivationNudgePlugin = createPlugin({
     id: "send-activation-nudge",
     name: "Send Activation Nudge",
     description:
-      "Nudge selected members members of this Activation Pod, " +
-      "starting a @dust conversation running the activation " +
-      "workflow. All members are selected by default: deselect to nudge only " +
-      "a subset.",
+      "Nudge selected members of this Activation Pod, starting a @dust " +
+      "conversation running the activation workflow. All members are selected " +
+      "by default: deselect to nudge only a subset.",
     resourceTypes: ["spaces"],
     args: {
       members: {
@@ -72,12 +71,19 @@ export const sendActivationNudgePlugin = createPlugin({
       { dangerouslyRequestAllGroups: true }
     );
 
+    // Re-fetch under admin auth so the pod's groups are attached;
+    // fetchDistinctActiveManualGroupMembersBySpaces reads space.groups.
+    const podWithGroups = await SpaceResource.fetchById(adminAuth, pod.sId);
+    if (!podWithGroups) {
+      return new Ok({ members: [] });
+    }
+
     const membersBySpaceModelId =
       await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
         adminAuth,
-        [pod]
+        [podWithGroups]
       );
-    const members = membersBySpaceModelId.get(pod.id) ?? [];
+    const members = membersBySpaceModelId.get(podWithGroups.id) ?? [];
 
     return new Ok({
       members: members.map((member) => ({
@@ -108,9 +114,9 @@ export const sendActivationNudgePlugin = createPlugin({
       { dangerouslyRequestAllGroups: true }
     );
 
-    // The activation conversation is created by a per-user trigger.
-    // So to nudge a member we ensure that member has an activation trigger,
-    // (provisioning one on their behalf if missing) then emit the event that fires it.
+    // The activation conversation is created by a per-user trigger. So to nudge
+    // a member we ensure that member has an activation trigger (provisioning one
+    // on their behalf if missing), then emit the event that fires it.
     const podViewResult = await getOrCreateActivationWebhookSourceView(
       adminAuth,
       pod
@@ -195,7 +201,7 @@ export const sendActivationNudgePlugin = createPlugin({
         nudgedCount: nudged.length,
         failedCount: failed.length,
       },
-      "Emitted activation nudge events via poke"
+      "Emitted activation nudge event via poke"
     );
 
     if (failed.length > 0) {


### PR DESCRIPTION
## Description
Permanent fix to #29288 to change the nudge conversation mechanism to be per-user, meaning the nudge conversation can now be sent to a subset of the members of the pod (via poke or the scheduler).

- Adds a member multi select (all selected by default) to the Poke plugin UI. 
- For each selected member, provisions their activation trigger if missing before emitting, so members without a trigger still get their own @dust conversation.
- Reports per-member outcomes.
- Uses the same per-user `emitActivationEvent` path as the scheduler, but as a manual support, the Poke plugin bypasses the scheduler's eligibility gating, so it can re-nudge someone.

## Tests
Tested the poke plugin flow locally.

## Risk
Behind activation pod Poke plugin.

## Deploy Plan
Deploy to front.