### PR TITLE
Pass sandbox function error codes through instead of re-deriving them

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -12450,19 +12450,7 @@
             "properties": {
               "code": {
                 "type": "string",
-                "enum": [
-                  "bad_input",
-                  "invalid_input",
-                  "import_failed",
-                  "threw",
-                  "bad_return",
-                  "http_error",
-                  "invalid_output",
-                  "function_not_found",
-                  "invocation_failed",
-                  "transport_error",
-                  "not_supported"
-                ]
+                "description": "Whatever classified the failure, forwarded as-is (a runner code such as `threw` or `http_error`, or the `type` of the API error that failed the call). Open by design, branch on the codes you handle and treat the rest as generic failures."
               },
               "message": {
                 "type": "string"

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1499,7 +1499,7 @@
  *           properties:
  *             code:
  *               type: string
- *               enum: [bad_input, invalid_input, import_failed, threw, bad_return, http_error, invalid_output, function_not_found, invocation_failed, transport_error, not_supported]
+ *               description: Whatever classified the failure, forwarded as-is (a runner code such as `threw` or `http_error`, or the `type` of the API error that failed the call). Open by design, branch on the codes you handle and treat the rest as generic failures.
  *             message:
  *               type: string
  *             status:

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -95,16 +95,22 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 const sendErrorToIframe = (
   request: CallFunctionRequest,
   error: SandboxFunctionCallError,
-  target: MessageEventSource
+  target: MessageEventSource,
+  {
+    conversationId,
+    workspaceId,
+  }: { conversationId: string | null; workspaceId: string }
 ) => {
   // Once handed over, the error belongs to Frame code and only comes back if the Frame reports it
   // itself, so log here to keep a trace of every failed call.
   datadogLogger.info("Sandbox function call failed", {
     code: error.code,
+    conversationId,
     errorMessage: error.message,
+    fileId: request.identifier,
     functionIdOrSlug: request.params.functionIdOrSlug,
-    identifier: request.identifier,
     status: error.status,
+    workspaceId,
   });
 
   target.postMessage(
@@ -296,6 +302,7 @@ function SandboxFunctionInvocation({
 
 // Custom hook to encapsulate the logic for handling visualization messages.
 function useVisualizationDataHandler({
+  conversationId,
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
@@ -305,7 +312,9 @@ function useVisualizationDataHandler({
   visualization,
   vizIframeRef,
   waitForSandboxFunctionInvocationResult,
+  workspaceId,
 }: {
+  conversationId: string | null;
   createSandboxFunctionInvocation: (
     functionIdOrSlug: string,
     input?: unknown
@@ -321,6 +330,7 @@ function useVisualizationDataHandler({
     functionId: string;
     invocationId: string;
   }) => Promise<Result<unknown, SandboxFunctionCallError>>;
+  workspaceId: string;
 }) {
   const sendNotification = useSendNotification();
   const { code } = visualization;
@@ -384,7 +394,10 @@ function useVisualizationDataHandler({
           );
 
           if (invocationRes.isErr()) {
-            sendErrorToIframe(data, invocationRes.error, event.source);
+            sendErrorToIframe(data, invocationRes.error, event.source, {
+              conversationId,
+              workspaceId,
+            });
             break;
           }
 
@@ -394,7 +407,10 @@ function useVisualizationDataHandler({
           });
 
           if (result.isErr()) {
-            sendErrorToIframe(data, result.error, event.source);
+            sendErrorToIframe(data, result.error, event.source, {
+              conversationId,
+              workspaceId,
+            });
           } else {
             sendResponseToIframe(data, result.value, event.source);
           }
@@ -465,6 +481,7 @@ function useVisualizationDataHandler({
     return () => window.removeEventListener("message", listener);
   }, [
     code,
+    conversationId,
     createSandboxFunctionInvocation,
     downloadFileFromBlob,
     getFileBlob,
@@ -476,6 +493,7 @@ function useVisualizationDataHandler({
     vizIframeRef,
     sendNotification,
     waitForSandboxFunctionInvocationResult,
+    workspaceId,
   ]);
 }
 
@@ -712,6 +730,7 @@ export const VisualizationActionIframe = forwardRef<
   );
 
   useVisualizationDataHandler({
+    conversationId,
     createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
@@ -721,6 +740,7 @@ export const VisualizationActionIframe = forwardRef<
     visualization,
     vizIframeRef,
     waitForSandboxFunctionInvocationResult,
+    workspaceId,
   });
 
   const { code, complete: codeFullyGenerated } = visualization;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -18,12 +18,14 @@ import type {
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
 import type {
+  CallFunctionRequest,
   CommandResultMap,
   EditTextFn,
   VisualizationRPCCommand,
   VisualizationRPCRequest,
 } from "@app/types/assistant/visualization";
 import { isVisualizationRPCRequest } from "@app/types/assistant/visualization";
+import { isAPIError } from "@app/types/error";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import {
   assertNever,
@@ -91,10 +93,20 @@ const sendResponseToIframe = <T extends VisualizationRPCCommand>(
 };
 
 const sendErrorToIframe = (
-  request: { command: "callFunction" } & VisualizationRPCRequest,
+  request: CallFunctionRequest,
   error: SandboxFunctionCallError,
   target: MessageEventSource
 ) => {
+  // Once handed over, the error belongs to Frame code and only comes back if the Frame reports it
+  // itself, so log here to keep a trace of every failed call.
+  datadogLogger.info("Sandbox function call failed", {
+    code: error.code,
+    errorMessage: error.message,
+    functionIdOrSlug: request.params.functionIdOrSlug,
+    identifier: request.identifier,
+    status: error.status,
+  });
+
   target.postMessage(
     {
       command: "answer",
@@ -676,10 +688,10 @@ export const VisualizationActionIframe = forwardRef<
         if (!response.ok) {
           const error = await getErrorFromResponse(response);
           return new Err({
-            code:
-              "type" in error && error.type === "sandbox_function_not_found"
-                ? "function_not_found"
-                : "invocation_failed",
+            // Forward the API error type verbatim. Re-deriving a code here would collapse every
+            // failure but one into `invocation_failed` and drop the only classification the
+            // endpoint produced.
+            code: isAPIError(error) ? error.type : "invocation_failed",
             message: error.message,
             status: response.status,
           });

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -210,7 +210,7 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.result).toBeUndefined();
     expect(invocation.error).toBeUndefined();
     expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
-      JSON.stringify({ version: 1, input: { message: "hello" } })
+      JSON.stringify({ version: 2, input: { message: "hello" } })
     );
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
@@ -275,13 +275,13 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.userId).toBeNull();
   });
 
-  it("returns an empty record for unsupported stored data versions", async () => {
+  it("returns an empty record for a version it does not know", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();
 
     await getPrivateUploadBucket()
       .file(invocation.gcsPath!)
-      .save(Buffer.from(JSON.stringify({ version: 2 }), "utf-8"));
+      .save(Buffer.from(JSON.stringify({ version: 3 }), "utf-8"));
 
     // Listings load every invocation's blob, so one unreadable record must not fail the listing.
     const refetched = await SandboxFunctionInvocationResource.fetchById(
@@ -290,6 +290,22 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     expect(refetched?.input).toBeUndefined();
     expect(refetched?.result).toBeUndefined();
+    expect(refetched?.error).toBeUndefined();
+  });
+
+  it("returns an empty record for a blob that is not valid JSON", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    await getPrivateUploadBucket()
+      .file(invocation.gcsPath!)
+      .save(Buffer.from('{"version": 2, "input"', "utf-8"));
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.input).toBeUndefined();
     expect(refetched?.error).toBeUndefined();
   });
 
@@ -371,7 +387,7 @@ describe("SandboxFunctionInvocationResource", () => {
     });
   });
 
-  it("reads a blob written before the code was persisted", async () => {
+  it("migrates a v1 blob, which recorded the message only", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();
 
@@ -394,6 +410,7 @@ describe("SandboxFunctionInvocationResource", () => {
       authenticator,
       { sandboxFunction, invocationId: invocation.sId }
     );
+    expect(refetched?.input).toEqual({ message: "hello" });
     expect(refetched?.error).toEqual({
       code: "invocation_failed",
       message: "written before codes existed",

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -234,7 +234,7 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.context).toEqual({ timezone: "Europe/Paris" });
     expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
       JSON.stringify({
-        version: 1,
+        version: 2,
         context: { timezone: "Europe/Paris" },
       })
     );
@@ -400,6 +400,7 @@ describe("SandboxFunctionInvocationResource", () => {
           JSON.stringify({
             version: 1,
             input: { message: "hello" },
+            context: { timezone: "Europe/Paris" },
             error: "written before codes existed",
           }),
           "utf-8"
@@ -411,10 +412,35 @@ describe("SandboxFunctionInvocationResource", () => {
       { sandboxFunction, invocationId: invocation.sId }
     );
     expect(refetched?.input).toEqual({ message: "hello" });
+    // Fields the v1 and v2 shapes have in common survive the migration.
+    expect(refetched?.context).toEqual({ timezone: "Europe/Paris" });
     expect(refetched?.error).toEqual({
       code: "invocation_failed",
       message: "written before codes existed",
     });
+
+    // The next write persists it as v2, so a blob is migrated once rather than on every read.
+    await refetched!.succeed({ commentId: "comment-1" });
+    expect(fileStorageMock.getObject(invocation.gcsPath!)).toContain(
+      '"version":2'
+    );
+  });
+
+  it("migrates a v1 blob that recorded no error", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    // The GCS path backfill wrote bare v1 blobs, so this shape is real.
+    await getPrivateUploadBucket()
+      .file(invocation.gcsPath!)
+      .save(Buffer.from(JSON.stringify({ version: 1 }), "utf-8"));
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.error).toBeUndefined();
+    expect(refetched?.input).toBeUndefined();
   });
 
   it("executes an invocation on the pod sandbox", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -275,7 +275,7 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(invocation.userId).toBeNull();
   });
 
-  it("rejects unsupported stored data versions", async () => {
+  it("returns an empty record for unsupported stored data versions", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();
 
@@ -283,12 +283,14 @@ describe("SandboxFunctionInvocationResource", () => {
       .file(invocation.gcsPath!)
       .save(Buffer.from(JSON.stringify({ version: 2 }), "utf-8"));
 
-    await expect(
-      SandboxFunctionInvocationResource.fetchById(authenticator, {
-        sandboxFunction,
-        invocationId: invocation.sId,
-      })
-    ).rejects.toThrow("Invalid sandbox function invocation data");
+    // Listings load every invocation's blob, so one unreadable record must not fail the listing.
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.input).toBeUndefined();
+    expect(refetched?.result).toBeUndefined();
+    expect(refetched?.error).toBeUndefined();
   });
 
   it("stores and reloads its result from GCS on success", async () => {
@@ -373,15 +375,20 @@ describe("SandboxFunctionInvocationResource", () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();
 
-    await invocation.fail(new Error("sandbox unavailable"));
-    fileStorageMock.setObject(
-      invocation.gcsPath!,
-      JSON.stringify({
-        version: 1,
-        input: { message: "hello" },
-        error: "sandbox unavailable",
-      })
-    );
+    // A message distinct from anything the current code writes, so the assertion can only pass
+    // by reading the seeded blob.
+    await getPrivateUploadBucket()
+      .file(invocation.gcsPath!)
+      .save(
+        Buffer.from(
+          JSON.stringify({
+            version: 1,
+            input: { message: "hello" },
+            error: "written before codes existed",
+          }),
+          "utf-8"
+        )
+      );
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
       authenticator,
@@ -389,7 +396,7 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     expect(refetched?.error).toEqual({
       code: "invocation_failed",
-      message: "sandbox unavailable",
+      message: "written before codes existed",
     });
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -160,7 +160,10 @@ describe("SandboxFunctionInvocationResource", () => {
       secondInvocation.sId,
     ]);
     expect(recentInvocations[0]?.result).toEqual({ commentId: "comment-3" });
-    expect(recentInvocations[1]?.error).toBe("second invocation failed");
+    expect(recentInvocations[1]?.error).toEqual({
+      code: "invocation_failed",
+      message: "second invocation failed",
+    });
     expect(recentInvocations[0]?.toJSONForLLM()).toMatchObject({
       invocationId: thirdInvocation.sId,
       status: "succeeded",
@@ -171,7 +174,10 @@ describe("SandboxFunctionInvocationResource", () => {
       invocationId: secondInvocation.sId,
       status: "errored",
       input: { message: "second" },
-      error: "second invocation failed",
+      error: {
+        code: "invocation_failed",
+        message: "second invocation failed",
+      },
     });
 
     const formatted = formatSandboxFunctionInvocations(
@@ -181,7 +187,8 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(formatted).toContain('"status": "succeeded"');
     expect(formatted).toContain('"input": {');
     expect(formatted).toContain('"result": {');
-    expect(formatted).toContain('"error": "second invocation failed"');
+    expect(formatted).toContain('"message": "second invocation failed"');
+    expect(formatted).toContain('"code": "invocation_failed"');
     expect(formatted).toContain('"createdAt":');
     expect(formatted).toContain('"updatedAt":');
   });
@@ -318,13 +325,19 @@ describe("SandboxFunctionInvocationResource", () => {
 
     expect(invocation.status).toBe("errored");
     expect(invocation.result).toBeUndefined();
-    expect(invocation.error).toBe("sandbox unavailable");
+    expect(invocation.error).toEqual({
+      code: "invocation_failed",
+      message: "sandbox unavailable",
+    });
     const refetched = await SandboxFunctionInvocationResource.fetchById(
       authenticator,
       { sandboxFunction, invocationId: invocation.sId }
     );
     expect(refetched?.result).toBeUndefined();
-    expect(refetched?.error).toBe("sandbox unavailable");
+    expect(refetched?.error).toEqual({
+      code: "invocation_failed",
+      message: "sandbox unavailable",
+    });
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "sandbox_function_invocation_error",
@@ -333,6 +346,51 @@ describe("SandboxFunctionInvocationResource", () => {
       }),
       { invocationId: invocation.sId }
     );
+  });
+
+  it("keeps the code and status of a classified failure", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    await invocation.fail({
+      code: "http_error",
+      message: "Function returned HTTP 503.",
+      status: 503,
+    });
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.error).toEqual({
+      code: "http_error",
+      message: "Function returned HTTP 503.",
+      status: 503,
+    });
+  });
+
+  it("reads a blob written before the code was persisted", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    await invocation.fail(new Error("sandbox unavailable"));
+    fileStorageMock.setObject(
+      invocation.gcsPath!,
+      JSON.stringify({
+        version: 1,
+        input: { message: "hello" },
+        error: "sandbox unavailable",
+      })
+    );
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.error).toEqual({
+      code: "invocation_failed",
+      message: "sandbox unavailable",
+    });
   });
 
   it("executes an invocation on the pod sandbox", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -38,10 +38,12 @@ import type {
 import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
@@ -51,34 +53,22 @@ const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
 const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
-const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
+const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
 
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
-// classified the failure (runner, API error type, front), and a blob written by a newer deploy
+// classified the failure (runner, API error type, front), and a code introduced by a newer deploy
 // must stay readable rather than fail to parse.
-const PersistedErrorSchema = z.object({
+const InvocationCallErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
   status: z.number().optional(),
 });
 
 export type PersistedSandboxFunctionCallError = z.infer<
-  typeof PersistedErrorSchema
+  typeof InvocationCallErrorSchema
 >;
 
-const PersistedSandboxFunctionCallErrorSchema = z.union([
-  PersistedErrorSchema,
-  // Blobs written before the code and status were persisted only carry the message. Every such
-  // blob went through `fail(Error)`, which classified as `invocation_failed`. Piped back through
-  // the object schema so both arms infer one shape and `status` stays readable without narrowing.
-  z
-    .string()
-    .transform((message) => ({ code: "invocation_failed", message }))
-    .pipe(PersistedErrorSchema),
-]);
-
-const SandboxFunctionInvocationDataSchema = z.object({
-  version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
+const InvocationDataBaseSchema = z.object({
   input: z.unknown().optional(),
   context: z
     .object({
@@ -86,12 +76,54 @@ const SandboxFunctionInvocationDataSchema = z.object({
     })
     .optional(),
   result: z.unknown().optional(),
-  error: PersistedSandboxFunctionCallErrorSchema.optional(),
 });
 
-type SandboxFunctionInvocationData = z.infer<
-  typeof SandboxFunctionInvocationDataSchema
->;
+// Every shape we have ever written, discriminated on `version` so a new one is an added arm rather
+// than a wider guess at what a blob contains. Reads accept all of them, writes always produce the
+// current version.
+const StoredInvocationDataSchema = z.discriminatedUnion("version", [
+  // v1 recorded the failure message only.
+  InvocationDataBaseSchema.extend({
+    version: z.literal(1),
+    error: z.string().optional(),
+  }),
+  // v2 records the whole call error, so `inspect_invocations` can report its code and status.
+  InvocationDataBaseSchema.extend({
+    version: z.literal(2),
+    error: InvocationCallErrorSchema.optional(),
+  }),
+]);
+
+type StoredInvocationData = z.infer<typeof StoredInvocationDataSchema>;
+
+type SandboxFunctionInvocationData = {
+  version: typeof SANDBOX_FUNCTION_INVOCATION_DATA_VERSION;
+  input?: unknown;
+  result?: unknown;
+  error?: PersistedSandboxFunctionCallError;
+};
+
+function migrateStoredInvocationData(
+  stored: StoredInvocationData
+): SandboxFunctionInvocationData {
+  switch (stored.version) {
+    case 1:
+      return {
+        version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
+        input: stored.input,
+        result: stored.result,
+        // v1 only ever recorded errors that went through `fail(Error)`, which classified them as
+        // `invocation_failed`.
+        ...(stored.error !== undefined
+          ? { error: { code: "invocation_failed", message: stored.error } }
+          : {}),
+      };
+    case 2:
+      return stored;
+    default:
+      return assertNever(stored);
+  }
+}
 
 export interface SandboxFunctionInvocationForLLM {
   createdAt: string;
@@ -103,26 +135,22 @@ export interface SandboxFunctionInvocationForLLM {
   updatedAt: string;
 }
 
-function parseSandboxFunctionInvocationData(
-  gcsPath: string,
+function safeParseStoredInvocationData(
   content: string
-): SandboxFunctionInvocationData {
-  const result = SandboxFunctionInvocationDataSchema.safeParse(
-    JSON.parse(content)
-  );
-  if (!result.success) {
-    // Listings load every invocation's blob, so throwing here would fail the whole listing over
-    // one unreadable record. That includes a blob written by a newer deploy during a rollout, so
-    // degrade to an empty record and keep the rest readable.
-    logger.error(
-      { gcsPath, error: result.error.message },
-      "Invalid sandbox function invocation data"
-    );
-
-    return { version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION };
+): Result<StoredInvocationData, Error> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch (err) {
+    return new Err(normalizeError(err));
   }
 
-  return result.data;
+  const parseResult = StoredInvocationDataSchema.safeParse(raw);
+  if (!parseResult.success) {
+    return new Err(new Error(fromError(parseResult.error).toString()));
+  }
+
+  return new Ok(parseResult.data);
 }
 
 function dustAPIBaseUrlForSandbox(): string {
@@ -352,10 +380,23 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     }
 
     const [buffer] = downloadResult.value;
-    this.data = parseSandboxFunctionInvocationData(
-      this.gcsPath,
+    const storedResult = safeParseStoredInvocationData(
       buffer.toString("utf-8")
     );
+    if (storedResult.isErr()) {
+      // Listings load every invocation's blob, so failing here would take down a whole listing
+      // over one unreadable record: a truncated write, or a blob a newer deploy wrote mid-rollout.
+      // Degrade to an empty record and keep the rest of the listing readable.
+      logger.error(
+        { gcsPath: this.gcsPath, error: storedResult.error.message },
+        "Invalid sandbox function invocation data"
+      );
+      this.data = { version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION };
+
+      return;
+    }
+
+    this.data = migrateStoredInvocationData(storedResult.value);
   }
 
   private async writeDataToGcs(): Promise<void> {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -53,6 +53,24 @@ const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
 const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
 
+// `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
+// classified the failure (runner, API error type, front), and a blob written by a newer deploy
+// must stay readable rather than fail to parse.
+const PersistedSandboxFunctionCallErrorSchema = z.union([
+  // Blobs written before the code and status were persisted only carry the message. Every such
+  // blob went through `fail(Error)`, which classified as `invocation_failed`.
+  z.string().transform((message) => ({ code: "invocation_failed", message })),
+  z.object({
+    code: z.string(),
+    message: z.string(),
+    status: z.number().optional(),
+  }),
+]);
+
+type PersistedSandboxFunctionCallError = z.infer<
+  typeof PersistedSandboxFunctionCallErrorSchema
+>;
+
 const SandboxFunctionInvocationDataSchema = z.object({
   version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
   input: z.unknown().optional(),
@@ -62,7 +80,7 @@ const SandboxFunctionInvocationDataSchema = z.object({
     })
     .optional(),
   result: z.unknown().optional(),
-  error: z.string().optional(),
+  error: PersistedSandboxFunctionCallErrorSchema.optional(),
 });
 
 type SandboxFunctionInvocationData = z.infer<
@@ -71,7 +89,7 @@ type SandboxFunctionInvocationData = z.infer<
 
 export interface SandboxFunctionInvocationForLLM {
   createdAt: string;
-  error?: string;
+  error?: PersistedSandboxFunctionCallError;
   input: unknown;
   invocationId: string;
   result?: unknown;
@@ -160,7 +178,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.result;
   }
 
-  get error(): string | undefined {
+  get error(): PersistedSandboxFunctionCallError | undefined {
     return this.data.error;
   }
 
@@ -173,7 +191,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       context: this.context,
-      error: callError.message,
+      // Persist the whole error: the code and status are what `inspect_invocations` needs to say
+      // why an invocation failed, and dropping them here would leave the message as the only
+      // record of a failure the stream classified precisely.
+      error: callError,
     };
     await this.writeDataToGcs();
     await this.update({ status: "errored" });

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -40,6 +40,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import type { Attributes, Transaction } from "sequelize";
 import { z } from "zod";
@@ -58,14 +59,14 @@ const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
 // classified the failure (runner, API error type, front), and a code introduced by a newer deploy
 // must stay readable rather than fail to parse.
-const InvocationCallErrorSchema = z.object({
+const StoredCallErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
   status: z.number().optional(),
 });
 
-export type PersistedSandboxFunctionCallError = z.infer<
-  typeof InvocationCallErrorSchema
+export type StoredSandboxFunctionCallError = z.infer<
+  typeof StoredCallErrorSchema
 >;
 
 const InvocationDataBaseSchema = z.object({
@@ -90,33 +91,35 @@ const StoredInvocationDataSchema = z.discriminatedUnion("version", [
   // v2 records the whole call error, so `inspect_invocations` can report its code and status.
   InvocationDataBaseSchema.extend({
     version: z.literal(2),
-    error: InvocationCallErrorSchema.optional(),
+    error: StoredCallErrorSchema.optional(),
   }),
 ]);
 
 type StoredInvocationData = z.infer<typeof StoredInvocationDataSchema>;
 
-type SandboxFunctionInvocationData = {
-  version: typeof SANDBOX_FUNCTION_INVOCATION_DATA_VERSION;
-  input?: unknown;
-  result?: unknown;
-  error?: PersistedSandboxFunctionCallError;
-};
+// Derived from the current arm rather than written out, so the two cannot drift. Bumping the
+// version constant makes `case 2` below stop typechecking until a migration exists.
+type SandboxFunctionInvocationData = Extract<
+  StoredInvocationData,
+  { version: typeof SANDBOX_FUNCTION_INVOCATION_DATA_VERSION }
+>;
 
 function migrateStoredInvocationData(
   stored: StoredInvocationData
 ): SandboxFunctionInvocationData {
   switch (stored.version) {
     case 1:
+      // Spread rather than list fields, so a field added to the shared base carries through
+      // instead of being silently dropped from every v1 blob on read.
       return {
+        ...stored,
         version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
-        input: stored.input,
-        result: stored.result,
         // v1 only ever recorded errors that went through `fail(Error)`, which classified them as
         // `invocation_failed`.
-        ...(stored.error !== undefined
-          ? { error: { code: "invocation_failed", message: stored.error } }
-          : {}),
+        error:
+          stored.error !== undefined
+            ? { code: "invocation_failed", message: stored.error }
+            : undefined,
       };
     case 2:
       return stored;
@@ -127,7 +130,7 @@ function migrateStoredInvocationData(
 
 export interface SandboxFunctionInvocationForLLM {
   createdAt: string;
-  error?: PersistedSandboxFunctionCallError;
+  error?: StoredSandboxFunctionCallError;
   input: unknown;
   invocationId: string;
   result?: unknown;
@@ -138,14 +141,12 @@ export interface SandboxFunctionInvocationForLLM {
 function safeParseStoredInvocationData(
   content: string
 ): Result<StoredInvocationData, Error> {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(content);
-  } catch (err) {
-    return new Err(normalizeError(err));
+  const jsonResult = safeParseJSON(content);
+  if (jsonResult.isErr()) {
+    return jsonResult;
   }
 
-  const parseResult = StoredInvocationDataSchema.safeParse(raw);
+  const parseResult = StoredInvocationDataSchema.safeParse(jsonResult.value);
   if (!parseResult.success) {
     return new Err(new Error(fromError(parseResult.error).toString()));
   }
@@ -219,7 +220,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.result;
   }
 
-  get error(): PersistedSandboxFunctionCallError | undefined {
+  get error(): StoredSandboxFunctionCallError | undefined {
     return this.data.error;
   }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -56,20 +56,26 @@ const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
 // classified the failure (runner, API error type, front), and a blob written by a newer deploy
 // must stay readable rather than fail to parse.
-const PersistedSandboxFunctionCallErrorSchema = z.union([
-  // Blobs written before the code and status were persisted only carry the message. Every such
-  // blob went through `fail(Error)`, which classified as `invocation_failed`.
-  z.string().transform((message) => ({ code: "invocation_failed", message })),
-  z.object({
-    code: z.string(),
-    message: z.string(),
-    status: z.number().optional(),
-  }),
-]);
+const PersistedErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  status: z.number().optional(),
+});
 
-type PersistedSandboxFunctionCallError = z.infer<
-  typeof PersistedSandboxFunctionCallErrorSchema
+export type PersistedSandboxFunctionCallError = z.infer<
+  typeof PersistedErrorSchema
 >;
+
+const PersistedSandboxFunctionCallErrorSchema = z.union([
+  PersistedErrorSchema,
+  // Blobs written before the code and status were persisted only carry the message. Every such
+  // blob went through `fail(Error)`, which classified as `invocation_failed`. Piped back through
+  // the object schema so both arms infer one shape and `status` stays readable without narrowing.
+  z
+    .string()
+    .transform((message) => ({ code: "invocation_failed", message }))
+    .pipe(PersistedErrorSchema),
+]);
 
 const SandboxFunctionInvocationDataSchema = z.object({
   version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
@@ -98,15 +104,22 @@ export interface SandboxFunctionInvocationForLLM {
 }
 
 function parseSandboxFunctionInvocationData(
+  gcsPath: string,
   content: string
 ): SandboxFunctionInvocationData {
   const result = SandboxFunctionInvocationDataSchema.safeParse(
     JSON.parse(content)
   );
   if (!result.success) {
-    throw new Error(
-      `Invalid sandbox function invocation data: ${result.error.message}`
+    // Listings load every invocation's blob, so throwing here would fail the whole listing over
+    // one unreadable record. That includes a blob written by a newer deploy during a rollout, so
+    // degrade to an empty record and keep the rest readable.
+    logger.error(
+      { gcsPath, error: result.error.message },
+      "Invalid sandbox function invocation data"
     );
+
+    return { version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION };
   }
 
   return result.data;
@@ -339,7 +352,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     }
 
     const [buffer] = downloadResult.value;
-    this.data = parseSandboxFunctionInvocationData(buffer.toString("utf-8"));
+    this.data = parseSandboxFunctionInvocationData(
+      this.gcsPath,
+      buffer.toString("utf-8")
+    );
   }
 
   private async writeDataToGcs(): Promise<void> {

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -185,12 +185,16 @@ const output = await callFunction("<podId>/<slug>", input);
 
 \`input\` must match the function's declared input schema (see \`get\`). The promise resolves to
 the parsed and validated \`schema.output\`. It rejects with a \`SandboxFunctionCallError\` (also
-exported by \`@dust/react-hooks\`) whose \`code\` distinguishes missing functions, invalid
-input/output, handler failures, HTTP errors, and transport failures; render loading and error
-states like for any other network call. Pod functions are only reachable from authenticated
-Pod Frames, not from public or shared Frames.`,
+exported by \`@dust/react-hooks\`) carrying a \`message\`, an optional HTTP \`status\`, and a
+\`code\`; render loading and error states like for any other network call. Treat \`code\` as an
+open string: it is whatever classified the failure, so branch on the ones you handle and fall
+back to a generic message for the rest. The ones worth branching on are \`invalid_input\` and
+\`invalid_output\` (the value does not match the declared schema), \`threw\` (the function threw),
+\`http_error\` (the function's own request failed, with \`status\`), \`sandbox_function_not_found\`
+(no such function), and \`not_supported\` (the Frame is public or shared). Pod functions are only
+reachable from authenticated Pod Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 3,
+  version: 4,
   icon: "PuzzleIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -135,6 +135,15 @@ class FileStorageMock {
     return this._objectStore.get(filePath);
   }
 
+  /**
+   * Seeds `filePath` with content, as if it had already been written. Use to
+   * stand up objects a test needs to read but cannot produce with the code
+   * under test, such as a blob written in an older format.
+   */
+  setObject(filePath: string, content: string): void {
+    this._objectStore.set(filePath, content);
+  }
+
   reset(): void {
     this._writeStreamCalls.length = 0;
     this._readStreamCalls.length = 0;

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -135,15 +135,6 @@ class FileStorageMock {
     return this._objectStore.get(filePath);
   }
 
-  /**
-   * Seeds `filePath` with content, as if it had already been written. Use to
-   * stand up objects a test needs to read but cannot produce with the code
-   * under test, such as a blob written in an older format.
-   */
-  setObject(filePath: string, content: string): void {
-    this._objectStore.set(filePath, content);
-  }
-
   reset(): void {
     this._writeStreamCalls.length = 0;
     this._readStreamCalls.length = 0;

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -3,6 +3,7 @@ import type {
   SandboxFunctionToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
+import type { APIErrorType } from "@app/types/error";
 
 export const SANDBOX_FUNCTION_INVOCATION_STATUSES = [
   "created",
@@ -42,16 +43,21 @@ export const SANDBOX_FUNCTION_RUNNER_ERROR_CODES = [
   "invalid_output",
 ] as const;
 
-export const SANDBOX_FUNCTION_CALL_ERROR_CODES = [
-  ...SANDBOX_FUNCTION_RUNNER_ERROR_CODES,
-  "function_not_found",
-  "invocation_failed",
-  "transport_error",
-  "not_supported",
-] as const;
+// Codes minted by front, for failures that happen outside the runner and therefore have no
+// upstream classification to forward.
+type SandboxFunctionFrontErrorCode =
+  | "invocation_failed"
+  | "transport_error"
+  | "not_supported";
 
+// A call error code is never re-derived along the way: it is the runner's code, the `type` of the
+// API error that failed the call, or one of the front codes above when nothing upstream classified
+// the failure. Keeping the original code means a Frame error points at where it came from instead
+// of at the layer that relabelled it.
 export type SandboxFunctionCallErrorCode =
-  (typeof SANDBOX_FUNCTION_CALL_ERROR_CODES)[number];
+  | (typeof SANDBOX_FUNCTION_RUNNER_ERROR_CODES)[number]
+  | SandboxFunctionFrontErrorCode
+  | APIErrorType;
 
 export type SandboxFunctionCallError = {
   code: SandboxFunctionCallErrorCode;

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -118,6 +118,7 @@ const VisualizationRPCRequestSchema = z.union([
 export type VisualizationRPCRequest = z.infer<
   typeof VisualizationRPCRequestSchema
 >;
+export type CallFunctionRequest = z.infer<typeof CallFunctionRequestSchema>;
 export type VisualizationRPCCommand = VisualizationRPCRequest["command"];
 
 // Define a mapped type for backward compatibility.

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -407,6 +407,23 @@ export function VisualizationWrapper({
     [ref, downloadFile, identifier]
   );
 
+  // A rejected promise nothing catches never reaches the ErrorBoundary, which only sees throws
+  // during render. Frame code is async throughout — a `callFunction` awaited without a `catch`,
+  // a failed fetch — so without this the Frame renders nothing and reports nothing.
+  useEffect(() => {
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const { reason } = event;
+      setErrorMessage(
+        reason instanceof Error ? reason : new Error(String(reason))
+      );
+    };
+
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+    return () =>
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+  }, []);
+
   useEffect(() => {
     const loadCode = async () => {
       try {

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -408,8 +408,13 @@ export function VisualizationWrapper({
   );
 
   // A rejected promise nothing catches never reaches the ErrorBoundary, which only sees throws
-  // during render. Frame code is async throughout — a `callFunction` awaited without a `catch`,
-  // a failed fetch — so without this the Frame renders nothing and reports nothing.
+  // during render. Frame code is async throughout (a `callFunction` awaited without a `catch`, a
+  // failed fetch), so without this the Frame shows a spinner forever and reports nothing.
+  //
+  // This surfaces the error even once the Frame has rendered, which does replace a Frame that was
+  // partly working with the parent's error card. That is the intent: a Frame with an uncaught
+  // rejection is broken, and the card feeds the error back to the model on retry. The event is
+  // deliberately not `preventDefault()`ed so the rejection still reaches the browser console.
   useEffect(() => {
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
       const { reason } = event;

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -1,46 +1,9 @@
-import { readFileSync } from "node:fs";
 import { CacheDataAPI } from "@viz/app/lib/data-apis/cache-data-api";
 import { RPCDataAPI } from "@viz/app/lib/data-apis/rpc-data-api";
-import {
-  SANDBOX_FUNCTION_CALL_ERROR_CODES,
-  SandboxFunctionCallError,
-} from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import { describe, expect, it } from "vitest";
 
-function extractStringArray(source: string, constantName: string): string[] {
-  const match = source.match(
-    new RegExp(`export const ${constantName} = \\[([\\s\\S]*?)\\] as const;`)
-  );
-  if (!match?.[1]) {
-    throw new Error(`Could not find ${constantName}.`);
-  }
-  return Array.from(match[1].matchAll(/"([^"]+)"/g), ([, value]) => value);
-}
-
 describe("sandbox function data APIs", () => {
-  it("keeps Frame error codes aligned with front", () => {
-    const runnerSource = readFileSync(
-      new URL(
-        "../../../../cli/dust-sandbox/functions-runner/protocol.ts",
-        import.meta.url
-      ),
-      "utf8"
-    );
-    const frontSource = readFileSync(
-      new URL(
-        "../../../../front/types/api/sandbox_functions.ts",
-        import.meta.url
-      ),
-      "utf8"
-    );
-    const frontCodes = [
-      ...extractStringArray(runnerSource, "RUNNER_ERROR_CODES"),
-      ...extractStringArray(frontSource, "SANDBOX_FUNCTION_CALL_ERROR_CODES"),
-    ];
-
-    expect(SANDBOX_FUNCTION_CALL_ERROR_CODES).toEqual(frontCodes);
-  });
-
   it("rejects RPC calls with a typed sandbox function error", async () => {
     const api = new RPCDataAPI(async () => {
       throw {
@@ -53,6 +16,32 @@ describe("sandbox function data APIs", () => {
 
     await expect(promise).rejects.toBeInstanceOf(SandboxFunctionCallError);
     await expect(promise).rejects.toMatchObject({ code: "invalid_output" });
+  });
+
+  it("forwards a code viz does not know about instead of relabelling it", async () => {
+    const api = new RPCDataAPI(async () => {
+      throw {
+        code: "sandbox_function_not_found",
+        message: "Sandbox function not found.",
+        status: 404,
+      };
+    });
+
+    await expect(api.callFunction("pod/function")).rejects.toMatchObject({
+      code: "sandbox_function_not_found",
+      status: 404,
+    });
+  });
+
+  it("falls back to transport_error when the payload is not a call error", async () => {
+    const api = new RPCDataAPI(async () => {
+      throw new Error("The iframe channel closed.");
+    });
+
+    await expect(api.callFunction("pod/function")).rejects.toMatchObject({
+      code: "transport_error",
+      message: "The iframe channel closed.",
+    });
   });
 
   it("rejects calls from public frames as unsupported", async () => {

--- a/viz/app/lib/data-apis/sandbox-function-call-error.ts
+++ b/viz/app/lib/data-apis/sandbox-function-call-error.ts
@@ -1,21 +1,11 @@
 import { z } from "zod";
 
-export const SANDBOX_FUNCTION_CALL_ERROR_CODES = [
-  "bad_input",
-  "invalid_input",
-  "import_failed",
-  "threw",
-  "bad_return",
-  "http_error",
-  "invalid_output",
-  "function_not_found",
-  "invocation_failed",
-  "transport_error",
-  "not_supported",
-] as const;
-
+// `code` is deliberately not an enum: front forwards the runner code or the API error type that
+// caused the failure rather than mapping it onto a viz-side taxonomy, so validating against a
+// copy of that taxonomy here would only turn every code viz has not heard of yet into
+// `transport_error`.
 const SandboxFunctionCallErrorPayloadSchema = z.object({
-  code: z.enum(SANDBOX_FUNCTION_CALL_ERROR_CODES),
+  code: z.string().min(1),
   message: z.string(),
   status: z.number().optional(),
 });


### PR DESCRIPTION
## Description

Follow-up on the review feedback on #28968.

The Frame parent was re-deriving the error code from the invocation response: `sandbox_function_not_found` became `function_not_found`, and everything else (403, 400, 500) collapsed into `invocation_failed`. That drops the only classification the endpoint produced, and leaves you walking six files to find out which layer relabelled what. It now forwards the API error type verbatim, and viz drops its copy of the code list so a code it has not heard of yet passes through instead of becoming `transport_error`. That also removes the test that regex-scraped two source files from other workspaces to keep the duplicated lists in sync, and the third copy of the list in the private swagger enum.

Two related gaps that made a failed call hard to trace at all:

- `fail()` persisted only `error.message`, so `inspect_invocations` could never show the code or status. It now persists the whole call error.
- Nothing logged a callFunction failure on the way out to the iframe. Added one log at the choke point.

Storing a different shape meant versioning the blob properly. The `version` field already existed but was never bumped, so it was about to start lying. It is now 2, reads discriminate on it across every shape we have written, and v1 migrates on read.

Last one: since #28968 the Frame gets errors by rejection, and React error boundaries do not catch async rejections. A Frame that awaits `callFunction` without a `catch` renders nothing, reports nothing, and no longer even hits the `console.error` that PR removed. Unhandled rejections now route into the existing error path (throw to ErrorBoundary, report to parent, Datadog, retry UI).

## Tests

Added cases for the parts CI would not otherwise cover: a forwarded code viz does not know about survives normalization, a classified failure keeps its code and status through the GCS round trip, a v1 blob migrates (including the bare `{version: 1}` shape the GCS path backfill wrote) and gets rewritten as v2, and an unreadable blob degrades instead of failing the read.

Not covered by a test: the `unhandledrejection` listener, which would need the whole Runner pipeline mounted.

## Risk

**The blob version bump is the part to look at.** Reads on this branch accept v1 and v2 and degrade on anything else, but that tolerant reader ships in the same deploy as the v2 writer, so it only protects the *next* schema change, not this one. Pods running today's `main` throw on a blob they cannot parse, and `baseFetch` loads every invocation's blob, so during the rolling window (and after a rollback) an old pod hitting any v2 blob fails the whole `inspect_invocations` listing for that function, not just that entry. Forward-fixable by rolling forward, and bounded by the `sandbox_functions` flag. If that window is not acceptable, say so and I will split the tolerant reader into its own PR to deploy first.

The skill doc changes what `code` values a Frame can expect, so Frames branching on `function_not_found` need `sandbox_function_not_found` instead. Every existing Frame is already breaking from #28968, so this rides along with that.

The `unhandledrejection` listener is the other behavior change worth watching. It is global to the iframe and fires after the Frame has rendered too, so a Frame that was partly working and has an uncaught background rejection now gets replaced by the parent's error card. That is deliberate: gating it on "nothing has rendered yet" would miss the main case (a Frame that mounts, fires `callFunction` in an effect, never catches, and spins forever), and the error card is what feeds the failure back to the model on retry. Frames that were quietly failing will start showing an error.

## Deploy Plan

Standard deploy, with the rolling-window caveat above. Rebased over #29392 (`context`/timezone), which touched the same schema.