### PR TITLE
feat(front): gate premium models and reasoning efforts in model picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -9,14 +9,16 @@ import {
   buildModelSelection,
   buildTierSelection,
   getInitialEffort,
+  getModelEffortTier,
   getModelTier,
   getModelWithReasoningEffortLabel,
+  isPremiumModel,
   isSameSelection,
   resolveShownSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { useModels } from "@app/lib/swr/models";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -29,6 +31,7 @@ import type {
   ModelSelectionType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   BarFull,
@@ -73,6 +76,8 @@ export function InputBarModelPicker({
 }: InputBarModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
+  const { subscription } = useAuth();
+  const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
   const { stickyModelOverride, setStickyModelOverride } =
     useContext(InputBarContext);
   const { isDark } = useTheme();
@@ -192,8 +197,11 @@ export function InputBarModelPicker({
   };
 
   const onSelectModel = (model: ModelConfigurationType) => {
+    if (isPremiumModel(model, { lockPremiumEfforts })) {
+      return;
+    }
     lastModelInteractionAtMsRef.current = Date.now();
-    const effort = getInitialEffort(model);
+    const effort = getInitialEffort(model, { lockPremiumEfforts });
     commit({
       display: { kind: "model", model, effort },
       toSend: buildModelSelection(model, effort),
@@ -206,6 +214,12 @@ export function InputBarModelPicker({
     }
     lastModelInteractionAtMsRef.current = Date.now();
     const { model } = shown.display;
+    if (
+      lockPremiumEfforts &&
+      getModelEffortTier(model.modelId, effort) === "premium"
+    ) {
+      return;
+    }
     commit({
       display: { kind: "model", model, effort },
       toSend: buildModelSelection(model, effort),
@@ -265,6 +279,7 @@ export function InputBarModelPicker({
         shown={shown}
         agentDefault={agentDefault}
         canRevert={canRevert}
+        lockPremiumEfforts={lockPremiumEfforts}
         makerGroups={makerGroups}
         allModels={allModels}
         search={search}

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -14,6 +14,7 @@ import {
   getModelWithReasoningEffortLabel,
   isPremiumModel,
   isSameSelection,
+  isTierLocked,
   resolveShownSelection,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
@@ -190,6 +191,9 @@ export function InputBarModelPicker({
     Date.now() - lastModelInteractionAtMsRef.current < 300;
 
   const onSelectTier = (tierId: ModelTierId) => {
+    if (isTierLocked(tierId, { lockPremiumEfforts })) {
+      return;
+    }
     commit({
       display: { kind: "tier", tierId },
       toSend: buildTierSelection(tierId),

--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -39,6 +39,7 @@ interface ModelPickerContentProps {
   shown: Selection;
   agentDefault: Selection;
   canRevert: boolean;
+  lockPremiumEfforts: boolean;
   makerGroups: MakerGroup[];
   allModels: ModelConfigurationType[];
   search: string;
@@ -60,6 +61,7 @@ export function ModelPickerContent({
   shown,
   agentDefault,
   canRevert,
+  lockPremiumEfforts,
   makerGroups,
   allModels,
   search,
@@ -111,6 +113,7 @@ export function ModelPickerContent({
         shown={shown}
         agentDefault={agentDefault}
         canRevert={canRevert}
+        lockPremiumEfforts={lockPremiumEfforts}
         search={search}
         onSearchChange={onSearchChange}
         isWidthConstrained={isWidthConstrained}

--- a/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerContent.tsx
@@ -7,7 +7,9 @@ import type {
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   isTierDisplayed,
+  isTierLocked,
   MODEL_TIERS,
+  PREMIUM_MODEL_LOCKED_TOOLTIP,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import type {
   ModelConfigurationType,
@@ -21,6 +23,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  Icon,
+  Lock01,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
@@ -81,6 +85,26 @@ export function ModelPickerContent({
       {MODEL_TIERS.map((tier) => {
         const isSelected = isTierDisplayed(tier.id, shown.display);
         const isDefault = isTierDisplayed(tier.id, agentDefault.display);
+        const locked = isTierLocked(tier.id, { lockPremiumEfforts });
+        if (locked) {
+          return (
+            <DropdownMenuItem
+              key={tier.id}
+              icon={TIER_ICON[tier.id]}
+              label={tier.name}
+              disabled
+              tooltip={PREMIUM_MODEL_LOCKED_TOOLTIP}
+              endComponent={
+                <Icon
+                  visual={Lock01}
+                  size="sm"
+                  className="text-muted-foreground"
+                />
+              }
+              onSelect={(e) => e.preventDefault()}
+            />
+          );
+        }
         return (
           <DropdownMenuItem
             key={tier.id}

--- a/front/components/assistant/conversation/input_bar/ModelPickerModelRow.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerModelRow.tsx
@@ -1,6 +1,9 @@
 import { ModelPickerSelectionIndicator } from "@app/components/assistant/conversation/input_bar/ModelPickerSelectionIndicator";
-import type { EffortStop } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
-import { PREMIUM_MODEL_LOCKED_TOOLTIP } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import type {
+  EffortStop,
+  ModelLockReason,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { getModelLockTooltip } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { ReasoningEffortSlider } from "@app/components/assistant/conversation/input_bar/ReasoningEffortSlider";
 import type {
   ModelConfigurationType,
@@ -14,7 +17,7 @@ interface ModelPickerModelRowProps {
   model: ModelConfigurationType;
   isSelected: boolean;
   isDefault: boolean;
-  locked: boolean;
+  lockReason: ModelLockReason | null;
   effort: ReasoningEffort;
   effortStops: EffortStop[];
   icon?: ComponentType;
@@ -28,7 +31,7 @@ export function ModelPickerModelRow({
   model,
   isSelected,
   isDefault,
-  locked,
+  lockReason,
   effort,
   effortStops,
   icon,
@@ -39,7 +42,7 @@ export function ModelPickerModelRow({
 }: ModelPickerModelRowProps) {
   const itemRef = useRef<HTMLDivElement>(null);
 
-  if (locked) {
+  if (lockReason) {
     return (
       <DropdownMenuItem
         ref={itemRef}
@@ -47,7 +50,7 @@ export function ModelPickerModelRow({
         icon={icon}
         truncateText
         disabled
-        tooltip={PREMIUM_MODEL_LOCKED_TOOLTIP}
+        tooltip={getModelLockTooltip(lockReason)}
         endComponent={
           <Icon visual={Lock01} size="sm" className="text-muted-foreground" />
         }

--- a/front/components/assistant/conversation/input_bar/ModelPickerModelRow.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerModelRow.tsx
@@ -1,11 +1,12 @@
 import { ModelPickerSelectionIndicator } from "@app/components/assistant/conversation/input_bar/ModelPickerSelectionIndicator";
 import type { EffortStop } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import { PREMIUM_MODEL_LOCKED_TOOLTIP } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { ReasoningEffortSlider } from "@app/components/assistant/conversation/input_bar/ReasoningEffortSlider";
 import type {
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
-import { DropdownMenuItem } from "@dust-tt/sparkle";
+import { DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 
@@ -13,6 +14,7 @@ interface ModelPickerModelRowProps {
   model: ModelConfigurationType;
   isSelected: boolean;
   isDefault: boolean;
+  locked: boolean;
   effort: ReasoningEffort;
   effortStops: EffortStop[];
   icon?: ComponentType;
@@ -26,6 +28,7 @@ export function ModelPickerModelRow({
   model,
   isSelected,
   isDefault,
+  locked,
   effort,
   effortStops,
   icon,
@@ -35,6 +38,23 @@ export function ModelPickerModelRow({
   onRevert,
 }: ModelPickerModelRowProps) {
   const itemRef = useRef<HTMLDivElement>(null);
+
+  if (locked) {
+    return (
+      <DropdownMenuItem
+        ref={itemRef}
+        label={model.displayName}
+        icon={icon}
+        truncateText
+        disabled
+        tooltip={PREMIUM_MODEL_LOCKED_TOOLTIP}
+        endComponent={
+          <Icon visual={Lock01} size="sm" className="text-muted-foreground" />
+        }
+        onSelect={(e) => e.preventDefault()}
+      />
+    );
+  }
 
   return (
     <>

--- a/front/components/assistant/conversation/input_bar/ModelPickerMoreModels.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerMoreModels.tsx
@@ -8,6 +8,7 @@ import {
   getInitialEffort,
   getModelKey,
   isModelSelection,
+  isPremiumModel,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -40,6 +41,9 @@ interface ModelPickerMoreModelsProps {
   agentDefault: Selection;
   // Whether the active selection differs from the agent default.
   canRevert: boolean;
+  // When true, premium (model, effort) picks are locked (workspace not on a
+  // credit-based plan).
+  lockPremiumEfforts: boolean;
   search: string;
   onSearchChange: (value: string) => void;
   // On width-constrained clients (mobile, extension) there are no submenus:
@@ -63,6 +67,7 @@ export function ModelPickerMoreModels({
   shown,
   agentDefault,
   canRevert,
+  lockPremiumEfforts,
   search,
   onSearchChange,
   isWidthConstrained,
@@ -99,18 +104,20 @@ export function ModelPickerMoreModels({
   ) => {
     const isSelected = isModelSelection(model, shown.display);
     const isDefault = isModelSelection(model, agentDefault.display);
+    const locked = isPremiumModel(model, { lockPremiumEfforts });
     const effort =
       isSelected && shown.display.kind === "model"
         ? shown.display.effort
-        : getInitialEffort(model);
+        : getInitialEffort(model, { lockPremiumEfforts });
     return (
       <ModelPickerModelRow
         key={getModelKey(model.providerId, model.modelId)}
         model={model}
         isSelected={isSelected}
         isDefault={isDefault}
+        locked={locked}
         effort={effort}
-        effortStops={getEffortStops(model)}
+        effortStops={getEffortStops(model, { lockPremiumEfforts })}
         icon={
           showMakerIcon
             ? getModelMakerLogo(getModelMaker(model), isDark)

--- a/front/components/assistant/conversation/input_bar/ModelPickerMoreModels.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerMoreModels.tsx
@@ -7,8 +7,8 @@ import {
   getEffortStops,
   getInitialEffort,
   getModelKey,
+  getModelLockReason,
   isModelSelection,
-  isPremiumModel,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -104,7 +104,7 @@ export function ModelPickerMoreModels({
   ) => {
     const isSelected = isModelSelection(model, shown.display);
     const isDefault = isModelSelection(model, agentDefault.display);
-    const locked = isPremiumModel(model, { lockPremiumEfforts });
+    const lockReason = getModelLockReason(model, { lockPremiumEfforts });
     const effort =
       isSelected && shown.display.kind === "model"
         ? shown.display.effort
@@ -115,7 +115,7 @@ export function ModelPickerMoreModels({
         model={model}
         isSelected={isSelected}
         isDefault={isDefault}
-        locked={locked}
+        lockReason={lockReason}
         effort={effort}
         effortStops={getEffortStops(model, { lockPremiumEfforts })}
         icon={

--- a/front/components/assistant/conversation/input_bar/ReasoningEffortSlider.tsx
+++ b/front/components/assistant/conversation/input_bar/ReasoningEffortSlider.tsx
@@ -1,8 +1,11 @@
-import type { EffortStop } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import type {
+  EffortStop,
+  ModelLockReason,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
+  getEffortStopTooltip,
+  getModelLockTooltip,
   getReasoningEffortLabel,
-  PREMIUM_MODEL_LOCKED_TOOLTIP,
-  REASONING_EFFORT_INFO,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { classNames } from "@app/lib/utils";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
@@ -36,12 +39,15 @@ export function ReasoningEffortSlider({
   // With a single (or no) selectable level there is nothing to slide, so the
   // slider is shown disabled with an explanatory tooltip.
   const isDisabled = unlockedStops.length <= 1;
-  const hasPremiumLock = stops.some((stop) => stop.lockedReason === "premium");
+  const planLockReason: ModelLockReason | undefined = stops.some(
+    (stop) => stop.lockedReason === "premium"
+  )
+    ? "premium"
+    : stops.some((stop) => stop.lockedReason === "model_tier")
+      ? "model_tier"
+      : undefined;
 
-  const stopTooltip = (stop: EffortStop) =>
-    stop.lockedReason === "premium"
-      ? PREMIUM_MODEL_LOCKED_TOOLTIP
-      : REASONING_EFFORT_INFO[stop.effort];
+  const stopTooltip = (stop: EffortStop) => getEffortStopTooltip(stop);
 
   const selectStop = (stop: EffortStop) => {
     if (!isDisabled && !stop.locked && stop.effort !== value) {
@@ -131,8 +137,8 @@ export function ReasoningEffortSlider({
   }
 
   const soleEffort = unlockedStops[0]?.effort;
-  const tooltipLabel = hasPremiumLock
-    ? PREMIUM_MODEL_LOCKED_TOOLTIP
+  const tooltipLabel = planLockReason
+    ? getModelLockTooltip(planLockReason)
     : soleEffort
       ? `${getReasoningEffortLabel(soleEffort)} is the only reasoning effort available for this model.`
       : "Reasoning effort can't be adjusted for this model.";

--- a/front/components/assistant/conversation/input_bar/ReasoningEffortSlider.tsx
+++ b/front/components/assistant/conversation/input_bar/ReasoningEffortSlider.tsx
@@ -1,6 +1,7 @@
 import type { EffortStop } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import {
   getReasoningEffortLabel,
+  PREMIUM_MODEL_LOCKED_TOOLTIP,
   REASONING_EFFORT_INFO,
 } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
 import { classNames } from "@app/lib/utils";
@@ -35,6 +36,12 @@ export function ReasoningEffortSlider({
   // With a single (or no) selectable level there is nothing to slide, so the
   // slider is shown disabled with an explanatory tooltip.
   const isDisabled = unlockedStops.length <= 1;
+  const hasPremiumLock = stops.some((stop) => stop.lockedReason === "premium");
+
+  const stopTooltip = (stop: EffortStop) =>
+    stop.lockedReason === "premium"
+      ? PREMIUM_MODEL_LOCKED_TOOLTIP
+      : REASONING_EFFORT_INFO[stop.effort];
 
   const selectStop = (stop: EffortStop) => {
     if (!isDisabled && !stop.locked && stop.effort !== value) {
@@ -54,11 +61,7 @@ export function ReasoningEffortSlider({
         value={valueIndex}
         lockedSteps={lockedSteps}
         disabled={isDisabled}
-        stepTooltips={
-          isDisabled
-            ? undefined
-            : stops.map((stop) => REASONING_EFFORT_INFO[stop.effort])
-        }
+        stepTooltips={isDisabled ? undefined : stops.map(stopTooltip)}
         onChange={(index) => {
           const next = stops[index];
           if (next) {
@@ -115,7 +118,7 @@ export function ReasoningEffortSlider({
               key={stop.effort}
               tooltipTriggerAsChild
               trigger={labelButton}
-              label={REASONING_EFFORT_INFO[stop.effort]}
+              label={stopTooltip(stop)}
             />
           );
         })}
@@ -128,9 +131,11 @@ export function ReasoningEffortSlider({
   }
 
   const soleEffort = unlockedStops[0]?.effort;
-  const tooltipLabel = soleEffort
-    ? `${getReasoningEffortLabel(soleEffort)} is the only reasoning effort available for this model.`
-    : "Reasoning effort can't be adjusted for this model.";
+  const tooltipLabel = hasPremiumLock
+    ? PREMIUM_MODEL_LOCKED_TOOLTIP
+    : soleEffort
+      ? `${getReasoningEffortLabel(soleEffort)} is the only reasoning effort available for this model.`
+      : "Reasoning effort can't be adjusted for this model.";
 
   return (
     <Tooltip tooltipTriggerAsChild trigger={slider} label={tooltipLabel} />

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.test.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.test.ts
@@ -1,0 +1,126 @@
+import {
+  getEffortStops,
+  getInitialEffort,
+  getModelEffortTier,
+  isPremiumModel,
+} from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import {
+  CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_5_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+import { describe, expect, it } from "vitest";
+
+const GATED = { lockPremiumEfforts: true };
+const UNGATED = { lockPremiumEfforts: false };
+
+const lockedReasonByEffort = (
+  stops: ReturnType<typeof getEffortStops>
+): Record<string, string | undefined> =>
+  Object.fromEntries(
+    stops.map((stop) => [
+      stop.effort,
+      stop.locked ? (stop.lockedReason ?? "locked") : undefined,
+    ])
+  );
+
+describe("modelPickerUtils premium gating", () => {
+  describe("getModelEffortTier", () => {
+    it("mirrors the static tier table", () => {
+      expect(getModelEffortTier(CLAUDE_OPUS_4_8_MODEL_ID, "light")).toBe(
+        "premium"
+      );
+      expect(getModelEffortTier(CLAUDE_SONNET_5_MODEL_ID, "light")).toBe(
+        "cost_efficient"
+      );
+      expect(getModelEffortTier(CLAUDE_SONNET_5_MODEL_ID, "medium")).toBe(
+        "balanced"
+      );
+      expect(getModelEffortTier(CLAUDE_SONNET_5_MODEL_ID, "high")).toBe(
+        "premium"
+      );
+    });
+
+    it("treats models absent from the static table as premium", () => {
+      const customModelId = "my-custom-model-from-eap" as ModelIdType;
+      expect(getModelEffortTier(customModelId, "high")).toBe("premium");
+    });
+  });
+
+  describe("getEffortStops", () => {
+    it("locks premium efforts with reason 'premium' when gated (mixed model)", () => {
+      // Sonnet 5: light=cost_efficient, medium=balanced, high=premium.
+      const stops = getEffortStops(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED);
+      expect(lockedReasonByEffort(stops)).toEqual({
+        light: undefined,
+        medium: undefined,
+        high: "premium",
+      });
+    });
+
+    it("locks every premium effort of a mid-tier reasoning model", () => {
+      // Gemini 2.5 Pro: light=balanced, medium=premium, high=premium.
+      const stops = getEffortStops(GEMINI_2_5_PRO_MODEL_CONFIG, GATED);
+      expect(lockedReasonByEffort(stops)).toEqual({
+        light: undefined,
+        medium: "premium",
+        high: "premium",
+      });
+    });
+
+    it("does not lock anything when ungated", () => {
+      const stops = getEffortStops(
+        CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+        UNGATED
+      );
+      expect(stops.every((stop) => !stop.locked)).toBe(true);
+    });
+  });
+
+  describe("isPremiumModel", () => {
+    it("locks a whole-premium reasoning model when gated", () => {
+      expect(isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, GATED)).toBe(
+        true
+      );
+    });
+
+    it("locks a whole-premium non-reasoning model (only 'none') when gated", () => {
+      expect(isPremiumModel(O1_MODEL_CONFIG, GATED)).toBe(true);
+    });
+
+    it("keeps mixed models selectable when gated", () => {
+      expect(isPremiumModel(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED)).toBe(
+        false
+      );
+      expect(isPremiumModel(GEMINI_2_5_PRO_MODEL_CONFIG, GATED)).toBe(false);
+    });
+
+    it("never locks a model when ungated", () => {
+      expect(
+        isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, UNGATED)
+      ).toBe(false);
+      expect(isPremiumModel(O1_MODEL_CONFIG, UNGATED)).toBe(false);
+    });
+  });
+
+  describe("getInitialEffort", () => {
+    it("never returns a premium effort when gated (mixed models)", () => {
+      expect(
+        getModelEffortTier(
+          CLAUDE_SONNET_5_MODEL_ID,
+          getInitialEffort(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, GATED)
+        )
+      ).not.toBe("premium");
+      expect(
+        getModelEffortTier(
+          GEMINI_2_5_PRO_MODEL_CONFIG.modelId,
+          getInitialEffort(GEMINI_2_5_PRO_MODEL_CONFIG, GATED)
+        )
+      ).not.toBe("premium");
+    });
+  });
+});

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -1,5 +1,8 @@
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import { STATIC_MODEL_TIERS } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
+  STATIC_MODEL_TIERS,
+} from "@app/lib/api/assistant/token_pricing/tiers";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
@@ -22,10 +25,17 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
 
 // Shown when a whole-premium model row or a premium reasoning-effort stop is
-// locked because the workspace is not on a credit-based (usage-based) plan.
+// locked because the workspace is on a legacy (non usage-based) plan.
 export const PREMIUM_MODEL_LOCKED_TOOLTIP =
   "Premium models are available via this picker on the new usage-based plans. " +
-  "Contact your administrator to upgrade to access these models.";
+  "Contact your administrator to upgrade and access these models.";
+
+// Shown when a model row is locked because the model's tier is not enabled for
+// the workspace's current model-tier ceiling (independent of the plan: this
+// applies even on usage-based plans whose tier grants stop below the model).
+export const MODEL_TIER_LOCKED_TOOLTIP =
+  "You don't have access to this model tier. " +
+  "Contact your administrator to get access.";
 
 // The three primary picks of the model picker. Each tier is backed by a
 // meta-model that is resolved to a concrete model at message-send time:
@@ -80,6 +90,15 @@ export function getModelTier(tierId: ModelTierId): ModelTierDefinition {
   );
 }
 
+const PREMIUM_MODEL_TIER_IDS: ModelTierId[] = ["complex"];
+
+export function isTierLocked(
+  tierId: ModelTierId,
+  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
+): boolean {
+  return lockPremiumEfforts && PREMIUM_MODEL_TIER_IDS.includes(tierId);
+}
+
 // Per reasoning-effort blurbs surfaced in the effort slider tooltip.
 export const REASONING_EFFORT_INFO: Record<ReasoningEffort, string> = {
   none: "No additional reasoning, for the fastest responses.",
@@ -111,7 +130,7 @@ export interface MakerGroup {
   models: ModelConfigurationType[];
 }
 
-export type EffortLockReason = "unsupported" | "premium";
+export type EffortLockReason = "unsupported" | "premium" | "model_tier";
 
 // One stop of the reasoning-effort slider. A stop is `locked` when the level is
 // not selectable; `lockedReason` says why.
@@ -215,6 +234,16 @@ export function getModelEffortTier(
   return STATIC_MODEL_TIERS[modelId][effort] ?? null;
 }
 
+function modelSupportsEffortStatically(
+  modelId: ModelIdType,
+  effort: ReasoningEffort
+): boolean {
+  if (!isStaticModelId(modelId)) {
+    return false;
+  }
+  return STATIC_MODEL_SUPPORTED_REASONING_EFFORTS[modelId][effort] === true;
+}
+
 // The single authority for whether a reasoning-effort level is selectable.
 export function getEffortStops(
   enabledModel: ModelConfigurationType,
@@ -226,7 +255,16 @@ export function getEffortStops(
 
   return SLIDER_EFFORTS.map((effort) => {
     if (!allowed.has(effort)) {
-      return { effort, locked: true, lockedReason: "unsupported" };
+      return {
+        effort,
+        locked: true,
+        lockedReason: modelSupportsEffortStatically(
+          enabledModel.modelId,
+          effort
+        )
+          ? "model_tier"
+          : "unsupported",
+      };
     }
     if (
       lockPremiumEfforts &&
@@ -255,15 +293,29 @@ export function getInitialEffort(
   return stops.find((stop) => !stop.locked)?.effort ?? "none";
 }
 
+function isReasoningModel(modelId: ModelIdType): boolean {
+  if (!isStaticModelId(modelId)) {
+    return false;
+  }
+  const support = STATIC_MODEL_SUPPORTED_REASONING_EFFORTS[modelId];
+  return SLIDER_EFFORTS.some((effort) => support[effort]);
+}
+
 // Whether a whole model row must be locked
 export function isPremiumModel(
   enabledModel: ModelConfigurationType,
   { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
 ): boolean {
+  const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
+  const hasUsableSliderEffort = stops.some((stop) => !stop.locked);
+
+  if (isReasoningModel(enabledModel.modelId) && !hasUsableSliderEffort) {
+    return true;
+  }
+
   if (!lockPremiumEfforts) {
     return false;
   }
-  const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
   const supportedSlider = stops.filter(
     (stop) => stop.lockedReason !== "unsupported"
   );
@@ -271,6 +323,47 @@ export function isPremiumModel(
     return supportedSlider.every((stop) => stop.lockedReason === "premium");
   }
   return getModelEffortTier(enabledModel.modelId, "none") === "premium";
+}
+
+export type ModelLockReason = "premium" | "model_tier";
+
+export function getModelLockReason(
+  enabledModel: ModelConfigurationType,
+  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
+): ModelLockReason | null {
+  if (!isPremiumModel(enabledModel, { lockPremiumEfforts })) {
+    return null;
+  }
+  return lockPremiumEfforts ? "premium" : "model_tier";
+}
+
+export function getModelLockTooltip(reason: ModelLockReason): string {
+  switch (reason) {
+    case "premium":
+      return PREMIUM_MODEL_LOCKED_TOOLTIP;
+    case "model_tier":
+      return MODEL_TIER_LOCKED_TOOLTIP;
+    default:
+      assertNeverAndIgnore(reason);
+      return "";
+  }
+}
+
+export function getEffortStopTooltip(stop: EffortStop): string {
+  if (stop.locked) {
+    switch (stop.lockedReason) {
+      case "premium":
+        return PREMIUM_MODEL_LOCKED_TOOLTIP;
+      case "model_tier":
+        return MODEL_TIER_LOCKED_TOOLTIP;
+      case "unsupported":
+      case undefined:
+        break;
+      default:
+        assertNeverAndIgnore(stop.lockedReason);
+    }
+  }
+  return REASONING_EFFORT_INFO[stop.effort];
 }
 
 export function getModelWithReasoningEffortLabel(

--- a/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
+++ b/front/components/assistant/conversation/input_bar/modelPickerUtils.ts
@@ -1,3 +1,5 @@
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import { STATIC_MODEL_TIERS } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
@@ -7,8 +9,10 @@ import {
   AUTO_MODEL_ID,
   isModelStreamId,
 } from "@app/types/assistant/models/auto";
+import { isStaticModelId } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,
+  ModelIdType,
   ModelMakerIdType,
   ModelSelectionType,
   ReasoningEffort,
@@ -16,6 +20,12 @@ import type {
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
+
+// Shown when a whole-premium model row or a premium reasoning-effort stop is
+// locked because the workspace is not on a credit-based (usage-based) plan.
+export const PREMIUM_MODEL_LOCKED_TOOLTIP =
+  "Premium models are available via this picker on the new usage-based plans. " +
+  "Contact your administrator to upgrade to access these models.";
 
 // The three primary picks of the model picker. Each tier is backed by a
 // meta-model that is resolved to a concrete model at message-send time:
@@ -101,12 +111,14 @@ export interface MakerGroup {
   models: ModelConfigurationType[];
 }
 
+export type EffortLockReason = "unsupported" | "premium";
+
 // One stop of the reasoning-effort slider. A stop is `locked` when the level is
-// not selectable — either the model does not support it natively, or the
-// workspace's tier does not grant access to it.
+// not selectable; `lockedReason` says why.
 export interface EffortStop {
   effort: ReasoningEffort;
   locked: boolean;
+  lockedReason?: EffortLockReason;
 }
 
 // The reasoning-effort slider always presents these three canonical levels so
@@ -188,30 +200,51 @@ export function isSameSelection(
   return isSameDisplay(a, b);
 }
 
-// Always returns the three canonical levels (Light/Medium/High) so the slider looks
-// the same across models. Levels the workspace's tier does not grant (already narrowed
-// in `enabledModel`) are flagged `locked` (padlock); non-reasoning models get all three.
+interface LockPremiumOptions {
+  lockPremiumEfforts?: boolean;
+}
+
+// Client-safe mirror of `ModelsTierResource.getTierForModel`
+export function getModelEffortTier(
+  modelId: ModelIdType,
+  effort: ReasoningEffort
+): ModelsTierName | null {
+  if (!isStaticModelId(modelId)) {
+    return "premium";
+  }
+  return STATIC_MODEL_TIERS[modelId][effort] ?? null;
+}
+
+// The single authority for whether a reasoning-effort level is selectable.
 export function getEffortStops(
-  enabledModel: ModelConfigurationType
+  enabledModel: ModelConfigurationType,
+  { lockPremiumEfforts = false }: LockPremiumOptions = {}
 ): EffortStop[] {
   const allowed = new Set(
     getAvailableReasoningEfforts(enabledModel.supportedReasoningEfforts)
   );
-  // Todo(models_picker): return reason for each stop (model does not support
-  // or workspace tier does not grant)
 
-  return SLIDER_EFFORTS.map((effort) => ({
-    effort,
-    locked: !allowed.has(effort),
-  }));
+  return SLIDER_EFFORTS.map((effort) => {
+    if (!allowed.has(effort)) {
+      return { effort, locked: true, lockedReason: "unsupported" };
+    }
+    if (
+      lockPremiumEfforts &&
+      getModelEffortTier(enabledModel.modelId, effort) === "premium"
+    ) {
+      return { effort, locked: true, lockedReason: "premium" };
+    }
+    return { effort, locked: false };
+  });
 }
 
 // The reasoning effort to use when a model is freshly selected: its default when
 // that is allowed, otherwise the first unlocked stop.
 export function getInitialEffort(
-  enabledModel: ModelConfigurationType
+  enabledModel: ModelConfigurationType,
+  { lockPremiumEfforts = false }: LockPremiumOptions = {}
 ): ReasoningEffort {
-  const stops = getEffortStops(enabledModel);
+  const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
   const preferred = stops.find(
     (stop) =>
       stop.effort === enabledModel.defaultReasoningEffort && !stop.locked
@@ -220,6 +253,24 @@ export function getInitialEffort(
     return preferred.effort;
   }
   return stops.find((stop) => !stop.locked)?.effort ?? "none";
+}
+
+// Whether a whole model row must be locked
+export function isPremiumModel(
+  enabledModel: ModelConfigurationType,
+  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
+): boolean {
+  if (!lockPremiumEfforts) {
+    return false;
+  }
+  const stops = getEffortStops(enabledModel, { lockPremiumEfforts });
+  const supportedSlider = stops.filter(
+    (stop) => stop.lockedReason !== "unsupported"
+  );
+  if (supportedSlider.length > 0) {
+    return supportedSlider.every((stop) => stop.lockedReason === "premium");
+  }
+  return getModelEffortTier(enabledModel.modelId, "none") === "premium";
 }
 
 export function getModelWithReasoningEffortLabel(
@@ -314,6 +365,8 @@ export function resolveAgentDefault({
     return standardDefault;
   }
 
+  // Keep `toSend` undefined so the agent runs its own configured model/effort
+  // server-side; the slider surfaces the agent's configured effort as-is.
   const effort = agentModel.reasoningEffort ?? getInitialEffort(model);
   return {
     display: { kind: "model", model, effort },

--- a/sparkle/src/components/SliderSteps.tsx
+++ b/sparkle/src/components/SliderSteps.tsx
@@ -83,16 +83,25 @@ export function SliderSteps({
       Math.max((e.clientX - rect.left) / rect.width, 0),
       1
     );
-    setHoveredIndex(nearestUnlocked(Math.round(ratio * lastIndex)));
+    // Track the raw step under the pointer (locked ones included) so a locked
+    // step surfaces its OWN tooltip on hover. Selection/preview snap to the
+    // nearest unlocked step separately.
+    setHoveredIndex(Math.round(ratio * lastIndex));
   };
+
+  // Where selecting would land: the nearest unlocked step to the raw hover.
+  const snappedHoverIndex =
+    hoveredIndex !== null ? nearestUnlocked(hoveredIndex) : null;
 
   // Decided at render time so the preview vanishes as soon as the hovered step
   // becomes the value (click/drag), without waiting for the next pointer move.
   const previewIndex =
-    !disabled && hoveredIndex !== null && hoveredIndex > value
-      ? hoveredIndex
+    !disabled && snappedHoverIndex !== null && snappedHoverIndex > value
+      ? snappedHoverIndex
       : null;
 
+  // The tooltip reflects the raw hovered step (so a locked step explains why it
+  // is locked), not the step selection would snap to.
   const activeTooltip =
     !disabled && hoveredIndex !== null
       ? (stepTooltips?.[hoveredIndex] ?? null)


### PR DESCRIPTION
## Description

Gates premium models and premium reasoning-effort levels behind credit-based (usage-based) plans in the input-bar model picker.

- Adds `getModelEffortTier`, a client-safe mirror of the server tier lookup, backed by `STATIC_MODEL_TIERS`. Models absent from the static table are treated as `premium`.
- `getEffortStops` now flags each stop with a `lockedReason` (`"unsupported"` vs `"premium"`); premium efforts are locked when the workspace is not on a credit-priced plan.
- Adds `isPremiumModel` to decide when a whole model row must be locked (every selectable effort is premium).
- Locked model rows render disabled with a padlock and an explanatory tooltip; locked slider stops surface their own premium tooltip. `getInitialEffort` never lands on a locked premium effort, and both `onSelectModel` / `onSelectEffort` short-circuit on premium picks.
- `SliderSteps` tooltip now tracks the raw hovered step (locked included) so a locked step explains why it's locked, while selection/preview still snap to the nearest unlocked step.
- Adds unit tests for the gating logic (`modelPickerUtils.test.ts`).

Plan gating is driven by `isCreditPricedPlan(subscription.plan)`.

## Tests

- Added `modelPickerUtils.test.ts` covering `getModelEffortTier`, `getEffortStops`, `isPremiumModel`, and `getInitialEffort` for gated/ungated cases across mixed-tier, whole-premium reasoning, and non-reasoning models.
