### PR TITLE
[front] Gate agent Insights tab on agent:publish permission

### DIFF
--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -211,7 +211,9 @@ export function AgentDetailsSheet({
     isServerSideMCPServerConfigurationWithName(arg, AGENT_MEMORY_SERVER_NAME)
   );
 
-  const showInsightsTabs = agentId != null && hasPermission("publish", "agent");
+  const showInsightsTabs =
+    agentId != null &&
+    (hasPermission("publish", "agent") || agentConfiguration?.canEdit);
 
   const DescriptionSection = () => {
     const lastAuthor = agentConfiguration?.lastAuthors?.[0];

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -15,6 +15,7 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
@@ -23,7 +24,6 @@ import type { TriggerType } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   ArrowLeft,
   Avatar,
@@ -163,6 +163,10 @@ export function AgentDetailsSheet({
     !isTriggersTabActive
   );
 
+  const { hasPermission } = useWorkspacePermissions(owner, {
+    disabled: !agentId,
+  });
+
   const handleAddTrigger = useCallback(() => {
     setTriggerEditMode({ type: "add" });
   }, []);
@@ -207,8 +211,7 @@ export function AgentDetailsSheet({
     isServerSideMCPServerConfigurationWithName(arg, AGENT_MEMORY_SERVER_NAME)
   );
 
-  const showInsightsTabs =
-    agentId != null && (isBuilder(owner) || agentConfiguration?.canEdit);
+  const showInsightsTabs = agentId != null && hasPermission("publish", "agent");
 
   const DescriptionSection = () => {
     const lastAuthor = agentConfiguration?.lastAuthors?.[0];


### PR DESCRIPTION
## Description

The Insights tab in `AgentDetailsSheet` was shown to any builder or agent editor. It is now gated on the workspace `publish` permission for `agent` (via `useWorkspacePermissions`), with the permissions fetch disabled while the sheet is closed. Fixes dust-tt/tasks#9752.

## Tests

Manual: verified in the agent details sheet that the Insights tab appears only for users holding the `publish` grant on `agent` and is hidden otherwise. Type-check and biome pass via pre-commit hooks.

## Risk

Low. UI-only visibility change; the Insights tab data endpoints already enforce their own authorization. Users who previously saw the tab as builders/editors but lack the `publish` grant will no longer see it. Safe to roll back by reverting the commit.

## Deploy Plan

Standard `front` deploy, no migrations or coordination required.