### PR TITLE
Skills: show the editor tab in readonly mode for non-editors

### DIFF
--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -102,7 +102,10 @@ export function SkillDetailsSheetContent({
 }: SkillDetailsSheetContentProps) {
   const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
 
-  const showEditorsTabs = skill.status !== "suggested" && skill.canAdministrate;
+  // The editors tab is shown to everyone (non-editors get a read-only list,
+  // SkillEditorsTab hides the remove column for them), except for global
+  // skills which are not editable.
+  const showEditorsTabs = skill.status !== "suggested" && !skill.isDefault;
 
   if (showEditorsTabs) {
     return (


### PR DESCRIPTION
## Description

To be consistent so we always have the editors tab for every custom skill.

## Tests

not tested

## Risk

low

## Deploy Plan

deploy front