### PR TITLE
admin governance: expose availability in skill endpoints 3/3

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { SKILL_ICON } from "@app/lib/skill";
+import { isDustProvidedSkill, SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
@@ -156,15 +156,14 @@ export function ManageSkillsPage() {
         sortedActiveSkills
           .filter(
             (s) =>
-              s.availability === "users_and_agents" ||
-              s.relations.editors === null
+              s.availability === "users_and_agents" || isDustProvidedSkill(s)
           )
           .sort((a, b) => {
-            // Display first the skills that have no editor (Dust-managed ones).
-            const aNoEditors = a.relations.editors === null;
-            const bNoEditors = b.relations.editors === null;
-            if (aNoEditors !== bNoEditors) {
-              return aNoEditors ? -1 : 1;
+            // Display Dust-managed skills first.
+            const aIsDustProvided = isDustProvidedSkill(a);
+            const bIsDustProvided = isDustProvidedSkill(b);
+            if (aIsDustProvided !== bIsDustProvided) {
+              return aIsDustProvided ? -1 : 1;
             }
             // Fallback to a name sort.
             return a.name.localeCompare(b.name);

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -154,7 +154,11 @@ export function ManageSkillsPage() {
       ),
       default: filteredList(
         sortedActiveSkills
-          .filter((s) => s.isDefault || s.relations.editors === null)
+          .filter(
+            (s) =>
+              s.availability === "users_and_agents" ||
+              s.relations.editors === null
+          )
           .sort((a, b) => {
             // Display first the skills that have no editor (Dust-managed ones).
             const aNoEditors = a.relations.editors === null;

--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -57,8 +57,8 @@ export function SkillOverviewTable({
             </PokeTableCell>
           </PokeTableRow>
           <PokeTableRow>
-            <PokeTableCell>Default</PokeTableCell>
-            <PokeTableCell>{skill.isDefault ? "Yes" : "No"}</PokeTableCell>
+            <PokeTableCell>Availability</PokeTableCell>
+            <PokeTableCell>{skill.availability}</PokeTableCell>
           </PokeTableRow>
           <PokeTableRow>
             <PokeTableCell>Tools count</PokeTableCell>

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -36,8 +36,10 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
       // Dust-managed non-default skills are displayed first: these are the baseline Discover capabilities.
       // Default skills are the ones that are discoverable.
       skills: skills.toSorted((a, b) => {
-        const aIsDiscover = a.editedBy === null && !a.isDefault;
-        const bIsDiscover = b.editedBy === null && !b.isDefault;
+        const aIsDiscover =
+          a.editedBy === null && a.availability !== "users_and_agents";
+        const bIsDiscover =
+          b.editedBy === null && b.availability !== "users_and_agents";
         if (aIsDiscover !== bIsDiscover) {
           return aIsDiscover ? -1 : 1;
         }

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,6 +1,7 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
 import { AGENT_FACING_DESCRIPTION_MAX_LENGTH } from "@app/lib/skills/labels";
 import {
+  SKILL_AVAILABILITIES,
   SKILL_REINFORCEMENT_MODES,
   SkillWithoutInstructionsAndToolsSchema,
 } from "@app/types/assistant/skill_configuration";
@@ -55,7 +56,7 @@ export const skillBuilderFormSchema = z.object({
   editors: z.array(editorUserSchema),
   tools: z.array(actionSchema),
   icon: z.string().nullable(),
-  isDefault: z.boolean(),
+  availability: z.enum(SKILL_AVAILABILITIES),
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -20,22 +20,23 @@ const MIN_DISCOVERABLE_DESCRIPTION_LENGTH = 150;
 export function SkillBuilderIsDefaultSection() {
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
   const { disabled: isReadOnly } = useFormState<SkillBuilderFormData>();
-  const isDefault = watch("isDefault");
+  const availability = watch("availability");
+  const isDiscoverable = availability === "users_and_agents";
   const agentFacingDescription = watch("agentFacingDescription");
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const isDescriptionTooShort =
     agentFacingDescription.trim().length < MIN_DISCOVERABLE_DESCRIPTION_LENGTH;
 
   const handleToggle = () => {
-    if (!isDefault) {
+    if (!isDiscoverable) {
       setShowConfirmDialog(true);
     } else {
-      setValue("isDefault", false, { shouldDirty: true });
+      setValue("availability", "workspace_users", { shouldDirty: true });
     }
   };
 
   const handleConfirm = () => {
-    setValue("isDefault", true, { shouldDirty: true });
+    setValue("availability", "users_and_agents", { shouldDirty: true });
     setShowConfirmDialog(false);
   };
 
@@ -44,7 +45,7 @@ export function SkillBuilderIsDefaultSection() {
       <div className="flex items-center gap-2">
         <SliderToggle
           disabled={isReadOnly}
-          selected={isDefault}
+          selected={isDiscoverable}
           onClick={handleToggle}
         />
         <span className="text-sm text-foreground">

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -4,6 +4,7 @@ import type {
   SkillRelations,
   SkillType,
 } from "@app/types/assistant/skill_configuration";
+import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { UserType } from "@app/types/user";
 
 /**
@@ -23,7 +24,7 @@ export function transformSkillTypeToFormData(
     tools: skill.tools.map(getDefaultMCPAction),
     fileAttachments: skill.fileAttachments,
     icon: skill.icon ?? null,
-    isDefault: skill.isDefault,
+    availability: skill.availability,
     reinforcement: skill.reinforcement,
     additionalSpaces: [],
     referencedSkills:
@@ -54,7 +55,7 @@ export function getDefaultSkillFormData({
     tools: [],
     fileAttachments: [],
     icon: null,
-    isDefault: false,
+    availability: DEFAULT_SKILL_AVAILABILITY,
     reinforcement: "on",
     additionalSpaces: [],
     referencedSkills: [],

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -47,7 +47,7 @@ export async function submitSkillBuilderForm({
             ? null
             : formData.instructionsHtml,
         icon: formData.icon,
-        isDefault: formData.isDefault,
+        availability: formData.availability,
         reinforcement: formData.reinforcement,
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,


### PR DESCRIPTION
## Description

The skill builder form holds and submits `availability` instead of the deprecated `isDefault`.
`SkillsContext`, `ManageSkillsPage` and the poke skill table read `availability` from the serialized skill; the front-end no longer uses `isDefault`.
Issue: https://github.com/dust-tt/tasks/issues/9730

## Stack

- 1/3: https://github.com/dust-tt/dust/pull/29381
- 2/3: https://github.com/dust-tt/dust/pull/29382
- 3/3: https://github.com/dust-tt/dust/pull/29383

## Tests

No new tests: pure representation change covered by the existing skill builder flows and the route tests of PR 2/3.

## Risk

Low, PR is easy to revert.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
