### PR TITLE
Fix input bar action spacing

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -431,7 +431,7 @@ export function MCPServerDetails({
   };
 
   return (
-    <FormProvider form={form}>
+    <FormProvider form={form} asForm={false}>
       <MCPServerDetailsSheet
         owner={owner}
         mcpServerView={mcpServerView}


### PR DESCRIPTION
## Description

The closed MCP details sheet emitted an empty form next to the Capabilities button. The input bar flex layout counted it as another item and added a second gap before the attachment button.

Use the existing provider-only form mode so the closed sheet keeps its form context without adding a layout element.

## Tests

Manually verified locally with `restricted_spaces_in_input_bar` enabled. Confirmed that the Capabilities, attachment, and Spaces actions have consistent spacing.

## Risk

Low. The sheet Save action already calls its submit handler directly.

## Deploy Plan

Standard deploy.