### PR TITLE
Use publish permission for protected tags

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.test.ts
@@ -1,0 +1,81 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/recent_authors", () => ({
+  agentConfigurationWasUpdatedBy: vi.fn(),
+}));
+
+function patchTags(workspace: { sId: string }, aId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/tags`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+async function setupTest() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "user",
+  });
+
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const protectedTag = await TagResource.makeNew(adminAuth, {
+    name: "Protected Tag",
+    kind: "protected",
+  });
+
+  return { workspace, user, agent, adminAuth, protectedTag };
+}
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/tags", () => {
+  it("rejects adding a protected tag without the publish:agent capability", async () => {
+    const { workspace, agent, protectedTag } = await setupTest();
+
+    const res = await patchTags(workspace, agent.sId, {
+      addTagIds: [protectedTag.sId],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toBe(
+      "Protected tags cannot be added or removed."
+    );
+
+    const tags = await TagResource.listForAgent(
+      await Authenticator.internalAdminForWorkspace(workspace.sId),
+      agent.id
+    );
+    expect(tags?.some((t) => t.sId === protectedTag.sId)).toBe(false);
+  });
+
+  it("allows adding a protected tag once the publish:agent capability is granted", async () => {
+    const { workspace, agent, adminAuth, protectedTag } = await setupTest();
+
+    await GroupPermissionResource.setForEverybody(adminAuth, {
+      grantType: "publish",
+      resourceType: "agent",
+    });
+
+    const res = await patchTags(workspace, agent.sId, {
+      addTagIds: [protectedTag.sId],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tags.map((t: { sId: string }) => t.sId)).toContain(
+      protectedTag.sId
+    );
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -2,7 +2,6 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { PatchAgentTagsResponseBody } from "@app/types/api/assistant/configuration/agent_tags";
-import { isBuilder } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -83,7 +82,7 @@ app.patch(
     }
 
     if (
-      !isBuilder(auth.getNonNullableWorkspace()) &&
+      !(await auth.hasWorkspacePermission("publish", "agent")) &&
       (tagsToAdd.some((tag) => tag.kind === "protected") ||
         tagsToRemove.some((tag) => tag.kind === "protected"))
     ) {

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -4,13 +4,13 @@ import { TagsSelector } from "@app/components/agent_builder/settings/TagsSelecto
 import { fetchWithErr } from "@app/components/agent_builder/settings/utils";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useTags } from "@app/lib/swr/tags";
 import type { BuilderSuggestionsType } from "@app/types/api/assistant";
 import type { APIError } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import { useMemo, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -48,6 +48,8 @@ export function TagsSection() {
   const { owner } = useAgentBuilderContext();
   const { getValues } = useFormContext<AgentBuilderFormData>();
   const { tags: allTags } = useTags({ owner });
+  const { hasPermission } = useWorkspacePermissions(owner);
+  const canManageProtectedTags = hasPermission("publish", "agent");
   const {
     fields: selectedTags,
     append,
@@ -100,7 +102,7 @@ export function TagsSection() {
           const currentTagIds = new Set(selectedTags.map((field) => field.sId));
           return allTags
             .filter((t) => !currentTagIds.has(t.sId))
-            .filter((t) => isBuilder(owner) || t.kind !== "protected")
+            .filter((t) => canManageProtectedTags || t.kind !== "protected")
             .filter(
               (tag) =>
                 tagsSuggestions.suggestions?.findIndex(

--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -1,8 +1,9 @@
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useCreateTag, useTags } from "@app/lib/swr/tags";
 import { tagsSorter } from "@app/lib/utils";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   Button,
   Chip,
@@ -52,6 +53,8 @@ export const TagsSelector = ({
     owner,
   });
   const { createTag } = useCreateTag({ owner });
+  const { hasPermission } = useWorkspacePermissions(owner);
+  const canManageProtectedTags = hasPermission("publish", "agent");
 
   const onMenuOpenChange = (open: boolean) => {
     setIsMenuOpen(open);
@@ -91,7 +94,7 @@ export const TagsSelector = ({
 
     const allFiltered = allTags
       .filter((t) => t.name.toLowerCase().includes(searchText.toLowerCase()))
-      .filter((t) => isBuilder(owner) || t.kind !== "protected")
+      .filter((t) => canManageProtectedTags || t.kind !== "protected")
       .sort(tagsSorter);
 
     const suggested = allFiltered.filter((t) => suggestedTagIds.has(t.sId));
@@ -99,7 +102,7 @@ export const TagsSelector = ({
       suggestedFilteredTags: suggested,
       otherFilteredTags: allFiltered,
     };
-  }, [suggestedTags, allTags, searchText, owner]);
+  }, [suggestedTags, allTags, searchText, canManageProtectedTags]);
 
   const exactMatch = allTags.find(
     (t) => t.name.toLowerCase() === searchText.toLowerCase()
@@ -236,7 +239,7 @@ export const TagsSelector = ({
             <Chip
               key={tag.sId}
               onRemove={
-                tag.kind === "protected" && !isBuilder(owner)
+                tag.kind === "protected" && !canManageProtectedTags
                   ? undefined
                   : () => onRemoveTag(tag.sId)
               }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -86,7 +86,7 @@ import { normalizeAsInternalDustError } from "@app/types/shared/utils/error_util
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { TagType } from "@app/types/tag";
 import type { UserType } from "@app/types/user";
-import { isAdmin, isBuilder } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
 import {
@@ -774,6 +774,11 @@ export async function createAgentConfiguration(
         );
       }
 
+      const canManageProtectedTags = await auth.hasWorkspacePermission(
+        "publish",
+        "agent"
+      );
+
       const existingTags = existingAgent
         ? await TagResource.listForAgent(auth, existingAgent.id)
         : [];
@@ -781,7 +786,7 @@ export async function createAgentConfiguration(
         .filter((t) => t.kind === "protected")
         .map((t) => t.sId);
       if (
-        !isBuilder(owner) &&
+        !canManageProtectedTags &&
         !existingReservedTags.every((reservedTagId) =>
           tags.some((tag) => tag.sId === reservedTagId)
         )
@@ -802,7 +807,7 @@ export async function createAgentConfiguration(
           const tagResource = tagResourceById.get(tag.sId);
           if (tagResource) {
             if (
-              !isBuilder(owner) &&
+              !canManageProtectedTags &&
               tagResource.kind === "protected" &&
               !existingReservedTags.includes(tagResource.sId)
             ) {


### PR DESCRIPTION
## Description

Part of the Admin Governance initiative — replaces `isBuilder()` checks around protected/reserved agent tags with the group-permissions-backed `auth.hasWorkspacePermission("publish", "agent")` capability check (dust-tt/tasks#9747).

- `front/lib/api/assistant/configuration/agent.ts` (`createAgentConfiguration`): replaced two `isBuilder(owner)` checks guarding add/remove of reserved (`kind: "protected"`) tags with a single `await auth.hasWorkspacePermission("publish", "agent")`, computed once and reused for both checks.
- `front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts` (PATCH tags route): same replacement for the "Protected tags cannot be added or removed" check.
- `front/components/agent_builder/settings/TagsSelector.tsx` and `TagsSection.tsx`: replaced the client-side `isBuilder(owner)` filters (which decide whether protected tags are addable/removable/suggested) with `hasPermission("publish", "agent")` from the existing `useWorkspacePermissions` hook (`front/lib/swr/permissions.ts`) — the client-side counterpart of `hasWorkspacePermission`, backed by `GET /api/w/:wId/permissions`.

## Tests

- New `front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.test.ts`: asserts a plain user without the `publish:agent` capability is rejected (400) adding a protected tag, and succeeds (200) once the capability is granted via `GroupPermissionResource.setForEverybody`.
- Existing `agent.test.ts` (16 tests) and the full `front-api` suite still pass.
- `npx tsgo --noEmit` clean on both `front` and `front-api`.
- No component test exists for `TagsSelector.tsx`/`TagsSection.tsx` (none existed before this change either); verified via typecheck + biome only.

## Risk

- Access to protected-tag mutation now depends on the `publish:agent` governance capability's configured scope, which defaults to `"builders"` via the shared `CAPABILITY_SEEDERS` (`governance_seeding.ts`) — same effective population as the old `isBuilder()` check, as long as the workspace's capability grant has been seeded/backfilled. A workspace without a seeded grant yet fails closed (denies non-admins), matching the fallback used elsewhere in the governance rollout.
- The frontend change relies on `useWorkspacePermissions`/`hasPermission` already being available (`front/lib/swr/permissions.ts`); no new client-side infrastructure was added by this PR.

## Deploy Plan

- Merge and deploy as usual. No new migration in this PR — relies on the `publish:agent` capability already being seeded via the shared Admin Governance seeding/backfill infrastructure.