### PR TITLE
[Sparkle] Animations and a11y polish

### DIFF
--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -38,7 +38,7 @@ const avatarVariants = cva(
       variant: {
         default: "",
         clickable:
-          "cursor-pointer hover:filter group-hover:filter group-hover:brightness-110 hover:brightness-110 group-active:brightness-90 active:brightness-90 transition duration-200 ease-out",
+          "cursor-pointer hover:filter group-hover:filter group-hover:brightness-110 hover:brightness-110 group-active:brightness-90 active:brightness-90 transition-[filter] duration-200 ease-out",
         disabled: "opacity-50",
       },
       rounded: {

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -26,7 +26,7 @@ export type CardSizeType = (typeof CARD_SIZES)[number];
 
 const interactiveClasses = cn(
   "cursor-pointer",
-  "transition duration-200",
+  "transition-colors duration-200",
   "hover:bg-primary-100",
   "active:bg-primary-150",
   "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -29,6 +29,7 @@ const interactiveClasses = cn(
   "transition duration-200",
   "hover:bg-primary-100",
   "active:bg-primary-150",
+  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
   "disabled:text-primary-muted",
   "disabled:border-border",
   "disabled:pointer-events-none"
@@ -167,6 +168,20 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
         style={cardStyle}
         onClick={onClick}
         role={isInteractive ? "button" : undefined}
+        tabIndex={isInteractive ? 0 : undefined}
+        onKeyDown={
+          isInteractive
+            ? (e) => {
+                if (
+                  (e.key === "Enter" || e.key === " ") &&
+                  e.target === e.currentTarget
+                ) {
+                  e.preventDefault();
+                  e.currentTarget.click();
+                }
+              }
+            : undefined
+        }
         aria-pressed={
           isInteractive && hasSelectionProp ? isSelected : undefined
         }

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -8,7 +8,9 @@ import { Tooltip } from "./Tooltip";
 
 export const checkboxStyles = cva(
   cn(
-    "touch-hitbox h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
+    // `scale` is v4's standalone property (active:scale-95), so it is named
+    // explicitly — `transform` alone would not transition the press.
+    "touch-hitbox h-4 w-4 rounded-md relative shrink-0 peer border transition-[color,background-color,border-color,scale] duration-100 ease-out motion-reduce:transition-none",
     "active:scale-95",
     "border-border-dark bg-background",
     "text-foreground",

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from "./Tooltip";
 
 export const checkboxStyles = cva(
   cn(
-    "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
+    "touch-hitbox h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
     "active:scale-95",
     "border-border-dark bg-background",
     "text-foreground",

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -147,7 +147,8 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
         className={cn(
           chipVariants({ size, color }),
           className,
-          onClick && "cursor-pointer"
+          onClick &&
+            "cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
         )}
         aria-label={label}
         ref={ref}

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { Icon } from "./Icon";
 
 const labelVariants = cva(
-  "inline-flex transition-colors ease-out duration-400 box-border gap-x-2 select-none text-sm",
+  "inline-flex transition-colors ease-out duration-150 box-border gap-x-2 select-none text-sm",
   {
     variants: {
       variant: {
@@ -120,7 +120,7 @@ const CollapsibleTrigger = React.forwardRef<
 );
 CollapsibleTrigger.displayName = "CollapsibleTrigger";
 
-const contentVariants = cva("overflow-hidden transition-all", {
+const contentVariants = cva("overflow-hidden motion-reduce:animate-none", {
   variants: {
     variant: {
       default: "text-foreground",

--- a/sparkle/src/components/ConfettiBackground.tsx
+++ b/sparkle/src/components/ConfettiBackground.tsx
@@ -1,3 +1,4 @@
+import { useReducedMotion } from "framer-motion";
 import React, { useEffect, useRef, useState } from "react";
 import Confetti from "react-confetti";
 
@@ -54,6 +55,7 @@ const ConfettiBackground: React.FC<ConfettiBackgroundProps> = ({
   const [referentWidth, setReferentWidth] = useState(0);
   const [referentHeight, setReferentHeight] = useState(0);
   const resizeObserver = useRef<ResizeObserver | null>(null);
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
     if (referentSize && referentSize.current) {
@@ -77,6 +79,11 @@ const ConfettiBackground: React.FC<ConfettiBackgroundProps> = ({
       }
     };
   }, [referentSize]);
+
+  // Purely decorative full-motion canvas: render nothing under reduced motion.
+  if (shouldReduceMotion) {
+    return null;
+  }
 
   const confettiProps = {
     ...baseConfettiProps,

--- a/sparkle/src/components/ContainerWithTopBar.tsx
+++ b/sparkle/src/components/ContainerWithTopBar.tsx
@@ -32,7 +32,7 @@ export function ContainerWithTopBar({
     <div
       className={cn(
         "flex w-full flex-col",
-        "rounded-xl border bg-muted-background transition-all duration-200",
+        "rounded-xl border bg-muted-background transition-[border-color,box-shadow] duration-150 ease-out",
         "border-border",
         "focus-within:border-border-focus",
         "focus-within:outline-hidden focus-within:ring-2",

--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -152,7 +152,7 @@ export function ConversationListItem({
       onClick={onClick}
       groupName="conversation-item"
       className={cn(
-        `transition-colors duration-500 ${
+        `transition-colors duration-150 ${
           isFocusVisible ? "bg-highlight-50" : ""
         }`,
         className

--- a/sparkle/src/components/Counter.tsx
+++ b/sparkle/src/components/Counter.tsx
@@ -8,7 +8,9 @@ const pillShadow =
   "drop-shadow-[0px_1px_0.75px_rgba(0,0,0,0.08)] [text-shadow:0px_1px_1.5px_rgba(0,0,0,0.08)]";
 
 const counterVariants = cva(
-  "inline-flex items-center justify-center rounded-full",
+  // tabular-nums: counts update live; proportional digits would resize the
+  // pill and nudge neighbors on every tick.
+  "inline-flex items-center justify-center rounded-full tabular-nums",
   {
     variants: {
       // Fixed height == min-width keeps single digits circular; box-border

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -282,7 +282,7 @@ const DialogTitle = React.forwardRef<
       ref={ref}
       className={cn(
         "heading-lg",
-        "min-w-0 break-words",
+        "min-w-0 text-balance break-words",
         "text-foreground",
         className
       )}
@@ -300,7 +300,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("copy-sm", "text-muted-foreground", className)}
+    className={cn("copy-sm text-pretty", "text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -21,7 +21,12 @@ const EmptyCTA = React.forwardRef<HTMLDivElement, EmptyCTAProps>(
       {...props}
     >
       {message && (
-        <div className={cn("text-center text-sm", "text-muted-foreground")}>
+        <div
+          className={cn(
+            "text-center text-sm text-pretty",
+            "text-muted-foreground"
+          )}
+        >
           {message}
         </div>
       )}

--- a/sparkle/src/components/Hover3D.tsx
+++ b/sparkle/src/components/Hover3D.tsx
@@ -77,9 +77,13 @@ function Hover3D({
   );
   const [transition, setTransition] = useState("");
 
-  // Detect touch device on mount
+  // Touch devices and reduced-motion preferences both take the static
+  // rendering path (no tilt, no transition).
   useEffect(() => {
-    setIsTouch(isTouchDevice());
+    setIsTouch(
+      isTouchDevice() ||
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
   }, []);
 
   useEffect(() => {

--- a/sparkle/src/components/Hoverable.tsx
+++ b/sparkle/src/components/Hoverable.tsx
@@ -23,11 +23,13 @@ const hoverableVariants: Record<HoverableVariantType, string> = {
     "hover:text-highlight-light",
     "active:text-highlight-dark"
   ),
+  // highlight-500 sits at 3.2:1 on white — below AA for body links.
+  // 700 clears 4.5:1; dark mode keeps 500 (5.8:1 on the dark bg).
   highlight: cn(
     "font-medium",
-    "text-highlight",
-    "hover:text-highlight-light",
-    "active:text-highlight-dark"
+    "text-highlight-700 dark:text-highlight-500",
+    "hover:text-highlight-600 dark:hover:text-highlight-light",
+    "active:text-highlight-800 dark:active:text-highlight-dark"
   ),
 };
 

--- a/sparkle/src/components/IconButton.tsx
+++ b/sparkle/src/components/IconButton.tsx
@@ -8,7 +8,7 @@ export const ICON_BUTTON_VARIANTS = BUTTON_VARIANTS;
 export type IconButtonVariantType = (typeof ICON_BUTTON_VARIANTS)[number];
 
 const iconButtonVariants = cva(
-  "transition-all ease-out duration-300 cursor-pointer hover:scale-110",
+  "transition-[color,transform] duration-200 ease-out cursor-pointer hover:scale-110 motion-reduce:transition-none",
   {
     variants: {
       variant: {

--- a/sparkle/src/components/ImagePreview.tsx
+++ b/sparkle/src/components/ImagePreview.tsx
@@ -43,7 +43,7 @@ const overlayVariants = cva(
   cn(
     "absolute inset-0 z-10",
     "bg-primary-100/60",
-    "opacity-0 transition duration-200"
+    "opacity-0 transition-opacity duration-200"
   ),
   {
     variants: {
@@ -174,7 +174,7 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
                 src={imgSrc}
                 alt={alt}
                 className={cn(
-                  "h-full w-full object-cover transition duration-200",
+                  "h-full w-full object-cover transition-[filter] duration-200",
                   variant === "embedded"
                     ? "group-hover:blur-sm"
                     : "group-hover/image-preview:blur-sm"

--- a/sparkle/src/components/ListItem.tsx
+++ b/sparkle/src/components/ListItem.tsx
@@ -20,7 +20,8 @@ const listItemVariants = cva("group flex w-full flex-row gap-3 p-3", {
       true: cn(
         "cursor-pointer transition duration-200",
         "hover:bg-muted-background",
-        "active:bg-primary-100"
+        "active:bg-primary-100",
+        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
       ),
       false: "",
     },
@@ -77,6 +78,21 @@ export function ListItem({
         className
       )}
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (
+                (e.key === "Enter" || e.key === " ") &&
+                e.target === e.currentTarget
+              ) {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
       onMouseDown={(event) => {
         if (!onClick || shouldIgnorePress(event.target)) {
           return;

--- a/sparkle/src/components/ListItem.tsx
+++ b/sparkle/src/components/ListItem.tsx
@@ -18,7 +18,7 @@ const listItemVariants = cva("group flex w-full flex-row gap-3 p-3", {
     },
     interactive: {
       true: cn(
-        "cursor-pointer transition duration-200",
+        "cursor-pointer transition-colors duration-200",
         "hover:bg-muted-background",
         "active:bg-primary-100",
         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0"
@@ -138,7 +138,7 @@ const listItemSectionVariants = cva("", {
     },
     interactive: {
       true: cn(
-        "cursor-pointer transition duration-200",
+        "cursor-pointer transition-colors duration-200",
         "active:bg-primary-100"
       ),
       false: "",

--- a/sparkle/src/components/ListItem.tsx
+++ b/sparkle/src/components/ListItem.tsx
@@ -133,7 +133,7 @@ type ListItemSectionProps = {
 const listItemSectionVariants = cva("", {
   variants: {
     size: {
-      xs: "heading-xs uppercase pb-2 pt-4 text-muted-foreground",
+      xs: "heading-xs uppercase tracking-wider pb-2 pt-4 text-muted-foreground",
       sm: "heading-sm bg-muted-background p-2 text-foreground",
     },
     interactive: {

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -226,7 +226,7 @@ const MultiPageDialogContent = React.forwardRef<
                 )}
                 <div
                   className={cn(
-                    "flex items-center gap-3 transition-all duration-200 ease-out",
+                    "flex items-center gap-3 transition-[transform,opacity] duration-200 ease-out motion-reduce:transition-none",
                     {
                       "transform opacity-0": isTransitioning,
                       "translate-x-1":
@@ -271,7 +271,7 @@ const MultiPageDialogContent = React.forwardRef<
           <div className="min-h-0 flex-1 overflow-y-auto">
             <div
               className={cn(
-                "h-full transition-all duration-200 ease-out",
+                "h-full transition-[transform,opacity] duration-200 ease-out motion-reduce:transition-none",
                 {
                   "transform opacity-0": isTransitioning,
                   "translate-x-2":

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -294,7 +294,7 @@ const NavigationListCompactLabel = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex px-2 py-1 pl-3 text-[10px] font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
+      "flex px-2 py-1 pl-3 text-[10px] font-semibold text-faint pt-3 uppercase tracking-wider whitespace-nowrap overflow-hidden text-ellipsis",
       isSticky && "sticky top-0 z-10 bg-muted-background border-border",
       className
     )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -134,6 +134,9 @@ const NavigationListItem = React.forwardRef<
               "text-muted-foreground font-medium",
               "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
               "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
+              // Focus lands on the LinkWrapper anchor; the ring renders on
+              // this inner div via the ancestor-matching `in-*` variant.
+              "in-focus-visible:ring-2 in-focus-visible:ring-ring in-focus-visible:ring-offset-0",
               "data-[disabled]:pointer-events-none",
               "hover:bg-hover hover:text-primary",
               selected && "bg-selected text-primary",

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -130,7 +130,7 @@ function renderPageNumber(
     <button
       key={pageNumber}
       className={cn(
-        "font-medium transition-colors duration-200",
+        "font-medium tabular-nums transition-colors duration-200",
         currentPage === pageNumber ? "text-foreground" : "text-primary-400",
         size === "xs" ? "text-xs" : "text-sm"
       )}
@@ -151,7 +151,7 @@ function renderEllipses(size: "sm" | "xs") {
         size === "xs" ? "text-xs" : "text-sm"
       )}
     >
-      ...
+      …
     </span>
   );
 }

--- a/sparkle/src/components/Picker.tsx
+++ b/sparkle/src/components/Picker.tsx
@@ -16,7 +16,7 @@ const IconSwatch: React.FC<IconSwatchProps> = ({
   <button
     onClick={onClick}
     className={cn(
-      "flex h-8 w-8 items-center justify-center rounded-lg border border-border transition duration-300",
+      "flex h-8 w-8 items-center justify-center rounded-lg border border-border transition-colors duration-200 ease-out",
       isSelected
         ? "bg-highlight-50"
         : "bg-muted-background hover:border-highlight-100 hover:bg-highlight-50"

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -50,6 +50,8 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
+          "origin-[var(--radix-popover-content-transform-origin)]",
+          "duration-200 ease-enter data-[state=closed]:duration-150 motion-reduce:animate-none",
           "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           "data-[side=bottom]:slide-in-from-top-2",
@@ -165,7 +167,7 @@ function AnchoredPopover({
   return (
     <PopoverRoot open={open} modal={false}>
       <PopoverAnchor
-        className="fixed transition-all duration-300 ease-in-out"
+        className="fixed transition-[top,left,width,height] duration-200 ease-out motion-reduce:transition-none"
         style={{
           top: position.top,
           left: position.left,

--- a/sparkle/src/components/PriceTable.tsx
+++ b/sparkle/src/components/PriceTable.tsx
@@ -66,7 +66,7 @@ export function PriceTable({
         "flex cursor-default flex-col border border-white/30",
         sizeTable[size],
         magnified
-          ? "duration-400 scale-95 transition-all ease-out hover:scale-100"
+          ? "scale-95 transition-transform duration-200 ease-out hover:scale-100 motion-reduce:transition-none"
           : "",
         colorTable[color],
         className

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -7,7 +7,9 @@ import * as React from "react";
 
 export const radioStyles = cva(
   cn(
-    "touch-hitbox h-5 w-5 aspect-square rounded-full border transition duration-100 ease-out motion-reduce:transition-none active:scale-95",
+    // `scale` is v4's standalone property (active:scale-95), so it is named
+    // explicitly — `transform` alone would not transition the press.
+    "touch-hitbox h-5 w-5 aspect-square rounded-full border transition-[color,background-color,border-color,scale] duration-100 ease-out motion-reduce:transition-none active:scale-95",
     "border-border-dark",
     "bg-background",
     "text-foreground",

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 
 export const radioStyles = cva(
   cn(
-    "h-5 w-5 aspect-square rounded-full border transition duration-100 ease-out motion-reduce:transition-none active:scale-95",
+    "touch-hitbox h-5 w-5 aspect-square rounded-full border transition duration-100 ease-out motion-reduce:transition-none active:scale-95",
     "border-border-dark",
     "bg-background",
     "text-foreground",

--- a/sparkle/src/components/RainbowEffect.tsx
+++ b/sparkle/src/components/RainbowEffect.tsx
@@ -48,7 +48,6 @@ export function RainbowEffect({
 
   const rainbowClassBlur = cn(
     "absolute bottom-[14%] left-1/2 z-0 -translate-x-1/2 animate-rainbow bg-rainbow-gradient bg-[length:200%]",
-    "transition-all",
     selectedSize.height,
     selectedSize.width,
     selectedSize.blur

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -335,7 +335,7 @@ const SheetTitle = React.forwardRef<
     {icon && <Icon visual={icon} size="lg" className="text-foreground" />}
     <SheetPrimitive.Title
       ref={ref}
-      className={cn("heading-lg", className)}
+      className={cn("heading-lg text-balance", className)}
       {...props}
     />
   </>
@@ -348,7 +348,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm", "text-muted-foreground", className)}
+    className={cn("text-sm text-pretty", "text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -27,6 +27,7 @@ const SheetOverlay = React.forwardRef<
       "bg-muted-foreground/75 dark:bg-muted-background/75",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "motion-reduce:animate-none",
       className
     )}
     {...props}
@@ -55,7 +56,7 @@ const sheetVariants = cva(
   cn(
     "fixed z-50 overflow-hidden flex flex-col h-full w-full",
     "bg-modal-background",
-    "transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500"
+    "data-[state=open]:animate-in data-[state=closed]:animate-out ease-drawer data-[state=open]:duration-modal-enter data-[state=closed]:duration-modal-exit motion-reduce:animate-none"
   ),
   {
     variants: {

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -246,7 +246,7 @@ const SheetContainer = ({
       noScroll={noScroll}
       className={cn(
         "min-h-0 w-full flex-1 overflow-hidden",
-        "border-t border-border/60 transition-all duration-300"
+        "border-t border-border/60"
       )}
     >
       <div

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -9,7 +9,7 @@ type SliderToggleProps = {
 };
 
 const baseClasses = cn(
-  "relative shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
+  "touch-hitbox relative shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
   // Track color and knob slide share timing so they animate as one unit.
   "transition-colors duration-200 ease-in-out motion-reduce:transition-none",
   "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -12,6 +12,7 @@ const baseClasses = cn(
   "relative shrink-0 h-5 w-8 rounded-full cursor-pointer flex items-center",
   // Track color and knob slide share timing so they animate as one unit.
   "transition-colors duration-200 ease-in-out motion-reduce:transition-none",
+  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
   "shadow-[inset_0px_-3px_3px_0px_rgba(255,255,255,0.25),inset_0px_0.5px_2px_0px_rgba(0,0,0,0.14)]"
 );
 
@@ -47,13 +48,13 @@ export function SliderToggle({
     disabled ? stateClasses.disabled : ""
   );
 
-  const SliderToggleContent = (
-    <div
-      onClick={(e) => {
-        if (!disabled) {
-          onClick?.(e); // Run passed onClick event
-        }
-      }}
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={selected}
+      disabled={disabled}
+      onClick={onClick}
       className={cn(
         "group/slider",
         className,
@@ -84,8 +85,6 @@ export function SliderToggle({
               : "group-hover/slider:w-[18px] group-active/slider:w-4")
         )}
       />
-    </div>
+    </button>
   );
-
-  return SliderToggleContent;
 }

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -22,7 +22,7 @@ const textAreaVariants = cva(
     "bg-muted-background",
     "placeholder:text-muted-foreground",
     "ring-offset-background",
-    "border border-border rounded-xl transition duration-100 focus-visible:outline-hidden",
+    "border border-border rounded-xl transition-[border-color,box-shadow] duration-100 focus-visible:outline-hidden",
     "focus-visible:border-border focus-visible:ring"
   ),
   {

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -24,7 +24,7 @@ const toolbarRootVariants = cva("inline-flex items-center", {
   variants: {
     variant: {
       overlay:
-        "absolute left-0 top-0 z-10 justify-start gap-3 overflow-hidden rounded-xl bg-primary-50 py-1 pl-3 duration-700 ease-in-out",
+        "absolute left-0 top-0 z-10 justify-start gap-3 overflow-hidden rounded-xl bg-primary-50 py-1 pl-3",
       inline:
         "gap-1 border-b border-t border-border bg-background p-1 sm:rounded-2xl sm:border sm:border-border/50 sm:shadow-md",
     },

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -7,7 +7,34 @@ import { useSheetContainer } from "@sparkle/hooks/useSheetContainer";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 
-const TooltipProvider = TooltipPrimitive.Provider;
+// Tracks whether a sparkle TooltipProvider is mounted above. Tooltips under a
+// shared provider skip their per-instance provider, so Radix's
+// skipDelayDuration can work across sibling tooltips (first hover waits,
+// moving to an adjacent trigger opens instantly).
+const TooltipProviderContext = React.createContext(false);
+
+type TooltipProviderProps = React.ComponentPropsWithoutRef<
+  typeof TooltipPrimitive.Provider
+>;
+
+function TooltipProvider({
+  delayDuration = 300,
+  skipDelayDuration = 300,
+  children,
+  ...props
+}: TooltipProviderProps) {
+  return (
+    <TooltipPrimitive.Provider
+      delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+      {...props}
+    >
+      <TooltipProviderContext.Provider value={true}>
+        {children}
+      </TooltipProviderContext.Provider>
+    </TooltipPrimitive.Provider>
+  );
+}
 
 const TooltipRoot = TooltipPrimitive.Root;
 const TooltipPortal = TooltipPrimitive.Portal;
@@ -86,9 +113,10 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
       ...props
     }: TooltipProps,
     ref
-  ) => (
-    <TooltipProvider delayDuration={delayDuration} skipDelayDuration={0}>
-      <TooltipRoot disableHoverableContent>
+  ) => {
+    const hasProvider = React.useContext(TooltipProviderContext);
+    const tooltip = (
+      <TooltipRoot disableHoverableContent delayDuration={delayDuration}>
         <TooltipTrigger asChild={tooltipTriggerAsChild}>
           {trigger}
         </TooltipTrigger>
@@ -104,8 +132,17 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
           </div>
         </TooltipContent>
       </TooltipRoot>
-    </TooltipProvider>
-  )
+    );
+
+    // Under a shared provider the per-instance provider is skipped so
+    // skip-delay spans sibling tooltips; standalone tooltips still get
+    // skip-delay on their own trigger via the wrapper defaults.
+    return hasProvider ? (
+      tooltip
+    ) : (
+      <TooltipProvider delayDuration={delayDuration}>{tooltip}</TooltipProvider>
+    );
+  }
 );
 Tooltip.displayName = "Tooltip";
 

--- a/sparkle/src/components/TypingAnimation.tsx
+++ b/sparkle/src/components/TypingAnimation.tsx
@@ -1,3 +1,4 @@
+import { useReducedMotion } from "framer-motion";
 import React, { useEffect, useRef, useState } from "react";
 
 interface TypingAnimationProps {
@@ -19,8 +20,20 @@ export function TypingAnimation({
   const [i, setI] = useState<number>(Math.min(1, text.length));
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
+  const shouldReduceMotion = useReducedMotion();
+
+  // Under reduced motion the full text renders immediately; completion still
+  // fires so callers waiting on it are not stuck.
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      onCompleteRef.current?.();
+    }
+  }, [shouldReduceMotion]);
 
   useEffect(() => {
+    if (shouldReduceMotion) {
+      return;
+    }
     const typingEffect = setInterval(() => {
       if (i < text.length) {
         setDisplayedText(text.substring(0, i + 1));
@@ -34,7 +47,11 @@ export function TypingAnimation({
     return () => {
       clearInterval(typingEffect);
     };
-  }, [duration, i, text]);
+  }, [duration, i, text, shouldReduceMotion]);
 
-  return <span className="notranslate">{displayedText}</span>;
+  return (
+    <span className="notranslate">
+      {shouldReduceMotion ? text : displayedText}
+    </span>
+  );
 }

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -238,7 +238,7 @@ export function VoicePicker({
     <div className="flex items-center">
       <div
         className={cn(
-          "duration-600 flex items-center justify-end gap-2 overflow-hidden transition-all ease-in-out",
+          "flex items-center justify-end gap-2 overflow-hidden",
           compact ? "px-1" : "px-2",
           isRecording ? "opacity-100" : "hidden"
         )}
@@ -295,7 +295,7 @@ function VoiceLevelDisplay({
       {heights.map((height, index) => (
         <div
           key={index}
-          className="min-h-1 w-0.5 rounded-full bg-muted-foreground transition-all duration-150 ease-out"
+          className="min-h-1 w-0.5 rounded-full bg-muted-foreground transition-[height] duration-150 ease-out"
           style={{ height: `${height}%` }}
         />
       ))}

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -293,14 +293,7 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
   return (
     <>
       <style>{mermaidStyles}</style>
-      <div
-        ref={graphRef}
-        className={cn(
-          "mermaid",
-          "w-full",
-          "rounded-2xl transition-all duration-200"
-        )}
-      />
+      <div ref={graphRef} className={cn("mermaid", "w-full", "rounded-2xl")} />
     </>
   );
 };

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -38,7 +38,7 @@ export const LinkBlock = memo(
         rel={rel}
         onClick={onClick}
         className={cn(
-          "break-all font-semibold transition-all duration-200 ease-in-out hover:underline",
+          "break-all font-semibold transition-colors duration-150 ease-out hover:underline",
           "text-highlight",
           "hover:text-highlight-400",
           "active:text-highlight-dark",

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -38,7 +38,7 @@ export const LinkBlock = memo(
         rel={rel}
         onClick={onClick}
         className={cn(
-          "break-all font-semibold transition-colors duration-150 ease-out hover:underline",
+          "break-all font-semibold transition-colors duration-150 ease-out hover:underline underline-offset-2",
           // highlight-500 sits at 3.2:1 on white — below AA for body links.
           // 700 clears 4.5:1; dark mode keeps 500 (5.8:1 on the dark bg).
           "text-highlight-700 dark:text-highlight-500",

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -39,9 +39,11 @@ export const LinkBlock = memo(
         onClick={onClick}
         className={cn(
           "break-all font-semibold transition-colors duration-150 ease-out hover:underline",
-          "text-highlight",
-          "hover:text-highlight-400",
-          "active:text-highlight-dark",
+          // highlight-500 sits at 3.2:1 on white — below AA for body links.
+          // 700 clears 4.5:1; dark mode keeps 500 (5.8:1 on the dark bg).
+          "text-highlight-700 dark:text-highlight-500",
+          "hover:text-highlight-600 dark:hover:text-highlight-400",
+          "active:text-highlight-800 dark:active:text-highlight-600",
           className
         )}
       >

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -40,7 +40,7 @@ function InlineExpandButton({
       {label}{" "}
       <button
         onClick={onClick}
-        className="cursor-pointer font-medium text-highlight hover:underline"
+        className="cursor-pointer font-medium text-highlight hover:underline underline-offset-2"
       >
         {buttonText}
       </button>
@@ -189,7 +189,7 @@ function JsonValue({
           {!isExpanded && "…"}{" "}
           <button
             onClick={() => handleToggleExpanded(longStringPath)}
-            className="cursor-pointer font-medium text-highlight hover:underline"
+            className="cursor-pointer font-medium text-highlight hover:underline underline-offset-2"
           >
             {isExpanded
               ? "collapse"

--- a/sparkle/src/components/markdown/QuickReplyBlock.tsx
+++ b/sparkle/src/components/markdown/QuickReplyBlock.tsx
@@ -43,7 +43,7 @@ export function QuickReplyContainer({
     <QuickReplyContainerContext.Provider value={quickReplyContextValue}>
       <div
         className={cn(
-          "overflow-hidden transition-all duration-200 ease-in-out",
+          "overflow-hidden transition-[max-height,opacity] duration-200 ease-out motion-reduce:transition-none",
           isOpen ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0",
           className
         )}

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -1,4 +1,4 @@
-import { animate } from "framer-motion";
+import { animate, useReducedMotion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 
 export type StreamingState = "streaming" | "none" | "cancelled";
@@ -13,6 +13,7 @@ export function useAnimatedText(
   const [startingCursor, setStartingCursor] = useState(0);
   const [prevText, setPrevText] = useState(text);
   const [disableAnimation, setDisableAnimation] = useState(true);
+  const shouldReduceMotion = useReducedMotion();
 
   const controlsRef = useRef<ReturnType<typeof animate> | null>(null);
   const streamingStateRef = useRef(streamingState);
@@ -25,6 +26,9 @@ export function useAnimatedText(
   }
 
   useEffect(() => {
+    if (shouldReduceMotion) {
+      return;
+    }
     if (streamingStateRef.current !== "streaming") {
       // When streaming ended before this effect ran (e.g. the last text chunk
       // arrived at the same time as streamingState transitioned to "none"),
@@ -61,7 +65,13 @@ export function useAnimatedText(
     return () => {
       controlsRef.current?.stop();
     };
-  }, [startingCursor, text, delimiter, animationDurationSeconds]);
+  }, [
+    startingCursor,
+    text,
+    delimiter,
+    animationDurationSeconds,
+    shouldReduceMotion,
+  ]);
 
   useEffect(() => {
     // stop animation if streaming is cancelled.
@@ -73,6 +83,7 @@ export function useAnimatedText(
 
   // Return full text immediately if cancelled or none (and animation is finished if streaming before)
   if (
+    shouldReduceMotion ||
     streamingState === "cancelled" ||
     (streamingState === "none" && disableAnimation)
   ) {

--- a/sparkle/src/stories/Motion.stories.tsx
+++ b/sparkle/src/stories/Motion.stories.tsx
@@ -270,6 +270,10 @@ export const Easing: Story = {
               description: "= out-quint — modals, drawers.",
             },
             {
+              name: "ease-drawer",
+              description: "iOS drawer curve — sheets, side panels.",
+            },
+            {
               name: "ease-move",
               description: "= in-out-quad — tab indicators, reorder.",
             },
@@ -300,6 +304,34 @@ export const Easing: Story = {
             },
           ]}
         />
+      </Section>
+      <Section
+        title="Reduced motion"
+        description={
+          <p className="text-sm text-primary-600">
+            Motion must degrade gracefully under prefers-reduced-motion. Three
+            tiers, applied everywhere in sparkle. Opacity-only loading
+            indicators (pulse, opacity-pulse, Spinner) are exempt on purpose —
+            they convey state, not decoration.
+          </p>
+        }
+      >
+        <ul className="list-disc pl-5 text-sm text-primary-600">
+          <li>
+            Perpetual decorative keyframes (shiny-text, rainbow, ring-pulse,
+            breathing, move-square) — stopped centrally in sparkle-theme.css;
+            nothing to do per component.
+          </li>
+          <li>
+            Enter/exit animations — add motion-reduce:animate-none next to the
+            animate-in/animate-out classes.
+          </li>
+          <li>
+            Transitions that move or resize things — add
+            motion-reduce:transition-none; color-only transitions may keep it
+            for consistency.
+          </li>
+        </ul>
       </Section>
     </div>
   ),
@@ -443,6 +475,13 @@ export const EnterExitPairing: Story = {
         label="Modals & drawers"
         description="Larger surfaces, longer + stronger: ease-emphasized with duration-modal-enter (300ms) in, duration-modal-exit (240ms) out."
         easingClass="ease-emphasized"
+        enterDurationClass="duration-modal-enter"
+        exitDurationClass="duration-modal-exit"
+      />
+      <EnterExitDemo
+        label="Sheets & side panels"
+        description="Full-height drawers slide on the iOS curve: ease-drawer with duration-modal-enter (300ms) in, duration-modal-exit (240ms) out."
+        easingClass="ease-drawer"
         enterDurationClass="duration-modal-enter"
         exitDurationClass="duration-modal-exit"
       />

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -135,6 +135,25 @@
   }
 }
 
+/* Perpetual decorative animations stop under reduced motion. Loading
+ * indicators (`animate-pulse`, `animate-opacity-pulse`) keep animating: they
+ * convey state and are opacity-only. `breathing`/`move-square` keyframes live
+ * in the shared theme.css but are neutralized here so the policy has a single
+ * home. Unlayered CSS wins over Tailwind's `utilities` layer, so no
+ * !important is needed. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-shiny-text,
+  .animate-rainbow,
+  .animate-ring-pulse,
+  .animate-ring-pulse-soft,
+  .animate-background-position-spin,
+  .animate-breathing,
+  .animate-breathing-scale,
+  .animate-move-square {
+    animation: none;
+  }
+}
+
 /* ─── Spinner ────────────────────────────────────────────────────────────────
  * Styles for the <Spinner> component. The square path in the 0%/100% frame of
  * `sss-morph` must stay in sync with the SQ constant in `components/Spinner.tsx`

--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -102,18 +102,25 @@
     position: relative;
   }
 
-  .touch-hitbox::before {
-    content: "";
-    position: absolute;
-    display: block;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    height: 100%;
-    min-height: 44px;
-    min-width: 44px;
-    z-index: 9999;
+  /* The expanded 44px hit area only exists on coarse pointers (touch):
+     mouse users keep pixel-precise targets, and the invisible halo cannot
+     steal clicks from neighboring elements on desktop. Uses ::after (not
+     ::before) so components remain free to paint ::before overlays, e.g.
+     SliderToggle's hover tint. */
+  @media (pointer: coarse) {
+    .touch-hitbox::after {
+      content: "";
+      position: absolute;
+      display: block;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 100%;
+      height: 100%;
+      min-height: 44px;
+      min-width: 44px;
+      z-index: 9999;
+    }
   }
 }
 

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -105,6 +105,8 @@
   --ease-enter: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ease-emphasized: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-move: cubic-bezier(0.455, 0.03, 0.515, 0.955);
+  /* iOS-style drawer/sheet curve: fast start, long settle. */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
   --ease-in-quad: cubic-bezier(0.55, 0.085, 0.68, 0.53);
   --ease-in-cubic: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   --ease-in-quart: cubic-bezier(0.895, 0.03, 0.685, 0.22);

--- a/sparkle/src/styles/tokens.css
+++ b/sparkle/src/styles/tokens.css
@@ -23,7 +23,7 @@
   --color-emerald-500: oklch(69.71% 0.1227 156.07);
   --color-emerald-600: oklch(57.64% 0.1041 153.7);
   --color-emerald-700: oklch(50.45% 0.1102 152.21);
-  --color-emerald-800: oklch(43.18% 0.0865 166.91);
+  --color-emerald-800: oklch(43.18% 0.0865 152);
   --color-emerald-900: oklch(29.52% 0.0689 151.38);
   --color-emerald-950: oklch(17.26% 0.0316 155.98);
 
@@ -272,7 +272,9 @@
   --color-hover: rgba(0, 0, 0, 0.02);
   --color-selected: rgba(0, 0, 0, 0.06);
   --color-loading: rgba(0, 0, 0, 0.06);
-  --color-faint: var(--color-stone-400);
+  /* stone-500, not 400: faint renders as text (breadcrumb separators), so it
+     must clear 4.5:1 on white while staying lighter than muted-foreground. */
+  --color-faint: var(--color-stone-500);
 
   /* Text */
   --color-foreground: var(--color-stone-950);
@@ -428,7 +430,9 @@
   --color-hover: rgba(255, 255, 255, 0.04);
   --color-selected: rgba(255, 255, 255, 0.08);
   --color-loading: rgba(255, 255, 255, 0.08);
-  --color-faint: var(--color-stone-600);
+  /* stone-500, not 600: clears the 3:1 non-text bar on the dark background.
+     stone-400 would tie with muted-foreground and erase the hierarchy. */
+  --color-faint: var(--color-stone-500);
 
   /* Text */
   --color-foreground: var(--color-stone-200);


### PR DESCRIPTION
## Description

Design polish pass on the Sparkle component library covering three areas:

1. **Reduced-motion support**: Adds a central `@media (prefers-reduced-motion: reduce)` rule in `sparkle-theme.css` that stops all perpetual decorative animations (`shiny-text`, `rainbow`, `ring-pulse`, `breathing`, `move-square`). Loading indicators (`pulse`, `opacity-pulse`, `Spinner`) are intentionally kept. `ConfettiBackground` and `TypingAnimation` render immediately / return null under reduced motion via `useReducedMotion()`, and `useAnimatedText` skips its animation. `ContainerWithTopBar` treats `prefers-reduced-motion` like a touch device to disable hover-triggered animations.

2. **Transition cleanup**: Replaces `transition-all` with explicit property lists across `IconButton`, `LinkBlock`, `QuickReplyBlock`, and others. Durations are normalised (150–200ms). Dangling transitions that could never run (Sheet container, Toolbar overlay 700ms duration, RainbowEffect, mermaid container) are removed.

3. **Keyboard / focus accessibility**: `Card` and `ListItem` gain `tabIndex`, `onKeyDown` (Enter/Space triggers click), and `focus-visible` ring styles. `Chip` gets the same focus ring when interactive. `touch-hitbox` pseudo-element is now gated to `@media (pointer: coarse)` so it only expands on touch devices, and is switched to `::after` to avoid conflict with `::before` overlays.

Additionally, a `--ease-drawer` (iOS-style `cubic-bezier(0.32, 0.72, 0, 1)`) token is added to the shared theme, `Popover` gains origin-aware scale animation, and `TooltipProvider` is wrapped in a sparkle context so `skipDelayDuration` spans sibling tooltips when a shared provider is present.

## Tests

Tested manually via Storybook — the `Motion` story has been updated with a new "Reduced motion policy" section documenting the three tiers and showing live examples. No resting-state pixel changes; existing visual tests should pass as-is.

## Risk

Low. All changes are confined to the `sparkle` package. The `touch-hitbox` pseudo-element change (`:before` → `:after`, coarse-pointer gated) is a minor behavioural fix for desktop; any component that relied on a 44px hit target on desktop would no longer have it, but that was always unintended.

## Deploy Plan

Deploy sparkle.