### PR TITLE
[front] fix: propagate user timezone to sandbox function tools

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -281,7 +281,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       functionIdOrSlug: sandboxFunction.sId,
       body: {
         input: { message: "hello" },
-        timezone: "Europe/Paris",
+        context: { timezone: "Europe/Paris" },
       },
     });
 
@@ -302,7 +302,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         sandboxFunction: expect.objectContaining({ sId: sandboxFunction.sId }),
         invocation: expect.objectContaining({
           sId: invocation.sId,
-          timezone: "Europe/Paris",
+          context: { timezone: "Europe/Paris" },
         }),
       }
     );

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -281,6 +281,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       functionIdOrSlug: sandboxFunction.sId,
       body: {
         input: { message: "hello" },
+        timezone: "Europe/Paris",
       },
     });
 
@@ -299,7 +300,10 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       expect.anything(),
       {
         sandboxFunction: expect.objectContaining({ sId: sandboxFunction.sId }),
-        invocation: expect.objectContaining({ sId: invocation.sId }),
+        invocation: expect.objectContaining({
+          sId: invocation.sId,
+          timezone: "Europe/Paris",
+        }),
       }
     );
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -39,6 +39,7 @@ const ResolveAuthenticationBodySchema = z
 const PostSandboxFunctionInvocationBodySchema = z
   .object({
     input: z.unknown().optional(),
+    timezone: z.string().optional(),
   })
   .strict();
 

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -43,7 +43,6 @@ const PostSandboxFunctionInvocationBodySchema = z
       .object({
         timezone: z.string().optional(),
       })
-      .strict()
       .optional(),
   })
   .strict();

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -39,7 +39,12 @@ const ResolveAuthenticationBodySchema = z
 const PostSandboxFunctionInvocationBodySchema = z
   .object({
     input: z.unknown().optional(),
-    timezone: z.string().optional(),
+    context: z
+      .object({
+        timezone: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -656,7 +656,9 @@ export const VisualizationActionIframe = forwardRef<
 
         const body: PostSandboxFunctionInvocationRequestBody = {
           input,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          },
         };
 
         const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -656,6 +656,7 @@ export const VisualizationActionIframe = forwardRef<
 
         const body: PostSandboxFunctionInvocationRequestBody = {
           input,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         };
 
         const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -1,5 +1,6 @@
 import {
   isAgentLoopRunContext,
+  isSandboxFunctionRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -204,7 +205,9 @@ export function getUserTimezone(toolContext?: ToolContext): string | null {
     }
   }
 
-  // TODO(spolu): extract user timezone from sandbox function once available
+  if (isSandboxFunctionRunContext(toolContext?.runContext)) {
+    return normalizeTimezone(toolContext.runContext.invocation.timezone);
+  }
 
   return null;
 }

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -206,7 +206,9 @@ export function getUserTimezone(toolContext?: ToolContext): string | null {
   }
 
   if (isSandboxFunctionRunContext(toolContext?.runContext)) {
-    return normalizeTimezone(toolContext.runContext.invocation.timezone);
+    return normalizeTimezone(
+      toolContext.runContext.invocation.context?.timezone
+    );
   }
 
   return null;

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -8,6 +8,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   isAgentLoopRunContext,
+  isSandboxFunctionRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
 import {
@@ -1159,7 +1160,9 @@ export function createProjectManagerTools(
             origin = userMessage.context.origin ?? origin;
             timezone = userMessage.context.timezone ?? timezone;
           }
-          // TODO(spolu): extract user timezone from sandbox function once available
+        }
+        if (isSandboxFunctionRunContext(toolContext?.runContext)) {
+          timezone = toolContext.runContext.invocation.timezone ?? timezone;
         }
 
         // Get agent configuration name & profile picture URL

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1162,7 +1162,8 @@ export function createProjectManagerTools(
           }
         }
         if (isSandboxFunctionRunContext(toolContext?.runContext)) {
-          timezone = toolContext.runContext.invocation.timezone ?? timezone;
+          timezone =
+            toolContext.runContext.invocation.context?.timezone ?? timezone;
         }
 
         // Get agent configuration name & profile picture URL

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -33,12 +33,12 @@ export async function callHandler(
 
   const timezone = isAgentLoopRunContext(runContext)
     ? runContext.userMessage.context.timezone
-    : runContext.invocation.timezone;
+    : runContext.invocation.context?.timezone;
   const result = await callSandboxFunction(
     auth,
     sandboxFunction,
     input,
-    timezone
+    timezone === undefined ? undefined : { timezone }
   );
   if (result.isErr()) {
     const { code, message } = result.error;

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -3,6 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { getPod } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -30,7 +31,15 @@ export async function callHandler(
     );
   }
 
-  const result = await callSandboxFunction(auth, sandboxFunction, input);
+  const timezone = isAgentLoopRunContext(runContext)
+    ? runContext.userMessage.context.timezone
+    : runContext.invocation.timezone;
+  const result = await callSandboxFunction(
+    auth,
+    sandboxFunction,
+    input,
+    timezone
+  );
   if (result.isErr()) {
     const { code, message } = result.error;
     return new Err(

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -118,14 +118,24 @@ describe("callSandboxFunction", () => {
   it("returns the parsed output on a successful result", async () => {
     const { auth, fn, invocationId } = await setup();
     mockResult({ greeting: "Hi, Soupinou" }, invocationId);
+    const invokeSpy = vi.spyOn(fn, "invoke");
 
-    const result = await callSandboxFunction(auth, fn, { name: "Soupinou" });
+    const result = await callSandboxFunction(
+      auth,
+      fn,
+      { name: "Soupinou" },
+      "Europe/Paris"
+    );
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       return;
     }
     expect(result.value).toEqual({ greeting: "Hi, Soupinou" });
+    expect(invokeSpy).toHaveBeenCalledWith(auth, {
+      input: { name: "Soupinou" },
+      timezone: "Europe/Paris",
+    });
   });
 
   it("returns a typed invocation error", async () => {

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -124,7 +124,7 @@ describe("callSandboxFunction", () => {
       auth,
       fn,
       { name: "Soupinou" },
-      "Europe/Paris"
+      { timezone: "Europe/Paris" }
     );
 
     expect(result.isOk()).toBe(true);
@@ -134,7 +134,7 @@ describe("callSandboxFunction", () => {
     expect(result.value).toEqual({ greeting: "Hi, Soupinou" });
     expect(invokeSpy).toHaveBeenCalledWith(auth, {
       input: { name: "Soupinou" },
-      timezone: "Europe/Paris",
+      context: { timezone: "Europe/Paris" },
     });
   });
 

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -15,9 +15,13 @@ const CALL_RESULT_WAIT_TIMEOUT_MS = 3 * 60 * 1_000;
 export async function callSandboxFunction(
   auth: Authenticator,
   sandboxFunction: SandboxFunctionResource,
-  input: unknown
+  input: unknown,
+  timezone?: string
 ): Promise<Result<unknown, SandboxFunctionCallError>> {
-  const invocationResult = await sandboxFunction.invoke(auth, { input });
+  const invocationResult = await sandboxFunction.invoke(auth, {
+    input,
+    timezone,
+  });
   if (invocationResult.isErr()) {
     return new Err({
       code: "invocation_failed",

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,7 +1,10 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionCallError,
+  SandboxFunctionInvocationContext,
+} from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -16,11 +19,11 @@ export async function callSandboxFunction(
   auth: Authenticator,
   sandboxFunction: SandboxFunctionResource,
   input: unknown,
-  timezone?: string
+  context?: SandboxFunctionInvocationContext
 ): Promise<Result<unknown, SandboxFunctionCallError>> {
   const invocationResult = await sandboxFunction.invoke(auth, {
     input,
-    timezone,
+    context,
   });
   if (invocationResult.isErr()) {
     return new Err({

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -213,27 +213,30 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(refetched?.input).toEqual({ message: "hello" });
   });
 
-  it("stores and reloads its timezone from GCS", async () => {
+  it("stores and reloads its context from GCS", async () => {
     const { authenticator, sandboxFunction } = await setupExecutionTest();
     const invocation = await SandboxFunctionInvocationResource.makeNew(
       authenticator,
       {
         sandboxFunction,
         input: undefined,
-        timezone: "Europe/Paris",
+        context: { timezone: "Europe/Paris" },
       }
     );
 
-    expect(invocation.timezone).toBe("Europe/Paris");
+    expect(invocation.context).toEqual({ timezone: "Europe/Paris" });
     expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
-      JSON.stringify({ version: 1, timezone: "Europe/Paris" })
+      JSON.stringify({
+        version: 1,
+        context: { timezone: "Europe/Paris" },
+      })
     );
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
       authenticator,
       { sandboxFunction, invocationId: invocation.sId }
     );
-    expect(refetched?.timezone).toBe("Europe/Paris");
+    expect(refetched?.context).toEqual({ timezone: "Europe/Paris" });
   });
 
   it("records the initiating user", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -213,6 +213,29 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(refetched?.input).toEqual({ message: "hello" });
   });
 
+  it("stores and reloads its timezone from GCS", async () => {
+    const { authenticator, sandboxFunction } = await setupExecutionTest();
+    const invocation = await SandboxFunctionInvocationResource.makeNew(
+      authenticator,
+      {
+        sandboxFunction,
+        input: undefined,
+        timezone: "Europe/Paris",
+      }
+    );
+
+    expect(invocation.timezone).toBe("Europe/Paris");
+    expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
+      JSON.stringify({ version: 1, timezone: "Europe/Paris" })
+    );
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.timezone).toBe("Europe/Paris");
+  });
+
   it("records the initiating user", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -55,6 +55,7 @@ const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
 const SandboxFunctionInvocationDataSchema = z.object({
   version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
   input: z.unknown().optional(),
+  timezone: z.string().optional(),
   result: z.unknown().optional(),
   error: z.string().optional(),
 });
@@ -146,6 +147,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.input;
   }
 
+  get timezone(): string | undefined {
+    return this.data.timezone;
+  }
+
   get result(): unknown {
     return this.data.result;
   }
@@ -162,6 +167,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
+      timezone: this.timezone,
       error: callError.message,
     };
     await this.writeDataToGcs();
@@ -182,6 +188,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
+      timezone: this.timezone,
       result,
     };
     await this.writeDataToGcs();
@@ -343,9 +350,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     {
       sandboxFunction,
       input,
+      timezone,
     }: {
       sandboxFunction: SandboxFunctionResource;
       input: unknown;
+      timezone?: string;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
@@ -368,6 +377,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const data: SandboxFunctionInvocationData = {
         version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
         input,
+        timezone,
       };
       const resource = new this(this.model, invocation.get(), {
         sandboxFunction,
@@ -396,6 +406,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     const invocation = await this.makeNew(auth, {
       sandboxFunction,
       input: body.input,
+      timezone: body.timezone,
     });
     await publishSandboxFunctionInvocationEvent(
       {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -31,6 +31,7 @@ import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_f
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionCallError,
+  SandboxFunctionInvocationContext,
   SandboxFunctionInvocationStatus,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
@@ -55,7 +56,12 @@ const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 1;
 const SandboxFunctionInvocationDataSchema = z.object({
   version: z.literal(SANDBOX_FUNCTION_INVOCATION_DATA_VERSION),
   input: z.unknown().optional(),
-  timezone: z.string().optional(),
+  context: z
+    .object({
+      timezone: z.string().optional(),
+    })
+    .strict()
+    .optional(),
   result: z.unknown().optional(),
   error: z.string().optional(),
 });
@@ -147,8 +153,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.input;
   }
 
-  get timezone(): string | undefined {
-    return this.data.timezone;
+  get context(): SandboxFunctionInvocationContext | undefined {
+    return this.data.context;
   }
 
   get result(): unknown {
@@ -167,7 +173,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
-      timezone: this.timezone,
+      context: this.context,
       error: callError.message,
     };
     await this.writeDataToGcs();
@@ -188,7 +194,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
-      timezone: this.timezone,
+      context: this.context,
       result,
     };
     await this.writeDataToGcs();
@@ -350,11 +356,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     {
       sandboxFunction,
       input,
-      timezone,
+      context,
     }: {
       sandboxFunction: SandboxFunctionResource;
       input: unknown;
-      timezone?: string;
+      context?: SandboxFunctionInvocationContext;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
@@ -377,7 +383,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const data: SandboxFunctionInvocationData = {
         version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
         input,
-        timezone,
+        context,
       };
       const resource = new this(this.model, invocation.get(), {
         sandboxFunction,
@@ -406,7 +412,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     const invocation = await this.makeNew(auth, {
       sandboxFunction,
       input: body.input,
-      timezone: body.timezone,
+      context: body.context,
     });
     await publishSandboxFunctionInvocationEvent(
       {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -60,7 +60,6 @@ const SandboxFunctionInvocationDataSchema = z.object({
     .object({
       timezone: z.string().optional(),
     })
-    .strict()
     .optional(),
   result: z.unknown().optional(),
   error: z.string().optional(),

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -112,9 +112,13 @@ export function isSandboxFunctionInvocationTerminalEvent(
   );
 }
 
+export type SandboxFunctionInvocationContext = {
+  timezone?: string;
+};
+
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
-  timezone?: string;
+  context?: SandboxFunctionInvocationContext;
 };
 
 export type PostSandboxFunctionInvocationResponseBody = {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -114,6 +114,7 @@ export function isSandboxFunctionInvocationTerminalEvent(
 
 export type PostSandboxFunctionInvocationRequestBody = {
   input?: unknown;
+  timezone?: string;
 };
 
 export type PostSandboxFunctionInvocationResponseBody = {


### PR DESCRIPTION
## Description

Sandbox functions currently lose the originating user timezone when they call tools. Google Calendar cannot format event data in that timezone, and `pod_manager` `create_conversation` falls back to the server timezone.

Especially useful for a use case where you would build a "Book a meeting with me!"

This PR exposes the timezone through sandbox function invocations.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
