### PR TITLE
Add tool search guidance to OpenAI requests

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/index.test.ts
@@ -1,6 +1,6 @@
 import { buildSystemBlocks } from "@app/lib/api/llm/clients/anthropic/index";
 import type { StructuredSystemPrompt } from "@app/lib/api/llm/types/options";
-import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import { ANTHROPIC_TOOL_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { describe, expect, it } from "vitest";
 
 const prompt: StructuredSystemPrompt = {
@@ -17,7 +17,7 @@ describe("buildSystemBlocks", () => {
   it("omits the tool search instruction by default", () => {
     const blocks = buildSystemBlocks(prompt, {});
 
-    expect(systemText(blocks)).not.toContain(TOOL_SEARCH_INSTRUCTION);
+    expect(systemText(blocks)).not.toContain(ANTHROPIC_TOOL_SEARCH_INSTRUCTION);
   });
 
   it("appends the tool search instruction to the shared tier when requested", () => {
@@ -30,12 +30,14 @@ describe("buildSystemBlocks", () => {
     const sharedBlock = blocks.find((b) =>
       b.text.includes("Shared directives.")
     );
-    expect(sharedBlock?.text).toContain(TOOL_SEARCH_INSTRUCTION);
+    expect(sharedBlock?.text).toContain(ANTHROPIC_TOOL_SEARCH_INSTRUCTION);
 
     const instructionsBlock = blocks.find((b) =>
       b.text.includes("You are a helpful agent.")
     );
-    expect(instructionsBlock?.text).not.toContain(TOOL_SEARCH_INSTRUCTION);
+    expect(instructionsBlock?.text).not.toContain(
+      ANTHROPIC_TOOL_SEARCH_INSTRUCTION
+    );
   });
 
   it("emits a shared block carrying the instruction even with no shared context", () => {
@@ -44,6 +46,6 @@ describe("buildSystemBlocks", () => {
       { includeToolSearchInstruction: true }
     );
 
-    expect(systemText(blocks)).toContain(TOOL_SEARCH_INSTRUCTION);
+    expect(systemText(blocks)).toContain(ANTHROPIC_TOOL_SEARCH_INSTRUCTION);
   });
 });

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -49,8 +49,8 @@ import type {
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  ANTHROPIC_TOOL_SEARCH_INSTRUCTION,
   includesToolSearchTool,
-  TOOL_SEARCH_INSTRUCTION,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -125,7 +125,9 @@ export function buildSystemBlocks(
   // byte-stable across the lifetime of the 1h block.
   const sharedText = [
     sharedContext.map((s) => s.content).join("\n"),
-    ...(includeToolSearchInstruction ? [TOOL_SEARCH_INSTRUCTION] : []),
+    ...(includeToolSearchInstruction
+      ? [ANTHROPIC_TOOL_SEARCH_INSTRUCTION]
+      : []),
   ]
     .filter(Boolean)
     .join("\n");

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -4,6 +4,7 @@ import {
   overwriteLLMParameters,
   supportsOpenAIExplicitPromptCaching,
 } from "@app/lib/api/llm/clients/openai/types";
+import { includesOpenAIToolSearchTool } from "@app/lib/api/llm/clients/openai/utils/tool_search";
 import { LLM } from "@app/lib/api/llm/llm";
 import type {
   BatchDeletionOutcome,
@@ -19,6 +20,7 @@ import type {
   LLMStreamMetadata,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
+import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import {
   toInput,
@@ -31,6 +33,7 @@ import {
   responseToLLMEvents,
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
+import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/api/llm/utils/tool_search";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -110,19 +113,30 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     const explicitPromptCaching = supportsOpenAIExplicitPromptCaching(
       this.modelId
     );
+    const tools = toToolsParam(specifications, {
+      forceToolCall,
+      toolSearchEnabled: toolSearchEnabled ?? false,
+    });
+    const normalizedPrompt = normalizePrompt(prompt);
+    const requestPrompt = includesOpenAIToolSearchTool(tools)
+      ? {
+          ...normalizedPrompt,
+          sharedContext: [
+            ...normalizedPrompt.sharedContext,
+            { role: "context" as const, content: TOOL_SEARCH_INSTRUCTION },
+          ],
+        }
+      : prompt;
 
     return {
       model: this.modelId,
-      input: toInput(prompt, conversation, "developer", {
+      input: toInput(requestPrompt, conversation, "developer", {
         cacheBreakpointOnLeadingMessage: explicitPromptCaching,
         cacheBreakpointsOnSystemPrompt: explicitPromptCaching,
       }),
       temperature: this.temperature ?? undefined,
       reasoning,
-      tools: toToolsParam(specifications, {
-        forceToolCall,
-        toolSearchEnabled: toolSearchEnabled ?? false,
-      }),
+      tools,
       text: {
         format: toResponseFormat(this.responseFormat, OPENAI_PROVIDER_ID),
       },

--- a/front/lib/api/llm/clients/openai/utils/tool_search.test.ts
+++ b/front/lib/api/llm/clients/openai/utils/tool_search.test.ts
@@ -1,0 +1,15 @@
+import {
+  includesOpenAIToolSearchTool,
+  OPENAI_TOOL_SEARCH_TOOL,
+} from "@app/lib/api/llm/clients/openai/utils/tool_search";
+import { describe, expect, it } from "vitest";
+
+describe("includesOpenAIToolSearchTool", () => {
+  it("is true when tool search is in the request", () => {
+    expect(includesOpenAIToolSearchTool([OPENAI_TOOL_SEARCH_TOOL])).toBe(true);
+  });
+
+  it("is false when tool search is not in the request", () => {
+    expect(includesOpenAIToolSearchTool([{ type: "function" }])).toBe(false);
+  });
+});

--- a/front/lib/api/llm/clients/openai/utils/tool_search.ts
+++ b/front/lib/api/llm/clients/openai/utils/tool_search.ts
@@ -1,0 +1,7 @@
+export const OPENAI_TOOL_SEARCH_TOOL = { type: "tool_search" } as const;
+
+export function includesOpenAIToolSearchTool(
+  tools: ReadonlyArray<{ type?: string | null }>
+): boolean {
+  return tools.some((tool) => tool.type === OPENAI_TOOL_SEARCH_TOOL.type);
+}

--- a/front/lib/api/llm/clients/openai/utils/tool_search_passthrough.ts
+++ b/front/lib/api/llm/clients/openai/utils/tool_search_passthrough.ts
@@ -6,8 +6,6 @@ import type {
 } from "openai/resources/responses/responses";
 import { z } from "zod";
 
-export const OPENAI_TOOL_SEARCH_TOOL = { type: "tool_search" } as const;
-
 const replayStatusSchema = z
   .enum(["in_progress", "completed", "incomplete"])
   .nullable()

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -4,10 +4,8 @@ import {
   isOpenAIResponsesWhitelistedModelId,
   OPENAI_MODEL_CONFIGS,
 } from "@app/lib/api/llm/clients/openai/types";
-import {
-  OPENAI_TOOL_SEARCH_TOOL,
-  parseOpenAIToolSearchItem,
-} from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
+import { OPENAI_TOOL_SEARCH_TOOL } from "@app/lib/api/llm/clients/openai/utils/tool_search";
+import { parseOpenAIToolSearchItem } from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
 import type { XaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type {
   ExclusiveToolChoiceParameters,

--- a/front/lib/api/llm/utils/tool_search.ts
+++ b/front/lib/api/llm/utils/tool_search.ts
@@ -1,0 +1,9 @@
+// Shared guidance for providers that can defer tool definitions behind a
+// server-side search tool.
+export const TOOL_SEARCH_INSTRUCTION =
+  "You can search for and load far more tools than are visible to you now, " +
+  "including ones that fetch live or account-specific data and act in external " +
+  "systems. When a request needs current state, the user's own systems, or an " +
+  "action your visible tools cannot take, search for a tool before making " +
+  "something up, answering from stale memory, or telling the user it is not " +
+  "possible.";

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -8,8 +8,8 @@ import { stripUnreplayableToolSearchBlocks } from "@app/lib/api/llm/clients/anth
 import type { Client } from "@app/lib/model_constructors/client";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import {
+  ANTHROPIC_TOOL_SEARCH_INSTRUCTION,
   includesToolSearchTool,
-  TOOL_SEARCH_INSTRUCTION,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import {
   assistantProviderPassthroughMessageToBlocks,
@@ -112,7 +112,10 @@ export function WithAnthropicAIInputConverter<
         max_tokens: this.constructor.maxOutputTokens,
         messages,
         system: includesToolSearchTool(anthropicTools)
-          ? [...system, { type: "text", text: TOOL_SEARCH_INSTRUCTION }]
+          ? [
+              ...system,
+              { type: "text", text: ANTHROPIC_TOOL_SEARCH_INSTRUCTION },
+            ]
           : system,
         thinking: thinkingConfig.thinking,
         tools: anthropicTools,

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
@@ -1,6 +1,6 @@
 import {
+  ANTHROPIC_TOOL_SEARCH_INSTRUCTION,
   includesToolSearchTool,
-  TOOL_SEARCH_INSTRUCTION,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
 import { toolSpecsToAnthropicAITools } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import type { ToolSpecification } from "@app/lib/model_constructors/types/input/configuration";
@@ -68,9 +68,9 @@ describe("includesToolSearchTool", () => {
   });
 });
 
-describe("TOOL_SEARCH_INSTRUCTION", () => {
+describe("ANTHROPIC_TOOL_SEARCH_INSTRUCTION", () => {
   it("is a non-empty hint that does not name the underlying search tool", () => {
-    expect(TOOL_SEARCH_INSTRUCTION.length).toBeGreaterThan(0);
-    expect(TOOL_SEARCH_INSTRUCTION).not.toContain("bm25");
+    expect(ANTHROPIC_TOOL_SEARCH_INSTRUCTION.length).toBeGreaterThan(0);
+    expect(ANTHROPIC_TOOL_SEARCH_INSTRUCTION).not.toContain("bm25");
   });
 });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.ts
@@ -1,3 +1,5 @@
+import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/api/llm/utils/tool_search";
+
 // Shared by the legacy LLM client (lib/api/llm/clients/anthropic) and the
 // model_constructors client. Both prepend the tool search tool when at least one
 // tool is deferred, and both surface the same system-prompt hint so the model
@@ -16,22 +18,16 @@ export const TOOL_SEARCH_TOOL = {
 // tool is prepended.
 const TOOL_SEARCH_TOOL_TYPE = TOOL_SEARCH_TOOL.type;
 
-// Added to the system prompt only when the search tool is in the request. Phrased
-// without naming the bm25 tool so it stays accurate across search implementations.
-//
-// The second paragraph steers the model away from mixing a tool search with a
-// regular tool call in the same turn: the API leaves such searches un-run (the
-// turn ends on the tool call), and replaying the un-run blocks is fragile.
+// Added to the system prompt only when the search tool is in the request. The
+// Anthropic-specific paragraph steers the model away from mixing a tool search
+// with a regular tool call in the same turn. The API leaves such searches un-run
+// when the turn ends on the tool call, and replaying the un-run blocks is fragile.
 // Skill-enabling tools are called out explicitly because they are the most
 // frequent offender observed in practice. It also discourages chaining searches
 // when a tool returned by the first search can already handle the task.
-export const TOOL_SEARCH_INSTRUCTION =
-  "You can search for and load far more tools than are visible to you now, " +
-  "including ones that fetch live or account-specific data and act in external " +
-  "systems. When a request needs current state, the user's own systems, or an " +
-  "action your visible tools cannot take, search for a tool before making " +
-  "something up, answering from stale memory, or telling the user it is not " +
-  "possible.\n\n" +
+export const ANTHROPIC_TOOL_SEARCH_INSTRUCTION =
+  TOOL_SEARCH_INSTRUCTION +
+  "\n\n" +
   "Never mix tool searches with other tool calls in the same turn. Issuing " +
   "several searches together is fine, but if you call any other tool " +
   "(including enabling a skill) in the same turn as a search, the search is " +

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -1,3 +1,5 @@
+import { includesOpenAIToolSearchTool } from "@app/lib/api/llm/clients/openai/utils/tool_search";
+import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/api/llm/utils/tool_search";
 import type { Client } from "@app/lib/model_constructors/client";
 import {
   assistantProviderPassthroughMessageToInputItems,
@@ -76,6 +78,10 @@ export function WithOpenAIResponsesInputConverter<
       } = config;
 
       const reasoningConfig = reasoningToOpenAIResponsesReasoning(reasoning);
+      const openAITools = toolSpecsToOpenAITools(tools, {
+        forceTool,
+        toolSearchEnabled: toolSearchEnabled ?? false,
+      });
 
       return {
         model: this.constructor.model,
@@ -83,6 +89,15 @@ export function WithOpenAIResponsesInputConverter<
         ...(cacheKey ? { prompt_cache_key: cacheKey } : {}),
         input: [
           ...this.systemMessagesToInputItems(conversation.system),
+          ...(includesOpenAIToolSearchTool(openAITools)
+            ? this.systemMessagesToInputItems([
+                {
+                  role: "system",
+                  type: "text",
+                  content: { value: TOOL_SEARCH_INSTRUCTION },
+                },
+              ])
+            : []),
           ...this.conversationToInput(conversation),
         ],
         ...(reasoningConfig
@@ -91,10 +106,7 @@ export function WithOpenAIResponsesInputConverter<
               include: ["reasoning.encrypted_content"],
             }
           : {}),
-        tools: toolSpecsToOpenAITools(tools, {
-          forceTool,
-          toolSearchEnabled: toolSearchEnabled ?? false,
-        }),
+        tools: openAITools,
         tool_choice: forceToolToToolChoice(tools, toToolChoiceInput(config)),
         ...(outputFormat
           ? { text: { format: outputFormatToResponseFormat(outputFormat) } }

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -1,3 +1,4 @@
+import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/api/llm/utils/tool_search";
 import {
   assistantProviderPassthroughMessageToInputItems,
   assistantReasoningMessageToInputItems,
@@ -226,6 +227,40 @@ describe("prompt cache breakpoints", () => {
         content: [{ type: "input_text", text: "Current request" }],
       },
     ]);
+  });
+
+  it("preserves cache breakpoints when adding tool search guidance", () => {
+    const payload = supportedEndpoint.buildRequestPayload(
+      {
+        conversation: {
+          system,
+          messages: [],
+        },
+      },
+      {
+        toolSearchEnabled: true,
+        tools: [
+          {
+            name: "search_docs",
+            description: "Search documentation",
+            inputSchema: { properties: {} },
+          },
+        ],
+      }
+    );
+
+    expect(payload.input).toBeDefined();
+    if (!payload.input) {
+      return;
+    }
+    expect(payload.input.slice(0, system.length)).toEqual(
+      supportedEndpoint.systemMessagesToInputItems(system)
+    );
+    expect(payload.input[system.length]).toEqual({
+      role: "developer",
+      content: [{ type: "input_text", text: TOOL_SEARCH_INSTRUCTION }],
+    });
+    expect(payload.tools?.[0]).toEqual({ type: "tool_search" });
   });
 
   it("does not serialize breakpoints on following messages without cache opt-in", () => {

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -1,7 +1,5 @@
-import {
-  OPENAI_TOOL_SEARCH_TOOL,
-  parseOpenAIToolSearchItem,
-} from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
+import { OPENAI_TOOL_SEARCH_TOOL } from "@app/lib/api/llm/clients/openai/utils/tool_search";
+import { parseOpenAIToolSearchItem } from "@app/lib/api/llm/clients/openai/utils/tool_search_passthrough";
 import type {
   OutputFormat,
   Reasoning,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
OpenAI previously exposed its native tool search capability without the system guidance already used for Anthropic. This adds the shared provider-neutral guidance to both OpenAI request paths whenever the final request actually contains the search tool.

The implementation follows the existing Anthropic pattern by checking the converted tools before inserting the
shared instruction. Requests without deferred tools remain unchanged, including forced-tool cases where search
is unnecessary.

Anthropic keeps its existing behavior and provider-specific sequencing guidance. The change intentionally adds
no guidance about reusing tools from earlier turns.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
