### PR TITLE
feat(sandbox): egress domain-request admin surface (pod + workspace)

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy.test.ts
@@ -9,10 +9,12 @@ const {
   mockEmitAuditLogEvent,
   mockReadWorkspacePolicy,
   mockWriteWorkspacePolicy,
+  mockDismissRequestedWorkspacePolicyDomain,
 } = vi.hoisted(() => ({
   mockEmitAuditLogEvent: vi.fn(),
   mockReadWorkspacePolicy: vi.fn(),
   mockWriteWorkspacePolicy: vi.fn(),
+  mockDismissRequestedWorkspacePolicyDomain: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
@@ -28,6 +30,8 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
 vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
   readWorkspacePolicy: mockReadWorkspacePolicy,
   writeWorkspacePolicy: mockWriteWorkspacePolicy,
+  dismissRequestedWorkspacePolicyDomain:
+    mockDismissRequestedWorkspacePolicyDomain,
 }));
 
 async function setupTest({
@@ -60,6 +64,17 @@ function putPolicy(wId: string, body: unknown) {
   });
 }
 
+function dismissRequest(wId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${wId}/sandbox/egress-policy/requests/dismiss`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
 describe("GET/PUT /api/w/:wId/sandbox/egress-policy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,6 +90,9 @@ describe("GET/PUT /api/w/:wId/sandbox/egress-policy", () => {
         return new Ok(policy);
       }
     );
+    mockDismissRequestedWorkspacePolicyDomain.mockResolvedValue(
+      new Ok({ allowedDomains: ["api.github.com"] })
+    );
   });
 
   it("returns the workspace egress policy to workspace admins with Computer enabled", async () => {
@@ -85,8 +103,69 @@ describe("GET/PUT /api/w/:wId/sandbox/egress-policy", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       policy: { allowedDomains: ["api.github.com"] },
+      requestedDomains: [],
     });
     expect(mockReadWorkspacePolicy).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it("surfaces pending requests from the same policy read", async () => {
+    const { workspace } = await setupTest();
+    mockReadWorkspacePolicy.mockResolvedValue(
+      new Ok({
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 42 }],
+      })
+    );
+
+    const response = await getPolicy(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      policy: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 42 }],
+      },
+      requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 42 }],
+    });
+    expect(mockReadWorkspacePolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses a pending request without granting it", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await dismissRequest(workspace.sId, {
+      domain: "api.stripe.com",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      policy: { allowedDomains: ["api.github.com"] },
+    });
+    expect(mockDismissRequestedWorkspacePolicyDomain).toHaveBeenCalledWith(
+      expect.any(Object),
+      { domain: "api.stripe.com" }
+    );
+    expect(mockWriteWorkspacePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a dismiss with a missing domain", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await dismissRequest(workspace.sId, {});
+
+    expect(response.status).toBe(400);
+    expect(mockDismissRequestedWorkspacePolicyDomain).not.toHaveBeenCalled();
+  });
+
+  it("rejects a dismiss from a non-admin user", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await dismissRequest(workspace.sId, {
+      domain: "api.stripe.com",
+    });
+
+    expect(response.status).toBe(403);
+    expect(mockDismissRequestedWorkspacePolicyDomain).not.toHaveBeenCalled();
   });
 
   it("updates the workspace egress policy with normalized domains", async () => {

--- a/front-api/routes/w/[wId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy.ts
@@ -4,6 +4,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import {
+  dismissRequestedWorkspacePolicyDomain,
   readWorkspacePolicy,
   writeWorkspacePolicy,
 } from "@app/lib/api/sandbox/egress_policy";
@@ -14,9 +15,15 @@ import type {
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 // Mounted at /api/w/:wId/sandbox/egress-policy.
 const app = workspaceApp();
+
+const DismissRequestBodySchema = z.object({
+  domain: z.string().min(1),
+});
 
 /** @ignoreswagger */
 app.get(
@@ -35,7 +42,13 @@ app.get(
       });
     }
 
-    return ctx.json({ policy: result.value });
+    // Requests live in the same policy file (the proxy ignores the section).
+    return ctx.json({
+      policy: result.value,
+      requestedDomains: (result.value.requestedDomains ?? []).map(
+        ({ domain, requestedAtMs }) => ({ domain, requestedAtMs })
+      ),
+    });
   }
 );
 
@@ -87,6 +100,41 @@ app.put(
         allowed_domains: result.value.allowedDomains.join(","),
       },
     });
+
+    return ctx.json({ policy: result.value });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/requests/dismiss",
+  async (ctx): HandlerResult<PutWorkspaceEgressPolicyResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const body = await ctx.req.json().catch(() => null);
+    const parsedBody = DismissRequestBodySchema.safeParse(body);
+    if (!parsedBody.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(parsedBody.error).toString(),
+        },
+      });
+    }
+
+    const result = await dismissRequestedWorkspacePolicyDomain(auth, {
+      domain: parsedBody.data.domain,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to dismiss sandbox egress domain request: ${result.error.message}`,
+        },
+      });
+    }
 
     return ctx.json({ policy: result.value });
   }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -55,6 +55,31 @@ function putPolicy(wId: string, spaceId: string, body: unknown) {
   );
 }
 
+function dismissRequest(wId: string, spaceId: string, domain: string) {
+  return honoApp.request(
+    `/api/w/${wId}/spaces/${spaceId}/sandbox/egress-policy/requests/dismiss`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain }),
+    }
+  );
+}
+
+function seedPolicyFile(
+  wId: string,
+  spaceId: string,
+  policy: {
+    allowedDomains: string[];
+    requestedDomains?: { domain: string; requestedAtMs: number }[];
+  }
+) {
+  fileStorageMock.setObject(
+    `w/${wId}/sandboxes/${spaceId}.json`,
+    JSON.stringify(policy)
+  );
+}
+
 describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
   beforeEach(() => {
     // The GCS global mock (registered in vite.setup.ts) is reset before each
@@ -70,7 +95,10 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     const response = await getPolicy(workspace.sId, pod.sId);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ policy: { allowedDomains: [] } });
+    expect(await response.json()).toEqual({
+      policy: { allowedDomains: [] },
+      requestedDomains: [],
+    });
   });
 
   it("persists domains and returns them on round-trip, normalized", async () => {
@@ -96,6 +124,7 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     const getResponse = await getPolicy(workspace.sId, pod.sId);
     expect(await getResponse.json()).toEqual({
       policy: { allowedDomains: ["api.github.com", "*.github.com"] },
+      requestedDomains: [],
     });
 
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
@@ -145,6 +174,86 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     expect(await response.json()).toMatchObject({
       error: { type: "feature_flag_not_found" },
     });
+  });
+
+  it("surfaces pending domain requests from the policy file", async () => {
+    const { workspace } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+    seedPolicyFile(workspace.sId, pod.sId, {
+      allowedDomains: ["api.github.com"],
+      requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+    });
+
+    const response = await getPolicy(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      policy: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+      },
+      requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+    });
+  });
+
+  it("dismisses a pending request without granting it", async () => {
+    const { workspace } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+    seedPolicyFile(workspace.sId, pod.sId, {
+      allowedDomains: ["api.github.com"],
+      requestedDomains: [
+        { domain: "api.stripe.com", requestedAtMs: 1 },
+        { domain: "api.notion.com", requestedAtMs: 2 },
+      ],
+    });
+
+    const response = await dismissRequest(
+      workspace.sId,
+      pod.sId,
+      "api.stripe.com"
+    );
+
+    expect(response.status).toBe(200);
+    const getResponse = await getPolicy(workspace.sId, pod.sId);
+    expect(await getResponse.json()).toEqual({
+      policy: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.notion.com", requestedAtMs: 2 }],
+      },
+      requestedDomains: [{ domain: "api.notion.com", requestedAtMs: 2 }],
+    });
+  });
+
+  it("resolves a request atomically when its domain is approved via PUT", async () => {
+    const { workspace } = await setupTest();
+    const pod = await SpaceFactory.project(workspace);
+    seedPolicyFile(workspace.sId, pod.sId, {
+      allowedDomains: [],
+      requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+    });
+
+    await putPolicy(workspace.sId, pod.sId, {
+      allowedDomains: ["api.stripe.com"],
+    });
+
+    const getResponse = await getPolicy(workspace.sId, pod.sId);
+    expect(await getResponse.json()).toEqual({
+      policy: { allowedDomains: ["api.stripe.com"] },
+      requestedDomains: [],
+    });
+  });
+
+  it("rejects a non-admin dismiss with a 403", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace);
+
+    const response = await dismissRequest(
+      workspace.sId,
+      pod.sId,
+      "api.stripe.com"
+    );
+
+    expect(response.status).toBe(403);
   });
 
   it("returns 400 for non-project spaces", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -4,6 +4,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import {
+  dismissRequestedOwnerPolicyDomain,
   readOwnerPolicy,
   writeOwnerPolicy,
 } from "@app/lib/api/sandbox/egress_policy";
@@ -15,6 +16,8 @@ import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/egress-policy. The parent
 // sandbox sub-app applies the workspace-admin and `sandbox_functions` gates;
@@ -27,6 +30,10 @@ import { withSpace } from "@front-api/middlewares/with_space";
 // survives sandbox destroy/recreate cycles, so nothing is written at sandbox
 // activation. Mirrors the workspace egress-policy route.
 const app = workspaceApp();
+
+const DismissRequestBodySchema = z.object({
+  domain: z.string().min(1),
+});
 
 /** @ignoreswagger */
 app.get(
@@ -57,7 +64,13 @@ app.get(
       });
     }
 
-    return ctx.json({ policy: result.value });
+    // Requests live in the same policy file (the proxy ignores the section).
+    return ctx.json({
+      policy: result.value,
+      requestedDomains: (result.value.requestedDomains ?? []).map(
+        ({ domain, requestedAtMs }) => ({ domain, requestedAtMs })
+      ),
+    });
   }
 );
 
@@ -126,6 +139,54 @@ app.put(
         space_id: space.sId,
       },
     });
+
+    return ctx.json({ policy: result.value });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/requests/dismiss",
+  withSpace({ requireCanReadOrAdministrate: true }),
+  async (ctx): HandlerResult<PutPodEgressPolicyResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    if (!space.isProject()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Pod egress policy is only available for project spaces.",
+        },
+      });
+    }
+
+    const body = await ctx.req.json().catch(() => null);
+    const parsedBody = DismissRequestBodySchema.safeParse(body);
+    if (!parsedBody.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(parsedBody.error).toString(),
+        },
+      });
+    }
+
+    const result = await dismissRequestedOwnerPolicyDomain(auth, {
+      ownerId: space.sId,
+      domain: parsedBody.data.domain,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to dismiss pod egress domain request: ${result.error.message}`,
+        },
+      });
+    }
 
     return ctx.json({ policy: result.value });
   }

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -5,6 +5,7 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import {
+  useDismissWorkspaceEgressRequest,
   useUpdateWorkspaceEgressPolicy,
   useUpdateWorkspaceSandboxAgentEgressRequests,
   useWorkspaceEgressPolicy,
@@ -35,6 +36,7 @@ export function NetworkSection() {
 
   const {
     policy,
+    requestedDomains,
     isWorkspaceEgressPolicyLoading,
     isWorkspaceEgressPolicyError,
   } = useWorkspaceEgressPolicy({
@@ -43,6 +45,8 @@ export function NetworkSection() {
   });
   const { updateWorkspaceEgressPolicy, isUpdatingWorkspaceEgressPolicy } =
     useUpdateWorkspaceEgressPolicy({ owner });
+  const { dismissWorkspaceEgressRequest, isDismissingRequest } =
+    useDismissWorkspaceEgressRequest({ owner });
   const {
     allowAgentEgressRequests,
     updateWorkspaceSandboxAgentEgressRequests,
@@ -96,6 +100,8 @@ export function NetworkSection() {
       );
     }
 
+    const allowedDomainSet = new Set(policy.allowedDomains);
+
     return (
       <Page.Vertical align="stretch" gap="lg">
         <div className="flex items-center justify-between gap-4 border-y border-border py-4">
@@ -126,10 +132,19 @@ export function NetworkSection() {
 
         <EgressDomainListEditor
           allowedDomains={policy.allowedDomains}
+          pendingRequests={requestedDomains.filter(
+            (request) => !allowedDomainSet.has(request.domain)
+          )}
+          onApproveRequest={(domain) =>
+            updateWorkspaceEgressPolicy({
+              allowedDomains: [...new Set([...policy.allowedDomains, domain])],
+            })
+          }
+          onRejectRequest={(domain) => dismissWorkspaceEgressRequest(domain)}
           onSave={(allowedDomains) =>
             updateWorkspaceEgressPolicy({ allowedDomains })
           }
-          isUpdating={isUpdatingWorkspaceEgressPolicy}
+          isUpdating={isUpdatingWorkspaceEgressPolicy || isDismissingRequest}
           emptyMessage="No workspace-specific domains are currently allowed."
         />
       </Page.Vertical>

--- a/front/components/pod/settings/PodNetworkSection.tsx
+++ b/front/components/pod/settings/PodNetworkSection.tsx
@@ -1,5 +1,6 @@
 import { EgressDomainListEditor } from "@app/components/sandbox/EgressDomainListEditor";
 import {
+  useDismissPodEgressRequest,
   usePodEgressPolicy,
   useUpdatePodEgressPolicy,
 } from "@app/lib/swr/pods";
@@ -15,14 +16,22 @@ interface PodNetworkSectionProps {
 // allowlist for the Pod's Shared Computer. Workspace-admin only (matching the
 // API), gated behind the `sandbox_functions` feature at the call site.
 export function PodNetworkSection({ owner, podId }: PodNetworkSectionProps) {
-  const { policy, isPodEgressPolicyLoading, isPodEgressPolicyError } =
-    usePodEgressPolicy({ owner, podId });
+  const {
+    policy,
+    requestedDomains,
+    isPodEgressPolicyLoading,
+    isPodEgressPolicyError,
+  } = usePodEgressPolicy({ owner, podId });
   const { updatePodEgressPolicy, isUpdatingPodEgressPolicy } =
     useUpdatePodEgressPolicy({ owner, podId });
+  const { dismissPodEgressRequest, isDismissingRequest } =
+    useDismissPodEgressRequest({ owner, podId });
 
   if (isPodEgressPolicyLoading) {
     return <Spinner />;
   }
+  const allowedDomainSet = new Set(policy.allowedDomains);
+
   if (isPodEgressPolicyError) {
     return (
       <ContentMessage
@@ -46,8 +55,17 @@ export function PodNetworkSection({ owner, podId }: PodNetworkSectionProps) {
 
       <EgressDomainListEditor
         allowedDomains={policy.allowedDomains}
+        pendingRequests={requestedDomains.filter(
+          (request) => !allowedDomainSet.has(request.domain)
+        )}
+        onApproveRequest={(domain) =>
+          updatePodEgressPolicy({
+            allowedDomains: [...new Set([...policy.allowedDomains, domain])],
+          })
+        }
+        onRejectRequest={(domain) => dismissPodEgressRequest(domain)}
         onSave={(allowedDomains) => updatePodEgressPolicy({ allowedDomains })}
-        isUpdating={isUpdatingPodEgressPolicy}
+        isUpdating={isUpdatingPodEgressPolicy || isDismissingRequest}
         emptyMessage="No Pod-specific domains are currently allowed."
       />
     </div>

--- a/front/components/sandbox/EgressDomainListEditor.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.tsx
@@ -1,5 +1,12 @@
 import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
-import { Button, ContentMessage, Input, Plus, Trash01 } from "@dust-tt/sparkle";
+import {
+  Button,
+  ContentMessage,
+  Input,
+  Plus,
+  Trash01,
+  XClose,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface EgressDomainListEditorProps {
@@ -10,6 +17,9 @@ interface EgressDomainListEditorProps {
   isUpdating: boolean;
   // Shown when the list is empty (scope wording differs per surface).
   emptyMessage: string;
+  pendingRequests?: { domain: string }[];
+  onApproveRequest?: (domain: string) => void;
+  onRejectRequest?: (domain: string) => void;
 }
 
 // Add/remove editor for a sandbox egress allowlist, shared by the workspace
@@ -21,6 +31,9 @@ export function EgressDomainListEditor({
   onSave,
   isUpdating,
   emptyMessage,
+  pendingRequests,
+  onApproveRequest,
+  onRejectRequest,
 }: EgressDomainListEditorProps) {
   const [domainInput, setDomainInput] = useState("");
 
@@ -90,12 +103,45 @@ export function EgressDomainListEditor({
         />
       </form>
 
-      {allowedDomains.length === 0 ? (
+      {allowedDomains.length === 0 && (pendingRequests?.length ?? 0) === 0 ? (
         <ContentMessage variant="outline" size="lg">
           {emptyMessage}
         </ContentMessage>
       ) : (
         <div className="flex w-full flex-col divide-y divide-separator">
+          {pendingRequests?.map((request) => (
+            <div key={request.domain} className="flex items-center gap-3 py-3">
+              <div
+                title={request.domain}
+                className="flex min-w-0 grow items-center gap-2 overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2"
+              >
+                <span className="font-mono text-sm text-foreground">
+                  {request.domain}
+                </span>
+                <span className="shrink-0 rounded-full bg-golden-100 px-2 py-0.5 text-xs font-medium text-golden-800">
+                  Pending approval
+                </span>
+              </div>
+              <Button
+                variant="highlight"
+                size="mini"
+                label="Approve"
+                tooltip={`Add ${request.domain} to the allowlist`}
+                disabled={isUpdating}
+                onClick={() => onApproveRequest?.(request.domain)}
+                className="shrink-0"
+              />
+              <Button
+                variant="ghost"
+                size="mini"
+                icon={XClose}
+                tooltip={`Reject ${request.domain}`}
+                disabled={isUpdating}
+                onClick={() => onRejectRequest?.(request.domain)}
+                className="shrink-0"
+              />
+            </div>
+          ))}
           {allowedDomains.map((domain) => (
             <div key={domain} className="flex items-center gap-3 py-3">
               <pre

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1493,6 +1493,7 @@ export function usePodEgressPolicy({
 
   return {
     policy: data?.policy ?? EMPTY_EGRESS_POLICY,
+    requestedDomains: data?.requestedDomains ?? emptyArray(),
     isPodEgressPolicyLoading: disabled ? false : isLoading,
     isPodEgressPolicyError: !!error,
     mutatePodEgressPolicy: mutate,
@@ -1536,7 +1537,16 @@ export function useUpdatePodEgressPolicy({
       }
 
       const data: PutPodEgressPolicyResponseBody = await response.json();
-      await mutatePodEgressPolicy({ policy: data.policy }, false);
+      // Keep requestedDomains, or the other pending rows vanish until refetch.
+      await mutatePodEgressPolicy(
+        {
+          policy: data.policy,
+          requestedDomains: (data.policy.requestedDomains ?? []).map(
+            ({ domain: d, requestedAtMs }) => ({ domain: d, requestedAtMs })
+          ),
+        },
+        false
+      );
       sendNotification({
         type: "success",
         title: "Pod network policy updated",
@@ -1557,4 +1567,67 @@ export function useUpdatePodEgressPolicy({
   };
 
   return { updatePodEgressPolicy, isUpdatingPodEgressPolicy };
+}
+
+export function useDismissPodEgressRequest({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const [isDismissingRequest, setIsDismissing] = useState(false);
+  const { mutatePodEgressPolicy } = usePodEgressPolicy({
+    owner,
+    podId,
+    disabled: true,
+  });
+
+  const dismissPodEgressRequest = async (domain: string): Promise<boolean> => {
+    setIsDismissing(true);
+    try {
+      const response = await clientFetch(
+        `${podEgressPolicyUrl(owner.sId, podId)}/requests/dismiss`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to reject domain request",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PutPodEgressPolicyResponseBody = await response.json();
+      await mutatePodEgressPolicy(
+        {
+          policy: data.policy,
+          requestedDomains: (data.policy.requestedDomains ?? []).map(
+            ({ domain: d, requestedAtMs }) => ({ domain: d, requestedAtMs })
+          ),
+        },
+        false
+      );
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to reject domain request",
+        description: "An unexpected error occurred. Please try again.",
+      });
+      return false;
+    } finally {
+      setIsDismissing(false);
+    }
+  };
+
+  return { dismissPodEgressRequest, isDismissingRequest };
 }

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -62,7 +62,8 @@ export function useWorkspaceEgressPolicy({
 
   return {
     policy: data?.policy ?? EMPTY_EGRESS_POLICY,
-    isWorkspaceEgressPolicyLoading: isLoading,
+    requestedDomains: data?.requestedDomains ?? emptyArray(),
+    isWorkspaceEgressPolicyLoading: disabled ? false : isLoading,
     isWorkspaceEgressPolicyError: !!error,
     mutateWorkspaceEgressPolicy: mutate,
   };
@@ -398,7 +399,16 @@ export function useUpdateWorkspaceEgressPolicy({
       }
 
       const data: PutWorkspaceEgressPolicyResponseBody = await response.json();
-      await mutateWorkspaceEgressPolicy({ policy: data.policy }, false);
+      // Keep requestedDomains, or the other pending rows vanish until refetch.
+      await mutateWorkspaceEgressPolicy(
+        {
+          policy: data.policy,
+          requestedDomains: (data.policy.requestedDomains ?? []).map(
+            ({ domain: d, requestedAtMs }) => ({ domain: d, requestedAtMs })
+          ),
+        },
+        false
+      );
       sendNotification({
         type: "success",
         title: "Network policy updated",
@@ -422,4 +432,66 @@ export function useUpdateWorkspaceEgressPolicy({
     updateWorkspaceEgressPolicy,
     isUpdatingWorkspaceEgressPolicy: isUpdating,
   };
+}
+
+export function useDismissWorkspaceEgressRequest({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isDismissingRequest, setIsDismissing] = useState(false);
+  const { mutateWorkspaceEgressPolicy } = useWorkspaceEgressPolicy({
+    owner,
+    disabled: true,
+  });
+
+  const dismissWorkspaceEgressRequest = async (
+    domain: string
+  ): Promise<boolean> => {
+    setIsDismissing(true);
+    try {
+      const response = await clientFetch(
+        `${workspaceEgressPolicyUrl(owner.sId)}/requests/dismiss`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to reject domain request",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PutWorkspaceEgressPolicyResponseBody = await response.json();
+      await mutateWorkspaceEgressPolicy(
+        {
+          policy: data.policy,
+          requestedDomains: (data.policy.requestedDomains ?? []).map(
+            ({ domain: d, requestedAtMs }) => ({ domain: d, requestedAtMs })
+          ),
+        },
+        false
+      );
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to reject domain request",
+        description: "An unexpected error occurred. Please try again.",
+      });
+      return false;
+    } finally {
+      setIsDismissing(false);
+    }
+  };
+
+  return { dismissWorkspaceEgressRequest, isDismissingRequest };
 }

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -203,6 +203,11 @@ class FileStorageMock {
     return this._objectStore.get(filePath);
   }
 
+  // Seed the in-memory object store directly (no write path).
+  setObject(filePath: string, content: string): void {
+    this._objectStore.set(filePath, content);
+  }
+
   reset(): void {
     this._writeStreamCalls.length = 0;
     this._readStreamCalls.length = 0;

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -2,6 +2,7 @@ import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 
 export type GetWorkspaceEgressPolicyResponseBody = {
   policy: EgressPolicy;
+  requestedDomains?: { domain: string; requestedAtMs: number }[];
 };
 
 export type PutWorkspaceEgressPolicyResponseBody = {
@@ -10,6 +11,7 @@ export type PutWorkspaceEgressPolicyResponseBody = {
 
 export type GetPodEgressPolicyResponseBody = {
   policy: EgressPolicy;
+  requestedDomains?: { domain: string; requestedAtMs: number }[];
 };
 
 export type PutPodEgressPolicyResponseBody = {


### PR DESCRIPTION
## Description

Follow up of `30474` (stacked on `30529`). Lights up the admin surface that reviews egress domain requests, for both the Pod and workspace allowlists.

Mirrored across the pod route (`/spaces/:spaceId/sandbox/egress-policy`) and the workspace route (`/sandbox/egress-policy`):

1. **Read.** The egress-policy `GET` sources pending requests from the same policy-file read that returns the allowlist (they ride in the same file; the proxy ignores the section) — no second fetch.
2. **Reject.** A new `POST /requests/dismiss` removes a request without granting it. Workspace-admin gated by the parent sandbox sub-app, same as the allowlist `PUT`.
3. **Approve.** No new path — `PUT`ting the allowlist with the domain appended resolves its request atomically (the write preserves the section; normalize drops the now-allowed request).
4. **Front.** `useDismissPodEgressRequest` / `useDismissWorkspaceEgressRequest` hooks + Reject wired into `PodNetworkSection` and the workspace `NetworkSection`; the shared `EgressDomainListEditor` renders the "Pending approval" rows with Approve/Reject buttons. The update hooks preserve `requestedDomains` on optimistic mutate so approving one request doesn't blank the others until revalidation.

## Risk

Low. Connects a previously inert surface to real data behind the existing workspace-admin gate. Dismiss grants nothing (never touches `allowedDomains`). Safe to rollback.

## Tests
<img width="940" height="252" alt="Screenshot 2026-08-14 at 2 11 22 PM" src="https://github.com/user-attachments/assets/1b91a718-e396-4968-b383-69435a37efba" />
<img width="557" height="340" alt="Screenshot 2026-08-14 at 2 11 05 PM" src="https://github.com/user-attachments/assets/0dff1091-8a76-483a-b6f2-deaf73f4fad6" />

Pod + workspace routes: pending requests surfaced from the file; dismiss removes a request without touching the allowlist; approve-via-PUT resolves atomically; non-admin dismiss → 403; missing-domain dismiss → 400; plus the existing GET/PUT/403/non-project cases. 20 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
