### PR TITLE
dsbx: extend DSEC substitution blocklist to remaining reflective headers

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -342,6 +342,24 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
             // which would round-trip a substituted secret to the client.
             | "access-control-request-headers"
             | "access-control-request-method"
+            // WebSocket handshake — the server echoes the selected
+            // subprotocol (and negotiated extensions) in the 101 response.
+            | "sec-websocket-protocol"
+            | "sec-websocket-extensions"
+            // Idempotency — APIs commonly echo the key in 409/422 error
+            // bodies ("key already used").
+            | "idempotency-key"
+            // Content-Disposition — upload endpoints often echo the filename
+            // back in JSON responses or error messages.
+            | "content-disposition"
+            // Prefer — RFC 7240 servers can answer with `Preference-Applied`
+            // mirroring what they honored.
+            | "prefer"
+            // Expect — a 417 response can quote the failed expectation.
+            | "expect"
+            // Last-Event-ID — SSE reconnection header, occasionally reflected
+            // by stream endpoints.
+            | "last-event-id"
     )
 }
 
@@ -610,6 +628,17 @@ mod tests {
             // CORS preflight.
             "access-control-request-headers",
             "access-control-request-method",
+            // WebSocket handshake.
+            "sec-websocket-protocol",
+            "sec-websocket-extensions",
+            // Idempotency.
+            "idempotency-key",
+            // Content-Disposition.
+            "content-disposition",
+            // Prefer / Expect / SSE.
+            "prefer",
+            "expect",
+            "last-event-id",
             // Prefix families.
             "sec-ch-ua",
             "sec-ch-ua-platform",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.55",
+      tag: "0.8.56",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.34/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.35/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.55";
-const DSBX_CLI_VERSION = "0.1.34";
+const DUST_BASE_IMAGE_VERSION = "0.8.56";
+const DSBX_CLI_VERSION = "0.1.35";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Follow-up to #29293. Audit of the standard request header list (MDN) against `is_unsafe_substitution_header` found the remaining headers whose values can round-trip back to the client:

- `sec-websocket-protocol` / `sec-websocket-extensions`: the server echoes the selected subprotocol and negotiated extensions in the 101 handshake. The dsbx upgrade path still substitutes headers before splicing raw frames, so a placeholder there comes back substituted. `sec-websocket-protocol` is the strongest of these; extensions rarely survive parsing but cost nothing to cover.
- `idempotency-key`: APIs commonly echo it in 409/422 error bodies.
- `content-disposition`: upload endpoints often echo filenames in JSON responses or errors.
- `prefer`: RFC 7240 `Preference-Applied` can mirror the value.
- `expect`: a 417 response can quote the failed expectation.
- `last-event-id`: occasionally reflected by SSE endpoints.

None of these are credential carriers, so blocklisting only affects placeholder traffic. Also bumps dsbx to 0.1.35 and dust-base to 0.8.56 to ship the change.

## Tests

- Extended the blocklist membership test; ran the full `forward` test suite locally (146 tests pass) and `registry.test.ts` (16 tests pass).

## Risk

Low. Same reasoning as #29293: these headers never legitimately carry secrets, so the only behavior change is placeholders in them passing through unsubstituted.

## Deploy Plan

1. Run the `Release dsbx CLI` workflow (`release-dsbx-cli.yml`) to publish `dsbx-v0.1.35`.
2. Run the `Sandbox Image Registry` workflow (`sandbox-img-registry.yml`) to build `dust-base:0.8.56` in eu and us.
3. Deploy front.
4. From prodbox, kill sandboxes still running the old image so they come back on 0.8.56.
