### PR TITLE
[Activation] Add ActivationPod model and migration

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,4 +1,5 @@
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
@@ -282,6 +283,7 @@ export function loadAllModels() {
     WorkspaceSensitivityLabelConfigModel,
     WorkspaceSandboxEnvVarModel,
     WorkspaceSeatLimitModel,
+    ActivationPodModel,
     ActivationRecommendationModel,
     ActivationNudgeModel,
   ];

--- a/front/lib/models/activation/activation_nudge.ts
+++ b/front/lib/models/activation/activation_nudge.ts
@@ -1,3 +1,4 @@
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
@@ -17,6 +18,10 @@ export class ActivationNudgeModel extends WorkspaceAwareModel<ActivationNudgeMod
   declare triggerId: ForeignKey<TriggerModel["id"]>;
   // The user targeted by the nudge.
   declare userId: ForeignKey<UserModel["id"]>;
+
+  // The Pod that was nudged, via ActivationPod. Nullable until backfilled;
+  // will replace spaceId/triggerId/userId above once migrated.
+  declare activationPodId: ForeignKey<ActivationPodModel["id"]> | null;
 }
 
 ActivationNudgeModel.init(
@@ -39,6 +44,7 @@ ActivationNudgeModel.init(
       { fields: ["spaceId"], concurrently: true },
       { fields: ["triggerId"], concurrently: true },
       { fields: ["userId"], concurrently: true },
+      { fields: ["activationPodId"], concurrently: true },
     ],
   }
 );
@@ -65,4 +71,12 @@ ActivationNudgeModel.belongsTo(UserModel, {
 });
 UserModel.hasMany(ActivationNudgeModel, {
   foreignKey: { name: "userId", allowNull: false },
+});
+
+ActivationNudgeModel.belongsTo(ActivationPodModel, {
+  foreignKey: { name: "activationPodId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+ActivationPodModel.hasMany(ActivationNudgeModel, {
+  foreignKey: { name: "activationPodId", allowNull: true },
 });

--- a/front/lib/models/activation/activation_pod.ts
+++ b/front/lib/models/activation/activation_pod.ts
@@ -1,0 +1,71 @@
+import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+// One row = one Activation Pod: a Pod (project space) provisioned by the
+// activation flow. Canonical record for a pod's owner and activation trigger,
+// replacing the ProjectMetadata provisioningSource flag and the join through
+// WebhookSourcesView/Trigger used to resolve a pod's trigger.
+export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  // The activation pod.
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  // The user for whom we created the activation pod.
+  declare userId: ForeignKey<UserModel["id"]>;
+  // The Pod's activation trigger. Null until provisioned.
+  declare triggerId: ForeignKey<TriggerModel["id"]> | null;
+}
+
+ActivationPodModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    modelName: "activation_pod",
+    sequelize: frontSequelize,
+    indexes: [
+      { unique: true, fields: ["spaceId"], concurrently: true },
+      { fields: ["userId"], concurrently: true },
+      { unique: true, fields: ["triggerId"], concurrently: true },
+    ],
+  }
+);
+
+ActivationPodModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+SpaceModel.hasOne(ActivationPodModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+});
+
+ActivationPodModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+UserModel.hasMany(ActivationPodModel, {
+  foreignKey: { name: "userId", allowNull: false },
+});
+
+ActivationPodModel.belongsTo(TriggerModel, {
+  foreignKey: { name: "triggerId", allowNull: true },
+  onDelete: "SET NULL",
+});
+TriggerModel.hasOne(ActivationPodModel, {
+  foreignKey: { name: "triggerId", allowNull: true },
+});

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -1,3 +1,4 @@
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
@@ -21,6 +22,8 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare updatedAt: CreationOptional<Date>;
 
   declare userId: ForeignKey<UserModel["id"]>;
+  // The Pod the recommendation was made in. Nullable until backfilled.
+  declare activationPodId: ForeignKey<ActivationPodModel["id"]> | null;
   declare status: ActivationRecommendationStatus;
   declare title: string;
   declare content: string;
@@ -49,6 +52,10 @@ ActivationRecommendationModel.init(
     userId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+    },
+    activationPodId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
     },
     status: {
       type: DataTypes.STRING,
@@ -89,6 +96,10 @@ ActivationRecommendationModel.init(
         concurrently: true,
       },
       {
+        fields: ["activationPodId"],
+        concurrently: true,
+      },
+      {
         fields: ["conversationId"],
         concurrently: true,
       },
@@ -111,6 +122,14 @@ ActivationRecommendationModel.belongsTo(UserModel, {
 UserModel.hasMany(ActivationRecommendationModel, {
   foreignKey: { name: "userId", allowNull: false },
   onDelete: "RESTRICT",
+});
+
+ActivationRecommendationModel.belongsTo(ActivationPodModel, {
+  foreignKey: { name: "activationPodId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+ActivationPodModel.hasMany(ActivationRecommendationModel, {
+  foreignKey: { name: "activationPodId", allowNull: true },
 });
 
 ActivationRecommendationModel.belongsTo(ConversationModel, {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1823,6 +1823,7 @@ describe("searchProjectsByNamePaginated", () => {
 // These are Sequelize model names (modelName property), not TypeScript class names
 const KNOWN_SPACE_RELATED_MODELS = [
   "activation_nudge",
+  "activation_pod",
   "agent_project_configuration",
   "app",
   "conversation_selected_spaces",

--- a/front/migrations/pre-deploy/20260722153324_create_activation_pods.sql
+++ b/front/migrations/pre-deploy/20260722153324_create_activation_pods.sql
@@ -1,0 +1,182 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."activation_pods_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" ADD COLUMN "activationPodId" bigint;
+
+/*
+Statement 2
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_nudges_activation_pod_id ON public.activation_nudges USING btree ("activationPodId");
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."activation_pods" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('activation_pods_id_seq'::regclass) NOT NULL,
+	"spaceId" bigint NOT NULL,
+	"userId" bigint NOT NULL,
+	"triggerId" bigint
+);
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY activation_pods_pkey ON public.activation_pods USING btree (id);
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" ADD CONSTRAINT "activation_pods_pkey" PRIMARY KEY USING INDEX "activation_pods_pkey";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY activation_pods_space_id ON public.activation_pods USING btree ("spaceId");
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY activation_pods_trigger_id ON public.activation_pods USING btree ("triggerId");
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_pods_user_id ON public.activation_pods USING btree ("userId");
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" ADD CONSTRAINT "activation_nudges_activationPodId_fkey" FOREIGN KEY ("activationPodId") REFERENCES activation_pods(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" VALIDATE CONSTRAINT "activation_nudges_activationPodId_fkey";
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."activation_pods_id_seq" OWNED BY "public"."activation_pods"."id";
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD COLUMN "activationPodId" bigint;
+
+/*
+Statement 13
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" ADD CONSTRAINT "activation_recommendations_activationPodId_fkey" FOREIGN KEY ("activationPodId") REFERENCES activation_pods(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 14
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_recommendations" VALIDATE CONSTRAINT "activation_recommendations_activationPodId_fkey";
+
+/*
+Statement 15
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_recommendations_activation_pod_id ON public.activation_recommendations USING btree ("activationPodId");
+
+/*
+Statement 16
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" ADD CONSTRAINT "activation_pods_triggerId_fkey" FOREIGN KEY ("triggerId") REFERENCES triggers(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 17
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" VALIDATE CONSTRAINT "activation_pods_triggerId_fkey";
+
+/*
+Statement 18
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" ADD CONSTRAINT "activation_pods_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES vaults(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 19
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" VALIDATE CONSTRAINT "activation_pods_spaceId_fkey";
+
+/*
+Statement 20
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" ADD CONSTRAINT "activation_pods_userId_fkey" FOREIGN KEY ("userId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 21
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" VALIDATE CONSTRAINT "activation_pods_userId_fkey";
+
+/*
+Statement 22
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" ADD CONSTRAINT "activation_pods_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 23
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" VALIDATE CONSTRAINT "activation_pods_workspaceId_fkey";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -10,6 +10,7 @@ import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
   AgentChildAgentConfigurationModel,
@@ -250,6 +251,16 @@ export async function scrubSpaceActivity({
   // `onDelete: "RESTRICT"`, so these rows must be removed before the space
   // can be hard-deleted.
   await ActivationNudgeModel.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: space.id,
+    },
+  });
+
+  // Delete the activation pod record for this space. The FK to spaces is
+  // `onDelete: "RESTRICT"`, so this row must be removed before the space
+  // can be hard-deleted.
+  await ActivationPodModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       spaceId: space.id,


### PR DESCRIPTION
## Description

Adds an `ActivationPod` model as the canonical record for an Activation Pod: its space, owner
(`userId`), and activation trigger (`triggerId`, nullable until provisioned). Today this data is
scattered — a pod is flagged via `ProjectMetadata.provisioningSource`, its owner only lives on the
trigger's `editor` field, and its trigger is resolved by joining through
`WebhookSourcesView`/`Trigger`. `ActivationPod` will replace that with a single row per pod.

This PR only adds the model and an additive schema migration:
- New `activation_pods` table.
- Nullable `activationPodId` FK added to `activation_nudges` and `activation_recommendations`.

Existing columns on `activation_nudges` (`spaceId`, `triggerId`, `userId`) are untouched for now.
Follow-up work will backfill `activationPodId` on existing rows, wire the resource/orchestrator
code to populate it going forward, then tighten both columns to `NOT NULL` and drop the old
`activation_nudges` columns in a later post-deploy migration.

## Deploy Plan

Purely additive (new table + nullable columns) — safe to deploy as a normal pre-deploy migration,
no backfill required before this ships.
