### PR TITLE
[front] perf: conversation-scoped side table joins in message fetches

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -221,6 +221,13 @@ async function _getConversation<V extends "light" | "full">(
     messages = paginatedMessages;
     paginationHasMore = hasMore;
   } else {
+    // The include.where lands in the LEFT JOIN ON clause (required: false keeps the OUTER join),
+    // letting the planner use the side tables' (workspaceId, conversationId) indexes instead of
+    // one PK probe per message. Relies on conversationId being backfilled on side tables.
+    const sideTableWhere = {
+      workspaceId: owner.id,
+      conversationId: conversation.id,
+    };
     messages = await MessageModel.findAll({
       where,
       order: [
@@ -232,11 +239,13 @@ async function _getConversation<V extends "light" | "full">(
           model: UserMessageModel,
           as: "userMessage",
           required: false,
+          where: sideTableWhere,
         },
         {
           model: AgentMessageModel,
           as: "agentMessage",
           required: false,
+          where: sideTableWhere,
         },
         // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
         // along with messages in one query). Only once we move to a MessageResource will we be able
@@ -245,11 +254,13 @@ async function _getConversation<V extends "light" | "full">(
           model: ContentFragmentModel,
           as: "contentFragment",
           required: false,
+          where: sideTableWhere,
         },
         {
           model: CompactionMessageModel,
           as: "compactionMessage",
           required: false,
+          where: sideTableWhere,
         },
       ],
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3502,6 +3502,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       lastRank,
     });
 
+    // The include.where lands in the LEFT JOIN ON clause (required: false keeps the OUTER join),
+    // letting the planner use the side tables' (workspaceId, conversationId) indexes instead of
+    // one PK probe per message. Relies on conversationId being backfilled on side tables.
+    const sideTableWhere = {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: this.id,
+    };
     // Fetch all messages (including content fragments and up to limit non-content-fragment messages)
     const messages = await MessageModel.findAll({
       where: {
@@ -3517,11 +3524,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: UserMessageModel,
           as: "userMessage",
           required: false,
+          where: sideTableWhere,
         },
         {
           model: AgentMessageModel,
           as: "agentMessage",
           required: false,
+          where: sideTableWhere,
         },
         // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
         // along with messages in one query). Only once we move to a MessageResource will we be able
@@ -3530,11 +3539,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: ContentFragmentModel,
           as: "contentFragment",
           required: false,
+          where: sideTableWhere,
         },
         {
           model: CompactionMessageModel,
           as: "compactionMessage",
           required: false,
+          where: sideTableWhere,
         },
       ],
     });


### PR DESCRIPTION
## Description

Adding the where clause (which is in fact an ON clause ... but sequelize ...) to all side joins



## Tests

Existing tests

## Risk

Low - we're narrowing the lookups required - indexes are already there, merged only after backfill ran
Blast radius: Given how critical this query is, fair to say most of the platform 😬 

## Deploy Plan

- Run backfill from #29359 
- Merge
- Deploy