### PR TITLE
[AGENTS] Stop exposing retired global agents via the public API

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -26,6 +26,22 @@ async function setupTest() {
   return { workspace, key, agentConfig };
 }
 
+function getAgentConfiguration(
+  workspace: { sId: string },
+  key: { secret: string },
+  agentId: string
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/assistant/agent_configurations/${agentId}`,
+    {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+      },
+    }
+  );
+}
+
 function patchAgentConfiguration(
   workspace: { sId: string },
   key: { secret: string },
@@ -44,6 +60,16 @@ function patchAgentConfiguration(
     }
   );
 }
+
+describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
+  it("returns 404 for a retired global agent (e.g. gpt-4)", async () => {
+    const { workspace, key } = await setupTest();
+
+    const response = await getAgentConfiguration(workspace, key, "gpt-4");
+
+    expect(response.status).toBe(404);
+  });
+});
 
 describe("PATCH /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
   it("applies configuration patch fields beyond userFavorite (regression dust-tt/dust#26698)", async () => {

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -3,6 +3,7 @@ import {
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
 import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
+import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import logger from "@app/logger/logger";
 import type {
@@ -291,10 +292,14 @@ app.get(
 
     const configVariant = variant ?? "light";
 
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: sId,
-      variant: configVariant,
-    });
+    // Retired global agents (e.g. gpt-4) stay resolvable internally for past conversations but
+    // must not be exposed through the public API.
+    const agentConfiguration = isRetiredGlobalAgent(sId)
+      ? null
+      : await getAgentConfiguration(auth, {
+          agentId: sId,
+          variant: configVariant,
+        });
 
     if (!agentConfiguration) {
       return apiError(ctx, {

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -986,6 +986,13 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
 ];
 
+// Retired global agents remain resolvable internally (to keep past conversations running) but
+// must not be surfaced to users/integrations. `getGlobalAgents` already filters them out of list
+// views; callers that fetch a specific agent by sId should use this to gate the public response.
+export function isRetiredGlobalAgent(sId: string): boolean {
+  return isGlobalAgentId(sId) && RETIRED_GLOBAL_AGENTS_SID.includes(sId);
+}
+
 const MODEL_ONLY_GLOBAL_AGENTS_SID: readonly GLOBAL_AGENTS_SID[] = [
   GLOBAL_AGENTS_SID.GPT35_TURBO,
   GLOBAL_AGENTS_SID.GPT4,


### PR DESCRIPTION
## Description

Retired global agents (e.g. `gpt-4`) stay resolvable internally so past conversations keep running, but the public `GET /api/v1/w/{wId}/assistant/agent_configurations/{sId}` endpoint now returns 404 for them instead of resolving them (they were leaking through the by-sId fetch, which bypasses the retired filter that already hides them from the list/search endpoints).

## Tests

Added a functional test asserting `GET …/agent_configurations/gpt-4` returns 404; ran the `agent_configurations` suite locally (8 files / 69 tests pass).

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`