### PR TITLE
[ASSISTANT] Block invocation of retired global agents

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1573,6 +1573,37 @@ describe("postUserMessage", () => {
     rateLimiterSpy.mockRestore();
   });
 
+  it("should reject mentions of a retired global agent", async () => {
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const result = await postUserMessage(auth, {
+      conversation,
+      content: `Hello @claude-4-sonnet`,
+      mentions: [
+        {
+          configurationId: GLOBAL_AGENTS_SID.CLAUDE_4_SONNET,
+        } satisfies AgentMention,
+      ],
+      context: {
+        username: userJson.username,
+        timezone: "UTC",
+        fullName: userJson.fullName,
+        email: userJson.email,
+        profilePictureUrl: userJson.image,
+        origin: "zapier",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(400);
+      expect(result.error.api_error.type).toBe("agent_inaccessible");
+    }
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
+  });
+
   it("should preserve agent mentions in the returned userMessage", async () => {
     const mentions: MentionType[] = [
       {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
+import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
@@ -767,7 +768,21 @@ export async function postUserMessage(
   let agentConfigurations = removeNulls(results[0]);
   let shouldCreateBranch = false;
 
+  // Retired global agents can't be invoked (new conversations or new messages).
+  // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
+  const isInternalRunAgent = agenticMessageData?.type === "run_agent";
+
   for (const agentConfig of agentConfigurations) {
+    if (!isInternalRunAgent && isRetiredGlobalAgent(agentConfig.sId)) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "agent_inaccessible",
+          message: `Assistant ${agentConfig.name} is retired and can no longer be used.`,
+        },
+      });
+    }
+
     if (!canAccessAgent(agentConfig)) {
       return new Err({
         status_code: 400,


### PR DESCRIPTION
## Description

Reject any new message or conversation that mentions a retired global agent (returning `agent_inaccessible` early), instead of letting it resolve to a model that no longer exists and failing later with a provider 404 — the model isn't supported anymore anyway, so failing fast is cleaner; the internal `run_agent` path stays exempt for hidden sub-agents.

## Tests

Added a functional test covering a `zapier`-origin mention of a retired agent; tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`