### PR TITLE
Do not honour selected Spaces in pod conversations

### DIFF
--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -19,6 +19,10 @@ import {
   type SelectedConversationSpacesError,
   validateSelectableSpaces,
 } from "@app/lib/api/assistant/conversation/selected_spaces";
+import {
+  moveConversationOutOfProject,
+  moveConversationToProject,
+} from "@app/lib/api/projects/conversations";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
@@ -32,7 +36,10 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  isPodConversation,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
@@ -173,6 +180,12 @@ describe("selected conversation Spaces", () => {
     const otherUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, otherUser, { role: "user" });
     return Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+  }
+
+  async function memberProjectSpace() {
+    const space = await SpaceFactory.project(workspace, user.id);
+    await addCurrentUser(space);
+    return space;
   }
 
   it("rejects selected Spaces when the feature flag is disabled", async () => {
@@ -623,6 +636,121 @@ describe("selected conversation Spaces", () => {
     expect(childSelectedSpaces.map((space) => space.sId)).toEqual([
       selectedSpace.sId,
     ]);
+  });
+
+  it("ignores selected Spaces at runtime for pod conversations", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const projectSpace = await memberProjectSpace();
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const podConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+      visibility: "unlisted",
+    });
+
+    // Selections cannot be created through the service in a pod conversation, so go through the
+    // resource directly to reproduce rows left over from before the conversation was moved.
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: podConversation,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: podConversation,
+      })
+    ).resolves.toEqual([globalSpace.sId]);
+  });
+
+  it("removes selected Spaces when the conversation moves into a project", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const projectSpace = await memberProjectSpace();
+    const conv = await conversation();
+
+    unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    const moveResult = await moveConversationToProject(auth, {
+      conversation: conv,
+      spaceId: projectSpace.sId,
+    });
+    expect(moveResult.isOk()).toBe(true);
+
+    expect(
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation: conv }
+      )
+    ).toEqual([]);
+    const allSelections =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        activeOnly: false,
+        conversation: conv,
+      });
+    expect(allSelections).toHaveLength(1);
+    expect(allSelections[0].removedAt).not.toBeNull();
+  });
+
+  it("does not resurrect selected Spaces when the conversation moves back out of a project", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const projectSpace = await memberProjectSpace();
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const conv = await conversation();
+
+    unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    const moveInResult = await moveConversationToProject(auth, {
+      conversation: conv,
+      spaceId: projectSpace.sId,
+    });
+    expect(moveInResult.isOk()).toBe(true);
+
+    const podConversation = await refetchConversation(auth, conv.sId);
+    expect(isPodConversation(podConversation)).toBe(true);
+
+    const moveOutResult = await moveConversationOutOfProject(auth, {
+      conversation: podConversation,
+    });
+    expect(moveOutResult.isOk()).toBe(true);
+
+    // Moving out rebuilds requestedSpaceIds from agents and content fragments only: the selected
+    // Space has no ACL backing anymore, so it must not come back into the runtime scope either.
+    const movedOutConversation = await refetchConversation(auth, conv.sId);
+    expect(isPodConversation(movedOutConversation)).toBe(false);
+    expect(movedOutConversation.requestedSpaceIds).not.toContain(
+      selectedSpace.sId
+    );
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: movedOutConversation,
+      })
+    ).resolves.toEqual([globalSpace.sId]);
   });
 
   it("ignores selected Spaces at runtime when the feature flag is disabled", async () => {

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -752,51 +752,6 @@ describe("selected conversation Spaces", () => {
     ).resolves.toEqual([globalSpace.sId]);
   });
 
-  it("does not resurrect selected Spaces created before the move-in cleared them", async () => {
-    await enableFeature();
-    const selectedSpace = await memberRestrictedSpace();
-    const projectSpace = await memberProjectSpace();
-    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
-      auth,
-      { requestedSpaceIds: [globalSpace.id] }
-    );
-    const conv = await conversation();
-
-    const moveInResult = await moveConversationToProject(auth, {
-      conversation: conv,
-      spaceId: projectSpace.sId,
-    });
-    expect(moveInResult.isOk()).toBe(true);
-
-    const podConversation = await refetchConversation(conv.sId);
-    expect(isPodConversation(podConversation)).toBe(true);
-
-    // Reproduce a row written before the move-in started clearing selections: the conversation is
-    // already in the project and still carries an active selection with no ACL backing.
-    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
-      conversation: podConversation,
-      origin: "input_bar",
-      spaces: [selectedSpace],
-    });
-
-    const moveOutResult = await moveConversationOutOfProject(auth, {
-      conversation: podConversation,
-    });
-    expect(moveOutResult.isOk()).toBe(true);
-
-    const movedOutConversation = await refetchConversation(conv.sId);
-    expect(isPodConversation(movedOutConversation)).toBe(false);
-    expect(movedOutConversation.requestedSpaceIds).not.toContain(
-      selectedSpace.sId
-    );
-    await expect(
-      getEffectiveSpaceIdsForAgentRun(auth, {
-        agentConfiguration,
-        conversation: movedOutConversation,
-      })
-    ).resolves.toEqual([globalSpace.sId]);
-  });
-
   it("ignores selected Spaces at runtime when the feature flag is disabled", async () => {
     const selectedSpace = await memberRestrictedSpace();
     const requestedSpaceModelIds = [globalSpace.id];

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -202,8 +202,7 @@ describe("selected conversation Spaces", () => {
   it("rejects selected Spaces for pod conversations", async () => {
     await enableFeature();
     const restrictedSpace = await memberRestrictedSpace();
-    const projectSpace = await SpaceFactory.project(workspace, user.id);
-    await addCurrentUser(projectSpace);
+    const projectSpace = await memberProjectSpace();
     const projectConversation = await ConversationFactory.create(auth, {
       agentConfigurationId: "test-agent",
       messagesCreatedAt: [],
@@ -741,6 +740,51 @@ describe("selected conversation Spaces", () => {
     // Moving out rebuilds requestedSpaceIds from agents and content fragments only: the selected
     // Space has no ACL backing anymore, so it must not come back into the runtime scope either.
     const movedOutConversation = await refetchConversation(auth, conv.sId);
+    expect(isPodConversation(movedOutConversation)).toBe(false);
+    expect(movedOutConversation.requestedSpaceIds).not.toContain(
+      selectedSpace.sId
+    );
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: movedOutConversation,
+      })
+    ).resolves.toEqual([globalSpace.sId]);
+  });
+
+  it("does not resurrect selected Spaces created before the move-in cleared them", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const projectSpace = await memberProjectSpace();
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const conv = await conversation();
+
+    const moveInResult = await moveConversationToProject(auth, {
+      conversation: conv,
+      spaceId: projectSpace.sId,
+    });
+    expect(moveInResult.isOk()).toBe(true);
+
+    const podConversation = await refetchConversation(conv.sId);
+    expect(isPodConversation(podConversation)).toBe(true);
+
+    // Reproduce a row written before the move-in started clearing selections: the conversation is
+    // already in the project and still carries an active selection with no ACL backing.
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: podConversation,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    const moveOutResult = await moveConversationOutOfProject(auth, {
+      conversation: podConversation,
+    });
+    expect(moveOutResult.isOk()).toBe(true);
+
+    const movedOutConversation = await refetchConversation(conv.sId);
     expect(isPodConversation(movedOutConversation)).toBe(false);
     expect(movedOutConversation.requestedSpaceIds).not.toContain(
       selectedSpace.sId

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -392,6 +392,15 @@ export async function getValidSelectedSpaceIdsForAgentRun(
     transaction?: Transaction;
   }
 ): Promise<string[]> {
+  // A pod conversation's ACL is pinned to its project space, so it cannot express the extra space
+  // requirements a selection implies. Honouring selections here would decouple the agent's runtime
+  // scope from the conversation's visibility: every project member would read retrieved content
+  // from Spaces they may not have access to. Selection write paths already bail out for pod
+  // conversations, and so does updateConversationRequirementsForSkills.
+  if (isPodConversation(conversation)) {
+    return [];
+  }
+
   const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("restricted_spaces_in_input_bar")) {
     return [];

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -11,6 +11,7 @@ import {
   UserConversationReadsModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -139,6 +140,75 @@ describe("moveConversationToProject", () => {
     expect(updatedConversation.requestedSpaceIds).toHaveLength(1);
     expect(updatedConversation.requestedSpaceIds[0]).toBe(projectSpace.sId);
     expect(isPodConversation(updatedConversation)).toBe(true);
+  });
+
+  it("removes the selected Spaces of the conversation being moved", async () => {
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    // The user selected a restricted Space from the input bar before the move.
+    const selectedSpace = await SpaceFactory.regular(workspace);
+    const selectedSpaceGroup = await fetchRegularAutoGroup(
+      selectedSpace,
+      internalAdminAuth
+    );
+    if (!selectedSpaceGroup) {
+      throw new Error("Selected space regular group not found");
+    }
+    await selectedSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: userJson,
+    });
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    const projectSpaceGroup = await fetchRegularAutoGroup(
+      projectSpace,
+      internalAdminAuth
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: userJson,
+    });
+
+    await auth.refresh();
+
+    const result = await moveConversationToProject(auth, {
+      conversation,
+      spaceId: projectSpace.sId,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // The project ACL cannot carry the selected Space requirement, so the selection is dropped.
+    const activeSelections =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        conversation,
+      });
+    expect(activeSelections).toEqual([]);
+
+    const allSelections =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        activeOnly: false,
+        conversation,
+      });
+    expect(allSelections).toHaveLength(1);
+    expect(allSelections[0].removedAt).not.toBeNull();
   });
 
   it("returns conversation_agent_running when an agent loop is running", async () => {

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -11,7 +11,6 @@ import {
   UserConversationReadsModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -140,75 +139,6 @@ describe("moveConversationToProject", () => {
     expect(updatedConversation.requestedSpaceIds).toHaveLength(1);
     expect(updatedConversation.requestedSpaceIds[0]).toBe(projectSpace.sId);
     expect(isPodConversation(updatedConversation)).toBe(true);
-  });
-
-  it("removes the selected Spaces of the conversation being moved", async () => {
-    const user = auth.getNonNullableUser();
-    const userJson = user.toJSON();
-
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [],
-    });
-
-    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-
-    // The user selected a restricted Space from the input bar before the move.
-    const selectedSpace = await SpaceFactory.regular(workspace);
-    const selectedSpaceGroup = await fetchRegularAutoGroup(
-      selectedSpace,
-      internalAdminAuth
-    );
-    if (!selectedSpaceGroup) {
-      throw new Error("Selected space regular group not found");
-    }
-    await selectedSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
-      user: userJson,
-    });
-    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
-      conversation,
-      origin: "input_bar",
-      spaces: [selectedSpace],
-    });
-
-    const projectSpace = await SpaceFactory.project(workspace);
-    const projectSpaceGroup = await fetchRegularAutoGroup(
-      projectSpace,
-      internalAdminAuth
-    );
-    if (!projectSpaceGroup) {
-      throw new Error("Project space regular group not found");
-    }
-    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
-      user: userJson,
-    });
-
-    await auth.refresh();
-
-    const result = await moveConversationToProject(auth, {
-      conversation,
-      spaceId: projectSpace.sId,
-    });
-
-    expect(result.isOk()).toBe(true);
-
-    // The project ACL cannot carry the selected Space requirement, so the selection is dropped.
-    const activeSelections =
-      await ConversationSelectedSpaceResource.listByConversation(auth, {
-        conversation,
-      });
-    expect(activeSelections).toEqual([]);
-
-    const allSelections =
-      await ConversationSelectedSpaceResource.listByConversation(auth, {
-        activeOnly: false,
-        conversation,
-      });
-    expect(allSelections).toHaveLength(1);
-    expect(allSelections[0].removedAt).not.toBeNull();
   });
 
   it("returns conversation_agent_running when an agent loop is running", async () => {

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -219,6 +219,16 @@ export async function moveConversationOutOfProject(
   const oldUpdatedAt = conversationResource.updatedAt;
   const participants = await conversationResource.listParticipants(auth);
 
+  // Selections are cleared when a conversation moves into a project, but conversations that were
+  // moved in before that behaviour shipped still carry active rows. They are inert while the
+  // conversation is a pod (getValidSelectedSpaceIdsForAgentRun ignores them), and the rebuild below
+  // does not re-add them to requestedSpaceIds, so leaving them would make them live again with no
+  // ACL backing. Clear them before dropping the project association, so the conversation is never
+  // outside a project with a live selection.
+  await ConversationSelectedSpaceResource.removeAllForConversation(auth, {
+    conversation: conversationResource,
+  });
+
   // Remove the project association.
   await conversationResource.updateSpaceId(auth, null);
 

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -10,6 +10,7 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -127,6 +128,15 @@ export async function moveConversationToProject(
     await conversationResource.updateSpaceId(auth, project, t);
     // See front/lib/api/assistant/conversation/mentions.ts updateConversationRequirements for more details
     await conversationResource.updateRequirements(auth, [project.id], t);
+
+    // The requirements above drop every Space the conversation used to require, including the ones
+    // that were selected from the input bar. Their selections must go with them: they no longer
+    // have any ACL backing, and moving the conversation out of the project later rebuilds
+    // requirements from agents and content fragments only, which would make them live again.
+    await ConversationSelectedSpaceResource.removeAllForConversation(auth, {
+      conversation: conversationResource,
+      transaction: t,
+    });
 
     // For participants who had already read the conversation (unread = false),
     // mark them as read using markAsReadForAuthUser to preserve their read status.

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -219,16 +219,6 @@ export async function moveConversationOutOfProject(
   const oldUpdatedAt = conversationResource.updatedAt;
   const participants = await conversationResource.listParticipants(auth);
 
-  // Selections are cleared when a conversation moves into a project, but conversations that were
-  // moved in before that behaviour shipped still carry active rows. They are inert while the
-  // conversation is a pod (getValidSelectedSpaceIdsForAgentRun ignores them), and the rebuild below
-  // does not re-add them to requestedSpaceIds, so leaving them would make them live again with no
-  // ACL backing. Clear them before dropping the project association, so the conversation is never
-  // outside a project with a live selection.
-  await ConversationSelectedSpaceResource.removeAllForConversation(auth, {
-    conversation: conversationResource,
-  });
-
   // Remove the project association.
   await conversationResource.updateSpaceId(auth, null);
 

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -266,6 +266,35 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     return updatedCount;
   }
 
+  // Removes every active selection of a conversation, whatever the Space. Unlike
+  // `removeForConversation`, this does not require the caller to enumerate (and therefore be able
+  // to read) the selected Spaces, which matters when the conversation ACL is reset independently
+  // of who is performing the operation.
+  static async removeAllForConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: { id: ModelId };
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    const [updatedCount] = await this.model.update(
+      { removedAt: new Date() },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          removedAt: null,
+        },
+        transaction,
+      }
+    );
+
+    return updatedCount;
+  }
+
   static async deleteForConversation(
     auth: Authenticator,
     {

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -230,6 +230,9 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     }, transaction);
   }
 
+  // Soft-removes the selections of specific Spaces. The selected_spaces route only accepts
+  // `mode: "add"` today, so this has no production caller yet: it is the counterpart of
+  // `upsertForConversation` for the deselect path, and is covered by this resource's tests.
   static async removeForConversation(
     auth: Authenticator,
     {


### PR DESCRIPTION
## Description

Selecting a Space from the input bar (`restricted_spaces_in_input_bar`) does two things:

1. It appends the Space to `conversation.requestedSpaceIds`, which is a **conjunctive** access requirement: a viewer must have read access to every listed Space to read the conversation.
2. It widens the agent's runtime scope for that conversation (`getEffectiveSpaceIdsForAgentRun` -> `SkillResource.listForAgentLoop` -> `getSkillServers` -> `DataSourceViewResource.listBySpaceIds`), which is what actually lets the agent retrieve from that Space.

(1) is the only thing that makes (2) safe. If a Space is in the agent's runtime scope but not in `requestedSpaceIds`, restricted data flows into a conversation that does not restrict its readers.

Pod conversations pin their ACL to the project space by design and are visible to everyone with read access to that project, so they cannot express any extra Space requirement. Selection is blocked at every **write** path (`listSelectableSpaces`, `validateSelectableSpaces`, `addSelectedConversationSpaces`), but the **runtime** path had no such guard, and nothing cleared the `conversation_selected_spaces` rows when a conversation moved into a project.

### Failure scenario, no malice required

1. Alice (who has access to the restricted "Legal" Space) selects Legal in a normal conversation. ACL and selection row both include Legal.
2. Alice moves that conversation into a team project. `moveConversationToProject` sets `spaceId` and overwrites `requestedSpaceIds` with `[project]`, dropping Legal. The selection row survives.
3. The conversation is now readable by all project members, including Bob who has no Legal access.
4. Alice posts. The agent loop runs under Alice's authenticator, `getValidSelectedSpaceIdsForAgentRun` still returns Legal (it only checked the feature flag, `canRead(auth)` and `isRegular()`), so the agent retrieves Legal documents into the conversation.
5. Bob reads them.

The picker is hidden in pod conversations, so there is no UI signal that Spaces are still attached.

### Fix

**Part A, runtime guard.** `getValidSelectedSpaceIdsForAgentRun` returns `[]` for pod conversations, mirroring what `updateConversationRequirementsForSkills` already does for the same reason.

**Part B, clear selections on move into a project.** `moveConversationToProject` soft-removes the conversation's selections, inside the same transaction that resets the requirements to `[project]`.

### Why Part A alone is not enough

If the conversation is later moved back **out** of the project, `moveConversationOutOfProject` calls `rebuildConversationRequirements`, which clears `requestedSpaceIds` and rebuilds it from agents and content fragments only. It does not re-add selected Spaces. The conversation is no longer a pod conversation, so the Part A guard stops applying and the stale selections become live again, now with no ACL backing at all. Same vulnerability, one move later.

I verified this: with only Part A applied, the round-trip test still fails.

### Clearing vs. re-including in `rebuildConversationRequirements`

I went with clearing. Re-including active selections when rebuilding requirements would keep the ACL and the runtime scope in sync in the move-out direction, but it silently re-restricts a conversation that has been visible to the whole project in the meantime, and it leaves a window (while the conversation sits in the project) where a selection exists with no ACL behind it. Clearing removes the ambiguity in one place, at the moment the ACL is actually reset, and keeps the invariant "an active selection always has a matching `requestedSpaceIds` entry" true at all times. Users can re-select the Space after moving the conversation out.

Together, Parts A and B make "a pod conversation never has a live selection" hold in both directions. `updateSpaceId` has exactly two callers: `moveConversationToProject`, which now clears, and `moveConversationOutOfProject`, which can only run on a conversation that already went through the former. Every write path that could add a selection already rejects pod conversations, and conversations created directly in a project are gated by `validateSelectableSpaces({ podId })`.

### Resource change

`ConversationSelectedSpaceResource.removeForConversation` takes a `SpaceResource[]`. Enumerating the selected Spaces goes through `listActiveSpacesByConversation`, which hydrates them via `SpaceResource.fetchByModelIds` and therefore drops Spaces the mover cannot read, which are exactly the rows we most need to remove. Added `removeAllForConversation`, which soft-removes every active row of the conversation without requiring the caller to read the Spaces first.

`removeForConversation` is kept: the `selected_spaces` route only accepts `mode: "add"` today, so it has no production caller yet, but it is the counterpart of `upsertForConversation` for the deselect path and is covered by the resource's own tests. It now carries a comment saying so, so it does not get pruned as dead code.

### Side benefit: sub-agent runs in pods stop failing

Part A also fixes a latent user-facing breakage. `run_agent` creates its child conversation with `spaceId: mainConversation.spaceId`, so a pod parent produces a pod child, and `copySelectedConversationSpacesToChild` then called `addSelectedConversationSpaces` on that pod child. That write path rejects pod conversations, so the error propagated and the whole sub-conversation setup failed with "Failed to inherit selected Spaces".

With the guard in place, `getValidSelectedSpaceIdsForAgentRun` returns `[]` for the pod parent, `copySelectedConversationSpacesToChild` short-circuits to `Ok`, and the sub-agent run proceeds normally.

## Tests

`front/lib/api/assistant/conversation/selected_spaces.test.ts`:

- `getEffectiveSpaceIdsForAgentRun` returns only the agent's own Spaces for a pod conversation that has active selections.
- Moving a conversation into a project removes its active selections (row soft-removed, `removedAt` set).
- Round trip: select, move in, move out, and the Space is neither in `requestedSpaceIds` nor in the effective runtime scope.

All three fail on `main` and pass here. The round-trip one is what proves Part A alone is insufficient: with only the runtime guard applied it still leaks the Space into `getEffectiveSpaceIdsForAgentRun`.

Typecheck clean, `npm run test` green on `selected_spaces.test.ts`, `projects/conversations.test.ts` and `conversation_selected_space_resource.test.ts` (41 tests).

## Risk

Low.

- The whole feature is behind `restricted_spaces_in_input_bar`, `stage: "dust_only"`. Workspaces without the flag never reach any of this code.
- Production currently has 10 rows in `conversation_selected_spaces`, all active, across a single workspace, and **zero** of them belong to a conversation with a non-null `spaceId`. So no conversation is in the affected state today, and after this ships none can enter it: move-in clears, and every selection write path already rejects pod conversations.
- Both parts only ever *narrow* scope. Part A returns `[]`, Part B soft-removes rows. Nothing widens access, so the failure mode of a bug here is "a selected Space is ignored when it should have been honoured", not a leak.
- Rollback-safe: reverting restores the previous behaviour. `removeAllForConversation` is a soft delete (`removedAt`), so rows cleared in the meantime are still on disk and could be reactivated by clearing `removedAt` if we ever needed to.

## Deploy Plan

Normal deploy, no special ordering.

- No schema migration: no model, column, or index changes.
- No backfill: the only rows a backfill would target are active selections on conversations already in a project, and there are none in production (0 of 10 rows). Part A would keep any such row inert anyway.
- Nothing to coordinate with clients: no API schema change, and the two affected endpoints (`selected_spaces`, `selectable_spaces`) keep their contracts.

Two sibling PRs, `spaces-initiator-gate` (#29374) and `spaces-acl-race` (#29376), also touch `front/lib/api/assistant/conversation/selected_spaces.ts` and will likely need a trivial rebase depending on merge order. Base here stays `main`.
