### PR TITLE
fix: changing workspace name is admin only

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -202,7 +202,7 @@ export const GovernancePage = () => {
       <ContentMessage>
         This page is WIP. Do not change unless you know what you are doing.
       </ContentMessage>
-      <WorkspaceNameEditor owner={owner} />
+      {isAdmin && <WorkspaceNameEditor owner={owner} />}
       <LinkedSectionNotice
         description="Groups assigned here are managed in"
         linkLabel="People → Groups"


### PR DESCRIPTION
## Description

This PR fixes the `WorkspaceNameEditor` component so that it is only rendered for admin users on the Governance page.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.