### PR TITLE
[front] enh: make enable/disable of global agents admin-only

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -1,6 +1,6 @@
 import { updateAgentConfigurationsScope } from "@app/lib/api/assistant/configuration/agent";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -16,7 +16,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsBuilder(),
+  ensureIsAdmin(),
   validate("json", BatchUpdateAgentScopeRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -1,6 +1,6 @@
 import { upsertGlobalAgentSettings } from "@app/lib/api/assistant/global_agents/global_agents";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -25,7 +25,7 @@ const app = workspaceApp();
 app.patch(
   "/",
   validate("param", ParamsSchema),
-  ensureIsBuilder(),
+  ensureIsAdmin(),
   validate("json", PatchGlobalAgentSettingsRequestBodySchema),
   async (ctx): HandlerResult<PatchGlobalAgentSettingResponseBody> => {
     const auth = ctx.get("auth");

--- a/front/components/assistant/manager/GlobalAgentAction.tsx
+++ b/front/components/assistant/manager/GlobalAgentAction.tsx
@@ -2,7 +2,7 @@ import { useAppRouter } from "@app/lib/platform";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   Dialog,
   DialogContainer,
@@ -44,7 +44,7 @@ export function GlobalAgentAction({
           }}
           selected={agent.status === "active"}
           disabled={
-            !isBuilder(owner) || agent.status === "disabled_missing_datasource"
+            !isAdmin(owner) || agent.status === "disabled_missing_datasource"
           }
         />
         <div className="whitespace-normal" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Description

Restrict enabling/disabling of global agents to workspace admins (previously builders), as part of the `isBuilder` removal effort. The `PATCH global_agents/:aId` and `POST agent_configurations/batch_update_scope` front-api routes now use `ensureIsAdmin()`, and the `GlobalAgentAction` toggle is disabled for non-admins to match. Fixes dust-tt/tasks#9748.

## Tests

Manually verified type-checking (`tsgo`) and formatting pass for both `front` and `front-api`; no behavior beyond the role gate changed.

## Risk

Low. Narrows an existing permission from builder to admin on two internal endpoints and one UI toggle; safe to roll back by reverting the commit.

## Deploy Plan

Standard deploy, no migrations or ordering constraints.