### PR TITLE
feat(sandbox): pod env var update and delete routes

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
@@ -1,0 +1,321 @@
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
+async function setupTest({
+  role = "admin",
+}: {
+  role?: MembershipRoleType;
+} = {}) {
+  const { workspace, auth, user, ...rest } = await createPrivateApiMockRequest({
+    role,
+  });
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+  const pod = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, auth, user, pod, ...rest };
+}
+
+function patchEnvVar(wId: string, spaceId: string, id: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${wId}/spaces/${spaceId}/sandbox/env-vars/${id}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function deleteEnvVar(wId: string, spaceId: string, id: string) {
+  return honoApp.request(
+    `/api/w/${wId}/spaces/${spaceId}/sandbox/env-vars/${id}`,
+    {
+      method: "DELETE",
+    }
+  );
+}
+
+describe("PATCH/DELETE /api/w/:wId/spaces/:spaceId/sandbox/env-vars/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects non-admin requests", async () => {
+    const { workspace, pod } = await setupTest({ role: "user" });
+
+    const response = await deleteEnvVar(
+      workspace.sId,
+      pod.sId,
+      "env_var_unknown"
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+  });
+
+  it("returns 404 for a missing sandbox environment variable", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+    const staleEnvVarId = upsert.value.resource.sId;
+    await upsert.value.resource.delete(auth);
+
+    const response = await deleteEnvVar(workspace.sId, pod.sId, staleEnvVarId);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for a non-project space", async () => {
+    const { workspace, auth, pod } = await setupTest();
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await deleteEnvVar(
+      workspace.sId,
+      regularSpace.sId,
+      upsert.value.resource.sId
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: { type: "space_not_found" },
+    });
+  });
+
+  it("returns 404 when targeting a workspace-scoped env var through the pod route", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "workspace", workspace: auth.getNonNullableWorkspace() },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await deleteEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId
+    );
+
+    expect(response.status).toBe(404);
+    // The workspace-scoped row must still exist.
+    expect(
+      await SandboxEnvVarResource.fetchByName(
+        auth,
+        { kind: "workspace", workspace: auth.getNonNullableWorkspace() },
+        "API_TOKEN"
+      )
+    ).not.toBeNull();
+  });
+
+  it("returns 404 when targeting another pod's env var", async () => {
+    const { workspace, auth, user, pod } = await setupTest();
+    const otherPod = await SpaceFactory.project(workspace, user.id);
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod: otherPod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const deleteResponse = await deleteEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId
+    );
+    expect(deleteResponse.status).toBe(404);
+
+    const patchResponse = await patchEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId,
+      { allowedDomains: ["api.example.com"] }
+    );
+    expect(patchResponse.status).toBe(404);
+
+    // The other pod's row must still exist.
+    expect(
+      await SandboxEnvVarResource.fetchByName(
+        auth,
+        { kind: "pod", pod: otherPod },
+        "API_TOKEN"
+      )
+    ).not.toBeNull();
+  });
+
+  it("deletes an existing sandbox environment variable", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await deleteEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(
+      await SandboxEnvVarResource.fetchByName(
+        auth,
+        { kind: "pod", pod },
+        "API_TOKEN"
+      )
+    ).toBeNull();
+  });
+
+  it("rejects an empty PATCH body", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await patchEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId,
+      {}
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+
+  it("promotes a config env var to an HTTPS secret", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await patchEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId,
+      { kind: "https_secret", allowedDomains: ["api.example.com"] }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      envVar: { kind: "https_secret", allowedDomains: ["api.example.com"] },
+    });
+  });
+
+  it("updates allowed domains on an HTTPS secret", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+        kind: "https_secret",
+        allowedDomains: ["api.example.com"],
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await patchEnvVar(
+      workspace.sId,
+      pod.sId,
+      upsert.value.resource.sId,
+      { allowedDomains: ["api.example.com", "api.github.com"] }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      envVar: { allowedDomains: ["api.example.com", "api.github.com"] },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].ts
@@ -1,0 +1,164 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import type { PatchSandboxEnvVarResponseBody } from "@app/lib/resources/sandbox_env_var_resource";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import { SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withSpace } from "@front-api/middlewares/with_space";
+import type { SuccessResponseBody } from "@front-api/routes/types";
+import { z } from "zod";
+
+const PatchPodSandboxEnvVarBodySchema = z
+  .object({
+    kind: z.enum(SANDBOX_ENV_VAR_KINDS).optional(),
+    allowedDomains: z.array(z.string()).optional(),
+  })
+  .refine(
+    (body) => body.kind !== undefined || body.allowedDomains !== undefined,
+    { message: "At least one field must be provided." }
+  );
+
+const ParamsSchema = z.object({
+  id: z.string(),
+});
+
+// Mounted at /api/w/:wId/spaces/:spaceId/sandbox/env-vars/:id.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  withSpace({ requireProject: true, requireCanReadOrAdministrate: true }),
+  validate("param", ParamsSchema),
+  validate("json", PatchPodSandboxEnvVarBodySchema),
+  async (ctx): HandlerResult<PatchSandboxEnvVarResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { id } = ctx.req.valid("param");
+
+    const { allowedDomains, kind } = ctx.req.valid("json");
+
+    const scope = { kind: "pod" as const, pod: space };
+    // Scope-filtered: workspace-scoped rows and rows of other pods resolve
+    // to null here.
+    const envVar = await SandboxEnvVarResource.fetchById(auth, scope, id);
+    if (!envVar) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Sandbox environment variable not found.",
+        },
+      });
+    }
+
+    // Phase 1 only permits one-way promotion. Demoting an HTTPS secret back
+    // to config would put the real value back into the agent environment.
+    if (kind === "config" && envVar.kind === "https_secret") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Demoting an HTTPS secret to a config environment variable is not supported.",
+        },
+      });
+    }
+
+    if (kind === "https_secret" && envVar.kind === "config") {
+      if (allowedDomains === undefined) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "allowedDomains is required when promoting to an HTTPS secret.",
+          },
+        });
+      }
+
+      const promoteResult = await envVar.promoteToHttpsSecret(auth, scope, {
+        allowedDomains,
+        context: getAuditLogContext(auth),
+      });
+      if (promoteResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: promoteResult.error.message,
+          },
+        });
+      }
+
+      return ctx.json({ envVar: promoteResult.value.toJSON() });
+    }
+
+    if (allowedDomains !== undefined) {
+      const updateResult = await envVar.updateAllowedDomains(auth, scope, {
+        allowedDomains,
+        context: getAuditLogContext(auth),
+      });
+      if (updateResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: updateResult.error.message,
+          },
+        });
+      }
+
+      return ctx.json({ envVar: updateResult.value.toJSON() });
+    }
+
+    return ctx.json({ envVar: envVar.toJSON() });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/",
+  withSpace({ requireProject: true, requireCanReadOrAdministrate: true }),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { id } = ctx.req.valid("param");
+
+    // Scope-filtered: workspace-scoped rows and rows of other pods resolve
+    // to null here.
+    const envVar = await SandboxEnvVarResource.fetchById(
+      auth,
+      { kind: "pod", pod: space },
+      id
+    );
+    if (!envVar) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Sandbox environment variable not found.",
+        },
+      });
+    }
+
+    const deleteResult = await envVar.delete(auth, {
+      context: getAuditLogContext(auth),
+    });
+    if (deleteResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: deleteResult.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
@@ -15,6 +15,8 @@ import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 
+import envVarId from "./[id]";
+
 const PostPodSandboxEnvVarBodySchema = z.object({
   name: z.string(),
   value: z.string(),
@@ -109,5 +111,7 @@ app.post(
     );
   }
 );
+
+app.route("/:id", envVarId);
 
 export default app;


### PR DESCRIPTION
## Description

Follow up of #30206 (list/create routes) — second of the two pod env var route PRs: **update and delete** (`PATCH`/`DELETE /api/w/:wId/spaces/:spaceId/sandbox/env-vars/:id`).

Same gates as the collection routes (workspace-admin + `sandbox_functions` at the sandbox router; project spaces only, via `withSpace({ requireProject: true })` from #30206). Fetches are scope-filtered — workspace rows and other pods' rows resolve to 404. PATCH supports allowed-domains updates and the one-way config → https_secret promotion; demotion is rejected.

## Risk

New endpoints only, admin + FF gated, no consumers until the UI PR. Safe to rollback.

## Tests

Update/delete functional tests: gating, cross-scope 404s (workspace row / other pod's row), promotion + demotion rejection, allowed-domains update, stale-id 404.
