### PR TITLE
Fix permission on agent imports

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
@@ -1,7 +1,6 @@
 import { importAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import type { ImportAgentConfigurationFromYAMLResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 /**
@@ -137,7 +136,6 @@ const app = publicApiApp();
 
 app.post(
   "/",
-  ensureIsBuilder(),
   async (ctx): HandlerResult<ImportAgentConfigurationFromYAMLResponseType> => {
     const auth = ctx.get("auth");
 

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -166,6 +166,17 @@ async function importAgentConfiguration(
   yamlConfig: AgentYAMLConfig,
   agentConfigurationId?: string
 ): Promise<ImportResult> {
+  const canCreate = await auth.hasWorkspacePermission("create", "agent");
+  if (!canCreate) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "assistant_saving_error",
+        message: "Creating agents is restricted.",
+      },
+    });
+  }
+
   const saveEnabledResult = await ensureAgentConfigurationSavingEnabled();
   if (saveEnabledResult.isErr()) {
     return saveEnabledResult;


### PR DESCRIPTION
## Description

Part of the Admin Governance initiative — replaces the `ensureIsBuilder()` role gate on the public YAML agent-import endpoint with the group-permissions-backed `auth.hasWorkspacePermission("create", "agent")` capability check, consistent with the other agent-creation entry points (`createPendingAgentConfiguration`, the agent builder's create-agent frontend check, skill creation).

- `front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts`: dropped the `ensureIsBuilder()` middleware — role gating is no longer applied at the route layer for this endpoint.
- `front/lib/api/assistant/configuration/yaml_import.ts` (`importAgentConfiguration`): added `auth.hasWorkspacePermission("create", "agent")` at the top of the function, returning the same `"Creating agents is restricted."` message (400, `assistant_saving_error`) used elsewhere when the capability isn't granted.

## Tests

- `npx tsgo --noEmit` clean on both `front` and `front-api`.
- No test file exists yet for `import.ts`/`importAgentConfiguration`'s authorization path specifically; verified via typecheck only.

## Risk

- Access to YAML agent import now depends on the `create:agent` governance capability's configured scope (defaults to `"everyone"` unless the workspace has the legacy `disallow_agent_creation_to_users` flag, per `CAPABILITY_SEEDERS` in `governance_seeding.ts`), rather than the raw `builder` role — same effective population as before for workspaces whose capability grant has been seeded/backfilled. A workspace without a seeded grant yet fails closed (denies non-admins).
- Moving the check from route-level middleware into the business-layer function means any other caller of `importAgentConfiguration` (if one exists outside this route) now also gets this enforcement — this is the intended tightening, not a side effect to work around.

## Deploy Plan

- Merge and deploy as usual. No new migration in this PR — relies on the `create:agent` capability already being seeded via the shared Admin Governance seeding/backfill infrastructure.