### PR TITLE
[LLM] Disable reasoning when forcing a tool on Anthropic models

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,4 +1,7 @@
-import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperatureWhenReasoning,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeHaikuFourDotFive<
   TBase extends abstract new (
@@ -14,7 +17,10 @@ export function WithDustClaudeHaikuFourDotFive<
     // Anthropic rejects a non-default temperature while thinking is active (drop
     // it → schema re-applies the required 1), and rejects temperature=1 while
     // thinking is disabled.
-    static readonly configParsers = [dropTemperatureWhenReasoning];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperatureWhenReasoning,
+    ];
   }
 
   return DustClaudeHaikuFourDotFive;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -1,4 +1,7 @@
-import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperature,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeOpusFourDotEightConfig<
   TBase extends abstract new (
@@ -16,7 +19,10 @@ export function WithDustClaudeOpusFourDotEightConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly configParsers = [dropTemperature];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperature,
+    ];
   }
 
   return DustClaudeOpusFourDotEight;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -1,4 +1,7 @@
-import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperature,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeOpusFourDotSevenConfig<
   TBase extends abstract new (
@@ -16,7 +19,10 @@ export function WithDustClaudeOpusFourDotSevenConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly configParsers = [dropTemperature];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperature,
+    ];
   }
 
   return DustClaudeOpusFourDotSeven;

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,4 +1,7 @@
-import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperatureWhenReasoning,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeOpusFourDotSixConfig<
   TBase extends abstract new (
@@ -17,7 +20,10 @@ export function WithDustClaudeOpusFourDotSixConfig<
     static readonly byok = true;
     // Opus 4.6 accepts a caller-supplied temperature, but Anthropic rejects
     // temperature=1 while thinking is disabled; drop it in that case only.
-    static readonly configParsers = [dropTemperatureWhenReasoning];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperatureWhenReasoning,
+    ];
   }
 
   return DustClaudeOpusFourDotSix;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -1,4 +1,7 @@
-import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperature,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeSonnetFiveConfig<
   TBase extends abstract new (
@@ -16,7 +19,10 @@ export function WithDustClaudeSonnetFiveConfig<
     static readonly maxOutputTokens = 64_000;
     static readonly byok = true;
     // Anthropic rejects an explicit temperature for this model.
-    static readonly configParsers = [dropTemperature];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperature,
+    ];
   }
 
   return DustClaudeSonnetFive;

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,4 +1,7 @@
-import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import {
+  disableReasoningWhenForcingTool,
+  dropTemperatureWhenReasoning,
+} from "@app/lib/llms/stream/types/configuration";
 
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
@@ -18,7 +21,10 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     // Anthropic rejects a non-default temperature while thinking is active (drop
     // it → schema re-applies the required 1), and rejects temperature=1 while
     // thinking is disabled.
-    static readonly configParsers = [dropTemperatureWhenReasoning];
+    static readonly configParsers = [
+      disableReasoningWhenForcingTool,
+      dropTemperatureWhenReasoning,
+    ];
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/stream/types/configuration.test.ts
+++ b/front/lib/llms/stream/types/configuration.test.ts
@@ -1,0 +1,27 @@
+import { disableReasoningWhenForcingTool } from "@app/lib/llms/stream/types/configuration";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import { describe, expect, it } from "vitest";
+
+describe("disableReasoningWhenForcingTool", () => {
+  it("forces reasoning to none when a tool is forced", () => {
+    const config: InputConfig = {
+      forceTool: "some_tool",
+      reasoning: { effort: "low" },
+      temperature: 0.2,
+    };
+
+    expect(disableReasoningWhenForcingTool(config)).toEqual({
+      ...config,
+      reasoning: { effort: "none" },
+    });
+  });
+
+  it("leaves reasoning untouched when no tool is forced", () => {
+    const config: InputConfig = {
+      reasoning: { effort: "low" },
+      temperature: 0.2,
+    };
+
+    expect(disableReasoningWhenForcingTool(config)).toBe(config);
+  });
+});

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -52,3 +52,16 @@ export function dropTemperature<C extends InputConfig>(config: C): C {
 export function dropReasoning<C extends InputConfig>(config: C): C {
   return { ...config, reasoning: undefined };
 }
+
+// `configParsers` helper: some providers (Anthropic) reject a forced tool call
+// while extended thinking is active, so disable reasoning when a tool is forced.
+// Apply before `dropTemperatureWhenReasoning` so the now-disabled reasoning keeps
+// any temperature the no-thinking branch allows.
+export function disableReasoningWhenForcingTool<C extends InputConfig>(
+  config: C
+): C {
+  if (config.forceTool !== undefined) {
+    return { ...config, reasoning: { effort: "none" } };
+  }
+  return config;
+}


### PR DESCRIPTION
## Description

Adds a `disableReasoningWhenForcingTool` config parser to the Anthropic union-schema models (Haiku 4.5, Sonnet 4.6/5, Opus 4.6/4.7/4.8) so a forced tool call routes to the no-thinking config branch instead of failing router validation with `invalid_union` (extended thinking and forced `tool_choice` are mutually exclusive on Anthropic).

## Tests

Added a unit test for the parser; type-checked locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`