### PR TITLE
[front] perf: Serve JIT-only light MCP server views to the conversation input bar

### DIFF
--- a/front-api/routes/w/[wId]/mcp/views/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.test.ts
@@ -1,0 +1,53 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const plainInputSchema: JSONSchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+};
+
+describe("GET /api/w/:wId/mcp/views", () => {
+  it("returns views with the full serialization", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Plain Server",
+      url: "https://plain-server.example.com",
+      tools: [
+        {
+          name: "search",
+          description: "Search things",
+          inputSchema: plainInputSchema,
+        },
+      ],
+    });
+    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views?spaceIds=${globalSpace.sId}` +
+        `&availabilities=manual,auto`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const serverViews: MCPServerViewType[] = body.serverViews;
+    const serverView = serverViews.find((v) => v.server.sId === server.sId);
+
+    expect(serverView).toBeDefined();
+
+    // Full serialization: tool input schemas and remote server specifics are present.
+    expect(serverView?.server.tools[0].inputSchema).toEqual(plainInputSchema);
+    expect(serverView?.server).toHaveProperty("url");
+    expect(serverView?.server).toHaveProperty("sharedSecret");
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 import view from "./[viewId]";
+import jit from "./jit";
 
 const MCPViewsRequestAvailabilitySchema = z.enum(["manual", "auto"]);
 type MCPViewsRequestAvailabilityType = z.infer<
@@ -136,6 +137,7 @@ app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
   });
 });
 
+app.route("/jit", jit);
 app.route("/:viewId", view);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/views/jit.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.test.ts
@@ -1,0 +1,131 @@
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const DUST_DATA_SOURCE_MIME = "application/vnd.dust.tool-input.data-source";
+
+// A tool input schema with a Dust configurable input on a required path: attaching such a
+// tool in a conversation is not possible, the view must be excluded from JIT responses.
+const requiredDustInputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    dataSources: {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: DUST_DATA_SOURCE_MIME },
+      },
+      required: ["uri", "mimeType"],
+    },
+  },
+  required: ["dataSources"],
+};
+
+const plainInputSchema: JSONSchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+};
+
+async function setup() {
+  const { workspace, globalSpace } = await createPrivateApiMockRequest({
+    role: "user",
+  });
+
+  const plainServer = await RemoteMCPServerFactory.create(workspace, {
+    name: "Plain Server",
+    url: "https://plain-server.example.com",
+    tools: [
+      {
+        name: "search",
+        description: "Search things",
+        inputSchema: plainInputSchema,
+      },
+    ],
+  });
+  await MCPServerViewFactory.create(workspace, plainServer.sId, globalSpace);
+
+  const configurableServer = await RemoteMCPServerFactory.create(workspace, {
+    name: "Configurable Server",
+    url: "https://configurable-server.example.com",
+    tools: [
+      {
+        name: "query_data_source",
+        description: "Query a configured data source",
+        inputSchema: requiredDustInputSchema,
+      },
+    ],
+  });
+  await MCPServerViewFactory.create(
+    workspace,
+    configurableServer.sId,
+    globalSpace
+  );
+
+  return { workspace, globalSpace, plainServer, configurableServer };
+}
+
+describe("GET /api/w/:wId/mcp/views/jit", () => {
+  it("filters out views requiring configuration and strips heavy data", async () => {
+    const { workspace, globalSpace, plainServer, configurableServer } =
+      await setup();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views/jit?spaceIds=${globalSpace.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const serverViews: MCPServerViewLightType[] = body.serverViews;
+    const plainView = serverViews.find((v) => v.server.sId === plainServer.sId);
+    const configurableView = serverViews.find(
+      (v) => v.server.sId === configurableServer.sId
+    );
+
+    // The view whose tool has a required Dust configurable input is excluded, based on the
+    // precomputed cachedToolsRequireConfiguration flag.
+    expect(configurableView).toBeUndefined();
+
+    // The JIT-attachable remote view is returned without its tools (surfaces needing them
+    // fetch the full server on demand).
+    expect(plainView).toBeDefined();
+    expect(plainView?.server.tools).toEqual([]);
+
+    // The light payload carries exactly the display fields — no authorization, no tool input
+    // schemas, no remote server specifics (url, secrets, lastError).
+    expect(Object.keys(plainView?.server ?? {}).sort()).toEqual([
+      "description",
+      "icon",
+      "name",
+      "sId",
+      "tools",
+    ]);
+    for (const view of serverViews) {
+      expect(Object.keys(view).sort()).toEqual([
+        "description",
+        "name",
+        "sId",
+        "server",
+      ]);
+      for (const tool of view.server.tools) {
+        expect(Object.keys(tool).sort()).toEqual(["description", "name"]);
+      }
+    }
+  });
+
+  it("returns 400 without spaceIds", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views/jit`
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/views/jit.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.ts
@@ -1,0 +1,69 @@
+import type { GetJITMCPServerViewsListResponseBody } from "@app/lib/api/mcp";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const GetJITMCPViewsRequestSchema = z.object({
+  spaceIds: z.array(z.string()),
+});
+
+// Mounted at /api/w/:wId/mcp/views/jit. Lists the views whose tools can be enabled directly in
+// a conversation (JIT), in a light serialization without tool input schemas, authorization or
+// remote server specifics. This feeds always-mounted surfaces (conversation capabilities
+// picker, slash menu), which is why it is a separate endpoint from the full listing.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetJITMCPServerViewsListResponseBody> => {
+    const auth = ctx.get("auth");
+    const spaceIds = ctx.req.query("spaceIds");
+
+    if (!spaceIds) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid query parameters",
+        },
+      });
+    }
+
+    const queryValidation = GetJITMCPViewsRequestSchema.safeParse({
+      spaceIds: spaceIds.split(","),
+    });
+    if (!queryValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(queryValidation.error).toString(),
+        },
+      });
+    }
+
+    // The JIT filter relies on the precomputed `cachedToolsRequireConfiguration` flag and the
+    // light serialization ships no remote tools, so no heavy attribute is fetched.
+    const views = await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
+      auth,
+      queryValidation.data.spaceIds
+    );
+
+    const serverViews = views
+      // Same availabilities as the full listing exposes: "auto_hidden_builder" is never served.
+      .filter((v) => {
+        const { availability } = v.getServerDisplayMetadata();
+        return availability === "manual" || availability === "auto";
+      })
+      .filter((v) => v.isJITAttachable())
+      .map((v) => v.toJSONLight());
+
+    return ctx.json({ success: true, serverViews });
+  }
+);
+
+export default app;

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -11,13 +11,12 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
 import {
   useAvailableMCPServers,
-  useMCPServerViewsFromSpaces,
+  useJITMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -64,7 +63,7 @@ type CapabilityPickerSearchItem = CapabilityPickerItemBase &
       }
     | {
         kind: "tool";
-        serverView: MCPServerViewType;
+        serverView: MCPServerViewLightType;
       }
     | {
         kind: "uninstalled_tool";
@@ -99,7 +98,7 @@ interface CapabilitiesPickerItemsListProps {
   items: CapabilityPickerItem[];
   onItemSelect: (item: CapabilityPickerItem) => void;
   onSkillDetails?: (skillId: string) => void;
-  onToolDetails?: (serverView: MCPServerViewType) => void;
+  onToolDetails?: (serverView: MCPServerViewLightType) => void;
 }
 
 export function CapabilitiesPickerItemsList({
@@ -163,8 +162,8 @@ export function CapabilitiesPickerItemsList({
 interface CapabilitiesPickerProps {
   owner: WorkspaceType;
   user: UserType | null;
-  selectedMCPServerViews: MCPServerViewType[];
-  onSelect: (serverView: MCPServerViewType) => void;
+  selectedMCPServerViews: MCPServerViewLightType[];
+  onSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   isLoading?: boolean;
   disabled?: boolean;
@@ -197,7 +196,7 @@ export function CapabilitiesPicker({
     string | null
   >(null);
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
-    useState<MCPServerViewType | null>(null);
+    useState<MCPServerViewLightType | null>(null);
 
   // Load capabilities when the picker mounts so the picker and slash menu share a warm SWR cache.
   const { spaces: globalSpaces } = useSpaces({
@@ -212,7 +211,7 @@ export function CapabilitiesPicker({
     serverViews,
     isLoading: isServerViewsLoading,
     mutateServerViews,
-  } = useMCPServerViewsFromSpaces(
+  } = useJITMCPServerViewsFromSpaces(
     owner,
     globalSpaces,
     CAPABILITIES_SWR_OPTIONS
@@ -288,7 +287,7 @@ export function CapabilitiesPicker({
     closeDropdown();
   };
 
-  const selectTool = (serverView: MCPServerViewType) => {
+  const selectTool = (serverView: MCPServerViewLightType) => {
     trackEvent({
       area: TRACKING_AREAS.TOOLS,
       object: "tool_select",
@@ -352,14 +351,13 @@ export function CapabilitiesPicker({
         });
       }
 
+      // The JIT views endpoint only returns views whose tools can be enabled directly in a
+      // conversation, no further filtering needed here.
       for (const serverView of serverViews) {
         const label = getMcpServerViewDisplayName(serverView);
         const description = getMcpServerViewDescription(serverView);
 
-        if (
-          !isJITMCPServerView(serverView) ||
-          selectedMCPServerViewIds.has(serverView.sId)
-        ) {
+        if (selectedMCPServerViewIds.has(serverView.sId)) {
           continue;
         }
 
@@ -527,7 +525,8 @@ export function CapabilitiesPicker({
             const updatedData = await mutateServerViews();
 
             const newServerView = updatedData?.serverViews?.find(
-              (v: MCPServerViewType) => v.server.name === createdServer.name
+              (v: MCPServerViewLightType) =>
+                v.server.name === createdServer.name
             );
 
             if (newServerView) {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -20,7 +20,7 @@ import {
   useConversationTools,
 } from "@app/hooks/conversations";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -258,7 +258,7 @@ export const InputBar = React.memo(function InputBar({
   // Tools selection
 
   const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
-    MCPServerViewType[]
+    MCPServerViewLightType[]
   >([]);
   const [selectedSpacesState, setSelectedSpacesState] =
     useState<SelectedSpacesState | null>(null);
@@ -406,7 +406,7 @@ export const InputBar = React.memo(function InputBar({
     : isWorkspaceSpacesLoading;
 
   const handleMCPServerViewSelect = useCallback(
-    (serverView: MCPServerViewType) => {
+    (serverView: MCPServerViewLightType) => {
       if (selectedMCPServerViewIds.has(serverView.sId)) {
         return;
       }
@@ -422,7 +422,7 @@ export const InputBar = React.memo(function InputBar({
   );
 
   const handleMCPServerViewDeselect = useCallback(
-    (serverView: MCPServerViewType) => {
+    (serverView: MCPServerViewLightType) => {
       if (!selectedMCPServerViewIds.has(serverView.sId)) {
         return;
       }

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -5,7 +5,7 @@ import type { InputBarAction } from "@app/components/assistant/conversation/inpu
 import { InputBarModelPicker } from "@app/components/assistant/conversation/input_bar/InputBarModelPicker";
 import type useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useAppRouter } from "@app/lib/platform";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { setQueryParam } from "@app/lib/utils/router";
@@ -56,7 +56,7 @@ interface InputBarButtonsProps {
   isInputDisabled: boolean;
   lastRequestedModel: ModelSelectionType | null;
   onAgentRemove: () => void;
-  onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
+  onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
   onModelSelectionChange?: (
     modelSelection: ModelSelectionType | undefined
   ) => void;
@@ -65,7 +65,7 @@ interface InputBarButtonsProps {
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   owner: WorkspaceType;
   selectedAgent: RichAgentMention | null;
-  selectedMCPServerViews: MCPServerViewType[];
+  selectedMCPServerViews: MCPServerViewLightType[];
   space: SpaceType | undefined;
   user: UserType | null;
   onAgentPickerOpenChange?: (open: boolean) => void;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -46,7 +46,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
@@ -228,8 +228,8 @@ export interface InputBarContainerProps {
   onVoiceActiveChange?: (active: boolean) => void;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
-  onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
-  onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
+  onMCPServerViewDeselect: (serverView: MCPServerViewLightType) => void;
+  onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
   onModelSelectionChange?: (
     modelSelection: ModelSelectionType | undefined
   ) => void;
@@ -244,7 +244,7 @@ export interface InputBarContainerProps {
   ) => void;
   pendingInputText: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
-  selectedMCPServerViews: MCPServerViewType[];
+  selectedMCPServerViews: MCPServerViewLightType[];
   selectedSpaceIds?: string[];
   selectableSpaces?: SelectableConversationSpaceType[];
   shouldShowSpacesAction?: boolean;
@@ -421,7 +421,7 @@ const InputBarContainer = ({
     string | null
   >(null);
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
-    useState<MCPServerViewType | null>(null);
+    useState<MCPServerViewLightType | null>(null);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
 

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -245,7 +245,8 @@ export function useSkillInstructionsEditor({
       return;
     }
 
-    if (isToolSlashCommand(item)) {
+    // Skill-builder slash items are built from full views (useSkillBuilderSlashCommandCapabilities).
+    if (isToolSlashCommand<MCPServerViewType>(item)) {
       editorInstance
         .chain()
         .focus()

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -27,7 +27,7 @@ function toolSuggestion({
   serverIcon?: MCPServerViewType["server"]["icon"];
   serverName?: string;
   sId: string;
-}): SlashCommandToolSuggestion {
+}): SlashCommandToolSuggestion<MCPServerViewType> {
   return {
     id: 1,
     sId,

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -4,7 +4,7 @@ import {
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
@@ -87,7 +87,9 @@ export type SlashCommandSkillSuggestion = Pick<
   | "userFacingDescription"
 >;
 
-export type SlashCommandToolSuggestion = MCPServerViewType & {
+export type SlashCommandToolSuggestion<
+  V extends MCPServerViewLightType = MCPServerViewLightType,
+> = V & {
   label?: string;
 };
 
@@ -100,14 +102,16 @@ export interface SkillSlashCommand extends SlashCommand {
   };
 }
 
-export interface ToolSlashCommand extends SlashCommand {
+export interface ToolSlashCommand<
+  V extends MCPServerViewLightType = MCPServerViewLightType,
+> extends SlashCommand {
   action: typeof SELECT_TOOL_SLASH_COMMAND_ACTION;
   data: {
     tool: {
       icon: string | null;
       id: string;
       name: string;
-      view: MCPServerViewType;
+      view: V;
     };
   };
 }
@@ -130,9 +134,9 @@ export function isSkillSlashCommand(
   return item.action === SELECT_SKILL_SLASH_COMMAND_ACTION;
 }
 
-export function isToolSlashCommand(
-  item: SlashCommand
-): item is ToolSlashCommand {
+export function isToolSlashCommand<
+  V extends MCPServerViewLightType = MCPServerViewLightType,
+>(item: SlashCommand): item is ToolSlashCommand<V> {
   return item.action === SELECT_TOOL_SLASH_COMMAND_ACTION;
 }
 
@@ -187,9 +191,9 @@ export function getSkillSlashCommandItem(
   };
 }
 
-export function getToolSlashCommandItem(
-  tool: SlashCommandToolSuggestion
-): ToolSlashCommand {
+export function getToolSlashCommandItem<V extends MCPServerViewLightType>(
+  tool: SlashCommandToolSuggestion<V>
+): ToolSlashCommand<V> {
   const name = getToolSlashCommandLabel(tool);
   const description = getMcpServerViewDescription(tool);
 

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function filterSlashCommandItems(
@@ -28,7 +29,9 @@ export function filterSlashCommandItems(
   );
 }
 
-export function buildCapabilitySlashCommandItems({
+export function buildCapabilitySlashCommandItems<
+  V extends MCPServerViewLightType,
+>({
   excludeSkillId,
   query,
   skillFilter,
@@ -40,8 +43,8 @@ export function buildCapabilitySlashCommandItems({
   query: string;
   skillFilter?: (skill: SlashCommandSkillSuggestion) => boolean;
   skills: SlashCommandSkillSuggestion[];
-  toolFilter?: (tool: SlashCommandToolSuggestion) => boolean;
-  tools: SlashCommandToolSuggestion[];
+  toolFilter?: (tool: SlashCommandToolSuggestion<V>) => boolean;
+  tools: SlashCommandToolSuggestion<V>[];
 }): SlashCommand[] {
   const normalizedQuery = query.trim().toLowerCase();
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -3,10 +3,12 @@ import {
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
-import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
+import {
+  useJITMCPServerViewsFromSpaces,
+  useMCPServerViewsFromSpaces,
+} from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -76,8 +78,14 @@ export function useInputBarSlashCommandCapabilities({
     status: "active",
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
+  // The JIT views endpoint only returns views whose tools can be enabled directly in a
+  // conversation, no further filtering needed here.
   const { serverViews, isLoading: isServerViewsLoading } =
-    useMCPServerViewsFromSpaces(owner, globalSpaces, CAPABILITIES_SWR_OPTIONS);
+    useJITMCPServerViewsFromSpaces(
+      owner,
+      globalSpaces,
+      CAPABILITIES_SWR_OPTIONS
+    );
 
   const capabilityItems = useMemo(
     () =>
@@ -87,7 +95,6 @@ export function useInputBarSlashCommandCapabilities({
         skills,
         tools: serverViews,
         toolFilter: (serverView) =>
-          isJITMCPServerView(serverView) &&
           !(selectedMCPServerViewIdsRef?.current ?? new Set()).has(
             serverView.sId
           ),

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -159,7 +159,8 @@ const SkillBuilderSlashCommandDropdownInner = forwardRef<
             editor.chain().focus().deleteRange(range).run();
             if (isSkillSlashCommand(item)) {
               onSkillDetailsRef?.current?.(item.data.skill);
-            } else if (isToolSlashCommand(item)) {
+            } else if (isToolSlashCommand<MCPServerViewType>(item)) {
+              // Skill-builder slash items are built from full views.
               onToolDetailsRef?.current?.(item.data.tool.view);
             }
             onClose();

--- a/front/components/shared/CapabilityDetailsSheets.tsx
+++ b/front/components/shared/CapabilityDetailsSheets.tsx
@@ -1,6 +1,7 @@
 import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import { useMCPServer } from "@app/lib/swr/mcp_servers";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
@@ -8,7 +9,7 @@ interface CapabilityDetailsSheetsProps {
   owner: WorkspaceType;
   user: UserType | null;
   selectedSkillId: string | null;
-  selectedMCPServerView: MCPServerViewType | null;
+  selectedMCPServerView: MCPServerViewLightType | null;
   onCloseSkill: () => void;
   onCloseTool: () => void;
   replaceOnSkillEdit?: boolean;
@@ -30,6 +31,20 @@ export function CapabilityDetailsSheets({
     disabled: !selectedSkillId,
   });
 
+  // List surfaces hold light views (no tools, no authorization); resolve the full view on
+  // open from the server endpoint (SWR-deduped with MCPServerDetails' own fetch).
+  const { server: mcpServerWithViews } = useMCPServer({
+    owner,
+    serverId: selectedMCPServerView?.server.sId ?? "",
+    disabled: !selectedMCPServerView,
+  });
+  const fullMCPServerView =
+    (selectedMCPServerView &&
+      mcpServerWithViews?.views.find(
+        (v) => v.sId === selectedMCPServerView.sId
+      )) ??
+    null;
+
   return (
     <>
       {user && (
@@ -44,7 +59,7 @@ export function CapabilityDetailsSheets({
 
       <MCPServerDetails
         owner={owner}
-        mcpServerView={selectedMCPServerView}
+        mcpServerView={fullMCPServerView}
         isOpen={selectedMCPServerView !== null}
         onClose={onCloseTool}
         readOnly

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -176,7 +176,10 @@ export function isRemoteMCPServerType(
   return serverType === "remote";
 }
 
-export function getMcpServerViewDescription(view: MCPServerViewType): string {
+export function getMcpServerViewDescription(view: {
+  description: string | null;
+  server: Pick<MCPServerType, "description">;
+}): string {
   return view.description ?? view.server.description;
 }
 

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -8,7 +8,7 @@ export { DEFAULT_MCP_SERVER_ICON };
 
 // MCP-specific function
 export const getAvatar = (
-  mcpServer: MCPServerType,
+  mcpServer: Pick<MCPServerType, "icon">,
   size: ComponentProps<typeof Avatar>["size"] = "sm"
 ) => {
   return getAvatarFromIcon(mcpServer.icon, size);

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -117,6 +117,30 @@ export interface MCPServerViewType {
   }[];
 }
 
+// Light variants for list surfaces that only render names, descriptions and icons (conversation
+// capabilities picker, slash menu). Served by GET /mcp/views/jit; full types are structurally
+// assignable to them.
+export type MCPToolLightType = Pick<MCPToolType, "name" | "description">;
+
+export type MCPServerLightType = Pick<
+  MCPServerType,
+  "sId" | "name" | "description" | "icon"
+> & {
+  tools: MCPToolLightType[];
+};
+
+export type MCPServerViewLightType = Pick<
+  MCPServerViewType,
+  "sId" | "name" | "description"
+> & {
+  server: MCPServerLightType;
+};
+
+export type GetJITMCPServerViewsListResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewLightType[];
+};
+
 export type MCPToolWithAvailabilityType = MCPToolType & {
   availability: MCPServerAvailability;
 };

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -20,9 +20,15 @@ import {
   INTERNAL_MCP_SERVERS,
   isAutoInternalMCPServerName,
   isValidInternalMCPServerId,
+  matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
-import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import type {
+  MCPServerLightType,
+  MCPServerType,
+  MCPServerViewLightType,
+  MCPServerViewType,
+} from "@app/lib/api/mcp";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
@@ -43,6 +49,7 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import { tracer } from "@app/logger/tracer";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
@@ -1255,6 +1262,24 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   }
 
   /**
+   * Server-side counterpart of `isJITMCPServerView`: true when the view's tools can be enabled
+   * directly in a conversation. Cheap — remote servers carry the precomputed
+   * `cachedToolsRequireConfiguration` flag, internal tools live in memory — so no heavy
+   * attribute is needed at fetch time.
+   */
+  isJITAttachable(): boolean {
+    if (matchesInternalMCPServerName(this.mcpServerId, "agent_memory")) {
+      return false;
+    }
+    if (this.serverType === "remote") {
+      return !this.getRemoteMCPServerResource().cachedToolsRequireConfiguration;
+    }
+    return !mcpToolsRequireConfiguration(
+      this.getInternalMCPServerResource().toJSON().tools
+    );
+  }
+
+  /**
    * The server's authorization config with the view's admin-configured scope restriction
    * applied. For remote servers this only needs the `authorization` heavy attribute.
    */
@@ -1701,6 +1726,46 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         permission: t.permission,
         enabled: t.enabled,
       })),
+    };
+  }
+
+  /**
+   * Light serialization for list surfaces (conversation capabilities picker, slash menu) that
+   * only render names, descriptions and icons. Remote tools are not included at all (surfaces
+   * needing them fetch the full server on demand), so no heavy attribute is required at fetch
+   * time.
+   */
+  toJSONLight(): MCPServerViewLightType {
+    let server: MCPServerLightType;
+    if (this.serverType === "remote") {
+      const remoteServer = this.getRemoteMCPServerResource();
+      server = {
+        sId: remoteServer.sId,
+        name: remoteServer.cachedName,
+        description:
+          remoteServer.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+        icon: remoteServer.icon,
+        tools: [],
+      };
+    } else {
+      const internalServer = this.getInternalMCPServerResource().toJSON();
+      server = {
+        sId: internalServer.sId,
+        name: internalServer.name,
+        description: internalServer.description,
+        icon: internalServer.icon,
+        tools: internalServer.tools.map(({ name, description }) => ({
+          name,
+          description,
+        })),
+      };
+    }
+
+    return {
+      sId: this.sId,
+      name: this.name,
+      description: this.description,
+      server,
     };
   }
 }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -10,6 +10,7 @@ import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_action
 import type {
   CreateMCPServerResponseBody,
   DeleteMCPServerResponseBody,
+  GetJITMCPServerViewsListResponseBody,
   GetMCPServerResponseBody,
   GetMCPServersResponseBody,
   GetMCPServersUsageResponseBody,
@@ -1285,6 +1286,36 @@ export function useMCPServerViewsFromSpaces(
     ["manual", "auto"],
     swrOptions
   );
+}
+
+/**
+ * JIT-attachable server views only (tools requiring configuration are filtered out
+ * server-side), in a light serialization without tool input schemas nor authorization.
+ * This is the cheap variant for always-mounted surfaces (conversation capabilities
+ * picker, slash menu).
+ */
+export function useJITMCPServerViewsFromSpaces(
+  owner: LightWorkspaceType,
+  spaces: SpaceType[],
+  swrOptions?: SWRConfiguration & { disabled?: boolean }
+) {
+  const { fetcher } = useFetcher();
+  const configFetcher: Fetcher<GetJITMCPServerViewsListResponseBody> = fetcher;
+
+  const spaceIds = spaces.map((s) => s.sId).join(",");
+
+  const url = `/api/w/${owner.sId}/mcp/views/jit?spaceIds=${spaceIds}`;
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    ...swrOptions,
+    ...(!spaces.length ? { disabled: true } : {}),
+  });
+
+  return {
+    serverViews: data?.serverViews ?? emptyArray(),
+    isLoading: !error && !data && spaces.length !== 0,
+    isError: error,
+    mutateServerViews: mutate,
+  };
 }
 
 export function useManualMCPServerViewsFromSpaces(


### PR DESCRIPTION
## Description

Final step is a new endpoint, which exposes a lighter contract and does not fetch the heavy attributes.

Contract: takes spaceIds only; always serves the manual + auto availabilities (never auto_hidden_builder), filtered server-side to JIT-attachable views (isJITMCPServerView: no agent_memory, no tool with a required Dust-configurable input).

Payload: light serialization via MCPServerViewResource.toJSONLight(). Tools keep {name, description} only (schemas dropped), authorization: null, no url/secrets/lastError. The read-only tool details sheet keeps working: it only renders tool names/descriptions from the list, and fetches the full server via /mcp/[serverId] on open.

## Tests

Added tests
Will frontedge it

## Risk

Low
Blast radius: every page load 🥲 

## Plan

- deploy front
