### PR TITLE
[front] Replace builder-role file write with the space.globalWrite capability

### DIFF
--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -162,13 +162,16 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     return accessError;
   }
 
-  if (!auth.isBuilder() && file.useCase !== "conversation") {
+  if (
+    !(await auth.hasWorkspacePermission("globalWrite", "space")) &&
+    file.useCase !== "conversation"
+  ) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can delete files.",
+          "You do not have permission to delete files in this workspace.",
       },
     });
   }
@@ -219,13 +222,16 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     return accessError;
   }
 
-  if (!auth.isBuilder() && file.useCase !== "conversation") {
+  if (
+    !(await auth.hasWorkspacePermission("globalWrite", "space")) &&
+    file.useCase !== "conversation"
+  ) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "You do not have permission to modify files in this workspace.",
       },
     });
   }

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -255,10 +255,14 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const isUploadUseCase =
     file.useCase === "upsert_table" || file.useCase === "folders_document";
   const canWriteInSpace = space ? space.canWrite(auth) : false;
+  const canManageWorkspaceFiles = await auth.hasWorkspacePermission(
+    "globalWrite",
+    "space"
+  );
 
   if (
     isUploadUseCase &&
-    !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
+    !((isFileAuthor && canWriteInSpace) || canManageWorkspaceFiles)
   ) {
     return apiError(ctx, {
       status_code: 403,
@@ -267,13 +271,13 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
         message: "You cannot edit files in that space.",
       },
     });
-  } else if (!auth.isBuilder() && file.useCase !== "conversation") {
+  } else if (!canManageWorkspaceFiles && file.useCase !== "conversation") {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "You do not have permission to modify files in this workspace.",
       },
     });
   }
@@ -314,10 +318,14 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const isUploadUseCase =
     file.useCase === "upsert_table" || file.useCase === "folders_document";
   const canWriteInSpace = space ? space.canWrite(auth) : false;
+  const canManageWorkspaceFiles = await auth.hasWorkspacePermission(
+    "globalWrite",
+    "space"
+  );
 
   if (
     isUploadUseCase &&
-    !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
+    !((isFileAuthor && canWriteInSpace) || canManageWorkspaceFiles)
   ) {
     return apiError(ctx, {
       status_code: 403,
@@ -328,7 +336,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   } else if (
     !space &&
-    !auth.isBuilder() &&
+    !canManageWorkspaceFiles &&
     file.useCase !== "conversation" &&
     file.useCase !== "avatar"
   ) {
@@ -337,7 +345,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "You do not have permission to modify files in this workspace.",
       },
     });
   }

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -53,14 +53,13 @@ app.patch(
           },
         });
       }
-      // biome-ignore lint/plugin/noDirectRoleCheck: conditional — only checked when file is not project_context
-    } else if (!auth.isBuilder()) {
+    } else if (!(await auth.hasWorkspacePermission("globalWrite", "space"))) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
           message:
-            "Only users that are `builders` for the current workspace can modify files.",
+            "You do not have permission to modify files in this workspace.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { WorkspacePermissionSet } from "@app/lib/resources/group_permission_registry";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -20,6 +21,7 @@ async function setup() {
     workspace: workspaceResource,
     subscription: null,
     authMethod: "internal",
+    workspacePermissions: WorkspacePermissionSet.all(),
   });
   return { workspace, user, auth };
 }

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -34,6 +34,7 @@ vi.mock("@app/lib/api/regions/config", () => ({
 }));
 
 import { Authenticator } from "@app/lib/auth";
+import { WorkspacePermissionSet } from "@app/lib/resources/group_permission_registry";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_IMAGE_1_5_MODEL_ID,
@@ -94,6 +95,7 @@ function makeAuth(): Authenticator {
     groupModelIds: [],
     subscription,
     authMethod: "internal",
+    workspacePermissions: WorkspacePermissionSet.empty(),
   });
 }
 

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -15,6 +15,7 @@ import { Authenticator } from "@app/lib/auth";
 import { SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { WorkspacePermissionSet } from "@app/lib/resources/group_permission_registry";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type {
   ModelConversationTypeMultiActions,
@@ -61,6 +62,7 @@ export function createMockAuthenticator(): Authenticator {
     groupModelIds: [],
     subscription,
     authMethod: "internal",
+    workspacePermissions: WorkspacePermissionSet.empty(),
   });
 }
 

--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -35,6 +35,13 @@ export interface CapabilitySeeder {
 
 export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
   {
+    // Manage content (files, documents) in open/global spaces. Replaces the legacy `builder` role
+    // write grant on those spaces (dust-tt/tasks#9746); seeded to the Builders group so it lands on
+    // exactly today's builder population.
+    capability: { grantType: "globalWrite", resourceType: "space" },
+    resolveTarget: async (_auth) => "builders",
+  },
+  {
     capability: { grantType: "create", resourceType: "agent" },
     resolveTarget: async (auth) => {
       const disallowsUserCreation =

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -1,5 +1,6 @@
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
+import { WorkspacePermissionSet } from "@app/lib/resources/group_permission_registry";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -29,6 +30,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       workspace: null,
       subscription: null,
       authMethod: "internal",
@@ -55,6 +57,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "none",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -81,6 +84,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -106,6 +110,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -133,6 +138,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -157,6 +163,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -188,6 +195,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "admin",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -200,6 +208,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -226,6 +235,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -254,6 +264,7 @@ describe("getUserForWorkspace", () => {
       user: user1,
       role: "user",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
       authMethod: "internal",
     });
@@ -281,6 +292,7 @@ describe("getUserForWorkspace", () => {
       user: superUser,
       role: "admin",
       groupModelIds: [],
+      workspacePermissions: WorkspacePermissionSet.empty(),
       subscription: null,
     });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -17,9 +17,8 @@ import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import {
-  allWorkspacePermissions,
   grantTypesForVerb,
-  workspacePermissionsFromGrants,
+  WorkspacePermissionSet,
 } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -49,7 +48,6 @@ import type {
   GrantVerb,
   WorkspacePermissions,
 } from "@app/types/group_permissions";
-import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
@@ -143,6 +141,8 @@ export class Authenticator {
   _authMethod: AuthMethodType;
   _providersHealth: ProvidersHealth | null;
   _clientIp?: string;
+  // Governance grants the caller holds, resolved by the factory (see `resolveWorkspacePermissions`)
+  _workspacePermissions: WorkspacePermissionSet;
 
   // Should only be called from the static methods below.
   constructor({
@@ -156,6 +156,7 @@ export class Authenticator {
     attributionKey,
     providersHealth,
     clientIp,
+    workspacePermissions,
   }: {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
@@ -167,6 +168,7 @@ export class Authenticator {
     attributionKey?: { id: ModelId; name: string };
     providersHealth?: ProvidersHealth | null;
     clientIp?: string;
+    workspacePermissions: WorkspacePermissionSet;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -181,6 +183,7 @@ export class Authenticator {
     this._attributionKey = attributionKey;
     this._providersHealth = providersHealth ?? null;
     this._clientIp = clientIp;
+    this._workspacePermissions = workspacePermissions;
     if (user) {
       tracer.setUser({
         id: user?.sId,
@@ -326,6 +329,11 @@ export class Authenticator {
         groupModelIds,
         subscription,
         providersHealth,
+        workspacePermissions: await this.resolveWorkspacePermissions({
+          workspace,
+          role,
+          groupModelIds,
+        }),
       });
     });
   }
@@ -360,6 +368,13 @@ export class Authenticator {
             transaction,
           })
         : [];
+      // Group memberships changed, so capabilities may have changed too: re-resolve them.
+      this._workspacePermissions =
+        await Authenticator.resolveWorkspacePermissions({
+          workspace: this._workspace,
+          role: this._role,
+          groupModelIds: this._groupModelIds,
+        });
     }
   }
 
@@ -400,14 +415,21 @@ export class Authenticator {
       subscription
     );
 
+    const role: RoleType = user?.isDustSuperUser ? "admin" : "none";
+    const groupModelIds = groups.map((g) => g.id);
     return new Authenticator({
       authMethod: "session",
       workspace,
       user,
-      role: user?.isDustSuperUser ? "admin" : "none",
-      groupModelIds: groups.map((g) => g.id),
+      role,
+      groupModelIds,
       subscription,
       providersHealth,
+      workspacePermissions: await this.resolveWorkspacePermissions({
+        workspace,
+        role,
+        groupModelIds,
+      }),
     });
   }
   /**
@@ -457,6 +479,11 @@ export class Authenticator {
       groupModelIds,
       subscription,
       providersHealth,
+      workspacePermissions: await this.resolveWorkspacePermissions({
+        workspace,
+        role,
+        groupModelIds,
+      }),
     });
   }
 
@@ -503,6 +530,11 @@ export class Authenticator {
         role: authData.role,
         subscription: authData.subscription,
         providersHealth,
+        workspacePermissions: await this.resolveWorkspacePermissions({
+          workspace,
+          role: authData.role,
+          groupModelIds: authData.groupModelIds,
+        }),
       })
     );
   }
@@ -644,6 +676,11 @@ export class Authenticator {
         groupModelIds,
         subscription,
         providersHealth,
+        workspacePermissions: await this.resolveWorkspacePermissions({
+          workspace,
+          role,
+          groupModelIds,
+        }),
       })
     );
   }
@@ -875,24 +912,44 @@ export class Authenticator {
       workspaceSubscription
     );
 
+    // If the key is associated with the workspace, we associate the groups.
+    const workspaceGroupModelIds = isKeyWorkspace
+      ? allGroups.map((g) => g.id)
+      : [];
+    const keyGroupModelIds = allGroups.map((g) => g.id);
+
+    const [workspacePermissions, keyPermissions] = await Promise.all([
+      this.resolveWorkspacePermissions({
+        workspace,
+        role,
+        groupModelIds: workspaceGroupModelIds,
+      }),
+      this.resolveWorkspacePermissions({
+        workspace: keyWorkspace,
+        role: "builder",
+        groupModelIds: keyGroupModelIds,
+      }),
+    ]);
+
     return {
       workspaceAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        // If the key is associated with the workspace, we associate the groups.
-        groupModelIds: isKeyWorkspace ? allGroups.map((g) => g.id) : [],
+        groupModelIds: workspaceGroupModelIds,
         key: key.toAuthJSON(),
         role,
         subscription: workspaceSubscription,
         workspace,
         providersHealth: workspaceProvidersHealth,
+        workspacePermissions,
       }),
       keyAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groupModelIds: allGroups.map((g) => g.id),
+        groupModelIds: keyGroupModelIds,
         key: key.toAuthJSON(),
         role: "builder",
         subscription: keySubscription,
         workspace: keyWorkspace,
+        workspacePermissions: keyPermissions,
       }),
     };
   }
@@ -923,13 +980,19 @@ export class Authenticator {
       subscription
     );
 
+    const groupModelIds = globalGroup ? [globalGroup.id] : [];
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "builder",
-      groupModelIds: globalGroup ? [globalGroup.id] : [],
+      groupModelIds,
       subscription,
       providersHealth,
+      workspacePermissions: await this.resolveWorkspacePermissions({
+        workspace,
+        role: "builder",
+        groupModelIds,
+      }),
     });
   }
 
@@ -970,13 +1033,19 @@ export class Authenticator {
       subscription
     );
 
+    const groupModelIds = groups.map((g) => g.id);
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "admin",
-      groupModelIds: groups.map((g) => g.id),
+      groupModelIds,
       subscription,
       providersHealth,
+      workspacePermissions: await this.resolveWorkspacePermissions({
+        workspace,
+        role: "admin",
+        groupModelIds,
+      }),
     });
   }
 
@@ -1057,6 +1126,11 @@ export class Authenticator {
       subscription: auth._subscription,
       workspace: auth._workspace,
       providersHealth: auth._providersHealth,
+      workspacePermissions: await Authenticator.resolveWorkspacePermissions({
+        workspace: auth._workspace,
+        role: "user",
+        groupModelIds,
+      }),
     });
   }
 
@@ -1071,6 +1145,8 @@ export class Authenticator {
       workspace: this._workspace,
       clientIp: this._clientIp,
       providersHealth: this._providersHealth,
+      // Role and groups are unchanged, so capabilities carry over unchanged.
+      workspacePermissions: this._workspacePermissions,
     });
   }
 
@@ -1107,64 +1183,70 @@ export class Authenticator {
   }
 
   /**
-   * Whether the caller holds a workspace-level capability. A capability is asked as a verb (e.g.
-   * "create"), expanded via the registry into the stored grant types (role names) that imply it, and
-   * checked against the type-wide (-1) group_permissions rows. Admins bypass unconditionally
-   * (billing/security are admin-by-default). Otherwise we look for a -1 grant on any of the caller's
-   * groups; "*" grants match any grant type / resource type.
-   *
-   * Cold path: a query per check is fine — no caching yet (pending auth-resolution decision).
+   * Whether the caller holds a workspace-level capability, asked as a type-level verb (e.g.
+   * "create" on "agent"). Reads the capabilities resolved at construction, which fold in
+   * admin-by-default access and "*" wildcard grants.
    */
   async hasWorkspacePermission(
     verb: GrantVerb,
     resourceType: ConcreteResourceType
   ): Promise<boolean> {
-    // Reject invalid capability queries (e.g. create/billing) up front, so a "*" grant can't satisfy
-    // a pair the registry forbids, and so callers fail fast on a programmer error.
+    // Reject invalid capability queries (e.g. create/billing) up front so callers fail fast on a
+    // programmer error rather than silently returning false.
     const grantTypes = grantTypesForVerb(resourceType, verb, "type");
     assert(
       grantTypes.length > 0,
       `Verb "${verb}" is not allowed (no type-level role grants it) on resource type "${resourceType}".`
     );
 
-    if (this.isAdmin()) {
-      return true;
-    }
     if (!this.workspace()) {
       return false;
     }
 
-    const grants = await GroupPermissionResource.listForGroups(this, {
-      groupModelIds: this._groupModelIds,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
-
-    return grants.some(
-      (grant) =>
-        (grant.resourceType === resourceType || grant.resourceType === "*") &&
-        (grant.grantType === "*" || grantTypes.includes(grant.grantType))
-    );
+    return this._workspacePermissions.hasTypeWide(resourceType, verb);
   }
 
   /**
-   * All workspace-level (type-wide) verbs the caller holds, grouped by resource type. This is the
-   * batch companion to hasWorkspacePermission: it expands every type-wide (-1) grant on the
-   * caller's groups into the verbs it confers. Admins hold every type-level capability by default,
-   * and "*" grants expand to all type-level verbs of the matched resource type(s), mirroring
-   * hasWorkspacePermission's semantics.
+   * The caller's governance grants, serialized to the wire shape consumed by the `/permissions`
+   * endpoint. Resolved at construction (see `resolveWorkspacePermissions`).
    */
   async getWorkspacePermissions(): Promise<WorkspacePermissions> {
-    // Admins bypass grants entirely: every type-level capability is theirs by default.
-    if (this.isAdmin()) {
-      return allWorkspacePermissions();
+    return this._workspacePermissions.toTypeWideWorkspacePermissions();
+  }
+
+  /**
+   * Resolves the grant set a caller holds, before an Authenticator exists. Admins hold every
+   * capability by default; other callers derive them from the grants on their groups. Cheap for
+   * admins and for callers with no groups (no query).
+   */
+  static async resolveWorkspacePermissions({
+    workspace,
+    role,
+    groupModelIds,
+  }: {
+    workspace?: WorkspaceResource | null;
+    role: RoleType;
+    groupModelIds: ModelId[];
+  }): Promise<WorkspacePermissionSet> {
+    if (!workspace) {
+      return WorkspacePermissionSet.empty();
+    }
+    if (role === "admin") {
+      return WorkspacePermissionSet.all();
     }
 
-    const grants = await GroupPermissionResource.listForGroups(this, {
-      groupModelIds: this._groupModelIds,
-      resourceId: WHOLE_TYPE_RESOURCE_ID,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      renderLightWorkspaceType({ workspace }),
+      { groupModelIds }
+    );
 
-    return workspacePermissionsFromGrants(grants);
+    return WorkspacePermissionSet.fromGrants(
+      grants.map((grant) => ({
+        grantType: grant.grantType,
+        resourceType: grant.resourceType,
+        resourceId: grant.resourceId,
+      }))
+    );
   }
 
   isSystemKey(): boolean {
@@ -1354,10 +1436,10 @@ export class Authenticator {
   }
 
   /**
-   * Determines if a user has a specific permission on a resource based on their role and group
-   * memberships.
+   * Determines if a user has a specific permission on a resource based on their role, workspace
+   * capabilities, and group memberships.
    *
-   * The permission check follows two independent paths (OR):
+   * The permission check follows three independent paths (OR):
    *
    * 1. Role-based permission check:
    *    Applies when the resource has role-based permissions configured.
@@ -1365,14 +1447,19 @@ export class Authenticator {
    *    - The resource has public access (role="none") for the requested permission, OR
    *    - The user's role has the required permission AND the resource belongs to user's workspace
    *
-   * 2. Group-based permission check:
+   * 2. Workspace-capability-based check:
+   *    Applies when the resource declares `workspacePermissions`.
+   *    Permission is granted if the user holds the declared workspace-level capability (a type-wide
+   *    `group_permissions` grant) AND the resource belongs to the user's workspace.
+   *
+   * 3. Group-based permission check:
    *    Applies when the resource has group-based permissions configured.
    *    Permission is granted if:
    *    - The user belongs to a group that has the required permission on this resource
    *
    * @param resourcePermission - The resource's permission configuration
    * @param permission - The specific permission being checked
-   * @returns true if either permission path grants access
+   * @returns true if any permission path grants access
    */
   private hasResourcePermission(
     resourcePermission: ResourcePermission,
@@ -1393,9 +1480,31 @@ export class Authenticator {
       ) {
         return true;
       }
+
+      // Second path: workspace-capability-based check. A resource can grant permissions to callers
+      // holding a governance grant (e.g. the type-wide `globalWrite` capability on `space`, or an
+      // instance grant on this resource). A type-wide grant satisfies an instance requirement.
+      const hasCapabilityPermission = (
+        resourcePermission.workspacePermissions ?? []
+      ).some(
+        (wp) =>
+          wp.permissions.includes(permission) &&
+          this._workspacePermissions.has(
+            wp.resourceType,
+            wp.resourceId,
+            wp.verb
+          )
+      );
+
+      if (
+        hasCapabilityPermission &&
+        workspace.id === resourcePermission.workspaceId
+      ) {
+        return true;
+      }
     }
 
-    // Second path: Group-based permission check.
+    // Third path: Group-based permission check.
     return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
         (gp) => gp.id === groupId && gp.permissions.includes(permission)
@@ -1447,6 +1556,8 @@ export class Authenticator {
       workspace: this._workspace,
       clientIp: this._clientIp,
       providersHealth: this._providersHealth,
+      // Attribution-only copy: role and groups are unchanged, so capabilities carry over unchanged.
+      workspacePermissions: this._workspacePermissions,
     });
   }
 
@@ -1518,6 +1629,11 @@ export class Authenticator {
       attributionKey: authType.attributionKey,
       providersHealth,
       clientIp: authType.clientIp,
+      workspacePermissions: await this.resolveWorkspacePermissions({
+        workspace,
+        role: authType.role,
+        groupModelIds: groupIds,
+      }),
     });
   }
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -49,6 +49,9 @@ export const ROLE_REGISTRY: Record<
     reader: { verbs: ["read"], levels: ["instance"] },
     member: { verbs: ["read", "write"], levels: ["instance"] },
     admin: { verbs: ["read", "write", "admin"], levels: ["instance"] },
+    // Workspace-level capability: manage content (files, documents) in open/global spaces. Replaces
+    // the legacy `builder` role write grant on those spaces (dust-tt/tasks#9746).
+    globalWrite: { verbs: ["globalWrite"], levels: ["type"] },
   },
   agent: {
     editor: { verbs: ["read", "write"], levels: ["instance"] },

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -1,5 +1,4 @@
 import type {
-  CapabilitySpec,
   ConcreteResourceType,
   GrantType,
   GrantVerb,
@@ -143,24 +142,27 @@ export function grantTypesForVerb(
   });
 }
 
-function typeLevelVerbsForGrant(
+// Verbs a grant type confers at `level`; empty when the role is not valid at that level.
+function verbsForGrantAtLevel(
   grantType: ConcreteGrantType,
-  resourceType: ConcreteResourceType
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
 ): GrantVerb[] {
   const role = ROLE_REGISTRY[resourceType][grantType];
-  if (!role || !role.levels.includes("type")) {
+  if (!role || !role.levels.includes(level)) {
     return [];
   }
   return role.verbs;
 }
 
-function allTypeLevelVerbsForResource(
-  resourceType: ConcreteResourceType
+// Every verb valid at `level` on `resourceType` — used to expand a "*" grant.
+function allVerbsForResourceAtLevel(
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
 ): GrantVerb[] {
   const verbs = new Set<GrantVerb>();
-  const roles = Object.values(ROLE_REGISTRY[resourceType]);
-  for (const role of roles) {
-    if (role.levels.includes("type")) {
+  for (const role of Object.values(ROLE_REGISTRY[resourceType])) {
+    if (role.levels.includes(level)) {
       for (const verb of role.verbs) {
         verbs.add(verb);
       }
@@ -182,55 +184,131 @@ function emptyWorkspacePermissions(): WorkspacePermissions {
   };
 }
 
-// Every type-level verb on every resource type — an admin's implicit full access.
-export function allWorkspacePermissions(): WorkspacePermissions {
-  const permissions = emptyWorkspacePermissions();
-  for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
-    if (!isConcreteResourceType(resourceType)) {
-      continue;
-    }
-    permissions[resourceType] = allTypeLevelVerbsForResource(resourceType);
-  }
-  return permissions;
+// A raw grant row as stored in `group_permissions`: a role name for a (resourceType, resourceId).
+export interface StoredGrant {
+  grantType: GrantType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
 }
 
-// The workspace-level verbs a caller's type-wide (-1) grants confer, grouped by resource type. A
-// "*" grantType fans out to every type-level verb of the resource; a "*" resourceType fans out to
-// every concrete resource type.
-export function workspacePermissionsFromGrants(
-  grants: CapabilitySpec[]
-): WorkspacePermissions {
-  const verbsByResource: Record<ConcreteResourceType, Set<GrantVerb>> = {
-    space: new Set(),
-    agent: new Set(),
-    skill: new Set(),
-    frame: new Set(),
-    billing: new Set(),
-    identity: new Set(),
-    audit_log: new Set(),
-    models_tier: new Set(),
-  };
+/**
+ * The governance grants a caller holds, resolved once at auth construction. Grants are keyed by
+ * (resourceType, resourceId): resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities
+ * (e.g. "create" on "agent") or a resource's model id for instance grants (e.g. "write" on a
+ * specific space). A type-wide grant satisfies an instance check on any id of that type.
+ */
+export class WorkspacePermissionSet {
+  private constructor(
+    private readonly grants: Map<
+      ConcreteResourceType,
+      Map<number, Set<GrantVerb>>
+    >,
+    // Admins hold every capability on every resource/instance by default.
+    private readonly isAdminAll: boolean
+  ) {}
 
-  for (const { grantType, resourceType } of grants) {
-    const resources =
-      resourceType === "*"
-        ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)
-        : [resourceType];
+  static empty(): WorkspacePermissionSet {
+    return new WorkspacePermissionSet(new Map(), false);
+  }
 
-    for (const resource of resources) {
-      const verbs =
-        grantType === "*"
-          ? allTypeLevelVerbsForResource(resource)
-          : typeLevelVerbsForGrant(grantType, resource);
-      verbs.forEach((verb) => verbsByResource[resource].add(verb));
+  static all(): WorkspacePermissionSet {
+    return new WorkspacePermissionSet(new Map(), true);
+  }
+
+  static fromGrants(grants: StoredGrant[]): WorkspacePermissionSet {
+    const map = new Map<ConcreteResourceType, Map<number, Set<GrantVerb>>>();
+    const add = (
+      resourceType: ConcreteResourceType,
+      resourceId: number,
+      verbs: GrantVerb[]
+    ) => {
+      if (verbs.length === 0) {
+        return;
+      }
+      let byId = map.get(resourceType);
+      if (!byId) {
+        byId = new Map();
+        map.set(resourceType, byId);
+      }
+      let set = byId.get(resourceId);
+      if (!set) {
+        set = new Set();
+        byId.set(resourceId, set);
+      }
+      for (const verb of verbs) {
+        set.add(verb);
+      }
+    };
+
+    for (const { grantType, resourceType, resourceId } of grants) {
+      // A "*" grant / -1 resourceId are always type-wide; concrete ids are instance-level.
+      const level: GrantLevel =
+        resourceId === WHOLE_TYPE_RESOURCE_ID ? "type" : "instance";
+      const resourceTypes =
+        resourceType === "*"
+          ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)
+          : [resourceType];
+
+      for (const rt of resourceTypes) {
+        const verbs =
+          grantType === "*"
+            ? allVerbsForResourceAtLevel(rt, level)
+            : verbsForGrantAtLevel(grantType, rt, level);
+        add(rt, resourceId, verbs);
+      }
     }
+
+    return new WorkspacePermissionSet(map, false);
   }
 
-  const permissions = emptyWorkspacePermissions();
-  for (const resource of GROUP_PERMISSION_RESOURCE_TYPES.filter(
-    isConcreteResourceType
-  )) {
-    permissions[resource] = [...verbsByResource[resource]];
+  // Whether the caller holds `verb` on the given resource instance. A type-wide (-1) grant on the
+  // resource type satisfies the check for any instance.
+  has(
+    resourceType: ConcreteResourceType,
+    resourceId: number,
+    verb: GrantVerb
+  ): boolean {
+    if (this.isAdminAll) {
+      return true;
+    }
+    const byId = this.grants.get(resourceType);
+    if (!byId) {
+      return false;
+    }
+    return (
+      (byId.get(resourceId)?.has(verb) ?? false) ||
+      (byId.get(WHOLE_TYPE_RESOURCE_ID)?.has(verb) ?? false)
+    );
   }
-  return permissions;
+
+  hasTypeWide(resourceType: ConcreteResourceType, verb: GrantVerb): boolean {
+    return this.has(resourceType, WHOLE_TYPE_RESOURCE_ID, verb);
+  }
+
+  // The type-wide (-1) capabilities the caller holds, as the flat per-resource-type record consumed
+  // by the `/permissions` endpoint and the Workspace & Governance page. Admins, who hold everything
+  // implicitly, are materialized as every type-level verb on every resource type.
+  toTypeWideWorkspacePermissions(): WorkspacePermissions {
+    const result = emptyWorkspacePermissions();
+
+    if (this.isAdminAll) {
+      for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
+        if (isConcreteResourceType(resourceType)) {
+          result[resourceType] = allVerbsForResourceAtLevel(
+            resourceType,
+            "type"
+          );
+        }
+      }
+      return result;
+    }
+
+    for (const [resourceType, byId] of this.grants) {
+      const typeWideVerbs = byId.get(WHOLE_TYPE_RESOURCE_ID);
+      if (typeWideVerbs) {
+        result[resourceType] = [...typeWideVerbs];
+      }
+    }
+    return result;
+  }
 }

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -30,9 +30,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("reader");
       expect(grants[0].resourceType).toBe("space");
@@ -49,9 +52,12 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.grant(auth, spec);
       await GroupPermissionResource.grant(auth, spec);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
     });
 
@@ -111,11 +117,14 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-        resourceType: "space",
-        resourceId: 1,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+          resourceType: "space",
+          resourceId: 1,
+        }
+      );
       expect(grants).toHaveLength(2);
       expect(new Set(grants.map((g) => g.groupId))).toEqual(
         new Set([groupA.id, groupB.id])
@@ -123,9 +132,12 @@ describe("GroupPermissionResource", () => {
     });
 
     it("returns [] for no groups without querying", async () => {
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [],
+        }
+      );
       expect(grants).toEqual([]);
     });
   });
@@ -152,9 +164,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("member");
     });
@@ -184,9 +199,12 @@ describe("GroupPermissionResource", () => {
         resourceId: 1,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("admin");
     });
@@ -220,9 +238,12 @@ describe("GroupPermissionResource", () => {
       });
       expect(deleted).toBe(2);
 
-      const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const remaining = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(remaining).toHaveLength(1);
       expect(remaining[0].resourceId).toBe(100);
     });
@@ -254,9 +275,12 @@ describe("GroupPermissionResource", () => {
 
       await GroupPermissionResource.deleteAllForWorkspace(auth);
 
-      const remaining = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const remaining = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(remaining).toEqual([]);
     });
   });
@@ -274,9 +298,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "agent",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(1);
       expect(grants[0].resourceId).toBe(-1);
     });
@@ -303,9 +330,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "billing",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(0);
     });
   });
@@ -318,9 +348,12 @@ describe("GroupPermissionResource", () => {
         resourceType: "skill",
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id, groupB.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id, groupB.id],
+        }
+      );
       expect(grants).toHaveLength(2);
       expect(grants.every((g) => g.resourceId === -1)).toBe(true);
     });
@@ -349,9 +382,12 @@ describe("GroupPermissionResource", () => {
         ],
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [groupA.id],
+        }
+      );
       expect(grants).toHaveLength(2);
     });
 
@@ -384,16 +420,19 @@ describe("GroupPermissionResource", () => {
       });
       expect(result.isOk()).toBe(true);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: (
-          await GroupResource.listAllWorkspaceGroups(auth, {
-            groupKinds: ["regular_auto"],
-          })
-        ).map((group) => group.id),
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 42,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: (
+            await GroupResource.listAllWorkspaceGroups(auth, {
+              groupKinds: ["regular_auto"],
+            })
+          ).map((group) => group.id),
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 42,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       const group = await GroupResource.fetchByModelIds(auth, [
@@ -427,12 +466,15 @@ describe("GroupPermissionResource", () => {
       });
       const grantGroups = [];
       for (const group of autoGroups) {
-        const grants = await GroupPermissionResource.listForGroups(auth, {
-          groupModelIds: [group.id],
-          grantType: "editor",
-          resourceType: "agent",
-          resourceId: 7,
-        });
+        const grants = await GroupPermissionResource.listForGroups(
+          auth.getNonNullableWorkspace(),
+          {
+            groupModelIds: [group.id],
+            grantType: "editor",
+            resourceType: "agent",
+            resourceId: 7,
+          }
+        );
         if (grants.length > 0) {
           grantGroups.push(group);
         }
@@ -464,12 +506,15 @@ describe("GroupPermissionResource", () => {
       const autoGroups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: ["regular_auto"],
       });
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: autoGroups.map((group) => group.id),
-        grantType: "editor",
-        resourceType: "skill",
-        resourceId: 99,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: autoGroups.map((group) => group.id),
+          grantType: "editor",
+          resourceType: "skill",
+          resourceId: 99,
+        }
+      );
       expect(grants).toHaveLength(0);
     });
 
@@ -500,16 +545,19 @@ describe("GroupPermissionResource", () => {
       });
       expect(result.isOk()).toBe(true);
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: (
-          await GroupResource.listAllWorkspaceGroups(auth, {
-            groupKinds: ["regular_auto"],
-          })
-        ).map((group) => group.id),
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 5,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: (
+            await GroupResource.listAllWorkspaceGroups(auth, {
+              groupKinds: ["regular_auto"],
+            })
+          ).map((group) => group.id),
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 5,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       const [group] = await GroupResource.fetchByModelIds(auth, [
@@ -535,12 +583,15 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
 
-      const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [globalGroup.id],
-        grantType: "reader",
-        resourceType: "space",
-        resourceId: 42,
-      });
+      const grants = await GroupPermissionResource.listForGroups(
+        auth.getNonNullableWorkspace(),
+        {
+          groupModelIds: [globalGroup.id],
+          grantType: "reader",
+          resourceType: "space",
+          resourceId: 42,
+        }
+      );
       expect(grants).toHaveLength(1);
 
       await GroupPermissionResource.revokeFromEverybody(auth, {
@@ -549,12 +600,15 @@ describe("GroupPermissionResource", () => {
         resourceId: 42,
       });
       expect(
-        await GroupPermissionResource.listForGroups(auth, {
-          groupModelIds: [globalGroup.id],
-          grantType: "reader",
-          resourceType: "space",
-          resourceId: 42,
-        })
+        await GroupPermissionResource.listForGroups(
+          auth.getNonNullableWorkspace(),
+          {
+            groupModelIds: [globalGroup.id],
+            grantType: "reader",
+            resourceType: "space",
+            resourceId: 42,
+          }
+        )
       ).toHaveLength(0);
     });
 

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -20,7 +20,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { UserType } from "@app/types/user";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -365,8 +365,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Read grants for the given groups, optionally narrowed by grant type / resource type /
   // resource. The (workspaceId, resourceType, resourceId) index backs type/resource-scoped reads.
+  // Grants for the given groups in a workspace. Takes a LightWorkspaceType (not an Authenticator) so
+  // it can resolve a caller's grant set before an Authenticator exists (see
+  // `Authenticator.resolveWorkspacePermissions`). Omit the filters to load every grant.
   static async listForGroups(
-    auth: Authenticator,
+    workspace: LightWorkspaceType,
     { groupModelIds, grantType, resourceType, resourceId }: ListForGroupsSpec
   ): Promise<GroupPermissionResource[]> {
     if (groupModelIds.length === 0) {
@@ -375,7 +378,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
     const rows = await GroupPermissionModel.findAll({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspace.id,
         groupId: groupModelIds,
         ...(grantType !== undefined ? { grantType } : {}),
         ...(resourceType !== undefined ? { resourceType } : {}),

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -6,6 +6,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind } from "@app/types/groups";
 import type {
   CombinedResourcePermissions,
@@ -186,9 +187,16 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
                 permissions: ["read"],
               },
             ],
-            roles: [
-              { role: "admin", permissions: ["admin", "read", "write"] },
-              { role: "builder", permissions: ["read", "write"] },
+            roles: [{ role: "admin", permissions: ["admin", "read", "write"] }],
+            // Mirrors the space-level grant: the workspace `space` write capability confers
+            // read+write, replacing the legacy `builder` role grant (dust-tt/tasks#9746).
+            workspacePermissions: [
+              {
+                resourceType: "space",
+                verb: "globalWrite",
+                resourceId: WHOLE_TYPE_RESOURCE_ID,
+                permissions: ["read", "write"],
+              },
             ],
             workspaceId: this.workspaceId,
           },

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -175,11 +175,14 @@ export class ModelsTierResource {
       return [];
     }
 
-    const grants = await GroupPermissionResource.listForGroups(auth, {
-      groupModelIds: [globalGroup.id],
-      grantType: MODELS_TIER_GRANT_TYPE,
-      resourceType: MODELS_TIER_RESOURCE_TYPE,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      auth.getNonNullableWorkspace(),
+      {
+        groupModelIds: [globalGroup.id],
+        grantType: MODELS_TIER_GRANT_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+      }
+    );
 
     return grants.flatMap((grant) => {
       const tierName = this.tierNameFromResourceId(grant.resourceId);
@@ -612,11 +615,14 @@ export class ModelsTierResource {
       return new Map();
     }
 
-    const grants = await GroupPermissionResource.listForGroups(auth, {
-      groupModelIds,
-      grantType: MODELS_TIER_GRANT_TYPE,
-      resourceType: MODELS_TIER_RESOURCE_TYPE,
-    });
+    const grants = await GroupPermissionResource.listForGroups(
+      auth.getNonNullableWorkspace(),
+      {
+        groupModelIds,
+        grantType: MODELS_TIER_GRANT_TYPE,
+        resourceType: MODELS_TIER_RESOURCE_TYPE,
+      }
+    );
 
     const tiersByGroupId = new Map<ModelId, ModelsTierName[]>();
     for (const grant of grants) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -21,6 +21,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
+import { WHOLE_TYPE_RESOURCE_ID } from "@app/types/group_permissions";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
@@ -1526,9 +1527,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
-          roles: [
-            { role: "admin", permissions: ["admin", "read", "write"] },
-            { role: "builder", permissions: ["read", "write"] },
+          roles: [{ role: "admin", permissions: ["admin", "read", "write"] }],
+          // The workspace-level `space` write capability confers read+write, replacing the legacy
+          // `builder` role grant (dust-tt/tasks#9746).
+          workspacePermissions: [
+            {
+              resourceType: "space",
+              verb: "globalWrite",
+              resourceId: WHOLE_TYPE_RESOURCE_ID,
+              permissions: ["read", "write"],
+            },
           ],
           groups: this.groups.map((group) => ({
             id: group.groupId,
@@ -1554,8 +1562,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
-            { role: "builder", permissions: ["read", "write"] },
             { role: "user", permissions: ["read"] },
+          ],
+          // The workspace-level `space` write capability confers read+write, replacing the legacy
+          // `builder` role grant (dust-tt/tasks#9746).
+          workspacePermissions: [
+            {
+              resourceType: "space",
+              verb: "globalWrite",
+              resourceId: WHOLE_TYPE_RESOURCE_ID,
+              permissions: ["read", "write"],
+            },
           ],
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -18,6 +18,9 @@ export const GRANT_VERBS = [
   "publish",
   "invite",
   "use",
+  // Manage content in open/global spaces workspace-wide (type-level only). Distinct from the
+  // instance-level `write` verb, which is granted per space via space membership.
+  "globalWrite",
 ] as const;
 export type GrantVerb = (typeof GRANT_VERBS)[number];
 
@@ -32,6 +35,7 @@ export const GRANT_TYPES = [
   "publish",
   "invite",
   "read",
+  "globalWrite",
   "use",
   "*",
 ] as const;

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -1,3 +1,4 @@
+import type { ConcreteResourceType, GrantVerb } from "./group_permissions";
 import type { ModelId } from "./shared/model_id";
 import type { RoleType } from "./user";
 
@@ -37,11 +38,35 @@ export type GroupResourcePermissions = {
 };
 
 /**
- * Defines combined group and role-based permissions for a resource.
+ * Represents permissions conferred by holding a workspace-level governance capability
+ * (a type-wide `group_permissions` grant, e.g. the `write` capability on `space`).
+ *
+ * Unlike role/group permissions, which are resolved synchronously from the Authenticator's role and
+ * group memberships, capabilities live in `group_permissions` and are resolved once at auth
+ * construction (see `Authenticator.getWorkspacePermissions`). A resource declares which capability
+ * grants it, and which permissions holding that capability confers on that resource.
+ *
+ * @property resourceType - The governance resource domain of the capability (e.g. "space")
+ * @property verb - The verb the caller must hold on `resourceType` (e.g. "globalWrite")
+ * @property resourceId - The grant's resource id: WHOLE_TYPE_RESOURCE_ID (-1) for a type-wide
+ *   capability, or a resource's model id for an instance grant. A type-wide grant held by the
+ *   caller also satisfies an instance requirement.
+ * @property permissions - Permissions granted on this resource when the caller holds the capability
+ */
+export type WorkspacePermissionGrant = {
+  resourceType: ConcreteResourceType;
+  verb: GrantVerb;
+  resourceId: number;
+  permissions: PermissionType[];
+};
+
+/**
+ * Defines combined group, role, and workspace-capability-based permissions for a resource.
  */
 export type CombinedResourcePermissions = {
   groups: GroupPermission[];
   roles: RolePermission[];
+  workspacePermissions?: WorkspacePermissionGrant[];
   workspaceId: ModelId;
 };
 


### PR DESCRIPTION
Add the type-level `globalWrite` capability on `space` and use it in place of the
legacy `builder` role: space requestedPermissions (global/conversations/open) grant
read+write to its holders, the file endpoints (private + v1) gate on
`hasWorkspacePermission("globalWrite", "space")` instead of `isBuilder()`, and the
capability is seeded to the Builders group so it lands on today's builder population.

Part of the builder-role deprecation (dust-tt/tasks#9746).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
