### PR TITLE
Make conversation Space ACL merge atomic

### DIFF
--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -188,6 +188,14 @@ describe("selected conversation Spaces", () => {
     return space;
   }
 
+  async function persistedRequestedSpaceIds(conversationId: string) {
+    const { requestedSpaceIds } = await refetchConversation(
+      auth,
+      conversationId
+    );
+    return [...requestedSpaceIds].sort();
+  }
+
   it("rejects selected Spaces when the feature flag is disabled", async () => {
     const restrictedSpace = await memberRestrictedSpace();
 
@@ -323,6 +331,112 @@ describe("selected conversation Spaces", () => {
           space_id: selectedSpace.sId,
         },
       })
+    );
+  });
+
+  it("merges Spaces added by successive requests into the conversation ACL", async () => {
+    await enableFeature();
+    const firstSpace = await memberRestrictedSpace();
+    const secondSpace = await memberRestrictedSpace();
+    const conv = await conversation();
+
+    const firstResult = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [firstSpace.sId],
+      })
+    );
+    expect(firstResult.effectiveAcl.spaceIds).toContain(firstSpace.sId);
+
+    const secondResult = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: await refetchConversation(auth, conv.sId),
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [secondSpace.sId],
+      })
+    );
+
+    expect(secondResult.effectiveAcl.spaceIds).toEqual(
+      expect.arrayContaining([firstSpace.sId, secondSpace.sId])
+    );
+    expect(secondResult.selectedSpaces.map((space) => space.sId)).toEqual(
+      expect.arrayContaining([firstSpace.sId, secondSpace.sId])
+    );
+    await expect(persistedRequestedSpaceIds(conv.sId)).resolves.toEqual(
+      [firstSpace.sId, secondSpace.sId].sort()
+    );
+  });
+
+  it("keeps Spaces added meanwhile when the caller holds a stale conversation", async () => {
+    await enableFeature();
+    const firstSpace = await memberRestrictedSpace();
+    const secondSpace = await memberRestrictedSpace();
+    const conv = await conversation();
+
+    // Snapshot taken before the first add, as an overlapping request would hold.
+    const staleConversation = {
+      ...conv,
+      requestedSpaceIds: [...conv.requestedSpaceIds],
+    };
+
+    unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [firstSpace.sId],
+      })
+    );
+
+    const staleResult = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: staleConversation,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [secondSpace.sId],
+      })
+    );
+
+    // The Space added by the first request must stay in the ACL: both selections are active, so an
+    // ACL that only requires one of them would expose the other's data to users without access.
+    await expect(persistedRequestedSpaceIds(conv.sId)).resolves.toEqual(
+      [firstSpace.sId, secondSpace.sId].sort()
+    );
+    expect(
+      (
+        await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+          auth,
+          { conversation: conv }
+        )
+      )
+        .map((space) => space.sId)
+        .sort()
+    ).toEqual([firstSpace.sId, secondSpace.sId].sort());
+    expect([...staleResult.effectiveAcl.spaceIds].sort()).toEqual(
+      [firstSpace.sId, secondSpace.sId].sort()
+    );
+  });
+
+  it("returns the persisted ACL as the effective ACL", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const conv = await conversation();
+
+    const result = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        enforceCreatorOnly: false,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      })
+    );
+
+    expect(result.effectiveAcl.viewerMustHaveAll).toBe(true);
+    await expect(persistedRequestedSpaceIds(conv.sId)).resolves.toEqual(
+      [...result.effectiveAcl.spaceIds].sort()
     );
   });
 

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -376,24 +376,20 @@ describe("selected conversation Spaces", () => {
     const secondSpace = await memberRestrictedSpace();
     const conv = await conversation();
 
-    // Snapshot taken before the first add, as an overlapping request would hold.
-    const staleConversation = {
-      ...conv,
-      requestedSpaceIds: [...conv.requestedSpaceIds],
-    };
-
     unwrapResult(
       await addSelectedConversationSpaces(auth, {
-        conversation: conv,
+        conversation: await refetchConversation(auth, conv.sId),
         enforceCreatorOnly: false,
         origin: "input_bar",
         spaceIds: [firstSpace.sId],
       })
     );
 
+    // `conv` still carries its pre-add `requestedSpaceIds`: the stale snapshot an overlapping
+    // request would hold.
     const staleResult = unwrapResult(
       await addSelectedConversationSpaces(auth, {
-        conversation: staleConversation,
+        conversation: conv,
         enforceCreatorOnly: false,
         origin: "input_bar",
         spaceIds: [secondSpace.sId],

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -266,26 +266,22 @@ export async function addSelectedConversationSpaces(
     }
 
     const spaces = selectableSpacesResult.value;
-    const requestedSpaceModelIds = removeNulls(
-      conversation.requestedSpaceIds.map(getResourceIdFromSId)
-    );
-    const selectedSpaceModelIds = spaces.map((space) => space.id);
-    const effectiveAclSpaceModelIds = uniq([
-      ...requestedSpaceModelIds,
-      ...selectedSpaceModelIds,
-    ]);
 
-    const updateResult = await ConversationResource.updateRequirements(
+    // The ACL must be merged against locked, current state rather than against `conversation`,
+    // which is the caller snapshot: the input bar fires one request per Space toggle, and two
+    // overlapping requests each writing the union of their own snapshot would drop one of the
+    // Spaces from the ACL while both selections stay active.
+    const appendResult = await ConversationResource.appendRequestedSpaceIds(
       auth,
       conversation.sId,
-      effectiveAclSpaceModelIds,
+      spaces.map((space) => space.id),
       t
     );
-    if (updateResult.isErr()) {
+    if (appendResult.isErr()) {
       return new Err(
         new SelectedConversationSpacesError(
           "space_not_selectable",
-          updateResult.error.message
+          appendResult.error.message
         )
       );
     }
@@ -308,10 +304,6 @@ export async function addSelectedConversationSpaces(
           transaction: t,
         }
       );
-    const effectiveAclSpaceIds = uniq([
-      ...conversation.requestedSpaceIds,
-      ...spaces.map((space) => space.sId),
-    ]);
 
     return new Ok({
       selectedSpaces: allSelectedSpaces.map((space) => ({
@@ -319,7 +311,9 @@ export async function addSelectedConversationSpaces(
         selected: true,
       })),
       effectiveAcl: {
-        spaceIds: effectiveAclSpaceIds,
+        // The persisted ACL, not an optimistic local union: callers feed it back into their own
+        // conversation object.
+        spaceIds: appendResult.value,
         viewerMustHaveAll: true as const,
       },
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -83,7 +83,10 @@ export type FetchConversationOptions = {
   dangerouslySkipPermissionFiltering?: boolean;
   includeForkingData?: boolean;
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
-  transaction?: Transaction; // Read within the given transaction, seeing its uncommitted writes
+  // Read within the given transaction, seeing its uncommitted writes. Only honored on the
+  // `baseFetchWithAuthorization` path (`fetchById`, `fetchByIds`, `listAll`, ...). Helpers that
+  // cherry-pick options, such as `fetchConversationWithoutContent`, still read outside of it.
+  transaction?: Transaction;
 };
 
 type SpaceConversationsFilter = "all" | "group" | "with_me";

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -83,6 +83,7 @@ export type FetchConversationOptions = {
   dangerouslySkipPermissionFiltering?: boolean;
   includeForkingData?: boolean;
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
+  transaction?: Transaction; // Read within the given transaction, seeing its uncommitted writes
 };
 
 type SpaceConversationsFilter = "all" | "group" | "with_me";
@@ -889,6 +890,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const workspace = auth.getNonNullableWorkspace();
     const { where } = this.getOptions(fetchConversationOptions);
 
+    const { transaction } = fetchConversationOptions ?? {};
+
     const conversations = await this.model.findAll({
       where: {
         ...where,
@@ -900,6 +903,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         : {}),
       limit: options.limit,
       order: options.order,
+      transaction,
     });
 
     const uniqueSpaceIds = uniq([
@@ -913,6 +917,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ? []
         : await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds, {
             includeDeleted: fetchConversationOptions?.includeDeleted,
+            transaction,
           });
 
     const spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));
@@ -993,6 +998,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             },
           },
           attributes: ["conversationId"],
+          transaction,
         })
       : [];
 
@@ -3562,13 +3568,44 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     requestedSpaceIds: number[],
     transaction?: Transaction
   ) {
-    const conversation = await ConversationResource.fetchById(auth, sId);
+    const conversation = await ConversationResource.fetchById(auth, sId, {
+      transaction,
+    });
     if (conversation === null) {
       return new Err(new ConversationError("conversation_not_found"));
     }
 
     await conversation.updateRequirements(auth, requestedSpaceIds, transaction);
     return new Ok(undefined);
+  }
+
+  /**
+   * Atomically merges `spaceModelIds` into the conversation requirements and returns the resulting
+   * requirement set (as space sIds).
+   *
+   * `requestedSpaceIds` is a conjunctive ACL: a viewer must have read access to every listed Space.
+   * Computing the union from a caller-held snapshot lets two overlapping requests overwrite each
+   * other, which would leave a Space materialized in the agent runtime scope with no matching ACL
+   * requirement. The merge therefore has to happen against locked, current state.
+   */
+  static async appendRequestedSpaceIds(
+    auth: Authenticator,
+    sId: string,
+    spaceModelIds: ModelId[],
+    transaction: Transaction
+  ): Promise<Result<string[], ConversationError>> {
+    const conversation = await ConversationResource.fetchById(auth, sId, {
+      transaction,
+    });
+    if (conversation === null) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    return conversation.appendRequestedSpaceIds(
+      auth,
+      spaceModelIds,
+      transaction
+    );
   }
 
   static async updateTitle(
@@ -3777,6 +3814,38 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       },
       transaction
     );
+  }
+
+  /**
+   * See {@link ConversationResource.appendRequestedSpaceIds}. The conversation row is re-read with
+   * `SELECT ... FOR UPDATE` inside the caller transaction, so concurrent appends serialize on the
+   * row instead of each writing the union of its own stale snapshot.
+   */
+  async appendRequestedSpaceIds(
+    auth: Authenticator,
+    spaceModelIds: ModelId[],
+    transaction: Transaction
+  ): Promise<Result<string[], ConversationError>> {
+    const lockedConversation = await ConversationResource.model.findOne({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      lock: transaction.LOCK.UPDATE,
+      transaction,
+    });
+    if (lockedConversation === null) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    await this.updateRequirements(
+      auth,
+      [...lockedConversation.requestedSpaceIds, ...spaceModelIds],
+      transaction
+    );
+
+    // `update` refreshes the instance from the `RETURNING` row, so this is the persisted value.
+    return new Ok(this.getRequestedSpaceIdsFromModel());
   }
 
   async updateSpaceId(


### PR DESCRIPTION
## Description

Attaching a Space from the input bar (`restricted_spaces_in_input_bar`) does two things:

1. it appends the Space to `conversation.requestedSpaceIds`, a **conjunctive** ACL where a viewer must have read access to *every* listed Space (the `.every(...)` filter in `ConversationResource.baseFetchWithAuthorization`);
2. it widens the agent's runtime scope for that conversation, which is what reaches real knowledge retrieval via `DataSourceViewResource.listBySpaceIds(auth, effectiveSpaceIds, ...)` in `skill_actions.ts`.

(1) is the only thing that makes (2) safe. A Space that is in the agent's runtime scope but missing from `requestedSpaceIds` means restricted data flows into a conversation that does not restrict its readers.

`addSelectedConversationSpaces` computed the new ACL from the **caller's snapshot** of the conversation and handed the precomputed array to `ConversationResource.updateRequirements`, which *overwrites* the column and never merges with current DB state. The picker fires one POST per checkbox toggle with no in-flight serialization, and the dropdown stays open on select, so ticking several Spaces quickly produces overlapping requests. Under READ COMMITTED (we set no isolation level in `withTransaction`) they interleave:

- request 1 snapshots `[A]`, computes `[A, X]`, writes `[A, X]`
- request 2 snapshots `[A]`, computes `[A, Y]`, writes `[A, Y]`

Final ACL is `[A, Y]`, losing X, while **both** selection rows committed and are active. The agent then has X in scope with no ACL requirement backing it, so users without access to X can read a conversation containing X's data. This is reachable from ordinary UI use, not just a crafted request.

### Fix

- New `ConversationResource.appendRequestedSpaceIds(auth, sId, spaceModelIds, transaction)` (instance + static pair, mirroring `updateRequirements`). It re-reads the conversation row with `SELECT ... FOR UPDATE` **inside the caller's transaction**, unions the locked value with the new ids, writes the result, and returns the persisted requirement set as space sIds. Concurrent appends now serialize on the row, so the selection rows and `requestedSpaceIds` can no longer disagree.
- `addSelectedConversationSpaces` uses it in place of the snapshot-based computation, and the lock is taken before the selection rows are upserted.
- `effectiveAcl.spaceIds` in the response is now the actual post-merge ACL instead of the optimistic locally-computed union. The message-post and conversation-create endpoints feed that value straight back into their local `conversation` object, so it has to be correct.
- Latent bug in the existing static `updateRequirements`: it called `fetchById` **without** the transaction, so the read ran on another connection and did not see the enclosing transaction. The transaction is now passed through (`FetchConversationOptions.transaction`, threaded into the conversation, space and participation reads in `baseFetchWithAuthorization`). It is opt-in, so every existing caller is unchanged. All callers of `updateRequirements` were checked (`permissions.ts` x2, `skill_permissions.ts`, `selected_spaces.ts` and the tests) and all of them are strictly better off reading inside their own transaction.

## Tests

`front/lib/api/assistant/conversation/selected_spaces.test.ts`:

- two successive adds of different Spaces both end up in `requestedSpaceIds` (merge semantics);
- **regression test**: an add performed against a stale conversation snapshot (one whose `requestedSpaceIds` predates another add) no longer drops the previously added Space, and the active selection rows and the ACL agree. Verified it fails on the pre-fix code with `expected [ 'vlt_3TWT…' ] to deeply equal [ 'vlt_2hYM…', 'vlt_3TWT…' ]`. The harness runs inside a CLS transaction, so a genuinely parallel-connection test is not expressible here; the stale snapshot is the reliable way to encode the interleaving;
- `effectiveAcl.spaceIds` matches what is actually persisted on the conversation.

Ran `selected_spaces`, `permissions`, `skill_permissions`, `conversation_resource`, `conversation_selected_space_resource`, plus everything under `lib/api/assistant/conversation` and `lib/api/projects`, for 403 tests green. `npx tsgo --noEmit` clean.

## Risk

This is the widest-reaching of the three Space-selection fixes, so two things are worth a reviewer's attention:

- **`FetchConversationOptions.transaction` is opt-in.** Every existing caller passes nothing and is therefore unchanged. It is threaded into all three reads in `baseFetchWithAuthorization` (the conversation, the spaces, the participations) rather than just the first, because threading only the conversation read would leave the space and participation reads able to filter out a conversation whose rows are still uncommitted.
- **The new row lock is taken inside the caller's transaction**, immediately before the selection rows are written, and released on commit. The conversation row is the only row locked.

The feature itself is behind `restricted_spaces_in_input_bar` (`stage: "dust_only"`), so it is only reachable internally today. Rollback-safe: no schema change, and reverting restores the previous (racy) merge without leaving data in a new shape.

## Deploy Plan

Normal deploy, no special ordering.

- No schema migration: no model, column, or index changes.
- No backfill. For context, the US production read replica currently has 10 rows in `conversation_selected_spaces`, all active, across a single workspace, consistent with the flag being `dust_only`.
- No API schema change; the affected endpoints keep their contracts.

### Follow-ups (not in this PR)

`updateConversationRequirements` (`conversation/permissions.ts`) and `updateConversationRequirementsForSkills` (`conversation/skill_permissions.ts`) have the same read-modify-write shape against a caller-held snapshot. They are additive and not driven by concurrent user toggles, so I kept them out of this PR, but they are the obvious candidates to adopt `appendRequestedSpaceIds` next.

Two sibling PRs, `spaces-initiator-gate` (#29374) and `spaces-pod-runtime-guard` (#29375), also touch `front/lib/api/assistant/conversation/selected_spaces.ts` and will likely need a trivial rebase depending on merge order. Base here stays `main`.
