### PR TITLE
fix(sandbox): isolate GCS mount credentials

### DIFF
--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -28,6 +28,7 @@ describe("buildMountCommand", () => {
     );
 
     expect(command).toContain("/usr/bin/gcsfuse");
+    expect(command).toContain("--token-url http://127.0.0.1:987/token/mount-0");
     expect(command).not.toContain("runuser");
     expect(command).toContain("-o allow_other");
     expect(command).toContain("--file-mode=666");
@@ -42,6 +43,7 @@ describe("buildMountCommand", () => {
     const command = renderRootCommand(
       buildMountCommand({
         bucket: "bucket-x",
+        targetIndex: 1,
         target: workloadTarget({
           gcsPrefix: "w/ws1/pods/spc1/sandbox-functions",
           sandboxMountPoint: "/sandbox-functions/pods/spc1",
@@ -52,6 +54,7 @@ describe("buildMountCommand", () => {
     );
 
     expect(command).toContain("-o allow_other,ro");
+    expect(command).toContain("--token-url http://127.0.0.1:987/token/mount-1");
   });
 
   test("pod_state_replica profile mounts as dust-state without allow_other or list caching", () => {
@@ -115,13 +118,15 @@ describe("pod sandbox mount wiring", () => {
       throw new Error("expected a GCSSandboxMountAdapter");
     }
 
-    // 1 unconditional bucket-get rule + 2 rules per prefix × 3 prefixes
-    // (files rw, sandbox-functions ro, state rw) = 7, under the 10-rule CAB
-    // ceiling.
+    // Each mount gets its own 1 + 2-rule CAB. The firewall is the sole caller
+    // authorization boundary; if a caller reaches the broker, each token still
+    // grants only its own target prefix.
     const rules = adapter.getAccessBoundaryRules();
-    expect(rules).toHaveLength(7);
+    expect(rules).toHaveLength(3);
+    expect(rules.every((tokenRules) => tokenRules.length === 3)).toBe(true);
 
     const conditions = rules
+      .flat()
       .map((rule) =>
         "availabilityCondition" in rule
           ? rule.availabilityCondition.expression

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import {
   buildMountCommand,
@@ -5,8 +6,24 @@ import {
   GCSSandboxMountAdapter,
 } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
-import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
-import { beforeAll, describe, expect, test } from "vitest";
+import {
+  type RootCommand,
+  renderRootCommand,
+} from "@app/lib/api/sandbox/root_command";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { mockMintDownscopedGcsToken } = vi.hoisted(() => ({
+  mockMintDownscopedGcsToken: vi.fn(),
+}));
+
+vi.mock(import("@app/lib/api/sandbox/gcs/token"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    mintDownscopedGcsToken: mockMintDownscopedGcsToken,
+  };
+});
 
 function workloadTarget(
   overrides: Partial<GCSMountTarget> = {}
@@ -19,6 +36,17 @@ function workloadTarget(
     mountProfile: "workload",
     ...overrides,
   };
+}
+
+function successfulExec() {
+  return new Ok({ exitCode: 0, stdout: "", stderr: "" });
+}
+
+function getRootCommandCall(
+  mock: { mock: { calls: unknown[][] } },
+  callIndex: number
+): string {
+  return renderRootCommand(mock.mock.calls[callIndex][1] as RootCommand);
 }
 
 describe("buildMountCommand", () => {
@@ -136,5 +164,179 @@ describe("pod sandbox mount wiring", () => {
     expect(conditions).toContain("w/ws1/pods/spc1/files/");
     expect(conditions).toContain("w/ws1/pods/spc1/sandbox-functions/");
     expect(conditions).toContain("w/ws1/pods/spc1/state/");
+  });
+});
+
+describe("GCS credential lifecycle", () => {
+  const auth = {
+    getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+  } as never;
+  const image = {
+    hasCapability: (capability: string) => capability === "gcsfuse",
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMintDownscopedGcsToken.mockResolvedValue(
+      new Ok({ accessToken: "token", expiresInSeconds: 3600 })
+    );
+  });
+
+  test("starts the broker only after firewall setup and fail-closes the deny-check", async () => {
+    const sandbox = {
+      sId: "sandbox-id",
+      execRoot: vi.fn().mockResolvedValue(successfulExec()),
+      requestKill: vi.fn(),
+    };
+    const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
+
+    const result = await adapter.setup(auth, sandbox as never, image);
+
+    expect(result.isOk()).toBe(true);
+    const command = getRootCommandCall(sandbox.execRoot, 1);
+    expect(command).toContain(
+      "/usr/local/bin/dust-gcs-token-firewall.sh; firewall_exit=$?"
+    );
+    expect(command).toContain("--connect-timeout 0.3 --max-time 1");
+    expect(command).toContain("deny_check_exit -ne 28");
+    expect(command.indexOf("exit $firewall_exit")).toBeLessThan(
+      command.indexOf("i=0; while")
+    );
+    expect(spawnSync("/bin/bash", ["-n", "-c", command]).status).toBe(0);
+  });
+
+  test("surfaces a firewall startup failure without polling the broker", async () => {
+    const sandbox = {
+      sId: "sandbox-id",
+      execRoot: vi
+        .fn()
+        .mockResolvedValueOnce(successfulExec())
+        .mockResolvedValueOnce(
+          new Ok({
+            exitCode: 1,
+            stdout: "",
+            stderr: "GCS token firewall setup failed (exit code 1)",
+          })
+        ),
+      requestKill: vi.fn(),
+    };
+    const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
+
+    const result = await adapter.setup(auth, sandbox as never, image);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("expected broker startup to fail");
+    }
+    expect(result.error.message).toContain(
+      "GCS token firewall setup failed (exit code 1)"
+    );
+    expect(result.error.message).not.toContain("not ready in time");
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
+  });
+
+  test("refreshes both firewall generations in one root exec", async () => {
+    const sandbox = {
+      sId: "sandbox-id",
+      exec: vi.fn(),
+      execRoot: vi.fn().mockResolvedValue(successfulExec()),
+      requestKill: vi.fn(),
+    };
+    const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
+
+    const result = await adapter.refreshCredential(
+      auth,
+      sandbox as never,
+      image
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
+    const firewallCommand = getRootCommandCall(sandbox.execRoot, 0);
+    expect(firewallCommand).toContain("dust-gcs-token-legacy");
+    expect(firewallCommand).toContain(
+      "/usr/local/bin/dust-gcs-token-firewall.sh"
+    );
+    expect(spawnSync("/bin/bash", ["-n", "-c", firewallCommand]).status).toBe(
+      0
+    );
+    expect(sandbox.exec).not.toHaveBeenCalled();
+    expect(sandbox.requestKill).not.toHaveBeenCalled();
+  });
+
+  test("refreshes the legacy token before recreating an old-image sandbox", async () => {
+    const sandbox = {
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(successfulExec()),
+      execRoot: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 127,
+          stdout: "",
+          stderr: "dust-gcs-current-firewall-failed",
+        })
+      ),
+      requestKill: vi.fn().mockResolvedValue(undefined),
+    };
+    const targets = [
+      workloadTarget(),
+      workloadTarget({
+        gcsPrefix: "w/ws1/pods/spc1/state",
+        sandboxMountPoint: "/pod-state/replica",
+        legacySandboxMountPoint: null,
+        mountProfile: "pod_state_replica",
+      }),
+    ];
+    const adapter = new GCSSandboxMountAdapter("bucket-x", targets);
+
+    const result = await adapter.refreshCredential(
+      auth,
+      sandbox as never,
+      image
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+    expect(mockMintDownscopedGcsToken).toHaveBeenCalledWith({
+      bucket: "bucket-x",
+      prefixes: targets.map((target) => ({
+        prefix: target.gcsPrefix,
+        readOnly: target.readOnly,
+      })),
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      auth,
+      "/usr/bin/tee /tmp/token.json >/dev/null",
+      {
+        stdin: JSON.stringify({
+          access_token: "token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+      }
+    );
+    expect(sandbox.requestKill).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not recreate a sandbox after a transient firewall exec error", async () => {
+    const sandbox = {
+      sId: "sandbox-id",
+      exec: vi.fn(),
+      execRoot: vi
+        .fn()
+        .mockResolvedValue(new Err(new Error("transient E2B error"))),
+      requestKill: vi.fn(),
+    };
+    const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
+
+    const result = await adapter.refreshCredential(
+      auth,
+      sandbox as never,
+      image
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockMintDownscopedGcsToken).not.toHaveBeenCalled();
+    expect(sandbox.exec).not.toHaveBeenCalled();
+    expect(sandbox.requestKill).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -3,6 +3,7 @@ import {
   mintDownscopedGcsToken,
 } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import {
   type RootCommand,
   rootCommand,
@@ -25,6 +26,10 @@ const TOKEN_DIRECTORY = "/run/dust-gcs";
 const TOKEN_SERVER_PATH = "/usr/local/bin/dust-gcs-token-server.py";
 const TOKEN_WRITER_PATH = "/usr/local/bin/dust-gcs-write-token.sh";
 const TOKEN_FIREWALL_PATH = "/usr/local/bin/dust-gcs-token-firewall.sh";
+const LEGACY_TOKEN_PATH = "/tmp/token.json";
+const LEGACY_TOKEN_FIREWALL_FAILURE_MARKER = "dust-gcs-legacy-firewall-failed";
+const CURRENT_TOKEN_FIREWALL_FAILURE_MARKER =
+  "dust-gcs-current-firewall-failed";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
@@ -178,21 +183,40 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     // 3-4. Start the root-owned token server and poll it ready in
     // ONE exec. Polling every 50ms returns the instant the server is listening
     // instead of a flat sleep 1, and folds three round-trips into one.
-    const tokenServerResult = await sandbox.execRoot(
-      auth,
-      rootCommand.unsafeShell(
-        `${TOKEN_FIREWALL_PATH} && ` +
-          `(/usr/bin/nohup ${TOKEN_SERVER_PATH} >${TOKEN_DIRECTORY}/server.log 2>&1 &) && ` +
-          `i=0; while [ $i -lt ${TOKEN_SERVER_POLL_ATTEMPTS} ]; do ` +
-          `/usr/bin/curl -sf ${TOKEN_SERVER_HEALTH_URL} > /dev/null 2>&1 || { ` +
-          `/usr/bin/sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; ` +
-          `i=$((i+1)); continue; }; ` +
-          `if /usr/sbin/runuser -u agent-proxied -- /usr/bin/curl -sf --max-time 1 ${tokenUrl(0)} > /dev/null 2>&1; then ` +
-          `exit 1; fi; exit 0; ` +
-          "done; exit 1",
-        "Start and readiness-check the root-owned GCS token broker"
-      ),
-      { timeoutMs: TOKEN_SERVER_EXEC_TIMEOUT_MS }
+    const tokenServerResult = await traceSandboxStartupPhase(
+      "gcs.token_server",
+      () =>
+        sandbox.execRoot(
+          auth,
+          rootCommand.unsafeShell(
+            `${TOKEN_FIREWALL_PATH}; firewall_exit=$?; ` +
+              `if [ $firewall_exit -ne 0 ]; then ` +
+              `/usr/bin/printf 'GCS token firewall setup failed (exit code %s)\\n' "$firewall_exit" >&2; ` +
+              `exit $firewall_exit; fi; ` +
+              `(/usr/bin/nohup ${TOKEN_SERVER_PATH} >${TOKEN_DIRECTORY}/server.log 2>&1 &); server_start_exit=$?; ` +
+              `if [ $server_start_exit -ne 0 ]; then ` +
+              `/usr/bin/printf 'GCS token server start failed (exit code %s)\\n' "$server_start_exit" >&2; ` +
+              `exit $server_start_exit; fi; ` +
+              `i=0; while [ $i -lt ${TOKEN_SERVER_POLL_ATTEMPTS} ]; do ` +
+              `if ! /usr/bin/curl -sf ${TOKEN_SERVER_HEALTH_URL} > /dev/null 2>&1; then ` +
+              `/usr/bin/sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; ` +
+              `i=$((i+1)); continue; fi; ` +
+              `/usr/sbin/runuser -u agent-proxied -- /usr/bin/curl -sf --connect-timeout 0.3 --max-time 1 ${tokenUrl(0)} > /dev/null 2>&1; ` +
+              `deny_check_exit=$?; ` +
+              `if [ $deny_check_exit -eq 0 ]; then ` +
+              `/usr/bin/printf 'GCS token firewall deny-check unexpectedly reached the broker\\n' >&2; ` +
+              `exit 1; fi; ` +
+              `if [ $deny_check_exit -ne 28 ]; then ` +
+              `/usr/bin/printf 'GCS token firewall deny-check could not be verified (exit code %s)\\n' "$deny_check_exit" >&2; ` +
+              `exit 1; fi; ` +
+              `exit 0; ` +
+              `done; ` +
+              `/usr/bin/printf 'GCS token server readiness timed out\\n' >&2; exit 1`,
+            "Start and readiness-check the root-owned GCS token broker"
+          ),
+          { timeoutMs: TOKEN_SERVER_EXEC_TIMEOUT_MS }
+        ),
+      { sandbox_id: sandbox.sId }
     );
     if (tokenServerResult.isErr()) {
       childLogger.error(
@@ -202,7 +226,12 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return tokenServerResult;
     }
     if (tokenServerResult.value.exitCode !== 0) {
-      const msg = "GCS token server not ready in time";
+      const details =
+        tokenServerResult.value.stderr.trim() ||
+        tokenServerResult.value.stdout.trim();
+      const msg = details
+        ? `GCS token server startup failed: ${details}`
+        : "GCS token server not ready in time";
       childLogger.error(
         {
           stdout: tokenServerResult.value.stdout,
@@ -225,10 +254,15 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
           return mkdirResult;
         }
 
-        const mountResult = await sandbox.execRoot(
-          auth,
-          buildMountCommand({ bucket, target, targetIndex: index }),
-          { timeoutMs: MOUNT_TIMEOUT_MS }
+        const mountResult = await traceSandboxStartupPhase(
+          "gcs.gcsfuse_mount",
+          () =>
+            sandbox.execRoot(
+              auth,
+              buildMountCommand({ bucket, target, targetIndex: index }),
+              { timeoutMs: MOUNT_TIMEOUT_MS }
+            ),
+          { mount_point: target.sandboxMountPoint }
         );
 
         if (mountResult.isErr()) {
@@ -301,18 +335,22 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
-    // Re-establish both the legacy and current broker UID drops before replacing any token files.
-    // This protects old 9876 servers during the image rollout and closes the wake window where
-    // systemd/nftables state may have been reset before the lifecycle egress check runs.
-    const legacyFirewallResult = await ensureLegacyTokenFirewall(auth, sandbox);
-    if (legacyFirewallResult.isErr()) {
-      await sandbox.requestKill();
-      return legacyFirewallResult;
-    }
-
-    const firewallResult = await ensureTokenFirewall(auth, sandbox);
+    // Re-establish both broker UID drops in one sandbox round-trip before replacing any token
+    // files. This protects old 9876 servers during the image rollout and closes the wake window
+    // where systemd/nftables state may have been reset before the lifecycle egress check runs.
+    const firewallResult = await ensureTokenFirewalls(auth, sandbox);
     if (firewallResult.isErr()) {
       if (firewallResult.error instanceof GCSMountImageHelperUnavailableError) {
+        if (firewallResult.error.helperPath === TOKEN_FIREWALL_PATH) {
+          const legacyRefreshResult = await mintAndWriteLegacyToken({
+            auth,
+            sandbox,
+            bucket: this.bucket,
+            targets: this.targets,
+          });
+          await sandbox.requestKill();
+          return legacyRefreshResult;
+        }
         await sandbox.requestKill();
       }
       return firewallResult;
@@ -337,9 +375,16 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       if (writeError.error instanceof GCSMountTokenWriterUnavailableError) {
         logger.warn(
           { sandboxId: sandbox.sId, error: writeError.error },
-          "GCS token writer is unavailable; requesting sandbox recreation"
+          "GCS token writer is unavailable; refreshing the legacy token and requesting sandbox recreation"
         );
+        const legacyRefreshResult = await mintAndWriteLegacyToken({
+          auth,
+          sandbox,
+          bucket: this.bucket,
+          targets: this.targets,
+        });
         await sandbox.requestKill();
+        return legacyRefreshResult;
       }
       return writeError;
     }
@@ -478,10 +523,15 @@ async function mintAndWriteToken({
   target: GCSMountTarget;
   targetIndex: number;
 }): Promise<Result<void, Error>> {
-  const tokenResult = await mintDownscopedGcsToken({
-    bucket,
-    prefixes: [{ prefix: target.gcsPrefix, readOnly: target.readOnly }],
-  });
+  const tokenResult = await traceSandboxStartupPhase(
+    "gcs.mint_token",
+    () =>
+      mintDownscopedGcsToken({
+        bucket,
+        prefixes: [{ prefix: target.gcsPrefix, readOnly: target.readOnly }],
+      }),
+    { mount_point: target.sandboxMountPoint }
+  );
   if (tokenResult.isErr()) {
     return tokenResult;
   }
@@ -518,59 +568,112 @@ async function mintAndWriteToken({
   return new Ok(undefined);
 }
 
-async function ensureTokenFirewall(
-  auth: Authenticator,
-  sandbox: SandboxResource
-): Promise<Result<void, Error>> {
-  const result = await sandbox.execRoot(
-    auth,
-    rootCommand.exec(TOKEN_FIREWALL_PATH)
+async function mintAndWriteLegacyToken({
+  auth,
+  sandbox,
+  bucket,
+  targets,
+}: {
+  auth: Authenticator;
+  sandbox: SandboxResource;
+  bucket: string;
+  targets: ReadonlyArray<GCSMountTarget>;
+}): Promise<Result<void, Error>> {
+  const tokenResult = await traceSandboxStartupPhase(
+    "gcs.mint_token",
+    () =>
+      mintDownscopedGcsToken({
+        bucket,
+        prefixes: targets.map((target) => ({
+          prefix: target.gcsPrefix,
+          readOnly: target.readOnly,
+        })),
+      }),
+    { credential_format: "legacy" }
   );
-  if (result.isErr()) {
-    return result;
+  if (tokenResult.isErr()) {
+    return tokenResult;
   }
-  if (result.value.exitCode === 126 || result.value.exitCode === 127) {
-    return new Err(
-      new GCSMountImageHelperUnavailableError(
-        TOKEN_FIREWALL_PATH,
-        result.value.exitCode
-      )
-    );
+
+  // Old images serve this file from the already-running agent-owned broker on port 9876. Keep
+  // this compatibility write for one image rollout so a pod's pre-destroy litestream flush can
+  // complete before the requested recreation.
+  const writeResult = await sandbox.exec(
+    auth,
+    `/usr/bin/tee ${LEGACY_TOKEN_PATH} >/dev/null`,
+    { stdin: buildTokenJson(tokenResult.value) }
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
   }
-  if (result.value.exitCode !== 0) {
+  if (writeResult.value.exitCode !== 0) {
     return new Err(
       new Error(
-        `GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
+        `Legacy GCS token write failed: ${writeResult.value.stderr || writeResult.value.stdout}`
       )
     );
   }
+
+  logger.warn(
+    {
+      sandboxId: sandbox.sId,
+      prefixes: targets.map((target) => target.gcsPrefix),
+    },
+    "GCS sandbox mount: refreshed legacy credential before sandbox recreation"
+  );
+
   return new Ok(undefined);
 }
 
-async function ensureLegacyTokenFirewall(
+async function ensureTokenFirewalls(
   auth: Authenticator,
   sandbox: SandboxResource
 ): Promise<Result<void, Error>> {
   const result = await sandbox.execRoot(
     auth,
     rootCommand.unsafeShell(
-      "if ! /usr/sbin/nft list table ip dust-gcs-token-legacy >/dev/null 2>&1; then " +
-        "/usr/sbin/nft add table ip dust-gcs-token-legacy; fi; " +
+      "install_legacy_firewall() { " +
+        "if ! /usr/sbin/nft list table ip dust-gcs-token-legacy >/dev/null 2>&1; then " +
+        "/usr/sbin/nft add table ip dust-gcs-token-legacy || return $?; fi; " +
         "if ! /usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output >/dev/null 2>&1; then " +
-        "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }'; fi; " +
+        "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }' || return $?; fi; " +
         "legacy_rules=$(/usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output 2>/dev/null || true); " +
         "if ! /usr/bin/grep -Fq 'meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop' <<<\"$legacy_rules\"; then " +
-        "/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop; fi",
-      "Protect legacy GCS token broker during image rollout"
+        "/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop || return $?; fi; " +
+        "return 0; }; " +
+        "install_legacy_firewall; legacy_firewall_exit=$?; " +
+        "if [ $legacy_firewall_exit -ne 0 ]; then " +
+        `/usr/bin/printf '${LEGACY_TOKEN_FIREWALL_FAILURE_MARKER}\\n' >&2; ` +
+        "exit $legacy_firewall_exit; fi; " +
+        `${TOKEN_FIREWALL_PATH}; current_firewall_exit=$?; ` +
+        "if [ $current_firewall_exit -ne 0 ]; then " +
+        `/usr/bin/printf '${CURRENT_TOKEN_FIREWALL_FAILURE_MARKER}\\n' >&2; ` +
+        "fi; exit $current_firewall_exit",
+      "Protect legacy and current GCS token brokers during image rollout"
     )
   );
   if (result.isErr()) {
     return result;
   }
+  if (result.value.exitCode === 126 || result.value.exitCode === 127) {
+    const helperPath = result.value.stderr.includes(
+      LEGACY_TOKEN_FIREWALL_FAILURE_MARKER
+    )
+      ? "/usr/sbin/nft"
+      : TOKEN_FIREWALL_PATH;
+    return new Err(
+      new GCSMountImageHelperUnavailableError(helperPath, result.value.exitCode)
+    );
+  }
   if (result.value.exitCode !== 0) {
+    const firewall = result.value.stderr.includes(
+      CURRENT_TOKEN_FIREWALL_FAILURE_MARKER
+    )
+      ? "Current"
+      : "Legacy";
     return new Err(
       new Error(
-        `Legacy GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
+        `${firewall} GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
       )
     );
   }

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -159,25 +159,22 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
           target,
           targetIndex: index,
         });
-        if (result.isErr()) {
-          childLogger.error(
-            { err: result.error, mountPoint: target.sandboxMountPoint },
-            "GCS sandbox mount: failed to prepare token"
-          );
-        }
-        return result;
+        return { result, target };
       },
       { concurrency: targets.length }
     );
 
-    const tokenWriteError = tokenResults.find((result) => result.isErr());
-    if (tokenWriteError) {
-      if (
-        tokenWriteError.error instanceof GCSMountTokenWriterUnavailableError
-      ) {
+    const tokenWriteFailure = tokenResults.find(({ result }) => result.isErr());
+    if (tokenWriteFailure?.result.isErr()) {
+      const { result, target } = tokenWriteFailure;
+      childLogger.error(
+        { err: result.error, mountPoint: target.sandboxMountPoint },
+        "GCS sandbox mount: failed to prepare token"
+      );
+      if (result.error instanceof GCSMountTokenWriterUnavailableError) {
         await sandbox.requestKill();
       }
-      return tokenWriteError;
+      return result;
     }
 
     // 3-4. Start the root-owned token server and poll it ready in

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -18,10 +18,51 @@ import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
 
 const MOUNT_TIMEOUT_MS = 30_000;
 
-const TOKEN_SERVER_URL = "http://127.0.0.1:9876";
+const TOKEN_SERVER_URL = "http://127.0.0.1:987";
+const TOKEN_SERVER_PATH_PREFIX = `${TOKEN_SERVER_URL}/token`;
+const TOKEN_SERVER_HEALTH_URL = `${TOKEN_SERVER_URL}/healthz`;
+const TOKEN_DIRECTORY = "/run/dust-gcs";
+const TOKEN_SERVER_PATH = "/usr/local/bin/dust-gcs-token-server.py";
+const TOKEN_WRITER_PATH = "/usr/local/bin/dust-gcs-write-token.sh";
+const TOKEN_FIREWALL_PATH = "/usr/local/bin/dust-gcs-token-firewall.sh";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
+
+class GCSMountImageHelperUnavailableError extends Error {
+  constructor(
+    readonly helperPath: string,
+    readonly exitCode: number
+  ) {
+    super(
+      `GCS mount helper is unavailable: ${helperPath} (exit code ${exitCode})`
+    );
+    this.name = "GCSMountImageHelperUnavailableError";
+  }
+}
+
+class GCSMountTokenWriterUnavailableError extends GCSMountImageHelperUnavailableError {
+  constructor(
+    readonly mountPoint: string,
+    exitCode: number
+  ) {
+    super(TOKEN_WRITER_PATH, exitCode);
+    this.message = `GCS token writer is unavailable for ${mountPoint} (exit code ${exitCode})`;
+    this.name = "GCSMountTokenWriterUnavailableError";
+  }
+}
+
+function tokenId(index: number): string {
+  return `mount-${index}`;
+}
+
+function tokenPath(index: number): string {
+  return `${TOKEN_DIRECTORY}/${tokenId(index)}.json`;
+}
+
+function tokenUrl(index: number): string {
+  return `${TOKEN_SERVER_PATH_PREFIX}/${tokenId(index)}`;
+}
 
 /**
  * Per-target mount profile.
@@ -59,11 +100,14 @@ export type GCSMountTarget = {
 /**
  * GCS-specific SandboxMountAdapter.
  *
- * Mounts one GCS prefix per target via gcsfuse using a CAB-scoped downscoped token
- * served by a lightweight HTTP token server baked into the sandbox image.
+ * Mounts one GCS prefix per target via gcsfuse using a per-target CAB-scoped downscoped token
+ * served by a root-owned HTTP token server baked into the sandbox image. The server listens on a
+ * privileged loopback port and a dedicated nftables table denies the untrusted workload UID access
+ * to that port, including when dev-unrestricted egress removes the general egress table. The UID
+ * firewall is the sole caller-authorization control; token ids are routing names, not secrets.
  *
- * Token budget: 1 unconditional rule + 2 rules per prefix, max 10 CAB rules total,
- * so at most 4 targets are supported.
+ * Each token has one unconditional rule plus two rules for its single prefix. The existing
+ * four-target limit is retained as an operational guard on concurrent mounts.
  */
 export class GCSSandboxMountAdapter implements SandboxMountAdapter {
   constructor(
@@ -72,7 +116,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
   ) {
     if (targets.length > 4) {
       throw new Error(
-        `GCSSandboxMountAdapter: too many targets (${targets.length}), CAB rule limit is 4.`
+        `GCSSandboxMountAdapter: too many targets (${targets.length}), mount target limit is 4.`
       );
     }
   }
@@ -97,34 +141,57 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       prefixes,
     });
 
-    // 1. Mint a CAB-scoped token covering every prefix, read-only where the target is.
-    const tokenResult = await mintDownscopedGcsToken({
-      bucket,
-      prefixes: targets.map((t) => ({
-        prefix: t.gcsPrefix,
-        readOnly: t.readOnly,
-      })),
-    });
-    if (tokenResult.isErr()) {
-      childLogger.error(
-        { err: tokenResult.error },
-        "GCS sandbox mount: failed to mint token"
-      );
-      return tokenResult;
+    // 1-2. Mint and write one CAB-scoped token per mount target. Keeping targets in separate
+    // credentials limits the blast radius of any individual credential; the UID firewall remains
+    // the caller-authorization boundary for the broker itself.
+    const tokenResults = await concurrentExecutor(
+      targets.map((target, index) => ({ target, index })),
+      async ({ target, index }) => {
+        const result = await mintAndWriteToken({
+          auth,
+          sandbox,
+          bucket,
+          target,
+          targetIndex: index,
+        });
+        if (result.isErr()) {
+          childLogger.error(
+            { err: result.error, mountPoint: target.sandboxMountPoint },
+            "GCS sandbox mount: failed to prepare token"
+          );
+        }
+        return result;
+      },
+      { concurrency: targets.length }
+    );
+
+    const tokenWriteError = tokenResults.find((result) => result.isErr());
+    if (tokenWriteError) {
+      if (
+        tokenWriteError.error instanceof GCSMountTokenWriterUnavailableError
+      ) {
+        await sandbox.requestKill();
+      }
+      return tokenWriteError;
     }
 
-    // 2-3. Write the token file, start the token server, and poll it ready in
+    // 3-4. Start the root-owned token server and poll it ready in
     // ONE exec. Polling every 50ms returns the instant the server is listening
     // instead of a flat sleep 1, and folds three round-trips into one.
-    const tokenJson = buildTokenJson(tokenResult.value);
-    const tokenServerResult = await sandbox.exec(
+    const tokenServerResult = await sandbox.execRoot(
       auth,
-      `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json; ` +
-        "nohup bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 & " +
-        `i=0; while [ $i -lt ${TOKEN_SERVER_POLL_ATTEMPTS} ]; do ` +
-        `curl -sf ${TOKEN_SERVER_URL} > /dev/null 2>&1 && exit 0; ` +
-        `sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; i=$((i+1)); ` +
-        "done; exit 1",
+      rootCommand.unsafeShell(
+        `${TOKEN_FIREWALL_PATH} && ` +
+          `(/usr/bin/nohup ${TOKEN_SERVER_PATH} >${TOKEN_DIRECTORY}/server.log 2>&1 &) && ` +
+          `i=0; while [ $i -lt ${TOKEN_SERVER_POLL_ATTEMPTS} ]; do ` +
+          `/usr/bin/curl -sf ${TOKEN_SERVER_HEALTH_URL} > /dev/null 2>&1 || { ` +
+          `/usr/bin/sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; ` +
+          `i=$((i+1)); continue; }; ` +
+          `if /usr/sbin/runuser -u agent-proxied -- /usr/bin/curl -sf --max-time 1 ${tokenUrl(0)} > /dev/null 2>&1; then ` +
+          `exit 1; fi; exit 0; ` +
+          "done; exit 1",
+        "Start and readiness-check the root-owned GCS token broker"
+      ),
       { timeoutMs: TOKEN_SERVER_EXEC_TIMEOUT_MS }
     );
     if (tokenServerResult.isErr()) {
@@ -146,10 +213,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Err(new Error(msg));
     }
 
-    // 4. Create mount directories and run gcsfuse concurrently for each target.
+    // 5. Create mount directories and run gcsfuse concurrently for each target.
     const mountResults = await concurrentExecutor(
-      [...targets],
-      async (target) => {
+      targets.map((target, index) => ({ target, index })),
+      async ({ target, index }) => {
         const mkdirResult = await sandbox.execRoot(
           auth,
           rootCommand.exec("/usr/bin/mkdir", ["-p", target.sandboxMountPoint])
@@ -160,7 +227,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         const mountResult = await sandbox.execRoot(
           auth,
-          buildMountCommand({ bucket, target }),
+          buildMountCommand({ bucket, target, targetIndex: index }),
           { timeoutMs: MOUNT_TIMEOUT_MS }
         );
 
@@ -184,7 +251,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
           return new Err(new Error(msg));
         }
 
-        // 5. Backward-compat symlink so old paths keep working.
+        // 6. Backward-compat symlink so old paths keep working.
         if (target.legacySandboxMountPoint) {
           const symlinkResult = await sandbox.execRoot(
             auth,
@@ -234,24 +301,47 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
-    const { targets } = this;
-    const tokenResult = await mintDownscopedGcsToken({
-      bucket: this.bucket,
-      prefixes: targets.map((t) => ({
-        prefix: t.gcsPrefix,
-        readOnly: t.readOnly,
-      })),
-    });
-    if (tokenResult.isErr()) {
-      return tokenResult;
+    // Re-establish both the legacy and current broker UID drops before replacing any token files.
+    // This protects old 9876 servers during the image rollout and closes the wake window where
+    // systemd/nftables state may have been reset before the lifecycle egress check runs.
+    const legacyFirewallResult = await ensureLegacyTokenFirewall(auth, sandbox);
+    if (legacyFirewallResult.isErr()) {
+      await sandbox.requestKill();
+      return legacyFirewallResult;
     }
 
-    const writeResult = await sandbox.exec(
-      auth,
-      `printf '%s' '${escapeSingleQuotes(buildTokenJson(tokenResult.value))}' > /tmp/token.json`
+    const firewallResult = await ensureTokenFirewall(auth, sandbox);
+    if (firewallResult.isErr()) {
+      if (firewallResult.error instanceof GCSMountImageHelperUnavailableError) {
+        await sandbox.requestKill();
+      }
+      return firewallResult;
+    }
+
+    const { targets } = this;
+    const writeResults = await concurrentExecutor(
+      targets.map((target, index) => ({ target, index })),
+      async ({ target, index }) => {
+        return mintAndWriteToken({
+          auth,
+          sandbox,
+          bucket: this.bucket,
+          target,
+          targetIndex: index,
+        });
+      },
+      { concurrency: targets.length }
     );
-    if (writeResult.isErr()) {
-      return writeResult;
+    const writeError = writeResults.find((result) => result.isErr());
+    if (writeError) {
+      if (writeError.error instanceof GCSMountTokenWriterUnavailableError) {
+        logger.warn(
+          { sandboxId: sandbox.sId, error: writeError.error },
+          "GCS token writer is unavailable; requesting sandbox recreation"
+        );
+        await sandbox.requestKill();
+      }
+      return writeError;
     }
 
     logger.info(
@@ -268,9 +358,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
   /** Exposed for testing and diagnostics. */
   getAccessBoundaryRules() {
-    return buildAccessBoundaryRules(
-      this.bucket,
-      this.targets.map((t) => ({ prefix: t.gcsPrefix, readOnly: t.readOnly }))
+    return this.targets.map((target) =>
+      buildAccessBoundaryRules(this.bucket, [
+        { prefix: target.gcsPrefix, readOnly: target.readOnly },
+      ])
     );
   }
 }
@@ -279,15 +370,17 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 export function buildMountCommand({
   bucket,
   target,
+  targetIndex = 0,
 }: {
   bucket: string;
   target: GCSMountTarget;
+  targetIndex?: number;
 }): RootCommand {
   const { gcsPrefix: prefix, sandboxMountPoint: mountPoint } = target;
 
   const commonFlags = [
     "--token-url",
-    TOKEN_SERVER_URL,
+    tokenUrl(targetIndex),
     // Disable token caching so gcsfuse fetches a fresh credential on every GCS API request.
     "--reuse-token-from-url=false",
     "--only-dir",
@@ -372,6 +465,114 @@ function buildTokenJson({
   });
 }
 
-function escapeSingleQuotes(s: string): string {
-  return s.replace(/'/g, "'\\''");
+async function mintAndWriteToken({
+  auth,
+  sandbox,
+  bucket,
+  target,
+  targetIndex,
+}: {
+  auth: Authenticator;
+  sandbox: SandboxResource;
+  bucket: string;
+  target: GCSMountTarget;
+  targetIndex: number;
+}): Promise<Result<void, Error>> {
+  const tokenResult = await mintDownscopedGcsToken({
+    bucket,
+    prefixes: [{ prefix: target.gcsPrefix, readOnly: target.readOnly }],
+  });
+  if (tokenResult.isErr()) {
+    return tokenResult;
+  }
+
+  // The bearer token is sent over stdin so it never appears in argv, shell history, or provider
+  // command tracing. The image helper writes it atomically as root with mode 0600.
+  const writeResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(TOKEN_WRITER_PATH, [tokenPath(targetIndex)]),
+    { stdin: buildTokenJson(tokenResult.value) }
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+  if (writeResult.value.exitCode !== 0) {
+    if (
+      writeResult.value.exitCode === 126 ||
+      writeResult.value.exitCode === 127
+    ) {
+      return new Err(
+        new GCSMountTokenWriterUnavailableError(
+          target.sandboxMountPoint,
+          writeResult.value.exitCode
+        )
+      );
+    }
+    return new Err(
+      new Error(
+        `GCS token write failed for ${target.sandboxMountPoint}: ${writeResult.value.stderr}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+async function ensureTokenFirewall(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(TOKEN_FIREWALL_PATH)
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode === 126 || result.value.exitCode === 127) {
+    return new Err(
+      new GCSMountImageHelperUnavailableError(
+        TOKEN_FIREWALL_PATH,
+        result.value.exitCode
+      )
+    );
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
+      )
+    );
+  }
+  return new Ok(undefined);
+}
+
+async function ensureLegacyTokenFirewall(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.unsafeShell(
+      "if ! /usr/sbin/nft list table ip dust-gcs-token-legacy >/dev/null 2>&1; then " +
+        "/usr/sbin/nft add table ip dust-gcs-token-legacy; fi; " +
+        "if ! /usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output >/dev/null 2>&1; then " +
+        "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }'; fi; " +
+        "legacy_rules=$(/usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output 2>/dev/null || true); " +
+        "if ! /usr/bin/grep -Fq 'meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop' <<<\"$legacy_rules\"; then " +
+        "/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop; fi",
+      "Protect legacy GCS token broker during image rollout"
+    )
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Legacy GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
+      )
+    );
+  }
+  return new Ok(undefined);
 }

--- a/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
@@ -23,8 +23,8 @@ export interface SandboxMountAdapter {
   ): Promise<Result<void, Error>>;
 
   /**
-   * Refresh the credential in an already-mounted sandbox without remounting.
-   * Overwrites the credential file that the credential server reads on the next request.
+   * Refresh the per-mount credentials in an already-mounted sandbox without remounting.
+   * The credential broker reads the atomically replaced files on the next request.
    */
   refreshCredential(
     auth: Authenticator,

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -429,7 +429,7 @@ export async function ensurePodStateHealthOnSleep(
   sandbox: SandboxResource,
   opts: {
     /**
-     * Rewrites /tmp/token.json. The sync flushes LTX files through gcsfuse,
+     * Rewrites the root-owned per-mount credentials. The sync flushes LTX files through gcsfuse,
      * and a sandbox can sit idle past the CAB token's ~1h lifetime (reaper
      * backlog): without a refresh the sync would fail on every retry,
      * forever.

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -165,11 +165,11 @@ function getStorageMountRole(): string {
  *
  *  3. objectUser (read/write) or objectViewer (read-only) with a resource.name condition, one rule
  *     per prefix. A read-only prefix gets no object create/delete, so a workload that extracts the
- *     loopback-served token (gcsfuse fetches it over http) still cannot write there.
+ *     broker-served token (gcsfuse fetches it over HTTP) still cannot write there.
  *
- * Total rule count is `1 + 2 * prefixes.length`. CAB allows up to 10 rules, so we support up to 4
- * concurrent prefixes. Current budget: a pod sandbox mounts files (rw) +
- * sandbox-functions (ro) + state (rw, the litestream replica prefix) = 3 prefixes = 7 rules.
+ * Total rule count is `1 + 2 * prefixes.length`. CAB allows up to 10 rules, so callers that
+ * intentionally combine prefixes support up to 4 concurrent prefixes. The gcsfuse mount adapter
+ * keeps the credentials separate and passes one prefix per token.
  *
  * Prefixes carry NO trailing slash: the conditions below append the '/' themselves, so a
  * trailing-slash prefix would produce 'state//' and silently break listing.

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -50,8 +50,8 @@ export type SandboxStartupPhase =
   | "egress.wait_healthy"
   | "egress.healthcheck"
   | "egress.install_trust_bundle"
-  // GCS FUSE mount sub-steps. token_server brackets the single exec that writes
-  // the token, starts the token server, and polls it ready (was three execs).
+  // Reserved GCS FUSE mount sub-steps for future finer-grained tracing. The current adapter
+  // groups setup under gcs_mount and refresh under gcs_refresh.
   | "gcs.mint_token"
   | "gcs.token_server"
   | "gcs.gcsfuse_mount"

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -50,8 +50,7 @@ export type SandboxStartupPhase =
   | "egress.wait_healthy"
   | "egress.healthcheck"
   | "egress.install_trust_bundle"
-  // Reserved GCS FUSE mount sub-steps for future finer-grained tracing. The current adapter
-  // groups setup under gcs_mount and refresh under gcs_refresh.
+  // GCS token minting, broker startup, and individual gcsfuse mount commands.
   | "gcs.mint_token"
   | "gcs.token_server"
   | "gcs.gcsfuse_mount"

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -103,16 +103,16 @@ async function ensureOwnerSandboxReady(
       const image = imageResult.value;
 
       // Only mount on first creation. e2b preserves the FUSE mount and the
-      // token server across betaPause + connect (verified empirically), so on
-      // wake we just need a fresh GCS access token in /tmp/token.json (the
-      // running token server will hand it to gcsfuse on the next request).
+      // root-owned token server across betaPause + connect (verified empirically),
+      // so on wake we just need fresh per-mount credentials in /run/dust-gcs.
       if (freshlyCreated) {
         // The image seeds /etc/dust/ca-bundle.pem with system roots, and
         // gcsfuse runs as root to storage.googleapis.com, which the in-sandbox
         // nftables ruleset never touches: every rule is scoped to the agent uid
         // (1003) and the chains default to accept, so root egress is never
-        // dropped, even mid-setup. The dev-unrestricted branch only tears the
-        // table down (loosening egress further), so it's safe to overlap too.
+        // dropped, even mid-setup. The dev-unrestricted branch tears down the
+        // general table but recreates the dedicated GCS broker drop, so it's
+        // safe to overlap too.
         // Egress prep can therefore run alongside the GCS mount, with egress
         // errors still taking precedence.
         const [prepResult, mountResult] = await Promise.all([

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -91,8 +91,8 @@ export class PodSandboxAdapter {
 
   // Pod state pre-sleep flush: every committed SQLite transaction must reach
   // the GCS replica before the sandbox may pause or be destroyed. The refresh
-  // callback rewrites /tmp/token.json first — the sync flushes through
-  // gcsfuse and the token may have expired while the sandbox sat idle.
+  // callback rewrites the root-owned per-mount credentials first — the sync
+  // flushes through gcsfuse and the token may have expired while the sandbox sat idle.
   private static podPreSleepCheck(
     auth: Authenticator,
     pod: SpaceResource


### PR DESCRIPTION
## Description

Switch GCS mounts to one CAB-scoped token per mount, written through the root-owned helper and served by the protected broker staged in #29447. The workload UID cannot reach the broker, and token files stay root-owned with mode 0600.

During the rollout, refresh writes a combined token to the legacy `/tmp/token.json` path when the new image helper is unavailable, then requests recreation. This keeps pod-state flushes working while old sandboxes drain. Transient provider errors do not trigger recreation.

Depends on #29447.

## Tests

Added coverage for per-mount grants, old-image refresh fallback, transient refresh errors, fail-closed broker startup, firewall ordering, and startup tracing.

## Risk

The cutover depends on the image from #29447. Mount and broker failures fail closed; old images retain a working credential long enough to flush and recreate.

## Deploy Plan

1. Merge #29447 and publish its dust-base and dsbx versions.
2. Deploy this application change after the image is available.
3. Open `/poke/kill` and trigger a kill request for the previous image.
4. Monitor GCS mint, broker startup, mount, legacy fallback, and denial-check spans and logs.
