### PR TITLE
[front] feat: add skill creation to Dust MCP

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -8,6 +8,36 @@ export const GET_SKILL_TOOL_NAME = "get_skill" as const;
 export const CREATE_SKILL_TOOL_NAME = "create_skill" as const;
 export const UPDATE_SKILL_TOOL_NAME = "update_skill" as const;
 
+export const CREATE_SKILL_DESCRIPTION =
+  "Create a new reusable Skill in this workspace: a named, reusable set of instructions an agent can later enable. v1 creates instructions-only skills.";
+
+export const CREATE_SKILL_INPUT_SCHEMA = z.object({
+  name: z.string().describe("Unique, human-readable skill name."),
+  userFacingDescription: z
+    .string()
+    .describe("Short description shown to users browsing skills."),
+  agentFacingDescription: z
+    .string()
+    .max(AGENT_FACING_DESCRIPTION_MAX_LENGTH)
+    .describe("Description used by agents to decide when to use the skill."),
+  instructions: z
+    .string()
+    .describe("The skill's instructions/playbook in markdown."),
+  icon: z
+    .string()
+    .optional()
+    .describe("Optional icon name; auto-suggested if omitted."),
+  bypassSimilarSkillCheck: z
+    .boolean()
+    .optional()
+    .describe(
+      "Bypass the similar skill check and create the skill anyway. Set to true " +
+        "only after the user explicitly confirms they want a separate skill."
+    ),
+});
+
+export type CreateSkillArgs = z.infer<typeof CREATE_SKILL_INPUT_SCHEMA>;
+
 export const SKILL_AUTHORING_TOOLS_METADATA = [
   {
     name: LIST_SKILLS_TOOL_NAME,
@@ -59,34 +89,8 @@ export const SKILL_AUTHORING_TOOLS_METADATA = [
   },
   {
     name: CREATE_SKILL_TOOL_NAME,
-    description:
-      "Create a new reusable Skill in this workspace: a named, reusable set of instructions an agent can later enable. v1 creates instructions-only skills.",
-    schema: {
-      name: z.string().describe("Unique, human-readable skill name."),
-      userFacingDescription: z
-        .string()
-        .describe("Short description shown to users browsing skills."),
-      agentFacingDescription: z
-        .string()
-        .max(AGENT_FACING_DESCRIPTION_MAX_LENGTH)
-        .describe(
-          "Description used by agents to decide when to use the skill."
-        ),
-      instructions: z
-        .string()
-        .describe("The skill's instructions/playbook in markdown."),
-      icon: z
-        .string()
-        .optional()
-        .describe("Optional icon name; auto-suggested if omitted."),
-      bypassSimilarSkillCheck: z
-        .boolean()
-        .optional()
-        .describe(
-          "Bypass the similar skill check and create the skill anyway. Set to true " +
-            "only after the user explicitly confirms they want a separate skill."
-        ),
-    },
+    description: CREATE_SKILL_DESCRIPTION,
+    schema: CREATE_SKILL_INPUT_SCHEMA.shape,
     stake: "high",
     displayLabels: {
       running: "Creating skill",

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -6,6 +6,7 @@ import {
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { CreateSkillArgs } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import {
   CREATE_SKILL_TOOL_NAME,
   GET_SKILL_TOOL_NAME,
@@ -231,6 +232,112 @@ function findDisallowedSpecialTagChanges(
   return disallowed;
 }
 
+export async function createSkill(
+  auth: Authenticator,
+  {
+    agentFacingDescription,
+    bypassSimilarSkillCheck,
+    icon,
+    instructions,
+    name,
+    userFacingDescription,
+  }: CreateSkillArgs
+): Promise<Result<SkillResource, MCPError>> {
+  const user = await requireCreateSkillPermission(auth);
+  if (user.isErr()) {
+    return new Err(user.error);
+  }
+
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    return new Err(new MCPError("Skill name cannot be empty."));
+  }
+
+  // A new skill has no attachments, so any special tag in the instructions
+  // would be dead markup. Keep created skills instructions-only.
+  const specialTags = findSpecialTagsPresent(instructions);
+  if (specialTags.length > 0) {
+    return new Err(
+      new MCPError(
+        `The instructions contain special tags (${specialTags.join(", ")}) ` +
+          "that are wired up in the builder, not authored as plain text. Create " +
+          "instructions-only skills; nested skills, knowledge, and tools must be " +
+          "attached in the builder."
+      )
+    );
+  }
+
+  const existingSkill = await SkillResource.fetchByName(auth, trimmedName);
+  if (existingSkill) {
+    return new Err(
+      new MCPError(`A skill with the name "${trimmedName}" already exists.`)
+    );
+  }
+
+  if (bypassSimilarSkillCheck !== true) {
+    const similarSkills = await findSimilarSkillSummaries(
+      auth,
+      agentFacingDescription
+    );
+    if (similarSkills.isErr()) {
+      return new Err(similarSkills.error);
+    }
+    if (similarSkills.value.length > 0) {
+      return new Err(
+        new MCPError(makeSimilarSkillsErrorMessage(similarSkills.value))
+      );
+    }
+  }
+
+  // Ignore an invalid agent-supplied icon and fall back to a suggestion
+  // rather than persisting a name that renders as a broken glyph.
+  let resolvedIcon = icon && isValidSkillIcon(icon) ? icon : null;
+  if (!resolvedIcon) {
+    const iconResult = await getSkillIconSuggestion(auth, {
+      name: trimmedName,
+      instructions,
+      agentFacingDescription,
+    });
+
+    if (iconResult.isOk()) {
+      resolvedIcon = iconResult.value;
+    } else {
+      logger.warn(
+        { err: iconResult.error },
+        "Failed to generate icon suggestion for skill"
+      );
+      resolvedIcon = "ActionListIcon";
+    }
+  }
+
+  const skill = await SkillResource.makeNew(
+    auth,
+    {
+      status: "active",
+      name: trimmedName,
+      agentFacingDescription,
+      userFacingDescription,
+      instructions,
+      instructionsHtml: convertMarkdownToBlockHtml(instructions),
+      editedBy: user.value.id,
+      requestedSpaceIds: [],
+      icon: resolvedIcon,
+      source: "agent",
+      sourceMetadata: null,
+      availability: DEFAULT_SKILL_AVAILABILITY,
+      reinforcement: "on",
+    },
+    {
+      mcpServerViews: [],
+      attachedKnowledge: [],
+    }
+  );
+
+  await auth.refresh();
+
+  return new Ok(skill);
+}
+
 const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
   [LIST_SKILLS_TOOL_NAME]: async ({ filter, cursor, limit }, { auth }) => {
     const user = requireInteractiveUser(auth);
@@ -325,110 +432,14 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
     ]);
   },
 
-  [CREATE_SKILL_TOOL_NAME]: async (
-    {
-      agentFacingDescription,
-      bypassSimilarSkillCheck,
-      icon,
-      instructions,
-      name,
-      userFacingDescription,
-    },
-    { auth }
-  ) => {
-    const user = await requireCreateSkillPermission(auth);
-    if (user.isErr()) {
-      return new Err(user.error);
+  [CREATE_SKILL_TOOL_NAME]: async (args, { auth }) => {
+    const result = await createSkill(auth, args);
+    if (result.isErr()) {
+      return new Err(result.error);
     }
-
-    const trimmedName = name.trim();
-    if (!trimmedName) {
-      return new Err(new MCPError("Skill name cannot be empty."));
-    }
-
-    // A new skill has no attachments, so any special tag in the instructions
-    // would be dead markup. Keep created skills instructions-only.
-    const specialTags = findSpecialTagsPresent(instructions);
-    if (specialTags.length > 0) {
-      return new Err(
-        new MCPError(
-          `The instructions contain special tags (${specialTags.join(", ")}) ` +
-            "that are wired up in the builder, not authored as plain text. Create " +
-            "instructions-only skills; nested skills, knowledge, and tools must be " +
-            "attached in the builder."
-        )
-      );
-    }
-
-    const existingSkill = await SkillResource.fetchByName(auth, trimmedName);
-    if (existingSkill) {
-      return new Err(
-        new MCPError(`A skill with the name "${trimmedName}" already exists.`)
-      );
-    }
-
-    if (bypassSimilarSkillCheck !== true) {
-      const similarSkills = await findSimilarSkillSummaries(
-        auth,
-        agentFacingDescription
-      );
-      if (similarSkills.isErr()) {
-        return new Err(similarSkills.error);
-      }
-      if (similarSkills.value.length > 0) {
-        return new Err(
-          new MCPError(makeSimilarSkillsErrorMessage(similarSkills.value))
-        );
-      }
-    }
-
-    // Ignore an invalid agent-supplied icon and fall back to a suggestion
-    // rather than persisting a name that renders as a broken glyph.
-    let resolvedIcon = icon && isValidSkillIcon(icon) ? icon : null;
-    if (!resolvedIcon) {
-      const iconResult = await getSkillIconSuggestion(auth, {
-        name: trimmedName,
-        instructions,
-        agentFacingDescription,
-      });
-
-      if (iconResult.isOk()) {
-        resolvedIcon = iconResult.value;
-      } else {
-        logger.warn(
-          { err: iconResult.error },
-          "Failed to generate icon suggestion for skill"
-        );
-        resolvedIcon = "ActionListIcon";
-      }
-    }
-
-    const skill = await SkillResource.makeNew(
-      auth,
-      {
-        status: "active",
-        name: trimmedName,
-        agentFacingDescription,
-        userFacingDescription,
-        instructions,
-        instructionsHtml: convertMarkdownToBlockHtml(instructions),
-        editedBy: user.value.id,
-        requestedSpaceIds: [],
-        icon: resolvedIcon,
-        source: "agent",
-        sourceMetadata: null,
-        availability: DEFAULT_SKILL_AVAILABILITY,
-        reinforcement: "on",
-      },
-      {
-        mcpServerViews: [],
-        attachedKnowledge: [],
-      }
-    );
-
-    await auth.refresh();
 
     const owner = auth.getNonNullableWorkspace();
+    const skill = result.value;
     const text = `Created skill "${skill.name}".`;
 
     return new Ok([

--- a/front/lib/api/mcp_server/README.md
+++ b/front/lib/api/mcp_server/README.md
@@ -16,7 +16,7 @@ HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and
 |---|---|
 | HTTP routing and wiring | `front-api/routes/mcp/` |
 | OAuth metadata discovery | `front-api/routes/mcp/well-known.ts` |
-| Tool definitions | `tools/` (registered from `server.ts`; grouped under `tools/agents/`, `tools/conversations/`, `tools/pods/`, `tools/search/`, `tools/files/`) |
+| Tool definitions | `tools/` (registered from `server.ts`; grouped under `tools/agents/`, `tools/conversations/`, `tools/pods/`, `tools/search/`, `tools/files/`, `tools/skills/`) |
 | Token verification | `auth.ts` |
 | User + workspace resolution from the token | `authenticator.ts` |
 | How tools access per-request auth | `context.ts`, `tools/register.ts` |

--- a/front/lib/api/mcp_server/server.test.ts
+++ b/front/lib/api/mcp_server/server.test.ts
@@ -1,0 +1,34 @@
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
+import { createDustMcpServer } from "@app/lib/api/mcp_server/server";
+import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { describe, expect, it } from "vitest";
+
+describe("Dust MCP server", () => {
+  it("exposes the create_skill tool", async () => {
+    const server = createDustMcpServer();
+    const client = new Client({ name: "dust-mcp-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryWithAuthTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const { tools } = await client.listTools();
+
+    expect(tools).toContainEqual(
+      expect.objectContaining({
+        name: "create_skill",
+        inputSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            agentFacingDescription: expect.objectContaining({
+              maxLength: AGENT_FACING_DESCRIPTION_MAX_LENGTH,
+            }),
+          }),
+        }),
+      })
+    );
+
+    await client.close();
+  });
+});

--- a/front/lib/api/mcp_server/server.ts
+++ b/front/lib/api/mcp_server/server.ts
@@ -33,6 +33,7 @@ Every call is scoped to the authenticated Dust user and workspace.
 - **Workspace**: the Dust organization you signed into. All tools operate within it.
 - **Conversation**: a chat thread with Dust agents. Conversations can live at workspace level or inside a Pod. Each has its own file system for attachments and generated files.
 - **Pod**: a Dust project space — shared context with a description, tasks, linked company-data nodes, conversations, and files.
+- **Skill**: a reusable set of instructions that Dust agents can enable when relevant.
 - **File system**: scoped paths such as \`conversation-<id>/...\` or \`pod-<id>/...\`.
 - **Search**: semantic search across all globally accessible Spaces in the workspace.`;
 

--- a/front/lib/api/mcp_server/tools/index.ts
+++ b/front/lib/api/mcp_server/tools/index.ts
@@ -5,6 +5,7 @@ import { registerFilesTools } from "./files";
 import { registerIdentityTool } from "./identity";
 import { registerPodsTools } from "./pods";
 import { registerSearchTools } from "./search";
+import { registerSkillsTools } from "./skills";
 
 export function registerDustMcpTools(server: McpServer) {
   registerIdentityTool(server);
@@ -13,4 +14,5 @@ export function registerDustMcpTools(server: McpServer) {
   registerPodsTools(server);
   registerSearchTools(server);
   registerFilesTools(server);
+  registerSkillsTools(server);
 }

--- a/front/lib/api/mcp_server/tools/skills/create.ts
+++ b/front/lib/api/mcp_server/tools/skills/create.ts
@@ -1,0 +1,42 @@
+import {
+  CREATE_SKILL_DESCRIPTION,
+  CREATE_SKILL_INPUT_SCHEMA,
+} from "@app/lib/api/actions/servers/skill_authoring/metadata";
+import { createSkill } from "@app/lib/api/actions/servers/skill_authoring/tools";
+import config from "@app/lib/api/config";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
+import {
+  mcpError,
+  mcpJsonResponse,
+} from "@app/lib/api/mcp_server/tools/response";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerSkillsCreateTool(server: McpServer) {
+  registerDustMcpTool(
+    server,
+    "create_skill",
+    {
+      description: CREATE_SKILL_DESCRIPTION,
+      inputSchema: CREATE_SKILL_INPUT_SCHEMA.shape,
+    },
+    async (auth, args) => {
+      const result = await createSkill(auth, args);
+      if (result.isErr()) {
+        return mcpError(result.error.message);
+      }
+
+      const skill = result.value;
+      const workspace = auth.workspace();
+      return mcpJsonResponse({
+        message: `Created skill "${skill.name}".`,
+        skillId: skill.sId,
+        skillName: skill.name,
+        url: `${config.getAppUrl()}${getSkillBuilderRoute(
+          workspace.sId,
+          skill.sId
+        )}`,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/skills/create.ts
+++ b/front/lib/api/mcp_server/tools/skills/create.ts
@@ -27,7 +27,7 @@ export function registerSkillsCreateTool(server: McpServer) {
       }
 
       const skill = result.value;
-      const workspace = auth.workspace();
+      const workspace = auth.getNonNullableWorkspace();
       return mcpJsonResponse({
         message: `Created skill "${skill.name}".`,
         skillId: skill.sId,

--- a/front/lib/api/mcp_server/tools/skills/index.ts
+++ b/front/lib/api/mcp_server/tools/skills/index.ts
@@ -1,0 +1,6 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSkillsCreateTool } from "./create";
+
+export function registerSkillsTools(server: McpServer) {
+  registerSkillsCreateTool(server);
+}


### PR DESCRIPTION
## Description

This PR adds a `create_skill` tool that reuses the existing `skill_authoring` schema and creation path to the existing Dust MCP.

This keeps permissions, duplicate detection, icon fallback, and instructions-only validation aligned across both MCP surfaces, and returns the created Skill id and builder URL.

Will add skill listing + maybe some other features in follow up PRs.

## Tests

- Added coverage for Dust MCP tool registration.

## Risk

- Low. Purely additive.

## Deploy Plan

- Deploy front.
