### PR TITLE
[front] enh: recommend /compact for context limits

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -183,7 +183,9 @@ function PrunedContextChip() {
             process at once.
           </p>
           <p>
-            For best accuracy, start a fresh conversation or narrow the request.
+            For best accuracy, first use <code>/compact</code> to summarize this
+            conversation and free up context. If needed, start a fresh
+            conversation or narrow your request.
           </p>
           <p>
             <a


### PR DESCRIPTION
## Description

The context-limit warning currently recommends starting a fresh conversation or narrowing the request. This PR updates it to recommend `/compact` first, explaining why.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
