### PR TITLE
Skills: fix condition to display editors panel

### DIFF
--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -2,7 +2,11 @@ import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { getSkillAvatarIcon, hasRelations } from "@app/lib/skill";
+import {
+  getSkillAvatarIcon,
+  hasRelations,
+  isDustProvidedSkill,
+} from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import type {
   SkillRelations,
@@ -104,8 +108,9 @@ export function SkillDetailsSheetContent({
 
   // The editors tab is shown to everyone (non-editors get a read-only list,
   // SkillEditorsTab hides the remove column for them), except for global
-  // skills which are not editable.
-  const showEditorsTabs = skill.status !== "suggested" && !skill.isDefault;
+  // skills which have no editor group.
+  const showEditorsTabs =
+    skill.status !== "suggested" && !isDustProvidedSkill(skill);
 
   if (showEditorsTabs) {
     return (


### PR DESCRIPTION
## Description
Fix https://github.com/dust-tt/dust/pull/29378

The condition to be a global skill is not `isDefault` 🤦 
`isDustProvidedSkill` is more relevant because it means exactly that: when provided by dust there is no editor to show
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
