### PR TITLE
[Activation] Add ActivationPod backfill script

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -10,8 +10,10 @@ import {
   ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import type { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -23,10 +25,23 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         ? runContext.conversation.id
         : null;
 
+      // Best-effort link to the pod the recommendation was made in: the
+      // activation conversation's space is the pod itself.
+      const podSpaceId = isAgentLoopRunContext(runContext)
+        ? runContext.conversation.spaceId
+        : null;
+      const pod = podSpaceId
+        ? await SpaceResource.fetchById(auth, podSpaceId)
+        : null;
+      const activationPod = pod
+        ? await ActivationPodResource.fetchBySpace(auth, pod)
+        : null;
+
       const rec = await ActivationRecommendationResource.makeNew(auth, {
         title,
         content,
         conversationId,
+        activationPodId: activationPod?.id ?? null,
       });
 
       return new Ok([

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -12,11 +12,13 @@ import {
 } from "@app/lib/api/projects/constants";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
@@ -382,6 +384,19 @@ export const joinActivationPodPlugin = createPlugin({
         )
       );
     }
+
+    // Record the canonical ActivationPod row now that the pod's owner and
+    // trigger are known. Best-effort: existing nudge/recommendation flows
+    // don't depend on it yet, so a lookup miss here shouldn't fail pod setup.
+    const activationTrigger = await TriggerResource.fetchById(
+      podMemberAuth,
+      triggerResult.value.triggerId
+    );
+    await ActivationPodResource.makeNew(auth, {
+      pod,
+      user: creator,
+      trigger: activationTrigger,
+    });
 
     // Fire the activation event so the trigger kicks off the initial conversation
     // as soon as the pod is provisioned.

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -59,12 +60,27 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   ): Promise<ActivationNudgeResource[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    // Best-effort link to the canonical ActivationPod, alongside the
+    // spaceId/triggerId/userId already denormalized below. Not every pod has
+    // one yet, so a lookup miss just leaves activationPodId null.
+    const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+      auth,
+      nudges.map(({ pod }) => pod.id)
+    );
+    const activationPodBySpaceId = new Map(
+      activationPods.map((activationPod) => [
+        activationPod.spaceId,
+        activationPod,
+      ])
+    );
+
     const created = await this.model.bulkCreate(
       nudges.map(({ pod, trigger }) => ({
         workspaceId,
         spaceId: pod.id,
         triggerId: trigger.id,
         userId: trigger.editor,
+        activationPodId: activationPodBySpaceId.get(pod.id)?.id ?? null,
       })),
       { returning: true }
     );

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -1,0 +1,120 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ActivationPodResource
+  extends ReadonlyAttributesType<ActivationPodModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ActivationPodResource extends BaseResource<ActivationPodModel> {
+  static model: ModelStatic<ActivationPodModel> = ActivationPodModel;
+
+  constructor(
+    _: ModelStatic<ActivationPodModel>,
+    blob: Attributes<ActivationPodModel>
+  ) {
+    super(ActivationPodModel, blob);
+  }
+
+  get sId(): string {
+    return ActivationPodResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("activation_pod", { id, workspaceId });
+  }
+
+  // Creates the canonical record for a newly provisioned Activation Pod.
+  static async makeNew(
+    auth: Authenticator,
+    {
+      pod,
+      user,
+      trigger,
+    }: {
+      pod: SpaceResource;
+      user: UserResource;
+      trigger?: TriggerResource | null;
+    }
+  ): Promise<ActivationPodResource> {
+    const model = await this.model.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: pod.id,
+      userId: user.id,
+      triggerId: trigger?.id ?? null,
+    });
+
+    return new this(this.model, model.get());
+  }
+
+  // Fetches the ActivationPod for a given Pod, if one exists.
+  static async fetchBySpace(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<ActivationPodResource | null> {
+    const [activationPod] = await this.fetchBySpaceModelIds(auth, [pod.id]);
+    return activationPod ?? null;
+  }
+
+  // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
+  // scheduler processes many pods at once).
+  static async fetchBySpaceModelIds(
+    auth: Authenticator,
+    spaceModelIds: ModelId[]
+  ): Promise<ActivationPodResource[]> {
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+
+    const activationPods = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: spaceModelIds,
+      },
+    });
+
+    return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
+  // Sets the Pod's activation trigger once it has been provisioned.
+  async setTrigger(trigger: TriggerResource): Promise<void> {
+    await this.update({ triggerId: trigger.id });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+}

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -56,7 +56,13 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     blob: Pick<
       CreationAttributes<ActivationRecommendationModel>,
       "title" | "content" | "conversationId"
-    >
+    > &
+      Partial<
+        Pick<
+          CreationAttributes<ActivationRecommendationModel>,
+          "activationPodId"
+        >
+      >
   ): Promise<ActivationRecommendationResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -68,6 +74,7 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       title: blob.title,
       content: blob.content,
       conversationId: blob.conversationId ?? null,
+      activationPodId: blob.activationPodId ?? null,
     });
 
     return new this(this.model, rec.get());
@@ -152,6 +159,23 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       resource: new this(this.model, rec.get()),
       conversationSId: rec.conversation?.sId ?? null,
     }));
+  }
+
+  // Detaches all recommendations from a Pod being deleted. Recommendations
+  // are owned by the user, not the pod, so they are kept and only unlinked.
+  static async detachActivationPod(
+    auth: Authenticator,
+    activationPodId: ModelId
+  ): Promise<void> {
+    await this.model.update(
+      { activationPodId: null },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          activationPodId,
+        },
+      }
+    );
   }
 
   async updateFields(fields: {

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -111,6 +111,9 @@ export const RESOURCES_PREFIX = {
 
   // Activation nudges.
   activation_nudge: "anu",
+
+  // Activation pods.
+  activation_pod: "apo",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/scripts/backfill_activation_pods.ts
+++ b/front/scripts/backfill_activation_pods.ts
@@ -1,0 +1,226 @@
+import { findActivationTrigger } from "@app/lib/api/activation/trigger";
+import { Authenticator } from "@app/lib/auth";
+import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
+import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
+import { Op } from "sequelize";
+
+// Backfills ActivationPod rows for Activation Pods created before ActivationPodResource
+// existed (see #29309, #29313), then backfills `activationPodId` on `activation_nudges` and
+// `activation_recommendations` rows created before the link existed.
+makeScript({}, async ({ execute }, logger) => {
+  const activationPodMetadata = await ProjectMetadataModel.findAll({
+    where: { provisioningSource: "activation", archivedAt: null },
+    // @ts-expect-error.
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  const existingActivationPods = await ActivationPodModel.findAll({
+    // @ts-expect-error.
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+  const spaceIdsWithActivationPod = new Set(
+    existingActivationPods.map((row) => row.spaceId)
+  );
+
+  const metadataToBackfill = activationPodMetadata.filter(
+    (row) => !spaceIdsWithActivationPod.has(row.spaceId)
+  );
+
+  const metadataByWorkspaceId = new Map<ModelId, typeof metadataToBackfill>();
+  for (const row of metadataToBackfill) {
+    const rows = metadataByWorkspaceId.get(row.workspaceId) ?? [];
+    rows.push(row);
+    metadataByWorkspaceId.set(row.workspaceId, rows);
+  }
+
+  let podsCreated = 0;
+  let podsSkipped = 0;
+
+  for (const [workspaceId, rows] of metadataByWorkspaceId) {
+    const workspace = await WorkspaceResource.fetchByModelId(workspaceId);
+    if (!workspace) {
+      logger.warn({ workspaceId }, "Workspace not found, skipping.");
+      podsSkipped += rows.length;
+      continue;
+    }
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+      dangerouslyRequestAllGroups: true,
+    });
+
+    const pods = await SpaceResource.fetchByModelIds(
+      auth,
+      rows.map((row) => row.spaceId)
+    );
+    const podBySpaceId = new Map(pods.map((pod) => [pod.id, pod]));
+
+    // Resolve every pod's trigger first so we can batch-fetch the editors' UserResources
+    // rather than fetching one user at a time.
+    const podsWithTrigger: { pod: SpaceResource; trigger: TriggerResource }[] =
+      [];
+    for (const row of rows) {
+      const pod = podBySpaceId.get(row.spaceId);
+      if (!pod) {
+        logger.warn(
+          { workspaceId, spaceId: row.spaceId },
+          "Pod space not found, skipping."
+        );
+        podsSkipped++;
+        continue;
+      }
+
+      const trigger = await findActivationTrigger(auth, pod);
+      if (!trigger) {
+        logger.warn(
+          { workspaceId, spaceId: row.spaceId },
+          "No activation trigger found for pod, skipping."
+        );
+        podsSkipped++;
+        continue;
+      }
+
+      podsWithTrigger.push({ pod, trigger });
+    }
+
+    const editorModelIds = [
+      ...new Set(podsWithTrigger.map(({ trigger }) => trigger.editor)),
+    ];
+    const editors = await UserResource.fetchByModelIds(editorModelIds);
+    const editorByModelId = new Map(editors.map((user) => [user.id, user]));
+
+    for (const { pod, trigger } of podsWithTrigger) {
+      const user = editorByModelId.get(trigger.editor);
+      if (!user) {
+        logger.warn(
+          { workspaceId, spaceId: pod.sId, editorModelId: trigger.editor },
+          "Trigger editor user not found, skipping."
+        );
+        podsSkipped++;
+        continue;
+      }
+
+      logger.info(
+        {
+          workspaceId,
+          spaceId: pod.sId,
+          userId: user.sId,
+          triggerId: trigger.sId,
+        },
+        execute ? "Creating ActivationPod." : "Would create ActivationPod."
+      );
+
+      if (execute) {
+        await ActivationPodResource.makeNew(auth, { pod, user, trigger });
+      }
+      podsCreated++;
+    }
+  }
+
+  logger.info({ podsCreated, podsSkipped }, "ActivationPod backfill complete.");
+
+  // Re-fetch so newly created rows (in --execute mode) are included below.
+  const allActivationPods = await ActivationPodModel.findAll({
+    // @ts-expect-error.
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+  const activationPodIdBySpaceId = new Map(
+    allActivationPods.map((row) => [row.spaceId, row.id])
+  );
+
+  const nudgesToBackfill = await ActivationNudgeModel.findAll({
+    where: { activationPodId: null },
+    // @ts-expect-error.
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  let nudgesUpdated = 0;
+  let nudgesSkipped = 0;
+  for (const nudge of nudgesToBackfill) {
+    const activationPodId = activationPodIdBySpaceId.get(nudge.spaceId);
+    if (!activationPodId) {
+      nudgesSkipped++;
+      continue;
+    }
+    if (execute) {
+      await nudge.update({ activationPodId });
+    }
+    nudgesUpdated++;
+  }
+  logger.info(
+    { nudgesUpdated, nudgesSkipped, total: nudgesToBackfill.length },
+    "activation_nudges backfill complete."
+  );
+
+  // Recommendations don't carry a spaceId directly; derive it from their conversation.
+  const recommendationsToBackfill = await ActivationRecommendationModel.findAll(
+    {
+      where: { activationPodId: null, conversationId: { [Op.ne]: null } },
+      // @ts-expect-error.
+      // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    }
+  );
+
+  const conversationIds = [
+    ...new Set(
+      removeNulls(recommendationsToBackfill.map((rec) => rec.conversationId))
+    ),
+  ];
+  const conversations = await ConversationModel.findAll({
+    where: { id: conversationIds },
+    // @ts-expect-error.
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+  const spaceIdByConversationId = new Map(
+    conversations.map((conversation) => [conversation.id, conversation.spaceId])
+  );
+
+  let recommendationsUpdated = 0;
+  let recommendationsSkipped = 0;
+  for (const rec of recommendationsToBackfill) {
+    const spaceId = rec.conversationId
+      ? spaceIdByConversationId.get(rec.conversationId)
+      : null;
+    const activationPodId = spaceId
+      ? activationPodIdBySpaceId.get(spaceId)
+      : null;
+    if (!activationPodId) {
+      recommendationsSkipped++;
+      continue;
+    }
+    if (execute) {
+      await rec.update({ activationPodId });
+    }
+    recommendationsUpdated++;
+  }
+  logger.info(
+    {
+      recommendationsUpdated,
+      recommendationsSkipped,
+      total: recommendationsToBackfill.length,
+    },
+    "activation_recommendations backfill complete."
+  );
+});


### PR DESCRIPTION
## Description

Stacked on #29313. Adds `scripts/backfill_activation_pods.ts` to backfill data that predates
`ActivationPodResource`:

- Creates `ActivationPod` rows for existing Activation Pods, resolving the owner and trigger via
  the existing `findActivationTrigger` join (the same lookup `isEligibleForNudge` uses today).
- Backfills `activationPodId` on `activation_nudges` rows (matched by `spaceId`).
- Backfills `activationPodId` on `activation_recommendations` rows (matched via their
  conversation's `spaceId`, since recommendations don't carry a `spaceId` directly).

Dry-run by default, `--execute` to apply.

## Tests

Ran locally in both dry-run and `--execute` mode against a pod created before this backfill
existed: it correctly created the missing `ActivationPod` row and backfilled the existing nudge's
`activationPodId`. Re-running with `--execute` afterwards was a no-op, confirming idempotency.
