### PR TITLE
[Activation] Wire ActivationPod into creation and read paths

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -12,11 +12,13 @@ import {
   ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import type { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import { Err, Ok } from "@app/types/shared/result";
@@ -127,10 +129,23 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         ? runContext.conversation.id
         : null;
 
+      // Best-effort link to the pod the recommendation was made in: the
+      // activation conversation's space is the pod itself.
+      const podSpaceId = isAgentLoopRunContext(runContext)
+        ? runContext.conversation.spaceId
+        : null;
+      const pod = podSpaceId
+        ? await SpaceResource.fetchById(auth, podSpaceId)
+        : null;
+      const activationPod = pod
+        ? await ActivationPodResource.fetchBySpace(auth, pod)
+        : null;
+
       const rec = await ActivationRecommendationResource.makeNew(auth, {
         title,
         content,
         conversationId,
+        activationPodId: activationPod?.id ?? null,
       });
 
       return new Ok([

--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/activation/nudge";
 import { ACTIVATION_WEBHOOK_SOURCE_NAME } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -25,11 +26,11 @@ import { describe, expect, it } from "vitest";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// Wires a trigger the same way `createActivationTrigger` does in production:
-// on the pod's own view of the shared Activation webhook source. This is
-// required for `isEligibleForNudge` to find it via `findActivationTrigger`,
-// which pinpoints the trigger by `webhookSourceViewId` rather than just
-// `kind === "webhook"` (a pod's space can hold other webhook triggers).
+// Wires a trigger the same way `createActivationTrigger` does in production
+// (on the pod's own view of the shared Activation webhook source), plus the
+// ActivationPod row `join_activation_pod.ts` creates alongside it. This is
+// required for `isEligibleForNudge`, which resolves the pod's trigger via
+// `ActivationPodResource` rather than the source/view/trigger join.
 async function createPodActivationTrigger(
   auth: Authenticator,
   pod: SpaceResource,
@@ -43,12 +44,20 @@ async function createPodActivationTrigger(
     webhookSourceId: source.sId,
   });
 
-  return TriggerFactory.webhook(auth, {
+  const trigger = await TriggerFactory.webhook(auth, {
     agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
     status: options.status ?? "enabled",
     spaceId: pod.id,
     webhookSourceViewId: podView.id,
   });
+
+  await ActivationPodResource.makeNew(auth, {
+    pod,
+    user: auth.getNonNullableUser(),
+    trigger,
+  });
+
+  return trigger;
 }
 
 describe("getActivationNudgeFrequencyCapDays", () => {

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,10 +1,10 @@
-import { findActivationTrigger } from "@app/lib/api/activation/trigger";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
@@ -45,13 +45,13 @@ export function getActivationNudgeMaxUnansweredCount(
 // count stops at the first answered nudge, so a reply resets the streak.
 async function countUnansweredNudgeStreak(
   auth: Authenticator,
-  pod: SpaceResource,
+  activationPod: ActivationPodResource,
   { limit }: { limit: number }
 ): Promise<number> {
-  const recentNudges = await ActivationNudgeResource.listRecentForSpace(auth, {
-    pod,
-    limit,
-  });
+  const recentNudges = await ActivationNudgeResource.listRecentForActivationPod(
+    auth,
+    { activationPod, limit }
+  );
   if (recentNudges.length === 0) {
     return 0;
   }
@@ -119,7 +119,14 @@ export async function isEligibleForNudge(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<boolean> {
-  const trigger = await findActivationTrigger(auth, pod);
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  if (!activationPod || activationPod.triggerId === null) {
+    return false;
+  }
+
+  const [trigger] = await TriggerResource.fetchByModelIds(auth, [
+    activationPod.triggerId,
+  ]);
   if (!trigger || trigger.status !== "enabled") {
     return false;
   }
@@ -128,9 +135,10 @@ export async function isEligibleForNudge(
     return false;
   }
 
-  const latestNudge = await ActivationNudgeResource.fetchLatestForSpace(auth, {
-    pod,
-  });
+  const latestNudge = await ActivationNudgeResource.fetchLatestForActivationPod(
+    auth,
+    { activationPod }
+  );
   if (!latestNudge) {
     return true;
   }
@@ -143,9 +151,13 @@ export async function isEligibleForNudge(
   }
 
   const maxUnansweredCount = getActivationNudgeMaxUnansweredCount(auth);
-  const unansweredStreak = await countUnansweredNudgeStreak(auth, pod, {
-    limit: maxUnansweredCount,
-  });
+  const unansweredStreak = await countUnansweredNudgeStreak(
+    auth,
+    activationPod,
+    {
+      limit: maxUnansweredCount,
+    }
+  );
 
   return unansweredStreak < maxUnansweredCount;
 }

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,7 +1,7 @@
 import { evaluateActivation } from "@app/lib/api/activation/evaluator";
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -33,7 +33,7 @@ export async function determineEligibleActivationUsers(
 ): Promise<Result<OrchestratorResult, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
-  const pods = await ProjectMetadataResource.fetchActivationPods(auth);
+  const pods = await ActivationPodResource.listForWorkspace(auth);
 
   const spaces = await SpaceResource.fetchByModelIds(
     auth,

--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -167,41 +167,6 @@ export async function createActivationTrigger(
   return new Ok({ triggerId: triggerRes.value.sId });
 }
 
-// Finds the pod's activation trigger: the trigger on the pod's own view of
-// the shared Activation webhook source (see
-// `getOrCreateActivationWebhookSourceView`). Filtering on `webhookSourceViewId`
-// rather than just `kind === "webhook"` matters because a pod's space can hold
-// other, unrelated webhook triggers. There is at most one activation trigger
-// per pod, since `createActivationTrigger` provisions exactly one per pod view.
-export async function findActivationTrigger(
-  auth: Authenticator,
-  pod: SpaceResource
-): Promise<TriggerResource | null> {
-  const source = await WebhookSourceResource.fetchByName(
-    auth,
-    ACTIVATION_WEBHOOK_SOURCE_NAME
-  );
-  if (!source) {
-    return null;
-  }
-
-  // `includeDeleted` so this still resolves for archived pods: eligibility
-  // gating needs to find the trigger first to then determine the pod is dead.
-  const podViews = await WebhookSourcesViewResource.listBySpace(auth, pod, {
-    includeDeleted: true,
-  });
-  const podView = podViews.find((v) => v.webhookSourceId === source.id);
-  if (!podView) {
-    return null;
-  }
-
-  const triggers = await TriggerResource.listByWebhookSourceViewId(
-    auth,
-    podView.id
-  );
-  return triggers[0] ?? null;
-}
-
 // Fires the activation trigger for a single pod by emitting an internal webhook
 // event. Returns the sId of the pod's activation trigger, if the event matched
 // it (a pod has at most one activation trigger, via `activationTriggerFilter`).

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -12,11 +12,13 @@ import {
 } from "@app/lib/api/projects/constants";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
@@ -42,22 +44,6 @@ function activationPodNameForCreator(
 
   const label = hasNameCollision ? creator.email : creatorFullName;
   return `${label}${ACTIVATION_POD_NAME_PREFIX}`;
-}
-
-async function markPodAsActivation(
-  auth: Authenticator,
-  pod: SpaceResource
-): Promise<Result<void, Error>> {
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-  if (!metadata) {
-    return new Err(
-      new Error("Project metadata not found for the newly created pod.")
-    );
-  }
-
-  await metadata.updateProvisioningSource("activation");
-
-  return new Ok(undefined);
 }
 
 async function setPodDefaultSkills(
@@ -326,11 +312,6 @@ export const joinActivationPodPlugin = createPlugin({
       }
     }
 
-    const activationResult = await markPodAsActivation(auth, pod);
-    if (activationResult.isErr()) {
-      return activationResult;
-    }
-
     // Star the pod for every member so it surfaces in their sidebar.
     await UserProjectPreferencesResource.setStarredForUsers(auth, {
       spaceModelId: pod.id,
@@ -382,6 +363,20 @@ export const joinActivationPodPlugin = createPlugin({
         )
       );
     }
+
+    // Record the canonical ActivationPod row now that the pod's owner and
+    // trigger are known. This is the record `isEligibleForNudge` and the
+    // activation scheduler use to find the pod and its trigger, so it must
+    // be created for the pod to ever be nudged.
+    const activationTrigger = await TriggerResource.fetchById(
+      podMemberAuth,
+      triggerResult.value.triggerId
+    );
+    await ActivationPodResource.makeNew(auth, {
+      pod,
+      user: creator,
+      trigger: activationTrigger,
+    });
 
     // Fire the activation event so the trigger kicks off the initial conversation
     // as soon as the pod is provisioned.

--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/activation/trigger";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -33,8 +33,8 @@ async function isActivationPod(
     return false;
   }
 
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-  return metadata?.provisioningSource === "activation";
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  return activationPod !== null;
 }
 
 export const sendActivationNudgePlugin = createPlugin({

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -2,8 +2,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
 import { triggerActivationNewConversationEmail } from "@app/lib/notifications/workflows/activation-new-conversation";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
@@ -130,11 +130,8 @@ const triggerProjectNewConversationNotifications = async (
   }
 
   // Activation pods send a dedicated email to the target user after the agent has replied.
-  const projectMetadata = await ProjectMetadataResource.fetchBySpace(
-    auth,
-    space
-  );
-  if (projectMetadata?.provisioningSource === "activation") {
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+  if (activationPod !== null) {
     return new Ok(undefined);
   }
 
@@ -269,11 +266,8 @@ export async function notifyActivationConversationAgentReplied(
     return;
   }
 
-  const projectMetadata = await ProjectMetadataResource.fetchBySpace(
-    auth,
-    space
-  );
-  if (projectMetadata?.provisioningSource !== "activation") {
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+  if (activationPod === null) {
     return;
   }
 

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -59,12 +60,27 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   ): Promise<ActivationNudgeResource[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    // Best-effort link to the canonical ActivationPod, alongside the
+    // spaceId/triggerId/userId already denormalized below. Not every pod has
+    // one yet, so a lookup miss just leaves activationPodId null.
+    const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+      auth,
+      nudges.map(({ pod }) => pod.id)
+    );
+    const activationPodBySpaceId = new Map(
+      activationPods.map((activationPod) => [
+        activationPod.spaceId,
+        activationPod,
+      ])
+    );
+
     const created = await this.model.bulkCreate(
       nudges.map(({ pod, trigger }) => ({
         workspaceId,
         spaceId: pod.id,
         triggerId: trigger.id,
         userId: trigger.editor,
+        activationPodId: activationPodBySpaceId.get(pod.id)?.id ?? null,
       })),
       { returning: true }
     );
@@ -73,23 +89,29 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   }
 
   // Fetches the most recent nudge recorded for a pod, if any.
-  static async fetchLatestForSpace(
+  static async fetchLatestForActivationPod(
     auth: Authenticator,
-    { pod }: { pod: SpaceResource }
+    { activationPod }: { activationPod: ActivationPodResource }
   ): Promise<ActivationNudgeResource | null> {
-    const [latest] = await this.listRecentForSpace(auth, { pod, limit: 1 });
+    const [latest] = await this.listRecentForActivationPod(auth, {
+      activationPod,
+      limit: 1,
+    });
     return latest ?? null;
   }
 
   // Fetches the `limit` most recent nudges recorded for a pod, newest first.
-  static async listRecentForSpace(
+  static async listRecentForActivationPod(
     auth: Authenticator,
-    { pod, limit }: { pod: SpaceResource; limit: number }
+    {
+      activationPod,
+      limit,
+    }: { activationPod: ActivationPodResource; limit: number }
   ): Promise<ActivationNudgeResource[]> {
     const nudges = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        spaceId: pod.id,
+        activationPodId: activationPod.id,
       },
       order: [["createdAt", "DESC"]],
       limit,

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -1,0 +1,131 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ActivationPodResource
+  extends ReadonlyAttributesType<ActivationPodModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ActivationPodResource extends BaseResource<ActivationPodModel> {
+  static model: ModelStatic<ActivationPodModel> = ActivationPodModel;
+
+  constructor(
+    _: ModelStatic<ActivationPodModel>,
+    blob: Attributes<ActivationPodModel>
+  ) {
+    super(ActivationPodModel, blob);
+  }
+
+  get sId(): string {
+    return ActivationPodResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("activation_pod", { id, workspaceId });
+  }
+
+  // Creates the canonical record for a newly provisioned Activation Pod.
+  static async makeNew(
+    auth: Authenticator,
+    {
+      pod,
+      user,
+      trigger,
+    }: {
+      pod: SpaceResource;
+      user: UserResource;
+      trigger?: TriggerResource | null;
+    }
+  ): Promise<ActivationPodResource> {
+    const model = await this.model.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: pod.id,
+      userId: user.id,
+      triggerId: trigger?.id ?? null,
+    });
+
+    return new this(this.model, model.get());
+  }
+
+  // Fetches the ActivationPod for a given Pod, if one exists.
+  static async fetchBySpace(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<ActivationPodResource | null> {
+    const [activationPod] = await this.fetchBySpaceModelIds(auth, [pod.id]);
+    return activationPod ?? null;
+  }
+
+  // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
+  // scheduler processes many pods at once).
+  static async fetchBySpaceModelIds(
+    auth: Authenticator,
+    spaceModelIds: ModelId[]
+  ): Promise<ActivationPodResource[]> {
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+
+    const activationPods = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: spaceModelIds,
+      },
+    });
+
+    return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
+  // Lists every ActivationPod in the calling workspace.
+  static async listForWorkspace(
+    auth: Authenticator
+  ): Promise<ActivationPodResource[]> {
+    const activationPods = await this.model.findAll({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+    });
+
+    return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
+  // Sets the Pod's activation trigger once it has been provisioned.
+  async setTrigger(trigger: TriggerResource): Promise<void> {
+    await this.update({ triggerId: trigger.id });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+}

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -56,7 +56,13 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     blob: Pick<
       CreationAttributes<ActivationRecommendationModel>,
       "title" | "content" | "conversationId"
-    >
+    > &
+      Partial<
+        Pick<
+          CreationAttributes<ActivationRecommendationModel>,
+          "activationPodId"
+        >
+      >
   ): Promise<ActivationRecommendationResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -68,6 +74,7 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       title: blob.title,
       content: blob.content,
       conversationId: blob.conversationId ?? null,
+      activationPodId: blob.activationPodId ?? null,
     });
 
     return new this(this.model, rec.get());
@@ -159,6 +166,23 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       resource: new this(this.model, rec.get()),
       conversationSId: rec.conversation?.sId ?? null,
     }));
+  }
+
+  // Detaches all recommendations from a Pod being deleted. Recommendations
+  // are owned by the user, not the pod, so they are kept and only unlinked.
+  static async detachActivationPod(
+    auth: Authenticator,
+    activationPodId: ModelId
+  ): Promise<void> {
+    await this.model.update(
+      { activationPodId: null },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          activationPodId,
+        },
+      }
+    );
   }
 
   async updateFields(fields: {

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -2,10 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  ProjectMetadataModel,
-  type ProvisioningSource,
-} from "@app/lib/resources/storage/models/project_metadata";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { PodMetadataType } from "@app/types/project_metadata";
@@ -106,22 +103,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       where: {
         spaceId: spaceModelIds,
         workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-
-    return models.map((model) =>
-      ProjectMetadataResource.fromModel(model, model.spaceId)
-    );
-  }
-
-  static async fetchActivationPods(
-    auth: Authenticator
-  ): Promise<ProjectMetadataResource[]> {
-    const models = await ProjectMetadataModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        provisioningSource: "activation" satisfies ProvisioningSource,
-        archivedAt: null,
       },
     });
 
@@ -240,13 +221,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     transaction?: Transaction
   ) {
     await this.update({ defaultAgentId }, transaction);
-  }
-
-  async updateProvisioningSource(
-    provisioningSource: ProvisioningSource | null,
-    transaction?: Transaction
-  ) {
-    await this.update({ provisioningSource }, transaction);
   }
 
   async setDefaultSkills(

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -111,6 +111,9 @@ export const RESOURCES_PREFIX = {
 
   // Activation nudges.
   activation_nudge: "anu",
+
+  // Activation pods.
+  activation_pod: "apo",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -159,6 +159,15 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return res.length > 0 ? res[0] : null;
   }
 
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[]
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: { id: ids },
+    });
+  }
+
   static listByAgentConfigurationId(
     auth: Authenticator,
     agentConfigurationId: string


### PR DESCRIPTION
## Description

Stacked on #29309. Wires `ActivationPodResource` into the flows that create and read Activation
Pod data, and switches all read paths off the two mechanisms it replaces:

- `join_activation_pod.ts` creates the canonical `ActivationPod` row once the pod's owner and
  trigger are known.
- `ActivationNudgeResource.bulkCreate` sets `activationPodId` on new nudges; the
  `activation_recommendations` MCP server derives the pod from the conversation's `spaceId` and
  links new recommendations to it.
- `ProjectMetadata.provisioningSource` is no longer set or read for activation pods
  (`markPodAsActivation`, `updateProvisioningSource`, `fetchActivationPods` removed).
  `send_activation_nudge.ts`'s `isActivationPod` and both activation checks in
  `project-new-conversation.ts` now query `ActivationPodResource` instead.
- `nudge.ts`'s `isEligibleForNudge` resolves a pod's trigger via `ActivationPodResource` +
  `TriggerResource.fetchByModelIds`, replacing the `findActivationTrigger`
  webhook-source/view/trigger join, which is now unused and removed.
- `orchestrator.ts`'s `determineEligibleActivationUsers` lists pods via
  `ActivationPodResource.listForWorkspace`.
- `ActivationNudgeResource.fetchLatestForSpace`/`listRecentForSpace` are renamed to
  `fetchLatestForActivationPod`/`listRecentForActivationPod` and now query by `activationPodId`
  instead of `spaceId`.

No backfill: this is a hard cutover for pod creation and reads, not a phased migration. Pods
created before this deploys won't have an `ActivationPod` row. The follow-up PR (#29321) deletes
any `activation_nudges` rows left without one when it drops the old columns.

## Tests

Updated `nudge.test.ts`'s `createPodActivationTrigger` fixture to also create the `ActivationPod`
row the new code path depends on. Ran the full activation-related suites (`nudge.test.ts`,
`activation_recommendation_resource.test.ts`, `project_metadata_resource.test.ts`) — all 35 tests
pass.
