### PR TITLE
[Activation] Drop old activation_nudges columns

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -51,13 +51,13 @@ async function createPodActivationTrigger(
     webhookSourceViewId: podView.id,
   });
 
-  await ActivationPodResource.makeNew(auth, {
+  const activationPod = await ActivationPodResource.makeNew(auth, {
     pod,
     user: auth.getNonNullableUser(),
     trigger,
   });
 
-  return trigger;
+  return { trigger, activationPod };
 }
 
 describe("getActivationNudgeFrequencyCapDays", () => {
@@ -114,14 +114,11 @@ describe("isEligibleForNudge", () => {
     const { authenticator, globalSpace } = await createResourceTest({
       role: "admin",
     });
-    const trigger = await createPodActivationTrigger(
+    const { activationPod } = await createPodActivationTrigger(
       authenticator,
       globalSpace
     );
-    await ActivationNudgeFactory.create(authenticator, {
-      pod: globalSpace,
-      trigger,
-    });
+    await ActivationNudgeFactory.create(authenticator, { activationPod });
 
     expect(await isEligibleForNudge(authenticator, globalSpace)).toBe(false);
   });
@@ -137,20 +134,18 @@ describe("isEligibleForNudge", () => {
       user.sId,
       workspace.sId
     );
-    const trigger = await createPodActivationTrigger(
+    const { activationPod } = await createPodActivationTrigger(
       refreshedAuth,
       globalSpace
     );
 
     // Two nudges, both outside the frequency cap window, with no reply.
     await ActivationNudgeFactory.create(refreshedAuth, {
-      pod: globalSpace,
-      trigger,
+      activationPod,
       createdAt: new Date(Date.now() - 10 * DAY_MS),
     });
     await ActivationNudgeFactory.create(refreshedAuth, {
-      pod: globalSpace,
-      trigger,
+      activationPod,
       createdAt: new Date(Date.now() - 5 * DAY_MS),
     });
 
@@ -168,19 +163,17 @@ describe("isEligibleForNudge", () => {
       user.sId,
       workspace.sId
     );
-    const trigger = await createPodActivationTrigger(
+    const { trigger, activationPod } = await createPodActivationTrigger(
       refreshedAuth,
       globalSpace
     );
 
     await ActivationNudgeFactory.create(refreshedAuth, {
-      pod: globalSpace,
-      trigger,
+      activationPod,
       createdAt: new Date(Date.now() - 10 * DAY_MS),
     });
     await ActivationNudgeFactory.create(refreshedAuth, {
-      pod: globalSpace,
-      trigger,
+      activationPod,
       createdAt: new Date(Date.now() - 5 * DAY_MS),
     });
 

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
 } from "@app/temporal/activation_scheduler/config";
 import isNumber from "lodash/isNumber";
-import uniq from "lodash/uniq";
 
 export function getActivationNudgeFrequencyCapDays(
   auth: Authenticator
@@ -46,6 +45,7 @@ export function getActivationNudgeMaxUnansweredCount(
 async function countUnansweredNudgeStreak(
   auth: Authenticator,
   activationPod: ActivationPodResource,
+  trigger: TriggerResource,
   { limit }: { limit: number }
 ): Promise<number> {
   const recentNudges = await ActivationNudgeResource.listRecentForActivationPod(
@@ -57,11 +57,10 @@ async function countUnansweredNudgeStreak(
   }
 
   const oldestNudge = recentNudges[recentNudges.length - 1];
-  const triggerIds = uniq(recentNudges.map((nudge) => nudge.triggerId));
   const replyTimestamps =
     await ConversationResource.listUserMessageTimestampsForTriggers(auth, {
-      triggerIds,
-      userId: oldestNudge.userId,
+      triggerIds: [trigger.id],
+      userId: activationPod.userId,
       since: oldestNudge.createdAt,
     });
 
@@ -154,9 +153,8 @@ export async function isEligibleForNudge(
   const unansweredStreak = await countUnansweredNudgeStreak(
     auth,
     activationPod,
-    {
-      limit: maxUnansweredCount,
-    }
+    trigger,
+    { limit: maxUnansweredCount }
   );
 
   return unansweredStreak < maxUnansweredCount;

--- a/front/lib/models/activation/activation_nudge.ts
+++ b/front/lib/models/activation/activation_nudge.ts
@@ -1,9 +1,6 @@
 import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
-import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
-import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
@@ -13,15 +10,7 @@ export class ActivationNudgeModel extends WorkspaceAwareModel<ActivationNudgeMod
   declare updatedAt: CreationOptional<Date>;
 
   // The Pod that was nudged.
-  declare spaceId: ForeignKey<SpaceModel["id"]>;
-  // The trigger that fired the nudge.
-  declare triggerId: ForeignKey<TriggerModel["id"]>;
-  // The user targeted by the nudge.
-  declare userId: ForeignKey<UserModel["id"]>;
-
-  // The Pod that was nudged, via ActivationPod. Nullable until backfilled;
-  // will replace spaceId/triggerId/userId above once migrated.
-  declare activationPodId: ForeignKey<ActivationPodModel["id"]> | null;
+  declare activationPodId: ForeignKey<ActivationPodModel["id"]>;
 }
 
 ActivationNudgeModel.init(
@@ -40,43 +29,14 @@ ActivationNudgeModel.init(
   {
     modelName: "activation_nudge",
     sequelize: frontSequelize,
-    indexes: [
-      { fields: ["spaceId"], concurrently: true },
-      { fields: ["triggerId"], concurrently: true },
-      { fields: ["userId"], concurrently: true },
-      { fields: ["activationPodId"], concurrently: true },
-    ],
+    indexes: [{ fields: ["activationPodId"], concurrently: true }],
   }
 );
 
-ActivationNudgeModel.belongsTo(SpaceModel, {
-  foreignKey: { name: "spaceId", allowNull: false },
-  onDelete: "RESTRICT",
-});
-SpaceModel.hasMany(ActivationNudgeModel, {
-  foreignKey: { name: "spaceId", allowNull: false },
-});
-
-ActivationNudgeModel.belongsTo(TriggerModel, {
-  foreignKey: { name: "triggerId", allowNull: false },
-  onDelete: "RESTRICT",
-});
-TriggerModel.hasMany(ActivationNudgeModel, {
-  foreignKey: { name: "triggerId", allowNull: false },
-});
-
-ActivationNudgeModel.belongsTo(UserModel, {
-  foreignKey: { name: "userId", allowNull: false },
-  onDelete: "RESTRICT",
-});
-UserModel.hasMany(ActivationNudgeModel, {
-  foreignKey: { name: "userId", allowNull: false },
-});
-
 ActivationNudgeModel.belongsTo(ActivationPodModel, {
-  foreignKey: { name: "activationPodId", allowNull: true },
+  foreignKey: { name: "activationPodId", allowNull: false },
   onDelete: "RESTRICT",
 });
 ActivationPodModel.hasMany(ActivationNudgeModel, {
-  foreignKey: { name: "activationPodId", allowNull: true },
+  foreignKey: { name: "activationPodId", allowNull: false },
 });

--- a/front/lib/resources/activation_nudge_resource.ts
+++ b/front/lib/resources/activation_nudge_resource.ts
@@ -1,11 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
-import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
-import type { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -46,9 +44,9 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   // Records that the pod's activation trigger fired.
   static async makeNew(
     auth: Authenticator,
-    { pod, trigger }: { pod: SpaceResource; trigger: TriggerResource }
+    { activationPod }: { activationPod: ActivationPodResource }
   ): Promise<ActivationNudgeResource> {
-    const [nudge] = await this.bulkCreate(auth, [{ pod, trigger }]);
+    const [nudge] = await this.bulkCreate(auth, [{ activationPod }]);
     return nudge;
   }
 
@@ -56,31 +54,14 @@ export class ActivationNudgeResource extends BaseResource<ActivationNudgeModel> 
   // insert (avoids one query per pod when the scheduler processes many pods).
   static async bulkCreate(
     auth: Authenticator,
-    nudges: { pod: SpaceResource; trigger: TriggerResource }[]
+    nudges: { activationPod: ActivationPodResource }[]
   ): Promise<ActivationNudgeResource[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Best-effort link to the canonical ActivationPod, alongside the
-    // spaceId/triggerId/userId already denormalized below. Not every pod has
-    // one yet, so a lookup miss just leaves activationPodId null.
-    const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
-      auth,
-      nudges.map(({ pod }) => pod.id)
-    );
-    const activationPodBySpaceId = new Map(
-      activationPods.map((activationPod) => [
-        activationPod.spaceId,
-        activationPod,
-      ])
-    );
-
     const created = await this.model.bulkCreate(
-      nudges.map(({ pod, trigger }) => ({
+      nudges.map(({ activationPod }) => ({
         workspaceId,
-        spaceId: pod.id,
-        triggerId: trigger.id,
-        userId: trigger.editor,
-        activationPodId: activationPodBySpaceId.get(pod.id)?.id ?? null,
+        activationPodId: activationPod.id,
       })),
       { returning: true }
     );

--- a/front/migrations/post-deploy/20260722163634_drop_activation_nudge_old_columns.sql
+++ b/front/migrations/post-deploy/20260722163634_drop_activation_nudge_old_columns.sql
@@ -1,0 +1,105 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP CONSTRAINT "activation_nudges_spaceId_fkey";
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP CONSTRAINT "activation_nudges_triggerId_fkey";
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP CONSTRAINT "activation_nudges_userId_fkey";
+
+/*
+Statement 3
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."activation_nudges_space_id";
+
+/*
+Statement 4
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."activation_nudges_trigger_id";
+
+/*
+Statement 5
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."activation_nudges_user_id";
+
+/*
+Hand-written: delete nudges that predate ActivationPod (no backfill is run for them) so the
+NOT NULL constraint below can be applied.
+  - DELETES_DATA: Deletes rows with a NULL activationPodId.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+DELETE FROM "public"."activation_nudges" WHERE "activationPodId" IS NULL;
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" ADD CONSTRAINT "activation_nudges_tmp_not_null_check" CHECK("activationPodId" IS NOT NULL) NOT VALID;
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" VALIDATE CONSTRAINT "activation_nudges_tmp_not_null_check";
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" ALTER COLUMN "activationPodId" SET NOT NULL;
+
+/*
+Statement 9
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP COLUMN "spaceId";
+
+/*
+Statement 10
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP COLUMN "triggerId";
+
+/*
+Statement 11
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP COLUMN "userId";
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_nudges" DROP CONSTRAINT "activation_nudges_tmp_not_null_check";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -28,6 +28,8 @@ import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { SubscriptionModel } from "@app/lib/models/plan";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -247,15 +249,30 @@ export async function scrubSpaceActivity({
     await UserProjectPreferencesResource.deleteAllBySpace(auth, space.id);
   }
 
-  // Delete activation nudges sent for this Pod. The FK to spaces is
-  // `onDelete: "RESTRICT"`, so these rows must be removed before the space
-  // can be hard-deleted.
-  await ActivationNudgeModel.destroy({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      spaceId: space.id,
-    },
-  });
+  // Delete the ActivationPod record for this Pod, if any. Its FK to spaces is
+  // `onDelete: "RESTRICT"`, so it (and anything referencing it) must be
+  // removed before the space can be hard-deleted.
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+  if (activationPod) {
+    // Nudges are owned by the pod: delete them outright.
+    await ActivationNudgeModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        activationPodId: activationPod.id,
+      },
+    });
+
+    // Recommendations are the user's, not the pod's: detach rather than delete.
+    await ActivationRecommendationResource.detachActivationPod(
+      auth,
+      activationPod.id
+    );
+
+    const deleteActivationPodResult = await activationPod.delete(auth, {});
+    if (deleteActivationPodResult.isErr()) {
+      throw deleteActivationPodResult.error;
+    }
+  }
 
   // Delete the activation pod record for this space. The FK to spaces is
   // `onDelete: "RESTRICT"`, so this row must be removed before the space

--- a/front/tests/utils/ActivationNudgeFactory.ts
+++ b/front/tests/utils/ActivationNudgeFactory.ts
@@ -1,21 +1,18 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 
 export class ActivationNudgeFactory {
   static async create(
     auth: Authenticator,
     {
-      pod,
-      trigger,
+      activationPod,
       createdAt,
-    }: { pod: SpaceResource; trigger: TriggerResource; createdAt?: Date }
+    }: { activationPod: ActivationPodResource; createdAt?: Date }
   ): Promise<ActivationNudgeResource> {
     const nudge = await ActivationNudgeResource.makeNew(auth, {
-      pod,
-      trigger,
+      activationPod,
     });
 
     if (createdAt) {


### PR DESCRIPTION
## Description

Stacked on #29313. Finishes the `ActivationPod` migration by dropping the columns it replaced on
`activation_nudges`:

- Model: `ActivationNudgeModel` no longer has `spaceId`/`triggerId`/`userId` — `activationPodId` is
  now the sole link, tightened to `NOT NULL`.
- The last remaining reads of the per-nudge `triggerId`/`userId` (in `countUnansweredNudgeStreak`,
  used to look up replies) now use the already-resolved `trigger` and `activationPod.userId` from
  the caller instead, since a nudge's target user and trigger are properties of its pod, not the
  nudge itself.
- `ActivationNudgeResource`/`ActivationNudgeFactory` simplified to take an `ActivationPodResource`
  directly instead of `{pod, trigger}` — no lookup-by-space needed at write time anymore.
- `poke/temporal/activities.ts` (space hard-delete): previously deleted nudges by `spaceId`
  directly to satisfy a `RESTRICT` FK before hard-deleting a space. Now goes through
  `ActivationPod` instead — deletes its nudges, detaches (nulls out) any recommendations, then
  deletes the `ActivationPod` row itself before the space delete proceeds.

Migration: `migrations/post-deploy/20260722163634_drop_activation_nudge_old_columns.sql` — deletes
any `activation_nudges` rows without an `activationPodId` (pods created before #29313 stopped
denormalizing `spaceId`/`triggerId`/`userId` and started requiring `ActivationPod`), then drops the
three old columns/constraints/indexes and sets `activationPodId` `NOT NULL`. No separate backfill:
this stack does a hard cutover rather than migrating historical data, so any pre-existing nudge
without a pod link is discarded here rather than reconstructed.

## Tests

Ran the full activation test suite (`nudge.test.ts`, `activation_recommendation_resource.test.ts`,
`project_metadata_resource.test.ts`) — all 35 tests pass. Verified the `DELETE ... WHERE
"activationPodId" IS NULL` statement executes cleanly against the local dev DB.
