### PR TITLE
feat(front): add admin setting to allow published agents on restricted model tiers

### DIFF
--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -144,6 +144,55 @@ describe("POST /api/w/:wId (workspace default agent)", () => {
   });
 });
 
+describe("POST /api/w/:wId (published agents restricted models)", () => {
+  it("sets allowRestrictedModelsForPublishedAgents in workspace metadata", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      allowRestrictedModelsForPublishedAgents: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.allowRestrictedModelsForPublishedAgents).toBe(
+      true
+    );
+  });
+
+  it("disables the override and preserves other metadata", async () => {
+    const { workspace } = await setup();
+
+    await post(workspace, { reinforcementCapAwuCredits: 5_000 });
+    await post(workspace, { allowRestrictedModelsForPublishedAgents: true });
+
+    const response = await post(workspace, {
+      allowRestrictedModelsForPublishedAgents: false,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.allowRestrictedModelsForPublishedAgents).toBe(
+      false
+    );
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        allowRestrictedModelsForPublishedAgents: true,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    }
+  });
+});
+
 describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
   it("sets disableWorkspaceAnalytics in workspace metadata", async () => {
     const { workspace } = await setup();

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -207,6 +207,10 @@ const WorkspaceAnalyticsUpdateBodySchema = z.object({
   disableWorkspaceAnalytics: z.boolean(),
 });
 
+const WorkspacePublishedAgentsRestrictedModelsUpdateBodySchema = z.object({
+  allowRestrictedModelsForPublishedAgents: z.boolean(),
+});
+
 const WorkspaceSlackPersonalFooterRemovalUpdateBodySchema = z.object({
   slackPersonalAllowFooterRemoval: z.boolean(),
 });
@@ -242,6 +246,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema,
   WorkspaceAuditLogsUpdateBodySchema,
   WorkspaceAnalyticsUpdateBodySchema,
+  WorkspacePublishedAgentsRestrictedModelsUpdateBodySchema,
   WorkspaceDefaultAgentUpdateBodySchema,
   WorkspaceSlackPersonalFooterRemovalUpdateBodySchema,
 ]);
@@ -578,6 +583,25 @@ app.post(
         context: getAuditLogContext(auth),
         metadata: {
           enabled: String(body.allowEmailAgents),
+        },
+      });
+    } else if ("allowRestrictedModelsForPublishedAgents" in body) {
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        allowRestrictedModelsForPublishedAgents:
+          body.allowRestrictedModelsForPublishedAgents,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.published_agents_restricted_models_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          enabled: String(body.allowRestrictedModelsForPublishedAgents),
         },
       });
     } else if ("allowReinforcement" in body) {

--- a/front/admin/audit_log_schemas/workspace.published_agents_restricted_models_updated.json
+++ b/front/admin/audit_log_schemas/workspace.published_agents_restricted_models_updated.json
@@ -1,0 +1,7 @@
+{
+  "action": "workspace.published_agents_restricted_models_updated",
+  "targets": [{ "type": "workspace" }],
+  "metadata": {
+    "enabled": "string"
+  }
+}

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -1,5 +1,6 @@
 import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
 import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
+import { usePublishedAgentsRestrictedModelsToggle } from "@app/hooks/usePublishedAgentsRestrictedModelsToggle";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getWorkspaceModelTierOptions } from "@app/lib/client/model_tier_options";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
@@ -8,7 +9,7 @@ import {
   useWorkspaceAllowedModelTiers,
 } from "@app/lib/swr/model_tiers";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Page, SettingsList } from "@dust-tt/sparkle";
+import { Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
 
 interface ModelTiersSettingsCardProps {
   owner: LightWorkspaceType;
@@ -25,6 +26,11 @@ export function ModelTiersSettingsCard({
   } = useWorkspaceAllowedModelTiers({ owner });
   const { setWorkspaceAllowedModelTier, isWorkspaceAllowedModelTierMutating } =
     useWorkspaceAllowedModelTierMutations({ owner });
+  const {
+    isEnabled: isRestrictedModelsForPublishedAgentsEnabled,
+    isChanging: isRestrictedModelsForPublishedAgentsChanging,
+    doTogglePublishedAgentsRestrictedModels,
+  } = usePublishedAgentsRestrictedModelsToggle({ owner });
 
   const selectedValue = workspaceMaxTierName ?? DEFAULT_MAX_MODEL_TIER;
 
@@ -50,6 +56,19 @@ export function ModelTiersSettingsCard({
               readOnly={readOnly}
               isLoading={isWorkspaceAllowedModelTiersLoading}
               isMutating={isWorkspaceAllowedModelTierMutating}
+            />
+          }
+        />
+        <SettingsList.Row
+          title="Published agents"
+          description="Allow all members to run published agents even when the agent's model tier is above their own access."
+          action={
+            <SliderToggle
+              selected={isRestrictedModelsForPublishedAgentsEnabled}
+              disabled={
+                readOnly || isRestrictedModelsForPublishedAgentsChanging
+              }
+              onClick={() => void doTogglePublishedAgentsRestrictedModels()}
             />
           }
         />

--- a/front/hooks/usePublishedAgentsRestrictedModelsToggle.ts
+++ b/front/hooks/usePublishedAgentsRestrictedModelsToggle.ts
@@ -1,0 +1,53 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { areRestrictedModelsAllowedForPublishedAgents } from "@app/types/user";
+import { useState } from "react";
+
+interface UsePublishedAgentsRestrictedModelsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function usePublishedAgentsRestrictedModelsToggle({
+  owner,
+}: UsePublishedAgentsRestrictedModelsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    areRestrictedModelsAllowedForPublishedAgents(owner)
+  );
+
+  const doTogglePublishedAgentsRestrictedModels = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowRestrictedModelsForPublishedAgents: !isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update published agents setting");
+      }
+      setIsEnabled(!isEnabled);
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to update published agents setting",
+        description:
+          "Could not update the published agents model access setting.",
+      });
+    }
+    setIsChanging(false);
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doTogglePublishedAgentsRestrictedModels,
+  };
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -113,6 +113,7 @@
   "workspace.open_projects_updated": 1,
   "workspace.private_conversation_urls_updated": 1,
   "workspace.programmatic_usage_limit_updated": 1,
+  "workspace.published_agents_restricted_models_updated": 1,
   "workspace.regional_models_only_updated": 1,
   "workspace.reinforcement_cap_updated": 1,
   "workspace.self_improvement_cap_per_skill_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -103,6 +103,7 @@ export const AUDIT_ACTIONS = [
   "workspace.open_projects_updated",
   "workspace.private_conversation_urls_updated",
   "workspace.programmatic_usage_limit_updated",
+  "workspace.published_agents_restricted_models_updated",
   "workspace.regional_models_only_updated",
   "workspace.reinforcement_cap_updated",
   "workspace.self_improvement_cap_per_skill_updated",

--- a/front/lib/model_tiers/access.test.ts
+++ b/front/lib/model_tiers/access.test.ts
@@ -1,0 +1,100 @@
+import { Authenticator } from "@app/lib/auth";
+import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("getModelTierAccessErrorForAgentConfiguration", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  async function restrictedUserAuth() {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await ModelsTierResource.setUserMaxAllowedTier(adminAuth, {
+      userId: user.sId,
+      tierName: "balanced",
+    });
+
+    return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  }
+
+  async function allowRestrictedModelsForPublishedAgents() {
+    const resource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!resource) {
+      throw new Error("Workspace not found.");
+    }
+    await resource.updateWorkspaceSettings({
+      metadata: { allowRestrictedModelsForPublishedAgents: true },
+    });
+  }
+
+  function accessErrorFor(
+    auth: Authenticator,
+    { agentScope }: { agentScope?: "visible" | "hidden" } = {}
+  ) {
+    return getModelTierAccessErrorForAgentConfiguration(auth, {
+      agentName: "test-agent",
+      model: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+      featureFlags: ["models_picker"],
+      agentScope,
+    });
+  }
+
+  it("blocks a published agent run when the override is off", async () => {
+    const auth = await restrictedUserAuth();
+
+    const error = await accessErrorFor(auth, { agentScope: "visible" });
+
+    expect(error?.code).toBe("model_tier_not_enabled");
+  });
+
+  it("allows a published agent run when the override is on", async () => {
+    await allowRestrictedModelsForPublishedAgents();
+    const auth = await restrictedUserAuth();
+
+    const error = await accessErrorFor(auth, { agentScope: "visible" });
+
+    expect(error).toBeNull();
+  });
+
+  it("still blocks unpublished agent runs when the override is on", async () => {
+    await allowRestrictedModelsForPublishedAgents();
+    const auth = await restrictedUserAuth();
+
+    const error = await accessErrorFor(auth, { agentScope: "hidden" });
+
+    expect(error?.code).toBe("model_tier_not_enabled");
+  });
+
+  it("still blocks the creation path (no agentScope) when the override is on", async () => {
+    await allowRestrictedModelsForPublishedAgents();
+    const auth = await restrictedUserAuth();
+
+    const error = await accessErrorFor(auth);
+
+    expect(error?.code).toBe("model_tier_not_enabled");
+  });
+
+  it("does not block when models_picker is disabled", async () => {
+    const auth = await restrictedUserAuth();
+
+    const error = await getModelTierAccessErrorForAgentConfiguration(auth, {
+      agentName: "test-agent",
+      model: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+      featureFlags: [],
+      agentScope: "visible",
+    });
+
+    expect(error).toBeNull();
+  });
+});

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -42,9 +42,6 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     model: ModelConfigurationType;
     reasoningEffort?: ReasoningEffort;
     featureFlags: WhitelistableFeature[];
-    // Only passed on the run path. The create/upgrade path deliberately omits
-    // it: the published-agents override must not let members configure agents
-    // with models above their own tier.
     agentScope?: AgentConfigurationScope;
   }
 ): Promise<GenericErrorContent | null> {

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -1,12 +1,16 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
-import type { GenericErrorContent } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationScope,
+  GenericErrorContent,
+} from "@app/types/assistant/agent";
 import type {
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { areRestrictedModelsAllowedForPublishedAgents } from "@app/types/user";
 
 export const MODEL_TIER_NOT_ENABLED_ERROR_CODE = "model_tier_not_enabled";
 
@@ -32,14 +36,28 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     model,
     reasoningEffort,
     featureFlags,
+    agentScope,
   }: {
     agentName: string;
     model: ModelConfigurationType;
     reasoningEffort?: ReasoningEffort;
     featureFlags: WhitelistableFeature[];
+    // Only passed on the run path. The create/upgrade path deliberately omits
+    // it: the published-agents override must not let members configure agents
+    // with models above their own tier.
+    agentScope?: AgentConfigurationScope;
   }
 ): Promise<GenericErrorContent | null> {
   if (!featureFlags.includes("models_picker")) {
+    return null;
+  }
+
+  // Workspace admins can allow members to run published agents whose model
+  // tier is above the member's own access.
+  if (
+    agentScope === "visible" &&
+    areRestrictedModelsAllowedForPublishedAgents(auth.getNonNullableWorkspace())
+  ) {
     return null;
   }
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -465,6 +465,7 @@ export async function runModel(
         model,
         reasoningEffort: model.reasoningEffort,
         featureFlags,
+        agentScope: agentConfiguration.scope,
       }
     );
     if (accessError) {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -97,6 +97,15 @@ export function isWorkspaceAnalyticsEnabled(
   return owner.metadata?.disableWorkspaceAnalytics !== true;
 }
 
+// When enabled, members can run published agents even if the agent's model
+// requires a tier above their own access. Disabled by default: such runs are
+// blocked. Admins can opt in via the workspace settings.
+export function areRestrictedModelsAllowedForPublishedAgents(
+  owner: LightWorkspaceType
+): boolean {
+  return owner.metadata?.allowRestrictedModelsForPublishedAgents === true;
+}
+
 /**
  * The default agent that should be pre-selected for new conversations.
  * A pod-level default agent takes precedence over the workspace-level default agent.


### PR DESCRIPTION
## Description

With `models_picker`, a published agent can be configured (by an editor who has access) with a model tier that some members are not granted. Their runs are currently blocked at step 0 of the agent loop with a `model_tier_not_enabled` error.

This adds a workspace admin setting to allow those runs anyway:

- New workspace metadata boolean `allowRestrictedModelsForPublishedAgents` (default off), updated via `POST /api/w/[wId]` (admin-only), following the `allowEmailAgents` pattern, with a new `workspace.published_agents_restricted_models_updated` audit event.
- `getModelTierAccessErrorForAgentConfiguration` takes an optional `agentScope`; the tier check is skipped when the agent is published (`scope === "visible"`) and the override is enabled. Only the run path passes the scope — creating/upgrading an agent with a restricted model stays blocked, so members cannot self-publish a premium-model agent to bypass tier controls. The model picker selectability logic is also unchanged.
- New "Published agents" toggle in the Models tier card (Admin → Usage), already admin- and `models_picker`-gated.

## Tests

- New functional tests for the endpoint branch (`front-api/routes/w/[wId]/index.test.ts`): sets/unsets the metadata key, preserves other metadata, 403 for non-admins.
- New `front/lib/model_tiers/access.test.ts`: override off/on × published/hidden/no-scope (creation path), plus the `models_picker`-disabled case.

## Risk

Low. The override is opt-in per workspace and defaults to off, preserving current behavior. Rollback-safe: reverting simply re-blocks the runs.

## Deploy Plan

Before merge: register the new audit schema and commit the regenerated version map in this PR (`npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`, requires `WORKOS_API_KEY`). Regular deploy otherwise.
