### PR TITLE
[front] Add action-recommendations API endpoint

### DIFF
--- a/front-api/routes/w/[wId]/action-recommendations/index.test.ts
+++ b/front-api/routes/w/[wId]/action-recommendations/index.test.ts
@@ -1,0 +1,118 @@
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupTest() {
+  const { workspace, auth } = await createPrivateApiMockRequest();
+  return { workspace, auth };
+}
+
+function getRecommendations(wId: string) {
+  return honoApp.request(`/api/w/${wId}/action-recommendations`);
+}
+
+function updateRecommendation(
+  wId: string,
+  recommendationId: string,
+  body: {
+    status?: "executed" | "dismissed";
+    createdSkillId?: string;
+    createdTriggerId?: string;
+  }
+) {
+  return honoApp.request(
+    `/api/w/${wId}/action-recommendations/${recommendationId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("GET /api/w/:wId/action-recommendations", () => {
+  it("returns the user's suggested recommendations", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const rec = await ActivationRecommendationResource.makeNew(auth, {
+      content: "Automate your Monday meeting prep",
+      title: "Next step",
+      conversationId: null,
+    });
+
+    const response = await getRecommendations(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.recommendations).toHaveLength(1);
+    expect(body.recommendations[0]).toEqual({
+      sId: rec.sId,
+      title: "Next step",
+      content: "Automate your Monday meeting prep",
+      conversationId: null,
+    });
+  });
+
+  it("excludes dismissed recommendations", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const rec = await ActivationRecommendationResource.makeNew(auth, {
+      content: "Already handled",
+      title: "Next step",
+      conversationId: null,
+    });
+    await rec.updateFields({ status: "dismissed" });
+
+    const response = await getRecommendations(workspace.sId);
+    const body = await response.json();
+    expect(body.recommendations).toHaveLength(0);
+  });
+});
+
+describe("PATCH /api/w/:wId/action-recommendations/:recommendationId", () => {
+  it("dismisses a recommendation so it no longer surfaces", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const rec = await ActivationRecommendationResource.makeNew(auth, {
+      content: "Scan Slack & Calendar for patterns",
+      title: "Next step",
+      conversationId: null,
+    });
+
+    const updateResponse = await updateRecommendation(workspace.sId, rec.sId, {
+      status: "dismissed",
+    });
+    expect(updateResponse.status).toBe(200);
+    const updateBody = await updateResponse.json();
+    expect(updateBody).toEqual({ success: true });
+
+    const getResponse = await getRecommendations(workspace.sId);
+    const getBody = await getResponse.json();
+    expect(getBody.recommendations).toHaveLength(0);
+  });
+
+  it("marks a recommendation as executed", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const rec = await ActivationRecommendationResource.makeNew(auth, {
+      content: "Set up your first automation",
+      title: "Next step",
+      conversationId: null,
+    });
+
+    const updateResponse = await updateRecommendation(workspace.sId, rec.sId, {
+      status: "executed",
+    });
+    expect(updateResponse.status).toBe(200);
+  });
+
+  it("returns 404 for an unknown recommendation", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await updateRecommendation(workspace.sId, "rec_unknown", {
+      status: "dismissed",
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/w/[wId]/action-recommendations/index.ts
+++ b/front-api/routes/w/[wId]/action-recommendations/index.ts
@@ -1,0 +1,61 @@
+import type {
+  GetActivationRecommendationsResponseBody,
+  UpdateActivationRecommendationResponseBody,
+} from "@app/lib/api/activation/recommendations";
+import {
+  listActivationRecommendationsForUser,
+  updateActivationRecommendationForUser,
+} from "@app/lib/api/activation/recommendations";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const UpdateRecommendationBodySchema = z.object({
+  status: z.enum(["executed", "dismissed"]).optional(),
+});
+
+// Mounted at /api/w/:wId/action-recommendations.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetActivationRecommendationsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const recommendations = await listActivationRecommendationsForUser(auth);
+
+    return ctx.json({ recommendations });
+  }
+);
+
+/** @ignoreswagger */
+app.patch(
+  "/:recommendationId",
+  validate("json", UpdateRecommendationBodySchema),
+  async (ctx): HandlerResult<UpdateActivationRecommendationResponseBody> => {
+    const auth = ctx.get("auth");
+    const recommendationId = ctx.req.param("recommendationId");
+    const { status } = ctx.req.valid("json");
+
+    const result = await updateActivationRecommendationForUser(auth, {
+      recommendationId,
+      status,
+    });
+
+    if (result === "not_found") {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "recommendation_not_found",
+          message: "Recommendation not found.",
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -27,6 +27,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 import { escape } from "html-escaper";
 import { z } from "zod";
+import actionRecommendations from "./action-recommendations";
 import analytics from "./analytics";
 import assistant from "./assistant";
 import auditLogs from "./audit-logs";
@@ -1017,6 +1018,7 @@ app.post(
 
 // Sub-apps using the catch-all default + the partial-subtree exception
 // targets declared above.
+app.route("/action-recommendations", actionRecommendations);
 app.route("/analytics", analytics);
 app.route("/model_tiers", modelTiers);
 app.route("/assistant", assistant);

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -16,13 +16,17 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
         .string()
         .max(4096)
         .describe(
-          "Short title for the recommendation, shown in the 'Your next steps' surface (5-10 words)."
+          "Action label shown in the recommendations list (6-8 words). " +
+            "Be specific enough that the user knows exactly what they would be doing. " +
+            "Example: 'Ask about recent Slack decisions'."
         ),
       content: z
         .string()
         .max(4096)
         .describe(
-          "One-sentence description of what the recommendation involves, shown as subtitle."
+          "Brief subtitle shown under the title in the recommendations list (8-10 words). " +
+            "Explain the 'how' or 'why' in plain language. " +
+            "Example: 'Find past decisions in your Slack workspace in seconds'."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,0 +1,77 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { removeNulls } from "@app/types/shared/utils/general";
+
+const NEXT_STEPS_WINDOW_DAYS = 30;
+const NEXT_STEPS_LIMIT = 5;
+
+export interface ActivationRecommendationForUserType {
+  sId: string;
+  title: string;
+  content: string;
+  conversationId: string | null;
+}
+
+export interface GetActivationRecommendationsResponseBody {
+  recommendations: ActivationRecommendationForUserType[];
+}
+
+export interface UpdateActivationRecommendationResponseBody {
+  success: true;
+}
+
+export async function listActivationRecommendationsForUser(
+  auth: Authenticator
+): Promise<ActivationRecommendationForUserType[]> {
+  const recs = await ActivationRecommendationResource.listSuggestedByUser(
+    auth,
+    {
+      limit: NEXT_STEPS_LIMIT,
+      sinceDaysAgo: NEXT_STEPS_WINDOW_DAYS,
+    }
+  );
+
+  const conversationModelIds = removeNulls(
+    recs.map((rec) => rec.conversationId)
+  );
+  const conversations =
+    conversationModelIds.length === 0
+      ? []
+      : await ConversationResource.fetchByModelIds(auth, conversationModelIds);
+  const sIdByModelId = new Map(conversations.map((c) => [c.id, c.sId]));
+
+  return recs.map((rec) => ({
+    sId: rec.sId,
+    title: rec.title,
+    content: rec.content,
+    conversationId:
+      rec.conversationId !== null
+        ? (sIdByModelId.get(rec.conversationId) ?? null)
+        : null,
+  }));
+}
+
+export async function updateActivationRecommendationForUser(
+  auth: Authenticator,
+  {
+    recommendationId,
+    status,
+  }: {
+    recommendationId: string;
+    status?: Exclude<ActivationRecommendationStatus, "suggested">;
+  }
+): Promise<"not_found" | "ok"> {
+  const rec = await ActivationRecommendationResource.fetchById(
+    auth,
+    recommendationId
+  );
+  if (!rec) {
+    return "not_found";
+  }
+
+  await rec.updateFields({ status });
+
+  return "ok";
+}

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,8 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { removeNulls } from "@app/types/shared/utils/general";
 
 const NEXT_STEPS_WINDOW_DAYS = 30;
 const NEXT_STEPS_LIMIT = 5;
@@ -33,23 +31,11 @@ export async function listActivationRecommendationsForUser(
     }
   );
 
-  const conversationModelIds = removeNulls(
-    recs.map((rec) => rec.conversationId)
-  );
-  const conversations =
-    conversationModelIds.length === 0
-      ? []
-      : await ConversationResource.fetchByModelIds(auth, conversationModelIds);
-  const sIdByModelId = new Map(conversations.map((c) => [c.id, c.sId]));
-
-  return recs.map((rec) => ({
-    sId: rec.sId,
-    title: rec.title,
-    content: rec.content,
-    conversationId:
-      rec.conversationId !== null
-        ? (sIdByModelId.get(rec.conversationId) ?? null)
-        : null,
+  return recs.map(({ resource, conversationSId }) => ({
+    sId: resource.sId,
+    title: resource.title,
+    content: resource.content,
+    conversationId: conversationSId,
   }));
 }
 

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -5,7 +5,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 // "suggested": shown to the user, no action taken yet
 // "executed": user ran the recommended action immediately (one-off)
@@ -27,6 +27,7 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
 
   // The conversation in which the recommendation was (originally) made
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
+  declare conversation?: NonAttribute<ConversationModel>;
   // FK to the skill created as a result of this recommendation (set when status = "skill_created")
   declare createdSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   // FK to the trigger created as a result of this recommendation (set when status = "trigger_created")

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import {
   ActivationRecommendationModel,
   type ActivationRecommendationStatus,
@@ -14,7 +15,9 @@ import type {
   CreationAttributes,
   ModelStatic,
   Transaction,
+  WhereOptions,
 } from "sequelize";
+import { Op } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationRecommendationResource
@@ -108,6 +111,42 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     });
 
     return recs.map((rec) => new this(this.model, rec.get()));
+  }
+
+  static async listSuggestedByUser(
+    auth: Authenticator,
+    { limit = 5, sinceDaysAgo }: { limit?: number; sinceDaysAgo?: number } = {}
+  ): Promise<{ resource: ActivationRecommendationResource; conversationSId: string | null }[]> {
+    const user = auth.getNonNullableUser();
+
+    const where: WhereOptions<ActivationRecommendationModel> = {
+      userId: user.id,
+      workspaceId: auth.getNonNullableWorkspace().id,
+      status: "suggested",
+    };
+
+    if (sinceDaysAgo !== undefined) {
+      const sinceMs = Date.now() - sinceDaysAgo * 24 * 60 * 60 * 1000;
+      where.createdAt = { [Op.gte]: new Date(sinceMs) };
+    }
+
+    const recs = await this.model.findAll({
+      where,
+      include: [
+        {
+          model: ConversationModel,
+          attributes: ["sId"],
+          required: false,
+        },
+      ],
+      order: [["createdAt", "DESC"]],
+      limit,
+    });
+
+    return recs.map((rec) => ({
+      resource: new this(this.model, rec.get()),
+      conversationSId: rec.conversation?.sId ?? null,
+    }));
   }
 
   async updateFields(fields: {

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -1,9 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
 import {
   ActivationRecommendationModel,
   type ActivationRecommendationStatus,
 } from "@app/lib/models/activation/activation_recommendation";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -116,7 +116,12 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
   static async listSuggestedByUser(
     auth: Authenticator,
     { limit = 5, sinceDaysAgo }: { limit?: number; sinceDaysAgo?: number } = {}
-  ): Promise<{ resource: ActivationRecommendationResource; conversationSId: string | null }[]> {
+  ): Promise<
+    {
+      resource: ActivationRecommendationResource;
+      conversationSId: string | null;
+    }[]
+  > {
     const user = auth.getNonNullableUser();
 
     const where: WhereOptions<ActivationRecommendationModel> = {

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -132,6 +132,8 @@ const API_ERROR_TYPES = [
   // Plugins:
   "plugin_not_found",
   "plugin_execution_failed",
+  // Action recommendations:
+  "recommendation_not_found",
   // Triggers:
   "trigger_not_found",
   "webhook_source_not_found",


### PR DESCRIPTION
## Summary

- Prereq: https://github.com/dust-tt/dust/pull/29196
- This purpose of this is only to support the UX as defined in: https://app.dust.tt/share/frame/8afb4896-9522-437a-b25f-a22dd0a278c5
- It is intentional that we don't surface the "activation" naming convention in the API as I don't think we will present that to users. Instead calling it action recommendation, but open to suggestions
- 1 api to list open recommendations + 1 api to update recommendation status

## Testing

* Functional tests
* Local calls with UX changes

## Risk

Low, new endpoints, not accessible via UX yet

## Deployment
1. Deploy front