### PR TITLE
[front] enh: Precompute cachedToolsRequireConfiguration on remote MCP servers

### DIFF
--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
@@ -1,14 +1,62 @@
+import {
+  DEFAULT_MCP_ACTION_VERSION,
+  DEFAULT_MCP_SERVER_ICON,
+} from "@app/lib/actions/constants";
+import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
+import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/actions/mcp_metadata"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    fetchRemoteServerMetaDataByServerId: vi.fn(),
+  };
+});
+
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+
+// A tool input schema with a Dust configurable input on a required path.
+const requiredDustInputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    dataSources: {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: "application/vnd.dust.tool-input.data-source" },
+      },
+      required: ["uri", "mimeType"],
+    },
+  },
+  required: ["dataSources"],
+};
+
+function metadataWithTools(tools: MCPToolType[]): Omit<MCPServerType, "sId"> {
+  return {
+    name: "Test Server",
+    version: DEFAULT_MCP_ACTION_VERSION,
+    description: "Test description",
+    icon: DEFAULT_MCP_SERVER_ICON,
+    authorization: null,
+    tools,
+    availability: "manual",
+    allowMultipleInstances: true,
+    documentationUrl: null,
+  };
+}
 
 async function setup(role: "builder" | "user" | "admin" = "admin") {
-  const { workspace, systemSpace } = await createPrivateApiMockRequest({
+  const { workspace, auth, systemSpace } = await createPrivateApiMockRequest({
     role,
     method: "POST",
   });
-  return { workspace, space: systemSpace };
+  return { workspace, auth, space: systemSpace };
 }
 
 function sync(workspace: { sId: string }, serverId: string) {
@@ -44,5 +92,60 @@ describe("POST /api/w/:wId/mcp/:serverId/sync", () => {
     expect(body.error.message).toContain(
       "Only admin users can perform this action."
     );
+  });
+
+  it("recomputes cachedToolsRequireConfiguration when tools change", async () => {
+    const { workspace, auth } = await setup("admin");
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      tools: [
+        {
+          name: "search",
+          description: "Search things",
+          inputSchema: undefined,
+        },
+      ],
+    });
+
+    // Created with tools that need no configuration.
+    const created = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(created?.cachedToolsRequireConfiguration).toBe(false);
+
+    // The remote server now exposes a tool with a required Dust configurable input.
+    vi.mocked(fetchRemoteServerMetaDataByServerId).mockResolvedValueOnce(
+      new Ok(
+        metadataWithTools([
+          {
+            name: "query_data_source",
+            description: "Query a configured data source",
+            inputSchema: requiredDustInputSchema,
+          },
+        ])
+      )
+    );
+
+    const response = await sync(workspace, server.sId);
+    expect(response.status).toBe(200);
+
+    const synced = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(synced?.cachedToolsRequireConfiguration).toBe(true);
+
+    // Syncing back to configuration-free tools flips it back.
+    vi.mocked(fetchRemoteServerMetaDataByServerId).mockResolvedValueOnce(
+      new Ok(
+        metadataWithTools([
+          {
+            name: "search",
+            description: "Search things",
+            inputSchema: undefined,
+          },
+        ])
+      )
+    );
+
+    const secondResponse = await sync(workspace, server.sId);
+    expect(secondResponse.status).toBe(200);
+
+    const resynced = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(resynced?.cachedToolsRequireConfiguration).toBe(false);
   });
 });

--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -24,6 +24,9 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare cachedName: string;
   declare cachedDescription: string | null;
   declare cachedTools: MCPToolType[];
+  // Derived from cachedTools at write time: true when at least one tool input schema forces a
+  // Dust configurable input, i.e. the server cannot be attached directly in a conversation.
+  declare cachedToolsRequireConfiguration: CreationOptional<boolean>;
 
   declare lastSyncAt: Date | null;
   declare lastError: string | null;
@@ -71,6 +74,11 @@ RemoteMCPServerModel.init(
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: [],
+    },
+    cachedToolsRequireConfiguration: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     lastSyncAt: {
       type: DataTypes.DATE,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -26,6 +26,7 @@ import {
   isResourceSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthConnectionMetadataType } from "@app/types/api/oauth/providers/mcp";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
@@ -219,7 +220,12 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     auth: Authenticator,
     blob: Omit<
       CreationAttributes<RemoteMCPServerModel>,
-      "name" | "description" | "spaceId" | "sId" | "lastSyncAt"
+      | "name"
+      | "description"
+      | "spaceId"
+      | "sId"
+      | "lastSyncAt"
+      | "cachedToolsRequireConfiguration"
     > & {
       oAuthUseCase: MCPOAuthUseCase | null;
     },
@@ -237,6 +243,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       sharedSecret: blob.sharedSecret,
       lastSyncAt: new Date(),
       authorization: blob.authorization,
+      cachedToolsRequireConfiguration: mcpToolsRequireConfiguration(
+        blob.cachedTools
+      ),
     };
 
     const server = await RemoteMCPServerModel.create(serverData, {
@@ -549,6 +558,12 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       cachedName,
       cachedDescription,
       cachedTools,
+      ...(cachedTools
+        ? {
+            cachedToolsRequireConfiguration:
+              mcpToolsRequireConfiguration(cachedTools),
+          }
+        : {}),
       lastSyncAt,
       ...(clearError ? { lastError: null } : {}),
     });

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerViewType, MCPToolType } from "@app/lib/api/mcp";
 import logger from "@app/logger/logger";
 import { isRecord } from "@app/types/shared/utils/general";
 import Ajv from "ajv";
@@ -573,18 +573,28 @@ export function jsonSchemaHasRequiredDustToolInput(
 }
 
 /**
- * True when no tool input schema forces a Dust configurable input on an all-required path
- * from the root (see {@link jsonSchemaHasRequiredDustToolInput}).
+ * True when at least one tool input schema forces a Dust configurable input on an all-required
+ * path from the root (see {@link jsonSchemaHasRequiredDustToolInput}). Such tools need an
+ * agent/skill configuration step and cannot be attached directly in a conversation.
  */
-export function hasNoRequiredProperties(view: MCPServerViewType): boolean {
-  const tools = view.server.tools;
+export function mcpToolsRequireConfiguration(
+  tools: Array<Pick<MCPToolType, "inputSchema">>
+): boolean {
   for (let t = 0; t < tools.length; t++) {
     const sch = tools[t].inputSchema;
     if (sch !== undefined && sch !== null) {
       if (jsonSchemaHasRequiredDustToolInput(sch, true)) {
-        return false;
+        return true;
       }
     }
   }
-  return true;
+  return false;
+}
+
+/**
+ * True when no tool input schema forces a Dust configurable input on an all-required path
+ * from the root (see {@link jsonSchemaHasRequiredDustToolInput}).
+ */
+export function hasNoRequiredProperties(view: MCPServerViewType): boolean {
+  return !mcpToolsRequireConfiguration(view.server.tools);
 }

--- a/front/migrations/pre-deploy/20260723105431_add_cached_tools_require_configuration_to_remote_mcp_servers.sql
+++ b/front/migrations/pre-deploy/20260723105431_add_cached_tools_require_configuration_to_remote_mcp_servers.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."remote_mcp_servers" ADD COLUMN "cachedToolsRequireConfiguration" boolean DEFAULT false NOT NULL;


### PR DESCRIPTION
## Description

#29353 re-enabled eager capability preloading: CapabilitiesPicker fires its data fetches on input-bar mount instead of on open. One of those fetches, GET /mcp/views, opts into all five remote_mcp_servers heavy attributes (authorization, cachedTools, customHeaders, lastError, sharedSecret) and ships full tool input schemas, redacted secrets and remote server specifics to the client. With eager preloading this lands on every conversation page load, induces a lot of detoasting (and AFAIK pg does not have a way to save us here, we have to change our data model)

Long story short we're introducing a new col called cachedToolsRequireConfiguration that will avoid reading tools entirely in the hot path mounted on every page load, and thus save us 20% of global i/o and 15% of cpu on our DB (at peak hours).

This step is migration + write path, then backfill, then introduce a new endpoint that has a lighter type while maintaining same functionality frontend wise.

Tradeoff: We will have more fetches on /mcp/views/[id] than before, as frontend will need to fetch the heavy type when opening the server pane.

## Tests

existing

## Risk

Low
RemoteMCPServer creation

## Plan

- Merge
- Pre-deploy
- Deploy