### PR TITLE
admin governance: expose availability in skill endpoints 2/3

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -14271,7 +14271,17 @@
           },
           "isDefault": {
             "type": "boolean",
-            "description": "Whether this skill is enabled by default"
+            "deprecated": true,
+            "description": "Whether this skill is enabled by default. Deprecated, use availability instead."
+          },
+          "availability": {
+            "type": "string",
+            "enum": [
+              "editors",
+              "workspace_users",
+              "users_and_agents"
+            ],
+            "description": "Who the skill is available to (users_and_agents makes it discoverable by agents)"
           },
           "instructions": {
             "type": "string",

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -738,7 +738,12 @@
  *           description: Whether the authenticated actor can edit the skill
  *         isDefault:
  *           type: boolean
- *           description: Whether this skill is enabled by default
+ *           deprecated: true
+ *           description: Whether this skill is enabled by default. Deprecated, use availability instead.
+ *         availability:
+ *           type: string
+ *           enum: [editors, workspace_users, users_and_agents]
+ *           description: Who the skill is available to (users_and_agents makes it discoverable by agents)
  *         instructions:
  *           type: string
  *           nullable: true

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -6,6 +6,7 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -356,6 +357,147 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
+  });
+
+  it("updates availability, giving it priority over the deprecated isDefault", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const basePayload = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    // Old clients still send only isDefault.
+    let response = await patchSkill(workspace, skill.sId, {
+      ...basePayload,
+      isDefault: true,
+    });
+    expect(response.status).toBe(200);
+    let updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.availability).toBe("users_and_agents");
+
+    // New clients send availability; it wins over a contradicting isDefault.
+    response = await patchSkill(workspace, skill.sId, {
+      ...basePayload,
+      isDefault: true,
+      availability: "workspace_users",
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.availability).toBe("workspace_users");
+    expect(data.skill.isDefault).toBe(false);
+    updatedSkill = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(updatedSkill?.availability).toBe("workspace_users");
+  });
+
+  it("rejects the editors availability when skill publication governance is off", async () => {
+    const { workspace, skill } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: skill.icon,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: skill.instructionsHtml,
+      availability: "editors",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("denies any edit to a non-editor even with the publish permission", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "admin",
+    });
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: "Renamed By Admin",
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: skill.icon,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: skill.instructionsHtml,
+      availability: "editors",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("denies an availability change to an editor without the publish permission", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+    });
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: skill.icon,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: skill.instructionsHtml,
+      availability: "users_and_agents",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets an editor without the publish permission edit when availability is unchanged", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+    });
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: "Renamed By Editor",
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: skill.icon,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: skill.instructionsHtml,
+    });
+
+    expect(response.status).toBe(200);
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill?.name).toBe("Renamed By Editor");
   });
 
   it("recomputes nested skill references from instructions", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -3,6 +3,7 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -17,7 +18,10 @@ import type {
   PatchSkillResponseBody,
 } from "@app/types/api/skills";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
-import { availabilityFromIsDefault } from "@app/types/assistant/skill_configuration";
+import {
+  availabilityFromIsDefault,
+  SKILL_AVAILABILITIES,
+} from "@app/types/assistant/skill_configuration";
 import type { APIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -54,7 +58,9 @@ const PatchSkillRequestBodySchema = z.object({
   instructionsHtml: z.string().nullable(),
   additionalRequestedSpaceIds: z.array(z.string()).optional(),
   fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
+  // @deprecated Use availability instead. Kept while old clients still send it.
   isDefault: z.boolean().optional(),
+  availability: z.enum(SKILL_AVAILABILITIES).optional(),
   reinforcement: z.enum(["auto", "on", "off"]).optional(),
 });
 
@@ -182,7 +188,55 @@ app.patch(
       });
     }
 
-    // Check if user can write.
+    // Resolve the requested availability once: isDefault is a deprecated alias; an explicit
+    // availability takes priority over it.
+    const requestedAvailability =
+      body.availability ??
+      (body.isDefault !== undefined
+        ? availabilityFromIsDefault(body.isDefault)
+        : undefined);
+
+    const hasSkillPublicationGovernance = await hasFeatureFlag(
+      auth,
+      "admin_governance_skill_publication"
+    );
+
+    // Without skill publication governance, keep the previous behavior: only the two
+    // legacy availability values are accepted.
+    if (!hasSkillPublicationGovernance && requestedAvailability === "editors") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            'Availability "editors" requires skill publication governance to be enabled.',
+        },
+      });
+    }
+
+    const availabilityChanged =
+      requestedAvailability !== undefined &&
+      requestedAvailability !== skill.availability;
+
+    // With skill publication governance, changing a skill's availability requires the
+    // workspace-level permission to publish skills — even for editors.
+    if (
+      hasSkillPublicationGovernance &&
+      availabilityChanged &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "You don't have permission to change this skill's availability.",
+        },
+      });
+    }
+
+    // Editing a skill remains editor-only; non-editors holding the publish permission use
+    // PATCH /skills/:sId/availability to publish or unpublish without editing.
     if (!skill.canWrite(auth)) {
       return apiError(ctx, {
         status_code: 403,
@@ -386,11 +440,7 @@ app.patch(
       icon: body.icon,
       instructions: body.instructions,
       instructionsHtml: body.instructionsHtml,
-      // isDefault is a deprecated alias in the API contract; the resource takes availability.
-      availability:
-        body.isDefault !== undefined
-          ? availabilityFromIsDefault(body.isDefault)
-          : undefined,
+      availability: requestedAvailability,
       mcpServerViews,
       name,
       reinforcement: body.reinforcement,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -9,6 +9,7 @@ import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -665,6 +666,86 @@ describe("POST /api/w/:wId/skills", () => {
       responseData.skill.sId
     );
     expect(createdSkill).not.toBeNull();
+  });
+
+  it("rejects the editors availability when skill publication governance is off", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const response = await postSkill(workspace, {
+      name: "Unpublished Skill",
+      agentFacingDescription: "To use in various situations",
+      userFacingDescription: "A skill",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      availability: "editors",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("keeps the default availability without requiring the publish permission when governance is on", async () => {
+    const { auth, workspace, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+    await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");
+
+    const response = await postSkill(workspace, {
+      name: "Draft Skill",
+      agentFacingDescription: "To use in various situations",
+      userFacingDescription: "A skill",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.skill.availability).toBe("workspace_users");
+  });
+
+  it("requires the publish permission to create a published skill when governance is on", async () => {
+    const { auth, workspace, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+    await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");
+
+    const response = await postSkill(workspace, {
+      name: "Published Skill",
+      agentFacingDescription: "To use in various situations",
+      userFacingDescription: "A skill",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      availability: "workspace_users",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets an admin create a published skill when governance is on", async () => {
+    const { auth, workspace } = await setupTest("admin");
+    await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");
+
+    const response = await postSkill(workspace, {
+      name: "Published Skill",
+      agentFacingDescription: "To use in various situations",
+      userFacingDescription: "A skill",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      availability: "users_and_agents",
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.skill.availability).toBe("users_and_agents");
   });
 
   it("creates skill references", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -4,6 +4,7 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -16,7 +17,10 @@ import type {
 } from "@app/types/api/skills";
 import {
   availabilityFromIsDefault,
+  DEFAULT_SKILL_AVAILABILITY,
+  SKILL_AVAILABILITIES,
   SKILL_REINFORCEMENT_MODES,
+  type SkillAvailability,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -53,7 +57,9 @@ const PostSkillRequestBodySchema = z.intersection(
     instructionsHtml: z.string().nullable(),
     additionalRequestedSpaceIds: z.array(z.string()).optional(),
     fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
+    // @deprecated Use availability instead. Kept while old clients still send it.
     isDefault: z.boolean().optional(),
+    availability: z.enum(SKILL_AVAILABILITIES).optional(),
     reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
   }),
   z.union([
@@ -74,6 +80,24 @@ const PostSkillRequestBodySchema = z.intersection(
     }),
   ])
 );
+
+// isDefault is a deprecated alias; an explicit availability takes priority over it. Returns
+// undefined when the caller did not request any availability.
+function resolveRequestedAvailability({
+  availability,
+  isDefault,
+}: {
+  availability?: SkillAvailability;
+  isDefault?: boolean;
+}): SkillAvailability | undefined {
+  if (availability !== undefined) {
+    return availability;
+  }
+  if (isDefault !== undefined) {
+    return availabilityFromIsDefault(isDefault);
+  }
+  return undefined;
+}
 
 // Mounted at /api/w/:wId/skills.
 const app = workspaceApp();
@@ -229,6 +253,46 @@ app.post(
         },
       });
     }
+
+    const hasSkillPublicationGovernance = await hasFeatureFlag(
+      auth,
+      "admin_governance_skill_publication"
+    );
+
+    // Without skill publication governance, keep the previous behavior: only the two
+    // legacy availability values are accepted.
+    if (!hasSkillPublicationGovernance && body.availability === "editors") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            'Availability "editors" requires skill publication governance to be enabled.',
+        },
+      });
+    }
+
+    const requestedAvailability = resolveRequestedAvailability(body);
+
+    // With skill publication governance, explicitly creating a skill already published
+    // (anything other than editors-only) requires the workspace-level permission to publish
+    // skills. The default availability is exempt so plain creation keeps working.
+    if (
+      hasSkillPublicationGovernance &&
+      requestedAvailability !== undefined &&
+      requestedAvailability !== "editors" &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "You don't have permission to publish skills.",
+        },
+      });
+    }
+
+    const availability = requestedAvailability ?? DEFAULT_SKILL_AVAILABILITY;
 
     const existingSkill = await SkillResource.fetchByName(auth, name);
 
@@ -393,7 +457,7 @@ app.post(
         icon,
         source: body.source ?? "web_app",
         sourceMetadata: body.sourceMetadata ?? null,
-        availability: availabilityFromIsDefault(body.isDefault ?? false),
+        availability,
         reinforcement: body.reinforcement ?? "on",
       },
       {

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -29,6 +29,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     canAdministrate: true,
     canWrite: true,
     isDefault: false,
+    availability: "workspace_users",
     ...overrides,
   };
 }

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -28,6 +28,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     canAdministrate: true,
     canWrite: true,
     isDefault: false,
+    availability: "workspace_users",
     ...overrides,
   };
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -4073,6 +4073,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       canWrite: this.canWrite(auth),
       canAdministrate: this.canAdministrate(auth),
       isDefault: isDefaultFromAvailability(this.availability),
+      availability: this.availability,
     };
   }
 

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -97,6 +97,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     canWrite: false,
     canAdministrate: false,
     isDefault: false,
+    availability: "workspace_users",
   };
 }
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -88,7 +88,9 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   ),
   canWrite: z.boolean(),
   canAdministrate: z.boolean(),
+  // @deprecated Use availability instead. Kept while old clients still read it.
   isDefault: z.boolean(),
+  availability: z.enum(SKILL_AVAILABILITIES),
 });
 
 export type SkillWithoutInstructionsAndToolsType = z.infer<


### PR DESCRIPTION
## Description

POST and PATCH `/skills` accept an optional `availability` param (3 states) with the deprecated `isDefault` alias still supported — an explicit availability wins — and `toJSON` now exposes `availability`.
With the `admin_governance_skill_publication` flag: explicitly creating a published skill or changing availability requires the skill publish permission; without the flag, only the two legacy values are accepted (previous behavior). The default availability is unchanged in both modes.
Issue: https://github.com/dust-tt/tasks/issues/9730

## Stack

- 1/3: https://github.com/dust-tt/dust/pull/29381
- 2/3: https://github.com/dust-tt/dust/pull/29382
- 3/3: https://github.com/dust-tt/dust/pull/29383

## Tests

Route tests: availability/isDefault priority rule, `editors` rejected flag-off, unpublished default flag-on, publish-permission 403s on create and update, editor edits unaffected when availability unchanged.

## Risk

Low, PR is easy to revert.

## Deploy Plan

Deploy front.

