### PR TITLE
admin governance: expose availability in skill endpoints 1/3

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -17,6 +17,7 @@ import type {
   PatchSkillResponseBody,
 } from "@app/types/api/skills";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
+import { availabilityFromIsDefault } from "@app/types/assistant/skill_configuration";
 import type { APIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -385,7 +386,11 @@ app.patch(
       icon: body.icon,
       instructions: body.instructions,
       instructionsHtml: body.instructionsHtml,
-      isDefault: body.isDefault,
+      // isDefault is a deprecated alias in the API contract; the resource takes availability.
+      availability:
+        body.isDefault !== undefined
+          ? availabilityFromIsDefault(body.isDefault)
+          : undefined,
       mcpServerViews,
       name,
       reinforcement: body.reinforcement,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -20,13 +20,16 @@ import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SkillResource", () => {
@@ -557,7 +560,7 @@ describe("SkillResource", () => {
   });
 
   describe("updateSkill", () => {
-    it("keeps availability in sync when updating isDefault", async () => {
+    it("updates availability and derives the serialized isDefault from it", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
         { name: "Test Skill For Availability Sync" }
@@ -574,7 +577,7 @@ describe("SkillResource", () => {
         userFacingDescription: skillResource.userFacingDescription,
         instructions: skillResource.instructions,
         icon: skillResource.icon,
-        isDefault: true,
+        availability: "users_and_agents",
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [],
@@ -595,7 +598,7 @@ describe("SkillResource", () => {
         userFacingDescription: skillResource.userFacingDescription,
         instructions: skillResource.instructions,
         icon: skillResource.icon,
-        isDefault: false,
+        availability: "workspace_users",
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [],
@@ -1270,6 +1273,87 @@ describe("SkillResource", () => {
       await expect(
         parentSkill.fetchChildSkills(testContext.authenticator)
       ).resolves.toHaveLength(0);
+    });
+  });
+
+  describe("updateAvailability", () => {
+    it("updates the availability for a caller with the publish permission", async () => {
+      // Admins hold every workspace-level capability, including publish on skills.
+      const skillResource = await SkillFactory.create(
+        testContext.authenticator,
+        { name: "Publishable Skill" }
+      );
+
+      await skillResource.updateAvailability(
+        testContext.authenticator,
+        "editors"
+      );
+
+      const updatedSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        skillResource.sId
+      );
+      expect(updatedSkill?.availability).toBe("editors");
+      expect(updatedSkill?.editedBy).toBe(skillResource.editedBy);
+    });
+
+    it("rejects a caller without the publish permission, even an editor", async () => {
+      const builder = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, builder, {
+        role: "builder",
+      });
+      const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        builder.sId,
+        testContext.workspace.sId
+      );
+
+      // The builder creates the skill, so they are an editor — editing rights are
+      // not sufficient to change availability.
+      const skillResource = await SkillFactory.create(builderAuth, {
+        name: "Non Publishable Skill",
+      });
+
+      await expect(
+        skillResource.updateAvailability(builderAuth, "users_and_agents")
+      ).rejects.toThrow(
+        "User is not authorized to update this skill's availability"
+      );
+    });
+
+    it("requires the publish permission to change availability through updateSkill when governance is on", async () => {
+      await FeatureFlagFactory.basic(
+        testContext.authenticator,
+        "admin_governance_skill_publication"
+      );
+
+      const builder = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, builder, {
+        role: "builder",
+      });
+      const builderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        builder.sId,
+        testContext.workspace.sId
+      );
+
+      const skillResource = await SkillFactory.create(builderAuth, {
+        name: "Governed Skill",
+      });
+
+      await expect(
+        skillResource.updateSkill(builderAuth, {
+          name: skillResource.name,
+          agentFacingDescription: skillResource.agentFacingDescription,
+          userFacingDescription: skillResource.userFacingDescription,
+          instructions: skillResource.instructions,
+          icon: skillResource.icon,
+          availability: "users_and_agents",
+          mcpServerViews: [],
+          attachedKnowledge: [],
+          requestedSpaceIds: [],
+        })
+      ).rejects.toThrow(
+        "User is not authorized to update this skill's availability"
+      );
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -10,6 +10,7 @@ import {
   hasSharedMembership,
 } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
@@ -78,6 +79,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
+  SkillAvailability,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -2815,11 +2817,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentFacingDescription,
       attachedKnowledge,
+      availability,
       fileAttachments,
       icon,
       instructions,
       instructionsHtml,
-      isDefault,
       mcpServerViews,
       name,
       reinforcement,
@@ -2831,11 +2833,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentFacingDescription: string;
       attachedKnowledge: SkillAttachedKnowledge[];
+      availability?: SkillAvailability;
       fileAttachments?: FileResource[];
       icon: string | null;
       instructions: string;
       instructionsHtml?: string | null;
-      isDefault?: boolean;
       mcpServerViews: MCPServerViewResource[];
       name: string;
       reinforcement?: SkillReinforcementMode;
@@ -2847,6 +2849,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
+
+    // With skill publication governance, changing the availability requires the
+    // workspace-level publish permission — even for editors.
+    if (
+      availability !== undefined &&
+      availability !== this.availability &&
+      (await hasFeatureFlag(auth, "admin_governance_skill_publication"))
+    ) {
+      assert(
+        await auth.hasWorkspacePermission("publish", "skill"),
+        "User is not authorized to update this skill's availability"
+      );
+    }
 
     // Snapshot the previous name and icon before updating to detect changes below.
     const previousName = this.name;
@@ -2881,10 +2896,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
-          // isDefault is a legacy alias kept at the interface level; the column is availability.
-          ...(isDefault !== undefined
-            ? { availability: availabilityFromIsDefault(isDefault) }
-            : {}),
+          ...(availability !== undefined ? { availability } : {}),
           ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
         transaction
@@ -2933,6 +2945,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     await this.upsertCurrentUserAsEditor(auth);
+  }
+
+  /**
+   * Update only the availability of the skill. Requires the workspace-level "publish"
+   * permission on skills — being an editor is neither required nor sufficient. Does not
+   * touch editedBy.
+   */
+  async updateAvailability(
+    auth: Authenticator,
+    availability: SkillAvailability
+  ): Promise<void> {
+    assert(
+      await auth.hasWorkspacePermission("publish", "skill"),
+      "User is not authorized to update this skill's availability"
+    );
+
+    await withTransaction(async (transaction) => {
+      // Save the current version before updating.
+      await this.saveVersion(auth, { transaction });
+      await this.update({ availability }, transaction);
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

Switch `SkillResource.updateSkill` to take `availability` instead of the deprecated `isDefault`, with a flag-gated publish-permission check on availability changes.
Add a new `updateAvailability` method allowing skill-publish permission holders to change a skill's availability without being an editor (no caller yet, used by a follow-up PR).
Issue: https://github.com/dust-tt/tasks/issues/9730

## Stack

- 1/3: https://github.com/dust-tt/dust/pull/29381
- 2/3: https://github.com/dust-tt/dust/pull/29382
- 3/3: https://github.com/dust-tt/dust/pull/29383

## Tests

New unit tests on `updateAvailability` (permission granted / denied even for editors) and on the `updateSkill` governance check; existing skill_resource tests updated.

## Risk

Low, PR is easy to revert.

## Deploy Plan

Deploy front.
