### PR TITLE
[front] refactor(github-skills): cleanup hooks + component

### DIFF
--- a/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
@@ -14,6 +14,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 
+// Mounted at /api/w/:wId/skills/import/github-connection.
 const app = workspaceApp();
 
 /** @ignoreswagger */

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -70,58 +70,11 @@ export function ImportFromRepositoryTab({
     onDetectedCountChange(detectedSkills.length);
   }, [detectedSkills.length, onDetectedCountChange]);
 
-  const showRepositoryNotFound = repositoryNotFound && !isConnectionLoading;
-
-  const hasRepositoryContent =
-    isDetecting ||
-    !!detectError ||
-    showRepositoryNotFound ||
-    detectedSkills.length > 0;
-
-  let repositoryContent = (
-    <DetectedSkillsList
-      detectedSkills={detectedSkills}
-      isDetecting={isDetecting}
-      detectError={detectError}
-    />
-  );
-  if (showRepositoryNotFound && connection) {
-    repositoryContent = (
-      <ContentMessage
-        variant="warning"
-        size="lg"
-        icon={InfoCircle}
-        title="GitHub connection can't access this repository"
-      >
-        The currently connected GitHub account can't access this repository.{" "}
-        {isAdmin(owner)
-          ? "Check the URL or reconnect with an account that has access."
-          : "Check the URL or ask an admin to reconnect with an account that has access."}
-      </ContentMessage>
-    );
-  } else if (showRepositoryNotFound && isAdmin(owner)) {
-    repositoryContent = (
-      <ConnectWorkspaceGitHubMessage
-        owner={owner}
-        onConnected={() => {
-          void mutateConnection();
-          triggerDetect(repoUrlField.value);
-        }}
-      />
-    );
-  } else if (showRepositoryNotFound) {
-    repositoryContent = (
-      <ContentMessage
-        variant="warning"
-        size="lg"
-        icon={InfoCircle}
-        title="Repository not found"
-      >
-        Check the URL. For private repos, ask an admin to connect a GitHub
-        account with access.
-      </ContentMessage>
-    );
-  }
+  const isEmpty =
+    !isDetecting &&
+    !detectError &&
+    !repositoryNotFound &&
+    detectedSkills.length === 0;
 
   return (
     <div className="flex flex-col gap-3 pt-4">
@@ -132,11 +85,7 @@ export function ImportFromRepositoryTab({
         onChange={(e) => {
           const trimmed = e.target.value.trim();
           repoUrlField.onChange(trimmed);
-          if (trimmed && parseGitHubRepoUrl(trimmed).isOk()) {
-            triggerDetect(trimmed);
-          } else {
-            clearDetection();
-          }
+          triggerDetect(trimmed);
         }}
         onBlur={repoUrlField.onBlur}
         placeholder="https://github.com/owner/repo"
@@ -144,8 +93,44 @@ export function ImportFromRepositoryTab({
         className="bg-muted-background"
       />
 
-      <div className={cn("flex flex-col", hasRepositoryContent && "min-h-40")}>
-        {repositoryContent}
+      <div className={cn("flex flex-col", !isEmpty && "min-h-40")}>
+        {repositoryNotFound &&
+          (hasConnection ? (
+            <ContentMessage
+              variant="warning"
+              size="lg"
+              icon={InfoCircle}
+              title="GitHub connection can't access this repository"
+            >
+              The currently connected GitHub account can't access this
+              repository.&nsbp;
+              {isAdmin(owner)
+                ? "Check the URL or reconnect with an account that has access."
+                : "Check the URL or ask an admin to reconnect with an account that has access."}
+            </ContentMessage>
+          ) : isAdmin(owner) ? (
+            <ConnectWorkspaceGitHubMessage
+              owner={owner}
+              onConnected={() => {
+                triggerDetect(repoUrlField.value);
+              }}
+            />
+          ) : (
+            <ContentMessage
+              variant="warning"
+              size="lg"
+              icon={InfoCircle}
+              title="Repository not found"
+            >
+              Check the URL. For private repos, ask an admin to connect a GitHub
+              account with access.
+            </ContentMessage>
+          ))}
+        <DetectedSkillsList
+          detectedSkills={detectedSkills}
+          isDetecting={isDetecting}
+          detectError={detectError}
+        />
       </div>
 
       {connection && (

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -101,7 +101,7 @@ export function ImportFromRepositoryTab({
               title="GitHub connection can't access this repository"
             >
               The currently connected GitHub account can't access this
-              repository.&nsbp;
+              repository.&nbsp;
               {isAdmin(owner)
                 ? "Check the URL or reconnect with an account that has access."
                 : "Check the URL or ask an admin to reconnect with an account that has access."}

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -3,6 +3,7 @@ import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkills
 import type { RepositoryImportFormValues } from "@app/components/skills/import/formSchema";
 import { GitHubConnectionRow } from "@app/components/skills/import/GitHubConnectionRow";
 import { isImportableSkillStatus } from "@app/lib/skill_detection";
+import { useWorkspaceGitHubConnection } from "@app/lib/swr/github_connection";
 import { useDetectSkillsFromRepo } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
@@ -65,10 +66,13 @@ export function ImportFromRepositoryTab({
     onDetectedCountChange(detectedSkills.length);
   }, [detectedSkills.length, onDetectedCountChange]);
 
+  const showRepositoryNotFound =
+    repositoryNotFound && !isConnectionLoading;
+
   const isEmpty =
     !isDetecting &&
     !detectError &&
-    !repositoryNotFound &&
+    !showRepositoryNotFound &&
     detectedSkills.length === 0;
 
   return (
@@ -89,8 +93,8 @@ export function ImportFromRepositoryTab({
       />
 
       <div className={cn("flex flex-col", !isEmpty && "min-h-40")}>
-        {repositoryNotFound &&
-          (hasConnection ? (
+        {showRepositoryNotFound &&
+          (connection ? (
             <ContentMessage
               variant="warning"
               size="lg"
@@ -107,6 +111,7 @@ export function ImportFromRepositoryTab({
             <ConnectWorkspaceGitHubMessage
               owner={owner}
               onConnected={() => {
+                void mutateConnection();
                 triggerDetect(repoUrlField.value);
               }}
             />

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -2,11 +2,7 @@ import { ConnectWorkspaceGitHubMessage } from "@app/components/skills/import/Con
 import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkillsList";
 import type { RepositoryImportFormValues } from "@app/components/skills/import/formSchema";
 import { GitHubConnectionRow } from "@app/components/skills/import/GitHubConnectionRow";
-import {
-  isImportableSkillStatus,
-  parseGitHubRepoUrl,
-} from "@app/lib/skill_detection";
-import { useWorkspaceGitHubConnection } from "@app/lib/swr/github_connection";
+import { isImportableSkillStatus } from "@app/lib/skill_detection";
 import { useDetectSkillsFromRepo } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
@@ -38,7 +34,6 @@ export function ImportFromRepositoryTab({
     detectError,
     repositoryNotFound,
     triggerDetect,
-    clearDetection,
   } = useDetectSkillsFromRepo({ owner });
 
   const { connection, isConnectionLoading, mutateConnection } =

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -66,8 +66,7 @@ export function ImportFromRepositoryTab({
     onDetectedCountChange(detectedSkills.length);
   }, [detectedSkills.length, onDetectedCountChange]);
 
-  const showRepositoryNotFound =
-    repositoryNotFound && !isConnectionLoading;
+  const showRepositoryNotFound = repositoryNotFound && !isConnectionLoading;
 
   const isEmpty =
     !isDetecting &&

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -2,9 +2,10 @@ import type { ImportFormValues } from "@app/components/skills/import/formSchema"
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
-import type {
-  DetectedSkillSummary,
-  DetectSkillsResponseBody,
+import {
+  type DetectedSkillSummary,
+  type DetectSkillsResponseBody,
+  parseGitHubRepoUrl,
 } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSkillHistoryResponseBody } from "@app/types/api/assistant/skills/history";
@@ -442,11 +443,19 @@ export function useDetectSkillsFromRepo({
   );
   const [isDetecting, setIsDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
-  const [repositoryNotFound, setRepositoryNotFound] = useState(false);
+  const [repositoryNotFound, setRepositoryNotFound] = useState<boolean>(false);
 
   const triggerDetect = useDebounceWithAbort(
     useCallback(
       async (repoUrl: string, signal: AbortSignal) => {
+        if (!repoUrl || parseGitHubRepoUrl(repoUrl).isErr()) {
+          setDetectedSkills([]);
+          setDetectError(null);
+          setRepositoryNotFound(false);
+          setIsDetecting(false);
+          return;
+        }
+
         setIsDetecting(true);
         setDetectError(null);
         setRepositoryNotFound(false);
@@ -469,9 +478,14 @@ export function useDetectSkillsFromRepo({
           }
           setDetectedSkills([]);
           if (isAPIErrorResponse(err)) {
-            setDetectError(err.error.message);
             setRepositoryNotFound(
               err.error.type === "skill_github_repository_not_found"
+            );
+            // Detect errors are errors we want to expose to consumers: repository not found is singled out above.
+            setDetectError(
+              err.error.type === "skill_github_repository_not_found"
+                ? null
+                : err.error.message
             );
           } else {
             setDetectError("Failed to detect skills from this repository.");
@@ -487,20 +501,12 @@ export function useDetectSkillsFromRepo({
     { delayMs: DETECT_SKILLS_DEBOUNCE_MS }
   );
 
-  const clearDetection = useCallback(() => {
-    setDetectedSkills([]);
-    setDetectError(null);
-    setRepositoryNotFound(false);
-    setIsDetecting(false);
-  }, []);
-
   return {
     isDetecting,
     detectError: !isDetecting ? detectError : null,
     detectedSkills: !isDetecting && !detectError ? detectedSkills : [],
     repositoryNotFound: !isDetecting ? repositoryNotFound : false,
     triggerDetect,
-    clearDetection,
   };
 }
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -503,9 +503,9 @@ export function useDetectSkillsFromRepo({
 
   return {
     isDetecting,
-    detectError: !isDetecting ? detectError : null,
-    detectedSkills: !isDetecting && !detectError ? detectedSkills : [],
-    repositoryNotFound: !isDetecting ? repositoryNotFound : false,
+    detectError: isDetecting ? null : detectError,
+    repositoryNotFound: !isDetecting && repositoryNotFound,
+    detectedSkills: isDetecting || detectError ? [] : detectedSkills,
     triggerDetect,
   };
 }


### PR DESCRIPTION
## Description

This PR simplifies the hook/component boundaries for the Skill import from GitHub feature.

Moves the responsibility of parsing the URL into the hook, remove the additional prop `clearDetection` and reorder the component to make it more readable.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
