### PR TITLE
[front] enh: add conversationId to message side tables (nullable, indexed)

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -955,6 +955,7 @@ describe("getConversation with branches", () => {
 
     const beforeBranchUserMessage = await UserMessageModel.create({
       userId: user.id,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       content: "before branch",
       userContextUsername: "testuser",
@@ -978,6 +979,7 @@ describe("getConversation with branches", () => {
 
     const atBranchUserMessage = await UserMessageModel.create({
       userId: user.id,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       content: "at branch",
       userContextUsername: "testuser",
@@ -1001,6 +1003,7 @@ describe("getConversation with branches", () => {
 
     const afterBranchUserMessage = await UserMessageModel.create({
       userId: user.id,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       content: "after branch main",
       userContextUsername: "testuser",
@@ -1032,6 +1035,7 @@ describe("getConversation with branches", () => {
 
     const branchUserMessage = await UserMessageModel.create({
       userId: user.id,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       content: "branch message",
       userContextUsername: "testuser",
@@ -1814,6 +1818,7 @@ describe("postUserMessage", () => {
       const compactionMessageRow = await CompactionMessageModel.create({
         status: "created",
         content: null,
+        conversationId: conversation.id,
         workspaceId: workspace.id,
       });
       await MessageModel.create({
@@ -1865,6 +1870,7 @@ describe("postUserMessage", () => {
       const compactionMessageRow = await CompactionMessageModel.create({
         status: "succeeded",
         content: "compacted summary",
+        conversationId: conversation.id,
         workspaceId: workspace.id,
       });
       await MessageModel.create({
@@ -3267,6 +3273,7 @@ describe("compactConversation", () => {
     const compactionMessageRow = await CompactionMessageModel.create({
       status: "succeeded",
       content: "compacted summary",
+      conversationId: conversation.id,
       workspaceId: workspace.id,
     });
     await MessageModel.create({
@@ -3307,6 +3314,7 @@ describe("compactConversation", () => {
       status: "created",
       agentConfigurationId: agentConfig.sId,
       agentConfigurationVersion: 0,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       skipToolsValidation: false,
     });
@@ -4400,6 +4408,7 @@ describe("isConversationEventAllowedForAuth", () => {
 
     const baseUserMessage = await UserMessageModel.create({
       userId: user.id,
+      conversationId: conversation.id,
       workspaceId: workspace.id,
       content: "Base message",
       userContextUsername: "testuser",

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -86,6 +86,7 @@ async function createUserMessage(
 
   const userMessage = await UserMessageModel.create({
     userId: user.id,
+    conversationId: conversation.id,
     workspaceId: workspace.id,
     content,
     userContextUsername: user.username,
@@ -129,6 +130,7 @@ async function createAgentMessage(
   const workspace = auth.getNonNullableWorkspace();
 
   const agentMessage = await AgentMessageModel.create({
+    conversationId: conversation.id,
     workspaceId: workspace.id,
     status,
     agentConfigurationId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -27,6 +27,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelResolutionMethodType } from "@app/types/assistant/models/types";
 import { MODEL_RESOLUTION_METHODS } from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
@@ -305,6 +306,9 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare userContextAuthMethod: string | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
+  // Denormalized from messages for conversation-scoped fetches (plain column, no FK — the value
+  // is derived from messages at write time). Nullable until backfilled.
+  declare conversationId: CreationOptional<ModelId | null>;
 
   declare user?: NonAttribute<UserModel>;
   declare key?: NonAttribute<KeyModel>;
@@ -401,6 +405,10 @@ UserMessageModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "user_message",
@@ -408,6 +416,15 @@ UserMessageModel.init(
     indexes: [
       { fields: ["userContextOrigin"], concurrently: true },
       { fields: ["workspaceId"], concurrently: true },
+      { fields: ["workspaceId", "conversationId"], concurrently: true },
+      // Backfill scaffolding: serves the keyset probe on rows not yet backfilled. Dropped once
+      // conversationId flips NOT NULL.
+      {
+        fields: ["id"],
+        where: { conversationId: null },
+        name: "user_messages_id_conversation_id_null",
+        concurrently: true,
+      },
       { fields: ["userContextApiKeyId"], concurrently: true },
       {
         fields: ["workspaceId", "agenticOriginMessageId"],
@@ -488,6 +505,10 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare resolvedModelId: string | null;
   declare resolvedReasoningEffort: string | null;
   declare modelResolutionMethod: ModelResolutionMethodType | null;
+
+  // Denormalized from messages for conversation-scoped fetches (plain column, no FK — the value
+  // is derived from messages at write time). Nullable until backfilled.
+  declare conversationId: CreationOptional<ModelId | null>;
 }
 
 AgentMessageModel.init(
@@ -601,12 +622,25 @@ AgentMessageModel.init(
         isIn: [MODEL_RESOLUTION_METHODS],
       },
     },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_message",
     sequelize: frontSequelize,
     indexes: [
       { fields: ["workspaceId"], concurrently: true },
+      { fields: ["workspaceId", "conversationId"], concurrently: true },
+      // Backfill scaffolding: serves the keyset probe on rows not yet backfilled. Dropped once
+      // conversationId flips NOT NULL.
+      {
+        fields: ["id"],
+        where: { conversationId: null },
+        name: "agent_messages_id_conversation_id_null",
+        concurrently: true,
+      },
       // Index for agent-based data retention queries.
       { fields: ["workspaceId", "agentConfigurationId"], concurrently: true },
     ],
@@ -738,6 +772,10 @@ export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessag
 
   declare status: CompactionMessageStatus;
   declare content: string | null;
+
+  // Denormalized from messages for conversation-scoped fetches (the conversation this compaction
+  // message belongs to — sourceConversationId is the compacted one). Nullable until backfilled.
+  declare conversationId: CreationOptional<ModelId | null>;
 }
 
 CompactionMessageModel.init(
@@ -769,6 +807,10 @@ CompactionMessageModel.init(
       type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "compaction_message",
@@ -776,6 +818,15 @@ CompactionMessageModel.init(
     indexes: [
       {
         fields: ["workspaceId"],
+        concurrently: true,
+      },
+      { fields: ["workspaceId", "conversationId"], concurrently: true },
+      // Backfill scaffolding: serves the keyset probe on rows not yet backfilled. Dropped once
+      // conversationId flips NOT NULL.
+      {
+        fields: ["id"],
+        where: { conversationId: null },
+        name: "compaction_messages_id_conversation_id_null",
         concurrently: true,
       },
     ],

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1458,7 +1458,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const messageWithAgent = await MessageModel.findAll({
       attributes: [
         [
-          Sequelize.fn("DISTINCT", Sequelize.col("conversationId")),
+          // Qualified: agent_messages also carries a conversationId column since the
+          // side-table denormalization, so the bare name is ambiguous in this join.
+          Sequelize.fn("DISTINCT", Sequelize.col("message.conversationId")),
           "conversationId",
         ],
       ],

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -14,6 +14,7 @@ import type {
   SupportedContentFragmentType,
 } from "@app/types/content_fragment";
 import type { ContentNodeType } from "@app/types/core/content_node";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
 export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentModel> {
@@ -42,6 +43,11 @@ export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentMod
   declare nodeId: string | null;
   declare nodeDataSourceViewId: ForeignKey<DataSourceViewModel["id"]> | null;
   declare nodeType: ContentNodeType | null;
+
+  // Denormalized from messages for conversation-scoped fetches (plain column, no FK — the value
+  // is derived from messages at write time). Permanently nullable: project-context fragments live
+  // on a space and have no owning conversation.
+  declare conversationId: CreationOptional<ModelId | null>;
 
   declare version: ContentFragmentVersion;
   declare expiredReason: ContentFragmentExpiredReason | null;
@@ -116,6 +122,10 @@ ContentFragmentModel.init(
       type: DataTypes.BIGINT,
       allowNull: true,
     },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "content_fragment",
@@ -137,6 +147,16 @@ ContentFragmentModel.init(
         fields: ["nodeDataSourceViewId"],
         concurrently: true,
         name: "content_fragments_node_dsv_id",
+      },
+      { fields: ["workspaceId", "conversationId"], concurrently: true },
+      // Backfill scaffolding: serves the keyset probe on rows not yet backfilled. Dropped with
+      // the sibling tables' indexes once their conversationId flips NOT NULL (this one stays
+      // nullable but is no longer backfill-probed).
+      {
+        fields: ["id"],
+        where: { conversationId: null },
+        name: "content_fragments_id_conversation_id_null",
+        concurrently: true,
       },
     ],
   }

--- a/front/migrations/pre-deploy/20260722200411_add_conversation_id_to_message_side_tables.sql
+++ b/front/migrations/pre-deploy/20260722200411_add_conversation_id_to_message_side_tables.sql
@@ -1,0 +1,91 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "conversationId" bigint;
+
+/*
+Statement 1
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_messages_id_conversation_id_null ON public.agent_messages USING btree (id) WHERE ("conversationId" IS NULL);
+
+/*
+Statement 2
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_messages_workspace_id_conversation_id ON public.agent_messages USING btree ("workspaceId", "conversationId");
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."compaction_messages" ADD COLUMN "conversationId" bigint;
+
+/*
+Statement 4
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY compaction_messages_id_conversation_id_null ON public.compaction_messages USING btree (id) WHERE ("conversationId" IS NULL);
+
+/*
+Statement 5
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY compaction_messages_workspace_id_conversation_id ON public.compaction_messages USING btree ("workspaceId", "conversationId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."content_fragments" ADD COLUMN "conversationId" bigint;
+
+/*
+Statement 7
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY content_fragments_id_conversation_id_null ON public.content_fragments USING btree (id) WHERE ("conversationId" IS NULL);
+
+/*
+Statement 8
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY content_fragments_workspace_id_conversation_id ON public.content_fragments USING btree ("workspaceId", "conversationId");
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."user_messages" ADD COLUMN "conversationId" bigint;
+
+/*
+Statement 10
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY user_messages_id_conversation_id_null ON public.user_messages USING btree (id) WHERE ("conversationId" IS NULL);
+
+/*
+Statement 11
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY user_messages_workspace_id_conversation_id ON public.user_messages USING btree ("workspaceId", "conversationId");


### PR DESCRIPTION
## Description

Add some denormalization to accelerate joins on message x user_message x ... by adding a conversationId col to these table.
This is NOT a foreign key, because the data integrity is already guaranteed by existing foreign keys transitively.

This only works if conversationId is added in the join ON clauses of course.


- conversationId NOT NULL index are removed at the top of the stack
- conversationId is made NOT NULL also at the top the stack, once backfill is confirmed

## Tests

Unit tests

## Risk

Low

## Deploy Plan

- Merge
- pre-deploy
- deploy