### PR TITLE
[front] enh: expose tables query outputs to pod functions

### DIFF
--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -22,7 +22,6 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import assert from "assert";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
@@ -208,7 +207,9 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     { auth, runContext }
   ) => {
     // TODO(spolu): move query CSV output to DFS
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    if (!isAgentLoopRunContext(runContext)) {
+      return new Err(new MCPError("AgentLoopRunContext expected"));
+    }
 
     const agentLoopRunContext = runContext;
 

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -2,7 +2,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getAgentDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   getAvailableWarehouses,
   getWarehouseNodes,
@@ -206,13 +205,6 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     { dataSources, tableIds, query, fileName },
     { auth, runContext }
   ) => {
-    // TODO(spolu): move query CSV output to DFS
-    if (!isAgentLoopRunContext(runContext)) {
-      return new Err(new MCPError("AgentLoopRunContext expected"));
-    }
-
-    const agentLoopRunContext = runContext;
-
     const dataSourceConfigurationsResult =
       await getAgentDataSourceConfigurations(
         auth,
@@ -259,7 +251,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
         table_id: node.node_id,
       })),
       query,
-      runContext: agentLoopRunContext,
+      runContext,
       fileName,
       connectorProvider,
     });

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -258,7 +258,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
         table_id: node.node_id,
       })),
       query,
-      conversationId: agentLoopRunContext.conversation.sId,
+      runContext: agentLoopRunContext,
       fileName,
       connectorProvider,
     });

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.test.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.test.ts
@@ -1,0 +1,100 @@
+import { isToolGeneratedFilePath } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
+import { executeQuery } from "@app/lib/api/actions/servers/query_tables_v2/helpers";
+import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import { CoreAPI } from "@app/types/core/core_api";
+import { Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("executeQuery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes query results to the pod function tool outputs folder", async () => {
+    const {
+      auth,
+      workspace,
+      invocation,
+      globalSpace,
+      podSpace,
+      sandboxFunction,
+    } = await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "common_utilities",
+      useCase: null,
+    });
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.id,
+      globalSpace
+    );
+    const action = await SandboxFunctionMCPActionFactory.create(auth, {
+      invocation,
+      mcpServerView: view,
+    });
+    const runContext: SandboxFunctionRunContext = {
+      contextType: "sandbox_function",
+      action,
+      invocation,
+      toolConfiguration: action.toolConfiguration,
+    };
+
+    fileStorageMock.reset();
+    vi.spyOn(CoreAPI.prototype, "queryDatabase").mockResolvedValue(
+      new Ok({
+        schema: [
+          { name: "name", value_type: "text", possible_values: null },
+          { name: "count", value_type: "int", possible_values: null },
+        ],
+        results: [{ value: { name: "Ada", count: 2 } }],
+      })
+    );
+
+    const result = await executeQuery(auth, {
+      tables: [
+        {
+          project_id: 1,
+          data_source_id: "data-source-id",
+          table_id: "table-id",
+        },
+      ],
+      query: "SELECT name, count FROM table-id",
+      runContext,
+      fileName: "query-results",
+      connectorProvider: null,
+    });
+
+    assert(result.isOk());
+    const fileOutput = result.value.find(isToolGeneratedFilePath);
+    assert(fileOutput);
+
+    const scopedPathPrefix = `pod-${podSpace.sId}/.tool_outputs/${sandboxFunction.slug}/`;
+    expect(fileOutput.resource.path).toBe(fileOutput.resource.uri);
+    expect(fileOutput.resource.path).toBe(
+      `${scopedPathPrefix}${fileOutput.resource.title}`
+    );
+    expect(fileOutput.resource.title).toMatch(/^\d+_query_results_.*\.csv$/);
+    expect(fileOutput.resource.contentType).toBe("text/csv");
+
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    const fileWrite = fileStorageMock.saveFileCalls[0];
+    const relativePath = fileOutput.resource.path.slice(
+      `pod-${podSpace.sId}/`.length
+    );
+    expect(fileWrite.filePath).toBe(
+      `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: podSpace.sId,
+      })}${relativePath}`
+    );
+    expect(fileWrite.content.toString()).toBe("name,count\nAda,2\n");
+    expect(fileWrite.contentType).toBe("text/csv");
+  });
+});

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -11,6 +11,7 @@ import type {
   ToolMarkerResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { EXECUTE_TABLES_QUERY_MARKER } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
 import type { Authenticator } from "@app/lib/auth";
@@ -92,12 +93,106 @@ export function verifyDataSourceViewReadAccess(
   return null;
 }
 
+async function generateAgentLoopQueryResultFiles(
+  auth: Authenticator,
+  {
+    queryTitle,
+    results,
+    runContext,
+    connectorProvider,
+  }: {
+    queryTitle: string;
+    results: CSVRecord[];
+    runContext: AgentLoopRunContext;
+    connectorProvider: ConnectorProvider | null;
+  }
+): Promise<TablesQueryContentItem[]> {
+  const conversationId = runContext.conversation.sId;
+
+  // Keep using the FileResource flow instead of DustFileSystem here so the file can
+  // be uploaded to the conversation data source and queried by `tables_query` in
+  // subsequent turns.
+  const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
+    title: queryTitle,
+    conversationId,
+    results,
+  });
+
+  // Upload the CSV file to the conversation data source.
+  await uploadFileToConversationDataSource({
+    auth,
+    file: csvFile,
+  });
+
+  // Append the CSV file to the output of the tool as an agent-generated file.
+  const content: TablesQueryContentItem[] = [
+    {
+      type: "resource",
+      resource: {
+        text: "Your query results were generated successfully. They are available as a structured CSV file.",
+        uri: csvFile.getPublicUrl(auth),
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+        fileId: csvFile.sId,
+        title: queryTitle,
+        contentType: csvFile.contentType,
+        snippet: csvSnippet,
+      },
+    },
+  ];
+
+  // Check if we should generate a section JSON file.
+  const shouldGenerateSectionFile = results.some((result) =>
+    Object.values(result).some(
+      (value) =>
+        typeof value === "string" &&
+        value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
+    )
+  );
+
+  if (shouldGenerateSectionFile) {
+    // First, we fetch the connector provider for the data source, cause the chunking
+    // strategy of the section file depends on it: Since all tables are from the same
+    // data source, we can just take the first table's data source view id.
+    const sectionColumnsPrefix = getSectionColumnsPrefix(connectorProvider);
+
+    // Generate the section file.
+    const sectionFile = await generateSectionFile(auth, {
+      title: queryTitle,
+      conversationId,
+      results,
+      sectionColumnsPrefix,
+    });
+
+    // Upload the section file to the conversation data source.
+    await uploadFileToConversationDataSource({
+      auth,
+      file: sectionFile,
+    });
+
+    // Append the section file to the output of the tool as an agent-generated file.
+    content.push({
+      type: "resource",
+      resource: {
+        text: "Results are also available as a rich text file that can be viewed.",
+        uri: sectionFile.getPublicUrl(auth),
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+        fileId: sectionFile.sId,
+        title: `${queryTitle} (Rich Text)`,
+        contentType: sectionFile.contentType,
+        snippet: null,
+      },
+    });
+  }
+
+  return content;
+}
+
 export async function executeQuery(
   auth: Authenticator,
   {
     tables,
     query,
-    conversationId,
+    runContext,
     fileName,
     connectorProvider,
   }: {
@@ -107,7 +202,7 @@ export async function executeQuery(
       table_id: string;
     }>;
     query: string;
-    conversationId: string;
+    runContext: AgentLoopRunContext;
     fileName: string;
     connectorProvider: ConnectorProvider | null;
   }
@@ -150,76 +245,13 @@ export async function executeQuery(
     const humanReadableDate = new Date().toISOString().split("T")[0];
     const queryTitle = `${fileName} (${humanReadableDate})`;
 
-    // Generate the CSV file.
-    const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
-      title: queryTitle,
-      conversationId,
+    const agentLoopContent = await generateAgentLoopQueryResultFiles(auth, {
+      queryTitle,
       results,
+      runContext,
+      connectorProvider,
     });
-
-    // Upload the CSV file to the conversation data source.
-    await uploadFileToConversationDataSource({
-      auth,
-      file: csvFile,
-    });
-
-    // Append the CSV file to the output of the tool as an agent-generated file.
-    content.push({
-      type: "resource",
-      resource: {
-        text: "Your query results were generated successfully. They are available as a structured CSV file.",
-        uri: csvFile.getPublicUrl(auth),
-        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-        fileId: csvFile.sId,
-        title: queryTitle,
-        contentType: csvFile.contentType,
-        snippet: csvSnippet,
-      },
-    });
-
-    // Check if we should generate a section JSON file.
-    const shouldGenerateSectionFile = results.some((result) =>
-      Object.values(result).some(
-        (value) =>
-          typeof value === "string" &&
-          value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
-      )
-    );
-
-    if (shouldGenerateSectionFile) {
-      // First, we fetch the connector provider for the data source, cause the chunking
-      // strategy of the section file depends on it: Since all tables are from the same
-      // data source, we can just take the first table's data source view id.
-      const sectionColumnsPrefix = getSectionColumnsPrefix(connectorProvider);
-
-      // Generate the section file.
-      const sectionFile = await generateSectionFile(auth, {
-        title: queryTitle,
-        conversationId,
-        results,
-        sectionColumnsPrefix,
-      });
-
-      // Upload the section file to the conversation data source.
-      await uploadFileToConversationDataSource({
-        auth,
-        file: sectionFile,
-      });
-
-      // Append the section file to the output of the tool as an agent-generated file.
-      content.push({
-        type: "resource",
-        resource: {
-          text: "Results are also available as a rich text file that can be viewed.",
-          uri: sectionFile.getPublicUrl(auth),
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-          fileId: sectionFile.sId,
-          title: `${queryTitle} (Rich Text)`,
-          contentType: sectionFile.contentType,
-          snippet: null,
-        },
-      });
-    }
+    content.push(...agentLoopContent);
   } else {
     content.push({
       type: "text",

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -21,9 +21,8 @@ import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
 import { toCsv } from "@app/lib/api/csv";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { podScopedPath } from "@app/lib/api/file_system/types";
+import { getToolOutputsScopedPath } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
-import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
@@ -227,10 +226,7 @@ async function writeSandboxFunctionQueryResultFile(
     name: queryTitle,
     ext: ".csv",
   });
-  const scopedPath = podScopedPath(
-    runContext.invocation.sandboxFunction.space.sId,
-    `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sandboxFunction.slug}/${outputFileName}`
-  );
+  const scopedPath = getToolOutputsScopedPath(runContext, outputFileName);
   const csvContent = await toCsv(results);
   const writeResult = await fileSystemResult.value.write(
     scopedPath,

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -7,19 +7,29 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   SqlQueryOutputType,
   ThinkingOutputType,
+  ToolGeneratedFilePathType,
   ToolGeneratedFileType,
   ToolMarkerResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { EXECUTE_TABLES_QUERY_MARKER } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { AgentLoopRunContext } from "@app/lib/actions/types";
+import type {
+  AgentLoopRunContext,
+  SandboxFunctionRunContext,
+  ToolRunContext,
+} from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
+import { toCsv } from "@app/lib/api/csv";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { podScopedPath } from "@app/lib/api/file_system/types";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { ConnectorProvider } from "@app/types/data_source";
-import { Err, Ok } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -30,6 +40,7 @@ type TablesQueryOutputResources =
   | ThinkingOutputType
   | SqlQueryOutputType
   | ToolGeneratedFileType
+  | ToolGeneratedFilePathType
   | ToolMarkerResourceType;
 
 type TablesQueryContentItem =
@@ -187,6 +198,64 @@ async function generateAgentLoopQueryResultFiles(
   return content;
 }
 
+async function writeSandboxFunctionQueryResultFile(
+  auth: Authenticator,
+  {
+    queryTitle,
+    results,
+    runContext,
+  }: {
+    queryTitle: string;
+    results: CSVRecord[];
+    runContext: SandboxFunctionRunContext;
+  }
+): Promise<Result<ToolGeneratedFilePathType, MCPError>> {
+  const fileSystemResult = await DustFileSystem.forPod(
+    auth,
+    runContext.invocation.sandboxFunction.space
+  );
+  if (fileSystemResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Error accessing query result files: ${fileSystemResult.error.message}`,
+        { cause: fileSystemResult.error }
+      )
+    );
+  }
+
+  const outputFileName = makeFileName({
+    name: queryTitle,
+    ext: ".csv",
+  });
+  const scopedPath = podScopedPath(
+    runContext.invocation.sandboxFunction.space.sId,
+    `${TOOL_OUTPUTS_FOLDER_NAME}/${runContext.invocation.sandboxFunction.slug}/${outputFileName}`
+  );
+  const csvContent = await toCsv(results);
+  const writeResult = await fileSystemResult.value.write(
+    scopedPath,
+    csvContent,
+    "text/csv"
+  );
+  if (writeResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Error saving database query results: ${writeResult.error.message}`,
+        { cause: writeResult.error }
+      )
+    );
+  }
+
+  return new Ok({
+    text: "Your query results were generated successfully. They are available as a structured CSV file.",
+    uri: scopedPath,
+    path: scopedPath,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+    title: outputFileName,
+    contentType: "text/csv",
+  });
+}
+
 export async function executeQuery(
   auth: Authenticator,
   {
@@ -202,7 +271,7 @@ export async function executeQuery(
       table_id: string;
     }>;
     query: string;
-    runContext: AgentLoopRunContext;
+    runContext: ToolRunContext;
     fileName: string;
     connectorProvider: ConnectorProvider | null;
   }
@@ -245,13 +314,36 @@ export async function executeQuery(
     const humanReadableDate = new Date().toISOString().split("T")[0];
     const queryTitle = `${fileName} (${humanReadableDate})`;
 
-    const agentLoopContent = await generateAgentLoopQueryResultFiles(auth, {
-      queryTitle,
-      results,
-      runContext,
-      connectorProvider,
-    });
-    content.push(...agentLoopContent);
+    switch (runContext.contextType) {
+      case "agent_loop": {
+        const agentLoopContent = await generateAgentLoopQueryResultFiles(auth, {
+          queryTitle,
+          results,
+          runContext,
+          connectorProvider,
+        });
+        content.push(...agentLoopContent);
+        break;
+      }
+      case "sandbox_function": {
+        const fileResult = await writeSandboxFunctionQueryResultFile(auth, {
+          queryTitle,
+          results,
+          runContext,
+        });
+        if (fileResult.isErr()) {
+          return fileResult;
+        }
+
+        content.push({
+          type: "resource",
+          resource: fileResult.value,
+        });
+        break;
+      }
+      default:
+        return assertNever(runContext);
+    }
   } else {
     content.push({
       type: "text",

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -20,8 +20,7 @@ import type {
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
 import { toCsv } from "@app/lib/api/csv";
-import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { getToolOutputsScopedPath } from "@app/lib/api/files/action_output_fs";
+import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -209,30 +208,16 @@ async function writeSandboxFunctionQueryResultFile(
     runContext: SandboxFunctionRunContext;
   }
 ): Promise<Result<ToolGeneratedFilePathType, MCPError>> {
-  const fileSystemResult = await DustFileSystem.forPod(
-    auth,
-    runContext.invocation.sandboxFunction.space
-  );
-  if (fileSystemResult.isErr()) {
-    return new Err(
-      new MCPError(
-        `Error accessing query result files: ${fileSystemResult.error.message}`,
-        { cause: fileSystemResult.error }
-      )
-    );
-  }
-
   const outputFileName = makeFileName({
     name: queryTitle,
     ext: ".csv",
   });
-  const scopedPath = getToolOutputsScopedPath(runContext, outputFileName);
   const csvContent = await toCsv(results);
-  const writeResult = await fileSystemResult.value.write(
-    scopedPath,
-    csvContent,
-    "text/csv"
-  );
+  const writeResult = await writeToToolOutputsFolder(auth, runContext, {
+    fileName: outputFileName,
+    content: csvContent,
+    contentType: "text/csv",
+  });
   if (writeResult.isErr()) {
     return new Err(
       new MCPError(
@@ -241,6 +226,7 @@ async function writeSandboxFunctionQueryResultFile(
       )
     );
   }
+  const scopedPath = writeResult.value;
 
   return new Ok({
     text: "Your query results were generated successfully. They are available as a structured CSV file.",

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -281,7 +281,7 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
         };
       }),
       query,
-      conversationId: agentLoopRunContext.conversation.sId,
+      runContext: agentLoopRunContext,
       fileName,
       connectorProvider,
     });

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -4,7 +4,6 @@ import { GET_DATABASE_SCHEMA_MARKER } from "@app/lib/actions/mcp_internal_action
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   executeQuery,
   verifyDataSourceViewReadAccess,
@@ -239,13 +238,6 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
     { tables, query, fileName },
     { auth, runContext }
   ) => {
-    // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    if (!isAgentLoopRunContext(runContext)) {
-      return new Err(new MCPError("AgentLoopRunContext expected"));
-    }
-
-    const agentLoopRunContext = runContext;
-
     const resolvedRes = await resolveTableConfigurations(auth, tables);
     if (resolvedRes.isErr()) {
       return resolvedRes;
@@ -282,7 +274,7 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
         };
       }),
       query,
-      runContext: agentLoopRunContext,
+      runContext,
       fileName,
       connectorProvider,
     });

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -28,7 +28,6 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import assert from "assert";
 
 function tablesFromUris(tableUris: string[]): TablesConfigurationToolType {
   return tableUris.map((uri) => ({
@@ -241,7 +240,9 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
     { auth, runContext }
   ) => {
     // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    if (!isAgentLoopRunContext(runContext)) {
+      return new Err(new MCPError("AgentLoopRunContext expected"));
+    }
 
     const agentLoopRunContext = runContext;
 

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -49,7 +49,7 @@ async function getDustFileSystemForRunContext(
   }
 }
 
-export function getToolOutputsScopedPath(
+function getToolOutputsScopedPath(
   runContext: ToolRunContext,
   fileName: string
 ): string {

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -49,7 +49,7 @@ async function getDustFileSystemForRunContext(
   }
 }
 
-function getToolOutputsScopedPath(
+export function getToolOutputsScopedPath(
   runContext: ToolRunContext,
   fileName: string
 ): string {


### PR DESCRIPTION
## Description

Better reviewed commit by commit (at least the first 2 separately)

Tables query and data warehouses currently require an agent-loop context because their CSV output is attached to a conversation.

This PR supports using Tables query and data warehouse in sandbox function invocations, in which case they write a CSV file in `.tool_outputs/{function-slug}` (wired in through `DustFileSystem`). The agent-loop path remains strictly the same.

The two paths (agent loop context or sandbox) look very different: for the agent loop one we can't rely on the `DustFileSystem` as it needs to have the csv file uploaded to the conversation data source for it to be tables-queryable in turn. Will be able to cleanup once we switch tables-query usage to fully leveraging the Computer (i.e. do pandas and stuff on the computer instead of the sqlite path).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
