### PR TITLE
dsbx: never substitute DSEC secrets into CORS preflight headers

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -337,6 +337,11 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
             | "if-unmodified-since"
             | "if-range"
             | "range"
+            // CORS preflight — servers commonly echo these values back in
+            // `Access-Control-Allow-Headers` / `Access-Control-Allow-Methods`,
+            // which would round-trip a substituted secret to the client.
+            | "access-control-request-headers"
+            | "access-control-request-method"
     )
 }
 
@@ -602,6 +607,9 @@ mod tests {
             "if-unmodified-since",
             "if-range",
             "range",
+            // CORS preflight.
+            "access-control-request-headers",
+            "access-control-request-method",
             // Prefix families.
             "sec-ch-ua",
             "sec-ch-ua-platform",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.54",
+      tag: "0.8.55",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.33/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.34/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.54";
-const DSBX_CLI_VERSION = "0.1.33";
+const DUST_BASE_IMAGE_VERSION = "0.8.55";
+const DSBX_CLI_VERSION = "0.1.34";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Found during a sandbox pen test: the DSEC substitution blocklist in `dsbx forward` did not cover CORS preflight headers. A sandbox workload could send a secret placeholder in `Access-Control-Request-Headers` to a host under the secret's allowed domains that reflects it (e.g. `play.google.com/log` echoes it verbatim in `Access-Control-Allow-Headers`), and read the real secret in the response.

Fix: add `access-control-request-headers` and `access-control-request-method` to `is_unsafe_substitution_header`, so the opaque placeholder travels upstream unsubstituted like the other reflection-prone headers.

Also bumps dsbx to 0.1.34 and the dust-base image to 0.8.55 so the fix can actually ship (dsbx is baked into the image at build time). Bedrock stays at 1.10.0 since the dsbx install happens in the dust-base layer.

## Tests

- Added both headers to the blocklist membership test; ran the full `forward` test suite locally (146 tests pass) and `registry.test.ts` (16 tests pass).
- Reproduced the reflection end to end against production before the fix (placeholder in preflight to `play.google.com/log` came back substituted in `Access-Control-Allow-Headers`).

## Risk

Low. Preflight headers are never credential carriers, so no legitimate secret use goes through them. Behavior change is limited to placeholders in those two headers now passing through unsubstituted.

## Deploy Plan

1. Run the `Release dsbx CLI` workflow (`release-dsbx-cli.yml`) to publish the `dsbx-v0.1.34` GitHub release.
2. Run the `Sandbox Image Registry` workflow (`sandbox-img-registry.yml`) to build the `dust-base:0.8.55` E2B template in eu and us.
3. Deploy front (picks up the new image pin).
4. From prodbox, kill sandboxes still running the old image so they get recreated on 0.8.55 instead of waiting up to 24h for the reaper.
