### PR TITLE
Admin governance: remove the skills 'isDefault' column and rely on availability

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -5,6 +5,7 @@ import {
   SKILL_INVOCATION_LABEL,
 } from "@app/lib/skills/labels";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -64,7 +65,7 @@ app.post(
         agentFacingDescription,
         instructions,
         icon: skillIcon,
-        isDefault: false,
+        availability: DEFAULT_SKILL_AVAILABILITY,
       },
       {
         mcpServerViewIds,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -15,6 +15,7 @@ import type {
   PostSkillResponseBody,
 } from "@app/types/api/skills";
 import {
+  availabilityFromIsDefault,
   SKILL_REINFORCEMENT_MODES,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
@@ -392,7 +393,7 @@ app.post(
         icon,
         source: body.source ?? "web_app",
         sourceMetadata: body.sourceMetadata ?? null,
-        isDefault: body.isDefault ?? false,
+        availability: availabilityFromIsDefault(body.isDefault ?? false),
         reinforcement: body.reinforcement ?? "on",
       },
       {

--- a/front/lib/api/actions/servers/poke/tools/skills.ts
+++ b/front/lib/api/actions/servers/poke/tools/skills.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/actions/servers/poke/tools/utils";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { isDefaultFromAvailability } from "@app/types/assistant/skill_configuration";
 import { Err } from "@app/types/shared/result";
 
 type SkillHandlers = Pick<
@@ -123,7 +124,7 @@ export const skillHandlers: SkillHandlers = {
         name: s.name,
         agentFacingDescription: s.agentFacingDescription,
         status: s.status,
-        isDefault: s.isDefault,
+        isDefault: isDefaultFromAvailability(s.availability),
         updatedAt: s.updatedAt.toISOString(),
         instructionsLength: s.instructions?.length ?? 0,
       })),
@@ -171,7 +172,7 @@ export const skillHandlers: SkillHandlers = {
         agentFacingDescription: skill.agentFacingDescription,
         userFacingDescription: skill.userFacingDescription,
         status: skill.status,
-        isDefault: skill.isDefault,
+        isDefault: isDefaultFromAvailability(skill.availability),
         updatedAt: skill.updatedAt.toISOString(),
         instructions: skill.instructions,
         instructionsLength: skill.instructions?.length ?? 0,

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -26,6 +26,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
 import { extractToolTags, serializeToolTag } from "@app/lib/tools/format";
 import logger from "@app/logger/logger";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -416,7 +417,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
         icon: resolvedIcon,
         source: "agent",
         sourceMetadata: null,
-        isDefault: false,
+        availability: DEFAULT_SKILL_AVAILABILITY,
         reinforcement: "on",
       },
       {

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -16,6 +16,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -248,7 +249,7 @@ export async function importSkillsFromFiles(
           icon,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
-          isDefault: false,
+          availability: DEFAULT_SKILL_AVAILABILITY,
         },
         {
           mcpServerViews: suggestedMCPServerViews,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -22,6 +22,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -213,7 +214,7 @@ export async function importSkillsFromGitHub(
             repoUrl,
             filePath: skill.skillMdPath,
           },
-          isDefault: false,
+          availability: DEFAULT_SKILL_AVAILABILITY,
         },
         {
           mcpServerViews: detectedMCPServerViews,

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -16,6 +16,7 @@ import type {
   SkillSourceType,
   SkillStatus,
 } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 
@@ -70,17 +71,10 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.JSONB,
     allowNull: true,
   },
-  isDefault: {
-    type: DataTypes.BOOLEAN,
-    allowNull: false,
-    defaultValue: false,
-  },
-  // Transition (isDefault -> availability): nullable with no default on purpose. NULL means
-  // "written by code predating the column, derive from isDefault". Will become NOT NULL once
-  // the backfill has run and isDefault is dropped.
   availability: {
     type: DataTypes.STRING,
-    allowNull: true,
+    allowNull: false,
+    defaultValue: DEFAULT_SKILL_AVAILABILITY,
   },
 } as const satisfies ModelAttributes;
 
@@ -119,8 +113,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
 
   declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
-  declare isDefault: boolean;
-  declare availability: SkillAvailability | null;
+  declare availability: CreationOptional<SkillAvailability>;
   declare favoriteCount: CreationOptional<number>;
 
   declare reinforcement: CreationOptional<SkillReinforcementMode>;
@@ -178,7 +171,7 @@ SkillConfigurationModel.init(
         concurrently: true,
       },
       {
-        fields: ["workspaceId", "status", "isDefault"],
+        fields: ["workspaceId", "status", "availability"],
         concurrently: true,
       },
       {

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -270,7 +270,6 @@ describe("pruneOutdatedSkillEditSuggestions", () => {
         instructions: skill.instructions,
         instructionsHtml: '<p data-block-id="block-2">New content.</p>',
         icon: skill.icon,
-        isDefault: skill.isDefault,
         mcpServerViews: skill.mcpServerViews,
         requestedSpaceIds: [],
         attachedKnowledge: [],
@@ -305,7 +304,6 @@ describe("pruneOutdatedSkillEditSuggestions", () => {
         instructionsHtml:
           '<p data-block-id="block-1">Updated A.</p><p data-block-id="block-2">B.</p>',
         icon: skill.icon,
-        isDefault: skill.isDefault,
         mcpServerViews: skill.mcpServerViews,
         requestedSpaceIds: [],
         attachedKnowledge: [],

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -38,7 +38,7 @@ export class GlobalSkillsRegistry {
     where: AllSkillConfigurationFindOptions["where"] = {}
   ): Promise<GlobalSkillDefinition[]> {
     return filterSkillDefinitions(auth, GLOBAL_SKILLS_ARRAY, where, {
-      isDefault: true,
+      availability: "users_and_agents",
     });
   }
 

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -5,6 +5,7 @@ import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export const SKILL_COMPANY_DATA_SERVER_NAME = "company_data";
@@ -123,7 +124,7 @@ export async function filterSkillDefinitions<T extends SkillDefinition>(
   auth: Authenticator,
   skills: readonly T[],
   where: AllSkillConfigurationFindOptions["where"] = {},
-  { isDefault }: { isDefault: boolean }
+  { availability }: { availability: SkillAvailability }
 ): Promise<T[]> {
   const filteredSkills = skills.filter((skill) => {
     if (where.sId && !matchesFilter(skill.sId, where.sId)) {
@@ -138,7 +139,10 @@ export async function filterSkillDefinitions<T extends SkillDefinition>(
       return false; // Code-defined skills are always active.
     }
 
-    if (where.isDefault !== undefined && where.isDefault !== isDefault) {
+    if (
+      where.availability !== undefined &&
+      where.availability !== availability
+    ) {
       return false;
     }
 

--- a/front/lib/resources/skill/code_defined/system_registry.ts
+++ b/front/lib/resources/skill/code_defined/system_registry.ts
@@ -37,7 +37,7 @@ export class SystemSkillsRegistry {
     where: AllSkillConfigurationFindOptions["where"] = {}
   ): Promise<SystemSkillDefinition[]> {
     return filterSkillDefinitions(auth, SYSTEM_SKILLS_ARRAY, where, {
-      isDefault: false,
+      availability: "workspace_users",
     });
   }
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -563,8 +563,10 @@ describe("SkillResource", () => {
         { name: "Test Skill For Availability Sync" }
       );
 
-      expect(skillResource.isDefault).toBe(false);
       expect(skillResource.availability).toBe("workspace_users");
+      expect(skillResource.toJSON(testContext.authenticator).isDefault).toBe(
+        false
+      );
 
       await skillResource.updateSkill(testContext.authenticator, {
         name: skillResource.name,
@@ -582,8 +584,10 @@ describe("SkillResource", () => {
         testContext.authenticator,
         skillResource.sId
       );
-      expect(updatedSkill?.isDefault).toBe(true);
       expect(updatedSkill?.availability).toBe("users_and_agents");
+      expect(updatedSkill?.toJSON(testContext.authenticator).isDefault).toBe(
+        true
+      );
 
       await skillResource.updateSkill(testContext.authenticator, {
         name: skillResource.name,
@@ -601,8 +605,10 @@ describe("SkillResource", () => {
         testContext.authenticator,
         skillResource.sId
       );
-      expect(revertedSkill?.isDefault).toBe(false);
       expect(revertedSkill?.availability).toBe("workspace_users");
+      expect(revertedSkill?.toJSON(testContext.authenticator).isDefault).toBe(
+        false
+      );
     });
 
     it("should add skill space requirements to agents using the skill", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -78,7 +78,6 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
-  SkillAvailability,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -422,18 +421,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
 
-    // Transition (isDefault -> availability): dual-write both columns from whichever one the
-    // caller provided, so old code reading isDefault stays correct during the rollout.
-    const availability =
-      blob.availability ?? availabilityFromIsDefault(blob.isDefault ?? false);
-
     // Use a transaction to ensure all creations succeed or all are rolled back.
     return withTransaction(async (transaction) => {
       const skill = await this.model.create(
         {
           ...blob,
-          availability,
-          isDefault: isDefaultFromAvailability(availability),
           instructionsHtml: blob.instructionsHtml ?? null,
           workspaceId: owner.id,
         },
@@ -1467,7 +1459,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const skills = await this.baseFetch(auth, {
       where: {
         status,
-        ...(isDefault !== undefined ? { isDefault } : {}),
+        // isDefault is a legacy alias kept at the interface level; the column is availability.
+        ...(isDefault !== undefined
+          ? { availability: availabilityFromIsDefault(isDefault) }
+          : {}),
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
         ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
       },
@@ -1506,7 +1501,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         where: {
           status: "active",
-          isDefault: true,
+          availability: "users_and_agents",
         },
       },
       { agentLoopData, effectiveSpaceIds }
@@ -2025,7 +2020,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         icon: def.icon,
         source: null,
         sourceMetadata: null,
-        isDefault: !SystemSkillsRegistry.isSystemSkill(def.sId),
         availability: SystemSkillsRegistry.isSystemSkill(def.sId)
           ? "workspace_users"
           : "users_and_agents",
@@ -2328,7 +2322,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           requestedSpaceIds: versionModel.requestedSpaceIds,
           source: versionModel.source,
           sourceMetadata: versionModel.sourceMetadata,
-          isDefault: versionModel.isDefault,
           availability: versionModel.availability,
           favoriteCount: this.favoriteCount,
           reinforcement: "auto",
@@ -2888,10 +2881,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
-          // Transition (isDefault -> availability): dual-write both columns until all code
-          // relies on availability and isDefault is dropped.
+          // isDefault is a legacy alias kept at the interface level; the column is availability.
           ...(isDefault !== undefined
-            ? { isDefault, availability: availabilityFromIsDefault(isDefault) }
+            ? { availability: availabilityFromIsDefault(isDefault) }
             : {}),
           ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
@@ -4047,14 +4039,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       })),
       canWrite: this.canWrite(auth),
       canAdministrate: this.canAdministrate(auth),
-      isDefault: isDefaultFromAvailability(this.getAvailability()),
+      isDefault: isDefaultFromAvailability(this.availability),
     };
-  }
-
-  getAvailability(): SkillAvailability {
-    // Transition (isDefault -> availability): NULL means the row predates the availability column
-    // and isDefault is authoritative.
-    return this.availability ?? availabilityFromIsDefault(this.isDefault);
   }
 
   private async saveVersion(
@@ -4120,7 +4106,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       sourceMetadata: this.sourceMetadata,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
-      isDefault: this.isDefault,
       availability: this.availability,
     };
 

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -1,6 +1,9 @@
 import type { SkillConfigurationModel } from "@app/lib/models/skill";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { SkillStatus } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillAvailability,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
 
 // Constrained find options include both global and custom skills.
 export type AllSkillConfigurationFindOptions = Omit<
@@ -12,7 +15,7 @@ export type AllSkillConfigurationFindOptions = Omit<
     sId?: string | string[];
     id?: number | number[];
     status?: SkillStatus | SkillStatus[];
-    isDefault?: boolean;
+    availability?: SkillAvailability;
   };
   onlyCustom?: false; // Default: include global skills.
 };

--- a/front/migrations/20260625_backfill_productboard_skill.ts
+++ b/front/migrations/20260625_backfill_productboard_skill.ts
@@ -15,6 +15,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Op } from "sequelize";
@@ -286,7 +287,7 @@ async function createProductboardSkill(
       instructionsHtml: convertMarkdownToBlockHtml(
         PRODUCTBOARD_SKILL_INSTRUCTIONS
       ),
-      isDefault: false,
+      availability: DEFAULT_SKILL_AVAILABILITY,
       name: PRODUCTBOARD_SKILL_NAME,
       reinforcement: "on",
       // The MCP server views are all on the global space in practice.

--- a/front/migrations/20260722_backfill_skill_availability.ts
+++ b/front/migrations/20260722_backfill_skill_availability.ts
@@ -1,74 +1,74 @@
-import {
-  SkillConfigurationModel,
-  SkillVersionModel,
-} from "@app/lib/models/skill";
-import { makeScript } from "@app/scripts/helpers";
-import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import { availabilityFromIsDefault } from "@app/types/assistant/skill_configuration";
-import type { ModelStatic } from "sequelize";
-
-const WORKSPACE_CONCURRENCY = 16;
-
-// Transition (isDefault -> availability): rows written by code predating the availability column
-// have a NULL availability and an authoritative isDefault. Run this once all pods write the
-// availability column (post-deploy), so no row can be updated by old code afterwards.
-const MODELS: {
-  table: string;
-  model: ModelStatic<SkillConfigurationModel>;
-}[] = [
-  { table: "skill_configurations", model: SkillConfigurationModel },
-  { table: "skill_versions", model: SkillVersionModel },
-];
-
-makeScript({}, async ({ execute }, logger) => {
-  let totalUpdated = 0;
-
-  await runOnAllWorkspaces(
-    async (workspace) => {
-      for (const { table, model } of MODELS) {
-        if (!execute) {
-          const wouldUpdateCount = await model.count({
-            where: { workspaceId: workspace.id, availability: null },
-          });
-
-          if (wouldUpdateCount > 0) {
-            logger.info(
-              { workspaceId: workspace.sId, table, wouldUpdateCount },
-              "Dry run: would backfill availability from isDefault"
-            );
-          }
-          continue;
-        }
-
-        let updated = 0;
-        for (const isDefault of [true, false]) {
-          // The `availability: null` guard makes the script safe to re-run and keeps rows
-          // already written by new code untouched. `silent` leaves updatedAt untouched.
-          const [count] = await model.update(
-            { availability: availabilityFromIsDefault(isDefault) },
-            {
-              where: {
-                workspaceId: workspace.id,
-                availability: null,
-                isDefault,
-              },
-              silent: true,
-            }
-          );
-          updated += count;
-        }
-
-        if (updated > 0) {
-          totalUpdated += updated;
-          logger.info(
-            { workspaceId: workspace.sId, table, updated },
-            "Backfilled skill availability"
-          );
-        }
-      }
-    },
-    { concurrency: WORKSPACE_CONCURRENCY }
-  );
-
-  logger.info({ totalUpdated }, "Completed skill availability backfill");
-});
+// import {
+//   SkillConfigurationModel,
+//   SkillVersionModel,
+// } from "@app/lib/models/skill";
+// import { makeScript } from "@app/scripts/helpers";
+// import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+// import { availabilityFromIsDefault } from "@app/types/assistant/skill_configuration";
+// import type { ModelStatic } from "sequelize";
+//
+// const WORKSPACE_CONCURRENCY = 16;
+//
+// // Transition (isDefault -> availability): rows written by code predating the availability column
+// // have a NULL availability and an authoritative isDefault. Run this once all pods write the
+// // availability column (post-deploy), so no row can be updated by old code afterwards.
+// const MODELS: {
+//   table: string;
+//   model: ModelStatic<SkillConfigurationModel>;
+// }[] = [
+//   { table: "skill_configurations", model: SkillConfigurationModel },
+//   { table: "skill_versions", model: SkillVersionModel },
+// ];
+//
+// makeScript({}, async ({ execute }, logger) => {
+//   let totalUpdated = 0;
+//
+//   await runOnAllWorkspaces(
+//     async (workspace) => {
+//       for (const { table, model } of MODELS) {
+//         if (!execute) {
+//           const wouldUpdateCount = await model.count({
+//             where: { workspaceId: workspace.id, availability: null },
+//           });
+//
+//           if (wouldUpdateCount > 0) {
+//             logger.info(
+//               { workspaceId: workspace.sId, table, wouldUpdateCount },
+//               "Dry run: would backfill availability from isDefault"
+//             );
+//           }
+//           continue;
+//         }
+//
+//         let updated = 0;
+//         for (const isDefault of [true, false]) {
+//           // The `availability: null` guard makes the script safe to re-run and keeps rows
+//           // already written by new code untouched. `silent` leaves updatedAt untouched.
+//           const [count] = await model.update(
+//             { availability: availabilityFromIsDefault(isDefault) },
+//             {
+//               where: {
+//                 workspaceId: workspace.id,
+//                 availability: null,
+//                 isDefault,
+//               },
+//               silent: true,
+//             }
+//           );
+//           updated += count;
+//         }
+//
+//         if (updated > 0) {
+//           totalUpdated += updated;
+//           logger.info(
+//             { workspaceId: workspace.sId, table, updated },
+//             "Backfilled skill availability"
+//           );
+//         }
+//       }
+//     },
+//     { concurrency: WORKSPACE_CONCURRENCY }
+//   );
+//
+//   logger.info({ totalUpdated }, "Completed skill availability backfill");
+// });

--- a/front/migrations/post-deploy/20260722112506_drop_skill_is_default.sql
+++ b/front/migrations/post-deploy/20260722112506_drop_skill_is_default.sql
@@ -1,86 +1,54 @@
 /*
 Statement 0
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_configurations" ADD CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ" CHECK("availability" IS NOT NULL) NOT VALID;
-
-/*
-Statement 1
+  - Plain SET NOT NULL scans the table under an ACCESS EXCLUSIVE lock; acceptable here as the
+    table is small. The availability backfill must have run (any remaining NULL fails this).
 */
 SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_configurations" VALIDATE CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ";
-
-/*
-Statement 2
-*/
-SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."skill_configurations" ALTER COLUMN "availability" SET NOT NULL;
 
 /*
-Statement 3
+Statement 1
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."skill_configurations" ALTER COLUMN "availability" SET DEFAULT 'workspace_users'::character varying;
 
 /*
-Statement 4
+Statement 2
+  - INDEX_DROPPED: Replaced by skill_configurations_workspace_id_status_availability (created
+    pre-deploy). Dropped explicitly before the column it references.
 */
-SET SESSION statement_timeout = 3000;
+SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_configurations" DROP CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ";
+DROP INDEX CONCURRENTLY IF EXISTS "public"."skill_configurations_workspace_id_status_is_default";
 
 /*
-Statement 5
+Statement 3
   - DELETES_DATA: Deletes the isDefault column. The availability backfill must have run.
-  - Also implicitly drops the skill_configurations_workspace_id_status_is_default index
-    (replaced by skill_configurations_workspace_id_status_availability, created pre-deploy):
-    DROP COLUMN drops indexes referencing the column.
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."skill_configurations" DROP COLUMN IF EXISTS "isDefault";
 
 /*
-Statement 6
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_versions" ADD CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q" CHECK("availability" IS NOT NULL) NOT VALID;
-
-/*
-Statement 7
+Statement 4
+  - Plain SET NOT NULL scans the table under an ACCESS EXCLUSIVE lock; acceptable here as the
+    table is small. The availability backfill must have run (any remaining NULL fails this).
 */
 SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_versions" VALIDATE CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q";
-
-/*
-Statement 8
-*/
-SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."skill_versions" ALTER COLUMN "availability" SET NOT NULL;
 
 /*
-Statement 9
+Statement 5
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."skill_versions" ALTER COLUMN "availability" SET DEFAULT 'workspace_users'::character varying;
 
 /*
-Statement 10
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."skill_versions" DROP CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q";
-
-/*
-Statement 11
+Statement 6
   - DELETES_DATA: Deletes the isDefault column. The availability backfill must have run.
 */
 SET SESSION statement_timeout = 3000;

--- a/front/migrations/post-deploy/20260722112506_drop_skill_is_default.sql
+++ b/front/migrations/post-deploy/20260722112506_drop_skill_is_default.sql
@@ -1,0 +1,88 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ADD CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ" CHECK("availability" IS NOT NULL) NOT VALID;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" VALIDATE CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ";
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ALTER COLUMN "availability" SET NOT NULL;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ALTER COLUMN "availability" SET DEFAULT 'workspace_users'::character varying;
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" DROP CONSTRAINT "pgschemadiff_tmpnn_4EqU48Y9Qjm2GrORrLv5qQ";
+
+/*
+Statement 5
+  - DELETES_DATA: Deletes the isDefault column. The availability backfill must have run.
+  - Also implicitly drops the skill_configurations_workspace_id_status_is_default index
+    (replaced by skill_configurations_workspace_id_status_availability, created pre-deploy):
+    DROP COLUMN drops indexes referencing the column.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" DROP COLUMN IF EXISTS "isDefault";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ADD CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q" CHECK("availability" IS NOT NULL) NOT VALID;
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" VALIDATE CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q";
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ALTER COLUMN "availability" SET NOT NULL;
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ALTER COLUMN "availability" SET DEFAULT 'workspace_users'::character varying;
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" DROP CONSTRAINT "pgschemadiff_tmpnn_5$OMSWeWSYqINKgDMvg68Q";
+
+/*
+Statement 11
+  - DELETES_DATA: Deletes the isDefault column. The availability backfill must have run.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" DROP COLUMN IF EXISTS "isDefault";

--- a/front/migrations/pre-deploy/20260722112505_skill_availability_index.sql
+++ b/front/migrations/pre-deploy/20260722112505_skill_availability_index.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY skill_configurations_workspace_id_status_availability ON public.skill_configurations USING btree ("workspaceId", status, availability);

--- a/front/scripts/create_hard_coded_suggested_skills.ts
+++ b/front/scripts/create_hard_coded_suggested_skills.ts
@@ -11,6 +11,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import { AGENT_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -271,8 +272,7 @@ async function createSuggestedSkills(
               editedBy: null,
               requestedSpaceIds: [],
               icon: skill.icon,
-              isDefault: false,
-              availability: "workspace_users",
+              availability: DEFAULT_SKILL_AVAILABILITY,
             },
             { transaction }
           );

--- a/front/scripts/create_meeting_prep_skill.ts
+++ b/front/scripts/create_meeting_prep_skill.ts
@@ -16,6 +16,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import { AGENT_GROUP_PREFIX } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
@@ -353,8 +354,7 @@ async function createMeetingPrepSkill(
         editedBy: null,
         requestedSpaceIds: [],
         icon: SKILL_ICON,
-        isDefault: false,
-        availability: "workspace_users",
+        availability: DEFAULT_SKILL_AVAILABILITY,
       },
       { transaction }
     );

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -8,6 +8,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SKILL_ICON } from "@app/lib/skill";
 import { serializeSkillTag } from "@app/lib/skills/format";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -57,7 +58,7 @@ export class SkillFactory {
         requestedSpaceIds,
         status,
         icon: SKILL_ICON.name,
-        isDefault: false,
+        availability: DEFAULT_SKILL_AVAILABILITY,
       },
       {
         mcpServerViews,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -17,8 +17,10 @@ export const SKILL_AVAILABILITIES = [
 ] as const;
 export type SkillAvailability = (typeof SKILL_AVAILABILITIES)[number];
 
-// Transition (isDefault -> availability): rows written before the availability column existed only
-// carry isDefault. Remove these mappings once the backfill has run and isDefault is dropped.
+export const DEFAULT_SKILL_AVAILABILITY: SkillAvailability = "workspace_users";
+
+// The DB column is availability; isDefault survives as a boolean alias in the API and
+// frontend. Remove these mappings once clients rely on availability directly.
 export function availabilityFromIsDefault(
   isDefault: boolean
 ): SkillAvailability {


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9725

Follow up of https://github.com/dust-tt/dust/pull/29289

Actually drop the isDefault column to rely 100% on the `availability` column. Both columns should be in perfect sync after previous PR.

The isDefault value is still exposed in the types and API at the moment, just no longer stored in DB.

## Tests

Manual test: changing the value in the UI do apply the change to the availability column.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

lock front
merge
run pre deploy migration
deploy front
unlock front
run post deploy migration
