### PR TITLE
add frame permission to seeder

### DIFF
--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -49,6 +49,8 @@ export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
     capability: { grantType: "create", resourceType: "skill" },
     resolveTarget: async (_auth) => "builders",
   },
+  // it's safe to set them to "everyone" because there is another workspace level permission check
+  // if inviting/publishing is allowed or not. We only check permission table if the feature itself is enabled
   {
     capability: { grantType: "invite", resourceType: "frame" },
     resolveTarget: async (_auth) => "everyone",

--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -51,6 +51,14 @@ export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
     capability: { grantType: "create", resourceType: "skill" },
     resolveTarget: async (_auth) => "builders",
   },
+  {
+    capability: { grantType: "invite", resourceType: "frame" },
+    resolveTarget: async (_auth) => "everyone",
+  },
+  {
+    capability: { grantType: "publish", resourceType: "frame" },
+    resolveTarget: async (_auth) => "everyone",
+  },
 ];
 
 export type ApplyCapabilityOutcome =


### PR DESCRIPTION
## Description
This PR is to add frame permissions to seeder. It's safe to set it to everyone, because there is another workspace level setting to toggle email invitation & public sharing. We will always first this check and if it's enabled we will check permission table so fine to set it to everyone by default. 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
