### PR TITLE
[front] perf: add workspaceId clause in group_vault

### DIFF
--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -1,6 +1,9 @@
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { faker } from "@faker-js/faker";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -179,5 +182,49 @@ describe("GET /api/poke/search - data source", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.results).toEqual([]);
+  });
+});
+
+describe("GET /api/poke/search - resource sId", () => {
+  it("returns the data source view when searching by its sId", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+
+    // The resource lives in a different workspace than the poke session's:
+    // the search must re-scope on the workspace embedded in the sId.
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const space = await SpaceFactory.regular(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    const response = await searchRequest(dataSourceView.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([
+      expect.objectContaining({
+        id: dataSourceView.id,
+        type: "Data Source View",
+      }),
+    ]);
+  });
+
+  it("returns the data source when searching by its sId", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const space = await SpaceFactory.regular(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    const response = await searchRequest(dataSourceView.dataSource.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([
+      expect.objectContaining({
+        id: dataSourceView.dataSource.id,
+        type: "Data Source",
+      }),
+    ]);
   });
 });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -24,8 +24,7 @@ import name from "./[name]";
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/datasets.
 //
 // Interacting with datasets requires write access to the app's space.
-// Read permission is not enough as it's available to all space users (or
-// everybody for public spaces).
+// Read permission is not enough as it's available to all space users.
 const app = workspaceApp();
 
 // Shared prelude for GET and POST: resolves the app from `:aId`, verifies it

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -420,7 +420,7 @@ export const createAgentMessages = async (
             }
 
             // In case of Project's conversation, we need to check if the agent configuration is
-            // using only the project spaces or public spaces/ Otherwise we reject the mention and
+            // using only the project spaces or open spaces. Otherwise we reject the mention and
             // do not create the agent message.
             if (isPodConversation(conversation)) {
               const canAgentBeUsed = await canAgentBeUsedInProjectConversation(

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -4,7 +4,7 @@ import {
   getWorkspaceInfos,
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import {
   dataSourceToPokeItem,
@@ -257,7 +257,7 @@ export async function searchPokeResources(
 ): Promise<PokeItemBase[]> {
   const resourceInfo = getResourceNameAndIdFromSId(searchTerm);
   if (resourceInfo) {
-    return searchPokeResourcesBySId(auth, resourceInfo);
+    return searchPokeResourcesBySId(resourceInfo);
   }
 
   return (
@@ -273,27 +273,47 @@ export async function searchPokeResources(
 }
 
 async function searchPokeResourcesBySId(
-  auth: Authenticator,
   resourceInfo: Exclude<ReturnType<typeof getResourceNameAndIdFromSId>, null>
 ): Promise<PokeItemBase[]> {
-  const { resourceName, sId } = resourceInfo;
+  const { resourceName, sId, workspaceModelId } = resourceInfo;
 
   switch (resourceName) {
     case "data_source_view":
-      const dataSourceView = await DataSourceViewResource.fetchById(auth, sId);
-      if (!dataSourceView) {
+    case "data_source": {
+      // The poke authenticator is not scoped to any workspace while resource
+      // fetches are; re-scope to the workspace embedded in the sId.
+      const [workspace] = await WorkspaceResource.fetchByModelIds([
+        workspaceModelId,
+      ]);
+      if (!workspace) {
         return [];
       }
+      const workspaceAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
 
-      return [await dataSourceViewToPokeItem(dataSourceView)];
+      if (resourceName === "data_source_view") {
+        const dataSourceView = await DataSourceViewResource.fetchById(
+          workspaceAuth,
+          sId
+        );
+        if (!dataSourceView) {
+          return [];
+        }
 
-    case "data_source":
-      const dataSource = await DataSourceResource.fetchByNameOrId(auth, sId);
+        return [await dataSourceViewToPokeItem(dataSourceView)];
+      }
+
+      const dataSource = await DataSourceResource.fetchByNameOrId(
+        workspaceAuth,
+        sId
+      );
       if (!dataSource) {
         return [];
       }
 
       return [await dataSourceToPokeItem(dataSource)];
+    }
 
     default:
       return [];

--- a/front/lib/resources/data_source_resource.test.ts
+++ b/front/lib/resources/data_source_resource.test.ts
@@ -1,6 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -246,5 +248,127 @@ describe("DataSourceResource.hardDelete", () => {
     expect(deleteConnectorSpy).toHaveBeenCalledWith(mockConnectorId, true);
 
     deleteConnectorSpy.mockRestore();
+  });
+});
+
+describe("DataSourceResource cross-workspace fetch", () => {
+  it("unsafeFetchByDustAPIProjectId resolves the space and its groups across workspaces for super users", async () => {
+    // Workspace A owns the space and the data source.
+    const workspaceA = await WorkspaceFactory.basic();
+    const spaceA = await SpaceFactory.regular(workspaceA);
+    const dustAPIProjectId = "cross-ws-project-super-user";
+    await DataSourceViewFactory.folder(workspaceA, spaceA, null, {
+      dustAPIProjectId,
+    });
+
+    // The lookup is authenticated against workspace B as a super user (the
+    // only cross-workspace path canFetch allows): the space groupSpaces join
+    // must resolve the groups of the space's own workspace, not the
+    // authenticated one.
+    const workspaceB = await WorkspaceFactory.basic();
+    const superUser = await UserFactory.superUser();
+    await MembershipFactory.associate(workspaceB, superUser, {
+      role: "admin",
+    });
+    const authB = await Authenticator.fromUserIdAndWorkspaceId(
+      superUser.sId,
+      workspaceB.sId
+    );
+
+    const dataSource = await DataSourceResource.unsafeFetchByDustAPIProjectId(
+      authB,
+      dustAPIProjectId
+    );
+
+    expect(dataSource).not.toBeNull();
+    expect(dataSource?.space.id).toBe(spaceA.id);
+    expect(dataSource?.space.groups.length).toBeGreaterThan(0);
+  });
+
+  it("unsafeFetchByDustAPIProjectId filters out other-workspace resources for non super users", async () => {
+    const workspaceA = await WorkspaceFactory.basic();
+    const spaceA = await SpaceFactory.regular(workspaceA);
+    const dustAPIProjectId = "cross-ws-project-regular-user";
+    await DataSourceViewFactory.folder(workspaceA, spaceA, null, {
+      dustAPIProjectId,
+    });
+
+    const workspaceB = await WorkspaceFactory.basic();
+    const authB = await Authenticator.internalAdminForWorkspace(workspaceB.sId);
+
+    const dataSource = await DataSourceResource.unsafeFetchByDustAPIProjectId(
+      authB,
+      dustAPIProjectId
+    );
+
+    expect(dataSource).toBeNull();
+  });
+
+  it("resolves every space when one bypassed query spans multiple workspaces", async () => {
+    // Two data sources sharing the same dustAPIProjectId in two different
+    // workspaces: the bypassed blob query returns both in a single call, so
+    // the space fetch must resolve spaces (and their groups) across both
+    // workspaces — a miss throws "Unreachable: space not found.".
+    const dustAPIProjectId = "multi-ws-project-id";
+    const workspaceA = await WorkspaceFactory.basic();
+    const spaceA = await SpaceFactory.regular(workspaceA);
+    await DataSourceViewFactory.folder(workspaceA, spaceA, null, {
+      dustAPIProjectId,
+    });
+
+    const workspaceB = await WorkspaceFactory.basic();
+    const spaceB = await SpaceFactory.regular(workspaceB);
+    await DataSourceViewFactory.folder(workspaceB, spaceB, null, {
+      dustAPIProjectId,
+    });
+
+    const superUser = await UserFactory.superUser();
+    await MembershipFactory.associate(workspaceB, superUser, {
+      role: "admin",
+    });
+    const authB = await Authenticator.fromUserIdAndWorkspaceId(
+      superUser.sId,
+      workspaceB.sId
+    );
+
+    const dataSource = await DataSourceResource.unsafeFetchByDustAPIProjectId(
+      authB,
+      dustAPIProjectId
+    );
+
+    expect(dataSource).not.toBeNull();
+    expect(dataSource?.space.workspaceId).toBe(dataSource?.workspaceId);
+    expect(dataSource?.space.groups.length).toBeGreaterThan(0);
+    expect(
+      dataSource?.space.groups.every(
+        (group) => group.workspaceId === dataSource.workspaceId
+      )
+    ).toBe(true);
+  });
+
+  it("scopes fetchById to the authenticated workspace, even for super users", async () => {
+    const workspaceA = await WorkspaceFactory.basic();
+    const spaceA = await SpaceFactory.regular(workspaceA);
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspaceA,
+      spaceA
+    );
+
+    const workspaceB = await WorkspaceFactory.basic();
+    const superUser = await UserFactory.superUser();
+    await MembershipFactory.associate(workspaceB, superUser, {
+      role: "admin",
+    });
+    const authB = await Authenticator.fromUserIdAndWorkspaceId(
+      superUser.sId,
+      workspaceB.sId
+    );
+
+    const dataSource = await DataSourceResource.fetchById(
+      authB,
+      dataSourceView.dataSource.sId
+    );
+
+    expect(dataSource).toBeNull();
   });
 });

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -139,16 +139,23 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
   ) {
     const { includeDeleted } = fetchDataSourceOptions ?? {};
 
+    // Scope to the authenticated workspace unless the caller performs an intentionally
+    // cross-workspace lookup (e.g. unsafeFetchByDustAPIProjectId).
+    const where: WhereOptions<DataSourceModel> =
+      options?.dangerouslyBypassWorkspaceIsolationSecurity
+        ? (options?.where ?? {})
+        : {
+            ...options?.where,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          };
+
     return this.baseFetchWithAuthorization(
       auth,
       {
         ...this.getOptions(fetchDataSourceOptions),
         ...options,
         includeDeleted,
-        // WORKSPACE_ISOLATION_BYPASS: Data sources can be public, preventing to enforce a
-        // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
-        // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-        dangerouslyBypassWorkspaceIsolationSecurity: true,
+        where,
       },
       transaction
     );
@@ -324,10 +331,6 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       where: {
         id: ids,
       },
-      // WORKSPACE_ISOLATION_BYPASS: Data sources can be public, preventing to enforce a
-      // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -241,14 +241,16 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   ) {
     const { includeDeleted } = fetchDataSourceViewOptions ?? {};
 
+    const where: WhereOptions<DataSourceViewModel> = {
+      ...options?.where,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    };
+
     const dataSourceViews = await this.baseFetchWithAuthorization(auth, {
       ...this.getOptions(fetchDataSourceViewOptions),
       ...options,
       includeDeleted,
-      // WORKSPACE_ISOLATION_BYPASS: Data source views can be public, preventing to enforce a
-      // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where,
     });
 
     const dataSourceIds = removeNulls(

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -87,23 +87,34 @@ export abstract class ResourceWithSpace<
       return [];
     }
 
-    // We use the model directly here; it's a very rare case where we don't check the workspace,
-    // which in this case is due to the fact that we may need to fetch data from public workspaces
-    // as well as the current workspace.
+    // Scope on the fetched blobs' workspaces rather than the authenticated one: some lookups
+    // are intentionally cross-workspace (e.g. unsafeFetchByDustAPIProjectId) and a blob always
+    // lives in the same workspace as its space.
+    const blobWorkspaceIds = [...new Set(blobs.map((b) => b.workspaceId))];
+
     const spaces = await ResourceWithSpace.spaceModel.findAll({
       where: {
         id: blobs.map((b) => b.vaultId),
+        workspaceId: blobWorkspaceIds,
       },
       include: [
         {
           as: "groupSpaces",
           model: GroupSpaceModel,
+          // A where on an include implies required: true;
+          // pass this required: false to keep the original behavior intact
+          required: false,
+          where: {
+            workspaceId: blobWorkspaceIds,
+          },
         },
       ],
       includeDeleted,
       transaction,
-      // WORKSPACE_ISOLATION_BYPASS: Spaces can be public, preventing to enforce a
-      // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
+      // WORKSPACE_ISOLATION_BYPASS: The where clause is scoped to the blobs' workspaces, which
+      // may span multiple workspaces when the blob query ran with the bypass (e.g.
+      // unsafeFetchByDustAPIProjectId); the static check only accepts a single workspaceId.
+      // Permissions are enforced by canFetch below.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -293,6 +293,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       {
         as: "groupSpaces",
         model: GroupSpaceModel,
+        // A where on an include implies required: true;
+        // pass this required: false to keep the original behavior intact
+        required: false,
+        where: { workspaceId: auth.getNonNullableWorkspace().id },
       },
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(includes || []),


### PR DESCRIPTION
## Description

We recently introduced a perf improvement by removing one join in the space fetch (was space x group_vault x group, now is vault x group_vault).

But while it's a 50% perf improvement, we can do better.

Indeed, postgres is systematically choosing to use either an nested loop, or a hash join with a seq scan.
This is because when computing join selectivity, pg only has `on vault.id = group_vault.vaultId`, it does not know about the transitive nature of a `workspaceId = $` predicate.

This selectivity gets backed into the different cost functions pg evaluates to choose a plan, and granted it's more nuanced in reality, it will do either 

1. Hash Join + Seq scan
   => That's terrible, but it's because PG has no way to know it can reduce the lookup by an order of magnitude. Any other index scan in the table would result in more work in its model.

2. Nested Loop + Index scan on vaultId
   => That's okayish on worskpaces with very little spaces, but with projects this ship is sailing. On workspace with more than say 40 spaces, hash join starts to become interesting.

If you want more context with actual plans : https://dust4ai.slack.com/archives/C050SM8NSPK/p1784708558128809?thread_ts=1784630404.245539&cid=C050SM8NSPK

Fix : Add worskpaceId in the ON join predicate. It has 0 added cost, and tells pg about the real selectivity, which means it can now use any index starting with workspaceId to build its hashmap and not scan the entire table \o/

## Tests

Tested locally

## Risk

Low
Blast radius: Poke search AFAIK

## Deploy Plan

Deploy front
