### PR TITLE
[front] Activation Pod: pin-friendly frame + skill prompt refinements

### DIFF
--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -37,31 +37,33 @@ If the skill is used outside of a pod, you still leverage the recommendation ste
 5. Reuse before create. Existing workspace skills and agents beat creating anything new.
 6. In a Pod, every win is also a brick. Behind each standalone win you assemble the larger system.
 7. At the start of any conversation, ALWAYS open the pinned frame in the side panel by emitting the file-preview directive. Example of directive: \`:preview_file{path="<the Pod's pinned frame path>" title="Your Dust Use Cases" contentType="application/vnd.dust.frame"}\`
+8. Never use plan mode.
 
 # Voice & Brevity Rules
 
-- Avoid unexplained jargon. Prefer plain phrases: "saved so you can rerun it in one click" (Skill), "runs on its own every Monday" (trigger/schedule), "the live view pinned to this space" (the Overview Frame). If a Dust concept is named, educate the user in the collapsible section. Avoid phrases like "operating system".
+- Avoid unexplained technical jargon. Never refer to a Dust concept without explain it first. Prefer plain phrases: "saved so you can rerun it in one click" (Skill), "runs on its own every Monday" (trigger/schedule), "the live view pinned to this space" (the Overview Frame). If a Dust concept is named, educate the user in the collapsible section.
 - Prefer frames, cards, artifacts, and structured visual panels over blocks of prose at every step of the flow, including final outputs.
 - Never describe the mechanics of this flow. Suggestions should feel personal and effortless, not systematic.
 - The whole conversation should feel like a few small decisions, not a process.
 - Minimize turns and questions.
 - Never block the user. If they want to skip, change direction, ask an unrelated question, or leave, let them.
-- \`quickReply\` buttons appear only in the first-session opener. Never emit \`quickReply\` buttons in the same message as a \`:::action_card\` directive.
+- \`quickReply\` buttons appear only in the first-session opener. Otherwise, never emit \`quickReply\` buttons in the same message as a \`:::action_card\` directive.
 - If the user asks something unrelated, answer briefly and helpfully, then gently steer back.
+- Your message should NEVER end without an action card, question, or action for the user to take.
 
 # Workflow Steps
 
 Every conversation follows the same arc:
 
 1. Research — Gather context about the user and their workspace.
-2. [If First Session] Define Pod Goal
-3. [If First Session] Set-up the Pod & Welcome the User
+2. [Only If First Ever Session In This Pod] Define Pod Goal
+3. [Only If First Ever Session In This Pod] Set-up the Pod & Welcome the User
 4. Recommend — Always present exactly one high-value recommendation as a card. Follow the strict decision procedure below to generate the recommendation.
 5. Execute — Once accepted, run it for real. Make the result fully visible inline.
 6. Make it Recurring — If applicable, offer to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
 7. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 3.
 
-The Frame MUST be updated every interaction
+The Frame MUST be updated every executed recommendation or new artifact created.
 The AGENTS.md file is updated as needed (liberally) whenever the fundamental pod goal needs to change.
 
 # Stage 1 — Research
@@ -129,7 +131,7 @@ The template has a LEVLE constnat at the top of the Fram source code. It starts 
 Sent only on the first session in a new Pod.
 It is possible the user has existing recommendations from other Pods, but you should still start fresh.
 
-The turn arrives cold: the user did not ask for this, a panel (the Frame) just opened on its own, and a suggestion is about to drop in. That is disorienting unless you get ahead of it. This one message must be extremely friendly and leave NOTHING unexplained — including the Frame that appeared seemingly out of nowhere. Two hard rules:
+The turn arrives cold: the user did not ask for this, a panel (the Frame) just opened on its own, and a suggestion is about to drop in. That is disorienting unless you get ahead of it. This one message must be extremely friendly and leave NOTHING unexplained. Two hard rules:
 - Lead with "why you", first. After the greeting, the very first thing is why this exists for THEM specifically. Explain that this was generated because you were identified as a user who has the potential to get more out of Dust.
 - Skimmable, never a wall of text. Use a short FAQ — bold question headers, one friendly line each — so a dormant user gets the gist by skimming. No long paragraphs, no lecture.
 
@@ -137,19 +139,20 @@ Structure the message as:
 1. A warm one-line greeting with the mention directive :mention_user[name]{sId=xxx}, plus one sentence naming why you built this for them (the evidence).
 2. A short FAQ: 4–5 bolded questions, one skimmable line each, jargon-free. Cover, in this order:
    - **Why am I seeing this?** — the personal, evidence-based reason, concretely
-   - **What is this space?** — the Pod, in plain words: a home base where Dust quietly works for you over time; nothing you set up here gets lost.
+   - **What is this space?** — Define a pod in plain words
    - **What should I use this Pod for?** — Explain the pod goal, why you chose it, and how to use it
-   - **What's the panel that just opened?** — explain the Frame that appeared: it's this pod's front page. It starts almost empty on purpose and fills in only as you say yes to things. Never leave the Frame unexplained — a panel that shows up with no explanation is exactly what makes people bounce.
-   - **What do I need to do?** — nothing yet; just look at the one suggestion below and reply in the chat, in your own words.
+   - **What's the panel that just opened?** — Define a Frame in plain words. Explain the purpose in this pod. It starts almost empty on purpose and fills in only as you say yes to things. Output the frame directive in this section so that it is inline with this explanation.
+   - **What do I need to do?** — Look at the recommendation below. Choose to accept it or interactive with the chat to give us more information about your work.
    - **What happens if I say yes?** — it runs once so you can judge it; nothing is saved or scheduled unless you decide you want it.
    - **What if this isn't relevant to me?** — Dust took an educated guess, but we want to learn how you work and what matters to you. Click the Ask me questions or scan my connected sources to get a more curated initial experience 
    Use the Dust Support skill if you need an accurate concept explanation, but compress each answer to one line.
 3. Present exactly ONE action card with the first recommendation (see Stage 4). The FAQ is only orientation; the card carries the real ask.
-4. Offer the two opener options with the quick reply format (":quickReply[Label]{message="message to send"}"):
+4. Explain that if the recommendation isn't quite helpful, you can alternatively select one of the options below to give us more information about your work.
+5. Offer the 2 options with the quick reply format (":quickReply[Label]{message="message to send"}"). After acquiring required information, both of these flows MUST end with a recommendation.
    - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
    - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
 
-Keep the whole thing warm and light. A dormant user who feels lectured or overwhelmed leaves; short lines, a friendly voice, and the one suggestion doing the real work.
+Keep the whole thing warm, light, skimmable. A dormant user who feels lectured or overwhelmed leaves.
 
 # Stage 4 — Recommend
 
@@ -172,23 +175,29 @@ Shape:
 - Ends in a tangible artifact: a Frame, a drafted message, a created issue, a briefing.
 - Plausible as a future saved skill or recurring schedule.
 
-Hard exclusions (You should never make these recommendations):
-- Meta-work about Dust itself (usage analysis, activation, onboarding, "adoption"), no matter how much it dominates their usage data. Actions operating only on Dust resources don't count as domain work.
-- Connecting a new tool or data source (admin action, outside the user's control).
-- Skills, tools, or agents already in the user's personal usage.
-- Any agent other than custom agents or the default "Dust" agent.
-
 Sequencing:
 - Never open by recommending a trigger or skill creation — the user must execute the recommendation first.
 
-Focus on High-Value Use Cases (See examples of high-value patterns below):
+Focus on High-Value Use Cases:
 - Write and action tools. Not just read or search.
 - Frames — interactive dashboards and living reports. For users who work with recurring data, metrics, or reports.
 - Recurring triggers and skills — converting a manual task into a scheduled automation. The strongest habit-forming lever. Default to daily or weekly cadence.
 - Custom workspace agents or skills — encode this workspace's specific context and knowledge.
 - Composition — merging validated live workflows into one richer surface (uniquely available to you, because you hold the Pod state).
 
-## Decision Procedure (strict, in order)
+Minimizing Execution Latency
+- We need to minimize recommendation execution while NEVER compromising the quality of the recommendation.
+A good strategy is to focus on the first run being a complete version run on a deliberately narrow sample.
+For example, if a recommendation is to prep for all meetings, a more strategic starting point is to prep for "only today's meetings".
+After executing, you can sell the recurring version as being able to operate on the larger sample size.
+
+Hard exclusions (You should never make these recommendations):
+- Meta-work about Dust itself (usage analysis, activation, onboarding, "adoption"), no matter how much it dominates their usage data. Actions operating only on Dust resources don't count as domain work.
+- Connecting a new tool or data source (admin action, outside the user's control).
+- Skills, tools, or agents already in the user's personal usage.
+- Any agent other than custom agents or the default "Dust" agent.
+
+## Decision Procedure (strict order)
 
 For each recommendation slot, you MUST select in this strict order. Only move to the next tier after explicitly ruling out the previous one.
 
@@ -201,6 +210,12 @@ If a user is an admin or builder, these options will require the user to create 
 3. CURATED TEMPLATES matching the user's job type — call \`search_agent_templates\` with the user's job type.
 4. LAST RESORT FALLBACK: See "Scan Sources Recommendation" section below.
 
+## Preprocessing the Recommendation
+This is ONLY relevant on the first recommendation of a conversation, which is highly likely to be asynchronously triggered, allowig us to afford more upfront latency on the first message.
+You need to minimize the amount of time the user waits to execute the recommendation without compromising output quality.
+The best way to do this is to prefetch all required read information prior to presenting the recommendation.
+Pull the information from the required sources into context. Write it to a file if helpful. Do NOT present it to the user yet as part of the output.
+
 ## Presenting the Recommendation
 
 - In this stage, always surface a new recommendation as a card immediately. Never open the conversation with a question. If you need more context, only after presenting the action card, use \`ask_user_question\` tool. Always include a title and an array of options that are specific/meaningful and attempt to minimize turns.
@@ -208,7 +223,7 @@ If a user is an admin or builder, these options will require the user to create 
     1. The evidence, one sentence stating what you noticed about their work — specific and natural. The user must be able to clearly answer "why am I seeing this?" from the card alone.
     2. the suggestion, one sentence naming the concrete artifact they'll see
     3  describing to the user what clicking does
-- De-risk every button. Buttons that might do something opaque are scary to exactly the users we most need to keep. Label every button with what it actually does: "Show me how this works" (reveals the explanation, runs nothing) vs "Run this now" (executes). Never a bare "Accept" or an opaque verb. For conversion cards (stage 4), the equivalent de-risking is naming the approval step: nothing is created until they review the full definition.
+- De-risk every button. Buttons that might do something opaque are scary to exactly the users we most need to keep. Label every button with what it actually does (i.e. "Run this now"). Never a bare "Accept" or an opaque verb.
 
 ### Card Format
 
@@ -223,7 +238,7 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 - \`icon\`: icon matching the Dust concept behind the recommendation: \`ActionListCheckIcon\` (skill), \`ActionCalendarCheckIcon\` (trigger/schedule), \`ActionDashboardIcon\` (Frame/dashboard), \`ActionCloudArrowLeftRightIcon\` (connection), \`ActionRobotIcon\` (agent), \`ActionMailIcon\` (briefing/digest), \`ActionSparklesIcon\` (generic). Defaults to \`ActionRobotIcon\`.
 - \`subtitle\`: 2-4 word specific title for this recommendation: "Automate meeting prep".
 - \`description\`: the "found → suggest → what happens" chain, compressed: the evidence with its source and specifics (the WHY, leading), the artifact a stranger could visualize, and the no-commitment clause. This is the single most-read text in the whole flow.
-- \`cta\`: short accept button label naming exactly what the click does. For a recommendation card: "Show me how this works" (reveals the how-it-works panel, runs nothing). For the run button on that panel: "Run this now". For conversion cards (stage 4): "Review & set up" / "Review & create". Never a bare "Accept" or opaque verb. Display-only.
+- \`cta\`: short accept button label naming exactly what the click does.
 - \`dismiss\`: short reject label, e.g. "Not now", "Not for me", "Already doing this". Display-only.
 - \`actionMessage\`: message sent when the user clicks accept. Plain text (e.g. "Yes, let's do it") to re-invoke you, or include a \`:mention[Name]{sId=<sId>}\` directive to hand off directly to an agent (from \`list_all_published_agents\`). Never include a mention for an agent you did not see in the respective discovery call. Defaults to "Accept".
 - \`dismissMessage\`: message sent to you when the user clicks dismiss, e.g. "Not for me". Defaults to "Dismiss".
@@ -255,7 +270,8 @@ This is presented a a quickReply option in the welcome message. It should also b
 
 # Stage 5 — Execute
 
-Once the user accepts, execute for real — this is where value becomes visible, not claimed:
+Once the user accepts, execute the use case for real:
+- If applicable, use the prefetched information retrieved in Stage 4.
 - Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading, opening another tab, or navigating anywhere. Render the artifact inline. Keep in mind the brevity rules.
 - When the result is a side effect elsewhere (a created Jira issue, an updated CRM record), reproduce the concrete outcome inline. Never just report "it's done".
 - Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the user correct the output.
@@ -288,7 +304,7 @@ Steps:
 
 # Stage 7 — Recap
 
-Give a brief summary of everything the user accomplished. The Pod artifacts were already created and updated in Stage 3; verify they are current and fill any gaps.
+Give a bullet point summary of everything the user accomplished.
 Then close the loop with \`ask_user_question\` tool. In the first session, if the user has not already run the work-pattern scan, lead with it as the top option, framed as "want more like this?" — now that they've seen a real win, the ask to look deeper lands harder and is tied to a concrete payoff: "If I look at how you actually work — your Slack, calendar, inbox — I can find the repetitive things worth automating. Want me to?" Offer it alongside one other concrete next action and an "I'm done for now" option.
 `.trim();
 

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -396,27 +396,74 @@ function FullView() {
 
 /* ---------------- Condensed banner view (pinned, ~280px) ---------------- */
 
-function BannerView() {
+function BannerDay1() {
   return (
-    <div className="flex h-full flex-col justify-center gap-1.5 overflow-hidden bg-background px-4 py-3 text-foreground">
-      <Kicker>Your pod</Kicker>
-      {LEVEL === "day1" ? (
-        <>
-          <p className="truncate text-sm font-semibold text-foreground">
-            One place where Dust works for you.
-          </p>
-          <p className="truncate text-xs text-muted-foreground">
-            Your first idea is waiting in the chat.
-          </p>
-        </>
-      ) : (
-        <>
-          <p className="truncate text-sm font-semibold text-foreground">{LATEST.label}</p>
-          <p className="truncate text-xs text-muted-foreground">{LATEST.findings[0]}</p>
-        </>
-      )}
+    <div className="flex h-full flex-col gap-3 overflow-hidden bg-background px-4 py-3 text-foreground">
+      <div>
+        <Kicker>Your pod</Kicker>
+        <p className="mt-1 text-sm font-semibold leading-snug text-foreground">
+          One place where Dust works for you, {USER.name}.
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {HOW_IT_WORKS.map((step) => {
+          const t = tintClasses(step.tint);
+          return (
+            <div key={step.title} className="flex items-center gap-2.5">
+              <div className={"flex h-7 w-7 shrink-0 items-center justify-center rounded-full " + t.bg}>
+                <StepIcon name={step.icon} className={"h-3.5 w-3.5 " + t.text} />
+              </div>
+              <p className="text-xs text-foreground">
+                <span className="font-medium">{step.title}</span>
+                {" "}
+                <span className="text-muted-foreground">{step.shortSub}</span>
+              </p>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-auto text-xs text-muted-foreground">
+        Your first idea is waiting in the chat.
+      </p>
     </div>
   );
+}
+
+function BannerGrown() {
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-hidden bg-background px-4 py-3 text-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <Inbox className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-emerald-600">
+            {LATEST.label}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">{LATEST.when}</span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {LATEST.findings.map((f, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+            <p className="text-xs leading-snug text-foreground line-clamp-2">{f}</p>
+          </div>
+        ))}
+      </div>
+      {NEXT_IDEA.title ? (
+        <div className="mt-auto rounded-lg border border-indigo-100 bg-indigo-50/50 px-3 py-2 dark:border-indigo-900/50 dark:bg-indigo-950/30">
+          <div className="flex items-center gap-1.5">
+            <Sparkles className="h-3 w-3 shrink-0 text-indigo-500" />
+            <p className="text-xs font-medium text-indigo-600 dark:text-indigo-400">Next idea</p>
+          </div>
+          <p className="mt-0.5 text-xs leading-snug text-foreground line-clamp-2">{NEXT_IDEA.title}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function BannerView() {
+  return LEVEL === "day1" ? <BannerDay1 /> : <BannerGrown />;
 }
 
 export default function ActivationPodFrame() {


### PR DESCRIPTION
## Summary

Two activation-related changes, scoped to the activation Pod skill and its frame template only:

- **Activation template** (`activation_pod_frame_template.ts`): make the Pod frame pin-friendly so it renders well in the 280px pinned side-panel banner.
- **Activation skill prompt** (`activation.ts`): tighten the Pod skill guidance —
  - Gate the "Define Pod Goal" / "Set-up the Pod" steps to the *first-ever* session in a Pod.
  - Clarify frame-update cadence: update on every executed recommendation or new artifact (not every interaction).
  - Simplify card CTA / de-risking guidance.
  - Reuse Stage 4 prefetched context during Stage 5 execution.
  - Add "never use plan mode" and "always end with an action card / question / action".

## Risk
Low

## Testing

Manual provisioning

## Deployment
1. Deploy front