### PR TITLE
Limit the pruned context indicator to the current interaction

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -166,6 +166,40 @@ describe("CheckpointedConversationWindowState", () => {
       "pending_first_result",
       "pending_second_result",
     ]);
+
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.prunedContext).toBe(true);
+  });
+
+  it("does not surface pruning from an earlier interaction", () => {
+    const state = makeState();
+
+    state.append(
+      interaction([
+        userMessage("first_question", 10),
+        assistantMessage("call_first"),
+        functionMessage("first", 11_000),
+        assistantMessage("call_second"),
+        functionMessage("second", 11_000),
+        assistantMessage("call_third"),
+        functionMessage("third", 11_000),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    expect(
+      toolResults(state).some((message) => isPruned(message.content))
+    ).toBe(true);
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.prunedContext).toBe(false);
   });
 
   it("waits for a full checkpoint of reclaimable results before moving the frontier", () => {

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -24,6 +24,7 @@ type ToolResultNode = {
   kind: "tool_result";
   message: Extract<MessageWithTokens, { role: "function" }>;
   tokenSavings: number;
+  pruned: boolean;
 };
 
 type PendingToolResult = {
@@ -52,6 +53,7 @@ function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
       kind: "tool_result",
       message,
       tokenSavings: getToolResultTokenSavings(message),
+      pruned: false,
     };
   }
 
@@ -169,9 +171,17 @@ export class CheckpointedConversationWindowState {
     // limit.
     return new Ok({
       interactions: this.renderedInteractions(),
-      prunedContext: this.prunedTokens > 0,
+      prunedContext: this.latestInteractionHasPrunedToolResults(),
       stats: this.stats(),
     });
+  }
+
+  private latestInteractionHasPrunedToolResults(): boolean {
+    const latestInteraction = this.interactions[this.interactions.length - 1];
+
+    return latestInteraction.messages.some(
+      (node) => node.kind === "tool_result" && node.pruned
+    );
   }
 
   private isModelInputCheckpoint(
@@ -228,6 +238,7 @@ export class CheckpointedConversationWindowState {
         this.eligibleToolResults[this.nextEligibleToolResultIndex];
 
       node.message = pruneToolResultMessage(node.message);
+      node.pruned = true;
       this.retainedTokens -= node.tokenSavings;
       this.prunedTokens += node.tokenSavings;
       this.eligibleToolResultTokenSavings -= node.tokenSavings;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The pruned context indicator was set whenever any tool result in the rendered history was pruned, causing the current agent message to show a warning even when pruning affected only older interactions.

This tracks pruning per tool result and surfaces the indicator only when the latest interaction contains a pruned result. Historical pruning still reduces context and remains represented in pruning metrics.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
