### PR TITLE
[front] perf: Serve JIT MCP server views without reading remote heavy attributes

### DIFF
--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.test.ts
@@ -1,14 +1,62 @@
+import {
+  DEFAULT_MCP_ACTION_VERSION,
+  DEFAULT_MCP_SERVER_ICON,
+} from "@app/lib/actions/constants";
+import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
+import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/actions/mcp_metadata"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    fetchRemoteServerMetaDataByServerId: vi.fn(),
+  };
+});
+
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+
+// A tool input schema with a Dust configurable input on a required path.
+const requiredDustInputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    dataSources: {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: "application/vnd.dust.tool-input.data-source" },
+      },
+      required: ["uri", "mimeType"],
+    },
+  },
+  required: ["dataSources"],
+};
+
+function metadataWithTools(tools: MCPToolType[]): Omit<MCPServerType, "sId"> {
+  return {
+    name: "Test Server",
+    version: DEFAULT_MCP_ACTION_VERSION,
+    description: "Test description",
+    icon: DEFAULT_MCP_SERVER_ICON,
+    authorization: null,
+    tools,
+    availability: "manual",
+    allowMultipleInstances: true,
+    documentationUrl: null,
+  };
+}
 
 async function setup(role: "builder" | "user" | "admin" = "admin") {
-  const { workspace, systemSpace } = await createPrivateApiMockRequest({
+  const { workspace, auth, systemSpace } = await createPrivateApiMockRequest({
     role,
     method: "POST",
   });
-  return { workspace, space: systemSpace };
+  return { workspace, auth, space: systemSpace };
 }
 
 function sync(workspace: { sId: string }, serverId: string) {
@@ -44,5 +92,60 @@ describe("POST /api/w/:wId/mcp/:serverId/sync", () => {
     expect(body.error.message).toContain(
       "Only admin users can perform this action."
     );
+  });
+
+  it("recomputes cachedToolsRequireConfiguration when tools change", async () => {
+    const { workspace, auth } = await setup("admin");
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      tools: [
+        {
+          name: "search",
+          description: "Search things",
+          inputSchema: undefined,
+        },
+      ],
+    });
+
+    // Created with tools that need no configuration.
+    const created = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(created?.cachedToolsRequireConfiguration).toBe(false);
+
+    // The remote server now exposes a tool with a required Dust configurable input.
+    vi.mocked(fetchRemoteServerMetaDataByServerId).mockResolvedValueOnce(
+      new Ok(
+        metadataWithTools([
+          {
+            name: "query_data_source",
+            description: "Query a configured data source",
+            inputSchema: requiredDustInputSchema,
+          },
+        ])
+      )
+    );
+
+    const response = await sync(workspace, server.sId);
+    expect(response.status).toBe(200);
+
+    const synced = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(synced?.cachedToolsRequireConfiguration).toBe(true);
+
+    // Syncing back to configuration-free tools flips it back.
+    vi.mocked(fetchRemoteServerMetaDataByServerId).mockResolvedValueOnce(
+      new Ok(
+        metadataWithTools([
+          {
+            name: "search",
+            description: "Search things",
+            inputSchema: undefined,
+          },
+        ])
+      )
+    );
+
+    const secondResponse = await sync(workspace, server.sId);
+    expect(secondResponse.status).toBe(200);
+
+    const resynced = await RemoteMCPServerResource.fetchById(auth, server.sId);
+    expect(resynced?.cachedToolsRequireConfiguration).toBe(false);
   });
 });

--- a/front-api/routes/w/[wId]/mcp/views/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.test.ts
@@ -1,0 +1,53 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const plainInputSchema: JSONSchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+};
+
+describe("GET /api/w/:wId/mcp/views", () => {
+  it("returns views with the full serialization", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Plain Server",
+      url: "https://plain-server.example.com",
+      tools: [
+        {
+          name: "search",
+          description: "Search things",
+          inputSchema: plainInputSchema,
+        },
+      ],
+    });
+    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views?spaceIds=${globalSpace.sId}` +
+        `&availabilities=manual,auto`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const serverViews: MCPServerViewType[] = body.serverViews;
+    const serverView = serverViews.find((v) => v.server.sId === server.sId);
+
+    expect(serverView).toBeDefined();
+
+    // Full serialization: tool input schemas and remote server specifics are present.
+    expect(serverView?.server.tools[0].inputSchema).toEqual(plainInputSchema);
+    expect(serverView?.server).toHaveProperty("url");
+    expect(serverView?.server).toHaveProperty("sharedSecret");
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 import view from "./[viewId]";
+import jit from "./jit";
 
 const MCPViewsRequestAvailabilitySchema = z.enum(["manual", "auto"]);
 type MCPViewsRequestAvailabilityType = z.infer<
@@ -136,6 +137,7 @@ app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
   });
 });
 
+app.route("/jit", jit);
 app.route("/:viewId", view);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/views/jit.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.test.ts
@@ -1,0 +1,122 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const DUST_DATA_SOURCE_MIME = "application/vnd.dust.tool-input.data-source";
+
+// A tool input schema with a Dust configurable input on a required path: attaching such a
+// tool in a conversation is not possible, the view must be excluded from JIT responses.
+const requiredDustInputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    dataSources: {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: DUST_DATA_SOURCE_MIME },
+      },
+      required: ["uri", "mimeType"],
+    },
+  },
+  required: ["dataSources"],
+};
+
+const plainInputSchema: JSONSchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+};
+
+async function setup() {
+  const { workspace, globalSpace } = await createPrivateApiMockRequest({
+    role: "user",
+  });
+
+  const plainServer = await RemoteMCPServerFactory.create(workspace, {
+    name: "Plain Server",
+    url: "https://plain-server.example.com",
+    tools: [
+      {
+        name: "search",
+        description: "Search things",
+        inputSchema: plainInputSchema,
+      },
+    ],
+  });
+  await MCPServerViewFactory.create(workspace, plainServer.sId, globalSpace);
+
+  const configurableServer = await RemoteMCPServerFactory.create(workspace, {
+    name: "Configurable Server",
+    url: "https://configurable-server.example.com",
+    tools: [
+      {
+        name: "query_data_source",
+        description: "Query a configured data source",
+        inputSchema: requiredDustInputSchema,
+      },
+    ],
+  });
+  await MCPServerViewFactory.create(
+    workspace,
+    configurableServer.sId,
+    globalSpace
+  );
+
+  return { workspace, globalSpace, plainServer, configurableServer };
+}
+
+describe("GET /api/w/:wId/mcp/views/jit", () => {
+  it("filters out views requiring configuration and strips heavy data", async () => {
+    const { workspace, globalSpace, plainServer, configurableServer } =
+      await setup();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views/jit?spaceIds=${globalSpace.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const serverViews: MCPServerViewType[] = body.serverViews;
+    const plainView = serverViews.find((v) => v.server.sId === plainServer.sId);
+    const configurableView = serverViews.find(
+      (v) => v.server.sId === configurableServer.sId
+    );
+
+    // The view whose tool has a required Dust configurable input is excluded.
+    expect(configurableView).toBeUndefined();
+
+    // The JIT-attachable view is returned with tool names and descriptions only.
+    expect(plainView).toBeDefined();
+    expect(plainView?.server.tools).toEqual([
+      { name: "search", description: "Search things" },
+    ]);
+    expect(plainView?.server.authorization).toBeNull();
+    expect(plainView?.server).not.toHaveProperty("url");
+    expect(plainView?.server).not.toHaveProperty("sharedSecret");
+    expect(plainView?.server).not.toHaveProperty("customHeaders");
+    expect(plainView?.server).not.toHaveProperty("lastError");
+
+    // No view in the light response carries tool input schemas.
+    for (const view of serverViews) {
+      for (const tool of view.server.tools) {
+        expect(tool).not.toHaveProperty("inputSchema");
+      }
+    }
+  });
+
+  it("returns 400 without spaceIds", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views/jit`
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/views/jit.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.test.ts
@@ -88,14 +88,14 @@ describe("GET /api/w/:wId/mcp/views/jit", () => {
       (v) => v.server.sId === configurableServer.sId
     );
 
-    // The view whose tool has a required Dust configurable input is excluded.
+    // The view whose tool has a required Dust configurable input is excluded, based on the
+    // precomputed cachedToolsRequireConfiguration flag.
     expect(configurableView).toBeUndefined();
 
-    // The JIT-attachable view is returned with tool names and descriptions only.
+    // The JIT-attachable remote view is returned without its tools nor any remote specifics
+    // (surfaces needing the tools fetch the full server on demand).
     expect(plainView).toBeDefined();
-    expect(plainView?.server.tools).toEqual([
-      { name: "search", description: "Search things" },
-    ]);
+    expect(plainView?.server.tools).toEqual([]);
     expect(plainView?.server.authorization).toBeNull();
     expect(plainView?.server).not.toHaveProperty("url");
     expect(plainView?.server).not.toHaveProperty("sharedSecret");

--- a/front-api/routes/w/[wId]/mcp/views/jit.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.ts
@@ -1,4 +1,3 @@
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { GetMCPServerViewsListResponseBody } from "@app/lib/api/mcp";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -45,21 +44,15 @@ app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
     });
   }
 
+  // The JIT filter relies on the precomputed `cachedToolsRequireConfiguration` flag and the
+  // light serialization ships no remote tools, so no heavy attribute is fetched.
   const views = await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
     auth,
-    queryValidation.data.spaceIds,
-    {
-      // The JIT filter inspects the tools of the views' servers.
-      includeHeavyAttributes: ["cachedTools"],
-    }
+    queryValidation.data.spaceIds
   );
 
   const serverViews = views
-    .filter((v) =>
-      isJITMCPServerView({
-        server: { sId: v.mcpServerId, tools: v.getTools() },
-      })
-    )
+    .filter((v) => v.isJITAttachable())
     .map((v) => v.toJSONLight())
     // Same availabilities as the full listing exposes: "auto_hidden_builder" is never served.
     .filter(

--- a/front-api/routes/w/[wId]/mcp/views/jit.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.ts
@@ -1,0 +1,73 @@
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { GetMCPServerViewsListResponseBody } from "@app/lib/api/mcp";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const GetJITMCPViewsRequestSchema = z.object({
+  spaceIds: z.array(z.string()),
+});
+
+// Mounted at /api/w/:wId/mcp/views/jit. Lists the views whose tools can be enabled directly in
+// a conversation (JIT), in a light serialization without tool input schemas, authorization or
+// remote server specifics. This feeds always-mounted surfaces (conversation capabilities
+// picker, slash menu), which is why it is a separate endpoint from the full listing.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
+  const auth = ctx.get("auth");
+  const spaceIds = ctx.req.query("spaceIds");
+
+  if (!spaceIds) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters",
+      },
+    });
+  }
+
+  const queryValidation = GetJITMCPViewsRequestSchema.safeParse({
+    spaceIds: spaceIds.split(","),
+  });
+  if (!queryValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: fromError(queryValidation.error).toString(),
+      },
+    });
+  }
+
+  const views = await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
+    auth,
+    queryValidation.data.spaceIds,
+    {
+      // The JIT filter inspects the tools of the views' servers.
+      includeHeavyAttributes: ["cachedTools"],
+    }
+  );
+
+  const serverViews = views
+    .filter((v) =>
+      isJITMCPServerView({
+        server: { sId: v.mcpServerId, tools: v.getTools() },
+      })
+    )
+    .map((v) => v.toJSONLight())
+    // Same availabilities as the full listing exposes: "auto_hidden_builder" is never served.
+    .filter(
+      (v) =>
+        v.server.availability === "manual" || v.server.availability === "auto"
+    );
+
+  return ctx.json({ success: true, serverViews });
+});
+
+export default app;

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -9,12 +9,14 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useMCPServer } from "@app/lib/swr/mcp_servers";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  LoadingBlock,
   Separator,
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
@@ -38,12 +40,30 @@ export function MCPServerDetailsInfo({
     return d.toLocaleDateString();
   }, [mcpServerView?.editedByUser]);
 
+  // Views listed by the JIT views endpoint come without their remote server tools, so in
+  // read-only mode the tools are fetched on demand (deduped by SWR with the parent's fetch).
+  const { server: fetchedServer, isMCPServerLoading } = useMCPServer({
+    owner,
+    serverId: mcpServerView?.server.sId ?? "",
+    disabled: !readOnly || !mcpServerView,
+  });
+
   if (!mcpServerView) {
     return null;
   }
 
   if (readOnly) {
-    const tools = mcpServerView.server.tools ?? [];
+    if (isMCPServerLoading) {
+      return (
+        <div className="flex flex-col gap-2">
+          <LoadingBlock className="h-6 w-[50%]" />
+          <LoadingBlock className="h-4 w-[80%]" />
+          <LoadingBlock className="h-4 w-[80%]" />
+        </div>
+      );
+    }
+
+    const tools = fetchedServer?.tools ?? mcpServerView.server.tools ?? [];
     return (
       <div className="flex flex-col gap-2">
         <div className="heading-lg">Available Tools ({tools.length})</div>

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -11,13 +11,12 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
 import {
   useAvailableMCPServers,
-  useMCPServerViewsFromSpaces,
+  useJITMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -212,7 +211,7 @@ export function CapabilitiesPicker({
     serverViews,
     isLoading: isServerViewsLoading,
     mutateServerViews,
-  } = useMCPServerViewsFromSpaces(
+  } = useJITMCPServerViewsFromSpaces(
     owner,
     globalSpaces,
     CAPABILITIES_SWR_OPTIONS
@@ -352,14 +351,13 @@ export function CapabilitiesPicker({
         });
       }
 
+      // The JIT views endpoint only returns views whose tools can be enabled directly in a
+      // conversation, no further filtering needed here.
       for (const serverView of serverViews) {
         const label = getMcpServerViewDisplayName(serverView);
         const description = getMcpServerViewDescription(serverView);
 
-        if (
-          !isJITMCPServerView(serverView) ||
-          selectedMCPServerViewIds.has(serverView.sId)
-        ) {
+        if (selectedMCPServerViewIds.has(serverView.sId)) {
           continue;
         }
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -3,10 +3,12 @@ import {
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { CAPABILITIES_SWR_OPTIONS } from "@app/lib/swr/capabilities";
-import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
+import {
+  useJITMCPServerViewsFromSpaces,
+  useMCPServerViewsFromSpaces,
+} from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -76,8 +78,14 @@ export function useInputBarSlashCommandCapabilities({
     status: "active",
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
+  // The JIT views endpoint only returns views whose tools can be enabled directly in a
+  // conversation, no further filtering needed here.
   const { serverViews, isLoading: isServerViewsLoading } =
-    useMCPServerViewsFromSpaces(owner, globalSpaces, CAPABILITIES_SWR_OPTIONS);
+    useJITMCPServerViewsFromSpaces(
+      owner,
+      globalSpaces,
+      CAPABILITIES_SWR_OPTIONS
+    );
 
   const capabilityItems = useMemo(
     () =>
@@ -87,7 +95,6 @@ export function useInputBarSlashCommandCapabilities({
         skills,
         tools: serverViews,
         toolFilter: (serverView) =>
-          isJITMCPServerView(serverView) &&
           !(selectedMCPServerViewIdsRef?.current ?? new Set()).has(
             serverView.sId
           ),

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -10,7 +10,7 @@ import type {
   FileAuthRequiredOutputResourceType,
   SingleResourceToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { hasNoRequiredProperties } from "@app/lib/utils/json_schemas";
 import type { OAuthProvider } from "@app/types/oauth/lib";
@@ -114,7 +114,9 @@ export function makeMCPToolExit({
   };
 }
 
-export function isJITMCPServerView(view: MCPServerViewType): boolean {
+export function isJITMCPServerView(view: {
+  server: Pick<MCPServerType, "sId" | "tools">;
+}): boolean {
   return (
     !matchesInternalMCPServerName(view.server.sId, "agent_memory") &&
     // Only tools that do not require any configuration can be enabled directly in a conversation.

--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -24,6 +24,9 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare cachedName: string;
   declare cachedDescription: string | null;
   declare cachedTools: MCPToolType[];
+  // Derived from cachedTools at write time: true when at least one tool input schema forces a
+  // Dust configurable input, i.e. the server cannot be attached directly in a conversation.
+  declare cachedToolsRequireConfiguration: CreationOptional<boolean>;
 
   declare lastSyncAt: Date | null;
   declare lastError: string | null;
@@ -71,6 +74,11 @@ RemoteMCPServerModel.init(
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: [],
+    },
+    cachedToolsRequireConfiguration: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     lastSyncAt: {
       type: DataTypes.DATE,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -20,13 +20,10 @@ import {
   INTERNAL_MCP_SERVERS,
   isAutoInternalMCPServerName,
   isValidInternalMCPServerId,
+  matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
-import type {
-  MCPServerType,
-  MCPServerViewType,
-  MCPToolType,
-} from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
@@ -47,6 +44,7 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { hasNoRequiredProperties } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import { tracer } from "@app/logger/tracer";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
@@ -1259,12 +1257,21 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   }
 
   /**
-   * The server's tools. For remote servers this requires the `cachedTools` heavy attribute.
+   * Server-side counterpart of `isJITMCPServerView`: true when the view's tools can be enabled
+   * directly in a conversation. Cheap — remote servers carry the precomputed
+   * `cachedToolsRequireConfiguration` flag, internal tools live in memory — so no heavy
+   * attribute is needed at fetch time.
    */
-  getTools(): MCPToolType[] {
-    return this.serverType === "remote"
-      ? this.getRemoteMCPServerResource().getCachedTools()
-      : this.getInternalMCPServerResource().toJSON().tools;
+  isJITAttachable(): boolean {
+    if (matchesInternalMCPServerName(this.mcpServerId, "agent_memory")) {
+      return false;
+    }
+    if (this.serverType === "remote") {
+      return !this.getRemoteMCPServerResource().cachedToolsRequireConfiguration;
+    }
+    return hasNoRequiredProperties({
+      server: { tools: this.getInternalMCPServerResource().toJSON().tools },
+    });
   }
 
   /**
@@ -1698,15 +1705,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   /**
    * Light serialization for list surfaces (conversation capabilities picker, slash menu) that
    * only render names, descriptions and icons. Tool input schemas, authorization and the remote
-   * server specifics (url, secrets, lastError) are omitted; for remote servers only the
-   * `cachedTools` heavy attribute is required at fetch time.
+   * server specifics (url, secrets, lastError) are omitted, and remote tools are not included
+   * at all (surfaces needing them fetch the full server on demand), so no heavy attribute is
+   * required at fetch time.
    */
   toJSONLight(): MCPServerViewType {
-    const tools = this.getTools().map(({ name, description }) => ({
-      name,
-      description,
-    }));
-
     let server: MCPServerType;
     if (this.serverType === "remote") {
       const remoteServer = this.getRemoteMCPServerResource();
@@ -1718,17 +1721,21 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         version: remoteServer.version,
         icon: remoteServer.icon,
         authorization: null,
-        tools,
+        tools: [],
         availability: "manual",
         allowMultipleInstances: true,
         documentationUrl: null,
         meta: remoteServer.meta,
       };
     } else {
+      const internalServer = this.getInternalMCPServerResource().toJSON();
       server = {
-        ...this.getInternalMCPServerResource().toJSON(),
+        ...internalServer,
         authorization: null,
-        tools,
+        tools: internalServer.tools.map(({ name, description }) => ({
+          name,
+          description,
+        })),
       };
     }
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -22,7 +22,11 @@ import {
   isValidInternalMCPServerId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
-import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import type {
+  MCPServerType,
+  MCPServerViewType,
+  MCPToolType,
+} from "@app/lib/api/mcp";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
@@ -1255,6 +1259,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   }
 
   /**
+   * The server's tools. For remote servers this requires the `cachedTools` heavy attribute.
+   */
+  getTools(): MCPToolType[] {
+    return this.serverType === "remote"
+      ? this.getRemoteMCPServerResource().getCachedTools()
+      : this.getInternalMCPServerResource().toJSON().tools;
+  }
+
+  /**
    * The server's authorization config with the view's admin-configured scope restriction
    * applied. For remote servers this only needs the `authorization` heavy attribute.
    */
@@ -1676,11 +1689,53 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     // Override the server's default authorization scope with the admin-configured
     // restriction if one has been set. This ensures personal connections and
     // platform OAuth setup both use the restricted scope.
-    const serverWithScope = {
+    return this.toJSONWithServer({
       ...server,
       authorization: this.getAuthorization(),
-    };
+    });
+  }
 
+  /**
+   * Light serialization for list surfaces (conversation capabilities picker, slash menu) that
+   * only render names, descriptions and icons. Tool input schemas, authorization and the remote
+   * server specifics (url, secrets, lastError) are omitted; for remote servers only the
+   * `cachedTools` heavy attribute is required at fetch time.
+   */
+  toJSONLight(): MCPServerViewType {
+    const tools = this.getTools().map(({ name, description }) => ({
+      name,
+      description,
+    }));
+
+    let server: MCPServerType;
+    if (this.serverType === "remote") {
+      const remoteServer = this.getRemoteMCPServerResource();
+      server = {
+        sId: remoteServer.sId,
+        name: remoteServer.cachedName,
+        description:
+          remoteServer.cachedDescription ?? DEFAULT_MCP_ACTION_DESCRIPTION,
+        version: remoteServer.version,
+        icon: remoteServer.icon,
+        authorization: null,
+        tools,
+        availability: "manual",
+        allowMultipleInstances: true,
+        documentationUrl: null,
+        meta: remoteServer.meta,
+      };
+    } else {
+      server = {
+        ...this.getInternalMCPServerResource().toJSON(),
+        authorization: null,
+        tools,
+      };
+    }
+
+    return this.toJSONWithServer(server);
+  }
+
+  private toJSONWithServer(server: MCPServerType): MCPServerViewType {
     return {
       id: this.id,
       sId: this.sId,
@@ -1690,7 +1745,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,
       serverType: this.serverType,
-      server: serverWithScope,
+      server,
       oAuthUseCase: this.oAuthUseCase,
       editedByUser: this.makeEditedBy(
         this.editedByUser,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -26,6 +26,7 @@ import {
   isResourceSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthConnectionMetadataType } from "@app/types/api/oauth/providers/mcp";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
@@ -219,7 +220,12 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     auth: Authenticator,
     blob: Omit<
       CreationAttributes<RemoteMCPServerModel>,
-      "name" | "description" | "spaceId" | "sId" | "lastSyncAt"
+      | "name"
+      | "description"
+      | "spaceId"
+      | "sId"
+      | "lastSyncAt"
+      | "cachedToolsRequireConfiguration"
     > & {
       oAuthUseCase: MCPOAuthUseCase | null;
     },
@@ -237,6 +243,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       sharedSecret: blob.sharedSecret,
       lastSyncAt: new Date(),
       authorization: blob.authorization,
+      cachedToolsRequireConfiguration: mcpToolsRequireConfiguration(
+        blob.cachedTools
+      ),
     };
 
     const server = await RemoteMCPServerModel.create(serverData, {
@@ -549,6 +558,12 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       cachedName,
       cachedDescription,
       cachedTools,
+      ...(cachedTools
+        ? {
+            cachedToolsRequireConfiguration:
+              mcpToolsRequireConfiguration(cachedTools),
+          }
+        : {}),
       lastSyncAt,
       ...(clearError ? { lastError: null } : {}),
     });

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1287,6 +1287,36 @@ export function useMCPServerViewsFromSpaces(
   );
 }
 
+/**
+ * JIT-attachable server views only (tools requiring configuration are filtered out
+ * server-side), in a light serialization without tool input schemas nor authorization.
+ * This is the cheap variant for always-mounted surfaces (conversation capabilities
+ * picker, slash menu).
+ */
+export function useJITMCPServerViewsFromSpaces(
+  owner: LightWorkspaceType,
+  spaces: SpaceType[],
+  swrOptions?: SWRConfiguration & { disabled?: boolean }
+) {
+  const { fetcher } = useFetcher();
+  const configFetcher: Fetcher<GetMCPServerViewsListResponseBody> = fetcher;
+
+  const spaceIds = spaces.map((s) => s.sId).join(",");
+
+  const url = `/api/w/${owner.sId}/mcp/views/jit?spaceIds=${spaceIds}`;
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    ...swrOptions,
+    ...(!spaces.length ? { disabled: true } : {}),
+  });
+
+  return {
+    serverViews: data?.serverViews ?? emptyArray(),
+    isLoading: !error && !data && spaces.length !== 0,
+    isError: error,
+    mutateServerViews: mutate,
+  };
+}
+
 export function useManualMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
   spaces: SpaceType[],

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import logger from "@app/logger/logger";
 import { isRecord } from "@app/types/shared/utils/general";
 import Ajv from "ajv";
@@ -576,7 +576,9 @@ export function jsonSchemaHasRequiredDustToolInput(
  * True when no tool input schema forces a Dust configurable input on an all-required path
  * from the root (see {@link jsonSchemaHasRequiredDustToolInput}).
  */
-export function hasNoRequiredProperties(view: MCPServerViewType): boolean {
+export function hasNoRequiredProperties(view: {
+  server: Pick<MCPServerType, "tools">;
+}): boolean {
   const tools = view.server.tools;
   for (let t = 0; t < tools.length; t++) {
     const sch = tools[t].inputSchema;

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -1,5 +1,5 @@
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import logger from "@app/logger/logger";
 import { isRecord } from "@app/types/shared/utils/general";
 import Ajv from "ajv";
@@ -573,20 +573,30 @@ export function jsonSchemaHasRequiredDustToolInput(
 }
 
 /**
+ * True when at least one tool input schema forces a Dust configurable input on an all-required
+ * path from the root (see {@link jsonSchemaHasRequiredDustToolInput}). Such tools need an
+ * agent/skill configuration step and cannot be attached directly in a conversation.
+ */
+export function mcpToolsRequireConfiguration(
+  tools: Array<Pick<MCPToolType, "inputSchema">>
+): boolean {
+  for (let t = 0; t < tools.length; t++) {
+    const sch = tools[t].inputSchema;
+    if (sch !== undefined && sch !== null) {
+      if (jsonSchemaHasRequiredDustToolInput(sch, true)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * True when no tool input schema forces a Dust configurable input on an all-required path
  * from the root (see {@link jsonSchemaHasRequiredDustToolInput}).
  */
 export function hasNoRequiredProperties(view: {
   server: Pick<MCPServerType, "tools">;
 }): boolean {
-  const tools = view.server.tools;
-  for (let t = 0; t < tools.length; t++) {
-    const sch = tools[t].inputSchema;
-    if (sch !== undefined && sch !== null) {
-      if (jsonSchemaHasRequiredDustToolInput(sch, true)) {
-        return false;
-      }
-    }
-  }
-  return true;
+  return !mcpToolsRequireConfiguration(view.server.tools);
 }

--- a/front/migrations/20260723_backfill_cached_tools_require_configuration.ts
+++ b/front/migrations/20260723_backfill_cached_tools_require_configuration.ts
@@ -1,0 +1,83 @@
+import type { MCPToolType } from "@app/lib/api/mcp";
+import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
+import { makeScript } from "@app/scripts/helpers";
+import { Op } from "sequelize";
+
+const BATCH_SIZE = 256;
+
+// Backfill `cachedToolsRequireConfiguration` from `cachedTools` for rows written before the
+// column existed (they carry the column default, `false`). Run once all pods double-write the
+// column on every `cachedTools` write (RemoteMCPServerResource.makeNew / updateMetadata), so no
+// row can be written the old way afterwards. Safe to re-run: recomputing is idempotent.
+makeScript({}, async ({ execute }, logger) => {
+  const RemoteMCPServerModelWithBypass: ModelStaticWorkspaceAware<RemoteMCPServerModel> =
+    RemoteMCPServerModel;
+
+  let lastId = 0;
+  let scanned = 0;
+  let mismatched = 0;
+
+  for (;;) {
+    const servers = await RemoteMCPServerModelWithBypass.findAll({
+      where: { id: { [Op.gt]: lastId } },
+      attributes: [
+        "id",
+        "workspaceId",
+        "cachedTools",
+        "cachedToolsRequireConfiguration",
+      ],
+      order: [["id", "ASC"]],
+      limit: BATCH_SIZE,
+      // WORKSPACE_ISOLATION_BYPASS: Migration script backfills the flag across all workspaces.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    if (servers.length === 0) {
+      break;
+    }
+    lastId = servers[servers.length - 1].id;
+    scanned += servers.length;
+
+    for (const server of servers) {
+      // Old rows can hold a NULL cachedTools despite the model type (column is nullable).
+      const cachedTools: MCPToolType[] | null = server.cachedTools;
+      const requireConfiguration = mcpToolsRequireConfiguration(
+        cachedTools ?? []
+      );
+
+      if (requireConfiguration === server.cachedToolsRequireConfiguration) {
+        continue;
+      }
+      mismatched++;
+
+      logger.info(
+        {
+          remoteMCPServerModelId: server.id,
+          workspaceId: server.workspaceId,
+          requireConfiguration,
+        },
+        execute
+          ? "Backfilling cachedToolsRequireConfiguration"
+          : "Would backfill cachedToolsRequireConfiguration"
+      );
+
+      if (execute) {
+        // `silent` leaves updatedAt untouched.
+        await RemoteMCPServerModel.update(
+          { cachedToolsRequireConfiguration: requireConfiguration },
+          {
+            where: { id: server.id, workspaceId: server.workspaceId },
+            silent: true,
+          }
+        );
+      }
+    }
+  }
+
+  logger.info(
+    { scanned, mismatched, execute },
+    "Completed cachedToolsRequireConfiguration backfill"
+  );
+});

--- a/front/migrations/pre-deploy/20260723105431_add_cached_tools_require_configuration_to_remote_mcp_servers.sql
+++ b/front/migrations/pre-deploy/20260723105431_add_cached_tools_require_configuration_to_remote_mcp_servers.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."remote_mcp_servers" ADD COLUMN "cachedToolsRequireConfiguration" boolean DEFAULT false NOT NULL;


### PR DESCRIPTION
## Context

Stacked on #29368 (3/3 of the cachedTools-elimination stack: column + double write → backfill → **endpoint switch**).

**Deploy after the #29368 backfill has run** — this is where the flag becomes load-bearing.

## Changes

- `GET /mcp/views/jit` now fetches views with **no** `remote_mcp_servers` heavy attribute. The JIT filter moves to `MCPServerViewResource.isJITAttachable()`: remote servers use the precomputed `cachedToolsRequireConfiguration` flag, internal servers keep the in-memory schema walk (free), `agent_memory` stays excluded. The full `/mcp/views` handler is untouched by this stack.
- `toJSONLight()` ships remote servers with `tools: []` (internal tools keep `{name, description}` — they cost nothing). The transient `getTools()` accessor from #29361 is removed.
- Read-only tool details sheet (`MCPServerDetailsInfo`): tools are fetched on demand via `useMCPServer` (`/mcp/[serverId]`), SWR-deduped with the fetch `MCPServerDetails` already makes on open, with a loading skeleton. So the "Available Tools" list still renders for remote servers despite the empty list payload.

Net effect on the input-bar hot path (with eager preloading from #29353): zero heavy jsonb columns read from `remote_mcp_servers`, and the response carries no tool schemas, secrets, or remote specifics.

## Tests

- `views/jit.test.ts` updated: excludes flag-true servers, remote views ship `tools: []`, no view carries `inputSchema`.
- All mcp route suites pass; `tsgo --noEmit` clean on `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)