### PR TITLE
[LLM] spread legacy model config onto stream endpoints, drop redundant defaultReasoningEffort

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -22,7 +22,6 @@ export function WithDustClaudeFableFiveConfig<
     static readonly displayName = "Claude Fable 5";
     static readonly description =
       "Anthropic's Claude Fable 5 model, their most intelligent model, a new tier above Opus (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_fable_five.ts
@@ -1,11 +1,24 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeFableFiveConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeFableFive extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeFableFiveConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeFableFiveConfig,
+    CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeFableFive extends WithConfig {
     static readonly displayName = "Claude Fable 5";
     static readonly description =
       "Anthropic's Claude Fable 5 model, their most intelligent model, a new tier above Opus (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeHaikuFourDotFive<
     static readonly displayName = "Claude 4.5 Haiku";
     static readonly description =
       "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).";
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
     // Anthropic rejects a non-default temperature while thinking is active (drop
     // it → schema re-applies the required 1), and rejects temperature=1 while

--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperatureWhenReasoning,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeHaikuFourDotFive<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeHaikuFourDotFive extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeHaikuFourDotFiveConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeHaikuFourDotFiveConfig,
+    CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeHaikuFourDotFive extends WithConfig {
     static readonly displayName = "Claude 4.5 Haiku";
     static readonly description =
       "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeOpusFourDotEightConfig<
     static readonly displayName = "Claude Opus 4.8";
     static readonly description =
       "Anthropic's Claude Opus 4.8 model, the latest and most capable model with stronger agentic coding, reasoning, and judgement (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperature,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeOpusFourDotEightConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeOpusFourDotEight extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeOpusFourDotEightConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeOpusFourDotEightConfig,
+    CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeOpusFourDotEight extends WithConfig {
     static readonly displayName = "Claude Opus 4.8";
     static readonly description =
       "Anthropic's Claude Opus 4.8 model, the latest and most capable model with stronger agentic coding, reasoning, and judgement (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeOpusFourDotSevenConfig<
     static readonly displayName = "Claude Opus 4.7";
     static readonly description =
       "Anthropic's Claude Opus 4.7 model, an advanced model with a step-change improvement in agentic coding (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperature,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeOpusFourDotSevenConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeOpusFourDotSeven extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeOpusFourDotSevenConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeOpusFourDotSevenConfig,
+    CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeOpusFourDotSeven extends WithConfig {
     static readonly displayName = "Claude Opus 4.7";
     static readonly description =
       "Anthropic's Claude Opus 4.7 model, an advanced model with a step-change improvement in agentic coding (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperatureWhenReasoning,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeOpusFourDotSixConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeOpusFourDotSix extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeOpusFourDotSixConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeOpusFourDotSixConfig,
+    CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeOpusFourDotSix extends WithConfig {
     static readonly displayName = "Claude Opus 4.6";
     static readonly description =
       "Anthropic's Claude Opus 4.6 model, an advanced model with enhanced reasoning capabilities (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeOpusFourDotSixConfig<
     static readonly displayName = "Claude Opus 4.6";
     static readonly description =
       "Anthropic's Claude Opus 4.6 model, an advanced model with enhanced reasoning capabilities (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperature,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeSonnetFiveConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeSonnetFive extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeSonnetFiveConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeSonnetFiveConfig,
+    CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeSonnetFive extends WithConfig {
     static readonly displayName = "Claude Sonnet 5";
     static readonly description =
       "Anthropic's Claude Sonnet 5 model, reaching near-Opus quality on coding and agentic work while balancing power and efficiency (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_five.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeSonnetFiveConfig<
     static readonly displayName = "Claude Sonnet 5";
     static readonly description =
       "Anthropic's Claude Sonnet 5 model, reaching near-Opus quality on coding and agentic work while balancing power and efficiency (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -2,13 +2,26 @@ import {
   disableReasoningWhenForcingTool,
   dropTemperatureWhenReasoning,
 } from "@app/lib/llms/stream/types/configuration";
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustClaudeSonnetFourDotSix extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustClaudeSonnetFourDotSixConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustClaudeSonnetFourDotSixConfig,
+    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustClaudeSonnetFourDotSix extends WithConfig {
     static readonly displayName = "Claude Sonnet 4.6";
     static readonly description =
       "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (250k context).";

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -25,7 +25,6 @@ export function WithDustClaudeSonnetFourDotSixConfig<
     static readonly displayName = "Claude Sonnet 4.6";
     static readonly description =
       "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (250k context).";
-    static readonly defaultReasoningEffort = "medium";
     // Dust caps usable context at 250k; the model itself supports 1M.
     static readonly contextSize = 250_000;
     // Dust caps output at 64k; the model itself supports 128k.

--- a/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
@@ -21,7 +21,6 @@ export function WithDustDeepSeekDeepSeekV4ProConfig<
     static readonly displayName = "DeepSeek V4 Pro (Fireworks)";
     static readonly description =
       "DeepSeek's V4 Pro Mixture-of-Experts model with frontier reasoning, advanced coding, and 1M context (served via Fireworks).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
@@ -1,9 +1,23 @@
+import { FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
+
 export function WithDustDeepSeekDeepSeekV4ProConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustDeepSeekDeepSeekV4Pro extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustDeepSeekDeepSeekV4ProConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustDeepSeekDeepSeekV4ProConfig,
+    FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustDeepSeekDeepSeekV4Pro extends WithConfig {
     static readonly displayName = "DeepSeek V4 Pro (Fireworks)";
     static readonly description =
       "DeepSeek's V4 Pro Mixture-of-Experts model with frontier reasoning, advanced coding, and 1M context (served via Fireworks).";

--- a/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
+++ b/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
@@ -1,9 +1,23 @@
+import { FIREWORKS_GLM_5P2_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
+
 export function WithDustZAiGlm52Config<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustZAiGlm52 extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustZAiGlm52Config extends Base {}
+  const WithConfig = Object.assign(
+    DustZAiGlm52Config,
+    FIREWORKS_GLM_5P2_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustZAiGlm52 extends WithConfig {
     static readonly displayName = "GLM-5.2 (Fireworks)";
     static readonly description =
       "Z.ai's GLM-5.2 Mixture-of-Experts model with advanced coding and long-horizon agentic capabilities (1M context, served via Fireworks).";

--- a/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
+++ b/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
@@ -21,7 +21,6 @@ export function WithDustZAiGlm52Config<
     static readonly displayName = "GLM-5.2 (Fireworks)";
     static readonly description =
       "Z.ai's GLM-5.2 Mixture-of-Experts model with advanced coding and long-horizon agentic capabilities (1M context, served via Fireworks).";
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
@@ -21,7 +21,6 @@ export function WithDustMoonshotAiKimiK2Dot5Config<
     static readonly displayName = "Kimi K2.5 (Fireworks)";
     static readonly description =
       "Moonshot AI's flagship agentic model with 262k context and vision support (served via Fireworks).";
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
@@ -1,9 +1,23 @@
+import { FIREWORKS_KIMI_K2P5_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
+
 export function WithDustMoonshotAiKimiK2Dot5Config<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMoonshotAiKimiK2Dot5 extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMoonshotAiKimiK2Dot5Config extends Base {}
+  const WithConfig = Object.assign(
+    DustMoonshotAiKimiK2Dot5Config,
+    FIREWORKS_KIMI_K2P5_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMoonshotAiKimiK2Dot5 extends WithConfig {
     static readonly displayName = "Kimi K2.5 (Fireworks)";
     static readonly description =
       "Moonshot AI's flagship agentic model with 262k context and vision support (served via Fireworks).";

--- a/front/lib/llms/providers/fireworks/models/kimi_k2_dot_six.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k2_dot_six.ts
@@ -1,9 +1,23 @@
+import { FIREWORKS_KIMI_K2P6_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
+
 export function WithDustMoonshotAiKimiK2Dot6Config<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMoonshotAiKimiK2Dot6 extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMoonshotAiKimiK2Dot6Config extends Base {}
+  const WithConfig = Object.assign(
+    DustMoonshotAiKimiK2Dot6Config,
+    FIREWORKS_KIMI_K2P6_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMoonshotAiKimiK2Dot6 extends WithConfig {
     static readonly displayName = "Kimi K2.6 (Fireworks)";
     static readonly description =
       "Moonshot AI's flagship agentic model with 262k context and vision support (served via Fireworks).";

--- a/front/lib/llms/providers/fireworks/models/kimi_k2_dot_six.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k2_dot_six.ts
@@ -21,7 +21,6 @@ export function WithDustMoonshotAiKimiK2Dot6Config<
     static readonly displayName = "Kimi K2.6 (Fireworks)";
     static readonly description =
       "Moonshot AI's flagship agentic model with 262k context and vision support (served via Fireworks).";
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,9 +1,23 @@
+import { GEMINI_3_1_FLASH_LITE_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+
 export function WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGoogleAiStudioGemini31FlashLite extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGoogleAiStudioGemini31FlashLiteConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGoogleAiStudioGemini31FlashLiteConfig,
+    GEMINI_3_1_FLASH_LITE_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGoogleAiStudioGemini31FlashLite extends WithConfig {
     static readonly displayName = "Gemini 3.1 Flash Lite";
     static readonly description =
       "Google's latest lightweight large context model (1m context).";

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -21,8 +21,6 @@ export function WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
     static readonly displayName = "Gemini 3.1 Flash Lite";
     static readonly description =
       "Google's latest lightweight large context model (1m context).";
-    // Mirrors the legacy default reasoning effort ("light" → "low").
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,9 +1,23 @@
+import { GEMINI_3_1_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+
 export function WithDustGoogleAiStudioGeminiThreeDotOneProConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGoogleAiStudioGeminiThreeDotOnePro extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGoogleAiStudioGeminiThreeDotOneProConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGoogleAiStudioGeminiThreeDotOneProConfig,
+    GEMINI_3_1_PRO_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGoogleAiStudioGeminiThreeDotOnePro extends WithConfig {
     static readonly displayName = "Gemini 3.1 Pro (Preview)";
     static readonly description =
       "Google's latest powerful model with enhanced reasoning (1m context).";

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -21,7 +21,6 @@ export function WithDustGoogleAiStudioGeminiThreeDotOneProConfig<
     static readonly displayName = "Gemini 3.1 Pro (Preview)";
     static readonly description =
       "Google's latest powerful model with enhanced reasoning (1m context).";
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -21,8 +21,6 @@ export function WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig<
     static readonly displayName = "Gemini 3.5 Flash";
     static readonly description =
       "Google's latest fast large context model (1m context).";
-    // Mirrors the legacy default reasoning effort ("light" → "low").
-    static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -1,9 +1,23 @@
+import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+
 export function WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGoogleAiStudioGeminiThreeDotFiveFlash extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGoogleAiStudioGeminiThreeDotFiveFlashConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGoogleAiStudioGeminiThreeDotFiveFlashConfig,
+    GEMINI_3_5_FLASH_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGoogleAiStudioGeminiThreeDotFiveFlash extends WithConfig {
     static readonly displayName = "Gemini 3.5 Flash";
     static readonly description =
       "Google's latest fast large context model (1m context).";

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -22,8 +22,6 @@ export function WithDustMistralCodestralConfig<
     static readonly displayName = "Mistral Codestral";
     static readonly description =
       "Mistral's `codestral` model, specifically designed and optimized for code generation tasks.";
-    // Codestral is a non-reasoning model.
-    static readonly defaultReasoningEffort = "none";
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -1,11 +1,24 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+import { MISTRAL_CODESTRAL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 
 export function WithDustMistralCodestralConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMistralCodestral extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMistralCodestralConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustMistralCodestralConfig,
+    MISTRAL_CODESTRAL_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMistralCodestral extends WithConfig {
     static readonly displayName = "Mistral Codestral";
     static readonly description =
       "Mistral's `codestral` model, specifically designed and optimized for code generation tasks.";

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -1,11 +1,24 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+import { MISTRAL_LARGE_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 
 export function WithDustMistralLargeConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMistralLarge extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMistralLargeConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustMistralLargeConfig,
+    MISTRAL_LARGE_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMistralLarge extends WithConfig {
     static readonly displayName = "Mistral Large";
     static readonly description = "Mistral's `large` model (256k context).";
     // Mistral Large is a non-reasoning model.

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -21,8 +21,6 @@ export function WithDustMistralLargeConfig<
   abstract class DustMistralLarge extends WithConfig {
     static readonly displayName = "Mistral Large";
     static readonly description = "Mistral's `large` model (256k context).";
-    // Mistral Large is a non-reasoning model.
-    static readonly defaultReasoningEffort = "none";
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,11 +1,24 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 
 export function WithDustMistralMedium35Config<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMistralMedium35 extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMistralMedium35Config extends Base {}
+  const WithConfig = Object.assign(
+    DustMistralMedium35Config,
+    MISTRAL_MEDIUM_3_5_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMistralMedium35 extends WithConfig {
     static readonly displayName = "Mistral Medium 3.5";
     static readonly description =
       "Mistral's `medium 3.5` model, multimodal and optimized for agentic and coding use cases (256k context).";

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -22,7 +22,6 @@ export function WithDustMistralMedium35Config<
     static readonly displayName = "Mistral Medium 3.5";
     static readonly description =
       "Mistral's `medium 3.5` model, multimodal and optimized for agentic and coding use cases (256k context).";
-    static readonly defaultReasoningEffort = "none";
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -1,11 +1,24 @@
 import { dropReasoning } from "@app/lib/llms/stream/types/configuration";
+import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 
 export function WithDustMistralSmallConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustMistralSmall extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustMistralSmallConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustMistralSmallConfig,
+    MISTRAL_SMALL_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustMistralSmall extends WithConfig {
     static readonly displayName = "Mistral Small";
     static readonly description = "Mistral's `small` model (128k context).";
     // Mistral Small is a non-reasoning model.

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -21,8 +21,6 @@ export function WithDustMistralSmallConfig<
   abstract class DustMistralSmall extends WithConfig {
     static readonly displayName = "Mistral Small";
     static readonly description = "Mistral's `small` model (128k context).";
-    // Mistral Small is a non-reasoning model.
-    static readonly defaultReasoningEffort = "none";
     // Legacy product value; the model has no separate output cap.
     static readonly maxOutputTokens = 2_048;
     static readonly byok = true;

--- a/front/lib/llms/providers/noop/models/noop.ts
+++ b/front/lib/llms/providers/noop/models/noop.ts
@@ -17,7 +17,6 @@ export function WithDustNoopConfig<
   abstract class DustNoop extends WithConfig {
     static readonly displayName = "Noop";
     static readonly description = "Noop model that does nothing.";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/noop/models/noop.ts
+++ b/front/lib/llms/providers/noop/models/noop.ts
@@ -1,9 +1,20 @@
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
+
 export function WithDustNoopConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustNoop extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustNoopConfig extends Base {}
+  const WithConfig = Object.assign(DustNoopConfig, NOOP_MODEL_CONFIG);
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustNoop extends WithConfig {
     static readonly displayName = "Noop";
     static readonly description = "Noop model that does nothing.";
     static readonly defaultReasoningEffort = "none";

--- a/front/lib/llms/providers/openai/models/gpt_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five.ts
@@ -1,11 +1,21 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFive extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveConfig extends Base {}
+  const WithConfig = Object.assign(DustGptFiveConfig, GPT_5_MODEL_CONFIG);
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFive extends WithConfig {
     static readonly displayName = "GPT-5";
     static readonly description =
       "OpenAI's GPT-5 reasoning model (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five.ts
@@ -19,7 +19,6 @@ export function WithDustGptFiveConfig<
     static readonly displayName = "GPT-5";
     static readonly description =
       "OpenAI's GPT-5 reasoning model (400k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
     static readonly configParsers = [dropTemperature];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotFiveConfig<
     static readonly displayName = "GPT-5.5";
     static readonly description =
       "OpenAI's GPT-5.5 reasoning model, with strong reasoning and tool-use capabilities (1M context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotFiveConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotFive extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotFiveConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotFiveConfig,
+    GPT_5_5_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotFive extends WithConfig {
     static readonly displayName = "GPT-5.5";
     static readonly description =
       "OpenAI's GPT-5.5 reasoning model, with strong reasoning and tool-use capabilities (1M context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotFourConfig<
     static readonly displayName = "GPT-5.4";
     static readonly description =
       "OpenAI's GPT-5.4 reasoning model for complex reasoning and agentic tasks (1M context).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotFourConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotFour extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotFourConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotFourConfig,
+    GPT_5_4_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotFour extends WithConfig {
     static readonly displayName = "GPT-5.4";
     static readonly description =
       "OpenAI's GPT-5.4 reasoning model for complex reasoning and agentic tasks (1M context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotFourMiniConfig<
     static readonly displayName = "GPT-5.4 Mini";
     static readonly description =
       "OpenAI's faster, cost-efficient GPT-5.4 for well-defined tasks (400k context).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_4_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotFourMiniConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotFourMini extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotFourMiniConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotFourMiniConfig,
+    GPT_5_4_MINI_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotFourMini extends WithConfig {
     static readonly displayName = "GPT-5.4 Mini";
     static readonly description =
       "OpenAI's faster, cost-efficient GPT-5.4 for well-defined tasks (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotFourNanoConfig<
     static readonly displayName = "GPT-5.4 Nano";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5.4 (400k context).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_nano.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_4_NANO_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotFourNanoConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotFourNano extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotFourNanoConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotFourNanoConfig,
+    GPT_5_4_NANO_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotFourNano extends WithConfig {
     static readonly displayName = "GPT-5.4 Nano";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5.4 (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotOneConfig<
     static readonly displayName = "GPT-5.1";
     static readonly description =
       "OpenAI's GPT-5.1 reasoning model (400k context).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
     static readonly configParsers = [dropTemperature];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
@@ -1,11 +1,24 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotOneConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotOne extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotOneConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotOneConfig,
+    GPT_5_1_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotOne extends WithConfig {
     static readonly displayName = "GPT-5.1";
     static readonly description =
       "OpenAI's GPT-5.1 reasoning model (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotSixLunaConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotSixLuna extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotSixLunaConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotSixLunaConfig,
+    GPT_5_6_LUNA_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotSixLuna extends WithConfig {
     static readonly displayName = "GPT-5.6 Luna";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5.6 model for high-volume workloads (272k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_luna.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotSixLunaConfig<
     static readonly displayName = "GPT-5.6 Luna";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5.6 model for high-volume workloads (272k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotSixSolConfig<
     static readonly displayName = "GPT-5.6 Sol";
     static readonly description =
       "OpenAI's most capable GPT-5.6 reasoning model for complex reasoning and agentic tasks (272k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_sol.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_6_SOL_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotSixSolConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotSixSol extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotSixSolConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotSixSolConfig,
+    GPT_5_6_SOL_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotSixSol extends WithConfig {
     static readonly displayName = "GPT-5.6 Sol";
     static readonly description =
       "OpenAI's most capable GPT-5.6 reasoning model for complex reasoning and agentic tasks (272k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_6_TERRA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotSixTerraConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotSixTerra extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotSixTerraConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotSixTerraConfig,
+    GPT_5_6_TERRA_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotSixTerra extends WithConfig {
     static readonly displayName = "GPT-5.6 Terra";
     static readonly description =
       "OpenAI's balanced GPT-5.6 model for strong reasoning and tool use (272k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_six_terra.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotSixTerraConfig<
     static readonly displayName = "GPT-5.6 Terra";
     static readonly description =
       "OpenAI's balanced GPT-5.6 model for strong reasoning and tool use (272k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
@@ -1,11 +1,24 @@
 import { dropTemperatureWhenReasoning } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_2_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveDotTwoConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveDotTwo extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveDotTwoConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveDotTwoConfig,
+    GPT_5_2_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveDotTwo extends WithConfig {
     static readonly displayName = "GPT-5.2";
     static readonly description =
       "OpenAI's GPT-5.2 reasoning model for complex reasoning tasks (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_two.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveDotTwoConfig<
     static readonly displayName = "GPT-5.2";
     static readonly description =
       "OpenAI's GPT-5.2 reasoning model for complex reasoning tasks (400k context).";
-    static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature while reasoning is on.
     static readonly configParsers = [dropTemperatureWhenReasoning];

--- a/front/lib/llms/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_mini.ts
@@ -1,11 +1,24 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveMiniConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveMini extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveMiniConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveMiniConfig,
+    GPT_5_MINI_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveMini extends WithConfig {
     static readonly displayName = "GPT-5 Mini";
     static readonly description =
       "OpenAI's faster, cost-efficient GPT-5 for well-defined tasks (400k context).";

--- a/front/lib/llms/providers/openai/models/gpt_five_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_mini.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveMiniConfig<
     static readonly displayName = "GPT-5 Mini";
     static readonly description =
       "OpenAI's faster, cost-efficient GPT-5 for well-defined tasks (400k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
     static readonly configParsers = [dropTemperature];

--- a/front/lib/llms/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_nano.ts
@@ -22,7 +22,6 @@ export function WithDustGptFiveNanoConfig<
     static readonly displayName = "GPT-5 Nano";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5 (400k context).";
-    static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
     // The Responses API rejects an explicit temperature for this model.
     static readonly configParsers = [dropTemperature];

--- a/front/lib/llms/providers/openai/models/gpt_five_nano.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_nano.ts
@@ -1,11 +1,24 @@
 import { dropTemperature } from "@app/lib/llms/stream/types/configuration";
+import { GPT_5_NANO_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 export function WithDustGptFiveNanoConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGptFiveNano extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGptFiveNanoConfig extends Base {}
+  const WithConfig = Object.assign(
+    DustGptFiveNanoConfig,
+    GPT_5_NANO_MODEL_CONFIG
+  );
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGptFiveNano extends WithConfig {
     static readonly displayName = "GPT-5 Nano";
     static readonly description =
       "OpenAI's fastest, most cost-efficient GPT-5 (400k context).";

--- a/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
+++ b/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
@@ -18,7 +18,6 @@ export function WithDustGrok45Config<
     static readonly displayName = "Grok 4.5";
     static readonly description =
       "xAI's Grok 4.5 flagship model (500k context, reasoning, vision).";
-    static readonly defaultReasoningEffort = "high";
     static readonly byok = false;
   }
 

--- a/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
+++ b/front/lib/llms/providers/xai/models/grok_four_dot_five.ts
@@ -1,9 +1,20 @@
+import { GROK_4_5_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+
 export function WithDustGrok45Config<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGrok45 extends Base {
+  // Spread the legacy model config onto the class statics (see
+  // `DustStreamEndpointConfiguration`). `Object.assign` returns
+  // `class & ModelConfigurationType`, so the fields are visible to the type
+  // checker without an unsafe cast.
+  abstract class DustGrok45Config extends Base {}
+  const WithConfig = Object.assign(DustGrok45Config, GROK_4_5_MODEL_CONFIG);
+
+  // Declared last so these own statics shadow (take precedence over) the spread
+  // config values.
+  abstract class DustGrok45 extends WithConfig {
     static readonly displayName = "Grok 4.5";
     static readonly description =
       "xAI's Grok 4.5 flagship model (500k context, reasoning, vision).";

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -21,7 +21,8 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
       description: string;
 
       // Behavior
-      defaultReasoningEffort: ReasoningEffortOf<C>;
+      // Commented out during transition
+      // defaultReasoningEffort: ReasoningEffortOf<C>;
 
       // Parsers applied in order to the config before it is validated by the
       // endpoint's schema. Omitted means identity; override per endpoint for

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -1,30 +1,38 @@
 import type { Where, WorkspaceConfig } from "@app/lib/llms/types/filter";
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
-type ReasoningEffortOf<C extends InputConfig> = NonNullable<
+export type ReasoningEffortOf<C extends InputConfig> = NonNullable<
   C["reasoning"]
 >["effort"];
 
+// `ModelConfigurationType` is the legacy model config. Endpoints port it onto
+// the new router by spreading the corresponding `*_DEFAULT_MODEL_CONFIG` onto
+// their statics. This is a transitional step: over time we want each endpoint to
+// declare its properties explicitly and drop the ones that are deprecated in the
+// new router (e.g. `regionalAvailability`, `recommendedTopK`, ...) rather than
+// carrying the whole legacy config forward.
 export type DustStreamEndpointConfiguration<C extends InputConfig> =
-  BaseEndpointConfiguration<C> & {
-    // Description
-    displayName: string;
-    description: string;
+  ModelConfigurationType &
+    BaseEndpointConfiguration<C> & {
+      // Description
+      displayName: string;
+      description: string;
 
-    // Behavior
-    defaultReasoningEffort: ReasoningEffortOf<C>;
+      // Behavior
+      defaultReasoningEffort: ReasoningEffortOf<C>;
 
-    // Parsers applied in order to the config before it is validated by the
-    // endpoint's schema. Omitted means identity; override per endpoint for
-    // provider quirks — e.g. dropping a non-default temperature when reasoning is
-    // active, which some schemas reject outright (Anthropic requires
-    // temperature=1 with thinking).
-    configParsers?: Array<(config: InputConfig) => InputConfig>;
+      // Parsers applied in order to the config before it is validated by the
+      // endpoint's schema. Omitted means identity; override per endpoint for
+      // provider quirks — e.g. dropping a non-default temperature when reasoning is
+      // active, which some schemas reject outright (Anthropic requires
+      // temperature=1 with thinking).
+      configParsers?: Array<(config: InputConfig) => InputConfig>;
 
-    // Filter
-    endpointFilter: Where<WorkspaceConfig>;
-  };
+      // Filter
+      endpointFilter: Where<WorkspaceConfig>;
+    };
 
 // `configParsers` helper: some providers reject any explicit temperature while
 // reasoning is active, so drop it when reasoning is on. Providers that require a


### PR DESCRIPTION
## Description

Port the legacy `ModelConfigurationType` onto the new stream-endpoint statics by spreading each model's `*_DEFAULT_MODEL_CONFIG`, then drop the now-redundant `defaultReasoningEffort` static from every endpoint (the value now comes from the spread config).

## Tests

Not needed — type-only refactor.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`