### PR TITLE
[Workspace Deletion] Allow deleting workspaces with data sources

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -40,6 +40,7 @@ describe("deleteWorkspacePlugin.execute", () => {
     const result = await deleteWorkspacePlugin.execute(auth, workspace, {
       confirmation: "DELETE",
       workspaceHasBeenRelocated: false,
+      deleteDataSources: false,
     });
 
     expect(result.isErr()).toBe(true);
@@ -49,7 +50,7 @@ describe("deleteWorkspacePlugin.execute", () => {
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
-  it("proceeds with data sources on a free plan with no Metronome contract", async () => {
+  it("blocks deletion with data sources unless explicitly requested", async () => {
     const workspace = await WorkspaceFactory.byok();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const globalSpace = await SpaceFactory.global(workspace);
@@ -58,6 +59,23 @@ describe("deleteWorkspacePlugin.execute", () => {
     const result = await deleteWorkspacePlugin.execute(auth, workspace, {
       confirmation: "DELETE",
       workspaceHasBeenRelocated: false,
+      deleteDataSources: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with data sources when explicitly requested", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.folder(workspace, globalSpace);
+
+    const result = await deleteWorkspacePlugin.execute(auth, workspace, {
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+      deleteDataSources: true,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -1,5 +1,7 @@
 import { deleteWorkspacePlugin } from "@app/lib/api/poke/plugins/workspaces/delete_workspace";
 import { Authenticator } from "@app/lib/auth";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -47,9 +49,11 @@ describe("deleteWorkspacePlugin.execute", () => {
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
-  it("proceeds when the workspace is on a free plan with no Metronome contract", async () => {
+  it("proceeds with data sources on a free plan with no Metronome contract", async () => {
     const workspace = await WorkspaceFactory.byok();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.folder(workspace, globalSpace);
 
     const result = await deleteWorkspacePlugin.execute(auth, workspace, {
       confirmation: "DELETE",

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -9,7 +9,6 @@ import {
   isWorkspaceRelocationDone,
 } from "@app/lib/api/workspace";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const deleteWorkspacePlugin = createPlugin({
@@ -28,7 +27,7 @@ export const deleteWorkspacePlugin = createPlugin({
         type: "boolean",
         description:
           "Purge workspace data in this region following a relocation. If true, will ignore " +
-          "data sources and subscription checks.",
+          "subscription checks.",
         label: "Workspace has been relocated?",
       },
     },
@@ -60,16 +59,7 @@ export const deleteWorkspacePlugin = createPlugin({
 
       await deleteWorkspace(workspace, { workspaceHasBeenRelocated });
     } else {
-      // If the workspace has not been relocated, we need to check if it has data sources or a
-      // paid plan.
-      const dataSources = await DataSourceResource.listByWorkspace(auth);
-      if (dataSources.length > 0) {
-        return new Err(
-          new Error(
-            "Workspace has data sources, please delete them before deleting the workspace."
-          )
-        );
-      }
+      // If the workspace has not been relocated, we need to check its subscription.
       const subscription = auth.getNonNullableSubscription();
       if (!isFreePlan(subscription.plan.code)) {
         return new Err(

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -9,6 +9,7 @@ import {
   isWorkspaceRelocationDone,
 } from "@app/lib/api/workspace";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const deleteWorkspacePlugin = createPlugin({
@@ -30,13 +31,19 @@ export const deleteWorkspacePlugin = createPlugin({
           "subscription checks.",
         label: "Workspace has been relocated?",
       },
+      deleteDataSources: {
+        type: "boolean",
+        description:
+          "Delete all data sources as part of the workspace deletion.",
+        label: "Delete all data sources",
+      },
     },
     requiredRoles: ["engineering"],
   },
   execute: async (
     auth,
     workspace,
-    { confirmation, workspaceHasBeenRelocated }
+    { confirmation, workspaceHasBeenRelocated, deleteDataSources }
   ) => {
     if (!workspace) {
       return new Err(new Error("Workspace not found"));
@@ -44,6 +51,17 @@ export const deleteWorkspacePlugin = createPlugin({
 
     if (confirmation !== "DELETE") {
       return new Err(new Error("Invalid confirmation, must type 'DELETE'"));
+    }
+
+    if (!deleteDataSources) {
+      const dataSources = await DataSourceResource.listByWorkspace(auth);
+      if (dataSources.length > 0) {
+        return new Err(
+          new Error(
+            'Workspace has data sources. Check "Delete all data sources" to delete them with the workspace.'
+          )
+        );
+      }
     }
 
     // If the workspace has been relocated, we can delete it immediately.

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -1,0 +1,61 @@
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { deleteSpacesActivity } from "@app/poke/temporal/activities";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/data_sources")>();
+  return {
+    ...actual,
+    hardDeleteDataSource: vi.fn(
+      async (auth: Authenticator, dataSource: DataSourceResource) => {
+        const result = await dataSource.delete(auth, { hardDelete: true });
+        if (result.isErr()) {
+          throw result.error;
+        }
+      }
+    ),
+  };
+});
+
+describe("deleteSpacesActivity", () => {
+  it("deletes a data source shared with a later space", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const ownerSpace = await SpaceFactory.regular(workspace);
+    const laterSpace = await SpaceFactory.regular(workspace);
+    const defaultView = await DataSourceViewFactory.folder(
+      workspace,
+      ownerSpace
+    );
+
+    const sharedView =
+      await DataSourceViewResource.createViewInSpaceFromDataSource(
+        auth,
+        laterSpace,
+        defaultView.dataSource,
+        ["node"]
+      );
+    expect(sharedView.isOk()).toBe(true);
+
+    await deleteSpacesActivity({ workspaceId: workspace.sId });
+
+    await expect(
+      DataSourceResource.fetchById(auth, defaultView.dataSource.sId, {
+        includeDeleted: true,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      SpaceResource.fetchById(auth, ownerSpace.sId, { includeDeleted: true })
+    ).resolves.toBeNull();
+    await expect(
+      SpaceResource.fetchById(auth, laterSpace.sId, { includeDeleted: true })
+    ).resolves.toBeNull();
+  });
+});

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -672,20 +672,21 @@ export async function deleteSpacesActivity({
     return a.createdAt.getTime() - b.createdAt.getTime();
   });
 
+  // Data sources can have views in several spaces, so soft-delete every view before deleting any
+  // data source.
+  const dataSourceViews = await DataSourceViewResource.listBySpaces(
+    auth,
+    sortedSpaces,
+    { includeDeleted: true }
+  );
+  for (const dataSourceView of dataSourceViews) {
+    await dataSourceView.delete(auth, { hardDelete: false });
+  }
+
   for (const space of sortedSpaces) {
     const res = await space.delete(auth, { hardDelete: false });
     if (res.isErr()) {
       throw res.error;
-    }
-
-    // Soft delete all the data source views of the space.
-    const dataSourceViews = await DataSourceViewResource.listBySpace(
-      auth,
-      space,
-      { includeDeleted: true }
-    );
-    for (const ds of dataSourceViews) {
-      await ds.delete(auth, { hardDelete: false });
     }
 
     // Soft delete all the data sources of the space.

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,5 +1,5 @@
 import type * as activities from "@app/poke/temporal/activities";
-import { patched, proxyActivities } from "@temporalio/workflow";
+import { proxyActivities } from "@temporalio/workflow";
 
 // Create a single proxy with all normal and long activities
 const normalActivityProxies = proxyActivities<typeof activities>({
@@ -68,26 +68,17 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
-  // Data source deletion may notify workspace admins, so keep memberships until spaces are deleted.
-  // The patch preserves replay compatibility for in-flight workflows using the previous order.
-  const deleteMembersAfterSpaces = patched("delete-members-after-spaces");
-
   await deleteConversationsActivity({ workspaceId });
   await deleteSkillsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteAppsActivity({ workspaceId });
-  if (!deleteMembersAfterSpaces) {
-    await deleteMembersActivity({ workspaceId });
-  }
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });
-  if (deleteMembersAfterSpaces) {
-    await deleteMembersActivity({ workspaceId });
-  }
+  await deleteMembersActivity({ workspaceId });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,5 +1,5 @@
 import type * as activities from "@app/poke/temporal/activities";
-import { proxyActivities } from "@temporalio/workflow";
+import { patched, proxyActivities } from "@temporalio/workflow";
 
 // Create a single proxy with all normal and long activities
 const normalActivityProxies = proxyActivities<typeof activities>({
@@ -68,17 +68,26 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
+  // Data source deletion may notify workspace admins, so keep memberships until spaces are deleted.
+  // The patch preserves replay compatibility for in-flight workflows using the previous order.
+  const deleteMembersAfterSpaces = patched("delete-members-after-spaces");
+
   await deleteConversationsActivity({ workspaceId });
   await deleteSkillsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteAppsActivity({ workspaceId });
-  await deleteMembersActivity({ workspaceId });
+  if (!deleteMembersAfterSpaces) {
+    await deleteMembersActivity({ workspaceId });
+  }
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });
+  if (deleteMembersAfterSpaces) {
+    await deleteMembersActivity({ workspaceId });
+  }
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });


### PR DESCRIPTION
## Description

The Poke workspace deletion action rejects workspaces that still have data sources, forcing operators to delete them one by one.

The guard was introduced in https://github.com/dust-tt/dust/pull/11406. The deletion workflow was then updated in https://github.com/dust-tt/dust/pull/11442 to soft-delete and scrub data sources while deleting spaces.

This PR adds a "Delete all data sources" checkbox to the Poke action. The checkbox defaults off and preserves the existing guard; when explicitly checked, the action lets the workspace deletion workflow clean up its data sources.

It also fixes the workflow ordering for data sources shared across spaces: all data source views are now soft-deleted workspace-wide before any data source or space is scrubbed. This prevents a later live view from blocking its data source deletion after the workflow has already removed other workspace data.

Membership deletion now runs after space deletion so GitHub data-source cleanup can still notify workspace admins.

The free-plan and Metronome-contract safeguards remain unchanged.

## Risks

Blast radius: Poke workspace deletion and workspace deletion workflow ordering.
Risk: standard

The workflow order change is intentionally unpatched. Deploy only when no workspace deletion workflows are running across the deployment.

## Deploy Plan

- Confirm no workspace deletion workflows are running
- Deploy front

## Tests

- [x] Poke workspace deletion blocks data sources by default
- [x] Poke workspace deletion accepts explicit data-source deletion
- [x] Multi-space data source deletion activity test
