### PR TITLE
[Activation] Migrate reads off ProjectMetadata flag and trigger join

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/activation/nudge";
 import { ACTIVATION_WEBHOOK_SOURCE_NAME } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -25,11 +26,11 @@ import { describe, expect, it } from "vitest";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// Wires a trigger the same way `createActivationTrigger` does in production:
-// on the pod's own view of the shared Activation webhook source. This is
-// required for `isEligibleForNudge` to find it via `findActivationTrigger`,
-// which pinpoints the trigger by `webhookSourceViewId` rather than just
-// `kind === "webhook"` (a pod's space can hold other webhook triggers).
+// Wires a trigger the same way `createActivationTrigger` does in production
+// (on the pod's own view of the shared Activation webhook source), plus the
+// ActivationPod row `join_activation_pod.ts` creates alongside it. This is
+// required for `isEligibleForNudge`, which resolves the pod's trigger via
+// `ActivationPodResource` rather than the source/view/trigger join.
 async function createPodActivationTrigger(
   auth: Authenticator,
   pod: SpaceResource,
@@ -43,12 +44,20 @@ async function createPodActivationTrigger(
     webhookSourceId: source.sId,
   });
 
-  return TriggerFactory.webhook(auth, {
+  const trigger = await TriggerFactory.webhook(auth, {
     agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
     status: options.status ?? "enabled",
     spaceId: pod.id,
     webhookSourceViewId: podView.id,
   });
+
+  await ActivationPodResource.makeNew(auth, {
+    pod,
+    user: auth.getNonNullableUser(),
+    trigger,
+  });
+
+  return trigger;
 }
 
 describe("getActivationNudgeFrequencyCapDays", () => {

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -1,10 +1,10 @@
-import { findActivationTrigger } from "@app/lib/api/activation/trigger";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
@@ -45,13 +45,13 @@ export function getActivationNudgeMaxUnansweredCount(
 // count stops at the first answered nudge, so a reply resets the streak.
 async function countUnansweredNudgeStreak(
   auth: Authenticator,
-  pod: SpaceResource,
+  activationPod: ActivationPodResource,
   { limit }: { limit: number }
 ): Promise<number> {
-  const recentNudges = await ActivationNudgeResource.listRecentForSpace(auth, {
-    pod,
-    limit,
-  });
+  const recentNudges = await ActivationNudgeResource.listRecentForActivationPod(
+    auth,
+    { activationPod, limit }
+  );
   if (recentNudges.length === 0) {
     return 0;
   }
@@ -119,7 +119,14 @@ export async function isEligibleForNudge(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<boolean> {
-  const trigger = await findActivationTrigger(auth, pod);
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  if (!activationPod || activationPod.triggerId === null) {
+    return false;
+  }
+
+  const [trigger] = await TriggerResource.fetchByModelIds(auth, [
+    activationPod.triggerId,
+  ]);
   if (!trigger || trigger.status !== "enabled") {
     return false;
   }
@@ -128,9 +135,10 @@ export async function isEligibleForNudge(
     return false;
   }
 
-  const latestNudge = await ActivationNudgeResource.fetchLatestForSpace(auth, {
-    pod,
-  });
+  const latestNudge = await ActivationNudgeResource.fetchLatestForActivationPod(
+    auth,
+    { activationPod }
+  );
   if (!latestNudge) {
     return true;
   }
@@ -143,9 +151,13 @@ export async function isEligibleForNudge(
   }
 
   const maxUnansweredCount = getActivationNudgeMaxUnansweredCount(auth);
-  const unansweredStreak = await countUnansweredNudgeStreak(auth, pod, {
-    limit: maxUnansweredCount,
-  });
+  const unansweredStreak = await countUnansweredNudgeStreak(
+    auth,
+    activationPod,
+    {
+      limit: maxUnansweredCount,
+    }
+  );
 
   return unansweredStreak < maxUnansweredCount;
 }

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,7 +1,7 @@
 import { evaluateActivation } from "@app/lib/api/activation/evaluator";
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -33,7 +33,7 @@ export async function determineEligibleActivationUsers(
 ): Promise<Result<OrchestratorResult, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
-  const pods = await ProjectMetadataResource.fetchActivationPods(auth);
+  const pods = await ActivationPodResource.listForWorkspace(auth);
 
   const spaces = await SpaceResource.fetchByModelIds(
     auth,

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -46,22 +46,6 @@ function activationPodNameForCreator(
   return `${label}${ACTIVATION_POD_NAME_PREFIX}`;
 }
 
-async function markPodAsActivation(
-  auth: Authenticator,
-  pod: SpaceResource
-): Promise<Result<void, Error>> {
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-  if (!metadata) {
-    return new Err(
-      new Error("Project metadata not found for the newly created pod.")
-    );
-  }
-
-  await metadata.updateProvisioningSource("activation");
-
-  return new Ok(undefined);
-}
-
 async function setPodDefaultSkills(
   auth: Authenticator,
   pod: SpaceResource,
@@ -328,11 +312,6 @@ export const joinActivationPodPlugin = createPlugin({
       }
     }
 
-    const activationResult = await markPodAsActivation(auth, pod);
-    if (activationResult.isErr()) {
-      return activationResult;
-    }
-
     // Star the pod for every member so it surfaces in their sidebar.
     await UserProjectPreferencesResource.setStarredForUsers(auth, {
       spaceModelId: pod.id,
@@ -386,8 +365,9 @@ export const joinActivationPodPlugin = createPlugin({
     }
 
     // Record the canonical ActivationPod row now that the pod's owner and
-    // trigger are known. Best-effort: existing nudge/recommendation flows
-    // don't depend on it yet, so a lookup miss here shouldn't fail pod setup.
+    // trigger are known. This is the record `isEligibleForNudge` and the
+    // activation scheduler use to find the pod and its trigger, so it must
+    // be created for the pod to ever be nudged.
     const activationTrigger = await TriggerResource.fetchById(
       podMemberAuth,
       triggerResult.value.triggerId

--- a/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
+++ b/front/lib/api/poke/plugins/spaces/send_activation_nudge.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/activation/trigger";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -33,8 +33,8 @@ async function isActivationPod(
     return false;
   }
 
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-  return metadata?.provisioningSource === "activation";
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  return activationPod !== null;
 }
 
 export const sendActivationNudgePlugin = createPlugin({

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -89,23 +89,29 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   }
 
   // Fetches the most recent nudge recorded for a pod, if any.
-  static async fetchLatestForSpace(
+  static async fetchLatestForActivationPod(
     auth: Authenticator,
-    { pod }: { pod: SpaceResource }
+    { activationPod }: { activationPod: ActivationPodResource }
   ): Promise<ActivationNudgeResource | null> {
-    const [latest] = await this.listRecentForSpace(auth, { pod, limit: 1 });
+    const [latest] = await this.listRecentForActivationPod(auth, {
+      activationPod,
+      limit: 1,
+    });
     return latest ?? null;
   }
 
   // Fetches the `limit` most recent nudges recorded for a pod, newest first.
-  static async listRecentForSpace(
+  static async listRecentForActivationPod(
     auth: Authenticator,
-    { pod, limit }: { pod: SpaceResource; limit: number }
+    {
+      activationPod,
+      limit,
+    }: { activationPod: ActivationPodResource; limit: number }
   ): Promise<ActivationNudgeResource[]> {
     const nudges = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        spaceId: pod.id,
+        activationPodId: activationPod.id,
       },
       order: [["createdAt", "DESC"]],
       limit,

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -95,6 +95,17 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPods.map((pod) => new this(this.model, pod.get()));
   }
 
+  // Lists every ActivationPod in the calling workspace.
+  static async listForWorkspace(
+    auth: Authenticator
+  ): Promise<ActivationPodResource[]> {
+    const activationPods = await this.model.findAll({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+    });
+
+    return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
   // Sets the Pod's activation trigger once it has been provisioned.
   async setTrigger(trigger: TriggerResource): Promise<void> {
     await this.update({ triggerId: trigger.id });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -2,10 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  ProjectMetadataModel,
-  type ProvisioningSource,
-} from "@app/lib/resources/storage/models/project_metadata";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { PodMetadataType } from "@app/types/project_metadata";
@@ -106,22 +103,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       where: {
         spaceId: spaceModelIds,
         workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-
-    return models.map((model) =>
-      ProjectMetadataResource.fromModel(model, model.spaceId)
-    );
-  }
-
-  static async fetchActivationPods(
-    auth: Authenticator
-  ): Promise<ProjectMetadataResource[]> {
-    const models = await ProjectMetadataModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        provisioningSource: "activation" satisfies ProvisioningSource,
-        archivedAt: null,
       },
     });
 
@@ -240,13 +221,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     transaction?: Transaction
   ) {
     await this.update({ defaultAgentId }, transaction);
-  }
-
-  async updateProvisioningSource(
-    provisioningSource: ProvisioningSource | null,
-    transaction?: Transaction
-  ) {
-    await this.update({ provisioningSource }, transaction);
   }
 
   async setDefaultSkills(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -159,6 +159,15 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return res.length > 0 ? res[0] : null;
   }
 
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[]
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: { id: ids },
+    });
+  }
+
   static listByAgentConfigurationId(
     auth: Authenticator,
     agentConfigurationId: string


### PR DESCRIPTION
## Description

Stacked on #29316, which backfills `ActivationPod` for existing pods. This PR switches all
remaining application code off the two mechanisms `ActivationPod` replaces:

- `join_activation_pod.ts` no longer sets `ProjectMetadata.provisioningSource = "activation"`
  (`markPodAsActivation` removed) — the `ActivationPod` row created right after the trigger is
  provisioned is now the sole marker.
- `send_activation_nudge.ts`'s `isActivationPod` checks for an `ActivationPod` row instead of the
  `provisioningSource` flag.
- `orchestrator.ts`'s `determineEligibleActivationUsers` lists pods via
  `ActivationPodResource.listForWorkspace` instead of `ProjectMetadataResource.fetchActivationPods`
  (now removed, along with the now-unused `updateProvisioningSource`).
- `nudge.ts`'s `isEligibleForNudge` resolves a pod's trigger via `ActivationPodResource` +
  `TriggerResource.fetchByModelIds` instead of `findActivationTrigger`'s
  webhook-source/view/trigger join.
- `ActivationNudgeResource.fetchLatestForSpace`/`listRecentForSpace` are renamed to
  `fetchLatestForActivationPod`/`listRecentForActivationPod` and now query by `activationPodId`
  instead of `spaceId`.

Left untouched on purpose: `ProjectMetadata.provisioningSource` and `findActivationTrigger` itself,
since `scripts/backfill_activation_pods.ts` still needs both to bridge pods that predate
`ActivationPod`. The denormalized `spaceId`/`triggerId`/`userId` columns on `activation_nudges` are
also untouched (still required NOT NULL) — dropping them is a separate schema migration.

## Tests

Updated `nudge.test.ts`'s `createPodActivationTrigger` fixture to also create the `ActivationPod`
row the new code path depends on. Ran the full activation-related suites
(`nudge.test.ts`, `activation_recommendation_resource.test.ts`, `project_metadata_resource.test.ts`)
— all 35 tests pass.
