### PR TITLE
Normalize legacy tool search metric tags

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -470,11 +470,11 @@ function* handleContentBlockStop(
   stateContainer.state = null;
 }
 
-// StatsD tags for the tool search counter, derived from this client's metadata.
+// Keep the legacy router aligned with model_constructors tool-search tags.
 function toolSearchTags(metadata: LLMClientMetadata): string[] {
   return [
-    `client_id:${metadata.clientId}`,
-    `inference_provider:${metadata.inferenceProvider}`,
+    `provider_id:${metadata.clientId}`,
+    `api:${metadata.inferenceProvider}`,
     `model_id:${metadata.modelId}`,
   ];
 }

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -153,8 +153,8 @@ function itemToEvents(
     case "tool_search_output": {
       logOpenAIToolSearchItem(item, {
         tags: [
-          `client_id:${metadata.clientId}`,
-          `inference_provider:${metadata.inferenceProvider}`,
+          `provider_id:${metadata.clientId}`,
+          `api:${metadata.inferenceProvider}`,
           `model_id:${metadata.modelId}`,
         ],
         logFields: metadata,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aligns legacy tool-search metric tags with the new router for unified Datadog dashboards. Existing behavior remains unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
