### PR TITLE
[front] Remove "builders" global agent audience

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
@@ -23,18 +23,6 @@ describe("canRoleSeeAudience", () => {
     }
   });
 
-  it("makes 'builders' visible to builders and admins, not users", async () => {
-    expect(canRoleSeeAudience("builders", await authForRole("admin"))).toBe(
-      true
-    );
-    expect(canRoleSeeAudience("builders", await authForRole("builder"))).toBe(
-      true
-    );
-    expect(canRoleSeeAudience("builders", await authForRole("user"))).toBe(
-      false
-    );
-  });
-
   it("makes 'admins' visible to admins only", async () => {
     expect(canRoleSeeAudience("admins", await authForRole("admin"))).toBe(true);
     expect(canRoleSeeAudience("admins", await authForRole("builder"))).toBe(

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -33,11 +33,7 @@ import {
 } from "@app/types/assistant/models/openai";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-export const GLOBAL_AGENT_AUDIENCES = [
-  "everyone",
-  "builders",
-  "admins",
-] as const;
+export const GLOBAL_AGENT_AUDIENCES = ["everyone", "admins"] as const;
 export type GlobalAgentAudience = (typeof GLOBAL_AGENT_AUDIENCES)[number];
 
 type AgentMetadata = {
@@ -55,8 +51,6 @@ export function canRoleSeeAudience(
   switch (audience) {
     case "everyone":
       return true;
-    case "builders":
-      return auth.isBuilder();
     case "admins":
       return auth.isAdmin();
     default:


### PR DESCRIPTION
Fixes dust-tt/tasks#9751

## Description

Removes the unused `"builders"` audience from the global agent metadata (`GLOBAL_AGENT_AUDIENCES` / `canRoleSeeAudience`). No global agent actually used it — only `"everyone"` and `"admins"` remain. This also drops the last `auth.isBuilder()` call in this file, as part of the broader `isBuilder` removal.

## Tests

Updated the existing `canRoleSeeAudience` test to drop the obsolete `"builders"` case; verified with `tsgo --noEmit`.

## Risk

Minimal — the removed audience value was unused, and the `assertNever` exhaustiveness check guarantees no branch is left unhandled. Safe to roll back.

## Deploy Plan

Standard deploy; no migration or coordination required.