### PR TITLE
[front-api] Gate Slack channel agent endpoints on agent:publish

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -5,7 +5,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -29,12 +28,21 @@ const app = workspaceApp();
 app.patch(
   "/",
   validate("param", ParamsSchema),
-  ensureIsBuilder(),
   validate("json", PatchLinkedSlackChannelsRequestBodySchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
+
+    if (!(await auth.hasWorkspacePermission("publish", "agent"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only users who can publish agents can perform this action.",
+        },
+      });
+    }
 
     if (body.auto_respond_without_mention) {
       const featureFlags = await getFeatureFlags(auth);

--- a/front-api/routes/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
@@ -4,7 +4,6 @@ import logger from "@app/logger/logger";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -14,9 +13,18 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsBuilder(),
   async (ctx): HandlerResult<GetSlackChannelsLinkedWithAgentResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("publish", "agent"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only users who can publish agents can perform this action.",
+        },
+      });
+    }
 
     const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
       DataSourceResource.listByConnectorProvider(auth, "slack"),

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -53,6 +53,7 @@ import { useEditors, useUpdateEditors } from "@app/lib/swr/agent_editors";
 import { useAgentTriggers } from "@app/lib/swr/agent_triggers";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
 import { useModels } from "@app/lib/swr/models";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -64,7 +65,6 @@ import type { TemplateInfo } from "@app/types/assistant/templates";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
-import { isBuilder } from "@app/types/user";
 import {
   ContentMessage,
   ContentMessageAction,
@@ -239,14 +239,17 @@ function AgentBuilderForm({
     agentConfigurationId: agentConfiguration?.sId ?? null,
   });
 
+  const { hasPermission } = useWorkspacePermissions(owner);
+  const canPublishAgent = hasPermission("publish", "agent");
+
   const { slackChannels: slackChannelsLinkedWithAgent } =
     useSlackChannelsLinkedWithAgent({
       workspaceId: owner.sId,
-      disabled: !agentConfiguration || !isBuilder(owner),
+      disabled: !agentConfiguration || !canPublishAgent,
     });
 
   const slackProvider = useMemo(() => {
-    if (!isBuilder(owner)) {
+    if (!canPublishAgent) {
       return null;
     }
 
@@ -261,7 +264,7 @@ function AgentBuilderForm({
       (dsv) => dsv.dataSource.connectorProvider === "slack"
     );
     return slackProvider ? "slack" : null;
-  }, [supportedDataSourceViews, owner]);
+  }, [supportedDataSourceViews, canPublishAgent]);
 
   const processedActions = useMemo(() => {
     return processActionsFromStorage(actions ?? emptyArray());

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -7,7 +7,7 @@ import { ManageUsersPanel } from "@app/components/assistant/conversation/space/M
 import { BecomeEditorButton } from "@app/components/shared/BecomeEditorButton";
 import { getPublishingRestrictionForOwner } from "@app/lib/api/assistant/publishing_restrictions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isBuilder } from "@app/types/user";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   Button,
   DropdownMenu,
@@ -59,6 +59,8 @@ export function AccessSection({
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { owner } = useAgentBuilderContext();
   const { featureFlags } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions(owner);
+  const canPublishAgent = hasPermission("publish", "agent");
 
   const {
     disabled: publishingToggleDisabled,
@@ -138,7 +140,7 @@ export function AccessSection({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {scope.value === "visible" && slackDataSource && isBuilder(owner) && (
+        {scope.value === "visible" && slackDataSource && canPublishAgent && (
           <>
             <Button
               variant="outline"


### PR DESCRIPTION
## Description

Part of the `isBuilder` removal effort (#9749). Moves the "link/list Slack channels for an agent" feature off the `isBuilder` role and onto the `agent:publish` workspace permission. Backend: the two `front-api` endpoints (PATCH linking channels, GET listing linked channels) now check `auth.hasWorkspacePermission("publish", "agent")` inline instead of the `ensureIsBuilder()` middleware, returning a 403 `workspace_auth_error` on failure. Frontend: `AgentBuilder.tsx` and `AccessSection.tsx` now gate the Slack channel fetch and the "Slack preferences" UI on the `agent:publish` permission (via `useWorkspacePermissions`) instead of `isBuilder(owner)`.

## Tests

`front-typecheck` and `front-api` typecheck/lint pass (pre-commit). No behavioral tests added; the change swaps one authorization gate for an equivalent capability check on both the API and the UI that drives it.

## Risk

Low. Authorization moves from the `isBuilder` role to the `agent:publish` capability, which is the intended set of users who manage published agents. Safe to roll back by reverting the commits.

## Deploy Plan

Standard `front` + `front-api` deploy, no migration or ordering constraints.
