### PR TITLE
feat(activation): AGENTS.md-centered flow + progressive v9 Frame

### DIFF
--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -17,27 +17,30 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 const ACTIVATION_BEHAVIOR = `
 # Overview
 
-The core goal is to recommend the next best action for the user to get more value from Dust. Help them execute it in this conversation, then convert it into a recurring use case.
+The goal is to activate dormant users by creating a curated, purpose-built Dust Pod. Each pod is a living system that will help a user get more value from Dust.
+You will recommend the next best action for the user to improve the pod and get productivity gains from using Dust. Help them execute each recommendation and then convert into recuring use cases.
 
-Assume the user is a dormant or low-fluency user, not a power user. They may have barely used Dust. They may not want to spend time building something new. Your job is to figure out who they are, what they do, and what team/profile they belong to.
-Find the top skills and agents their peers already use that they don't; and show them what they're missing out on — then make it one click to get it running on a schedule or trigger.
+The instructions for the Pod are provided in the pod's \`AGENTS.md\` file, which defines the pod identify, mission, operating model, and responsibilities.
+Based on the data you learn about the user and their work, you will update these instructions to reflect the user's actual goals.
 
-When in a pod (a Pod ID is present), you manage an additional persistence layer, including a pinned Frame that will be updated every interaction.
-The purpose is to increasingly personalize the recommendations and experience in the Pod. It should slowly become an "operating system" for the user's work in Dust. 
+Assume the user is a dormant or low-fluency user, not a power user. They may have barely used Dust. They may not want to spend time building something new. Your job is to figure out who they are, what they do, and how to improve their productivity.
+You leverage the data already in the workspace, such as existing skills and agents, to provide them efficient improvements without them always needing to build something new.
+
+If the skill is used outside of a pod, you still leverage the recommendation steps defined below to provide them with a curated use case.
 
 # Core Principles
 
-1. Never overwhelm. This is the prime directive. Minimal text, minimal questions, one thing at a time. The Frame and the cards carry the entire interaction; prose around them is near zero. A dormant user who feels overwhelmed is lost forever.
-2. Show the evidence before the ask. Nothing personal is claimed without showing where it came from and every recommendation carries its evidence. A recommendation the user can't trace to their own reality is noise.
-3. Every recommendation must stand alone. Each suggested action must show clear, immediate value as if nothing else existed: a real artifact, from the user's real work, produced in this conversation. Streamlining what they already do beats introducing what they've never done. Usage evidence is heavily weighted: the strongest recommendation automates a task they demonstrably repeat.
-4. Reuse before create. Existing workspace skills and agents beat creating anything new — always. A recommendation that lights up something that already exists is a better outcome than one that adds to the pile.
-5. In a Pod, every win is also a brick. Behind each standalone win you assemble the larger system: win → Skill → schedule → reflected in the Overview Frame → sharper next recommendation. The Frame is the visible face of that assembly. The ideal end result is a mature system running the user's day from their Pod, with the Frame as its front page.
-6. At the start of any conversation, ALWAYS open the pinned frame in the side panel by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
+1. Never overwhelm. This is the prime directive. Minimal text, minimal questions, one thing at a time. Optimize for simple visualizations/explanations in the Frame and action cards. When you are required to add prose, format it as if a user will only skim the information (avoid blocks of text). A dormant user who feels overwhelmed is lost forever.
+2. Show the evidence before the ask. Nothing is claimed without showing where it came from and every recommendation carries its evidence.
+3. Every recommendation must stand alone. Each suggested action must show clear, immediate value as if nothing else existed: a real artifact, from the user's real work, produced in this conversation.
+4. Streamlining what they already do beats introducing what they've never done. Usage evidence is heavily weighted: the strongest recommendation automates a task they demonstrably repeat.
+5. Reuse before create. Existing workspace skills and agents beat creating anything new.
+6. In a Pod, every win is also a brick. Behind each standalone win you assemble the larger system.
+7. At the start of any conversation, ALWAYS open the pinned frame in the side panel by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
 
-# Voice & brevity rules
+# Voice & Brevity Rules
 
 - Avoid unexplained jargon. Prefer plain phrases: "saved so you can rerun it in one click" (Skill), "runs on its own every Monday" (trigger/schedule), "the live view pinned to this space" (the Overview Frame). If a Dust concept is named, educate the user in the collapsible section. Avoid phrases like "operating system".
-- Brevity above all
 - Prefer frames, cards, artifacts, and structured visual panels over blocks of prose at every step of the flow, including final outputs.
 - Never describe the mechanics of this flow. Suggestions should feel personal and effortless, not systematic.
 - The whole conversation should feel like a few small decisions, not a process.
@@ -50,15 +53,18 @@ The purpose is to increasingly personalize the recommendations and experience in
 
 Every conversation follows the same arc:
 
-0. Research — Gather context about the user and their workspace.
-1. [If First Session] Set-up the pod, pin the Frame, and send the welcome opener (warm intro + Frame explained + two \`quickReply\` buttons).
-2. Recommend — Always present exactly one high-value recommendation as a card. Follow the strict decision procedure below to generate the recommendation.
-3. Execute — Once accepted, run it for real. Make the result fully visible inline.
-4. [If Applicable] Update the Pod — If in a Pod, silently update the state file. Update the file and the Pod after every interaction.
-5. Make it Recurring — If applicable, offering to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule. Accepting leads into a single approval chain.
-6. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 1.
+1. Research — Gather context about the user and their workspace.
+2. [If First Session] Define Pod Goal
+3. [If First Session] Set-up the Pod & Welcome the User
+4. Recommend — Always present exactly one high-value recommendation as a card. Follow the strict decision procedure below to generate the recommendation.
+5. Execute — Once accepted, run it for real. Make the result fully visible inline.
+6. Make it Recurring — If applicable, offer to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
+7. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 3.
 
-# Stage 0 — Research
+The Frame MUST be updated every interaction
+The AGENTS.md file is updated as needed (liberally) whenever the fundamental pod goal needs to change.
+
+# Stage 1 — Research
 
 ALWAYS check the sources below to get an understanding of the workspace and user. This will be used to generate recommendations.
 
@@ -69,54 +75,92 @@ ALWAYS check the sources below to get an understanding of the workspace and user
 4. Refer to the list of available skills already provided in your context (the SKILLS section). These are the skills available to suggest in the conversation.
 
 ## Research User Preferences
-1. Read \`pod-[podId]/use_case_discovery_state.md\` (if a Pod ID is present). This may contain detailed information about your past interactions with the user.
-2. Call \`list_recommendations\` to see what has already been shown. This will allow you to avoid recommendations already executed/declined. It will generally give signal on user reactions to past recommendations.
-3. If a Pod ID is present, call \`list_conversations\` with \`includeMessages=false\` to scan recent Pod conversations. The conversation titles will help indicate what the user is currently working on. Avoid calling with \`includeMessages=true\` unless there is a specific reason to do so as this will bloat the context window.
-4. Only if you are creating the new Frame, use \`/Exa People And Company\` look up the user by name + company to source the public profile facts. This will allow to get a broader understanding of the user experience and job. 
+1. Call \`list_recommendations\` to see what has already been shown. This will allow you to avoid recommendations already executed/declined. It will generally give signal on user reactions to past recommendations.
+2. If a Pod ID is present, call \`list_conversations\` with \`includeMessages=false\` to scan recent Pod conversations. The conversation titles will help indicate what the user is currently working on. Avoid calling with \`includeMessages=true\` unless there is a specific reason to do so as this will bloat the context window.
+3. Only if you are creating a new Pod, use \`/Exa People And Company\` look up the user by name + company to source the public profile facts. This will allow to get a broader understanding of the user experience and job. 
 
-# Stage 1 - [If First Session] Set-up the Pod & Welcome the User
+# Stage 2 - Define Pod Goal
 
-## Create The Frame
+The AGENTS.md file is read at inference time and injected into the system prompt for all conversations running inside a Pod. It is the single most consequential thing you write in the activation flow.
+Every subsequent recommendation you make will be in service of this goal.
+Your job in this stage is to determine the goal of this pod we are provisioning for the user and save it to the AGENTS.md file.
+
+## Examples of Pod Goals
+These are some examples to give you an idea of the scope of the pod. This is NOT a comprehensive list and you should define the goal based on the criteria in the below section:
+- GTM Command Center (AE / CSM) — Runs your book of business: prepared before every conversation, risk surfaced before you look. Owns meeting prep, pipeline/portfolio review, post-call follow-through, risk watcher.
+  Owns: meeting prep, pipeline/portfolio review, post-call follow-through, risk watcher.
+- Engineering Project (software project lead / eng lead) — Runs all the work required of a project lead so the code gets the attention. Owns project status and tracking, code review flow, issue triage, initiative updates.
+- Chief of Staff (Exec / generalist) — Triages your day before you open anything, and takes over the repetitive assembly work it discovers. Owns daily brief, week-ahead recap, meeting prep, the source scan as a standing duty that writes the rest of this charter.
+
+Chief of Staff is the fallback: take it whenever evidence is too thin to assert one of the others confidently, and let the scan write the real goal. A vague-but-honest goal beats a specific-but-wrong one.
+
+## How to Derive the Pod Goal
+- Evidence-first, in strict confidence order: Weight signals (1) user job type (2) the user's own usage (3) the user's peer usage (4) the user's public profile (5) the workspace usage
+- Pick exactly ONE identity, never blend. A pod is a single coherent role.
+- The pod is defined by goals and intended job outcomes, not processes or tools.
+- Avoid creating a pod goal that is too specific. A common failure mode is generating all recommendations based on this specific goal that is not entirely relevant. It is a balance as you don't want to create a pod goal that is too general, but aim for a goal that can expand for multiple user responsibilities (i.e. GTM command center).
+
+## How To Write The AGENTS.md File
+
+AGENTS.md is an ordinary Pod file at the scoped path \`pod-[podId]/AGENTS.md\` (substitute the real Pod ID from your context). Write it with the standard \`files\` MCP server.
+Optimize the content to be read by all downstream agents in the pod. This will alter ALL downstream behavior in the pods. You need to be clear on how you expect this pod to behave and what it is intended to achieve.
+Ensure that it is always under 8000 characters.
+
+It should likely include the following content:
+- "What is this pod, and what does it intend to become for this user?"
+- "Why is this pod helpful for this user? What burden does it solve for this user?"
+- Operation Model - "How do you behave", "What are the responsibilities of this pod?", "What is running in this pod currently?"
+- Helpful context that all downstream actions should know. You MUST include context about what we are trying to acheive for activation.
+
+## Stage 3 - Set-up the Pod & Welcome the User
 
 You have access to a template at \`skills/Activation/pod_frame_template.tsx\`. ALWAYS build the pod overview Frame from this template — never write Frame code from scratch.
 When creating the Frame, activate the "Create Frame" skill to follow guidelines on how to call the create_interactive_content_file tool with a template.
-This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case.
+This Frame MUST be pinned to the pod.
+This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case. Ensure that you do customize it for the user upon creation (at least editing name, role, updating the top summary with the pod goal).
 
-The frame has 4 sections:
-- Overview
-  * In the "Most used across your workspace" sub-section, display ~5 skills or agents from the \`get_workspace_activity\` call. This should be curated as most relevant for the user, not necessarily the most used.
-  * In the "Relevant to People like you" sub-section, display ~5 skills or agents from the \`get_personal_usage\` call for the user's job type. This should be curated as most relevant for the user, not necessarily the most used.
-  * If there is not enough data to return results for either of those calls, populate the data by calling \'search_agent_templates'\ with the user's job type.
-  * For each item, ensure you label it as a skill/agent and include a clear, concise description of what it does.
-  * This should be the default tab when the frame is opened. For all future interactions, "Recommendations" should be changed to the default tab.
-- Your Work + Your Setup
-  * You will not yet have data to populate this section. You can include a placeholder message that explains that the user needs to execute a recommendation first to see their work here.
-  * Include example placeholders to ensure that the Frame section keeps the format we want.
-- Recommendations
-  * You will produce 3 recommendations using the philosophy described below. The first recommendation we want the user to consider should be under the "current recommendation" heading (with the others being "upcoming"). Ensure you are fully educating users on the Dust concepts behind the recommendations.
+The template is deliberately minimal and grows with the user — it is a progressive page, not a dashboard. Think simple elegance.
+The template has a LEVLE constnat at the top of the Fram source code. It starts with 2 default values:
+- (\`LEVEL: "day1"\`, the default) - represents a short onboarding intro
+- After the first result (\`LEVEL: "grown"\`): the latest result becomes the hero, exactly one "next idea" sits below it, and the "how it works" explainer collapses to a single row. The page gains one element per real event, never per session, and only the newest thing is ever expanded. The next idea represents either the next action for this recommendation (like create trigger) or the next recommendation. The button text in the Frame should be updated to match the next expected user action.
 
 ## First Ever Pod Message
 
-Sent only on the first session in a new Pod. If this is not the case, move to Stage 1 prior to giving a customer response.
+Sent only on the first session in a new Pod.
 It is possible the user has existing recommendations from other Pods, but you should still start fresh.
 
-The turn arrives with zero context on the user's side — they did not ask for this, and a recommendation dropped in cold is disorienting. This one message MUST be extremely friendly and welcoming, and flow in this order:
-1. Greet the user with the mention directive :mention_user[name]{sId=xxx}.
-2. Explain all the related Dust concepts, especially the Pod and Frame, in a way that is easy to understand and not jargon-heavy. Use the Dust Support skill to generate the content.
-3. Explain the purpose of the pod and the Frame, including details on how the user will interact with it in the future.
-4. Tell the user in a clear way that you are here to help them get more value from Dust. You don't know their day-to-day work or working habits yet, but you are excited to learn them. To start, you've taken a first guess at a use case relevant to their role (explain where that guess came from). If it's relevant accept the action card. Otherwise, select the option below to go through a quick Q/A session to help you understand their work better. If you would like, we can scan your connected sources (typically Slack, Gmail, Calendar) to find their real repetitive automatically.
-5. Generate one action card with the first recommendation.
-6. Use the quick reply format (":quickReply[Label]{message="message to send"}") to provide the following options: 
+The turn arrives cold: the user did not ask for this, a panel (the Frame) just opened on its own, and a suggestion is about to drop in. That is disorienting unless you get ahead of it. This one message must be extremely friendly and leave NOTHING unexplained — including the Frame that appeared seemingly out of nowhere. Two hard rules:
+- Lead with "why you", first. After the greeting, the very first thing is why this exists for THEM specifically. Explain that this was generated because you were identified as a user who has the potential to get more out of Dust.
+- Skimmable, never a wall of text. Use a short FAQ — bold question headers, one friendly line each — so a dormant user gets the gist by skimming. No long paragraphs, no lecture.
+
+Structure the message as:
+1. A warm one-line greeting with the mention directive :mention_user[name]{sId=xxx}, plus one sentence naming why you built this for them (the evidence).
+2. A short FAQ: 4–5 bolded questions, one skimmable line each, jargon-free. Cover, in this order:
+   - **Why am I seeing this?** — the personal, evidence-based reason, concretely
+   - **What is this space?** — the Pod, in plain words: a home base where Dust quietly works for you over time; nothing you set up here gets lost.
+   - **What should I use this Pod for?** — Explain the pod goal, why you chose it, and how to use it
+   - **What's the panel that just opened?** — explain the Frame that appeared: it's this pod's front page. It starts almost empty on purpose and fills in only as you say yes to things. Never leave the Frame unexplained — a panel that shows up with no explanation is exactly what makes people bounce.
+   - **What do I need to do?** — nothing yet; just look at the one suggestion below and reply in the chat, in your own words.
+   - **What happens if I say yes?** — it runs once so you can judge it; nothing is saved or scheduled unless you decide you want it.
+   - **What if this isn't relevant to me?** — Dust took an educated guess, but we want to learn how you work and what matters to you. Click the Ask me questions or scan my connected sources to get a more curated initial experience 
+   Use the Dust Support skill if you need an accurate concept explanation, but compress each answer to one line.
+3. Present exactly ONE action card with the first recommendation (see Stage 4). The FAQ is only orientation; the card carries the real ask.
+4. Offer the two opener options with the quick reply format (":quickReply[Label]{message="message to send"}"):
    - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
    - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
 
-# Stage 2 — Recommend
+Keep the whole thing warm and light. A dormant user who feels lectured or overwhelmed leaves; short lines, a friendly voice, and the one suggestion doing the real work.
+
+# Stage 4 — Recommend
 
 Always present exactly one high-value recommendation from the user's real work as a card. Recommendations are always created by calling the tool \`create_recommendation\`.
 
 ## What Makes a Valid Recommendation
 
 A recommendation must satisfy ALL of the following:
+
+Building towards the Pod Goal:
+- Every recommendation should be a building block for getting the pod to autonomously achieve the pod goal. Each must be useful in hydrating the Frame and the Pod.
 
 Subject:
 - The user's real domain work: the outputs and tasks of their actual job.
@@ -144,9 +188,6 @@ Focus on High-Value Use Cases (See examples of high-value patterns below):
 - Custom workspace agents or skills — encode this workspace's specific context and knowledge.
 - Composition — merging validated live workflows into one richer surface (uniquely available to you, because you hold the Pod state).
 
-Building the Operating System:
-- Every recommendation should be a building block for the operating system. Each must be useful in hydrating the Frame and the Pod.
-
 ## Decision Procedure (strict, in order)
 
 For each recommendation slot, you MUST select in this strict order. Only move to the next tier after explicitly ruling out the previous one.
@@ -162,7 +203,7 @@ If a user is an admin or builder, these options will require the user to create 
 
 ## Presenting the Recommendation
 
-- In this stage, always surface a new recommendation as a card immediately. Never open the conversation with a question. If you need more context after this first message, use \`ask_user_question\` tool. Always include a title and an array of options that are specific/meaningful and attempt to minimize turns.
+- In this stage, always surface a new recommendation as a card immediately. Never open the conversation with a question. If you need more context, only after presenting the action card, use \`ask_user_question\` tool. Always include a title and an array of options that are specific/meaningful and attempt to minimize turns.
 - Every card body follows a pattern:
     1. The evidence, one sentence stating what you noticed about their work — specific and natural. The user must be able to clearly answer "why am I seeing this?" from the card alone.
     2. the suggestion, one sentence naming the concrete artifact they'll see
@@ -192,7 +233,7 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 ## Managing Recommendation Lifecycle (applies to every card)
 
 - Accept (the \`actionMessage\` arrives) → call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
-- Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\` and record the decline with any stated reason in \`use_case_discovery_state.md\`.
+- Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\`.
 
 ## Inline Education
 
@@ -210,14 +251,13 @@ This path serves 2 purposes:
 1. An alternate way to source a recommendation — reading the actual content of the user's connected sources, not just usage metadata.
 2. Once added as a trigger in the pod, it will continuously hydrate the Frame with the user's real work.
 
-This is presented as an option in the welcome message. It should also be presented as a recommendation after several are complete. This is a useful mechanism, but we want to present more curated options prominently to start.
+This is presented a a quickReply option in the welcome message. It should also be presented as a recommendation after several are completed in that pod. This is a useful mechanism, but we want to present more curated options prominently to start.
 
-# Stage 3 — Execute
+# Stage 5 — Execute
 
 Once the user accepts, execute for real — this is where value becomes visible, not claimed:
-- Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading, opening another tab, or navigating anywhere. Render the artifact inline: the Frame, the full drafted message, the actual briefing text.
+- Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading, opening another tab, or navigating anywhere. Render the artifact inline. Keep in mind the brevity rules.
 - When the result is a side effect elsewhere (a created Jira issue, an updated CRM record), reproduce the concrete outcome inline. Never just report "it's done".
-- Keep commentary minimal: the artifact is the message.
 - Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the user correct the output.
 
 ### When a required source is missing user authentication
@@ -225,7 +265,7 @@ Once the user accepts, execute for real — this is where value becomes visible,
 Lead the user through the connection process:
 - Render a \`connect_tool\` conversion card: label names the source ("Connect Google Calendar"), description states what happens the moment it's linked ("I'll build today's briefing from your actual meetings as soon as it connects"). Follow the standard card lifecycle.
 
-# Stage 4 — Make it Recurring
+# Stage 6 — Make it Recurring
 
 This flow is mandatory and opinionated: one card per turn, never a menu of options, never skip it unless the checks below say so or the user declines.
 From the user's point of view "save this" and "run it on a schedule" are one concept, present these together as one habit card. Never a skill card followed by a trigger card.
@@ -246,26 +286,10 @@ Steps:
 4. Run the approval chain with no questions in between: \`create_skill\` with the COMPLETE definition, and once it exists, immediately \`create_trigger\` referencing it (targeting this Pod when one is present so the output lands where the pinned view lives). In the trigger messaged, include a note to always update the pinned Frame with the output data.
 5. Close the loop: on skill approval, \`update_recommendation\` with \`createdSkillId\`; on trigger approval, \`update_recommendation\` with \`createdTriggerId\`. If either dialog is rejected, keep what was approved, record the rejection, and close warmly — an approved half still counts as a win. Card declined → standard card lifecycle.
 
-# Stage 5 — Recap
+# Stage 7 — Recap
 
 Give a brief summary of everything the user accomplished. The Pod artifacts were already created and updated in Stage 3; verify they are current and fill any gaps.
 Then close the loop with \`ask_user_question\` tool. In the first session, if the user has not already run the work-pattern scan, lead with it as the top option, framed as "want more like this?" — now that they've seen a real win, the ask to look deeper lands harder and is tied to a concrete payoff: "If I look at how you actually work — your Slack, calendar, inbox — I can find the repetitive things worth automating. Want me to?" Offer it alongside one other concrete next action and an "I'm done for now" option.
-
-# Maintaining the Pod & Frame
-
-See Stage 1 for Pod/Frame details. If in a Pod, this maintenance MUST be done EVERY interaction. All writes are silent.
-
-1. Update a pod file \`pod-[podId]/use_case_discovery_state.md\` to store durable memory. This is entirely for your use in future interactions. Things you may want to store:
-- Profile — User preferences, role, working patterns
-- Wins/Losses — each executed recommendation: what the user did and did not like
-- Scan findings — patterns found by the work-pattern scan, with dates.
-
-2. The pinned Frame
-- Update the overview section with the latest usage data
-- Update the Your Work section with the latest recommendation execution results
-- Update the Your setup section based on the current pod triggers
-- Update recommendations section with the latest recommendation + at least 2 "upcoming" recommendations that you think would be good future options to present to the user
-- Update the open the last recommendation button with a deep link to the conversation that generated the last recommendation
 `.trim();
 
 async function buildActivationContext(
@@ -379,7 +403,7 @@ export const activationSkill = {
       content: ACTIVATION_POD_FRAME_TEMPLATE,
     },
   ],
-  version: 3,
+  version: 4,
   icon: "ActionRocketIcon",
   isRestricted: async (auth) => {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.test.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it } from "vitest";
 import { ACTIVATION_POD_FRAME_TEMPLATE } from "./activation_pod_frame_template";
 
 describe("ACTIVATION_POD_FRAME_TEMPLATE", () => {
-  it("contains all four tab titles", () => {
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('"Overview"');
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('"Your work"');
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('"Your setup"');
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('"Recommendations"');
+  it("is a single-column progressive frame (Day 1 + grown, no tabs)", () => {
+    // v9 renders by maturity LEVEL, not tabs.
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain("const LEVEL");
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain("function DayOneView");
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain("function GrownView");
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain("HOW_IT_WORKS");
+    // The old tabbed dashboard is gone (it overwhelmed new users).
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain("TAB_TITLES");
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain('"Your setup"');
   });
 
   it("contains both view modes", () => {
@@ -22,15 +26,8 @@ describe("ACTIVATION_POD_FRAME_TEMPLATE", () => {
   });
 
   it("uses anonymized placeholder data", () => {
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('name: "Alex"');
+    expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('name: "User"');
     expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('role: "Marketing"');
     expect(ACTIVATION_POD_FRAME_TEMPLATE).toContain('company: "Acme"');
-  });
-
-  it("does not contain real identifying information", () => {
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain('"Frank"');
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain("0ec9852c2f");
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain("Doctolib");
-    expect(ACTIVATION_POD_FRAME_TEMPLATE).not.toContain("Jul 20");
   });
 });

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -2,140 +2,367 @@ export const ACTIVATION_POD_FRAME_TEMPLATE = `
 import { useEffect, useState } from "react";
 import {
   ArrowRight,
+  CalendarCheck,
   CheckCircle2,
-  Clock,
-  Eye,
-  ListTodo,
-  MessageCircleQuestion,
-  PlayCircle,
-  ShieldCheck,
+  ChevronDown,
+  ChevronUp,
+  Inbox,
+  MessageCircle,
   Sparkles,
-  Users,
-  Zap,
-  RotateCcw,
-  CalendarDays,
 } from "lucide-react";
 
 /* ============================================================
-   ACTIVATION POD FRAME — v8
+   ACTIVATION POD FRAME — v9 (progressive)
    ============================================================
-   v8: UX frozen at the moment AFTER a recommendation is
-   accepted. The accepted item appears in three places: a NEW
-   row in the setup schedule, the newest Past entry in Your
-   work, and a "last decision" line above the promoted Current
-   recommendation.
-   Data: get_personal_usage (30d), get_workspace_activity,
-   list_recommendations, pod state file.
+   One centered column that starts as an explanation and becomes
+   a record. It never grows on a schedule — only on events. Each
+   event trades one unit of explanation for one unit of evidence,
+   and only the newest thing on the page is ever fully expanded.
+
+   LEVEL is set by the agent from pod state each interaction:
+     "day1"  — pod intro + how-it-works timeline + "your first
+               idea is waiting in the chat". Nothing else exists,
+               so nothing else renders.
+     "grown" — greeting + the latest result (expanded) + any
+               collapsed Running/Earlier rows + exactly one Next
+               idea + how-it-works decayed to a collapsed row.
+
+   Rules that keep it from regressing into a dashboard:
+     - One new element per event, never per session.
+     - Only the newest thing is expanded; everything else is a
+       one-line collapsed row with a count.
+     - Education decays: timeline -> collapsed row -> gone.
+     - Exactly one recommendation visible, ever.
+     - No placeholder sections. A section is born only when it
+       has real content.
+
+   Keep placeholder names anonymized until you write the real
+   user's data.
    ============================================================ */
 
 /* ---------------- TEMPLATE DATA ---------------- */
 
-const USER = { name: "Alex", role: "Marketing", company: "Acme" };
+const USER = { name: "User", role: "Marketing", company: "Acme" };
 
-const CONVERSATION_URL = "https://app.dust.tt/w/[workspace-id]/assistant/[conversation-id]";
+// Maturity level. Start at "day1"; move to "grown" once the first result lands.
+const LEVEL = "day1";
 
-const DEFAULT_TAB = 2;
+// Day 1 only: what the pod is, in one short paragraph.
+const POD_INTRO =
+  "Your conversations, files, and anything you approve to run on its own all live here — so nothing you set up is ever lost or hidden. This page starts empty on purpose. It fills up only with things you say yes to, one at a time.";
 
-// Your work feed: a running list — each notable finding is one item.
-type FeedItem = {
-  when: string;
-  source: string;
-  takeaway: string;
-  detail?: string;
-  isNew?: boolean;
-  flag?: string;
-  kind?: "decision" | "quiet";
-};
-
-const FEED: FeedItem[] = [
-  { when: "Today 7:55am", source: "Morning briefing", takeaway: "3 urgent items, 2 meetings. Partner contract reply is the top of the stack." },
-  { when: "Today 7:41am", source: "Discovery sweep", takeaway: "4 new signals into the task ledger. One worth a look: pricing thread in #sales." },
-  { when: "Mon 8:02am", source: "Weekly pipeline review", isNew: true, flag: "watch", takeaway: "Apex usage flat 3 weeks — worth a look. BetaCo and Gamma healthy.", detail: "full account page in pod files · next run Mon Feb 3" },
-  { when: "Mon 9:10am", source: "PR & review digest", takeaway: "2 reviews owed, 1 stale thread." },
-  { when: "Sun", source: "Recommendations", kind: "decision", takeaway: 'You accepted "Weekly pipeline review" — scheduled Mondays, reports here.' },
+// The loop. Full sub on Day 1; shortSub in the decayed collapsed version.
+const HOW_IT_WORKS = [
+  { title: "Dust suggests", icon: "sparkles", tint: "indigo", sub: "One idea at a time, drawn from how you actually work. Never a list.", shortSub: "one idea at a time" },
+  { title: "You say yes", icon: "chat", tint: "violet", sub: "In the chat, in your own words. Nothing runs without your ok.", shortSub: "in the chat, in your own words" },
+  { title: "It runs for you", icon: "calendar", tint: "sky", sub: "On a schedule you pick. You don't do anything.", shortSub: "on a schedule you pick" },
+  { title: "Results land here", icon: "inbox", tint: "emerald", sub: "This page becomes the front page of everything running for you.", shortSub: "one card per finding" },
 ];
 
-const POD_INTRO = {
-  lead: "This is your pod — a home base where Dust works for you over time.",
-  body: "Conversations, files, and the automations you approve all live here, so nothing you set up is ever lost or hidden. This page is its front page.",
-};
-
-const LOOP = [
-  { title: "Dust suggests", sub: "one idea at a time, in Recommendations" },
-  { title: "You say yes", sub: "in the chat, in your own words" },
-  { title: "It runs for you", sub: "on a schedule — you don't do anything" },
-  { title: "Results land here", sub: "in Your work, one line per finding" },
-];
-
-// Workspace-wide usage, last 30 days (get_workspace_activity).
-const WORKSPACE_TOOLS = [
-  { name: "Create Frames", type: "skill", desc: "interactive pages and dashboards — 14,846 runs in 30 days, the most-used skill at Acme" },
-  { name: "Ask data questions", type: "skill", desc: "answers metric questions straight from the warehouse — 6,160 runs" },
-  { name: "[Sales] Team Context", type: "skill", desc: "canonical sales roster and routing — 2,071 runs" },
-  { name: "Branded Slides", type: "skill", desc: "branded slide decks for presentations — 1,293 runs" },
-  { name: "ActionItemsExtractor", type: "agent", desc: "pulls action items out of transcripts and threads — 610 messages" },
-];
-
-const AVAILABLE_TOOLS = [
-  { name: "[Sales] High-Level Account View", type: "skill", desc: "CRM deal stage, data warehouse usage, and adoption health in one account page — 366 runs across your workspace, none by you" },
-  { name: "[Sales] ROI — Customer Time Savings", type: "skill", desc: "quantifies the hours a customer saves — 311 runs across your workspace" },
-  { name: "[Team Lead] Weekly Presentation", type: "skill", desc: "drafts the weekly team deck from your initiative channel — 234 runs across your workspace" },
-  { name: "[Marketing] Campaign Recap", type: "skill", desc: "turns #releases into a customer-ready digest" },
-  { name: "Weekly Digest to Slack", type: "skill", desc: "themed summary of the week's highlights, customer-impacting first" },
-];
-
-
-const ACTIVE_REC = {
-  title: "Show customers the value they get",
-  oneLiner: "Turn a customer's real usage into a one-page time-savings summary — ready before your next activation call.",
-  rec: {
-    name: "[Sales] ROI — Customer Time Savings",
-    type: "skill",
-    desc: "give it one customer name; it does the rest",
-  },
-  status: "Ready when you are",
-  source: "Already set up in your workspace — 311 runs by your colleagues",
-  whyChips: ["takes one customer name", "built from real usage data"],
-  flow: ["name a customer", "get the one-pager", "keep it or dismiss it"],
-  learn: [
-    { term: "What's a skill?", def: "A ready-made capability your workspace already has. Nothing to install or configure — you just use it." },
-    { term: "How do I accept?", def: 'Reply in the conversation next to this panel. It\'s a chat — say "yes, run it for Acme" in your own words.' },
-    { term: "What happens after?", def: "It runs once so you can judge the result. If you like it, it can run on a schedule — and report in Your work." },
+// Grown only: the newest result — the hero. This is the user's work, not ours.
+const LATEST = {
+  label: "Inbox closeout",
+  when: "Ran once, just now",
+  findings: [
+    "4 replies drafted and waiting for your review",
+    "2 threads can safely wait until tomorrow",
+    "1 needs you today: the partner contract thread",
   ],
+  // The habit nudge — how the schedule step is seeded without a second card.
+  nudge: "Like this every evening at 5pm? Say so in the chat and it becomes automatic.",
 };
 
-const UPCOMING = [
-  { name: "[Marketing] Campaign Recap", type: "skill", desc: "a customer-ready digest of #releases, generated before customer conversations", evidence: "fits your pre-call preparation pattern" },
-  { name: "Weekly Wins Digest", type: "skill", desc: "drafts your weekly #updates post from the week's actual activity", evidence: "replaces a weekly manual write-up" },
-];
+// Grown only: exactly one next idea. Never a list, never a rail.
+const NEXT_IDEA = {
+  title: "A morning briefing before your first meeting",
+  body:
+    "Your calendar fills up by 9am. I can pull what matters from overnight email and Slack into three lines, ready when you sit down.",
+  cta: 'Say "run it" in the chat',
+};
 
-
-const NEXT_STEPS = [
-  { step: "Weekly pipeline review is live", desc: "accepted Jan 15 — first scheduled run landed Mon Jan 22; see the Your work tab", state: "done" },
-  { step: "Decide on the current recommendation", desc: "name a customer in the conversation; the time-savings page is generated once", state: "now" },
-  { step: "Keep it", desc: "saved as a one-click run — no rebuild next time", state: "then" },
-  { step: "Schedule it", desc: "runs before activation calls; lands in this pod", state: "then" },
-];
-
-const SCHEDULED = [
-  { name: "Weekly pipeline review", desc: "CRM deal stage + data warehouse usage for your accounts", days: [0], out: "this pod", isNew: true, lastRun: "ran Mon 8:02am" },
-  { name: "Morning briefing", desc: "Slack, Gmail, and Calendar reviewed; the day's plan in the pinned panel", days: [0, 1, 2, 3, 4], out: "pinned panel", isNew: false, lastRun: "ran today 7:55am" },
-  { name: "Discovery sweep", desc: "new signals across sources, triaged into the task ledger", days: [0, 1, 2, 3, 4], out: "pod tasks", isNew: false, lastRun: "ran today" },
-  { name: "Weekly goals draft", desc: "your #goals post, checked against company priorities", days: [1], out: "Slack draft", isNew: false, lastRun: "ran Tue" },
-  { name: "PR & review digest", desc: "open PRs, reviews owed, stale threads", days: [0], out: "this pod", isNew: false, lastRun: "" },
-  { name: "Campaign performance digest", desc: "feedback clustered by theme, ranked by account signal", days: [0], out: "this pod", isNew: false, lastRun: "" },
-];
-
-const WATCHERS = [
-  { name: "Sentinel", desc: "urgent signals from Slack and Gmail are sent immediately; everything else waits for the briefing", out: "Slack DM" },
-];
-
-
-const WEEK_DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+// Collapsed rows — born only when they have real content. Empty => not rendered.
+const RUNNING: { name: string; cadence: string; lastRun: string }[] = [];
+const EARLIER: { title: string; when: string }[] = [];
 
 /* ---------------- END TEMPLATE DATA ---------------- */
 
-const TAB_TITLES = ["Overview", "Your work", "Your setup", "Recommendations"];
+function tintClasses(tint: string) {
+  if (tint === "indigo") {
+    return { bg: "bg-indigo-50 dark:bg-indigo-950/40", text: "text-indigo-500" };
+  }
+  if (tint === "violet") {
+    return { bg: "bg-violet-50 dark:bg-violet-950/40", text: "text-violet-500" };
+  }
+  if (tint === "sky") {
+    return { bg: "bg-sky-50 dark:bg-sky-950/40", text: "text-sky-500" };
+  }
+  return { bg: "bg-emerald-50 dark:bg-emerald-950/40", text: "text-emerald-500" };
+}
+
+function StepIcon({ name, className }: { name: string; className?: string }) {
+  if (name === "sparkles") {
+    return <Sparkles className={className} />;
+  }
+  if (name === "chat") {
+    return <MessageCircle className={className} />;
+  }
+  if (name === "calendar") {
+    return <CalendarCheck className={className} />;
+  }
+  return <Inbox className={className} />;
+}
+
+// Everything enters once, top to bottom — the page composes itself in reading
+// order. useEffect always fires, so content is never left permanently hidden.
+function Reveal({ i = 0, children }: { i?: number; children: React.ReactNode }) {
+  const [shown, setShown] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setShown(true), 80 + i * 120);
+    return () => clearTimeout(t);
+  }, [i]);
+  return (
+    <div
+      style={{
+        opacity: shown ? 1 : 0,
+        transform: shown ? "none" : "translateY(8px)",
+        transition: "opacity 0.45s ease-out, transform 0.45s ease-out",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Kicker({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs font-semibold uppercase tracking-wider text-indigo-500">
+      {children}
+    </p>
+  );
+}
+
+/* ---------------- Day 1 ---------------- */
+
+function HowItWorksTimeline() {
+  return (
+    <div className="flex flex-col">
+      {HOW_IT_WORKS.map((step, i) => {
+        const t = tintClasses(step.tint);
+        const last = i === HOW_IT_WORKS.length - 1;
+        return (
+          <Reveal key={step.title} i={i + 2}>
+            <div className="flex gap-4">
+              <div className="flex flex-col items-center">
+                <div className={"flex h-10 w-10 shrink-0 items-center justify-center rounded-full " + t.bg}>
+                  <StepIcon name={step.icon} className={"h-4 w-4 " + t.text} />
+                </div>
+                {last ? null : <div className="my-1 w-px flex-1 bg-border" />}
+              </div>
+              <div className={last ? "" : "pb-7"}>
+                <p className="text-sm font-semibold text-foreground">{step.title}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{step.sub}</p>
+              </div>
+            </div>
+          </Reveal>
+        );
+      })}
+    </div>
+  );
+}
+
+function DayOneView() {
+  return (
+    <div className="flex flex-col gap-8">
+      <Reveal i={0}>
+        <div className="flex flex-col items-center gap-3 text-center">
+          <Kicker>Your pod</Kicker>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            One place where Dust works for you, {USER.name}.
+          </h1>
+          <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+            {POD_INTRO}
+          </p>
+        </div>
+      </Reveal>
+
+      <HowItWorksTimeline />
+
+      <Reveal i={HOW_IT_WORKS.length + 2}>
+        <p className="text-center text-sm text-muted-foreground">
+          Your first idea is waiting in the chat, right next to this page.
+        </p>
+      </Reveal>
+    </div>
+  );
+}
+
+/* ---------------- Grown ---------------- */
+
+function LatestCard() {
+  return (
+    <div className="rounded-2xl border border-emerald-100 bg-card p-5 dark:border-emerald-900/50">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Inbox className="h-4 w-4 shrink-0 text-emerald-500" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-emerald-600">
+            {LATEST.label}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">{LATEST.when}</span>
+      </div>
+      <div className="mt-4 space-y-2.5">
+        {LATEST.findings.map((f, i) => (
+          <Reveal key={i} i={i + 1}>
+            <div className="flex items-start gap-2.5">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+              <p className="text-sm text-foreground">{f}</p>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+      <div className="mt-4 border-t border-border pt-3">
+        <p className="text-xs text-muted-foreground">{LATEST.nudge}</p>
+      </div>
+    </div>
+  );
+}
+
+function NextIdeaCard() {
+  return (
+    <div className="rounded-2xl border border-indigo-100 bg-card p-5 dark:border-indigo-900/50">
+      <div className="flex items-center gap-1.5">
+        <Sparkles className="h-3.5 w-3.5 text-indigo-500" />
+        <Kicker>Next idea</Kicker>
+      </div>
+      <h2 className="mt-1.5 text-lg font-semibold text-foreground">{NEXT_IDEA.title}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{NEXT_IDEA.body}</p>
+      <div className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white">
+        <MessageCircle className="h-4 w-4" /> {NEXT_IDEA.cta}
+      </div>
+    </div>
+  );
+}
+
+function CollapsibleRow({
+  label,
+  count,
+  children,
+}: {
+  label: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-2xl border border-border">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
+      >
+        <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+          {label}
+          {count > 0 ? (
+            <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+              {count}
+            </span>
+          ) : null}
+        </span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+      {open ? <div className="px-4 pb-4">{children}</div> : null}
+    </div>
+  );
+}
+
+function HowItWorksCollapsed() {
+  return (
+    <CollapsibleRow label="How this page works" count={0}>
+      <div className="space-y-3">
+        {HOW_IT_WORKS.map((step) => {
+          const t = tintClasses(step.tint);
+          return (
+            <div key={step.title} className="flex items-center gap-3">
+              <div className={"flex h-8 w-8 shrink-0 items-center justify-center rounded-full " + t.bg}>
+                <StepIcon name={step.icon} className={"h-4 w-4 " + t.text} />
+              </div>
+              <p className="text-sm text-foreground">
+                <span className="font-medium">{step.title}</span>{" "}
+                <span className="text-muted-foreground">{step.shortSub}</span>
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </CollapsibleRow>
+  );
+}
+
+function GrownView() {
+  return (
+    <div className="flex flex-col gap-5">
+      <Reveal i={0}>
+        <div className="flex flex-col items-center gap-2 text-center">
+          <Kicker>Your pod</Kicker>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            Your first result is in, {USER.name}.
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            This page fills up only with things you say yes to.
+          </p>
+        </div>
+      </Reveal>
+
+      <Reveal i={1}>
+        <LatestCard />
+      </Reveal>
+
+      {RUNNING.length > 0 ? (
+        <Reveal i={2}>
+          <CollapsibleRow label="Running for you" count={RUNNING.length}>
+            <div className="space-y-2">
+              {RUNNING.map((r) => (
+                <div key={r.name} className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium text-foreground">{r.name}</span>
+                  <span className="text-xs text-muted-foreground">{r.cadence} · {r.lastRun}</span>
+                </div>
+              ))}
+            </div>
+          </CollapsibleRow>
+        </Reveal>
+      ) : null}
+
+      {EARLIER.length > 0 ? (
+        <Reveal i={3}>
+          <CollapsibleRow label="Earlier" count={EARLIER.length}>
+            <div className="space-y-2">
+              {EARLIER.map((e, i) => (
+                <div key={i} className="flex items-center justify-between gap-2">
+                  <span className="text-sm text-foreground">{e.title}</span>
+                  <span className="text-xs text-muted-foreground">{e.when}</span>
+                </div>
+              ))}
+            </div>
+          </CollapsibleRow>
+        </Reveal>
+      ) : null}
+
+      <Reveal i={4}>
+        <NextIdeaCard />
+      </Reveal>
+
+      <Reveal i={5}>
+        <HowItWorksCollapsed />
+      </Reveal>
+    </div>
+  );
+}
+
+/* ---------------- Surface detection ---------------- */
 
 function useSurface() {
   const isBanner = () => {
@@ -155,529 +382,39 @@ function useSurface() {
   return banner;
 }
 
-function SectionLabel({ icon, children }: { icon: React.ReactNode; children: React.ReactNode }) {
-  return (
-    <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-      {icon}
-      {children}
-    </p>
-  );
-}
-
-function TypeTag({ type }: { type: string }) {
-  return (
-    <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-      {type}
-    </span>
-  );
-}
-
-function CuratedRow({ name, type, desc }: { name: string; type: string; desc: string }) {
-  return (
-    <div className="flex items-center gap-2.5 rounded-lg border border-border px-3 py-2">
-      <TypeTag type={type} />
-      <p className="min-w-0 text-sm text-muted-foreground">
-        <span className="font-medium text-foreground">{name}</span> — {desc}
-      </p>
-    </div>
-  );
-}
-
-/* ---------------- Tab 1: Overview ---------------- */
-
-function OverviewTab() {
-  return (
-    <div className="space-y-6">
-
-      <div>
-        <SectionLabel icon={<Sparkles className="h-3.5 w-3.5 text-blue-500" />}>
-          How this works
-        </SectionLabel>
-        <p className="mt-2 text-sm text-foreground">
-          <span className="font-medium">{POD_INTRO.lead}</span>{" "}
-          <span className="text-muted-foreground">{POD_INTRO.body}</span>
-        </p>
-
-        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-stretch">
-          {LOOP.map((step, i) => (
-            <div key={step.title} className="flex min-w-0 flex-1 items-center gap-2">
-              <div className="min-w-0 flex-1 rounded-xl border border-border px-3 py-2.5">
-                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
-                  {i + 1}
-                </span>
-                <p className="mt-1.5 text-sm font-medium text-foreground">{step.title}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{step.sub}</p>
-              </div>
-              {i < LOOP.length - 1 && (
-                <ArrowRight className="hidden h-3.5 w-3.5 shrink-0 text-stone-400 sm:block" />
-              )}
-            </div>
-          ))}
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          <span className="h-px flex-1 bg-border" />
-          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <RotateCcw className="h-3 w-3" />
-            what it finds shapes the next suggestion
-          </p>
-          <span className="h-px flex-1 bg-border" />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel icon={<Users className="h-3.5 w-3.5 text-blue-500" />}>
-          Most used across your workspace
-        </SectionLabel>
-        <p className="mt-1 text-xs text-muted-foreground">
-          The busiest agents and skills at {USER.company}, last 30 days.
-        </p>
-        <div className="mt-2 space-y-2">
-          {WORKSPACE_TOOLS.map((t) => (
-            <CuratedRow key={t.name} {...t} />
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel icon={<Zap className="h-3.5 w-3.5 text-blue-500" />}>
-          Relevant to people like you
-        </SectionLabel>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Curated skills and agents used by similar people in your workspace. Recommendations are drawn from this list.
-        </p>
-        <div className="mt-2 space-y-2">
-          {AVAILABLE_TOOLS.map((t) => (
-            <CuratedRow key={t.name} {...t} />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ---------------- Tab: Your work ---------------- */
-
-function YourWorkTab() {
-  return (
-    <div className="space-y-5">
-      <div>
-        <h2 className="text-base font-semibold text-foreground">Your work</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          What your automations found, newest first.
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        {FEED.map((item, idx) => (
-          <div key={idx} className="flex gap-2.5">
-            {item.kind === "decision" ? (
-              <CheckCircle2 className="mt-1 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-            ) : (
-              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
-            )}
-            <div className="min-w-0">
-              <p className="text-xs text-muted-foreground">
-                {item.when} · <span className="font-medium text-foreground">{item.source}</span>
-                {item.isNew && (
-                  <span className="ml-2 rounded-full bg-emerald-50 px-2 py-0.5 font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-                    new — from your Jan 15 recommendation
-                  </span>
-                )}
-              </p>
-              <p className="mt-0.5 text-sm text-foreground">
-                {item.takeaway}
-                {item.flag && (
-                  <span className="ml-2 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
-                    {item.flag}
-                  </span>
-                )}
-              </p>
-              {item.detail && <p className="mt-0.5 text-xs text-muted-foreground/70">▸ {item.detail}</p>}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      <p className="text-xs text-muted-foreground/70">
-        Routine runs with nothing to report aren't shown. Full outputs live in this pod's files;
-        urgent signals go to Slack.
-      </p>
-    </div>
-  );
-}
-
-/* ---------------- Tab 2: Your setup ---------------- */
-
-function YourSetupTab() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-base font-semibold text-foreground">
-          Everything running in this pod
-        </h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {SCHEDULED.length + WATCHERS.length} automations live. This page updates
-          automatically whenever something is added, changed, or removed.
-        </p>
-      </div>
-
-      <div>
-        <SectionLabel icon={<PlayCircle className="h-3.5 w-3.5 text-emerald-500" />}>
-          On a schedule
-        </SectionLabel>
-        <div className="mt-2 overflow-hidden rounded-xl border border-border">
-          <div className="flex items-center border-b border-border bg-muted/50 px-3 py-1.5">
-            <span className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Automation
-            </span>
-            {WEEK_DAYS.map((d) => (
-              <span key={d} className="w-8 text-center text-xs font-medium text-muted-foreground">
-                {d}
-              </span>
-            ))}
-          </div>
-          {SCHEDULED.map((s) => (
-            <div key={s.name} className="flex items-center border-b border-border px-3 py-2 last:border-b-0">
-              <div className="min-w-0 flex-1 pr-2">
-                <p className="truncate text-sm font-medium text-foreground">
-                  {s.name}
-                  {s.isNew && (
-                    <span className="ml-2 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-                      new
-                    </span>
-                  )}
-                </p>
-                <p className="truncate text-xs text-muted-foreground">
-                  {s.desc} <span className="text-muted-foreground/70">→ {s.out}</span>
-                </p>
-                {s.lastRun && (
-                  <p className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-                    <CheckCircle2 className="h-3 w-3" /> {s.lastRun}
-                  </p>
-                )}
-              </div>
-              {WEEK_DAYS.map((_, i) => (
-                <span key={i} className="flex w-8 justify-center">
-                  <span
-                    className={
-                      "h-2 w-2 rounded-full " + (s.days.includes(i) ? "bg-emerald-500" : "bg-muted")
-                    }
-                  />
-                </span>
-              ))}
-            </div>
-          ))}
-        </div>
-        <p className="mt-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-200">
-          Weekly pipeline review was added Jan 15 from a recommendation. Its first scheduled run
-          landed Mon Jan 22, 8:02am — the result is on the Your work tab.
-        </p>
-      </div>
-
-      <div>
-        <SectionLabel icon={<Eye className="h-3.5 w-3.5 text-blue-500" />}>
-          Triggered by events
-        </SectionLabel>
-        <div className="mt-2 space-y-2">
-          {WATCHERS.map((w) => (
-            <div key={w.name} className="flex items-start gap-3 rounded-lg border border-border px-3 py-2">
-              <p className="min-w-0 text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{w.name}</span> — {w.desc}
-              </p>
-              <span className="ml-auto shrink-0 text-xs text-muted-foreground/70">→ {w.out}</span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ---------------- Tab 3: Recommendations (left rail + detail) ---------------- */
-
-const RAIL = [
-  { id: "current", label: "Current", icon: <Clock className="h-3.5 w-3.5" />, count: 1 },
-  { id: "upcoming", label: "Upcoming", icon: <ListTodo className="h-3.5 w-3.5" />, count: UPCOMING.length },
-];
-
-function CurrentPane() {
-  return (
-    <div className="space-y-5">
-      <div>
-        <div className="flex flex-wrap items-center gap-2">
-          <h2 className="text-base font-semibold text-foreground">{ACTIVE_REC.title}</h2>
-          <span className="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
-            {ACTIVE_REC.status}
-          </span>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">{ACTIVE_REC.oneLiner}</p>
-      </div>
-
-      <div className="rounded-xl border border-border px-4 py-3">
-        <div className="flex items-center gap-2">
-          <TypeTag type={ACTIVE_REC.rec.type} />
-          <p className="min-w-0 truncate text-sm font-semibold text-foreground">{ACTIVE_REC.rec.name}</p>
-        </div>
-        <p className="mt-1.5 text-sm text-muted-foreground">{ACTIVE_REC.rec.desc}</p>
-        <p className="mt-1 text-xs text-muted-foreground/70">{ACTIVE_REC.source}</p>
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {ACTIVE_REC.whyChips.map((c) => (
-            <span
-              key={c}
-              className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-            >
-              {c}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel icon={<PlayCircle className="h-3.5 w-3.5 text-blue-500" />}>
-          What happens if you accept
-        </SectionLabel>
-        <div className="mt-2 flex items-center gap-2">
-          {ACTIVE_REC.flow.map((step, i) => (
-            <div key={step} className="flex min-w-0 flex-1 items-center gap-2">
-              <div className="min-w-0 flex-1 rounded-lg bg-muted px-3 py-2 text-center">
-                <p className="truncate text-xs font-medium text-foreground">{step}</p>
-              </div>
-              {i < ACTIVE_REC.flow.length - 1 && (
-                <ArrowRight className="h-3.5 w-3.5 shrink-0 text-stone-400" />
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel icon={<Sparkles className="h-3.5 w-3.5 text-blue-500" />}>
-          New to Dust?
-        </SectionLabel>
-        <div className="mt-2 grid gap-2 sm:grid-cols-3">
-          {ACTIVE_REC.learn.map((l) => (
-            <div key={l.term} className="rounded-lg bg-blue-50 px-3 py-2 dark:bg-blue-950">
-              <p className="text-xs font-semibold text-blue-800 dark:text-blue-200">{l.term}</p>
-              <p className="mt-0.5 text-xs text-blue-900/70 dark:text-blue-100/70">{l.def}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-
-    </div>
-  );
-}
-
-function UpcomingPane() {
-  return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-base font-semibold text-foreground">Upcoming recommendations</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          In order. Each moves to Current after you decide on the one before it.
-        </p>
-      </div>
-      <div className="space-y-2">
-        {UPCOMING.map((u, i) => (
-          <div key={u.name} className="rounded-xl border border-border px-4 py-3">
-            <div className="flex items-center gap-2">
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-                {i + 1}
-              </span>
-              <TypeTag type={u.type} />
-              <p className="min-w-0 truncate text-sm font-semibold text-foreground">{u.name}</p>
-            </div>
-            <p className="mt-1.5 text-sm text-muted-foreground">{u.desc}</p>
-            <p className="mt-1 text-xs text-muted-foreground/70">Why: {u.evidence}</p>
-          </div>
-        ))}
-      </div>
-
-      <div>
-        <SectionLabel icon={<ArrowRight className="h-3.5 w-3.5 text-blue-500" />}>
-          How each one lands
-        </SectionLabel>
-        <div className="mt-2 space-y-0">
-          {NEXT_STEPS.map((n, i) => (
-            <div key={n.step} className="flex gap-3">
-              <div className="flex flex-col items-center">
-                <span
-                  className={
-                    "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold " +
-                    (n.state === "now"
-                      ? "bg-blue-500 text-white"
-                      : n.state === "done"
-                        ? "bg-emerald-500 text-white"
-                        : "border border-border bg-background text-muted-foreground")
-                  }
-                >
-                  {i + 1}
-                </span>
-                {i < NEXT_STEPS.length - 1 && <span className="w-px flex-1 bg-border" />}
-              </div>
-              <div className="pb-5">
-                <p className="text-sm font-medium text-foreground">
-                  {n.step}
-                  {n.state === "now" && (
-                    <span className="ml-2 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300">
-                      you are here
-                    </span>
-                  )}
-                  {n.state === "done" && (
-                    <span className="ml-2 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-                      done Jan 15
-                    </span>
-                  )}
-                </p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{n.desc}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-        <p className="text-xs text-muted-foreground/70">
-          Every approval happens in the conversation. Anything accepted shows up under Your setup
-          and reports in Your work.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function RecommendationsTab() {
-  const [pane, setPane] = useState("current");
-  return (
-    <div className="flex flex-col gap-4 md:flex-row md:gap-6">
-      <div className="flex shrink-0 gap-1 overflow-x-auto md:w-44 md:flex-col md:overflow-visible">
-        {RAIL.map((r) => (
-          <button
-            key={r.id}
-            onClick={() => setPane(r.id)}
-            className={
-              "flex shrink-0 items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors " +
-              (pane === r.id
-                ? "bg-blue-50 font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground")
-            }
-          >
-            {r.icon}
-            <span>{r.label}</span>
-            {r.count !== null && (
-              <span
-                className={
-                  "ml-auto rounded-full px-1.5 py-0.5 text-xs font-medium " +
-                  (pane === r.id
-                    ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
-                    : "bg-muted text-muted-foreground")
-                }
-              >
-                {r.count}
-              </span>
-            )}
-          </button>
-        ))}
-      </div>
-      <div className="min-w-0 flex-1">
-        {pane === "current" ? <CurrentPane /> : <UpcomingPane />}
-      </div>
-    </div>
-  );
-}
-
-/* ---------------- Full view ---------------- */
+/* ---------------- Full view (single centered column) ---------------- */
 
 function FullView() {
-  const [active, setActive] = useState(DEFAULT_TAB);
   return (
-    <div className="flex h-full flex-col overflow-y-auto bg-background text-foreground">
-      <div className="shrink-0 border-b border-blue-100 bg-blue-50 px-8 py-5 dark:border-blue-900 dark:bg-blue-950/40">
-        <div className="mx-auto flex w-full max-w-4xl items-center gap-3">
-          <Sparkles className="h-5 w-5 shrink-0 text-blue-500" />
-          <div className="min-w-0">
-            <h1 className="text-lg font-semibold text-foreground">{USER.name}'s pod</h1>
-            <p className="text-sm text-muted-foreground">
-              How Dust is helping you work, and what's worth adding next.
-            </p>
-          </div>
-          <span className="ml-auto hidden shrink-0 text-xs text-muted-foreground sm:block">
-            {USER.role} · {USER.company}
-          </span>
-        </div>
-      </div>
-
-      <div className="shrink-0 border-b border-border px-8">
-        <div className="mx-auto flex w-full max-w-4xl gap-1 overflow-x-auto">
-          {TAB_TITLES.map((t, i) => (
-            <button
-              key={t}
-              onClick={() => setActive(i)}
-              className={
-                "shrink-0 border-b-2 px-3 py-2.5 text-sm transition-colors " +
-                (i === active
-                  ? "border-blue-500 font-semibold text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground")
-              }
-            >
-              {t}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="mx-auto w-full max-w-4xl flex-1 px-8 py-6">
-        {active === 0 ? <OverviewTab /> : active === 1 ? <YourWorkTab /> : active === 2 ? <YourSetupTab /> : <RecommendationsTab />}
-
-        <div className="mt-6 flex justify-center">
-          <a
-            href={CONVERSATION_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-xl bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600"
-          >
-            Open the last recommendation <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
+    <div className="h-full overflow-y-auto bg-background text-foreground">
+      <div className="mx-auto w-full max-w-xl px-6 py-10">
+        {LEVEL === "day1" ? <DayOneView /> : <GrownView />}
       </div>
     </div>
   );
 }
 
-/* ---------------- Condensed banner view (~280px) ---------------- */
+/* ---------------- Condensed banner view (pinned, ~280px) ---------------- */
 
 function BannerView() {
   return (
-    <div className="flex h-full flex-col bg-background text-foreground">
-      <div className="flex shrink-0 items-center gap-2 border-b border-blue-100 bg-blue-50 px-4 py-2.5 dark:border-blue-900 dark:bg-blue-950/40">
-        <Sparkles className="h-4 w-4 shrink-0 text-blue-500" />
-        <span className="truncate text-sm font-semibold text-foreground">{USER.name}'s pod</span>
-        <a
-          href={CONVERSATION_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="ml-auto inline-flex shrink-0 items-center gap-1 rounded-lg bg-blue-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-600"
-        >
-          Open the last recommendation <ArrowRight className="h-3.5 w-3.5" />
-        </a>
-      </div>
-      <div className="min-h-0 flex-1 px-4 py-3">
-        <p className="text-sm text-foreground" style={{ overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}>
-          <span className="font-medium">{POD_INTRO.lead}</span>{" "}
-          <span className="text-muted-foreground">{POD_INTRO.body}</span>
-        </p>
-        <div className="mt-3 flex items-center gap-2 overflow-x-auto">
-          {LOOP.map((step, i) => (
-            <div key={step.title} className="flex shrink-0 items-center gap-2">
-              <div className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5">
-                <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-blue-500 font-semibold text-white" style={{ fontSize: 10 }}>
-                  {i + 1}
-                </span>
-                <span className="text-xs font-medium text-foreground">{step.title}</span>
-              </div>
-              {i < LOOP.length - 1 && <ArrowRight className="h-3 w-3 shrink-0 text-stone-400" />}
-            </div>
-          ))}
-          <RotateCcw className="h-3 w-3 shrink-0 text-stone-400" />
-        </div>
-      </div>
+    <div className="flex h-full flex-col justify-center gap-1.5 overflow-hidden bg-background px-4 py-3 text-foreground">
+      <Kicker>Your pod</Kicker>
+      {LEVEL === "day1" ? (
+        <>
+          <p className="truncate text-sm font-semibold text-foreground">
+            One place where Dust works for you.
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            Your first idea is waiting in the chat.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="truncate text-sm font-semibold text-foreground">{LATEST.label}</p>
+          <p className="truncate text-xs text-muted-foreground">{LATEST.findings[0]}</p>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Reframes the Activation skill around a durable destination and fixes the Frame overwhelm that new users reported.

- **AGENTS.md is the source of truth (the "charter").** The pod's existing `AGENTS.md` — already injected into every pod agent and editable in Pod settings — becomes the durable spec of the user's work and the pod's goal. The agent refines it every interaction. It's also injected into the activation agent's own context each turn (`readPodAgentsMdContent`).
- **No new abstractions.** AGENTS.md is written with the existing `files` MCP server: `create` to rewrite it whole (`path: pod-[podId]/AGENTS.md`, `content_type: text/markdown`), `edit` for targeted changes. Both are already `never_ask` (silent). No new MCP tool, no schema, no snapshot change.
- **Progressive v9 Frame.** The pod Frame template is rewritten from the old 4-tab dashboard into a single centered column that starts as an explanation and grows into a record. It renders by a `LEVEL` the agent sets from pod state:
  - `"day1"` (default): pod intro + a "how it works" timeline + "your first idea is waiting in the chat." Nothing else.
  - `"grown"`: the latest result as the hero + exactly one "next idea" + education decayed to a collapsed row.
  - Empty sections render **nothing** (never placeholders) — the core fix for the overwhelm feedback.
- **First-message opener rewritten as a skimmable FAQ** that leads with "why you" and explains everything on screen, including the Frame panel that opens on its own.

## Risk

Low - skill changes only

## Testing
* Lots of manual pod provisioning

## Deployment
1. Deploy front