### PR TITLE
[front] Only the conversation creator can add Spaces to an existing conversation

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -318,6 +318,9 @@ app.post(
         spaceIds: context.selectedSpaceIds,
         origin: "input_bar",
         auditContext: getAuditLogContext(auth),
+        // Widening the scope of an existing conversation is irreversible and can lock the other
+        // participants out, so only its creator may do it.
+        enforceCreatorOnly: true,
       });
       if (selectedSpacesResult.isErr()) {
         return apiErrorForSelectedSpaces(ctx, selectedSpacesResult.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces.ts
@@ -110,6 +110,9 @@ app.post(
       spaceIds,
       origin: "input_bar",
       auditContext: getAuditLogContext(auth),
+      // Widening the scope of an existing conversation is irreversible and can lock the other
+      // participants out, so only its creator may do it.
+      enforceCreatorOnly: true,
     });
     if (result.isErr()) {
       return apiErrorForSelectedSpaces(ctx, result.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces_errors.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces_errors.ts
@@ -15,6 +15,14 @@ export function apiErrorForSelectedSpaces(
           message: error.message,
         },
       });
+    case "conversation_not_creator":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "conversation_access_restricted",
+          message: error.message,
+        },
+      });
     case "conversation_not_mutable":
     case "space_not_selectable":
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -313,6 +313,10 @@ app.post(
         spaceIds: allSelectedSpaceIds,
         origin: "input_bar",
         auditContext: getAuditLogContext(auth),
+        // The conversation was just created by this caller and has no participant row yet (the
+        // `upsertParticipation` call below is what creates the creator row), so there is no other
+        // participant to evict and nothing to check against.
+        enforceCreatorOnly: false,
       });
       if (selectedSpacesResult.isErr()) {
         return apiErrorForSelectedSpaces(ctx, selectedSpacesResult.error);

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -20,6 +20,7 @@ import {
   validateSelectableSpaces,
 } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -28,7 +29,10 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
@@ -135,6 +139,25 @@ describe("selected conversation Spaces", () => {
     });
   }
 
+  // `ConversationFactory` does not create participants, so tests that exercise the creator gate
+  // have to materialize them explicitly. The first participant by `createdAt` is the creator.
+  async function participate(
+    conv: ConversationWithoutContentType,
+    participantAuth: Authenticator
+  ) {
+    await ConversationResource.upsertParticipation(participantAuth, {
+      conversation: conv,
+      action: "posted",
+      user: participantAuth.getNonNullableUser().toJSON(),
+    });
+  }
+
+  async function otherWorkspaceMember() {
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    return Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+  }
+
   it("rejects selected Spaces when the feature flag is disabled", async () => {
     const restrictedSpace = await memberRestrictedSpace();
 
@@ -161,6 +184,7 @@ describe("selected conversation Spaces", () => {
     expectErrCode(
       await addSelectedConversationSpaces(auth, {
         conversation: projectConversation,
+        enforceCreatorOnly: false,
         origin: "input_bar",
         spaceIds: [restrictedSpace.sId],
       }),
@@ -250,6 +274,7 @@ describe("selected conversation Spaces", () => {
     const result = unwrapResult(
       await addSelectedConversationSpaces(auth, {
         conversation: conv,
+        enforceCreatorOnly: false,
         origin: "input_bar",
         spaceIds: [selectedSpace.sId, selectedSpace.sId],
       })
@@ -281,6 +306,7 @@ describe("selected conversation Spaces", () => {
     expectErrCode(
       await addSelectedConversationSpaces(auth, {
         conversation: { ...conv, sId: missingConversationId },
+        enforceCreatorOnly: false,
         origin: "input_bar",
         spaceIds: [selectedSpace.sId],
       }),
@@ -293,6 +319,103 @@ describe("selected conversation Spaces", () => {
       )
     ).toEqual([]);
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects added Spaces from a participant who did not create the conversation", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const conv = await conversation();
+    await participate(conv, auth);
+
+    const otherAuth = await otherWorkspaceMember();
+    // `isConversationCreator` orders participants by `createdAt`, so make sure the two rows do not
+    // land on the same timestamp.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await participate(conv, otherAuth);
+
+    // The other participant can read the conversation and can read the Space...
+    expect(
+      await ConversationResource.fetchById(otherAuth, conv.sId)
+    ).not.toBeNull();
+    expect(
+      (
+        await validateSelectableSpaces(otherAuth, {
+          spaceIds: [selectedSpace.sId],
+        })
+      ).isOk()
+    ).toBe(true);
+
+    // ...but they still cannot widen the conversation's access requirements.
+    expectErrCode(
+      await addSelectedConversationSpaces(otherAuth, {
+        conversation: conv,
+        enforceCreatorOnly: true,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      }),
+      "conversation_not_creator"
+    );
+    expect(
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation: conv }
+      )
+    ).toEqual([]);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("lets the conversation creator add Spaces to an existing conversation", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const conv = await conversation();
+    await participate(conv, auth);
+
+    const otherAuth = await otherWorkspaceMember();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await participate(conv, otherAuth);
+
+    const result = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: true,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    expect(result.selectedSpaces).toEqual([
+      expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
+    ]);
+    expect(result.effectiveAcl.spaceIds).toContain(selectedSpace.sId);
+  });
+
+  it("selects Spaces on the conversation creation path, before any participant exists", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const conv = await conversation();
+
+    // A conversation being created has no participant row yet (participation is upserted after the
+    // Spaces are materialized), so the creator gate cannot be satisfied there, and the creation
+    // path opts out of it.
+    expectErrCode(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: true,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      }),
+      "conversation_not_creator"
+    );
+
+    const result = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+    expect(result.effectiveAcl.spaceIds).toContain(selectedSpace.sId);
   });
 
   it("uses selected Spaces as effective runtime scope when still valid", async () => {
@@ -410,6 +533,43 @@ describe("selected conversation Spaces", () => {
         conversation: childConversation,
       });
     expect(selectedSpaceRow.origin).toBe("parent_conversation");
+  });
+
+  it("copies selected Spaces to a child conversation when the caller did not create the parent", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const parentConversation = await conversation();
+    const childConversation = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: parentConversation,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+    await participate(parentConversation, auth);
+
+    // A participant who is not the creator can still run a sub-agent, and the child conversation
+    // must inherit the parent's Spaces: inheritance is system-initiated and revalidated against the
+    // caller, so the creator gate does not apply to it.
+    const otherAuth = await otherWorkspaceMember();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await participate(parentConversation, otherAuth);
+
+    unwrapResult(
+      await copySelectedConversationSpacesToChild(otherAuth, {
+        parentConversation,
+        childConversationId: childConversation.sId,
+      })
+    );
+
+    const childSelectedSpaces =
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation: childConversation }
+      );
+    expect(childSelectedSpaces.map((space) => space.sId)).toEqual([
+      selectedSpace.sId,
+    ]);
   });
 
   it("ignores selected Spaces at runtime when the feature flag is disabled", async () => {

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -152,6 +152,23 @@ describe("selected conversation Spaces", () => {
     });
   }
 
+  // `addSelectedConversationSpaces` materializes the new ACL on the row, so callers that need the
+  // updated `requestedSpaceIds` have to re-read the conversation, like the routes do.
+  async function refetchConversation(
+    readerAuth: Authenticator,
+    conversationId: string
+  ) {
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        readerAuth,
+        conversationId
+      );
+    if (conversationRes.isErr()) {
+      throw conversationRes.error;
+    }
+    return conversationRes.value;
+  }
+
   async function otherWorkspaceMember() {
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, otherUser, { role: "user" });
@@ -387,6 +404,42 @@ describe("selected conversation Spaces", () => {
       expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
     ]);
     expect(result.effectiveAcl.spaceIds).toContain(selectedSpace.sId);
+  });
+
+  it("lets a non-creator participant re-send the Spaces the conversation already requires", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const conv = await conversation();
+    await participate(conv, auth);
+
+    const otherAuth = await otherWorkspaceMember();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await participate(conv, otherAuth);
+
+    unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: true,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    // The input bar resends the conversation's whole selection on every message, so a non-creator
+    // participant must not be locked out of posting by the creator gate.
+    const result = unwrapResult(
+      await addSelectedConversationSpaces(otherAuth, {
+        conversation: await refetchConversation(otherAuth, conv.sId),
+        enforceCreatorOnly: true,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    expect(result.effectiveAcl.spaceIds).toContain(selectedSpace.sId);
+    expect(result.selectedSpaces).toEqual([
+      expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
+    ]);
   });
 
   it("selects Spaces on the conversation creation path, before any participant exists", async () => {

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -162,7 +162,8 @@ export async function validateSelectableSpaces(
  * widening the scope of a conversation that already exists. It is only false on paths where there
  * is no one to evict: conversation creation (the conversation is brand new, and has no participant
  * row yet) and sub-agent inheritance (the child conversation is system-created and its Spaces were
- * already validated against the same user on the parent).
+ * already validated against the same user on the parent). Even when it is true, the gate only fires
+ * on calls that actually widen `conversation.requestedSpaceIds`.
  */
 export async function addSelectedConversationSpaces(
   auth: Authenticator,
@@ -210,7 +211,15 @@ export async function addSelectedConversationSpaces(
     });
   }
 
-  if (enforceCreatorOnly) {
+  // The input bar resends the conversation's whole current selection with every message, so most
+  // calls do not actually widen anything. Re-selecting a Space the conversation already requires
+  // cannot evict anyone, so the creator gate only applies to a real widening of the ACL.
+  const requestedSpaceIds = new Set(conversation.requestedSpaceIds);
+  const widensConversationAcl = dedupedSpaceIds.some(
+    (spaceId) => !requestedSpaceIds.has(spaceId)
+  );
+
+  if (enforceCreatorOnly && widensConversationAcl) {
     const conversationResource = await ConversationResource.fetchById(
       auth,
       conversation.sId

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -25,6 +25,7 @@ import type { Transaction } from "sequelize";
 export class SelectedConversationSpacesError extends Error {
   constructor(
     readonly code:
+      | "conversation_not_creator"
       | "conversation_not_mutable"
       | "conversation_not_found"
       | "feature_flag_not_found"
@@ -153,6 +154,16 @@ export async function validateSelectableSpaces(
   return new Ok(spaces);
 }
 
+/**
+ * Selected Spaces are a conjunctive access requirement: a viewer must have read access to *every*
+ * Space of `conversation.requestedSpaceIds` to read the conversation, and there is no removal path
+ * once a Space is selected. Adding a Space to an existing conversation can therefore permanently
+ * evict the other participants, so `enforceCreatorOnly` must be true whenever the caller is a user
+ * widening the scope of a conversation that already exists. It is only false on paths where there
+ * is no one to evict: conversation creation (the conversation is brand new, and has no participant
+ * row yet) and sub-agent inheritance (the child conversation is system-created and its Spaces were
+ * already validated against the same user on the parent).
+ */
 export async function addSelectedConversationSpaces(
   auth: Authenticator,
   {
@@ -160,6 +171,7 @@ export async function addSelectedConversationSpaces(
     spaceIds,
     origin,
     auditContext,
+    enforceCreatorOnly,
     sourceSelections,
     transaction,
   }: {
@@ -167,6 +179,7 @@ export async function addSelectedConversationSpaces(
     spaceIds: string[];
     origin: ConversationSelectedSpaceOrigin;
     auditContext?: AuditLogContext;
+    enforceCreatorOnly: boolean;
     sourceSelections?: ConversationSelectedSpaceResource[];
     transaction?: Transaction;
   }
@@ -195,6 +208,33 @@ export async function addSelectedConversationSpaces(
         viewerMustHaveAll: true as const,
       },
     });
+  }
+
+  if (enforceCreatorOnly) {
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    if (!conversationResource) {
+      return new Err(
+        new SelectedConversationSpacesError(
+          "conversation_not_found",
+          "Conversation not found or access was denied."
+        )
+      );
+    }
+
+    // `isConversationCreator` errors when the conversation has no participant at all, which is the
+    // same as "the caller is not the creator" from this endpoint's point of view.
+    const isCreatorRes = await conversationResource.isConversationCreator(auth);
+    if (isCreatorRes.isErr() || !isCreatorRes.value) {
+      return new Err(
+        new SelectedConversationSpacesError(
+          "conversation_not_creator",
+          "Only the user who created the conversation can select Spaces for it."
+        )
+      );
+    }
   }
 
   let newlyActiveSpaces: SpaceResource[] = [];
@@ -416,6 +456,10 @@ export async function copySelectedConversationSpacesToChild(
     conversation: childConversation.toJSON(),
     spaceIds: selectedSpaceIds,
     origin: "parent_conversation",
+    // System-initiated inheritance: the child conversation is created by the run_agent tool and has
+    // no participant, and the inherited Spaces were revalidated against the same `auth` on the
+    // parent just above. There is no one to evict here.
+    enforceCreatorOnly: false,
     sourceSelections,
   });
   if (result.isErr()) {


### PR DESCRIPTION
## Description

`conversation.requestedSpaceIds` is a **conjunctive** access requirement: a viewer must have read access to *every* Space in the list to read the conversation (see the `.every(...)` filter in `ConversationResource` and `isConversationReadableFromRequestedSpaces`).

Selecting a Space from the input bar appends to that list, and there is no removal path today: `ConversationSelectedSpaceResource.removeForConversation` is never called in production, and the UI disables deselection once the conversation exists. So appending a Space is irreversible.

The append endpoint (`POST /api/w/:wId/assistant/conversations/:cId/selected_spaces`) only gated on the caller being able to **read** the conversation, with no participant, creator, or role check. Same for posting a message with `selectedSpaceIds`. Combined with the two properties above, any user who can read a shared conversation could permanently evict every other participant from it, including their own messages, by selecting a Space those participants lack. Recovery required direct DB surgery.

### Fix

Only the conversation creator may add Spaces to an existing conversation.

`addSelectedConversationSpaces` takes a new explicit `enforceCreatorOnly: boolean` parameter (required, so every call site has to make the decision). When true, it resolves the `ConversationResource` and reuses the existing `ConversationResource.isConversationCreator(auth)` helper, the same one `deleteOrLeaveConversation` uses, which defines the creator as the earliest `ConversationParticipantModel` row by `createdAt`.

| Call site | `enforceCreatorOnly` | Why |
| --- | --- | --- |
| `conversations/[cId]/selected_spaces.ts` (append endpoint) | `true` | User widening an existing conversation. |
| `conversations/[cId]/messages/index.ts` (post message with `selectedSpaceIds`) | `true` | Same, via the message payload. |
| `conversations/index.ts` (create conversation with `selectedSpaceIds`) | `false` | See below. |
| `copySelectedConversationSpacesToChild` (run_agent sub-agent) | `false` | See below. |

I deliberately used an explicit named flag rather than inferring intent from `origin` or from the participant count: inferring from participant count would silently re-open the hole for any future path that adds Spaces before participation, and `origin` is an audit/provenance field, not an authorization one.

### Why the create path is unaffected

On conversation creation, `addSelectedConversationSpaces` runs **before** `ConversationResource.upsertParticipation`. At that moment the brand-new conversation has zero participant rows, so `isConversationCreator` returns `Err("No participants found for conversation")`. A naive unconditional check inside the service would therefore break conversation creation outright. It is also the one moment where there is provably nobody to evict: the caller is the only person who has ever touched the conversation. Hence the explicit `false`, with a comment at the call site pointing at the `upsertParticipation` that follows.

### Why sub-agent inheritance is unaffected

`copySelectedConversationSpacesToChild` copies the parent's Spaces into a run_agent child conversation. That child is created by the tool with `depth >= 1`, and the create route only upserts participation when `depth === 0`, so the child has no participant either. More importantly the inherited Spaces were already revalidated against the same `auth` on the parent (`getValidSelectedSpaceIdsForAgentRun`) immediately above, and the flow is system-initiated: a participant who is not the creator must still be able to run a sub-agent. Hence `false` there too.

### The gate only fires on an actual widening

`enforceCreatorOnly: true` alone is not enough to decide to reject. The input bar resends the conversation's **whole** current selection in `context.selectedSpaceIds` on every message (`InputBar.tsx` unions the conversation's persisted selections with any local ones, and additions on an existing conversation already go through the dedicated `selected_spaces` endpoint). Gating every non-empty call would therefore have rejected plain re-sends and locked non-creator participants out of posting *any* message in a conversation that already had selected Spaces.

So the check only runs when the request adds a Space that is not already in `conversation.requestedSpaceIds`. That is exactly the security property being protected: if the Space is already part of the conjunctive ACL, every current reader already has access to it, so there is nobody the call could evict. A direct API call that does add a new Space still hits the creator check.

### Error handling

New `"conversation_not_creator"` code on the `SelectedConversationSpacesError` union (no HTTP shapes in `lib/api`), mapped to `403 conversation_access_restricted` in `selected_spaces_errors.ts` alongside the existing mappings.

## Tests

Extended `front/lib/api/assistant/conversation/selected_spaces.test.ts` (16 tests, all passing):

- a non-creator participant who **can** read the conversation and **can** read the Space is rejected with `conversation_not_creator`, nothing is persisted, and no audit event is emitted;
- a non-creator participant re-sending the Spaces the conversation already requires is **not** rejected, since the message-post path resends the full selection on every message;
- the creator can still add Spaces to a conversation that already has other participants;
- the creation path (zero participant rows) still works with `enforceCreatorOnly: false`, and the same call with `true` fails, which is exactly why the create path opts out;
- sub-agent inheritance still works when the caller is a participant who did **not** create the parent conversation.

Typecheck clean on `front` and `front-api`. Also re-ran `front/lib/api/actions/servers/run_agent/conversation.test.ts` and the front-api conversation and message route tests.

## Risk

Low. The feature is behind `restricted_spaces_in_input_bar`, which is `stage: "dust_only"`, so it is only reachable internally today.

This change makes an endpoint **stricter**, so the only regression risk is wrongly rejecting a legitimate caller. The two paths where that would hurt, conversation creation and sub-agent inheritance, both opt out explicitly and have dedicated tests, and the "only on an actual widening" condition is what keeps non-creator participants able to keep posting in a conversation that already has selected Spaces.

Rollback-safe: no schema change, no data written differently. Reverting restores the previous (permissive) behaviour.

## Deploy Plan

Normal deploy, no special ordering.

- No schema migration: no model, column, or index changes.
- No backfill. For context, the US production read replica currently has 10 rows in `conversation_selected_spaces`, all active, across a single workspace, consistent with the flag being `dust_only`.
- No API schema change; the affected endpoints keep their contracts.

Two sibling PRs, `spaces-pod-runtime-guard` (#29375) and `spaces-acl-race` (#29376), also touch `front/lib/api/assistant/conversation/selected_spaces.ts` and will likely need a trivial rebase depending on merge order. Base here stays `main`.
