### PR TITLE
[front] enh: show skill import GitHub connection user on hover

### DIFF
--- a/front/components/skills/import/GitHubConnectionRow.tsx
+++ b/front/components/skills/import/GitHubConnectionRow.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   GithubMonoLogo,
+  Tooltip,
 } from "@dust-tt/sparkle";
 
 interface GitHubConnectionRowProps {
@@ -46,10 +47,15 @@ export function GitHubConnectionRow({
       </div>
       <Chip size="xs" color="success" label="Connected" />
       {connection.connectedBy && (
-        <Avatar
-          size="xxs"
-          name={connection.connectedBy.fullName}
-          visual={connection.connectedBy.imageUrl ?? undefined}
+        <Tooltip
+          label={connection.connectedBy.fullName}
+          trigger={
+            <Avatar
+              size="xxs"
+              name={connection.connectedBy.fullName}
+              visual={connection.connectedBy.imageUrl ?? undefined}
+            />
+          }
         />
       )}
       {isAdmin(owner) && (

--- a/front/components/skills/import/GitHubConnectionRow.tsx
+++ b/front/components/skills/import/GitHubConnectionRow.tsx
@@ -49,12 +49,15 @@ export function GitHubConnectionRow({
       {connection.connectedBy && (
         <Tooltip
           label={connection.connectedBy.fullName}
+          tooltipTriggerAsChild
           trigger={
-            <Avatar
-              size="xxs"
-              name={connection.connectedBy.fullName}
-              visual={connection.connectedBy.imageUrl ?? undefined}
-            />
+            <div className="cursor-default">
+              <Avatar
+                size="xxs"
+                name={connection.connectedBy.fullName}
+                visual={connection.connectedBy.imageUrl ?? undefined}
+              />
+            </div>
           }
         />
       )}


### PR DESCRIPTION
## Description

Show the name of the user who connected the shared GitHub account when hovering their avatar in the skill import dialog.

The backend already sent the relevant data, so the github connection row reuses that field with the standard tooltip.

<img width="620" height="402" alt="image" src="https://github.com/user-attachments/assets/3d9bdfde-f444-4b24-9934-648d06bdebff" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
