### PR TITLE
[front] perf: extended stats on messages (workspaceId, conversationId)

### DIFF
--- a/front/migrations/pre-deploy/20260722195624_add_dependencies_statistics_on_messages.sql
+++ b/front/migrations/pre-deploy/20260722195624_add_dependencies_statistics_on_messages.sql
@@ -1,0 +1,8 @@
+-- conversationId functionally determines workspaceId, but the planner multiplies both
+-- selectivities, underestimating conversation-scoped fetches by ~60x on large workspaces.
+-- Functional-dependency statistics let it use the conversationId selectivity alone.
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE STATISTICS IF NOT EXISTS messages_workspace_id_conversation_id_dependencies (dependencies)
+  ON "workspaceId", "conversationId" FROM messages;
+ANALYZE messages;


### PR DESCRIPTION
## Description

Tl;Dr messages x agent_messages x user_messages x whatnot sits at the bottom of a lot of endpoints + activities (no surprise), and postgres grossly underestimates the number of rows returned by lookups. 
The consequences is PG choosing plans that it thinks are the best for the given amount of rows, eg a nested loop vs hash join. 
There are probably more causes to this underestimating, but the two I could identify and confirm are:

- PG is not aware of the correlation between conversationId and workspaceId -> it's 1, workspaceId being a partition key in our data model, so it multiplies both selectivities which drops the number of estimated rows by 40-100x.
- our `statistics_target` (sample resolution + many other thing) is still the default value, but increasing it on a big table could have ripple effects that I have fully listed, and after reading more of pg code and the paper it cited in the sampling function, and doing some distributions reconstruction from our datawarehouse, I'm confident it's not the biggest bang for buck in the two.

See https://github.com/dust-tt/dust-infra/pull/742 "Example: Message in a big join query" for more context.

In this PR we introduce a conversationId, workspaceId stat and launch an ANALYZE.

Subsequent PRs will change a bit the datamodel by creating a conversationId col on agent_message + user_message (with double write and backfill) and add them in the join clauses, to reduce drastically the lookup size required to do a join.

## Tests

N/A


## Risk

Low

## Deploy Plan

- merge
- run pre-deploy