### PR TITLE
feat: check publish agent permission backend

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -406,8 +406,10 @@ describe("create agent capability", () => {
     const { workspace, authenticator: adminAuth } = await createResourceTest({
       role: "admin",
     });
-    const existingAgent =
-      await AgentConfigurationFactory.createTestAgent(adminAuth);
+    const existingAgent = await AgentConfigurationFactory.createTestAgent(
+      adminAuth,
+      { scope: "hidden" }
+    );
     const { authenticator, user } = await memberAuthInGroup(workspace);
     // No capability grant for this user; only editing rights on the existing agent matter here.
     const editorGroupRes = await GroupResource.findEditorGroupForAgent(
@@ -906,5 +908,254 @@ describe("updateAgentConfigurationsScope", () => {
 
     expect(refreshedEditorTrigger!.status).toBe("enabled");
     expect(refreshedNonEditorTrigger!.status).toBe("disabled");
+  });
+});
+
+describe("publish agent capability", () => {
+  type TestAgent = Awaited<
+    ReturnType<typeof AgentConfigurationFactory.createTestAgent>
+  >;
+
+  // Builds a non-admin editor of `agent` (so they can save new versions and pass the canEdit
+  // filter). With `withPublishCapability`, grants the workspace-wide publish permission to a group
+  // the user belongs to. Editing an existing agent is not create-gated, so no create grant is
+  // needed here — this isolates the publish/unpublish check.
+  async function editorAuthFor(
+    workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"],
+    agent: TestAgent,
+    { withPublishCapability = false }: { withPublishCapability?: boolean } = {}
+  ) {
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+      adminAuth,
+      agent
+    );
+    if (editorGroupRes.isErr()) {
+      throw editorGroupRes.error;
+    }
+    await GroupFactory.withMembers(adminAuth, editorGroupRes.value, [user]);
+
+    if (withPublishCapability) {
+      const group = await GroupFactory.regularAuto(workspace, "publishers");
+      await GroupPermissionResource.grantTypeWide(adminAuth, {
+        group,
+        grantType: "publish",
+        resourceType: "agent",
+      });
+      await GroupFactory.withMembers(adminAuth, group, [user]);
+    }
+
+    // Created after all group memberships so the authenticator resolves them without a refresh.
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    return { authenticator, user };
+  }
+
+  async function saveVersionWithScope(
+    auth: Authenticator,
+    agent: TestAgent,
+    user: Awaited<ReturnType<typeof UserFactory.basic>>,
+    scope: "hidden" | "visible"
+  ) {
+    return createAgentConfiguration(auth, {
+      name: agent.name,
+      description: "Test",
+      instructions: null,
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope,
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      agentConfigurationId: agent.sId,
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      authorId: user.id,
+    });
+  }
+
+  it("rejects publishing (hidden → visible) for an editor without the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "hidden",
+    });
+    const { authenticator, user } = await editorAuthFor(workspace, agent);
+
+    const result = await saveVersionWithScope(
+      authenticator,
+      agent,
+      user,
+      "visible"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "You don't have permission to publish agents."
+      );
+    }
+  });
+
+  it("allows publishing (hidden → visible) for an editor granted the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "hidden",
+    });
+    const { authenticator, user } = await editorAuthFor(workspace, agent, {
+      withPublishCapability: true,
+    });
+
+    const result = await saveVersionWithScope(
+      authenticator,
+      agent,
+      user,
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects unpublishing (visible → hidden) for an editor without the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "visible",
+    });
+    const { authenticator, user } = await editorAuthFor(workspace, agent);
+
+    const result = await saveVersionWithScope(
+      authenticator,
+      agent,
+      user,
+      "hidden"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "You don't have permission to publish agents."
+      );
+    }
+  });
+
+  it("allows unpublishing (visible → hidden) for an editor granted the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "visible",
+    });
+    const { authenticator, user } = await editorAuthFor(workspace, agent, {
+      withPublishCapability: true,
+    });
+
+    const result = await saveVersionWithScope(
+      authenticator,
+      agent,
+      user,
+      "hidden"
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("does not gate a new version that keeps the agent visible", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "visible",
+    });
+    const { authenticator, user } = await editorAuthFor(workspace, agent);
+
+    // The published state does not change, so no publish permission is required to edit.
+    const result = await saveVersionWithScope(
+      authenticator,
+      agent,
+      user,
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects a bulk scope change to visible without the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "hidden",
+    });
+    const { authenticator } = await editorAuthFor(workspace, agent);
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [agent.sId],
+      "visible"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "You don't have permission to publish agents."
+      );
+    }
+  });
+
+  it("rejects a bulk scope change to hidden without the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "visible",
+    });
+    const { authenticator } = await editorAuthFor(workspace, agent);
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [agent.sId],
+      "hidden"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "You don't have permission to publish agents."
+      );
+    }
+  });
+
+  it("allows a bulk scope change for an editor granted the publish capability", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      scope: "hidden",
+    });
+    const { authenticator } = await editorAuthFor(workspace, agent, {
+      withPublishCapability: true,
+    });
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [agent.sId],
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+
+    const row = await AgentConfigurationModel.findOne({
+      where: { sId: agent.sId, workspaceId: workspace.id },
+    });
+    expect(row!.scope).toBe("visible");
   });
 });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -11,11 +11,6 @@ import {
 } from "@app/lib/api/assistant/configuration/helpers";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
-import {
-  canPublishForAuth,
-  getPublishingRestrictionLevel,
-  PUBLISHING_RESTRICTIONS,
-} from "@app/lib/api/assistant/publishing_restrictions";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import {
   buildAuditLogTarget,
@@ -23,7 +18,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DustError } from "@app/lib/error";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
@@ -571,31 +566,41 @@ export async function createAgentConfiguration(
 
   // For hidden agents, track previous editors to disable triggers when editors are removed.
   let previousEditorIds: Set<ModelId> = new Set();
+  // The scope the agent has before this write. A new agent starts hidden, so saving it
+  // visible counts as publishing.
+  let currentScope: AgentConfigurationScope = "hidden";
   if (agentConfigurationId) {
     const existingAgent = await getAgentConfiguration(auth, {
       agentId: agentConfigurationId,
       variant: "light",
     });
-    if (existingAgent && scope === "hidden") {
-      const editorGroupRes = await GroupResource.findEditorGroupForAgent(
-        auth,
-        existingAgent
-      );
-      if (editorGroupRes.isOk()) {
-        const members = await editorGroupRes.value.getActiveMembers(auth);
-        previousEditorIds = new Set(members.map((m) => m.id));
+    if (existingAgent) {
+      currentScope = existingAgent.scope;
+      if (scope === "hidden") {
+        const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+          auth,
+          existingAgent
+        );
+        if (editorGroupRes.isOk()) {
+          const members = await editorGroupRes.value.getActiveMembers(auth);
+          previousEditorIds = new Set(members.map((m) => m.id));
+        }
       }
     }
-    if (existingAgent && existingAgent.scope !== "visible") {
-      const { canPublish, message } = await canPublishAgent(auth);
-      if (!canPublish && scope === "visible" && status === "active") {
-        return new Err(new Error(message!));
-      }
-    }
-  } else {
+  }
+
+  if (
+    needsPublishPermission({
+      currentScope,
+      newScope: scope,
+      isActive: status === "active",
+    })
+  ) {
     const { canPublish, message } = await canPublishAgent(auth);
-    if (!canPublish && scope === "visible" && status === "active") {
-      return new Err(new Error(message ?? "Publishing agents is restricted."));
+    if (!canPublish) {
+      return new Err(
+        new Error(message ?? "You don't have permission to publish agents.")
+      );
     }
   }
 
@@ -1912,12 +1917,35 @@ async function canPublishAgent(auth: Authenticator): Promise<{
   canPublish: boolean;
   message: string | null;
 }> {
-  const featureFlags = await getFeatureFlags(auth);
-  const level = getPublishingRestrictionLevel(featureFlags);
-  if (!level || canPublishForAuth(auth, level)) {
+  const canPublish = await auth.hasWorkspacePermission("publish", "agent");
+  if (canPublish) {
     return { canPublish: true, message: null };
   }
-  return { canPublish: false, message: PUBLISHING_RESTRICTIONS[level].message };
+  return {
+    canPublish: false,
+    message: "You don't have permission to publish agents.",
+  };
+}
+
+// Does changing an agent's scope publish or unpublish it? Both require the workspace "publish
+// agents" permission. Publishing means an active agent becomes visible; unpublishing means an
+// active visible agent becomes hidden. A pure edit, or any change on a non-active
+// (draft/pending/archived) agent, needs no publish permission.
+function needsPublishPermission({
+  currentScope,
+  newScope,
+  isActive,
+}: {
+  currentScope: AgentConfigurationScope;
+  newScope: AgentConfigurationScope;
+  isActive: boolean;
+}): boolean {
+  if (!isActive) {
+    return false;
+  }
+  const publishes = currentScope !== "visible" && newScope === "visible";
+  const unpublishes = currentScope === "visible" && newScope === "hidden";
+  return publishes || unpublishes;
 }
 
 export async function updateAgentConfigurationsScope(
@@ -1941,12 +1969,19 @@ export async function updateAgentConfigurationsScope(
     return new Ok(undefined);
   }
 
-  const { canPublish, message } = await canPublishAgent(auth);
-  if (scope === "visible" && !canPublish) {
-    if (
-      editableAgents.some((a) => a.scope !== "visible" && a.status === "active")
-    ) {
-      return new Err(new Error(message ?? "Publishing agents is restricted."));
+  const batchNeedsPublishPermission = editableAgents.some((a) =>
+    needsPublishPermission({
+      currentScope: a.scope,
+      newScope: scope,
+      isActive: a.status === "active",
+    })
+  );
+  if (batchNeedsPublishPermission) {
+    const { canPublish, message } = await canPublishAgent(auth);
+    if (!canPublish) {
+      return new Err(
+        new Error(message ?? "You don't have permission to publish agents.")
+      );
     }
   }
 


### PR DESCRIPTION
## Description

This PR enforces the agent publish permission check in the backend by replacing the previous feature-flag-based publishing restriction logic with a direct workspace permission check (`auth.hasWorkspacePermission("publish", "agent")`).

The previous check is enforced to not allow users without the permission to unpublish a published agent. This was already enforced in the frontend.

## Tests

Added tests covering: rejection when publishing/unpublishing without the permission, success when the permission is granted via a group, and no gate for edits that don't change the visibility.

## Risks

Low.

## Deploy Plan

Deploy after backfill script completes.