### PR TITLE
[LLM] Add Claude Fable 5 EU agent-platform stream endpoint

### DIFF
--- a/front/lib/llms/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform.ts
@@ -1,0 +1,25 @@
+import { WithDustClaudeFableFiveConfig } from "@app/lib/llms/providers/anthropic/models/claude_fable_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicClaudeFableFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform";
+
+export class DustAnthropicClaudeFableFiveEuropeAgentPlatformStream extends WithDustClaudeFableFiveConfig(
+  AnthropicClaudeFableFiveEuropeAgentPlatformStream
+) {
+  static readonly endpointFilter = {
+    and: [
+      { featureFlags: { contains: "claude_fable_5_feature" as const } },
+      {
+        or: [
+          {
+            featureFlags: {
+              contains: "use_vertex_for_supported_models" as const,
+            },
+          },
+          { isCreditPriced: { eq: true } },
+        ],
+      },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAnthropicClaudeFableFiveEuropeAgentPlatformStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,4 +1,5 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { DustAnthropicClaudeFableFiveEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform";
 import { DustAnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { DustAnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
@@ -62,6 +63,8 @@ import type {
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 
 export const DUST_STREAM_ENDPOINTS = {
+  [DustAnthropicClaudeFableFiveEuropeAgentPlatformStream.id]:
+    DustAnthropicClaudeFableFiveEuropeAgentPlatformStream,
   [DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream.id]:
     DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream,
   [DustAnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream.id]:
@@ -98,20 +101,25 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicClaudeSonnetFiveGlobalAnthropicStream,
   [DustAnthropicClaudeSonnetFourDotSixGlobalAnthropicStream.id]:
     DustAnthropicClaudeSonnetFourDotSixGlobalAnthropicStream,
+
   [DustDeepSeekDeepSeekV4ProGlobalFireworksStream.id]:
     DustDeepSeekDeepSeekV4ProGlobalFireworksStream,
+
   [DustZAiGlmFiveDotTwoGlobalFireworksStream.id]:
     DustZAiGlmFiveDotTwoGlobalFireworksStream,
+
   [DustMoonshotAiKimiK2Dot5GlobalFireworksStream.id]:
     DustMoonshotAiKimiK2Dot5GlobalFireworksStream,
   [DustMoonshotAiKimiK2Dot6GlobalFireworksStream.id]:
     DustMoonshotAiKimiK2Dot6GlobalFireworksStream,
+
   [DustGoogleAiStudioGeminiThreeDotOneFlashLiteGlobalGoogleAiStudioStream.id]:
     DustGoogleAiStudioGeminiThreeDotOneFlashLiteGlobalGoogleAiStudioStream,
   [DustGoogleAiStudioGeminiThreeDotOneProGlobalGoogleAiStudioStream.id]:
     DustGoogleAiStudioGeminiThreeDotOneProGlobalGoogleAiStudioStream,
   [DustGoogleAiStudioGeminiThreeDotFiveFlashGlobalGoogleAiStudioStream.id]:
     DustGoogleAiStudioGeminiThreeDotFiveFlashGlobalGoogleAiStudioStream,
+
   [DustMistralCodestralEuropeMistralStream.id]:
     DustMistralCodestralEuropeMistralStream,
   [DustMistralMistralLargeEuropeMistralStream.id]:
@@ -120,7 +128,9 @@ export const DUST_STREAM_ENDPOINTS = {
     DustMistralMistralMedium35EuropeMistralStream,
   [DustMistralMistralSmallEuropeMistralStream.id]:
     DustMistralMistralSmallEuropeMistralStream,
+
   [DustNoopNoopGlobalNoopStream.id]: DustNoopNoopGlobalNoopStream,
+
   [DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesStream.id]:
     DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesStream,
   [DustOpenAIGptFiveDotFourMiniEuropeOpenAIResponsesStream.id]:

--- a/front/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeFableFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_fable_five";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AnthropicClaudeFableFiveEuropeAgentPlatformStream extends WithAnthropicClaudeFableFiveConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 13.75,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 13.75,
+    longCacheCreated: 22.0,
+    cacheHit: 1.1,
+    standardInput: 11.0,
+    standardOutput: 55.0,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AnthropicClaudeFableFiveEuropeAgentPlatformStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,4 +1,5 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { AnthropicClaudeFableFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform";
 import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
@@ -55,6 +56,8 @@ import { OpenAIGptFiveNanoGlobalOpenAIResponsesStream } from "@app/lib/model_con
 import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
 
 export const STREAM_ENDPOINTS = {
+  [AnthropicClaudeFableFiveEuropeAgentPlatformStream.id]:
+    AnthropicClaudeFableFiveEuropeAgentPlatformStream,
   [AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream.id]:
     AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream,
   [AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream.id]:

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_eu_agent_platform.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_eu_agent_platform.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+
+import { AnthropicClaudeFableFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform";
+import {
+  HAS_REASONING,
+  INPUT_CONFIGURATION_ERROR,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AnthropicClaudeFableFiveEuropeAgentPlatformStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AnthropicClaudeFableFiveEuropeAgentPlatformStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    tests: {
+      // Minimal reasoning effort is not supported by the model.
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      // Fable has adaptive thinking always on: "none" is clamped to low.
+      "reasoning/no-tools/t-default/r-none": [HAS_REASONING],
+
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-default/r-maximal": null,
+      "simple/no-tools/t-0/r-default": null,
+      "simple/no-tools/t-0/r-none": null,
+      "simple/no-tools/t-0/r-low": null,
+      "simple/no-tools/t-0/r-medium": null,
+      "simple/no-tools/t-0/r-high": null,
+      "simple/no-tools/t-0/r-maximal": null,
+      "simple/no-tools/t-0.1/r-default": null,
+      "simple/no-tools/t-0.1/r-none": null,
+      "simple/no-tools/t-0.1/r-low": null,
+      "simple/no-tools/t-0.1/r-medium": null,
+      "simple/no-tools/t-0.1/r-high": null,
+      "simple/no-tools/t-0.1/r-maximal": null,
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-maximal": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": null,
+      "calc/calc/t-0.1/r-medium": null,
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_fable_five_eu_agent_platform.test.ts
+runStreamEndpointTests(
+  AnthropicClaudeFableFiveEuropeAgentPlatformStream,
+  AnthropicClaudeFableFiveEuropeAgentPlatformStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -3,6 +3,7 @@
 // type-check when a new endpoint is added to `STREAM_ENDPOINTS` without a
 // matching test file exporting its `setup`, forcing the test to be written.
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
+import { AnthropicClaudeFableFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_eu_agent_platform";
 import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
@@ -57,6 +58,7 @@ import { OpenAIGptFiveMiniGlobalOpenAIResponsesStream } from "@app/lib/model_con
 import { OpenAIGptFiveNanoEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_eu_openai_responses";
 import { OpenAIGptFiveNanoGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_nano_global_openai_responses";
 import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/z_ai_glm_five_dot_two_global_fireworks";
+import { AnthropicClaudeFableFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_eu_agent_platform.test";
 import { AnthropicClaudeFableFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_global_anthropic.test";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform.test";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic.test";
@@ -136,6 +138,8 @@ export const STREAM_ENDPOINT_SETUPS = {
     GoogleAiStudioGeminiThreeDotOneFlashLiteGlobalAgentPlatformStreamSetup,
   [GoogleAiStudioGeminiThreeDotOneProGlobalAgentPlatformStream.id]:
     GoogleAiStudioGeminiThreeDotOneProGlobalAgentPlatformStreamSetup,
+  [AnthropicClaudeFableFiveEuropeAgentPlatformStream.id]:
+    AnthropicClaudeFableFiveEuropeAgentPlatformStreamSetup,
   [AnthropicClaudeFableFiveGlobalAnthropicStream.id]:
     AnthropicClaudeFableFiveGlobalAnthropicStreamSetup,
   [AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream.id]:


### PR DESCRIPTION
## Description

Add a Claude Fable 5 stream endpoint served via the EU agent-platform (Vertex) route, so Fable 5 resolves through the new router in EU regional workspaces instead of falling back to the legacy router.

## Tests

Added the characterization test file, mirroring the Fable 5 global contract. Not yet run against the live API — it requires `RUN_LLM_TEST=true` and Vertex ADC. Confirm Fable 5 is actually served on Vertex `europe-west1` before merging.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`