### PR TITLE
[front] Load workspace permissions as a resourceId-aware set in the Authenticator

### DIFF
--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -311,7 +311,7 @@ describe("GET /api/v1/w/[wId]/skills", () => {
 
 describe("POST /api/v1/w/[wId]/skills", () => {
   it("sets availability when creating and updating imported skills", async () => {
-    const { auth, workspace } = await createPublicApiMockRequest();
+    const { key, workspace } = await createPublicApiMockRequest();
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -326,6 +326,12 @@ describe("POST /api/v1/w/[wId]/skills", () => {
         resourceType: "skill",
       });
     }
+    // The permission set is resolved once at Authenticator construction, so build the request auth
+    // after the grants above for its snapshot to include them.
+    const { workspaceAuth: auth } = await Authenticator.fromKey(
+      key,
+      workspace.sId
+    );
 
     const importWithAvailability = async ({
       availability,
@@ -371,17 +377,24 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("rejects discoverable imports without the make-discoverable permission", async () => {
-    const { auth, workspace } = await createPublicApiMockRequest();
+    const { key, workspace } = await createPublicApiMockRequest();
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
     await SpaceFactory.defaults(adminAuth);
+    // Everything but make_discoverable, which is what this test asserts is missing.
     for (const grantType of ["create", "publish"] as const) {
       await GroupPermissionResource.setForEverybody(adminAuth, {
         grantType,
         resourceType: "skill",
       });
     }
+    // The permission set is resolved once at Authenticator construction, so build the request auth
+    // after the grants above for its snapshot to include them.
+    const { workspaceAuth: auth } = await Authenticator.fromKey(
+      key,
+      workspace.sId
+    );
 
     const result = await importSkillsFromFiles(auth, {
       uploadedFiles: [

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -407,7 +407,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("adds provided editors to new and existing imported skills", async () => {
-    const { auth, workspace } = await createPublicApiMockRequest();
+    const { key, workspace } = await createPublicApiMockRequest();
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -419,6 +419,12 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       grantType: "create",
       resourceType: "skill",
     });
+    // The permission set is resolved once at Authenticator construction, so build the request auth
+    // after the grant above for its snapshot to include the create/skill capability.
+    const { workspaceAuth: auth } = await Authenticator.fromKey(
+      key,
+      workspace.sId
+    );
     const firstEditor = await UserFactory.basic();
     const secondEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, firstEditor, {

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import { PermissionSet } from "@app/lib/resources/group_permission_registry";
+import { GroupPermissions } from "@app/lib/resources/group_permission_registry";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -22,7 +22,7 @@ async function setup() {
     workspace: workspaceResource,
     subscription: null,
     authMethod: "internal",
-    permissions: PermissionSet.empty(),
+    permissions: GroupPermissions.empty(),
   });
   return { workspace, user, auth, globalSpace };
 }

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -22,7 +22,7 @@ async function setup() {
     workspace: workspaceResource,
     subscription: null,
     authMethod: "internal",
-    permissions: PermissionSet.all(),
+    permissions: PermissionSet.empty(),
   });
   return { workspace, user, auth, globalSpace };
 }

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { PermissionSet } from "@app/lib/resources/group_permission_registry";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -21,6 +22,7 @@ async function setup() {
     workspace: workspaceResource,
     subscription: null,
     authMethod: "internal",
+    permissions: PermissionSet.all(),
   });
   return { workspace, user, auth, globalSpace };
 }

--- a/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.test.ts
+++ b/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.test.ts
@@ -34,7 +34,7 @@ vi.mock("@app/lib/api/regions/config", () => ({
 }));
 
 import { Authenticator } from "@app/lib/auth";
-import { PermissionSet } from "@app/lib/resources/group_permission_registry";
+import { GroupPermissions } from "@app/lib/resources/group_permission_registry";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_IMAGE_1_5_MODEL_ID,
@@ -95,7 +95,7 @@ function makeAuth(): Authenticator {
     groupModelIds: [],
     subscription,
     authMethod: "internal",
-    permissions: PermissionSet.empty(),
+    permissions: GroupPermissions.empty(),
   });
 }
 

--- a/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.test.ts
+++ b/front/lib/api/actions/servers/image_generation/getImageGenerationLLM.test.ts
@@ -34,6 +34,7 @@ vi.mock("@app/lib/api/regions/config", () => ({
 }));
 
 import { Authenticator } from "@app/lib/auth";
+import { PermissionSet } from "@app/lib/resources/group_permission_registry";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_IMAGE_1_5_MODEL_ID,
@@ -94,6 +95,7 @@ function makeAuth(): Authenticator {
     groupModelIds: [],
     subscription,
     authMethod: "internal",
+    permissions: PermissionSet.empty(),
   });
 }
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1779,7 +1779,11 @@ export async function filterAgentsByRequestedSpaces(
 
   const allowedBySpaceIds = validAgents.filter((agent) =>
     auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, agent.requestedSpaceIds, auth.getNonNullableWorkspace().id)
+      createResourcePermissionsFromSpacesWithMap(
+        spaceIdToGroupsMap,
+        agent.requestedSpaceIds,
+        auth.getNonNullableWorkspace().id
+      )
     )
   );
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -30,7 +30,7 @@ import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import {
-  createResourcePermissionsFromSpacesWithMap,
+  createAccessControlListFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -1778,8 +1778,9 @@ export async function filterAgentsByRequestedSpaces(
   );
 
   const allowedBySpaceIds = validAgents.filter((agent) =>
-    auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(
+    auth.hasPermissionForAcls(
+      "read",
+      createAccessControlListFromSpacesWithMap(
         spaceIdToGroupsMap,
         agent.requestedSpaceIds,
         auth.getNonNullableWorkspace().id

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1779,10 +1779,7 @@ export async function filterAgentsByRequestedSpaces(
 
   const allowedBySpaceIds = validAgents.filter((agent) =>
     auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(
-        spaceIdToGroupsMap,
-        agent.requestedSpaceIds
-      )
+      createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, agent.requestedSpaceIds, auth.getNonNullableWorkspace().id)
     )
   );
 

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -3,6 +3,7 @@ import {
   getUserForWorkspace,
 } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
+import { PermissionSet } from "@app/lib/resources/group_permission_registry";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
@@ -38,6 +39,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       workspace: null,
       subscription: null,
       authMethod: "internal",
@@ -64,6 +66,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -90,6 +93,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -115,6 +119,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -142,6 +147,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -166,6 +172,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -197,6 +204,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "admin",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -209,6 +217,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -235,6 +244,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -263,6 +273,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -290,6 +301,7 @@ describe("getUserForWorkspace", () => {
       user: superUser,
       role: "admin",
       groupModelIds: [],
+      permissions: PermissionSet.empty(),
       subscription: null,
     });
 

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -3,7 +3,7 @@ import {
   getUserForWorkspace,
 } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
-import { PermissionSet } from "@app/lib/resources/group_permission_registry";
+import { GroupPermissions } from "@app/lib/resources/group_permission_registry";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
@@ -39,7 +39,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       workspace: null,
       subscription: null,
       authMethod: "internal",
@@ -66,7 +66,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -93,7 +93,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -119,7 +119,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -147,7 +147,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -172,7 +172,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -204,7 +204,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "admin",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -217,7 +217,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -244,7 +244,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -273,7 +273,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -301,7 +301,7 @@ describe("getUserForWorkspace", () => {
       user: superUser,
       role: "admin",
       groupModelIds: [],
-      permissions: PermissionSet.empty(),
+      permissions: GroupPermissions.empty(),
       subscription: null,
     });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1524,13 +1524,13 @@ export class Authenticator {
         return true;
       }
 
-      // Second path: group permissions check (the `group_permissions` table). When the resource
-      // declares a `resourceType`, the caller passes if they hold the requested permission — used
-      // directly as a grant verb, since `PermissionType` ⊆ `GrantVerb` — on this
-      // `(resourceType, resourceId)`. A type-wide grant satisfies the check for any instance (see
-      // `PermissionSet.has`).
+      // Second path: group permissions check (the `group_permissions` table). A
+      // GroupResourcePermission declares a `resourceType`; the caller passes if they hold the
+      // requested permission — used directly as a grant verb, since `PermissionType` ⊆ `GrantVerb`
+      // — on this `(resourceType, resourceId)`. A type-wide grant satisfies the check for any
+      // instance (see `PermissionSet.has`).
       if (
-        resourcePermission.resourceType !== undefined &&
+        "resourceType" in resourcePermission &&
         workspace.id === resourcePermission.workspaceId &&
         this._permissions.has(
           resourcePermission.resourceType,
@@ -1543,11 +1543,15 @@ export class Authenticator {
     }
 
     // Third path: legacy group permissions check (inline groups).
-    return this._groupModelIds.some((groupId) =>
-      resourcePermission.groups.some(
-        (gp) => gp.id === groupId && gp.permissions.includes(permission)
-      )
-    );
+    if ("groups" in resourcePermission) {
+      return this._groupModelIds.some((groupId) =>
+        resourcePermission.groups.some(
+          (gp) => gp.id === groupId && gp.permissions.includes(permission)
+        )
+      );
+    }
+
+    return false;
   }
 
   canAdministrate(resourcePermissions: ResourcePermission[]): boolean {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -57,10 +57,7 @@ import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
-import type {
-  PermissionType,
-  ResourcePermission,
-} from "@app/types/resource_permissions";
+import type { ResourcePermission } from "@app/types/resource_permissions";
 import { hasRolePermissions } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
@@ -1225,8 +1222,9 @@ export class Authenticator {
 
   /**
    * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
-   * "create" on "agent"). Admins hold every workspace capability by default; everyone else derives
-   * it from the grants resolved at construction (which fold in "*" wildcard grants).
+   * "create" on "agent"). A thin wrapper over `hasPermission` against a type-wide
+   * `GroupResourcePermission`: the synthetic admin role grants admins every capability by default,
+   * and everyone else derives it from their type-wide grants (which fold in "*" wildcard grants).
    */
   async hasWorkspacePermission(
     verb: GrantVerb,
@@ -1240,17 +1238,18 @@ export class Authenticator {
       `Verb "${verb}" is not allowed (no type-level role grants it) on resource type "${resourceType}".`
     );
 
-    if (!this.workspace()) {
+    const workspace = this.workspace();
+    if (!workspace) {
       return false;
     }
 
-    // Admins hold every workspace-wide capability by default (this is where role-based access is
-    // layered on top of the grant set; the PermissionSet itself holds only grants).
-    if (this.isAdmin()) {
-      return true;
-    }
-
-    return this._permissions.hasTypeWide(resourceType, verb);
+    // A type-wide target (no resourceId). The admin role carries `verb` so admins pass by role;
+    // everyone else falls through to the group_permissions type-wide grant.
+    return this.hasPermission(verb, {
+      roles: [{ role: "admin", permissions: [verb] }],
+      resourceType,
+      workspaceId: workspace.id,
+    });
   }
 
   /**
@@ -1463,90 +1462,61 @@ export class Authenticator {
   }
 
   /**
-   * Checks if the user has the specified permission across all resource permissions.
-   *
-   * This method applies a conjunction (AND) over all resource permission entries. The user
-   * must have the required permission in EVERY entry for the check to pass.
+   * Checks whether the caller holds `verb` on EVERY one of the given resource permission targets
+   * (conjunction). The caller must pass each target for the check to succeed.
    */
   hasPermissionForAllResources(
     resourcePermissions: ResourcePermission[],
-    permission: PermissionType
+    verb: GrantVerb
   ): boolean {
-    // Apply conjunction (AND) over all resource permission entries.
-    return resourcePermissions.every((rp) =>
-      this.hasResourcePermission(rp, permission)
-    );
+    return resourcePermissions.every((rp) => this.hasPermission(verb, rp));
   }
 
   /**
-   * Determines if a user has a specific permission on a resource based on their role, workspace
-   * capabilities, and group memberships.
+   * Determines whether the caller holds `verb` on a single resource permission target. `verb` is a
+   * grant verb (`PermissionType` ⊆ `GrantVerb`, plus type-level capabilities like "create").
+   * Handles both instance targets and type-wide targets: a `GroupResourcePermission` with
+   * `resourceId` omitted resolves to the type-wide (-1) grant.
    *
-   * The permission check follows three independent paths (OR):
-   *
-   * 1. Role-based permission check:
-   *    Applies when the resource has role-based permissions configured.
-   *    Permission is granted if:
-   *    - The resource has public access (role="none") for the requested permission, OR
-   *    - The user's role has the required permission AND the resource belongs to user's workspace
-   *
-   * 2. Group permissions check (the `group_permissions` table):
-   *    Applies when the resource declares a `resourceType`.
-   *    Permission is granted if the user holds the requested permission as a grant verb on the
-   *    resource's `(resourceType, resourceId)` AND the resource belongs to the user's workspace.
-   *
-   * 3. Legacy group permissions check (inline groups):
-   *    Applies when the resource lists inline group grants.
-   *    Permission is granted if:
-   *    - The user belongs to a group that has the required permission on this resource
-   *
-   * @param resourcePermission - The resource's permission configuration
-   * @param permission - The specific permission being checked
-   * @returns true if any permission path grants access
+   * Three independent paths (OR):
+   * 1. Role: the caller's workspace role grants `verb` (and the target is in the caller's workspace).
+   * 2. Group permissions (the `group_permissions` table): the caller holds `verb` as a grant on the
+   *    target's `(resourceType, resourceId)` — a type-wide grant satisfies any instance.
+   * 3. Legacy group permissions (inline groups): the caller belongs to a listed group granting `verb`.
    */
-  private hasResourcePermission(
-    resourcePermission: ResourcePermission,
-    permission: PermissionType
-  ): boolean {
-    // First path: Role-based permission check.
-    if (hasRolePermissions(resourcePermission)) {
+  hasPermission(verb: GrantVerb, target: ResourcePermission): boolean {
+    // 1. Role-based check.
+    if (hasRolePermissions(target)) {
       const workspace = this.getNonNullableWorkspace();
 
-      // Check workspace-specific role permissions.
-      const hasRolePermission = resourcePermission.roles.some(
-        (r) => this.role() === r.role && r.permissions.includes(permission)
-      );
-
       if (
-        hasRolePermission &&
-        workspace.id === resourcePermission.workspaceId
+        workspace.id === target.workspaceId &&
+        target.roles.some(
+          (r) => this.role() === r.role && r.permissions.includes(verb)
+        )
       ) {
         return true;
       }
 
-      // Second path: group permissions check (the `group_permissions` table). A
-      // GroupResourcePermission declares a `resourceType`; the caller passes if they hold the
-      // requested permission — used directly as a grant verb, since `PermissionType` ⊆ `GrantVerb`
-      // — on this `(resourceType, resourceId)`. A type-wide grant satisfies the check for any
-      // instance (see `PermissionSet.has`).
+      // 2. Group permissions check (the `group_permissions` table).
       if (
-        "resourceType" in resourcePermission &&
-        workspace.id === resourcePermission.workspaceId &&
+        "resourceType" in target &&
+        workspace.id === target.workspaceId &&
         this._permissions.has(
-          resourcePermission.resourceType,
-          resourcePermission.resourceId ?? WHOLE_TYPE_RESOURCE_ID,
-          permission
+          target.resourceType,
+          target.resourceId ?? WHOLE_TYPE_RESOURCE_ID,
+          verb
         )
       ) {
         return true;
       }
     }
 
-    // Third path: legacy group permissions check (inline groups).
-    if ("groups" in resourcePermission) {
+    // 3. Legacy group permissions check (inline groups).
+    if ("groups" in target) {
       return this._groupModelIds.some((groupId) =>
-        resourcePermission.groups.some(
-          (gp) => gp.id === groupId && gp.permissions.includes(permission)
+        target.groups.some(
+          (gp) => gp.id === groupId && gp.permissions.includes(verb)
         )
       );
     }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -20,9 +20,9 @@ import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import {
   allWorkspacePermissions,
+  GroupPermissions,
+  type GroupPermissionsJSON,
   grantTypesForVerb,
-  PermissionSet,
-  type PermissionSetJSON,
 } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -57,8 +57,10 @@ import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
-import type { AccessRule } from "@app/types/resource_permissions";
-import { hasRoleGrants } from "@app/types/resource_permissions";
+import type {
+  AccessControlList,
+  GroupGrant,
+} from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
@@ -121,7 +123,7 @@ export interface AuthenticatorType {
   key?: KeyAuthType;
   attributionKey?: { id: ModelId; name: string };
   clientIp?: string;
-  permissions?: PermissionSetJSON;
+  permissions?: GroupPermissionsJSON;
 }
 
 /**
@@ -146,7 +148,7 @@ export class Authenticator {
   _providersHealth: ProvidersHealth | null;
   _clientIp?: string;
   // Governance grants the caller holds, resolved by the factory (see `resolvePermissions`)
-  _permissions: PermissionSet;
+  _permissions: GroupPermissions;
 
   // Should only be called from the static methods below.
   constructor({
@@ -172,7 +174,7 @@ export class Authenticator {
     attributionKey?: { id: ModelId; name: string };
     providersHealth?: ProvidersHealth | null;
     clientIp?: string;
-    permissions: PermissionSet;
+    permissions: GroupPermissions;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -201,21 +203,23 @@ export class Authenticator {
   }
 
   /**
-   * Converts an array of arrays of group sIDs into AccessRule objects.
+   * Converts an array of arrays of group sIDs into AccessControlList objects.
    *
    * This utility method creates standard read/write permissions for each group.
    *
    * Permission logic:
    * - A user must belong to AT LEAST ONE group from EACH sub-array.
-   *   Each sub-array creates a AccessRule entry that can be satisfied by ANY of its groups.
+   *   Each sub-array creates a AccessControlList entry that can be satisfied by ANY of its groups.
    *   Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
    *
    * @param groupIds - Array of arrays of group string identifiers
-   * @returns Array of AccessRule objects, one entry per sub-array
+   * @param workspaceId - The workspace the resources belong to
+   * @returns Array of AccessControlList objects, one entry per sub-array
    */
   static createResourcePermissionsFromGroupIds(
-    groupIds: string[][]
-  ): AccessRule[] {
+    groupIds: string[][],
+    workspaceId: ModelId
+  ): AccessControlList[] {
     const getIdFromSIdOrThrow = (groupId: string) => {
       const id = getResourceIdFromSId(groupId);
       if (!id) {
@@ -226,10 +230,12 @@ export class Authenticator {
 
     // Each group in the same entry enforces OR relationship.
     return groupIds.map((group) => ({
+      roles: [],
       groups: group.map((groupId) => ({
         id: getIdFromSIdOrThrow(groupId),
         permissions: ["read", "write"],
       })),
+      workspaceId,
     }));
   }
 
@@ -1222,9 +1228,9 @@ export class Authenticator {
 
   /**
    * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
-   * "create" on "agent"). A thin wrapper over `hasPermission` against a type-wide
-   * `GrantedAccessRule`: the synthetic admin role grants admins every capability by default,
-   * and everyone else derives it from their type-wide grants (which fold in "*" wildcard grants).
+   * "create" on "agent"). A thin wrapper over `hasPermission` against a handmade, type-wide ACL:
+   * the synthetic admin role grants admins every capability by default, and everyone else derives
+   * it from their type-wide `group_permissions` grants.
    */
   async hasWorkspacePermission(
     verb: GrantVerb,
@@ -1243,11 +1249,9 @@ export class Authenticator {
       return false;
     }
 
-    // A type-wide target (no resourceId). The admin role carries `verb` so admins pass by role;
-    // everyone else falls through to the group_permissions type-wide grant.
     return this.hasPermission(verb, {
       roles: [{ role: "admin", permissions: [verb] }],
-      resourceType,
+      groups: this.getGroupPermissions(resourceType, WHOLE_TYPE_RESOURCE_ID),
       workspaceId: workspace.id,
     });
   }
@@ -1261,7 +1265,7 @@ export class Authenticator {
     if (this.isAdmin()) {
       return allWorkspacePermissions();
     }
-    return this._permissions.toTypeWideWorkspacePermissions();
+    return this._permissions.toWorkspacePermissions();
   }
 
   /**
@@ -1278,9 +1282,9 @@ export class Authenticator {
     workspace?: WorkspaceResource | null;
     role: RoleType;
     groupModelIds: ModelId[];
-  }): Promise<PermissionSet> {
+  }): Promise<GroupPermissions> {
     if (!workspace) {
-      return PermissionSet.empty();
+      return GroupPermissions.empty();
     }
 
     const grants = await GroupPermissionResource.listForGroups(
@@ -1288,7 +1292,7 @@ export class Authenticator {
       { groupModelIds }
     );
 
-    return PermissionSet.fromGrants(grants);
+    return GroupPermissions.fromGrants(grants);
   }
 
   isSystemKey(): boolean {
@@ -1462,75 +1466,62 @@ export class Authenticator {
   }
 
   /**
-   * Checks whether the caller holds `verb` on EVERY one of the given access rules (conjunction).
-   * The caller must pass each rule for the check to succeed.
+   * The caller's governance grants on `(resourceType, resourceId)`, as group→verb entries, folding
+   * in the type-wide (-1) grants. Caller-scoped (only the caller's groups). Resources fold this into
+   * their `AccessControlList`; pass `WHOLE_TYPE_RESOURCE_ID` for a workspace-wide capability.
    */
-  hasPermissionForAll(verb: GrantVerb, rules: AccessRule[]): boolean {
-    return rules.every((rule) => this.hasPermission(verb, rule));
+  getGroupPermissions(
+    resourceType: ConcreteResourceType,
+    resourceId: number
+  ): GroupGrant[] {
+    return this._permissions.forResource(resourceType, resourceId);
   }
 
   /**
-   * Determines whether the caller holds `verb` on a single resource permission target. `verb` is a
-   * grant verb (instance verbs like read/write/admin, or type-level capabilities like "create").
-   * Handles both instance targets and type-wide targets: a `GrantedAccessRule` with
-   * `resourceId` omitted resolves to the type-wide (-1) grant.
-   *
-   * Three independent paths (OR):
-   * 1. Role: the caller's workspace role grants `verb` (and the target is in the caller's workspace).
-   * 2. Group permissions (the `group_permissions` table): the caller holds `verb` as a grant on the
-   *    target's `(resourceType, resourceId)` — a type-wide grant satisfies any instance.
-   * 3. Legacy group permissions (inline groups): the caller belongs to a listed group granting `verb`.
+   * Checks whether the caller holds `verb` on EVERY one of the given ACLs (conjunction). The caller
+   * must pass each ACL for the check to succeed.
    */
-  hasPermission(verb: GrantVerb, target: AccessRule): boolean {
-    // 1. Role-based check.
-    if (hasRoleGrants(target)) {
-      const workspace = this.getNonNullableWorkspace();
+  hasPermissionForAll(verb: GrantVerb, acls: AccessControlList[]): boolean {
+    return acls.every((acl) => this.hasPermission(verb, acl));
+  }
 
-      if (
-        workspace.id === target.workspaceId &&
-        target.roles.some(
-          (r) => this.role() === r.role && r.permissions.includes(verb)
-        )
-      ) {
-        return true;
-      }
-
-      // 2. Group permissions check (the `group_permissions` table).
-      if (
-        "resourceType" in target &&
-        workspace.id === target.workspaceId &&
-        this._permissions.has(
-          target.resourceType,
-          target.resourceId ?? WHOLE_TYPE_RESOURCE_ID,
-          verb
-        )
-      ) {
-        return true;
-      }
-    }
-
-    // 3. Legacy group permissions check (inline groups).
-    if ("groups" in target) {
-      return this._groupModelIds.some((groupId) =>
-        target.groups.some(
-          (gp) => gp.id === groupId && gp.permissions.includes(verb)
-        )
+  /**
+   * Determines whether the caller holds `verb` on a single ACL. `verb` is a grant verb (instance
+   * verbs like read/write/admin, or type-level capabilities like "create"). Two paths (OR):
+   * 1. Role: the caller's workspace role grants `verb` (and the ACL is in the caller's workspace).
+   * 2. Group: the caller belongs to a listed group that grants `verb`.
+   *
+   * The group-membership check is kept even when the ACL's groups are already caller-scoped (built
+   * from `getGroupPermissions`): it lets the same checker also evaluate ACLs that list every group
+   * (e.g. legacy inline groups), filtering by membership at check time.
+   */
+  hasPermission(verb: GrantVerb, acl: AccessControlList): boolean {
+    // Role path: gated to the caller's workspace (a role only applies within its own workspace).
+    const grantedByRole =
+      this.getNonNullableWorkspace().id === acl.workspaceId &&
+      acl.roles.some(
+        (r) => this.role() === r.role && r.permissions.includes(verb)
       );
+    if (grantedByRole) {
+      return true;
     }
 
-    return false;
+    // Group path: group membership is inherently workspace-scoped, so it needs no workspace gate.
+    return this._groupModelIds.some((groupId) =>
+      acl.groups.some((g) => g.id === groupId && g.permissions.includes(verb))
+    );
   }
 
-  canAdministrate(rules: AccessRule[]): boolean {
-    return this.hasPermissionForAll("admin", rules);
+  canAdministrate(acls: AccessControlList[]): boolean {
+    return this.hasPermissionForAll("admin", acls);
   }
 
-  canRead(rules: AccessRule[]): boolean {
-    return this.hasPermissionForAll("read", rules);
+  canRead(acls: AccessControlList[]): boolean {
+    return this.hasPermissionForAll("read", acls);
   }
 
-  canWrite(rules: AccessRule[]): boolean {
-    return this.hasPermissionForAll("write", rules);
+  canWrite(acls: AccessControlList[]): boolean {
+    return this.hasPermissionForAll("write", acls);
   }
 
   key(): KeyAuthType | null {
@@ -1640,8 +1631,8 @@ export class Authenticator {
       providersHealth,
       clientIp: authType.clientIp,
       permissions: authType.permissions
-        ? PermissionSet.fromJSON(authType.permissions)
-        : PermissionSet.empty(),
+        ? GroupPermissions.fromJSON(authType.permissions)
+        : GroupPermissions.empty(),
     });
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1638,7 +1638,13 @@ export class Authenticator {
       clientIp: authType.clientIp,
       permissions: authType.permissions
         ? GroupPermissions.fromJSON(authType.permissions)
-        : GroupPermissions.empty(),
+        : // Payloads serialized before governance grants existed (in-flight Temporal workflows
+          // across the deploy) carry no permissions: resolve them from the groups rather than
+          // running with an empty grant set, which would silently deny every capability check.
+          await this.resolvePermissions({
+            workspace,
+            groupModelIds: groupIds,
+          }),
     });
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1474,7 +1474,7 @@ export class Authenticator {
 
   /**
    * Determines whether the caller holds `verb` on a single resource permission target. `verb` is a
-   * grant verb (`PermissionType` ⊆ `GrantVerb`, plus type-level capabilities like "create").
+   * grant verb (instance verbs like read/write/admin, or type-level capabilities like "create").
    * Handles both instance targets and type-wide targets: a `GroupResourcePermission` with
    * `resourceId` omitted resolves to the type-wide (-1) grant.
    *

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -19,9 +19,9 @@ import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import {
-  allWorkspacePermissions,
   grantTypesForVerb,
-  workspacePermissionsFromGrants,
+  PermissionSet,
+  type PermissionSetJSON,
 } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -123,6 +123,7 @@ export interface AuthenticatorType {
   key?: KeyAuthType;
   attributionKey?: { id: ModelId; name: string };
   clientIp?: string;
+  permissions?: PermissionSetJSON;
 }
 
 /**
@@ -146,6 +147,8 @@ export class Authenticator {
   _authMethod: AuthMethodType;
   _providersHealth: ProvidersHealth | null;
   _clientIp?: string;
+  // Governance grants the caller holds, resolved by the factory (see `resolvePermissions`)
+  _permissions: PermissionSet;
 
   // Should only be called from the static methods below.
   constructor({
@@ -159,6 +162,7 @@ export class Authenticator {
     attributionKey,
     providersHealth,
     clientIp,
+    permissions,
   }: {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
@@ -170,6 +174,7 @@ export class Authenticator {
     attributionKey?: { id: ModelId; name: string };
     providersHealth?: ProvidersHealth | null;
     clientIp?: string;
+    permissions: PermissionSet;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -184,6 +189,8 @@ export class Authenticator {
     this._attributionKey = attributionKey;
     this._providersHealth = providersHealth ?? null;
     this._clientIp = clientIp;
+    this._permissions = permissions;
+
     if (user) {
       tracer.setUser({
         id: user?.sId,
@@ -329,6 +336,11 @@ export class Authenticator {
         groupModelIds,
         subscription,
         providersHealth,
+        permissions: await this.resolvePermissions({
+          workspace,
+          role,
+          groupModelIds,
+        }),
       });
     });
   }
@@ -363,6 +375,12 @@ export class Authenticator {
             transaction,
           })
         : [];
+      // Group memberships changed, so capabilities may have changed too: re-resolve them.
+      this._permissions = await Authenticator.resolvePermissions({
+        workspace: this._workspace,
+        role: this._role,
+        groupModelIds: this._groupModelIds,
+      });
     }
   }
 
@@ -403,14 +421,21 @@ export class Authenticator {
       subscription
     );
 
+    const role: RoleType = user?.isDustSuperUser ? "admin" : "none";
+    const groupModelIds = groups.map((g) => g.id);
     return new Authenticator({
       authMethod: "session",
       workspace,
       user,
-      role: user?.isDustSuperUser ? "admin" : "none",
-      groupModelIds: groups.map((g) => g.id),
+      role,
+      groupModelIds,
       subscription,
       providersHealth,
+      permissions: await this.resolvePermissions({
+        workspace,
+        role,
+        groupModelIds,
+      }),
     });
   }
   /**
@@ -460,6 +485,11 @@ export class Authenticator {
       groupModelIds,
       subscription,
       providersHealth,
+      permissions: await this.resolvePermissions({
+        workspace,
+        role,
+        groupModelIds,
+      }),
     });
   }
 
@@ -506,6 +536,11 @@ export class Authenticator {
         role: authData.role,
         subscription: authData.subscription,
         providersHealth,
+        permissions: await this.resolvePermissions({
+          workspace,
+          role: authData.role,
+          groupModelIds: authData.groupModelIds,
+        }),
       })
     );
   }
@@ -649,6 +684,11 @@ export class Authenticator {
         groupModelIds,
         subscription,
         providersHealth,
+        permissions: await this.resolvePermissions({
+          workspace,
+          role,
+          groupModelIds,
+        }),
       })
     );
   }
@@ -912,24 +952,44 @@ export class Authenticator {
       workspaceSubscription
     );
 
+    // If the key is associated with the workspace, we associate the groups.
+    const workspaceGroupModelIds = isKeyWorkspace
+      ? allGroups.map((g) => g.id)
+      : [];
+    const keyGroupModelIds = allGroups.map((g) => g.id);
+
+    const [permissions, keyPermissions] = await Promise.all([
+      this.resolvePermissions({
+        workspace,
+        role,
+        groupModelIds: workspaceGroupModelIds,
+      }),
+      this.resolvePermissions({
+        workspace: keyWorkspace,
+        role: "builder",
+        groupModelIds: keyGroupModelIds,
+      }),
+    ]);
+
     return {
       workspaceAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        // If the key is associated with the workspace, we associate the groups.
-        groupModelIds: isKeyWorkspace ? allGroups.map((g) => g.id) : [],
+        groupModelIds: workspaceGroupModelIds,
         key: key.toAuthJSON(),
         role,
         subscription: workspaceSubscription,
         workspace,
         providersHealth: workspaceProvidersHealth,
+        permissions,
       }),
       keyAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groupModelIds: allGroups.map((g) => g.id),
+        groupModelIds: keyGroupModelIds,
         key: key.toAuthJSON(),
         role: "builder",
         subscription: keySubscription,
         workspace: keyWorkspace,
+        permissions: keyPermissions,
       }),
     };
   }
@@ -960,13 +1020,19 @@ export class Authenticator {
       subscription
     );
 
+    const groupModelIds = globalGroup ? [globalGroup.id] : [];
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "builder",
-      groupModelIds: globalGroup ? [globalGroup.id] : [],
+      groupModelIds,
       subscription,
       providersHealth,
+      permissions: await this.resolvePermissions({
+        workspace,
+        role: "builder",
+        groupModelIds,
+      }),
     });
   }
 
@@ -1007,13 +1073,19 @@ export class Authenticator {
       subscription
     );
 
+    const groupModelIds = groups.map((g) => g.id);
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "admin",
-      groupModelIds: groups.map((g) => g.id),
+      groupModelIds,
       subscription,
       providersHealth,
+      permissions: await this.resolvePermissions({
+        workspace,
+        role: "admin",
+        groupModelIds,
+      }),
     });
   }
 
@@ -1094,6 +1166,11 @@ export class Authenticator {
       subscription: auth._subscription,
       workspace: auth._workspace,
       providersHealth: auth._providersHealth,
+      permissions: await Authenticator.resolvePermissions({
+        workspace: auth._workspace,
+        role: "user",
+        groupModelIds,
+      }),
     });
   }
 
@@ -1108,6 +1185,8 @@ export class Authenticator {
       workspace: this._workspace,
       clientIp: this._clientIp,
       providersHealth: this._providersHealth,
+      // Role and groups are unchanged, so capabilities carry over unchanged.
+      permissions: this._permissions,
     });
   }
 
@@ -1144,64 +1223,64 @@ export class Authenticator {
   }
 
   /**
-   * Whether the caller holds a workspace-level capability. A capability is asked as a verb (e.g.
-   * "create"), expanded via the registry into the stored grant types (role names) that imply it, and
-   * checked against the type-wide (-1) group_permissions rows. Admins bypass unconditionally
-   * (billing/security are admin-by-default). Otherwise we look for a -1 grant on any of the caller's
-   * groups; "*" grants match any grant type / resource type.
-   *
-   * Cold path: a query per check is fine — no caching yet (pending auth-resolution decision).
+   * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
+   * "create" on "agent"). Reads the capabilities resolved at construction, which fold in
+   * admin-by-default access and "*" wildcard grants.
    */
   async hasWorkspacePermission(
     verb: GrantVerb,
     resourceType: ConcreteResourceType
   ): Promise<boolean> {
-    // Reject invalid capability queries (e.g. create/billing) up front, so a "*" grant can't satisfy
-    // a pair the registry forbids, and so callers fail fast on a programmer error.
+    // Reject invalid capability queries (e.g. create/billing) up front so callers fail fast on a
+    // programmer error rather than silently returning false.
     const grantTypes = grantTypesForVerb(resourceType, verb, "type");
     assert(
       grantTypes.length > 0,
       `Verb "${verb}" is not allowed (no type-level role grants it) on resource type "${resourceType}".`
     );
 
-    if (this.isAdmin()) {
-      return true;
-    }
     if (!this.workspace()) {
       return false;
     }
 
-    const grants = await GroupPermissionResource.listForGroups(this, {
-      groupModelIds: this._groupModelIds,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
-
-    return grants.some(
-      (grant) =>
-        (grant.resourceType === resourceType || grant.resourceType === "*") &&
-        (grant.grantType === "*" || grantTypes.includes(grant.grantType))
-    );
+    return this._permissions.hasTypeWide(resourceType, verb);
   }
 
   /**
-   * All workspace-level (type-wide) verbs the caller holds, grouped by resource type. This is the
-   * batch companion to hasWorkspacePermission: it expands every type-wide (-1) grant on the
-   * caller's groups into the verbs it confers. Admins hold every type-level capability by default,
-   * and "*" grants expand to all type-level verbs of the matched resource type(s), mirroring
-   * hasWorkspacePermission's semantics.
+   * The caller's governance grants, serialized to the wire shape consumed by the `/permissions`
+   * endpoint. Resolved at construction (see `resolvePermissions`).
    */
   async getWorkspacePermissions(): Promise<WorkspacePermissions> {
-    // Admins bypass grants entirely: every type-level capability is theirs by default.
-    if (this.isAdmin()) {
-      return allWorkspacePermissions();
+    return this._permissions.toTypeWideWorkspacePermissions();
+  }
+
+  /**
+   * Resolves the grant set a caller holds, before an Authenticator exists. Admins hold every
+   * capability by default; other callers derive them from the grants on their groups. Cheap for
+   * admins and for callers with no groups (no query).
+   */
+  static async resolvePermissions({
+    workspace,
+    role,
+    groupModelIds,
+  }: {
+    workspace?: WorkspaceResource | null;
+    role: RoleType;
+    groupModelIds: ModelId[];
+  }): Promise<PermissionSet> {
+    if (!workspace) {
+      return PermissionSet.empty();
+    }
+    if (role === "admin") {
+      return PermissionSet.all();
     }
 
-    const grants = await GroupPermissionResource.listForGroups(this, {
-      groupModelIds: this._groupModelIds,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      renderLightWorkspaceType({ workspace }),
+      { groupModelIds }
+    );
 
-    return workspacePermissionsFromGrants(grants);
+    return PermissionSet.fromGrants(grants);
   }
 
   isSystemKey(): boolean {
@@ -1391,10 +1470,10 @@ export class Authenticator {
   }
 
   /**
-   * Determines if a user has a specific permission on a resource based on their role and group
-   * memberships.
+   * Determines if a user has a specific permission on a resource based on their role, workspace
+   * capabilities, and group memberships.
    *
-   * The permission check follows two independent paths (OR):
+   * The permission check follows three independent paths (OR):
    *
    * 1. Role-based permission check:
    *    Applies when the resource has role-based permissions configured.
@@ -1402,14 +1481,19 @@ export class Authenticator {
    *    - The resource has public access (role="none") for the requested permission, OR
    *    - The user's role has the required permission AND the resource belongs to user's workspace
    *
-   * 2. Group-based permission check:
+   * 2. Governance-grant check:
+   *    Applies when the resource declares a `resourceType`.
+   *    Permission is granted if the user holds the requested permission as a grant verb on the
+   *    resource's `(resourceType, resourceId)` AND the resource belongs to the user's workspace.
+   *
+   * 3. Group-based permission check:
    *    Applies when the resource has group-based permissions configured.
    *    Permission is granted if:
    *    - The user belongs to a group that has the required permission on this resource
    *
    * @param resourcePermission - The resource's permission configuration
    * @param permission - The specific permission being checked
-   * @returns true if either permission path grants access
+   * @returns true if any permission path grants access
    */
   private hasResourcePermission(
     resourcePermission: ResourcePermission,
@@ -1430,9 +1514,25 @@ export class Authenticator {
       ) {
         return true;
       }
+
+      // Second path: governance-grant check. When the resource declares a `resourceType`, the
+      // caller passes if they hold the requested permission — used directly as a grant verb, since
+      // `PermissionType` ⊆ `GrantVerb` — on this `(resourceType, resourceId)`. A type-wide grant
+      // satisfies the check for any instance (see `PermissionSet.has`).
+      if (
+        resourcePermission.resourceType !== undefined &&
+        workspace.id === resourcePermission.workspaceId &&
+        this._permissions.has(
+          resourcePermission.resourceType,
+          resourcePermission.resourceId ?? WHOLE_TYPE_RESOURCE_ID,
+          permission
+        )
+      ) {
+        return true;
+      }
     }
 
-    // Second path: Group-based permission check.
+    // Third path: Group-based permission check.
     return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
         (gp) => gp.id === groupId && gp.permissions.includes(permission)
@@ -1484,6 +1584,8 @@ export class Authenticator {
       workspace: this._workspace,
       clientIp: this._clientIp,
       providersHealth: this._providersHealth,
+      // Attribution-only copy: role and groups are unchanged, so capabilities carry over unchanged.
+      permissions: this._permissions,
     });
   }
 
@@ -1502,6 +1604,7 @@ export class Authenticator {
       key: this._key,
       attributionKey: this._attributionKey,
       clientIp: this._clientIp,
+      permissions: this._permissions.toJSON(),
     };
   }
 
@@ -1555,6 +1658,9 @@ export class Authenticator {
       attributionKey: authType.attributionKey,
       providersHealth,
       clientIp: authType.clientIp,
+      permissions: authType.permissions
+        ? PermissionSet.fromJSON(authType.permissions)
+        : PermissionSet.empty(),
     });
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1490,13 +1490,13 @@ export class Authenticator {
    *    - The resource has public access (role="none") for the requested permission, OR
    *    - The user's role has the required permission AND the resource belongs to user's workspace
    *
-   * 2. Governance-grant check:
+   * 2. Group permissions check (the `group_permissions` table):
    *    Applies when the resource declares a `resourceType`.
    *    Permission is granted if the user holds the requested permission as a grant verb on the
    *    resource's `(resourceType, resourceId)` AND the resource belongs to the user's workspace.
    *
-   * 3. Group-based permission check:
-   *    Applies when the resource has group-based permissions configured.
+   * 3. Legacy group permissions check (inline groups):
+   *    Applies when the resource lists inline group grants.
    *    Permission is granted if:
    *    - The user belongs to a group that has the required permission on this resource
    *
@@ -1524,10 +1524,11 @@ export class Authenticator {
         return true;
       }
 
-      // Second path: governance-grant check. When the resource declares a `resourceType`, the
-      // caller passes if they hold the requested permission — used directly as a grant verb, since
-      // `PermissionType` ⊆ `GrantVerb` — on this `(resourceType, resourceId)`. A type-wide grant
-      // satisfies the check for any instance (see `PermissionSet.has`).
+      // Second path: group permissions check (the `group_permissions` table). When the resource
+      // declares a `resourceType`, the caller passes if they hold the requested permission — used
+      // directly as a grant verb, since `PermissionType` ⊆ `GrantVerb` — on this
+      // `(resourceType, resourceId)`. A type-wide grant satisfies the check for any instance (see
+      // `PermissionSet.has`).
       if (
         resourcePermission.resourceType !== undefined &&
         workspace.id === resourcePermission.workspaceId &&
@@ -1541,7 +1542,7 @@ export class Authenticator {
       }
     }
 
-    // Third path: Group-based permission check.
+    // Third path: legacy group permissions check (inline groups).
     return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
         (gp) => gp.id === groupId && gp.permissions.includes(permission)

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -19,6 +19,7 @@ import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import {
+  allWorkspacePermissions,
   grantTypesForVerb,
   PermissionSet,
   type PermissionSetJSON,
@@ -1224,8 +1225,8 @@ export class Authenticator {
 
   /**
    * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
-   * "create" on "agent"). Reads the capabilities resolved at construction, which fold in
-   * admin-by-default access and "*" wildcard grants.
+   * "create" on "agent"). Admins hold every workspace capability by default; everyone else derives
+   * it from the grants resolved at construction (which fold in "*" wildcard grants).
    */
   async hasWorkspacePermission(
     verb: GrantVerb,
@@ -1243,25 +1244,36 @@ export class Authenticator {
       return false;
     }
 
+    // Admins hold every workspace-wide capability by default (this is where role-based access is
+    // layered on top of the grant set; the PermissionSet itself holds only grants).
+    if (this.isAdmin()) {
+      return true;
+    }
+
     return this._permissions.hasTypeWide(resourceType, verb);
   }
 
   /**
-   * The caller's governance grants, serialized to the wire shape consumed by the `/permissions`
-   * endpoint. Resolved at construction (see `resolvePermissions`).
+   * The caller's workspace capabilities, as the wire shape consumed by the `/permissions` endpoint.
+   * Admins hold every capability by default; everyone else derives them from the grants resolved at
+   * construction.
    */
   async getWorkspacePermissions(): Promise<WorkspacePermissions> {
+    if (this.isAdmin()) {
+      return allWorkspacePermissions();
+    }
     return this._permissions.toTypeWideWorkspacePermissions();
   }
 
   /**
-   * Resolves the grant set a caller holds, before an Authenticator exists. Admins hold every
-   * capability by default; other callers derive them from the grants on their groups. Cheap for
-   * admins and for callers with no groups (no query).
+   * Resolves the grant set a caller holds, before an Authenticator exists. Returns only the grants
+   * on the caller's groups — no role logic. Admin-by-default access to workspace-wide capabilities
+   * is layered on by `hasWorkspacePermission` / `getWorkspacePermissions`, so being an admin does
+   * NOT confer access to a specific instance unless a grant grants it. Cheap for callers with no
+   * groups (no query).
    */
   static async resolvePermissions({
     workspace,
-    role,
     groupModelIds,
   }: {
     workspace?: WorkspaceResource | null;
@@ -1270,9 +1282,6 @@ export class Authenticator {
   }): Promise<PermissionSet> {
     if (!workspace) {
       return PermissionSet.empty();
-    }
-    if (role === "admin") {
-      return PermissionSet.all();
     }
 
     const grants = await GroupPermissionResource.listForGroups(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -57,8 +57,8 @@ import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
-import type { ResourcePermission } from "@app/types/resource_permissions";
-import { hasRolePermissions } from "@app/types/resource_permissions";
+import type { AccessRule } from "@app/types/resource_permissions";
+import { hasRoleGrants } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
@@ -201,21 +201,21 @@ export class Authenticator {
   }
 
   /**
-   * Converts an array of arrays of group sIDs into ResourcePermission objects.
+   * Converts an array of arrays of group sIDs into AccessRule objects.
    *
    * This utility method creates standard read/write permissions for each group.
    *
    * Permission logic:
    * - A user must belong to AT LEAST ONE group from EACH sub-array.
-   *   Each sub-array creates a ResourcePermission entry that can be satisfied by ANY of its groups.
+   *   Each sub-array creates a AccessRule entry that can be satisfied by ANY of its groups.
    *   Example: [[1,2], [3,4]] means (1 OR 2) AND (3 OR 4)
    *
    * @param groupIds - Array of arrays of group string identifiers
-   * @returns Array of ResourcePermission objects, one entry per sub-array
+   * @returns Array of AccessRule objects, one entry per sub-array
    */
   static createResourcePermissionsFromGroupIds(
     groupIds: string[][]
-  ): ResourcePermission[] {
+  ): AccessRule[] {
     const getIdFromSIdOrThrow = (groupId: string) => {
       const id = getResourceIdFromSId(groupId);
       if (!id) {
@@ -1223,7 +1223,7 @@ export class Authenticator {
   /**
    * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
    * "create" on "agent"). A thin wrapper over `hasPermission` against a type-wide
-   * `GroupResourcePermission`: the synthetic admin role grants admins every capability by default,
+   * `GrantedAccessRule`: the synthetic admin role grants admins every capability by default,
    * and everyone else derives it from their type-wide grants (which fold in "*" wildcard grants).
    */
   async hasWorkspacePermission(
@@ -1462,20 +1462,17 @@ export class Authenticator {
   }
 
   /**
-   * Checks whether the caller holds `verb` on EVERY one of the given resource permission targets
-   * (conjunction). The caller must pass each target for the check to succeed.
+   * Checks whether the caller holds `verb` on EVERY one of the given access rules (conjunction).
+   * The caller must pass each rule for the check to succeed.
    */
-  hasPermissionForAllResources(
-    resourcePermissions: ResourcePermission[],
-    verb: GrantVerb
-  ): boolean {
-    return resourcePermissions.every((rp) => this.hasPermission(verb, rp));
+  hasPermissionForAll(verb: GrantVerb, rules: AccessRule[]): boolean {
+    return rules.every((rule) => this.hasPermission(verb, rule));
   }
 
   /**
    * Determines whether the caller holds `verb` on a single resource permission target. `verb` is a
    * grant verb (instance verbs like read/write/admin, or type-level capabilities like "create").
-   * Handles both instance targets and type-wide targets: a `GroupResourcePermission` with
+   * Handles both instance targets and type-wide targets: a `GrantedAccessRule` with
    * `resourceId` omitted resolves to the type-wide (-1) grant.
    *
    * Three independent paths (OR):
@@ -1484,9 +1481,9 @@ export class Authenticator {
    *    target's `(resourceType, resourceId)` — a type-wide grant satisfies any instance.
    * 3. Legacy group permissions (inline groups): the caller belongs to a listed group granting `verb`.
    */
-  hasPermission(verb: GrantVerb, target: ResourcePermission): boolean {
+  hasPermission(verb: GrantVerb, target: AccessRule): boolean {
     // 1. Role-based check.
-    if (hasRolePermissions(target)) {
+    if (hasRoleGrants(target)) {
       const workspace = this.getNonNullableWorkspace();
 
       if (
@@ -1524,16 +1521,16 @@ export class Authenticator {
     return false;
   }
 
-  canAdministrate(resourcePermissions: ResourcePermission[]): boolean {
-    return this.hasPermissionForAllResources(resourcePermissions, "admin");
+  canAdministrate(rules: AccessRule[]): boolean {
+    return this.hasPermissionForAll("admin", rules);
   }
 
-  canRead(resourcePermissions: ResourcePermission[]): boolean {
-    return this.hasPermissionForAllResources(resourcePermissions, "read");
+  canRead(rules: AccessRule[]): boolean {
+    return this.hasPermissionForAll("read", rules);
   }
 
-  canWrite(resourcePermissions: ResourcePermission[]): boolean {
-    return this.hasPermissionForAllResources(resourcePermissions, "write");
+  canWrite(rules: AccessRule[]): boolean {
+    return this.hasPermissionForAll("write", rules);
   }
 
   key(): KeyAuthType | null {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -18,10 +18,10 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import type { GroupPermissionsJSON } from "@app/lib/resources/group_permission_registry";
 import {
   allWorkspacePermissions,
   GroupPermissions,
-  type GroupPermissionsJSON,
   grantTypesForVerb,
 } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -343,7 +343,6 @@ export class Authenticator {
         providersHealth,
         permissions: await this.resolvePermissions({
           workspace,
-          role,
           groupModelIds,
         }),
       });
@@ -383,7 +382,6 @@ export class Authenticator {
       // Group memberships changed, so capabilities may have changed too: re-resolve them.
       this._permissions = await Authenticator.resolvePermissions({
         workspace: this._workspace,
-        role: this._role,
         groupModelIds: this._groupModelIds,
       });
     }
@@ -438,7 +436,6 @@ export class Authenticator {
       providersHealth,
       permissions: await this.resolvePermissions({
         workspace,
-        role,
         groupModelIds,
       }),
     });
@@ -492,7 +489,6 @@ export class Authenticator {
       providersHealth,
       permissions: await this.resolvePermissions({
         workspace,
-        role,
         groupModelIds,
       }),
     });
@@ -543,7 +539,6 @@ export class Authenticator {
         providersHealth,
         permissions: await this.resolvePermissions({
           workspace,
-          role: authData.role,
           groupModelIds: authData.groupModelIds,
         }),
       })
@@ -691,7 +686,6 @@ export class Authenticator {
         providersHealth,
         permissions: await this.resolvePermissions({
           workspace,
-          role,
           groupModelIds,
         }),
       })
@@ -963,18 +957,28 @@ export class Authenticator {
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
 
-    const [permissions, keyPermissions] = await Promise.all([
-      this.resolvePermissions({
+    let permissions: GroupPermissions;
+    let keyPermissions: GroupPermissions;
+    if (isKeyWorkspace) {
+      // Same workspace and same groups: both Authenticators share one resolution rather than
+      // running the same query twice. Safe to share the instance, GroupPermissions is immutable.
+      permissions = await this.resolvePermissions({
         workspace,
-        role,
         groupModelIds: workspaceGroupModelIds,
-      }),
-      this.resolvePermissions({
-        workspace: keyWorkspace,
-        role: "builder",
-        groupModelIds: keyGroupModelIds,
-      }),
-    ]);
+      });
+      keyPermissions = permissions;
+    } else {
+      [permissions, keyPermissions] = await Promise.all([
+        this.resolvePermissions({
+          workspace,
+          groupModelIds: workspaceGroupModelIds,
+        }),
+        this.resolvePermissions({
+          workspace: keyWorkspace,
+          groupModelIds: keyGroupModelIds,
+        }),
+      ]);
+    }
 
     return {
       workspaceAuth: new Authenticator({
@@ -1035,7 +1039,6 @@ export class Authenticator {
       providersHealth,
       permissions: await this.resolvePermissions({
         workspace,
-        role: "builder",
         groupModelIds,
       }),
     });
@@ -1088,7 +1091,6 @@ export class Authenticator {
       providersHealth,
       permissions: await this.resolvePermissions({
         workspace,
-        role: "admin",
         groupModelIds,
       }),
     });
@@ -1173,7 +1175,6 @@ export class Authenticator {
       providersHealth: auth._providersHealth,
       permissions: await Authenticator.resolvePermissions({
         workspace: auth._workspace,
-        role: "user",
         groupModelIds,
       }),
     });
@@ -1281,7 +1282,6 @@ export class Authenticator {
     groupModelIds,
   }: {
     workspace?: WorkspaceResource | null;
-    role: RoleType;
     groupModelIds: ModelId[];
   }): Promise<GroupPermissions> {
     if (!workspace) {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -217,7 +217,7 @@ export class Authenticator {
    * @param workspaceId - The workspace the resources belong to
    * @returns Array of AccessControlList objects, one entry per sub-array
    */
-  static createResourcePermissionsFromGroupIds(
+  static createAccessControlListFromGroupIds(
     groupIds: string[][],
     workspaceId: ModelId
   ): AccessControlList[] {
@@ -1494,12 +1494,13 @@ export class Authenticator {
     return targets.every((target) => this.hasPermission(verb, target));
   }
 
-  // Whether the caller holds `verb` on every ACL in the list (conjunction). Callers that already
-  // hold raw ACLs (e.g. `canRead`, the conversation space checks) use this directly.
-  private hasPermissionForAcls(
-    verb: GrantVerb,
-    acls: AccessControlList[]
-  ): boolean {
+  /**
+   * Whether the caller holds `verb` on every ACL in the list (conjunction). This is the raw-ACL
+   * entry point: callers that already hold built or derived ACLs (e.g. a space's served ACLs, the
+   * cross-space conversation checks) use this directly, rather than going through a
+   * `WithAccessControl` target.
+   */
+  hasPermissionForAcls(verb: GrantVerb, acls: AccessControlList[]): boolean {
     return acls.every((acl) => this.hasPermissionForAcl(verb, acl));
   }
 
@@ -1527,18 +1528,6 @@ export class Authenticator {
     return this._groupModelIds.some((groupId) =>
       acl.groups.some((g) => g.id === groupId && g.permissions.includes(verb))
     );
-  }
-
-  canAdministrate(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAcls("admin", acls);
-  }
-
-  canRead(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAcls("read", acls);
-  }
-
-  canWrite(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAcls("write", acls);
   }
 
   key(): KeyAuthType | null {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -60,6 +60,7 @@ import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
   AccessControlList,
   GroupGrant,
+  WithAccessControl,
 } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
@@ -1249,7 +1250,7 @@ export class Authenticator {
       return false;
     }
 
-    return this.hasPermission(verb, {
+    return this.hasPermissionForAcl(verb, {
       roles: [{ role: "admin", permissions: [verb] }],
       groups: this.getGroupPermissions(resourceType, WHOLE_TYPE_RESOURCE_ID),
       workspaceId: workspace.id,
@@ -1478,24 +1479,40 @@ export class Authenticator {
   }
 
   /**
-   * Checks whether the caller holds `verb` on EVERY one of the given ACLs (conjunction). The caller
-   * must pass each ACL for the check to succeed.
+   * Whether the caller holds `verb` on `target` — i.e. on EVERY access-control list the target
+   * declares (a resource may declare multiple ACLs that must all hold). `verb` is a grant verb
+   * (instance verbs like read/write/admin, or type-level capabilities like "create").
    */
-  hasPermissionForAll(verb: GrantVerb, acls: AccessControlList[]): boolean {
-    return acls.every((acl) => this.hasPermission(verb, acl));
+  hasPermission(verb: GrantVerb, target: WithAccessControl): boolean {
+    return this.hasPermissionForAcls(verb, target.getAccessControlLists(this));
   }
 
   /**
-   * Determines whether the caller holds `verb` on a single ACL. `verb` is a grant verb (instance
-   * verbs like read/write/admin, or type-level capabilities like "create"). Two paths (OR):
-   * 1. Role: the caller's workspace role grants `verb` (and the ACL is in the caller's workspace).
-   * 2. Group: the caller belongs to a listed group that grants `verb`.
-   *
-   * The group-membership check is kept even when the ACL's groups are already caller-scoped (built
-   * from `getGroupPermissions`): it lets the same checker also evaluate ACLs that list every group
-   * (e.g. legacy inline groups), filtering by membership at check time.
+   * Whether the caller holds `verb` on EVERY one of the given targets (conjunction).
    */
-  hasPermission(verb: GrantVerb, acl: AccessControlList): boolean {
+  hasPermissionForAll(verb: GrantVerb, targets: WithAccessControl[]): boolean {
+    return targets.every((target) => this.hasPermission(verb, target));
+  }
+
+  // Whether the caller holds `verb` on every ACL in the list (conjunction). Callers that already
+  // hold raw ACLs (e.g. `canRead`, the conversation space checks) use this directly.
+  private hasPermissionForAcls(
+    verb: GrantVerb,
+    acls: AccessControlList[]
+  ): boolean {
+    return acls.every((acl) => this.hasPermissionForAcl(verb, acl));
+  }
+
+  // Single-ACL check. Two paths (OR):
+  // 1. Role: the caller's workspace role grants `verb` (and the ACL is in the caller's workspace).
+  // 2. Group: the caller belongs to a listed group that grants `verb`.
+  // The group-membership check is kept even when the ACL's groups are already caller-scoped (built
+  // from `getGroupPermissions`): it lets the same checker also evaluate ACLs that list every group
+  // (e.g. legacy inline groups), filtering by membership at check time.
+  private hasPermissionForAcl(
+    verb: GrantVerb,
+    acl: AccessControlList
+  ): boolean {
     // Role path: gated to the caller's workspace (a role only applies within its own workspace).
     const grantedByRole =
       this.getNonNullableWorkspace().id === acl.workspaceId &&
@@ -1513,15 +1530,15 @@ export class Authenticator {
   }
 
   canAdministrate(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAll("admin", acls);
+    return this.hasPermissionForAcls("admin", acls);
   }
 
   canRead(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAll("read", acls);
+    return this.hasPermissionForAcls("read", acls);
   }
 
   canWrite(acls: AccessControlList[]): boolean {
-    return this.hasPermissionForAll("write", acls);
+    return this.hasPermissionForAcls("write", acls);
   }
 
   key(): KeyAuthType | null {

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -181,3 +181,45 @@ describe("Authenticator.getWorkspacePermissions", () => {
     });
   });
 });
+
+describe("Authenticator.fromJSON", () => {
+  it("resolves the grants of a payload serialized before permissions existed", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+
+    const group = await GroupFactory.regularManual(workspace, "A");
+    await GroupPermissionResource.setGroups(
+      adminAuth,
+      { grantType: "publish", resourceType: "agent" },
+      [group]
+    );
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await GroupFactory.withMembers(adminAuth, group, [user]);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // In-flight Temporal workflows carry payloads serialized before the permissions field existed.
+    const { permissions, ...legacyAuthType } = auth.toJSON();
+    expect(permissions).toBeDefined();
+
+    const restored = await Authenticator.fromJSON(legacyAuthType);
+
+    expect(await restored.getWorkspacePermissions()).toEqual(
+      await auth.getWorkspacePermissions()
+    );
+    expect(await restored.hasWorkspacePermission("publish", "agent")).toBe(
+      true
+    );
+  });
+});

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1356,7 +1356,11 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should resolve space ids to group permissions", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, [globalSpace.id], auth.getNonNullableWorkspace().id);
+    const permissions = createResourcePermissionsFromSpacesWithMap(
+      spaceIdToGroupsMap,
+      [globalSpace.id],
+      auth.getNonNullableWorkspace().id
+    );
 
     expect(permissions).toBeDefined();
     expect(Array.isArray(permissions)).toBe(true);
@@ -1365,7 +1369,11 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should handle multiple space ids", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, [globalSpace.id, regularSpace.id], auth.getNonNullableWorkspace().id);
+    const permissions = createResourcePermissionsFromSpacesWithMap(
+      spaceIdToGroupsMap,
+      [globalSpace.id, regularSpace.id],
+      auth.getNonNullableWorkspace().id
+    );
 
     expect(permissions).toBeDefined();
     expect(permissions.length).toBeGreaterThan(0);
@@ -1384,7 +1392,9 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   it("should handle empty space ids array", () => {
     const permissions = createResourcePermissionsFromSpacesWithMap(
       spaceIdToGroupsMap,
-      [], auth.getNonNullableWorkspace().id);
+      [],
+      auth.getNonNullableWorkspace().id
+    );
 
     expect(permissions).toBeDefined();
     expect(permissions).toEqual([]);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -20,7 +20,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
-  createResourcePermissionsFromSpacesWithMap,
+  createAccessControlListFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -1356,7 +1356,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should resolve space ids to group permissions", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(
+    const permissions = createAccessControlListFromSpacesWithMap(
       spaceIdToGroupsMap,
       [globalSpace.id],
       auth.getNonNullableWorkspace().id
@@ -1369,7 +1369,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should handle multiple space ids", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(
+    const permissions = createAccessControlListFromSpacesWithMap(
       spaceIdToGroupsMap,
       [globalSpace.id, regularSpace.id],
       auth.getNonNullableWorkspace().id
@@ -1381,7 +1381,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
 
   it("should throw assertion error for missing spaces", () => {
     expect(() =>
-      createResourcePermissionsFromSpacesWithMap(
+      createAccessControlListFromSpacesWithMap(
         spaceIdToGroupsMap,
         [99999], // Non-existent space Id.
         auth.getNonNullableWorkspace().id
@@ -1390,7 +1390,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should handle empty space ids array", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(
+    const permissions = createAccessControlListFromSpacesWithMap(
       spaceIdToGroupsMap,
       [],
       auth.getNonNullableWorkspace().id

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1356,10 +1356,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should resolve space ids to group permissions", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(
-      spaceIdToGroupsMap,
-      [globalSpace.id]
-    );
+    const permissions = createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, [globalSpace.id], auth.getNonNullableWorkspace().id);
 
     expect(permissions).toBeDefined();
     expect(Array.isArray(permissions)).toBe(true);
@@ -1368,10 +1365,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   });
 
   it("should handle multiple space ids", () => {
-    const permissions = createResourcePermissionsFromSpacesWithMap(
-      spaceIdToGroupsMap,
-      [globalSpace.id, regularSpace.id]
-    );
+    const permissions = createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, [globalSpace.id, regularSpace.id], auth.getNonNullableWorkspace().id);
 
     expect(permissions).toBeDefined();
     expect(permissions.length).toBeGreaterThan(0);
@@ -1381,7 +1375,8 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
     expect(() =>
       createResourcePermissionsFromSpacesWithMap(
         spaceIdToGroupsMap,
-        [99999] // Non-existent space Id.
+        [99999], // Non-existent space Id.
+        auth.getNonNullableWorkspace().id
       )
     ).toThrow("No group IDs found for space ID 99999");
   });
@@ -1389,8 +1384,7 @@ describe("createResourcePermissionsFromSpacesWithMap", () => {
   it("should handle empty space ids array", () => {
     const permissions = createResourcePermissionsFromSpacesWithMap(
       spaceIdToGroupsMap,
-      []
-    );
+      [], auth.getNonNullableWorkspace().id);
 
     expect(permissions).toBeDefined();
     expect(permissions).toEqual([]);

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1147,10 +1147,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const spaceBasedAccessible = validConversations.filter((c) =>
       auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
-          spaceIdToGroupsMap,
-          c.requestedSpaceIds
-        )
+        createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, c.requestedSpaceIds, auth.getNonNullableWorkspace().id)
       )
     );
 
@@ -1265,10 +1262,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
     return auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(
-        spaceIdToGroupsMap,
-        conversation.requestedSpaceIds
-      )
+      createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, conversation.requestedSpaceIds, auth.getNonNullableWorkspace().id)
     );
   }
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -17,7 +17,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
-  createResourcePermissionsFromSpacesWithMap,
+  createAccessControlListFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -1146,8 +1146,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
     const spaceBasedAccessible = validConversations.filter((c) =>
-      auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
+      auth.hasPermissionForAcls(
+        "read",
+        createAccessControlListFromSpacesWithMap(
           spaceIdToGroupsMap,
           c.requestedSpaceIds,
           auth.getNonNullableWorkspace().id
@@ -1265,8 +1266,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
-    return auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(
+    return auth.hasPermissionForAcls(
+      "read",
+      createAccessControlListFromSpacesWithMap(
         spaceIdToGroupsMap,
         conversation.requestedSpaceIds,
         auth.getNonNullableWorkspace().id

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1147,7 +1147,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const spaceBasedAccessible = validConversations.filter((c) =>
       auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, c.requestedSpaceIds, auth.getNonNullableWorkspace().id)
+        createResourcePermissionsFromSpacesWithMap(
+          spaceIdToGroupsMap,
+          c.requestedSpaceIds,
+          auth.getNonNullableWorkspace().id
+        )
       )
     );
 
@@ -1262,7 +1266,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
     return auth.canRead(
-      createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, conversation.requestedSpaceIds, auth.getNonNullableWorkspace().id)
+      createResourcePermissionsFromSpacesWithMap(
+        spaceIdToGroupsMap,
+        conversation.requestedSpaceIds,
+        auth.getNonNullableWorkspace().id
+      )
     );
   }
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -240,6 +240,24 @@ export interface GroupPermissionsJSON {
  * Holds only grants — it knows nothing about roles. Admin-by-default access is applied by the
  * Authenticator. Because we only load the caller's groups, this is caller-scoped: `forResource`
  * returns the caller's matching groups, which resources fold into an `AccessControlList`.
+ *
+ * Example — the grant rows of a caller belonging to groups 7 and 9:
+ *
+ *   | groupId | grantType | resourceType | resourceId |
+ *   | ------- | --------- | ------------ | ---------- |
+ *   | 7       | member    | space        | 12         |
+ *   | 9       | reader    | space        | 12         |
+ *   | 7       | create    | skill        | -1         |
+ *
+ * become (with read=1, write=2, admin=4, create=8):
+ *
+ *   {
+ *     space: { 12: { 7: 0b0011, 9: 0b0001 } },
+ *     skill: { -1: { 7: 0b1000 } },
+ *   }
+ *
+ * `member` expands to read + write via the registry, so group 7 holds mask 3 on space 12. The
+ * skill row is type-wide (-1), so it answers a "create" check on any skill.
  */
 export class GroupPermissions {
   private constructor(

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -15,6 +15,8 @@ import {
   isConcreteResourceType,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
+import type { GroupGrant } from "@app/types/resource_permissions";
+import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
 /**
@@ -216,63 +218,52 @@ function maskToVerbs(mask: number): GrantVerb[] {
 // full resource and to keep the reference type-only.
 type GrantRow = Pick<
   GroupPermissionResource,
-  "grantType" | "resourceType" | "resourceId"
+  "groupId" | "grantType" | "resourceType" | "resourceId"
 >;
 
-// JSON-serializable form of a PermissionSet, embedded in a serialized Authenticator so it can be
-// restored without re-querying `group_permissions`. Preserves the raw bitmask map exactly.
-export interface PermissionSetJSON {
-  // resourceType -> resourceId -> verb bitmask. resourceId keys become strings after a JSON
-  // round-trip; `fromJSON` coerces them back to numbers.
-  grants: Partial<Record<ConcreteResourceType, Record<number, number>>>;
+// JSON-serializable form of GroupPermissions, embedded in a serialized Authenticator so it can be
+// restored without re-querying `group_permissions`. resourceType -> resourceId -> groupId -> verb
+// bitmask (numeric keys become strings after a JSON round-trip; `fromJSON` coerces them back).
+export interface GroupPermissionsJSON {
+  grants: Partial<
+    Record<ConcreteResourceType, Record<number, Record<number, number>>>
+  >;
 }
 
 /**
- * The governance grants a caller holds, resolved once at auth construction. Grants are keyed by
- * (resourceType, resourceId): resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities
- * (e.g. "create" on "agent") or a resource's model id for instance grants (e.g. "write" on a
- * specific space). A type-wide grant satisfies an instance check on any id of that type.
+ * The governance grants the *caller* holds, resolved once at auth construction and kept group-
+ * granular. Keyed by (resourceType, resourceId, groupId) -> verb bitmask: resourceId is
+ * WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities (e.g. "create" on "agent") or a resource's
+ * model id for instance grants. A type-wide grant satisfies an instance check on any id of that
+ * type.
  *
- * This holds only the caller's grants — it knows nothing about roles. Admin-by-default access to
- * workspace-wide capabilities is applied by the Authenticator (see `hasWorkspacePermission`), not
- * here.
+ * Holds only grants — it knows nothing about roles. Admin-by-default access is applied by the
+ * Authenticator. Because we only load the caller's groups, this is caller-scoped: `forResource`
+ * returns the caller's matching groups, which resources fold into an `AccessControlList`.
  */
-export class PermissionSet {
+export class GroupPermissions {
   private constructor(
-    // resourceType -> resourceId -> verb bitmask. resourceId WHOLE_TYPE_RESOURCE_ID (-1) is the
-    // type-wide entry. Values are bitmasks (see VERB_BIT), not Sets, to keep the footprint small.
-    private readonly grants: Map<ConcreteResourceType, Map<number, number>>
+    // resourceType -> resourceId -> groupId -> verb bitmask (see VERB_BIT). resourceId
+    // WHOLE_TYPE_RESOURCE_ID (-1) is the type-wide entry.
+    private readonly grants: Map<
+      ConcreteResourceType,
+      Map<number, Map<ModelId, number>>
+    >
   ) {}
 
-  static empty(): PermissionSet {
-    return new PermissionSet(new Map());
+  static empty(): GroupPermissions {
+    return new GroupPermissions(new Map());
   }
 
-  // Rebuilds a set from its serialized form (see toJSON) — no DB access.
-  static fromJSON(json: PermissionSetJSON): PermissionSet {
-    const map = new Map<ConcreteResourceType, Map<number, number>>();
-    for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
-      if (!isConcreteResourceType(resourceType)) {
-        continue;
-      }
-      const record = json.grants[resourceType];
-      if (!record) {
-        continue;
-      }
-      const byId = new Map<number, number>();
-      for (const [resourceId, mask] of Object.entries(record)) {
-        byId.set(Number(resourceId), mask);
-      }
-      map.set(resourceType, byId);
-    }
-    return new PermissionSet(map);
-  }
-
-  static fromGrants(grants: readonly GrantRow[]): PermissionSet {
-    const map = new Map<ConcreteResourceType, Map<number, number>>();
+  static fromGrants(grants: readonly GrantRow[]): GroupPermissions {
+    const map = new Map<
+      ConcreteResourceType,
+      Map<number, Map<ModelId, number>>
+    >();
     const add = (
       resourceType: ConcreteResourceType,
       resourceId: number,
+      groupId: ModelId,
       mask: number
     ) => {
       if (mask === 0) {
@@ -283,10 +274,15 @@ export class PermissionSet {
         byId = new Map();
         map.set(resourceType, byId);
       }
-      byId.set(resourceId, (byId.get(resourceId) ?? 0) | mask);
+      let byGroup = byId.get(resourceId);
+      if (!byGroup) {
+        byGroup = new Map();
+        byId.set(resourceId, byGroup);
+      }
+      byGroup.set(groupId, (byGroup.get(groupId) ?? 0) | mask);
     };
 
-    for (const { grantType, resourceType, resourceId } of grants) {
+    for (const { groupId, grantType, resourceType, resourceId } of grants) {
       // A "*" grant / -1 resourceId are always type-wide; concrete ids are instance-level.
       const level: GrantLevel =
         resourceId === WHOLE_TYPE_RESOURCE_ID ? "type" : "instance";
@@ -304,73 +300,122 @@ export class PermissionSet {
           grantType === "*"
             ? allVerbsForResourceAtLevel(rt, level)
             : verbsForGrantAtLevel(grantType, rt, level);
-        add(rt, resourceId, verbsToMask(verbs));
+        add(rt, resourceId, groupId, verbsToMask(verbs));
       }
     }
 
-    return new PermissionSet(map);
+    return new GroupPermissions(map);
   }
 
-  // Whether the caller holds `verb` on the given resource instance. A type-wide (-1) grant on the
-  // resource type satisfies the check for any instance.
-  has(
+  // Rebuilds from the serialized form (see toJSON) — no DB access.
+  static fromJSON(json: GroupPermissionsJSON): GroupPermissions {
+    const map = new Map<
+      ConcreteResourceType,
+      Map<number, Map<ModelId, number>>
+    >();
+    for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
+      if (!isConcreteResourceType(resourceType)) {
+        continue;
+      }
+      const byIdRecord = json.grants[resourceType];
+      if (!byIdRecord) {
+        continue;
+      }
+      const byId = new Map<number, Map<ModelId, number>>();
+      for (const [resourceId, byGroupRecord] of Object.entries(byIdRecord)) {
+        const byGroup = new Map<ModelId, number>();
+        for (const [groupId, mask] of Object.entries(byGroupRecord)) {
+          byGroup.set(Number(groupId), mask);
+        }
+        byId.set(Number(resourceId), byGroup);
+      }
+      map.set(resourceType, byId);
+    }
+    return new GroupPermissions(map);
+  }
+
+  // The caller's groups' grants on (resourceType, resourceId), folding in the type-wide (-1) grants
+  // so a workspace-wide grant satisfies an instance lookup. Caller-scoped: only groups the caller
+  // belongs to appear (that is all we load).
+  forResource(
     resourceType: ConcreteResourceType,
-    resourceId: number,
-    verb: GrantVerb
-  ): boolean {
+    resourceId: number
+  ): GroupGrant[] {
     const byId = this.grants.get(resourceType);
     if (!byId) {
-      return false;
+      return [];
     }
-    const bit = VERB_BIT.get(verb) ?? 0;
-    return (
-      ((byId.get(resourceId) ?? 0) & bit) !== 0 ||
-      ((byId.get(WHOLE_TYPE_RESOURCE_ID) ?? 0) & bit) !== 0
-    );
-  }
-
-  // Serializes the full grant map (bitmasks intact) for embedding in a serialized Authenticator,
-  // so `fromJSON` can restore it without hitting the DB. Round-trips exactly.
-  toJSON(): PermissionSetJSON {
-    const grants: Partial<
-      Record<ConcreteResourceType, Record<number, number>>
-    > = {};
-    for (const [resourceType, byId] of this.grants) {
-      const record: Record<number, number> = {};
-      for (const [resourceId, mask] of byId) {
-        record[resourceId] = mask;
+    const merged = new Map<ModelId, number>();
+    for (const key of new Set([resourceId, WHOLE_TYPE_RESOURCE_ID])) {
+      const byGroup = byId.get(key);
+      if (!byGroup) {
+        continue;
       }
-      grants[resourceType] = record;
+      for (const [groupId, mask] of byGroup) {
+        merged.set(groupId, (merged.get(groupId) ?? 0) | mask);
+      }
     }
-    return { grants };
+    return [...merged].map(([id, mask]) => ({
+      id,
+      permissions: maskToVerbs(mask),
+    }));
   }
 
-  // The type-wide (-1) capabilities the caller's grants confer, as the flat per-resource-type record
-  // consumed by the auth context and the Workspace & Governance page. This reflects grants only;
-  // admin-by-default access is layered on by the Authenticator (see `getWorkspacePermissions`).
-  toTypeWideWorkspacePermissions(): WorkspacePermissions {
+  // The type-wide (-1) verbs the caller's grants confer per resource type — the flat record for the
+  // auth context / Workspace & Governance page. Grants only; admin-by-default is layered on by the
+  // Authenticator (see `getWorkspacePermissions`).
+  toWorkspacePermissions(): WorkspacePermissions {
     const result = emptyWorkspacePermissions();
-
     for (const [resourceType, byId] of this.grants) {
-      const typeWideMask = byId.get(WHOLE_TYPE_RESOURCE_ID);
-      if (typeWideMask) {
-        result[resourceType] = maskToVerbs(typeWideMask);
+      const byGroup = byId.get(WHOLE_TYPE_RESOURCE_ID);
+      if (!byGroup) {
+        continue;
+      }
+      let mask = 0;
+      for (const groupMask of byGroup.values()) {
+        mask |= groupMask;
+      }
+      if (mask) {
+        result[resourceType] = maskToVerbs(mask);
       }
     }
     return result;
   }
 
-  // Human-readable dump for debugging: decodes every bitmask back to verbs. resourceId -1 is
-  // rendered as "*" (type-wide). Not for production paths — inspection only.
+  // Serializes the group-granular grant map for embedding in a serialized Authenticator, so
+  // `fromJSON` can restore it without hitting the DB. Round-trips exactly.
+  toJSON(): GroupPermissionsJSON {
+    const grants: Partial<
+      Record<ConcreteResourceType, Record<number, Record<number, number>>>
+    > = {};
+    for (const [resourceType, byId] of this.grants) {
+      const byIdRecord: Record<number, Record<number, number>> = {};
+      for (const [resourceId, byGroup] of byId) {
+        const byGroupRecord: Record<number, number> = {};
+        for (const [groupId, mask] of byGroup) {
+          byGroupRecord[groupId] = mask;
+        }
+        byIdRecord[resourceId] = byGroupRecord;
+      }
+      grants[resourceType] = byIdRecord;
+    }
+    return { grants };
+  }
+
+  // Human-readable dump for debugging: decodes bitmasks to verbs. resourceId -1 renders as "*"
+  // (type-wide). Not for production paths — inspection only.
   toString(): string {
     const parts: string[] = [];
     for (const [resourceType, byId] of this.grants) {
-      const entries = [...byId.entries()].map(([resourceId, mask]) => {
+      const entries = [...byId.entries()].flatMap(([resourceId, byGroup]) => {
         const id = resourceId === WHOLE_TYPE_RESOURCE_ID ? "*" : resourceId;
-        return `${id}: [${maskToVerbs(mask).join(", ")}]`;
+        return [...byGroup.entries()].map(
+          ([groupId, mask]) =>
+            `${id}/group:${groupId}: [${maskToVerbs(mask).join(", ")}]`
+        );
       });
       parts.push(`${resourceType}: { ${entries.join(", ")} }`);
     }
-    return `PermissionSet { ${parts.join("; ")} }`;
+    return `GroupPermissions { ${parts.join("; ")} }`;
   }
 }

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -329,10 +329,6 @@ export class PermissionSet {
     );
   }
 
-  hasTypeWide(resourceType: ConcreteResourceType, verb: GrantVerb): boolean {
-    return this.has(resourceType, WHOLE_TYPE_RESOURCE_ID, verb);
-  }
-
   // Serializes the full grant map (bitmasks intact) for embedding in a serialized Authenticator,
   // so `fromJSON` can restore it without hitting the DB. Round-trips exactly.
   toJSON(): PermissionSetJSON {

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -222,7 +222,6 @@ type GrantRow = Pick<
 // JSON-serializable form of a PermissionSet, embedded in a serialized Authenticator so it can be
 // restored without re-querying `group_permissions`. Preserves the raw bitmask map exactly.
 export interface PermissionSetJSON {
-  isAdminAll: boolean;
   // resourceType -> resourceId -> verb bitmask. resourceId keys become strings after a JSON
   // round-trip; `fromJSON` coerces them back to numbers.
   grants: Partial<Record<ConcreteResourceType, Record<number, number>>>;
@@ -233,22 +232,20 @@ export interface PermissionSetJSON {
  * (resourceType, resourceId): resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities
  * (e.g. "create" on "agent") or a resource's model id for instance grants (e.g. "write" on a
  * specific space). A type-wide grant satisfies an instance check on any id of that type.
+ *
+ * This holds only the caller's grants — it knows nothing about roles. Admin-by-default access to
+ * workspace-wide capabilities is applied by the Authenticator (see `hasWorkspacePermission`), not
+ * here.
  */
 export class PermissionSet {
   private constructor(
     // resourceType -> resourceId -> verb bitmask. resourceId WHOLE_TYPE_RESOURCE_ID (-1) is the
     // type-wide entry. Values are bitmasks (see VERB_BIT), not Sets, to keep the footprint small.
-    private readonly grants: Map<ConcreteResourceType, Map<number, number>>,
-    // Admins hold every capability on every resource/instance by default.
-    private readonly isAdminAll: boolean
+    private readonly grants: Map<ConcreteResourceType, Map<number, number>>
   ) {}
 
   static empty(): PermissionSet {
-    return new PermissionSet(new Map(), false);
-  }
-
-  static all(): PermissionSet {
-    return new PermissionSet(new Map(), true);
+    return new PermissionSet(new Map());
   }
 
   // Rebuilds a set from its serialized form (see toJSON) — no DB access.
@@ -268,7 +265,7 @@ export class PermissionSet {
       }
       map.set(resourceType, byId);
     }
-    return new PermissionSet(map, json.isAdminAll);
+    return new PermissionSet(map);
   }
 
   static fromGrants(grants: readonly GrantRow[]): PermissionSet {
@@ -311,7 +308,7 @@ export class PermissionSet {
       }
     }
 
-    return new PermissionSet(map, false);
+    return new PermissionSet(map);
   }
 
   // Whether the caller holds `verb` on the given resource instance. A type-wide (-1) grant on the
@@ -321,11 +318,6 @@ export class PermissionSet {
     resourceId: number,
     verb: GrantVerb
   ): boolean {
-    // Admins hold every *type-wide* capability by default, but not implicit *instance* grants
-    // (e.g. write on a specific restricted space) — instance access stays role/group-based.
-    if (this.isAdminAll) {
-      return resourceId === WHOLE_TYPE_RESOURCE_ID;
-    }
     const byId = this.grants.get(resourceType);
     if (!byId) {
       return false;
@@ -342,7 +334,7 @@ export class PermissionSet {
   }
 
   // Serializes the full grant map (bitmasks intact) for embedding in a serialized Authenticator,
-  // so `fromJSON` can restore it without hitting the DB. Round-trips exactly (incl. the admin flag).
+  // so `fromJSON` can restore it without hitting the DB. Round-trips exactly.
   toJSON(): PermissionSetJSON {
     const grants: Partial<
       Record<ConcreteResourceType, Record<number, number>>
@@ -354,26 +346,14 @@ export class PermissionSet {
       }
       grants[resourceType] = record;
     }
-    return { isAdminAll: this.isAdminAll, grants };
+    return { grants };
   }
 
-  // The type-wide (-1) capabilities the caller holds, as the flat per-resource-type record consumed
-  // by the auth context and the Workspace & Governance page. Admins, who hold everything
-  // implicitly, are materialized as every type-level verb on every resource type.
+  // The type-wide (-1) capabilities the caller's grants confer, as the flat per-resource-type record
+  // consumed by the auth context and the Workspace & Governance page. This reflects grants only;
+  // admin-by-default access is layered on by the Authenticator (see `getWorkspacePermissions`).
   toTypeWideWorkspacePermissions(): WorkspacePermissions {
     const result = emptyWorkspacePermissions();
-
-    if (this.isAdminAll) {
-      for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
-        if (isConcreteResourceType(resourceType)) {
-          result[resourceType] = allVerbsForResourceAtLevel(
-            resourceType,
-            "type"
-          );
-        }
-      }
-      return result;
-    }
 
     for (const [resourceType, byId] of this.grants) {
       const typeWideMask = byId.get(WHOLE_TYPE_RESOURCE_ID);
@@ -387,9 +367,6 @@ export class PermissionSet {
   // Human-readable dump for debugging: decodes every bitmask back to verbs. resourceId -1 is
   // rendered as "*" (type-wide). Not for production paths — inspection only.
   toString(): string {
-    if (this.isAdminAll) {
-      return "PermissionSet(admin: all)";
-    }
     const parts: string[] = [];
     for (const [resourceType, byId] of this.grants) {
       const entries = [...byId.entries()].map(([resourceId, mask]) => {

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -1,5 +1,7 @@
+// Type-only import (erased at runtime) so the registry can name the resource shape `fromGrants`
+// consumes without a runtime cycle — `group_permission_resource` value-imports this module.
+import type { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import type {
-  CapabilitySpec,
   ConcreteResourceType,
   GrantType,
   GrantVerb,
@@ -8,6 +10,7 @@ import type {
 } from "@app/types/group_permissions";
 import {
   emptyWorkspacePermissions,
+  GRANT_VERBS,
   GROUP_PERMISSION_RESOURCE_TYPES,
   isConcreteResourceType,
   WHOLE_TYPE_RESOURCE_ID,
@@ -145,24 +148,28 @@ export function grantTypesForVerb(
   });
 }
 
-function typeLevelVerbsForGrant(
+// Verbs a grant type confers at `level`; empty when the role is not valid at that level, or the
+// resource type is unknown (e.g. a stale grant row for a removed type).
+function verbsForGrantAtLevel(
   grantType: ConcreteGrantType,
-  resourceType: ConcreteResourceType
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
 ): GrantVerb[] {
   const role = ROLE_REGISTRY[resourceType]?.[grantType];
-  if (!role || !role.levels.includes("type")) {
+  if (!role || !role.levels.includes(level)) {
     return [];
   }
   return role.verbs;
 }
 
-function allTypeLevelVerbsForResource(
-  resourceType: ConcreteResourceType
+// Every verb valid at `level` on `resourceType` — used to expand a "*" grant.
+function allVerbsForResourceAtLevel(
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
 ): GrantVerb[] {
   const verbs = new Set<GrantVerb>();
-  const roles = Object.values(ROLE_REGISTRY[resourceType]);
-  for (const role of roles) {
-    if (role.levels.includes("type")) {
+  for (const role of Object.values(ROLE_REGISTRY[resourceType] ?? {})) {
+    if (role.levels.includes(level)) {
       for (const verb of role.verbs) {
         verbs.add(verb);
       }
@@ -175,55 +182,222 @@ function allTypeLevelVerbsForResource(
 export function allWorkspacePermissions(): WorkspacePermissions {
   const permissions = emptyWorkspacePermissions();
   for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
-    if (!isConcreteResourceType(resourceType)) {
-      continue;
+    if (isConcreteResourceType(resourceType)) {
+      permissions[resourceType] = allVerbsForResourceAtLevel(
+        resourceType,
+        "type"
+      );
     }
-    permissions[resourceType] = allTypeLevelVerbsForResource(resourceType);
   }
   return permissions;
 }
 
-// The workspace-level verbs a caller's type-wide (-1) grants confer, grouped by resource type. A
-// "*" grantType fans out to every type-level verb of the resource; a "*" resourceType fans out to
-// every concrete resource type.
-export function workspacePermissionsFromGrants(
-  grants: CapabilitySpec[]
-): WorkspacePermissions {
-  const verbsByResource: Record<ConcreteResourceType, Set<GrantVerb>> = {
-    space: new Set(),
-    agent: new Set(),
-    skill: new Set(),
-    frame: new Set(),
-    billing: new Set(),
-    security: new Set(),
-    models_tier: new Set(),
-    dust_app: new Set(),
-  };
+// The held verb set for a (resourceType, resourceId) is stored as a bitmask integer rather than a
+// `Set<GrantVerb>`, to keep the per-request footprint small — one primitive per entry instead of a
+// heap Set. There are <10 verbs, so a single bit each fits comfortably in an int.
+const VERB_BIT = new Map<GrantVerb, number>(
+  GRANT_VERBS.map((verb, index): [GrantVerb, number] => [verb, 1 << index])
+);
 
-  for (const { grantType, resourceType } of grants) {
-    const resources =
-      resourceType === "*"
-        ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)
-        : [resourceType];
+function verbsToMask(verbs: GrantVerb[]): number {
+  let mask = 0;
+  for (const verb of verbs) {
+    mask |= VERB_BIT.get(verb) ?? 0;
+  }
+  return mask;
+}
 
-    for (const resource of resources) {
-      if (!ROLE_REGISTRY[resource]) {
+function maskToVerbs(mask: number): GrantVerb[] {
+  return GRANT_VERBS.filter((verb) => (mask & (VERB_BIT.get(verb) ?? 0)) !== 0);
+}
+
+// The grant fields `fromGrants` reads. `GroupPermissionResource` satisfies this structurally, so
+// callers pass resources directly (no DTO conversion); typed as a Pick to avoid coupling to the
+// full resource and to keep the reference type-only.
+type GrantRow = Pick<
+  GroupPermissionResource,
+  "grantType" | "resourceType" | "resourceId"
+>;
+
+// JSON-serializable form of a PermissionSet, embedded in a serialized Authenticator so it can be
+// restored without re-querying `group_permissions`. Preserves the raw bitmask map exactly.
+export interface PermissionSetJSON {
+  isAdminAll: boolean;
+  // resourceType -> resourceId -> verb bitmask. resourceId keys become strings after a JSON
+  // round-trip; `fromJSON` coerces them back to numbers.
+  grants: Partial<Record<ConcreteResourceType, Record<number, number>>>;
+}
+
+/**
+ * The governance grants a caller holds, resolved once at auth construction. Grants are keyed by
+ * (resourceType, resourceId): resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities
+ * (e.g. "create" on "agent") or a resource's model id for instance grants (e.g. "write" on a
+ * specific space). A type-wide grant satisfies an instance check on any id of that type.
+ */
+export class PermissionSet {
+  private constructor(
+    // resourceType -> resourceId -> verb bitmask. resourceId WHOLE_TYPE_RESOURCE_ID (-1) is the
+    // type-wide entry. Values are bitmasks (see VERB_BIT), not Sets, to keep the footprint small.
+    private readonly grants: Map<ConcreteResourceType, Map<number, number>>,
+    // Admins hold every capability on every resource/instance by default.
+    private readonly isAdminAll: boolean
+  ) {}
+
+  static empty(): PermissionSet {
+    return new PermissionSet(new Map(), false);
+  }
+
+  static all(): PermissionSet {
+    return new PermissionSet(new Map(), true);
+  }
+
+  // Rebuilds a set from its serialized form (see toJSON) — no DB access.
+  static fromJSON(json: PermissionSetJSON): PermissionSet {
+    const map = new Map<ConcreteResourceType, Map<number, number>>();
+    for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
+      if (!isConcreteResourceType(resourceType)) {
         continue;
       }
-
-      const verbs =
-        grantType === "*"
-          ? allTypeLevelVerbsForResource(resource)
-          : typeLevelVerbsForGrant(grantType, resource);
-      verbs.forEach((verb) => verbsByResource[resource].add(verb));
+      const record = json.grants[resourceType];
+      if (!record) {
+        continue;
+      }
+      const byId = new Map<number, number>();
+      for (const [resourceId, mask] of Object.entries(record)) {
+        byId.set(Number(resourceId), mask);
+      }
+      map.set(resourceType, byId);
     }
+    return new PermissionSet(map, json.isAdminAll);
   }
 
-  const permissions = emptyWorkspacePermissions();
-  for (const resource of GROUP_PERMISSION_RESOURCE_TYPES.filter(
-    isConcreteResourceType
-  )) {
-    permissions[resource] = [...verbsByResource[resource]];
+  static fromGrants(grants: readonly GrantRow[]): PermissionSet {
+    const map = new Map<ConcreteResourceType, Map<number, number>>();
+    const add = (
+      resourceType: ConcreteResourceType,
+      resourceId: number,
+      mask: number
+    ) => {
+      if (mask === 0) {
+        return;
+      }
+      let byId = map.get(resourceType);
+      if (!byId) {
+        byId = new Map();
+        map.set(resourceType, byId);
+      }
+      byId.set(resourceId, (byId.get(resourceId) ?? 0) | mask);
+    };
+
+    for (const { grantType, resourceType, resourceId } of grants) {
+      // A "*" grant / -1 resourceId are always type-wide; concrete ids are instance-level.
+      const level: GrantLevel =
+        resourceId === WHOLE_TYPE_RESOURCE_ID ? "type" : "instance";
+      const resourceTypes =
+        resourceType === "*"
+          ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)
+          : [resourceType];
+
+      for (const rt of resourceTypes) {
+        // Skip stale grant rows for resource types no longer in the registry.
+        if (!isConcreteResourceType(rt) || !ROLE_REGISTRY[rt]) {
+          continue;
+        }
+        const verbs =
+          grantType === "*"
+            ? allVerbsForResourceAtLevel(rt, level)
+            : verbsForGrantAtLevel(grantType, rt, level);
+        add(rt, resourceId, verbsToMask(verbs));
+      }
+    }
+
+    return new PermissionSet(map, false);
   }
-  return permissions;
+
+  // Whether the caller holds `verb` on the given resource instance. A type-wide (-1) grant on the
+  // resource type satisfies the check for any instance.
+  has(
+    resourceType: ConcreteResourceType,
+    resourceId: number,
+    verb: GrantVerb
+  ): boolean {
+    // Admins hold every *type-wide* capability by default, but not implicit *instance* grants
+    // (e.g. write on a specific restricted space) — instance access stays role/group-based.
+    if (this.isAdminAll) {
+      return resourceId === WHOLE_TYPE_RESOURCE_ID;
+    }
+    const byId = this.grants.get(resourceType);
+    if (!byId) {
+      return false;
+    }
+    const bit = VERB_BIT.get(verb) ?? 0;
+    return (
+      ((byId.get(resourceId) ?? 0) & bit) !== 0 ||
+      ((byId.get(WHOLE_TYPE_RESOURCE_ID) ?? 0) & bit) !== 0
+    );
+  }
+
+  hasTypeWide(resourceType: ConcreteResourceType, verb: GrantVerb): boolean {
+    return this.has(resourceType, WHOLE_TYPE_RESOURCE_ID, verb);
+  }
+
+  // Serializes the full grant map (bitmasks intact) for embedding in a serialized Authenticator,
+  // so `fromJSON` can restore it without hitting the DB. Round-trips exactly (incl. the admin flag).
+  toJSON(): PermissionSetJSON {
+    const grants: Partial<
+      Record<ConcreteResourceType, Record<number, number>>
+    > = {};
+    for (const [resourceType, byId] of this.grants) {
+      const record: Record<number, number> = {};
+      for (const [resourceId, mask] of byId) {
+        record[resourceId] = mask;
+      }
+      grants[resourceType] = record;
+    }
+    return { isAdminAll: this.isAdminAll, grants };
+  }
+
+  // The type-wide (-1) capabilities the caller holds, as the flat per-resource-type record consumed
+  // by the auth context and the Workspace & Governance page. Admins, who hold everything
+  // implicitly, are materialized as every type-level verb on every resource type.
+  toTypeWideWorkspacePermissions(): WorkspacePermissions {
+    const result = emptyWorkspacePermissions();
+
+    if (this.isAdminAll) {
+      for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
+        if (isConcreteResourceType(resourceType)) {
+          result[resourceType] = allVerbsForResourceAtLevel(
+            resourceType,
+            "type"
+          );
+        }
+      }
+      return result;
+    }
+
+    for (const [resourceType, byId] of this.grants) {
+      const typeWideMask = byId.get(WHOLE_TYPE_RESOURCE_ID);
+      if (typeWideMask) {
+        result[resourceType] = maskToVerbs(typeWideMask);
+      }
+    }
+    return result;
+  }
+
+  // Human-readable dump for debugging: decodes every bitmask back to verbs. resourceId -1 is
+  // rendered as "*" (type-wide). Not for production paths — inspection only.
+  toString(): string {
+    if (this.isAdminAll) {
+      return "PermissionSet(admin: all)";
+    }
+    const parts: string[] = [];
+    for (const [resourceType, byId] of this.grants) {
+      const entries = [...byId.entries()].map(([resourceId, mask]) => {
+        const id = resourceId === WHOLE_TYPE_RESOURCE_ID ? "*" : resourceId;
+        return `${id}: [${maskToVerbs(mask).join(", ")}]`;
+      });
+      parts.push(`${resourceType}: { ${entries.join(", ")} }`);
+    }
+    return `PermissionSet { ${parts.join("; ")} }`;
+  }
 }

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -31,9 +31,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("reader");
       expect(grants[0].resourceType).toBe("space");
@@ -50,9 +53,12 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.grant(auth, spec);
       await GroupPermissionResource.grant(auth, spec);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
     });
 
@@ -139,11 +145,14 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-        resourceType: "space",
-        resourceId: 1,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+          resourceType: "space",
+          resourceId: 1,
+        }
+      );
       expect(grants).toHaveLength(2);
       expect(new Set(grants.map((g) => g.groupId))).toEqual(
         new Set([groupA.id, groupB.id])
@@ -151,9 +160,12 @@ describe("GroupPermissionResource", () => {
     });
 
     it("returns [] for no groups without querying", async () => {
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [],
+        }
+      );
       expect(grants).toEqual([]);
     });
   });
@@ -180,9 +192,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("member");
     });
@@ -212,9 +227,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("admin");
     });
@@ -248,9 +266,12 @@ describe("GroupPermissionResource", () => {
       });
       expect(deleted).toBe(2);
 
-      const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const remaining = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(remaining).toHaveLength(1);
       expect(remaining[0].resourceId).toBe(100);
     });
@@ -282,9 +303,12 @@ describe("GroupPermissionResource", () => {
 
       await GroupPermissionResource.deleteAllForWorkspace(auth);
 
-      const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const remaining = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(remaining).toEqual([]);
     });
   });
@@ -302,9 +326,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "agent",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].resourceId).toBe(-1);
     });
@@ -331,9 +358,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "billing",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(0);
     });
   });
@@ -346,9 +376,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "skill",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(grants).toHaveLength(2);
       expect(grants.every((g) => g.resourceId === -1)).toBe(true);
     });
@@ -377,9 +410,12 @@ describe("GroupPermissionResource", () => {
         ],
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupB.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupB.id],
+        }
+      );
       expect(grants).toHaveLength(2);
     });
 
@@ -427,16 +463,19 @@ describe("GroupPermissionResource", () => {
       });
       expect(result.isOk()).toBe(true);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: (
-          await GroupResource.listAllWorkspaceGroups(auth, {
-            groupKinds: ["regular_auto"],
-          })
-        ).map((group) => group.id),
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 42,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: (
+            await GroupResource.listAllWorkspaceGroups(auth, {
+              groupKinds: ["regular_auto"],
+            })
+          ).map((group) => group.id),
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 42,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       const group = await GroupResource.fetchByModelIds(auth, [
@@ -460,16 +499,19 @@ describe("GroupPermissionResource", () => {
       const repeat = await GroupPermissionResource.grantToUser(auth, spec);
       expect(repeat.isOk()).toBe(true);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: (
-          await GroupResource.listAllWorkspaceGroups(auth, {
-            groupKinds: ["regular_auto"],
-          })
-        ).map((group) => group.id),
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 42,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: (
+            await GroupResource.listAllWorkspaceGroups(auth, {
+              groupKinds: ["regular_auto"],
+            })
+          ).map((group) => group.id),
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 42,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       const [backingGroup] = await GroupResource.fetchByModelIds(auth, [
@@ -502,12 +544,15 @@ describe("GroupPermissionResource", () => {
       });
       const grantGroups = [];
       for (const group of autoGroups) {
-        const grants = await GroupPermissionResource.listForGroups(auth, {
-          groupModelIds: [group.id],
-          grantType: "editor",
-          resourceType: "agent",
-          resourceId: 7,
-        });
+        const grants = await GroupPermissionResource.listForGroups(
+          auth.getNonNullableWorkspace(),
+          {
+            groupModelIds: [group.id],
+            grantType: "editor",
+            resourceType: "agent",
+            resourceId: 7,
+          }
+        );
         if (grants.length > 0) {
           grantGroups.push(group);
         }
@@ -539,12 +584,15 @@ describe("GroupPermissionResource", () => {
       const autoGroups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: ["regular_auto"],
       });
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: autoGroups.map((group) => group.id),
-        grantType: "editor",
-        resourceType: "skill",
-        resourceId: 99,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: autoGroups.map((group) => group.id),
+          grantType: "editor",
+          resourceType: "skill",
+          resourceId: 99,
+        }
+      );
       expect(grants).toHaveLength(0);
     });
 
@@ -575,16 +623,19 @@ describe("GroupPermissionResource", () => {
       });
       expect(result.isOk()).toBe(true);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: (
-          await GroupResource.listAllWorkspaceGroups(auth, {
-            groupKinds: ["regular_auto"],
-          })
-        ).map((group) => group.id),
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 5,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: (
+            await GroupResource.listAllWorkspaceGroups(auth, {
+              groupKinds: ["regular_auto"],
+            })
+          ).map((group) => group.id),
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 5,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       const [group] = await GroupResource.fetchByModelIds(auth, [
@@ -610,12 +661,15 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [globalGroup.id],
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 42,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [globalGroup.id],
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 42,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       await GroupPermissionResource.revokeFromEverybody(auth, {
@@ -624,12 +678,15 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
       expect(
-        await GroupPermissionResource.listForGroups(auth, {
-          groupModelIds: [globalGroup.id],
-          grantType: "reader",
-          resourceType: "space",
-          resourceId: 42,
-        })
+        await GroupPermissionResource.listForGroups(
+          auth.getNonNullableWorkspace(),
+          {
+            groupModelIds: [globalGroup.id],
+            grantType: "reader",
+            resourceType: "space",
+            resourceId: 42,
+          }
+        )
       ).toHaveLength(0);
     });
 

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -20,7 +20,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { UserType } from "@app/types/user";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -395,8 +395,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Read grants for the given groups, optionally narrowed by grant type / resource type /
   // resource. The (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
+  // Grants for the given groups in a workspace. Takes a LightWorkspaceType (not an Authenticator) so
+  // it can resolve a caller's grant set before an Authenticator exists (see
+  // `Authenticator.resolvePermissions`). Omit the filters to load every grant.
   static async listForGroups(
-    auth: Authenticator,
+    workspace: LightWorkspaceType,
     { groupModelIds, grantType, resourceType, resourceId }: ListForGroupsSpec
   ): Promise<GroupPermissionResource[]> {
     if (groupModelIds.length === 0) {
@@ -405,7 +408,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
     const rows = await GroupPermissionModel.findAll({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspace.id,
         groupId: groupModelIds,
         ...(grantType !== undefined ? { grantType } : {}),
         ...(resourceType !== undefined ? { resourceType } : {}),

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2251,7 +2251,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     newName: string
   ): Promise<Result<undefined, Error>> {
-    if (!auth.canAdministrate(this.requestedPermissions())) {
+    if (!auth.canAdministrate(this.getAccessControlLists(auth))) {
       return new Err(new Error("Only admins can update group names."));
     }
 
@@ -2574,7 +2574,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * @returns Array of AccessControlList objects defining the default access
    * configuration
    */
-  requestedPermissions(): AccessControlList[] {
+  getAccessControlLists(auth: Authenticator): AccessControlList[] {
     if (this.kind === "agent_editors" || this.kind === "skill_editors") {
       return [
         {
@@ -2672,15 +2672,15 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   canRead(auth: Authenticator): boolean {
-    return auth.canRead(this.requestedPermissions());
+    return auth.canRead(this.getAccessControlLists(auth));
   }
 
   canWrite(auth: Authenticator): boolean {
-    return auth.canWrite(this.requestedPermissions());
+    return auth.canWrite(this.getAccessControlLists(auth));
   }
 
   canAdministrate(auth: Authenticator): boolean {
-    return auth.canAdministrate(this.requestedPermissions());
+    return auth.canAdministrate(this.getAccessControlLists(auth));
   }
 
   isSystem(): boolean {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -35,7 +35,7 @@ import {
   isRegularManualGroupKind,
   isSkillEditorGroupKind,
 } from "@app/types/groups";
-import type { AccessRule } from "@app/types/resource_permissions";
+import type { AccessControlList } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -2571,10 +2571,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * NOT inherited, i.e., if you set a permission for role "user", an "admin"
    * will NOT have it
    *
-   * @returns Array of AccessRule objects defining the default access
+   * @returns Array of AccessControlList objects defining the default access
    * configuration
    */
-  requestedPermissions(): AccessRule[] {
+  requestedPermissions(): AccessControlList[] {
     if (this.kind === "agent_editors" || this.kind === "skill_editors") {
       return [
         {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -35,7 +35,7 @@ import {
   isRegularManualGroupKind,
   isSkillEditorGroupKind,
 } from "@app/types/groups";
-import type { ResourcePermission } from "@app/types/resource_permissions";
+import type { AccessRule } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -2571,10 +2571,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * NOT inherited, i.e., if you set a permission for role "user", an "admin"
    * will NOT have it
    *
-   * @returns Array of ResourcePermission objects defining the default access
+   * @returns Array of AccessRule objects defining the default access
    * configuration
    */
-  requestedPermissions(): ResourcePermission[] {
+  requestedPermissions(): AccessRule[] {
     if (this.kind === "agent_editors" || this.kind === "skill_editors") {
       return [
         {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2251,7 +2251,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     newName: string
   ): Promise<Result<undefined, Error>> {
-    if (!auth.canAdministrate(this.getAccessControlLists(auth))) {
+    if (!auth.hasPermission("admin", this)) {
       return new Err(new Error("Only admins can update group names."));
     }
 
@@ -2672,15 +2672,15 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   canRead(auth: Authenticator): boolean {
-    return auth.canRead(this.getAccessControlLists(auth));
+    return auth.hasPermission("read", this);
   }
 
   canWrite(auth: Authenticator): boolean {
-    return auth.canWrite(this.getAccessControlLists(auth));
+    return auth.hasPermission("write", this);
   }
 
   canAdministrate(auth: Authenticator): boolean {
-    return auth.canAdministrate(this.getAccessControlLists(auth));
+    return auth.hasPermission("admin", this);
   }
 
   isSystem(): boolean {

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -6,8 +6,8 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  LegacyCombinedResourcePermissions,
-  LegacyGroupPermission,
+  InlineGroupGrant,
+  LegacyAccessRule,
 } from "@app/types/resource_permissions";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
@@ -164,15 +164,16 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyAccessRule[]> {
     if (this.space.isProject()) {
       // Only gets the editor groups correponding to the space management mode
       const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-      const editorGroupsPermissions: LegacyGroupPermission[] =
-        editorGroupSpaces.map((egs) => ({
+      const editorGroupsPermissions: InlineGroupGrant[] = editorGroupSpaces.map(
+        (egs) => ({
           id: egs.groupId,
           permissions: ["admin", "read", "write"],
-        }));
+        })
+      );
       return [
         {
           groups: editorGroupsPermissions,

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -6,7 +6,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  CombinedResourcePermissions,
+  LegacyCombinedResourcePermissions,
   LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -164,16 +164,15 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
     if (this.space.isProject()) {
       // Only gets the editor groups correponding to the space management mode
       const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-      const editorGroupsPermissions: LegacyGroupPermission[] = editorGroupSpaces.map(
-        (egs) => ({
+      const editorGroupsPermissions: LegacyGroupPermission[] =
+        editorGroupSpaces.map((egs) => ({
           id: egs.groupId,
           permissions: ["admin", "read", "write"],
-        })
-      );
+        }));
       return [
         {
           groups: editorGroupsPermissions,

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -148,7 +148,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       return false;
     }
     const acls = await this.getAccessControlLists(auth);
-    return auth.canWrite(acls);
+    return auth.hasPermissionForAcls("write", acls);
   }
 
   async canRemoveMember(
@@ -161,7 +161,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       return false;
     }
     const acls = await this.getAccessControlLists(auth);
-    return auth.canWrite(acls);
+    return auth.hasPermissionForAcls("write", acls);
   }
 
   async getAccessControlLists(

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -147,8 +147,8 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       // Editor group stays empty while admin-controlled.
       return false;
     }
-    const requestedPermissions = await this.requestedPermissions();
-    return auth.canWrite(requestedPermissions);
+    const acls = await this.getAccessControlLists(auth);
+    return auth.canWrite(acls);
   }
 
   async canRemoveMember(
@@ -160,11 +160,13 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     if (!skipCheckLastMember && editorsCount <= 1) {
       return false;
     }
-    const requestedPermissions = await this.requestedPermissions();
-    return auth.canWrite(requestedPermissions);
+    const acls = await this.getAccessControlLists(auth);
+    return auth.canWrite(acls);
   }
 
-  async requestedPermissions(): Promise<AccessControlList[]> {
+  async getAccessControlLists(
+    auth: Authenticator
+  ): Promise<AccessControlList[]> {
     if (this.space.isProject()) {
       // Only gets the editor groups correponding to the space management mode
       const editorGroupSpaces = await this.getEditorGroupSpaces(true);

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -7,7 +7,7 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
   CombinedResourcePermissions,
-  GroupPermission,
+  LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
@@ -168,7 +168,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     if (this.space.isProject()) {
       // Only gets the editor groups correponding to the space management mode
       const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-      const editorGroupsPermissions: GroupPermission[] = editorGroupSpaces.map(
+      const editorGroupsPermissions: LegacyGroupPermission[] = editorGroupSpaces.map(
         (egs) => ({
           id: egs.groupId,
           permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -6,8 +6,8 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  InlineGroupGrant,
-  LegacyAccessRule,
+  AccessControlList,
+  GroupGrant,
 } from "@app/types/resource_permissions";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
@@ -164,11 +164,11 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<LegacyAccessRule[]> {
+  async requestedPermissions(): Promise<AccessControlList[]> {
     if (this.space.isProject()) {
       // Only gets the editor groups correponding to the space management mode
       const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-      const editorGroupsPermissions: InlineGroupGrant[] = editorGroupSpaces.map(
+      const editorGroupsPermissions: GroupGrant[] = editorGroupSpaces.map(
         (egs) => ({
           id: egs.groupId,
           permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -9,7 +9,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { GroupKind } from "@app/types/groups";
 import type {
   CombinedResourcePermissions,
-  GroupPermission,
+  LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -214,7 +214,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       case "project": {
         // Only gets the editor groups correponding to the space management mode
         const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-        const editorGroupsPermissions: GroupPermission[] =
+        const editorGroupsPermissions: LegacyGroupPermission[] =
           editorGroupSpaces.map((egs) => ({
             id: egs.groupId,
             permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -142,7 +142,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       }
     }
     const acls = await this.getAccessControlLists(auth);
-    return auth.canWrite(acls);
+    return auth.hasPermissionForAcls("write", acls);
   }
 
   async canRemoveMember(
@@ -158,7 +158,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       }
     }
     const acls = await this.getAccessControlLists(auth);
-    return auth.canWrite(acls);
+    return auth.hasPermissionForAcls("write", acls);
   }
 
   async getAccessControlLists(

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -8,8 +8,8 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { GroupKind } from "@app/types/groups";
 import type {
-  InlineGroupGrant,
-  LegacyAccessRule,
+  AccessControlList,
+  GroupGrant,
 } from "@app/types/resource_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -161,7 +161,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<LegacyAccessRule[]> {
+  async requestedPermissions(): Promise<AccessControlList[]> {
     switch (this.space.kind) {
       case "system":
         return [
@@ -214,11 +214,12 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       case "project": {
         // Only gets the editor groups correponding to the space management mode
         const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-        const editorGroupsPermissions: InlineGroupGrant[] =
-          editorGroupSpaces.map((egs) => ({
+        const editorGroupsPermissions: GroupGrant[] = editorGroupSpaces.map(
+          (egs) => ({
             id: egs.groupId,
             permissions: ["admin", "read", "write"],
-          }));
+          })
+        );
         return [
           {
             groups: [

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -8,7 +8,7 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { GroupKind } from "@app/types/groups";
 import type {
-  CombinedResourcePermissions,
+  LegacyCombinedResourcePermissions,
   LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -161,7 +161,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
     switch (this.space.kind) {
       case "system":
         return [

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -141,8 +141,8 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
         return true;
       }
     }
-    const requestedPermissions = await this.requestedPermissions();
-    return auth.canWrite(requestedPermissions);
+    const acls = await this.getAccessControlLists(auth);
+    return auth.canWrite(acls);
   }
 
   async canRemoveMember(
@@ -157,11 +157,13 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
         return true;
       }
     }
-    const requestedPermissions = await this.requestedPermissions();
-    return auth.canWrite(requestedPermissions);
+    const acls = await this.getAccessControlLists(auth);
+    return auth.canWrite(acls);
   }
 
-  async requestedPermissions(): Promise<AccessControlList[]> {
+  async getAccessControlLists(
+    auth: Authenticator
+  ): Promise<AccessControlList[]> {
     switch (this.space.kind) {
       case "system":
         return [

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -8,8 +8,8 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { GroupKind } from "@app/types/groups";
 import type {
-  LegacyCombinedResourcePermissions,
-  LegacyGroupPermission,
+  InlineGroupGrant,
+  LegacyAccessRule,
 } from "@app/types/resource_permissions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -161,7 +161,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyAccessRule[]> {
     switch (this.space.kind) {
       case "system":
         return [
@@ -214,7 +214,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       case "project": {
         // Only gets the editor groups correponding to the space management mode
         const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-        const editorGroupsPermissions: LegacyGroupPermission[] =
+        const editorGroupsPermissions: InlineGroupGrant[] =
           editorGroupSpaces.map((egs) => ({
             id: egs.groupId,
             permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -7,7 +7,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { LegacyCombinedResourcePermissions } from "@app/types/resource_permissions";
+import type { LegacyAccessRule } from "@app/types/resource_permissions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
@@ -31,7 +31,7 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     super(GroupSpaceModel, blob);
   }
 
-  abstract requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]>;
+  abstract requestedPermissions(): Promise<LegacyAccessRule[]>;
   abstract canAddMember(auth: Authenticator, userId: string): Promise<boolean>;
   abstract canRemoveMember(
     auth: Authenticator,

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -7,7 +7,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { CombinedResourcePermissions } from "@app/types/resource_permissions";
+import type { LegacyCombinedResourcePermissions } from "@app/types/resource_permissions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
@@ -31,7 +31,7 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     super(GroupSpaceModel, blob);
   }
 
-  abstract requestedPermissions(): Promise<CombinedResourcePermissions[]>;
+  abstract requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]>;
   abstract canAddMember(auth: Authenticator, userId: string): Promise<boolean>;
   abstract canRemoveMember(
     auth: Authenticator,

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -31,7 +31,9 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     super(GroupSpaceModel, blob);
   }
 
-  abstract requestedPermissions(): Promise<AccessControlList[]>;
+  abstract getAccessControlLists(
+    auth: Authenticator
+  ): Promise<AccessControlList[]>;
   abstract canAddMember(auth: Authenticator, userId: string): Promise<boolean>;
   abstract canRemoveMember(
     auth: Authenticator,

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -7,7 +7,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { LegacyAccessRule } from "@app/types/resource_permissions";
+import type { AccessControlList } from "@app/types/resource_permissions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
@@ -31,7 +31,7 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     super(GroupSpaceModel, blob);
   }
 
-  abstract requestedPermissions(): Promise<LegacyAccessRule[]>;
+  abstract requestedPermissions(): Promise<AccessControlList[]>;
   abstract canAddMember(auth: Authenticator, userId: string): Promise<boolean>;
   abstract canRemoveMember(
     auth: Authenticator,

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -8,7 +8,7 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
   CombinedResourcePermissions,
-  GroupPermission,
+  LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
@@ -148,7 +148,7 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     );
     // Only gets the editor groups correponding to the space management mode
     const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-    const editorGroupsPermissions: GroupPermission[] = editorGroupSpaces.map(
+    const editorGroupsPermissions: LegacyGroupPermission[] = editorGroupSpaces.map(
       (egs) => ({
         id: egs.groupId,
         permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -7,8 +7,8 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  InlineGroupGrant,
-  LegacyAccessRule,
+  AccessControlList,
+  GroupGrant,
 } from "@app/types/resource_permissions";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
@@ -141,14 +141,14 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     return false;
   }
 
-  async requestedPermissions(): Promise<LegacyAccessRule[]> {
+  async requestedPermissions(): Promise<AccessControlList[]> {
     assert(
       this.space.isProject(),
       "Viewer permissions only apply to project spaces"
     );
     // Only gets the editor groups correponding to the space management mode
     const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-    const editorGroupsPermissions: InlineGroupGrant[] = editorGroupSpaces.map(
+    const editorGroupsPermissions: GroupGrant[] = editorGroupSpaces.map(
       (egs) => ({
         id: egs.groupId,
         permissions: ["admin", "read", "write"],

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -141,7 +141,9 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     return false;
   }
 
-  async requestedPermissions(): Promise<AccessControlList[]> {
+  async getAccessControlLists(
+    auth: Authenticator
+  ): Promise<AccessControlList[]> {
     assert(
       this.space.isProject(),
       "Viewer permissions only apply to project spaces"

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -7,7 +7,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  CombinedResourcePermissions,
+  LegacyCombinedResourcePermissions,
   LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import assert from "assert";
@@ -141,19 +141,18 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     return false;
   }
 
-  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
     assert(
       this.space.isProject(),
       "Viewer permissions only apply to project spaces"
     );
     // Only gets the editor groups correponding to the space management mode
     const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-    const editorGroupsPermissions: LegacyGroupPermission[] = editorGroupSpaces.map(
-      (egs) => ({
+    const editorGroupsPermissions: LegacyGroupPermission[] =
+      editorGroupSpaces.map((egs) => ({
         id: egs.groupId,
         permissions: ["admin", "read", "write"],
-      })
-    );
+      }));
     return [
       {
         groups: [

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -7,8 +7,8 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type {
-  LegacyCombinedResourcePermissions,
-  LegacyGroupPermission,
+  InlineGroupGrant,
+  LegacyAccessRule,
 } from "@app/types/resource_permissions";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
@@ -141,18 +141,19 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     return false;
   }
 
-  async requestedPermissions(): Promise<LegacyCombinedResourcePermissions[]> {
+  async requestedPermissions(): Promise<LegacyAccessRule[]> {
     assert(
       this.space.isProject(),
       "Viewer permissions only apply to project spaces"
     );
     // Only gets the editor groups correponding to the space management mode
     const editorGroupSpaces = await this.getEditorGroupSpaces(true);
-    const editorGroupsPermissions: LegacyGroupPermission[] =
-      editorGroupSpaces.map((egs) => ({
+    const editorGroupsPermissions: InlineGroupGrant[] = editorGroupSpaces.map(
+      (egs) => ({
         id: egs.groupId,
         permissions: ["admin", "read", "write"],
-      }));
+      })
+    );
     return [
       {
         groups: [

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -177,11 +177,14 @@ export class ModelsTierResource {
       return [];
     }
 
-    const grants = await GroupPermissionResource.listForGroups(auth, {
-      groupModelIds: [globalGroup.id],
-      grantType: MODELS_TIER_GRANT_TYPE,
-      resourceType: MODELS_TIER_RESOURCE_TYPE,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      auth.getNonNullableWorkspace(),
+      {
+        groupModelIds: [globalGroup.id],
+        grantType: MODELS_TIER_GRANT_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+      }
+    );
 
     return grants.flatMap((grant) => {
       const tierName = this.tierNameFromResourceId(grant.resourceId);
@@ -622,11 +625,14 @@ export class ModelsTierResource {
       return new Map();
     }
 
-    const grants = await GroupPermissionResource.listForGroups(auth, {
-      groupModelIds,
-      grantType: MODELS_TIER_GRANT_TYPE,
-      resourceType: MODELS_TIER_RESOURCE_TYPE,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      auth.getNonNullableWorkspace(),
+      {
+        groupModelIds,
+        grantType: MODELS_TIER_GRANT_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+      }
+    );
 
     const tiersByGroupId = new Map<ModelId, ModelsTierName[]>();
     for (const grant of grants) {

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -21,9 +21,9 @@ export function createSpaceIdToGroupsMap(
   const spaceIdToGroupsMap = new Map<ModelId, string[]>();
 
   for (const space of allFetchedSpaces) {
-    // Use `requestedPermissions` to get up-to-date permission groups (this includes provisioned groups).
-    // TODO: Refactor to avoid calling `requestedPermissions` but still get the right groups.
-    const permissions = space.requestedPermissions();
+    // Use `getAccessControlLists` to get up-to-date permission groups (this includes provisioned groups).
+    // TODO: Refactor to avoid calling `getAccessControlLists` but still get the right groups.
+    const permissions = space.getAccessControlLists(auth);
     const groupIds = permissions.flatMap((permission) =>
       permission.groups.map((group) =>
         GroupResource.modelIdToSId({

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -46,7 +46,7 @@ export function createSpaceIdToGroupsMap(
  * @param requestedSpaceIds - Array of space ids that need permission resolution
  * @returns Array of AccessControlList objects for use with Authenticator permission methods
  */
-export function createResourcePermissionsFromSpacesWithMap(
+export function createAccessControlListFromSpacesWithMap(
   spaceIdToGroupsMap: Map<ModelId, string[]>,
   requestedSpaceIds: ModelId[],
   workspaceId: ModelId
@@ -62,7 +62,7 @@ export function createResourcePermissionsFromSpacesWithMap(
     resolvedGroupIds.push(groupIds);
   }
 
-  return Authenticator.createResourcePermissionsFromGroupIds(
+  return Authenticator.createAccessControlListFromGroupIds(
     resolvedGroupIds,
     workspaceId
   );

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ResourcePermission } from "@app/types/resource_permissions";
+import type { AccessRule } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -39,17 +39,17 @@ export function createSpaceIdToGroupsMap(
 }
 
 /**
- * Creates ResourcePermission objects from space ids using a pre-built space-to-groups mapping.
+ * Creates AccessRule objects from space ids using a pre-built space-to-groups mapping.
  * This is the optimized version that avoids rebuilding the map on each call.
  *
  * @param spaceIdToGroupsMap - Pre-built mapping from space ids to group IDs
  * @param requestedSpaceIds - Array of space ids that need permission resolution
- * @returns Array of ResourcePermission objects for use with Authenticator permission methods
+ * @returns Array of AccessRule objects for use with Authenticator permission methods
  */
 export function createResourcePermissionsFromSpacesWithMap(
   spaceIdToGroupsMap: Map<ModelId, string[]>,
   requestedSpaceIds: ModelId[]
-): ResourcePermission[] {
+): AccessRule[] {
   const resolvedGroupIds: string[][] = [];
 
   for (const spaceId of requestedSpaceIds) {

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { AccessRule } from "@app/types/resource_permissions";
+import type { AccessControlList } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -39,17 +39,18 @@ export function createSpaceIdToGroupsMap(
 }
 
 /**
- * Creates AccessRule objects from space ids using a pre-built space-to-groups mapping.
+ * Creates AccessControlList objects from space ids using a pre-built space-to-groups mapping.
  * This is the optimized version that avoids rebuilding the map on each call.
  *
  * @param spaceIdToGroupsMap - Pre-built mapping from space ids to group IDs
  * @param requestedSpaceIds - Array of space ids that need permission resolution
- * @returns Array of AccessRule objects for use with Authenticator permission methods
+ * @returns Array of AccessControlList objects for use with Authenticator permission methods
  */
 export function createResourcePermissionsFromSpacesWithMap(
   spaceIdToGroupsMap: Map<ModelId, string[]>,
-  requestedSpaceIds: ModelId[]
-): AccessRule[] {
+  requestedSpaceIds: ModelId[],
+  workspaceId: ModelId
+): AccessControlList[] {
   const resolvedGroupIds: string[][] = [];
 
   for (const spaceId of requestedSpaceIds) {
@@ -61,5 +62,8 @@ export function createResourcePermissionsFromSpacesWithMap(
     resolvedGroupIds.push(groupIds);
   }
 
-  return Authenticator.createResourcePermissionsFromGroupIds(resolvedGroupIds);
+  return Authenticator.createResourcePermissionsFromGroupIds(
+    resolvedGroupIds,
+    workspaceId
+  );
 }

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -196,8 +196,8 @@ export abstract class ResourceWithSpace<
 
   // Permissions.
 
-  requestedPermissions() {
-    return this.space.requestedPermissions();
+  getAccessControlLists(auth: Authenticator) {
+    return this.space.getAccessControlLists(auth);
   }
 
   canAdministrate(auth: Authenticator) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -668,10 +668,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
       auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
-          spaceIdToGroupsMap,
-          skill.requestedSpaceIds
-        )
+        createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, skill.requestedSpaceIds, auth.getNonNullableWorkspace().id)
       )
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -668,7 +668,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
       auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, skill.requestedSpaceIds, auth.getNonNullableWorkspace().id)
+        createResourcePermissionsFromSpacesWithMap(
+          spaceIdToGroupsMap,
+          skill.requestedSpaceIds,
+          auth.getNonNullableWorkspace().id
+        )
       )
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -37,7 +37,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import {
-  createResourcePermissionsFromSpacesWithMap,
+  createAccessControlListFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -667,8 +667,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
-      auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
+      auth.hasPermissionForAcls(
+        "read",
+        createAccessControlListFromSpacesWithMap(
           spaceIdToGroupsMap,
           skill.requestedSpaceIds,
           auth.getNonNullableWorkspace().id

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -31,8 +31,8 @@ import {
   SPACE_GROUP_PREFIX,
 } from "@app/types/groups";
 import type {
-  InlineGroupGrant,
-  LegacyAccessRule,
+  AccessControlList,
+  GroupGrant,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1756,9 +1756,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * - Read/Write: Group members
    * - Admin: Workspace admins
    *
-   * @returns Array of AccessRule objects based on space type
+   * @returns Array of AccessControlList objects based on space type
    */
-  requestedPermissions(): LegacyAccessRule[] {
+  requestedPermissions(): AccessControlList[] {
     // System space.
     if (this.isSystem()) {
       return [
@@ -1799,7 +1799,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Open space.
     // Currently only using global group for simplicity.
-    // TODO(2024-10-25 flav): Refactor to store a list of AccessRule on conversations and
+    // TODO(2024-10-25 flav): Refactor to store a list of AccessControlList on conversations and
     // agent_configurations. This will allow proper handling of multiple groups instead of only
     // using the global group as a temporary solution.
     if (this.isRegularAndOpen()) {
@@ -1821,7 +1821,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               });
             }
             return acc;
-          }, [] as InlineGroupGrant[]),
+          }, [] as GroupGrant[]),
         },
       ];
     }
@@ -1851,7 +1851,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               }
             }
             return acc;
-          }, [] as InlineGroupGrant[]),
+          }, [] as GroupGrant[]),
         },
       ];
     }
@@ -1869,7 +1869,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             });
           }
           return acc;
-        }, [] as InlineGroupGrant[]),
+        }, [] as GroupGrant[]),
       },
     ];
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -31,7 +31,7 @@ import {
   SPACE_GROUP_PREFIX,
 } from "@app/types/groups";
 import type {
-  CombinedResourcePermissions,
+  LegacyCombinedResourcePermissions,
   LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -1758,7 +1758,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    *
    * @returns Array of ResourcePermission objects based on space type
    */
-  requestedPermissions(): CombinedResourcePermissions[] {
+  requestedPermissions(): LegacyCombinedResourcePermissions[] {
     // System space.
     if (this.isSystem()) {
       return [

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1758,7 +1758,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    *
    * @returns Array of AccessControlList objects based on space type
    */
-  requestedPermissions(): AccessControlList[] {
+  getAccessControlLists(auth: Authenticator): AccessControlList[] {
     // System space.
     if (this.isSystem()) {
       return [
@@ -1899,15 +1899,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   canAdministrate(auth: Authenticator) {
-    return auth.canAdministrate(this.requestedPermissions());
+    return auth.canAdministrate(this.getAccessControlLists(auth));
   }
 
   canWrite(auth: Authenticator) {
-    return auth.canWrite(this.requestedPermissions());
+    return auth.canWrite(this.getAccessControlLists(auth));
   }
 
   canRead(auth: Authenticator) {
-    return auth.canRead(this.requestedPermissions());
+    return auth.canRead(this.getAccessControlLists(auth));
   }
 
   canReadOrAdministrate(auth: Authenticator) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -31,8 +31,8 @@ import {
   SPACE_GROUP_PREFIX,
 } from "@app/types/groups";
 import type {
-  LegacyCombinedResourcePermissions,
-  LegacyGroupPermission,
+  InlineGroupGrant,
+  LegacyAccessRule,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1756,9 +1756,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * - Read/Write: Group members
    * - Admin: Workspace admins
    *
-   * @returns Array of ResourcePermission objects based on space type
+   * @returns Array of AccessRule objects based on space type
    */
-  requestedPermissions(): LegacyCombinedResourcePermissions[] {
+  requestedPermissions(): LegacyAccessRule[] {
     // System space.
     if (this.isSystem()) {
       return [
@@ -1799,7 +1799,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Open space.
     // Currently only using global group for simplicity.
-    // TODO(2024-10-25 flav): Refactor to store a list of ResourcePermission on conversations and
+    // TODO(2024-10-25 flav): Refactor to store a list of AccessRule on conversations and
     // agent_configurations. This will allow proper handling of multiple groups instead of only
     // using the global group as a temporary solution.
     if (this.isRegularAndOpen()) {
@@ -1821,7 +1821,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               });
             }
             return acc;
-          }, [] as LegacyGroupPermission[]),
+          }, [] as InlineGroupGrant[]),
         },
       ];
     }
@@ -1851,7 +1851,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               }
             }
             return acc;
-          }, [] as LegacyGroupPermission[]),
+          }, [] as InlineGroupGrant[]),
         },
       ];
     }
@@ -1869,7 +1869,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             });
           }
           return acc;
-        }, [] as LegacyGroupPermission[]),
+        }, [] as InlineGroupGrant[]),
       },
     ];
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1899,15 +1899,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   canAdministrate(auth: Authenticator) {
-    return auth.canAdministrate(this.getAccessControlLists(auth));
+    return auth.hasPermission("admin", this);
   }
 
   canWrite(auth: Authenticator) {
-    return auth.canWrite(this.getAccessControlLists(auth));
+    return auth.hasPermission("write", this);
   }
 
   canRead(auth: Authenticator) {
-    return auth.canRead(this.getAccessControlLists(auth));
+    return auth.hasPermission("read", this);
   }
 
   canReadOrAdministrate(auth: Authenticator) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -32,7 +32,7 @@ import {
 } from "@app/types/groups";
 import type {
   CombinedResourcePermissions,
-  GroupPermission,
+  LegacyGroupPermission,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1821,7 +1821,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               });
             }
             return acc;
-          }, [] as GroupPermission[]),
+          }, [] as LegacyGroupPermission[]),
         },
       ];
     }
@@ -1851,7 +1851,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               }
             }
             return acc;
-          }, [] as GroupPermission[]),
+          }, [] as LegacyGroupPermission[]),
         },
       ];
     }
@@ -1869,7 +1869,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             });
           }
           return acc;
-        }, [] as GroupPermission[]),
+        }, [] as LegacyGroupPermission[]),
       },
     ];
   }

--- a/front/migrations/20240906_2_backfill_agents_groupIds.ts
+++ b/front/migrations/20240906_2_backfill_agents_groupIds.ts
@@ -100,7 +100,7 @@
 //   const groupIds = (
 //     await DataSourceViewResource.fetchByIds(auth, dataSourceViewIds)
 //   ).flatMap((view) =>
-//     view.requestedPermissions().flatMap((rp) => rp.groups.map((g) => g.id))
+//     view.getAccessControlLists().flatMap((rp) => rp.groups.map((g) => g.id))
 //   );
 //
 //   if (execute) {

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -10,6 +10,14 @@
 
 // Verbs are the granular capabilities a role grants. They are never stored — roles map to them in
 // the registry, and capability questions are expressed in verbs.
+//
+// A verb's position in this array is its bit in the `PermissionSet` bitmask (verb at index i => bit
+// `1 << i`; see `group_permission_registry`). Consequences:
+// - Never reorder or remove a verb: it would silently reassign every subsequent verb's bit and
+//   change the meaning of already-computed masks.
+// - Add new verbs only at the end.
+// - Keep the total at most 31 verbs: JS bitwise operators work on 32-bit integers, so beyond that
+//   the shift overflows and masks break.
 export const GRANT_VERBS = [
   "read",
   "write",

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -1,4 +1,4 @@
-import type { ConcreteResourceType } from "./group_permissions";
+import type { ConcreteResourceType, GrantVerb } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
 
@@ -13,22 +13,22 @@ export type PermissionType = (typeof SUPPORTED_OPERATIONS)[number];
  * that path for new code.
  *
  * @property id - Unique identifier for the group (ModelId type)
- * @property permissions - Array of permissions granted to the group
+ * @property permissions - Grant verbs granted to the group
  */
 export type LegacyGroupPermission = {
   id: ModelId;
-  permissions: PermissionType[];
+  permissions: GrantVerb[];
 };
 
 /**
  * Represents permissions assigned to a specific role.
  *
  * @property role - The type of role (RoleType)
- * @property permissions - Array of permissions granted to the role
+ * @property permissions - Grant verbs granted to the role
  */
 export type RolePermission = {
   role: RoleType;
-  permissions: PermissionType[];
+  permissions: GrantVerb[];
 };
 
 /**

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -1,3 +1,5 @@
+import type { Authenticator } from "@app/lib/auth";
+
 import type { GrantVerb } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
@@ -42,3 +44,13 @@ export type AccessControlList = {
   groups: GroupGrant[];
   workspaceId: ModelId;
 };
+
+/**
+ * A resource whose access is governed by one or more access-control lists. The caller passes when
+ * they satisfy every ACL returned by `getAccessControlLists(auth)` (see
+ * `Authenticator.hasPermission`). `auth` is passed so a resource can build its ACL from the caller's
+ * governance grants (`auth.getGroupPermissions`) — e.g. the per-workspace flip.
+ */
+export interface WithAccessControl {
+  getAccessControlLists(auth: Authenticator): AccessControlList[];
+}

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -9,8 +9,8 @@ export type PermissionType = (typeof SUPPORTED_OPERATIONS)[number];
 
 /**
  * Legacy: permissions assigned to a specific group, listed inline on a resource's permission
- * config. Being migrated to the `group_permissions` table (see `CombinedResourcePermissions`'s
- * governance-grant channel); prefer that path for new code.
+ * config. Being migrated to the `group_permissions` table (see `GroupResourcePermission`); prefer
+ * that path for new code.
  *
  * @property id - Unique identifier for the group (ModelId type)
  * @property permissions - Array of permissions granted to the group
@@ -40,40 +40,52 @@ export type LegacyGroupResourcePermissions = {
 };
 
 /**
- * Defines combined group, role, and governance-grant-based permissions for a resource.
- *
- * When `resourceType` is set, the resource is also checked against the caller's `group_permissions`
- * grants (resolved at auth construction — see `Authenticator.resolvePermissions`): the caller
- * passes if they hold the requested permission, used directly as a grant verb since
- * `PermissionType` ⊆ `GrantVerb`, on this `(resourceType, resourceId)`. `resourceId` defaults to
- * the type-wide grant when omitted, and a type-wide grant also satisfies an instance requirement
- * (see `PermissionSet.has`).
+ * Legacy: role-based grants plus inline group grants for a resource, with no `group_permissions`
+ * table involvement. Being migrated to `GroupResourcePermission`.
  *
  * @property groups - Legacy inline group-based grants: a caller in a listed group gets its
- *   permissions (being migrated to the governance-grant channel below)
+ *   permissions
+ * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
+ * @property workspaceId - The resource's workspace; role and legacy-group checks only apply when it
+ *   matches the caller's workspace
+ */
+export type LegacyCombinedResourcePermissions = {
+  groups: LegacyGroupPermission[];
+  roles: RolePermission[];
+  workspaceId: ModelId;
+};
+
+/**
+ * Role-based grants plus the `group_permissions` table (the governance-grant channel). The resource
+ * is identified by `(resourceType, resourceId)`; a caller passes if their role grants the requested
+ * permission, or if they hold it as a grant verb (`PermissionType` ⊆ `GrantVerb`) on that resource
+ * — grants are resolved at auth construction (see `Authenticator.resolvePermissions`). `resourceId`
+ * omitted means the type-wide (-1) grant, and a type-wide grant satisfies an instance requirement
+ * (see `PermissionSet.has`).
+ *
  * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
  * @property resourceType - The governance resource domain to check (e.g. "space")
  * @property resourceId - The resource's model id; omitted means the type-wide (-1) grant
- * @property workspaceId - The resource's workspace; role and governance-grant checks only apply
+ * @property workspaceId - The resource's workspace; the role and governance-grant checks only apply
  *   when it matches the caller's workspace
  */
-export type CombinedResourcePermissions = {
-  groups: LegacyGroupPermission[];
+export type GroupResourcePermission = {
   roles: RolePermission[];
-  resourceType?: ConcreteResourceType;
+  resourceType: ConcreteResourceType;
   resourceId?: number;
   workspaceId: ModelId;
 };
 
 /**
- * Represents the complete permission configuration for a resource.
- * Can be either:
- * - Group-based permissions only
- * - Both group and role-based permissions combined
+ * Represents the complete permission configuration for a resource. One of:
+ * - Legacy inline group-based permissions only (`LegacyGroupResourcePermissions`)
+ * - Legacy roles + inline groups (`LegacyCombinedResourcePermissions`)
+ * - Roles + the group_permissions table (`GroupResourcePermission`)
  */
 export type ResourcePermission =
   | LegacyGroupResourcePermissions
-  | CombinedResourcePermissions;
+  | LegacyCombinedResourcePermissions
+  | GroupResourcePermission;
 
 /**
  * Type guard to determine if a permission configuration includes role-based access control.
@@ -83,6 +95,8 @@ export type ResourcePermission =
  */
 export function hasRolePermissions(
   resourcePermission: ResourcePermission
-): resourcePermission is CombinedResourcePermissions {
+): resourcePermission is
+  | LegacyCombinedResourcePermissions
+  | GroupResourcePermission {
   return "roles" in resourcePermission;
 }

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -4,13 +4,13 @@ import type { RoleType } from "./user";
 
 /**
  * Legacy: permissions assigned to a specific group, listed inline on a resource's permission
- * config. Being migrated to the `group_permissions` table (see `GroupResourcePermission`); prefer
+ * config. Being migrated to the `group_permissions` table (see `GrantedAccessRule`); prefer
  * that path for new code.
  *
  * @property id - Unique identifier for the group (ModelId type)
  * @property permissions - Grant verbs granted to the group
  */
-export type LegacyGroupPermission = {
+export type InlineGroupGrant = {
   id: ModelId;
   permissions: GrantVerb[];
 };
@@ -21,7 +21,7 @@ export type LegacyGroupPermission = {
  * @property role - The type of role (RoleType)
  * @property permissions - Grant verbs granted to the role
  */
-export type RolePermission = {
+export type RoleGrant = {
   role: RoleType;
   permissions: GrantVerb[];
 };
@@ -30,13 +30,13 @@ export type RolePermission = {
  * Legacy: group-based permissions for a resource, managed through inline group assignments.
  * Superseded by the `group_permissions` governance-grant channel.
  */
-export type LegacyGroupResourcePermissions = {
-  groups: LegacyGroupPermission[];
+export type LegacyGroupAccessRule = {
+  groups: InlineGroupGrant[];
 };
 
 /**
  * Legacy: role-based grants plus inline group grants for a resource, with no `group_permissions`
- * table involvement. Being migrated to `GroupResourcePermission`.
+ * table involvement. Being migrated to `GrantedAccessRule`.
  *
  * @property groups - Legacy inline group-based grants: a caller in a listed group gets its
  *   permissions
@@ -44,9 +44,9 @@ export type LegacyGroupResourcePermissions = {
  * @property workspaceId - The resource's workspace; role and legacy-group checks only apply when it
  *   matches the caller's workspace
  */
-export type LegacyCombinedResourcePermissions = {
-  groups: LegacyGroupPermission[];
-  roles: RolePermission[];
+export type LegacyAccessRule = {
+  groups: InlineGroupGrant[];
+  roles: RoleGrant[];
   workspaceId: ModelId;
 };
 
@@ -64,8 +64,8 @@ export type LegacyCombinedResourcePermissions = {
  * @property workspaceId - The resource's workspace; the role and governance-grant checks only apply
  *   when it matches the caller's workspace
  */
-export type GroupResourcePermission = {
-  roles: RolePermission[];
+export type GrantedAccessRule = {
+  roles: RoleGrant[];
   resourceType: ConcreteResourceType;
   resourceId?: number;
   workspaceId: ModelId;
@@ -73,14 +73,14 @@ export type GroupResourcePermission = {
 
 /**
  * Represents the complete permission configuration for a resource. One of:
- * - Legacy inline group-based permissions only (`LegacyGroupResourcePermissions`)
- * - Legacy roles + inline groups (`LegacyCombinedResourcePermissions`)
- * - Roles + the group_permissions table (`GroupResourcePermission`)
+ * - Legacy inline group-based permissions only (`LegacyGroupAccessRule`)
+ * - Legacy roles + inline groups (`LegacyAccessRule`)
+ * - Roles + the group_permissions table (`GrantedAccessRule`)
  */
-export type ResourcePermission =
-  | LegacyGroupResourcePermissions
-  | LegacyCombinedResourcePermissions
-  | GroupResourcePermission;
+export type AccessRule =
+  | LegacyGroupAccessRule
+  | LegacyAccessRule
+  | GrantedAccessRule;
 
 /**
  * Type guard to determine if a permission configuration includes role-based access control.
@@ -88,10 +88,8 @@ export type ResourcePermission =
  * @param resourcePermission - The resource permission configuration to check
  * @returns True if the configuration includes role-based permissions
  */
-export function hasRolePermissions(
-  resourcePermission: ResourcePermission
-): resourcePermission is
-  | LegacyCombinedResourcePermissions
-  | GroupResourcePermission {
+export function hasRoleGrants(
+  resourcePermission: AccessRule
+): resourcePermission is LegacyAccessRule | GrantedAccessRule {
   return "roles" in resourcePermission;
 }

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -2,11 +2,6 @@ import type { ConcreteResourceType, GrantVerb } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
 
-// Supported operations for resource permissions.
-export const SUPPORTED_OPERATIONS = ["admin", "read", "write"] as const;
-
-export type PermissionType = (typeof SUPPORTED_OPERATIONS)[number];
-
 /**
  * Legacy: permissions assigned to a specific group, listed inline on a resource's permission
  * config. Being migrated to the `group_permissions` table (see `GroupResourcePermission`); prefer
@@ -58,8 +53,8 @@ export type LegacyCombinedResourcePermissions = {
 /**
  * Role-based grants plus the `group_permissions` table (the governance-grant channel). The resource
  * is identified by `(resourceType, resourceId)`; a caller passes if their role grants the requested
- * permission, or if they hold it as a grant verb (`PermissionType` ⊆ `GrantVerb`) on that resource
- * — grants are resolved at auth construction (see `Authenticator.resolvePermissions`). `resourceId`
+ * verb, or if they hold it as a grant on that resource — grants are resolved at auth construction
+ * (see `Authenticator.resolvePermissions`). `resourceId`
  * omitted means the type-wide (-1) grant, and a type-wide grant satisfies an instance requirement
  * (see `PermissionSet.has`).
  *

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -1,25 +1,23 @@
-import type { ConcreteResourceType, GrantVerb } from "./group_permissions";
+import type { GrantVerb } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
 
 /**
- * Legacy: permissions assigned to a specific group, listed inline on a resource's permission
- * config. Being migrated to the `group_permissions` table (see `GrantedAccessRule`); prefer
- * that path for new code.
+ * A group and the verbs it is granted on a resource.
  *
- * @property id - Unique identifier for the group (ModelId type)
- * @property permissions - Grant verbs granted to the group
+ * @property id - The group's model id
+ * @property permissions - Grant verbs the group holds
  */
-export type InlineGroupGrant = {
+export type GroupGrant = {
   id: ModelId;
   permissions: GrantVerb[];
 };
 
 /**
- * Represents permissions assigned to a specific role.
+ * A role and the verbs it is granted on a resource.
  *
- * @property role - The type of role (RoleType)
- * @property permissions - Grant verbs granted to the role
+ * @property role - The workspace role
+ * @property permissions - Grant verbs the role holds
  */
 export type RoleGrant = {
   role: RoleType;
@@ -27,69 +25,20 @@ export type RoleGrant = {
 };
 
 /**
- * Legacy: group-based permissions for a resource, managed through inline group assignments.
- * Superseded by the `group_permissions` governance-grant channel.
- */
-export type LegacyGroupAccessRule = {
-  groups: InlineGroupGrant[];
-};
-
-/**
- * Legacy: role-based grants plus inline group grants for a resource, with no `group_permissions`
- * table involvement. Being migrated to `GrantedAccessRule`.
+ * The access rules for a resource: the roles and groups that confer verbs, scoped to a workspace.
  *
- * @property groups - Legacy inline group-based grants: a caller in a listed group gets its
- *   permissions
- * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
- * @property workspaceId - The resource's workspace; role and legacy-group checks only apply when it
- *   matches the caller's workspace
+ * A resource builds its own ACL (see each resource's `acl(auth)`) from role rules and/or the
+ * caller's governance grants (`Authenticator.getGroupPermissions`). The Authenticator evaluates it
+ * with `hasPermission`: a caller passes if their role grants the verb, or they belong to a listed
+ * group that grants it. When the groups come from governance grants, the list is caller-scoped
+ * (only the caller's groups) — an ACL is a check artifact, not a complete "who has access" listing.
+ *
+ * @property roles - Role-based grants: a caller whose workspace role matches gets its verbs
+ * @property groups - Group-based grants: a caller in a listed group gets its verbs
+ * @property workspaceId - The resource's workspace; checks only apply within the caller's workspace
  */
-export type LegacyAccessRule = {
-  groups: InlineGroupGrant[];
+export type AccessControlList = {
   roles: RoleGrant[];
+  groups: GroupGrant[];
   workspaceId: ModelId;
 };
-
-/**
- * Role-based grants plus the `group_permissions` table (the governance-grant channel). The resource
- * is identified by `(resourceType, resourceId)`; a caller passes if their role grants the requested
- * verb, or if they hold it as a grant on that resource — grants are resolved at auth construction
- * (see `Authenticator.resolvePermissions`). `resourceId`
- * omitted means the type-wide (-1) grant, and a type-wide grant satisfies an instance requirement
- * (see `PermissionSet.has`).
- *
- * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
- * @property resourceType - The governance resource domain to check (e.g. "space")
- * @property resourceId - The resource's model id; omitted means the type-wide (-1) grant
- * @property workspaceId - The resource's workspace; the role and governance-grant checks only apply
- *   when it matches the caller's workspace
- */
-export type GrantedAccessRule = {
-  roles: RoleGrant[];
-  resourceType: ConcreteResourceType;
-  resourceId?: number;
-  workspaceId: ModelId;
-};
-
-/**
- * Represents the complete permission configuration for a resource. One of:
- * - Legacy inline group-based permissions only (`LegacyGroupAccessRule`)
- * - Legacy roles + inline groups (`LegacyAccessRule`)
- * - Roles + the group_permissions table (`GrantedAccessRule`)
- */
-export type AccessRule =
-  | LegacyGroupAccessRule
-  | LegacyAccessRule
-  | GrantedAccessRule;
-
-/**
- * Type guard to determine if a permission configuration includes role-based access control.
- *
- * @param resourcePermission - The resource permission configuration to check
- * @returns True if the configuration includes role-based permissions
- */
-export function hasRoleGrants(
-  resourcePermission: AccessRule
-): resourcePermission is LegacyAccessRule | GrantedAccessRule {
-  return "roles" in resourcePermission;
-}

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -8,12 +8,14 @@ export const SUPPORTED_OPERATIONS = ["admin", "read", "write"] as const;
 export type PermissionType = (typeof SUPPORTED_OPERATIONS)[number];
 
 /**
- * Represents permissions assigned to a specific group.
+ * Legacy: permissions assigned to a specific group, listed inline on a resource's permission
+ * config. Being migrated to the `group_permissions` table (see `CombinedResourcePermissions`'s
+ * governance-grant channel); prefer that path for new code.
  *
  * @property id - Unique identifier for the group (ModelId type)
  * @property permissions - Array of permissions granted to the group
  */
-export type GroupPermission = {
+export type LegacyGroupPermission = {
   id: ModelId;
   permissions: PermissionType[];
 };
@@ -30,11 +32,11 @@ export type RolePermission = {
 };
 
 /**
- * Defines group-based permissions for a resource.
- * Used when access control is managed through group assignments.
+ * Legacy: group-based permissions for a resource, managed through inline group assignments.
+ * Superseded by the `group_permissions` governance-grant channel.
  */
-export type GroupResourcePermissions = {
-  groups: GroupPermission[];
+export type LegacyGroupResourcePermissions = {
+  groups: LegacyGroupPermission[];
 };
 
 /**
@@ -47,7 +49,8 @@ export type GroupResourcePermissions = {
  * the type-wide grant when omitted, and a type-wide grant also satisfies an instance requirement
  * (see `PermissionSet.has`).
  *
- * @property groups - Group-based grants: a caller in a listed group gets its permissions
+ * @property groups - Legacy inline group-based grants: a caller in a listed group gets its
+ *   permissions (being migrated to the governance-grant channel below)
  * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
  * @property resourceType - The governance resource domain to check (e.g. "space")
  * @property resourceId - The resource's model id; omitted means the type-wide (-1) grant
@@ -55,7 +58,7 @@ export type GroupResourcePermissions = {
  *   when it matches the caller's workspace
  */
 export type CombinedResourcePermissions = {
-  groups: GroupPermission[];
+  groups: LegacyGroupPermission[];
   roles: RolePermission[];
   resourceType?: ConcreteResourceType;
   resourceId?: number;
@@ -69,7 +72,7 @@ export type CombinedResourcePermissions = {
  * - Both group and role-based permissions combined
  */
 export type ResourcePermission =
-  | GroupResourcePermissions
+  | LegacyGroupResourcePermissions
   | CombinedResourcePermissions;
 
 /**

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -1,3 +1,4 @@
+import type { ConcreteResourceType } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
 
@@ -37,11 +38,27 @@ export type GroupResourcePermissions = {
 };
 
 /**
- * Defines combined group and role-based permissions for a resource.
+ * Defines combined group, role, and governance-grant-based permissions for a resource.
+ *
+ * When `resourceType` is set, the resource is also checked against the caller's `group_permissions`
+ * grants (resolved at auth construction — see `Authenticator.resolvePermissions`): the caller
+ * passes if they hold the requested permission, used directly as a grant verb since
+ * `PermissionType` ⊆ `GrantVerb`, on this `(resourceType, resourceId)`. `resourceId` defaults to
+ * the type-wide grant when omitted, and a type-wide grant also satisfies an instance requirement
+ * (see `PermissionSet.has`).
+ *
+ * @property groups - Group-based grants: a caller in a listed group gets its permissions
+ * @property roles - Role-based grants: a caller whose workspace role matches gets its permissions
+ * @property resourceType - The governance resource domain to check (e.g. "space")
+ * @property resourceId - The resource's model id; omitted means the type-wide (-1) grant
+ * @property workspaceId - The resource's workspace; role and governance-grant checks only apply
+ *   when it matches the caller's workspace
  */
 export type CombinedResourcePermissions = {
   groups: GroupPermission[];
   roles: RolePermission[];
+  resourceType?: ConcreteResourceType;
+  resourceId?: number;
   workspaceId: ModelId;
 };
 


### PR DESCRIPTION
## Description

Foundation of the space-permissions migration ([#9477](https://github.com/dust-tt/tasks/issues/9477) / [#9774](https://github.com/dust-tt/tasks/issues/9774)): give the `Authenticator` a small, stable authorization surface, and model a resource's access rules as a single **flat `AccessControlList`** that the resource builds and the auth evaluates.

```
#29379 (this)  →  #29619 backfill  →  #29639 shadow  →  #29763 flip
```

### Responsibility split
- **`Authenticator`** knows only the *caller* — role, group memberships, and (preloaded once at construction) the caller's `group_permissions` grants. It evaluates a fully-resolved ACL and answers governance lookups; it knows nothing about any specific resource's rules.
- **A resource** knows its *own* rules — it builds an `AccessControlList` from role rules and/or the caller's governance grants.

### What it does

**One flat type + one interface** (`types/resource_permissions.ts`):
```ts
type GroupGrant = { id: ModelId; permissions: GrantVerb[] };
type RoleGrant  = { role: RoleType; permissions: GrantVerb[] };
type AccessControlList = { roles: RoleGrant[]; groups: GroupGrant[]; workspaceId: ModelId };

interface WithAccessControl {
  getAccessControlLists(auth: Authenticator): AccessControlList[];
}
```
The `ResourcePermission` union (and `PermissionType`) are gone — everything speaks `GrantVerb`. A resource implements `WithAccessControl`; `auth` is passed so it can build its ACL from the caller's governance grants (`auth.getGroupPermissions`) — needed for the shadow candidate and the flip.

**`GroupPermissions`** (`group_permission_registry.ts`) — the caller's grants, group-granular and indexed by `resourceType → resourceId → groupId → verb-bitmask`, resolved once at auth construction (replaces `PermissionSet`). Serializable (`toJSON`/`fromJSON`) so it round-trips through a serialized `Authenticator` (Temporal) without re-querying.

**Authenticator surface:**
- `hasPermission(verb, target)` — pure/sync: the caller holds `verb` on **every** ACL the `WithAccessControl` target declares. Role path (workspace-gated) OR group-membership path.
- `hasPermissionForAll(verb, targets)` — conjunction across targets.
- `hasPermissionForAcls(verb, acls)` — the raw-ACL primitive, for callers that already hold built or derived ACLs (a space's served ACLs, the cross-space conversation/agent/skill checks) rather than a `WithAccessControl` target.
- `getGroupPermissions(resourceType, resourceId)` — the caller's matching `group→verbs`, folding in the type-wide (`-1`) grants. Caller-scoped.
- `hasWorkspacePermission(verb, resourceType)` — thin wrapper over the ACL check against a handmade type-wide ACL whose synthetic admin role gives admins every workspace capability by default.
- `getWorkspacePermissions()` — admins → all; others derive from their type-wide grants.

The `Authenticator.canRead` / `canWrite` / `canAdministrate` convenience methods are gone — resources keep their own thin `canX(auth)` wrappers that call `hasPermission(verb, this)` (or `hasPermissionForAcls` for derived ACLs).

**Resources** expose `getAccessControlLists(auth)` (returning `AccessControlList[]`, renamed from `requestedPermissions()`); consuming `getGroupPermissions` + moving shadow into the resource come in the shadow/flip PRs.

## Risk
Low / behavior-preserving. No space populates the table yet (starts in #29619), so the served result is unchanged. Admin semantics preserved (all workspace capabilities; no implicit instance access).

## Tests
`group_permission_*`, `user`, `space_resource`, `conversation_resource` suites pass; front-api permission suites pass; `tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
