### PR TITLE
[front] Fix trailing empty text stealing body slot in agent messages

### DIFF
--- a/front/lib/api/assistant/activity_steps.test.ts
+++ b/front/lib/api/assistant/activity_steps.test.ts
@@ -44,6 +44,7 @@ function render(
   );
 }
 
+
 describe("renderAgentMessageContentView", () => {
   it("treats a single plain text content as the body, with no steps", async () => {
     expect(
@@ -104,6 +105,65 @@ describe("renderAgentMessageContentView", () => {
       chainOfThought: "pondering\n",
       activitySteps: [
         { type: "thinking", content: "pondering\n", id: "cot-0-0", step: 0 },
+      ],
+    });
+  });
+
+  it("keeps the body when a function call and trailing empty text follow it", async () => {
+    // Regression: a trailing empty text after a tool call used to steal the body
+    // slot, demoting the real answer to a content step in the Work timeline.
+    // The action step must still appear — the fix must not swallow it.
+    expect(
+      await renderAgentMessageContentView(
+        [
+          {
+            step: 0,
+            content: {
+              type: "reasoning",
+              value: { reasoning: "Let me think", metadata: "", tokens: 0, provider: "openai" },
+            },
+          },
+          { step: 0, content: { type: "text_content", value: "The answer" } },
+          {
+            step: 0,
+            content: {
+              type: "function_call",
+              value: { id: "fc_1", name: "save", arguments: "{}" },
+            },
+          },
+          { step: 1, content: { type: "text_content", value: "" } },
+        ],
+        [
+          {
+            id: 1,
+            sId: "act_1",
+            createdAt: 0,
+            updatedAt: 0,
+            agentMessageId: 1,
+            mcpServerId: null,
+            functionCallId: "fc_1",
+            functionCallName: "save",
+            internalMCPServerName: null,
+            toolName: "save",
+            step: 0,
+            params: {},
+            citationsAllocated: 0,
+            status: "succeeded",
+            executionDurationMs: null,
+            displayLabels: { running: "Saving", done: "Saved" },
+            generatedFiles: [],
+            output: null,
+          },
+        ],
+        agentConfiguration,
+        "msg_test"
+      )
+    ).toEqual({
+      content: "The answer",
+      chainOfThought: "Let me think",
+      activitySteps: [
+        { type: "thinking", content: "Let me think", id: "reasoning-0-0", step: 0 },
+        { type: "action", label: "Saved", id: "action-1", actionId: "act_1", internalMCPServerName: null, toolName: "save", step: 0 },
       ],
     });
   });

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -83,11 +83,33 @@ export async function renderAgentMessageContentView(
 ): Promise<AgentMessageContentView> {
   const actionsByCallId = new Map(actions.map((a) => [a.functionCallId, a]));
 
-  // Find the last text_content index — that item stays as the message body
-  // and should NOT become a content activity step.
+  // Parse each text_content once, stripping any inline chain-of-thought
+  // delimiters. The parsed result is the single notion of "user-facing content"
+  // shared by everything below.
+  const parsedTextByIndex = new Map<
+    number,
+    { content: string | null; chainOfThought: string | null }
+  >();
+  for (const [index, c] of contents.entries()) {
+    if (isAgentTextContent(c.content)) {
+      const contentParser = new AgentMessageContentParser(
+        agentConfiguration,
+        messageId,
+        getCoTDelimitersConfiguration({ agentConfiguration })
+      );
+      parsedTextByIndex.set(
+        index,
+        await contentParser.parseContents([c.content.value])
+      );
+    }
+  }
+
+  // The message body is the LAST text_content whose user-facing content is
+  // non-empty after trimming — it stays as the body and does NOT become a
+  // content activity step.
   let lastTextContentIndex = -1;
   for (let i = contents.length - 1; i >= 0; i--) {
-    if (isAgentTextContent(contents[i].content)) {
+    if (parsedTextByIndex.get(i)?.content?.trim()) {
       lastTextContentIndex = i;
       break;
     }
@@ -110,14 +132,10 @@ export async function renderAgentMessageContentView(
     }
 
     if (isAgentTextContent(c.content)) {
-      const contentParser = new AgentMessageContentParser(
-        agentConfiguration,
-        messageId,
-        getCoTDelimitersConfiguration({ agentConfiguration })
-      );
-      const parsedContent = await contentParser.parseContents([
-        c.content.value,
-      ]);
+      const parsedContent = parsedTextByIndex.get(index);
+      if (!parsedContent) {
+        continue;
+      }
 
       if (parsedContent.chainOfThought?.trim()) {
         activitySteps.push({
@@ -161,6 +179,8 @@ export async function renderAgentMessageContentView(
 
   const { content, chainOfThought } = await selectBodyAndChainOfThought(
     contents,
+    parsedTextByIndex,
+    lastTextContentIndex,
     agentConfiguration,
     messageId
   );
@@ -168,12 +188,21 @@ export async function renderAgentMessageContentView(
   return { content, chainOfThought, activitySteps };
 }
 
-// Body = the last text fragment (final answer); chain of thought = native
-// reasoning when present, otherwise the parsed CoT from the text fragments.
-// This branching is preserved exactly from the previous reload implementation
-// (messages.ts) so live === reload.
+// Body = the final answer; chain of thought = native reasoning when present,
+// otherwise the parsed CoT from the text fragments.
+//
+// When native reasoning is present, the body is the last NON-EMPTY text fragment
+// (identified by `lastTextContentIndex`).
+//
+// With multiple text fragments, only that last non-empty one is the body; every
+// earlier non-empty fragment is demoted to a content step.
 async function selectBodyAndChainOfThought(
   contents: Array<{ step: number; content: AgentContentItemType }>,
+  parsedTextByIndex: Map<
+    number,
+    { content: string | null; chainOfThought: string | null }
+  >,
+  lastTextContentIndex: number,
   agentConfiguration: LightAgentConfigurationType,
   messageId: string
 ): Promise<{ content: string | null; chainOfThought: string | null }> {
@@ -187,14 +216,12 @@ async function selectBodyAndChainOfThought(
     }
   }
 
-  const textFragments = interleaveConditionalNewlines(textValues);
-
   if (reasoningValues.length > 0) {
     return {
-      // For multiple steps outputting text content, we want to display only the
-      // last one as the final answer.
       content:
-        textFragments.length > 0 ? textFragments[textFragments.length - 1] : "",
+        lastTextContentIndex >= 0
+          ? (parsedTextByIndex.get(lastTextContentIndex)?.content ?? "")
+          : "",
       chainOfThought: reasoningValues
         .filter((r): r is string => !!r)
         .join("\n\n"),
@@ -206,7 +233,9 @@ async function selectBodyAndChainOfThought(
     messageId,
     getCoTDelimitersConfiguration({ agentConfiguration })
   );
-  const parsedContent = await contentParser.parseContents(textFragments);
+  const parsedContent = await contentParser.parseContents(
+    interleaveConditionalNewlines(textValues)
+  );
   return {
     content: parsedContent.content,
     chainOfThought: parsedContent.chainOfThought,


### PR DESCRIPTION
## Summary

- **Bug**: When a native-reasoning model (e.g. GPT 5.x) emits a substantive answer mid-run and then finishes with a tool call followed by a trailing empty/whitespace text fragment, that empty fragment claimed the `lastTextContentIndex` body slot. The real answer was demoted to a `content-*` step in the Work timeline and the body rendered as blank.

- **Root cause**: Asymmetry between the `lastTextContentIndex` scan (which accepted any `text_content`, including empty ones) and the demotion check (which required non-empty content to push a content step). An empty trailing text would win the body slot while rendering nothing.

- **Fix**: Parse each `text_content` once upfront into `parsedTextByIndex` (avoiding duplicate parsing), and skip fragments with empty user-facing content when scanning for the last body candidate. The demotion check reuses the same parsed result for symmetry.

## Testing

- `renderAgentMessageContentView > keeps the body when a function call and trailing empty text follow it` — new regression test covering the exact failure shape (reasoning + answer + function call + trailing empty text at the next step); asserts body is the answer and the action step still appears in `activitySteps`
- All 5 unit tests pass locally

## Risk

Low. Change is confined to `renderAgentMessageContentView` (pure function, no DB) and `selectBodyAndChainOfThought`. The only behavioral difference is that trailing empty/whitespace text fragments no longer win the body slot — they're skipped in favor of the last fragment with actual content.