### PR TITLE
[GitHub MCP] Handle inaccessible team reviewers

### DIFF
--- a/front/lib/api/actions/servers/github/tools/index.test.ts
+++ b/front/lib/api/actions/servers/github/tools/index.test.ts
@@ -1,0 +1,146 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { graphqlMock } = vi.hoisted(() => ({
+  graphqlMock: vi.fn(),
+}));
+
+vi.mock("@octokit/core", () => ({
+  Octokit: class {
+    graphql = graphqlMock;
+  },
+}));
+
+const pageInfo = {
+  hasNextPage: false,
+  endCursor: null,
+  startCursor: null,
+  hasPreviousPage: false,
+};
+
+const pullRequest = {
+  number: 1,
+  title: "Team review",
+  state: "OPEN",
+  createdAt: "2026-07-22T00:00:00Z",
+  updatedAt: "2026-07-22T00:00:00Z",
+  mergedAt: null,
+  closedAt: null,
+  author: { login: "octocat" },
+  baseRefName: "main",
+  headRefName: "feature",
+  additions: 1,
+  deletions: 0,
+  changedFiles: 1,
+  labels: { nodes: [] },
+  assignees: { nodes: [] },
+  reviewRequests: { nodes: [{ requestedReviewer: null }] },
+  comments: { totalCount: 0 },
+  reviews: { totalCount: 0 },
+};
+
+const searchResponse = {
+  search: {
+    issueCount: 1,
+    pageInfo,
+    nodes: [
+      {
+        ...pullRequest,
+        __typename: "PullRequest",
+        body: "",
+        url: "https://github.com/dust-tt/dust/pull/1",
+        repository: { owner: { login: "dust-tt" }, name: "dust" },
+      },
+    ],
+  },
+};
+
+const listResponse = {
+  repository: {
+    pullRequests: {
+      pageInfo,
+      nodes: [pullRequest],
+    },
+  },
+};
+
+describe("GitHub pull request tools", () => {
+  beforeEach(() => {
+    graphqlMock.mockReset();
+  });
+
+  it.each([
+    ["search_advanced", { query: "is:pr" }, searchResponse],
+    ["list_pull_requests", { owner: "dust-tt", repo: "dust" }, listResponse],
+  ])("retries %s without team details when GitHub denies them", async (toolName, params, response) => {
+    const reviewerAccessError = Object.assign(
+      new Error("Resource not accessible by integration"),
+      {
+        errors: [
+          {
+            type: "FORBIDDEN",
+            path: [
+              "repository",
+              "pullRequests",
+              "nodes",
+              0,
+              "reviewRequests",
+              "nodes",
+              0,
+              "requestedReviewer",
+              "slug",
+            ],
+          },
+        ],
+      }
+    );
+    graphqlMock.mockRejectedValueOnce(reviewerAccessError);
+    graphqlMock.mockResolvedValueOnce(response);
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const tool = createGithubTools(authenticator).find(
+      ({ name }) => name === toolName
+    );
+    if (!tool) {
+      throw new Error(`Tool not found: ${toolName}`);
+    }
+
+    const extra: Omit<ToolHandlerExtra, "runContext"> = {
+      auth: authenticator,
+      authInfo: {
+        token: "github-token",
+        clientId: "github-client",
+        scopes: [],
+      },
+      requestId: "github-reviewer-test",
+      sendNotification: async () => {},
+      sendRequest: async () => {
+        throw new Error("Unexpected MCP request");
+      },
+      signal: new AbortController().signal,
+    };
+
+    // @ts-expect-error These handlers do not read runContext.
+    const result = await tool.handler(params, extra);
+
+    expect(result.isOk()).toBe(true);
+    expect(graphqlMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("... on Team"),
+      expect.any(Object)
+    );
+    expect(graphqlMock).toHaveBeenNthCalledWith(
+      2,
+      expect.not.stringContaining("... on Team"),
+      expect.any(Object)
+    );
+    if (result.isOk()) {
+      expect(result.value[1]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining('"reviewRequests": []'),
+      });
+    }
+  });
+});

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -48,6 +48,8 @@ function isTeamReviewerAccessError(error: unknown): boolean {
   );
 }
 
+// GitHub App tokens without organization Members access cannot resolve Team reviewers. Retry
+// without the Team fragment so valid pull request data is not discarded with the error.
 async function graphqlWithReviewerFallback<T>(
   octokit: Octokit,
   query: string,

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -19,6 +19,53 @@ import type {
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 
 const GITHUB_GET_PULL_REQUEST_ACTION_MAX_COMMITS = 32;
+const GITHUB_TEAM_REVIEWER_FRAGMENT = `... on Team {
+  slug
+}`;
+
+function isTeamReviewerAccessError(error: unknown): boolean {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("errors" in error) ||
+    !Array.isArray(error.errors)
+  ) {
+    return false;
+  }
+
+  return (
+    error.errors.length > 0 &&
+    error.errors.every(
+      (graphQLError) =>
+        typeof graphQLError === "object" &&
+        graphQLError !== null &&
+        "type" in graphQLError &&
+        graphQLError.type === "FORBIDDEN" &&
+        "path" in graphQLError &&
+        Array.isArray(graphQLError.path) &&
+        graphQLError.path.includes("reviewRequests")
+    )
+  );
+}
+
+async function graphqlWithReviewerFallback<T>(
+  octokit: Octokit,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  try {
+    return await octokit.graphql<T>(query, variables);
+  } catch (error) {
+    if (!isTeamReviewerAccessError(error)) {
+      throw error;
+    }
+
+    return octokit.graphql<T>(
+      query.replace(GITHUB_TEAM_REVIEWER_FRAGMENT, ""),
+      variables
+    );
+  }
+}
 
 function getReviewerIdentifier(
   reviewer: { login?: string; slug?: string } | null
@@ -2226,9 +2273,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                         ... on User {
                           login
                         }
-                        ... on Team {
-                          slug
-                        }
+                        ${GITHUB_TEAM_REVIEWER_FRAGMENT}
                       }
                     }
                   }
@@ -2243,12 +2288,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const results = (await octokit.graphql(searchQuery, {
-          searchQuery: query,
-          first,
-          after,
-          before,
-        })) as {
+        const results = await graphqlWithReviewerFallback<{
           search: {
             issueCount: number;
             pageInfo: {
@@ -2345,7 +2385,12 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                 }
             >;
           };
-        };
+        }>(octokit, searchQuery, {
+          searchQuery: query,
+          first,
+          after,
+          before,
+        });
 
         const formattedResults = results.search.nodes.map((node) => {
           const base = {
@@ -2487,9 +2532,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                         ... on User {
                           login
                         }
-                        ... on Team {
-                          slug
-                        }
+                        ${GITHUB_TEAM_REVIEWER_FRAGMENT}
                       }
                     }
                   }
@@ -2515,18 +2558,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           graphqlStates = ["MERGED"];
         }
 
-        const pullRequests = (await octokit.graphql(query, {
-          owner,
-          repo,
-          before,
-          after,
-          first: perPage,
-          orderBy: {
-            field: sort,
-            direction: direction,
-          },
-          states: graphqlStates,
-        })) as {
+        const pullRequests = await graphqlWithReviewerFallback<{
           repository: {
             pullRequests: {
               pageInfo: {
@@ -2579,7 +2611,18 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               }[];
             };
           };
-        };
+        }>(octokit, query, {
+          owner,
+          repo,
+          before,
+          after,
+          first: perPage,
+          orderBy: {
+            field: sort,
+            direction: direction,
+          },
+          states: graphqlStates,
+        });
 
         const formattedPullRequests =
           pullRequests.repository.pullRequests.nodes.map((pr) => ({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9593

`list_pull_requests` and `search_advanced` request the slug of team reviewers. GitHub App installation tokens without organization Members read access return node-level `FORBIDDEN` errors for that field, and Octokit turns those partial GraphQL responses into failures for the entire result page.

Retry only these reviewer-specific authorization failures without the Team fragment. The tools still return the pull requests and user review requests, while connections allowed to read teams keep returning team slugs.

## Risks

Blast radius: GitHub MCP pull request listing and advanced search
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] targeted tests for `list_pull_requests` and `search_advanced` reviewer fallback