### PR TITLE
[front] perf: preload Skill Builder slash capabilities

### DIFF
--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -1,5 +1,7 @@
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo, useState } from "react";
@@ -38,6 +40,14 @@ export function SkillBuilderProvider({
   skillId,
   children,
 }: SkillBuilderProviderProps) {
+  // SpacesProvider and MCPServerViewsProvider preload the tools shown by the
+  // slash command. Preload active skills as well before its dropdown mounts.
+  useSkills({
+    owner,
+    status: "active",
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
+  });
+
   const [selectedSuggestionId, setSelectedSuggestionId] = useState<
     string | null
   >(null);


### PR DESCRIPTION
## Description

Same as https://github.com/dust-tt/dust/pull/29127 for the Skill Builder.

The Skill Builder capabilities list lists skills and MCP server views (which require fetching the spaces). Spaces and MCP server views are already loaded eagerly by `SpacesProvider` and `MCPServerViewsProvider`, but active skills were only fetched after the slash dropdown mounted, leaving the list waiting on that request.

This PR preloads active skills when Skill Builder mounts. The dropdown continues using the same SWR cache key, making the list significantly snappier.

## Tests

- Tested locally.

## Risk

- Low. More DB load but significantly less than https://github.com/dust-tt/dust/pull/29127 so if that one is fine, this one is as well.

## Deploy Plan

- Deploy front.
