### PR TITLE
[front] Fix seats flagged "near limit" after pro→business contract switch

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -686,10 +686,6 @@ export async function applyContractStartSubscriptionSwap({
     metronomeCustomerId: customerId,
     metronomeContractId: contractId,
     planCode: targetPlanCode ?? "",
-    // Reconcile against the contract that just started, not the DB-active one:
-    // the subscription swap (and contract-cache flush) below hasn't happened
-    // yet, so `getActiveContract` would still resolve the previous contract and
-    // read the wrong seat allowance — flagging every seat as "near limit".
     contract: contractResult.value,
   });
   if (!targetPlanCode) {

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -686,6 +686,11 @@ export async function applyContractStartSubscriptionSwap({
     metronomeCustomerId: customerId,
     metronomeContractId: contractId,
     planCode: targetPlanCode ?? "",
+    // Reconcile against the contract that just started, not the DB-active one:
+    // the subscription swap (and contract-cache flush) below hasn't happened
+    // yet, so `getActiveContract` would still resolve the previous contract and
+    // read the wrong seat allowance — flagging every seat as "near limit".
+    contract: contractResult.value,
   });
   if (!targetPlanCode) {
     logger.info(

--- a/front/lib/api/metronome/reconcile_credit_state.test.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.test.ts
@@ -1,4 +1,5 @@
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -13,10 +14,14 @@ const {
   mockListMetronomeSeatBalances,
   mockFetchPerUserAwuUsage,
   mockGetCachedDefaultCapThresholdsBySeatType,
+  mockGetSeatAllowancesByNormalizedSeatType,
+  mockSetUserNearLimit,
 } = vi.hoisted(() => ({
   mockListMetronomeSeatBalances: vi.fn(),
   mockFetchPerUserAwuUsage: vi.fn(),
   mockGetCachedDefaultCapThresholdsBySeatType: vi.fn(),
+  mockGetSeatAllowancesByNormalizedSeatType: vi.fn(),
+  mockSetUserNearLimit: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/client", async () => {
@@ -47,6 +52,24 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   };
 });
 
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return {
+    ...actual,
+    getSeatAllowancesByNormalizedSeatType:
+      mockGetSeatAllowancesByNormalizedSeatType,
+  };
+});
+
+vi.mock("@app/lib/metronome/user_block", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/user_block")
+  >("@app/lib/metronome/user_block");
+  return { ...actual, setUserNearLimit: mockSetUserNearLimit };
+});
+
 const METRONOME_CUSTOMER_ID = "cust_test_reconcile";
 const METRONOME_CONTRACT_ID = "ct_test_reconcile";
 
@@ -67,6 +90,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
   mockGetCachedDefaultCapThresholdsBySeatType.mockResolvedValue({});
+  mockGetSeatAllowancesByNormalizedSeatType.mockResolvedValue({});
+  mockSetUserNearLimit.mockResolvedValue(undefined);
 });
 
 describe("reconcileWorkspaceUserCreditStates", () => {
@@ -161,5 +186,54 @@ describe("reconcileWorkspaceUserCreditStates", () => {
     // Shared inputs fetched once for the whole workspace, not per user.
     expect(mockListMetronomeSeatBalances).toHaveBeenCalledTimes(1);
     expect(mockFetchPerUserAwuUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads seat allowances from the passed contract, not the DB-active one", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "pro",
+    });
+
+    // The bug: at contract.start the DB-active contract still resolves to the
+    // previous (legacy) contract, whose pro allowance is 0. Passing the started
+    // contract must yield the real 8000 allowance instead — mirror that by
+    // returning the correct allowance only when a contract is provided.
+    mockGetSeatAllowancesByNormalizedSeatType.mockImplementation(
+      async (_workspaceId: string, contract?: unknown) =>
+        contract ? { pro: 8000 } : { pro: 0 }
+    );
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok([seatBalance(user.sId, 8000, 8000)])
+    );
+    // 5000 consumed: below 80% of the real 8000 cap (6400), but above 80% of
+    // the buggy 0 cap — so the near-limit flag hinges on which cap is used.
+    mockFetchPerUserAwuUsage.mockResolvedValue(
+      new Ok(new Map([[user.sId, 5000]]))
+    );
+
+    const startedContract = { id: "ct_started" } as unknown as CachedContract;
+
+    await reconcileWorkspaceUserCreditStates({
+      workspace: renderLightWorkspaceType({ workspace }),
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      metronomeContractId: METRONOME_CONTRACT_ID,
+      planCode: "CP_BUSINESS_PLAN",
+      contract: startedContract,
+    });
+
+    expect(mockGetSeatAllowancesByNormalizedSeatType).toHaveBeenCalledWith(
+      workspace.sId,
+      startedContract
+    );
+    // With the correct 8000 cap the user is NOT near limit; the bug flagged it.
+    expect(mockSetUserNearLimit).toHaveBeenCalledWith(
+      workspace.sId,
+      user.sId,
+      false
+    );
   });
 });

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -500,12 +500,6 @@ export async function reconcileWorkspaceUserCreditStates({
   metronomeCustomerId: string;
   metronomeContractId: string;
   planCode: string;
-  // The contract being reconciled against. Pass it when it may differ from the
-  // workspace's DB-active contract (e.g. the `contract.start` webhook running
-  // before the subscription swap): the seat allowances must be read from this
-  // contract, not from `getActiveContract`, which would otherwise resolve the
-  // previous contract and collapse the per-user cap to zero — flagging every
-  // seat as "near limit". Defaults to the DB-active contract when omitted.
   contract?: CachedContract | null;
 }): Promise<void> {
   if (!isCreditPricedPlanPrefix(planCode)) {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/lib/metronome/live_user_credit_inputs";
 import { fetchPerApiKeyAwuUsage } from "@app/lib/metronome/per_api_key_usage";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
@@ -493,11 +494,19 @@ export async function reconcileWorkspaceUserCreditStates({
   metronomeCustomerId,
   metronomeContractId,
   planCode,
+  contract,
 }: {
   workspace: LightWorkspaceType;
   metronomeCustomerId: string;
   metronomeContractId: string;
   planCode: string;
+  // The contract being reconciled against. Pass it when it may differ from the
+  // workspace's DB-active contract (e.g. the `contract.start` webhook running
+  // before the subscription swap): the seat allowances must be read from this
+  // contract, not from `getActiveContract`, which would otherwise resolve the
+  // previous contract and collapse the per-user cap to zero — flagging every
+  // seat as "near limit". Defaults to the DB-active contract when omitted.
+  contract?: CachedContract | null;
 }): Promise<void> {
   if (!isCreditPricedPlanPrefix(planCode)) {
     return;
@@ -514,7 +523,7 @@ export async function reconcileWorkspaceUserCreditStates({
   try {
     const [seatAllowancesResult, creditUsageConfig, membershipsResult] =
       await Promise.all([
-        getSeatAllowancesByNormalizedSeatType(workspaceId),
+        getSeatAllowancesByNormalizedSeatType(workspaceId, contract),
         CreditUsageConfigurationResource.fetchByWorkspaceModelId(workspace.id),
         MembershipResource.getActiveMemberships({ workspace }),
       ]);

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -667,16 +667,10 @@ export function getAwuAllocationForNormalizedSeatType(
 
 /**
  * Resolve the seat AWU allowance for each normalized pool-limit seat type of
- * a contract. Returns an empty record when the workspace has no active
- * contract. Used to derive total per-user cap thresholds (pool override + seat
- * allowance) from the pool-only override persisted on memberships.
- *
- * Pass an explicit `contract` when the caller already holds the contract to
- * reconcile against and it may differ from the workspace's DB-active contract
- * — e.g. the `contract.start` webhook, which reconciles per-user state against
- * the newly-started contract *before* the DB subscription swap (and cache
- * flush) has happened, so `getActiveContract` would still resolve the previous
- * contract and yield the wrong (often zero) allowance.
+ * a contract, defaulting to the workspace's active contract. Returns an empty
+ * record when there is no contract. Used to derive total per-user cap
+ * thresholds (pool override + seat allowance) from the pool-only override
+ * persisted on memberships.
  */
 export async function getSeatAllowancesByNormalizedSeatType(
   workspaceId: string,

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -667,23 +667,30 @@ export function getAwuAllocationForNormalizedSeatType(
 
 /**
  * Resolve the seat AWU allowance for each normalized pool-limit seat type of
- * the workspace's active contract. Returns an empty record when the workspace
- * has no active contract. Used to derive total per-user cap thresholds (pool
- * override + seat allowance) from the pool-only override persisted on
- * memberships.
+ * a contract. Returns an empty record when the workspace has no active
+ * contract. Used to derive total per-user cap thresholds (pool override + seat
+ * allowance) from the pool-only override persisted on memberships.
+ *
+ * Pass an explicit `contract` when the caller already holds the contract to
+ * reconcile against and it may differ from the workspace's DB-active contract
+ * — e.g. the `contract.start` webhook, which reconciles per-user state against
+ * the newly-started contract *before* the DB subscription swap (and cache
+ * flush) has happened, so `getActiveContract` would still resolve the previous
+ * contract and yield the wrong (often zero) allowance.
  */
 export async function getSeatAllowancesByNormalizedSeatType(
-  workspaceId: string
+  workspaceId: string,
+  contract?: CachedContract | null
 ): Promise<Partial<Record<NormalizedPoolLimitSeatType, number>>> {
-  const contract = await getActiveContract(workspaceId);
-  if (!contract) {
+  const resolvedContract = contract ?? (await getActiveContract(workspaceId));
+  if (!resolvedContract) {
     return {};
   }
   const productSeatTypes = await getProductSeatTypes();
   const allowances: Partial<Record<NormalizedPoolLimitSeatType, number>> = {};
   for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
     allowances[seatType] = getAwuAllocationForNormalizedSeatType(
-      contract,
+      resolvedContract,
       seatType,
       productSeatTypes
     );


### PR DESCRIPTION
## Problem

After a future-dated contract switch (e.g. the legacy-pro → business migration run via `migrate_legacy_pro_monthly_to_business.ts`), many workspaces end up with **all seats flagged "near limit"**. A manual reconcile (poke `reconcile-credit-state`) clears them. Some workspaces switch cleanly, others flip every user — pointing at a race with the contract state at cutover.

## Root cause

The flag is set at `contract.start`, not by the script. In `applyContractStartSubscriptionSwap`, `reconcileWorkspaceUserCreditStates` runs **before** the DB subscription swap (and contract-cache flush). It reads per-seat **balances** from the newly-started contract (passed in as `metronomeContractId`) but per-seat **allowances** from `getSeatAllowancesByNormalizedSeatType` → `getActiveContract`, which still resolves the **previous** contract.

For legacy-pro sources the previous contract has no new-pricing per-seat AWU credit, so the allowance is `0`:

```
effectiveCap = poolCap(0) + seatAllowance(0) = 0
nearLimit    = consumedAwuCredits >= 0.8 * 0   →   consumed >= 0   →   true for any usage
```

A later manual reconcile runs after the swap, so `getActiveContract` returns the business contract with the correct allowance → the flag clears. Same function, correct inputs — which is exactly why manual reconcile "fixes" it.

## Fix

Thread the contract being reconciled into the allowance lookup, so seat balances and allowances always come from the **same** contract. `getSeatAllowancesByNormalizedSeatType` gets an optional `contract` param; the `contract.start` webhook passes the started contract. Falls back to the DB-active contract when omitted (the manual/poke path, where the DB is already correct), so no other caller changes behaviour.

## Test

Adds a regression test in `reconcile_credit_state.test.ts`: with 5000 consumed and a passed contract whose pro allowance is 8000, the user is **not** near limit (5000 < 6400); the pre-fix path (allowance 0) would have flagged it. Also asserts the contract is forwarded to the allowance lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)