### PR TITLE
[Conversation Rendering] Fix stale pruning assertion

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.test.ts
@@ -277,7 +277,7 @@ describe("renderConversationForModel", () => {
     expect(tool4.content).toContain("This tool result is no longer available");
     expect(tool5.content).toContain("This tool result is no longer available");
     expect(tool12.content).toBe("result_12");
-    expect(res.value.prunedContext).toBe(true);
+    expect(res.value.prunedContext).toBe(false);
   });
 
   it("prunes a long current turn in a checkpoint and preserves its latest result", async () => {


### PR DESCRIPTION
## Description

Fixes a regression introduced in https://github.com/dust-tt/dust/pull/29267.

That PR made `prunedContext` report whether the latest interaction contains pruned tool results, but left one test expecting pruning from an older interaction to set the flag. Align the assertion with the checkpointed-window semantics and its dedicated test coverage.

## Risks

Blast radius: Conversation-rendering test expectations only.
Risk: none

## Tests

- [x] `NODE_ENV=test npm test lib/api/assistant/conversation_rendering/index.test.ts`

## Deploy Plan

- No deployment required; test-only change.