### PR TITLE
[front] enh: expose image generation outputs to pod functions

### DIFF
--- a/front/lib/api/actions/servers/image_generation/helpers.test.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.test.ts
@@ -1,0 +1,86 @@
+import { isToolGeneratedFilePath } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolContext } from "@app/lib/actions/types";
+import { uploadAndFormatImageResponse } from "@app/lib/api/actions/servers/image_generation/helpers";
+import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+describe("uploadAndFormatImageResponse", () => {
+  it("writes generated images to the pod function tool outputs folder", async () => {
+    const {
+      auth,
+      workspace,
+      invocation,
+      globalSpace,
+      podSpace,
+      sandboxFunction,
+    } = await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "common_utilities",
+      useCase: null,
+    });
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.id,
+      globalSpace
+    );
+    const action = await SandboxFunctionMCPActionFactory.create(auth, {
+      invocation,
+      mcpServerView: view,
+    });
+    const toolContext: ToolContext = {
+      runContext: {
+        contextType: "sandbox_function",
+        action,
+        invocation,
+        toolConfiguration: action.toolConfiguration,
+      },
+    };
+
+    fileStorageMock.reset();
+    const imageContent = Buffer.from("generated image bytes");
+    const result = await uploadAndFormatImageResponse(
+      auth,
+      toolContext,
+      [
+        {
+          base64: `data:image/png;base64,${imageContent.toString("base64")}`,
+          mimeType: "image/png",
+        },
+      ],
+      "generated-image.png"
+    );
+
+    assert(result.isOk());
+    expect(result.value).toHaveLength(1);
+    const fileOutput = result.value.find(isToolGeneratedFilePath);
+    assert(fileOutput);
+
+    const scopedPathPrefix = `pod-${podSpace.sId}/.tool_outputs/${sandboxFunction.slug}/`;
+    expect(fileOutput.resource.path).toBe(fileOutput.resource.uri);
+    expect(fileOutput.resource.path).toBe(
+      `${scopedPathPrefix}${fileOutput.resource.title}`
+    );
+    expect(fileOutput.resource.title).toMatch(/^\d+_generated_image\.png$/);
+    expect(fileOutput.resource.contentType).toBe("image/png");
+
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    const fileWrite = fileStorageMock.saveFileCalls[0];
+    const relativePath = fileOutput.resource.path.slice(
+      `pod-${podSpace.sId}/`.length
+    );
+    expect(fileWrite.filePath).toBe(
+      `${getPodFilesBasePath({
+        workspaceId: workspace.sId,
+        podId: podSpace.sId,
+      })}${relativePath}`
+    );
+    expect(fileWrite.content).toEqual(imageContent);
+    expect(fileWrite.contentType).toBe("image/png");
+  });
+});

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -30,7 +30,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import assert from "assert";
 
 export type ImageGenerationErrorCode =
   | "api_error"
@@ -281,11 +280,7 @@ export async function uploadAndFormatImageResponse(
 ): Promise<
   Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
 > {
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-  if (!toolContext?.runContext) {
+  if (!isAgentLoopRunContext(toolContext?.runContext)) {
     return new Err(
       new MCPError("No conversation context available for file upload", {
         tracked: false,

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -1,15 +1,19 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   MCPProgressNotificationType,
+  ToolGeneratedFilePathType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import {
-  type AgentLoopRunContext,
-  isAgentLoopRunContext,
-  type ToolContext,
+import type {
+  AgentLoopRunContext,
+  SandboxFunctionRunContext,
+  ToolContext,
 } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { getToolOutputsScopedPath } from "@app/lib/api/files/action_output_fs";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,6 +32,7 @@ import {
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -272,15 +277,101 @@ async function uploadAndFormatAgentLoopImageResponse(
   return new Ok(resources);
 }
 
+async function writeSandboxFunctionImageResponse(
+  auth: Authenticator,
+  runContext: SandboxFunctionRunContext,
+  images: Base64ImageData[],
+  fileName: string
+): Promise<
+  Result<
+    Array<{ type: "resource"; resource: ToolGeneratedFilePathType }>,
+    MCPError
+  >
+> {
+  const fileSystemResult = await DustFileSystem.forPod(
+    auth,
+    runContext.invocation.sandboxFunction.space
+  );
+  if (fileSystemResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Error accessing generated image files: ${fileSystemResult.error.message}`,
+        { cause: fileSystemResult.error }
+      )
+    );
+  }
+
+  const baseFileName = stripFileExtension(fileName);
+  const resources: Array<{
+    type: "resource";
+    resource: ToolGeneratedFilePathType;
+  }> = [];
+
+  for (const [index, image] of images.entries()) {
+    const mimeType = image.mimeType ?? DEFAULT_IMAGE_MIME_TYPE;
+    if (!isSupportedImageContentType(mimeType)) {
+      return new Err(
+        new MCPError(`Unsupported image type: ${mimeType}`, {
+          tracked: false,
+        })
+      );
+    }
+
+    const extension = extensionsForContentType(mimeType)[0] ?? ".png";
+    const outputBaseName =
+      images.length > 1 ? `${baseFileName}-${index + 1}` : baseFileName;
+    const outputFileName = makeFileName({
+      name: outputBaseName,
+      ext: extension,
+    });
+    const scopedPath = getToolOutputsScopedPath(runContext, outputFileName);
+    const base64Data = image.base64.replace(/^data:image\/[^;]+;base64,/, "");
+    const content = Buffer.from(base64Data, "base64");
+    const writeResult = await fileSystemResult.value.write(
+      scopedPath,
+      content,
+      mimeType
+    );
+    if (writeResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Error saving generated image: ${writeResult.error.message}`,
+          { cause: writeResult.error }
+        )
+      );
+    }
+
+    resources.push({
+      type: "resource",
+      resource: {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+        uri: scopedPath,
+        path: scopedPath,
+        title: outputFileName,
+        contentType: mimeType,
+        text: `Generated image: ${outputFileName}`,
+      },
+    });
+  }
+
+  return new Ok(resources);
+}
+
 export async function uploadAndFormatImageResponse(
   auth: Authenticator,
   toolContext: ToolContext | undefined,
   images: Base64ImageData[],
   fileName: string
 ): Promise<
-  Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
+  Result<
+    Array<{
+      type: "resource";
+      resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
+    }>,
+    MCPError
+  >
 > {
-  if (!isAgentLoopRunContext(toolContext?.runContext)) {
+  if (!toolContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file upload", {
         tracked: false,
@@ -288,12 +379,25 @@ export async function uploadAndFormatImageResponse(
     );
   }
 
-  return uploadAndFormatAgentLoopImageResponse(
-    auth,
-    toolContext.runContext,
-    images,
-    fileName
-  );
+  const { runContext } = toolContext;
+  switch (runContext.contextType) {
+    case "agent_loop":
+      return uploadAndFormatAgentLoopImageResponse(
+        auth,
+        runContext,
+        images,
+        fileName
+      );
+    case "sandbox_function":
+      return writeSandboxFunctionImageResponse(
+        auth,
+        runContext,
+        images,
+        fileName
+      );
+    default:
+      return assertNever(runContext);
+  }
 }
 
 async function processSingleImageFile(

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -11,8 +11,7 @@ import type {
   ToolContext,
 } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
-import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { getToolOutputsScopedPath } from "@app/lib/api/files/action_output_fs";
+import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
@@ -288,19 +287,6 @@ async function writeSandboxFunctionImageResponse(
     MCPError
   >
 > {
-  const fileSystemResult = await DustFileSystem.forPod(
-    auth,
-    runContext.invocation.sandboxFunction.space
-  );
-  if (fileSystemResult.isErr()) {
-    return new Err(
-      new MCPError(
-        `Error accessing generated image files: ${fileSystemResult.error.message}`,
-        { cause: fileSystemResult.error }
-      )
-    );
-  }
-
   const baseFileName = stripFileExtension(fileName);
   const resources: Array<{
     type: "resource";
@@ -324,14 +310,13 @@ async function writeSandboxFunctionImageResponse(
       name: outputBaseName,
       ext: extension,
     });
-    const scopedPath = getToolOutputsScopedPath(runContext, outputFileName);
     const base64Data = image.base64.replace(/^data:image\/[^;]+;base64,/, "");
     const content = Buffer.from(base64Data, "base64");
-    const writeResult = await fileSystemResult.value.write(
-      scopedPath,
+    const writeResult = await writeToToolOutputsFolder(auth, runContext, {
+      fileName: outputFileName,
       content,
-      mimeType
-    );
+      contentType: mimeType,
+    });
     if (writeResult.isErr()) {
       return new Err(
         new MCPError(
@@ -340,6 +325,7 @@ async function writeSandboxFunctionImageResponse(
         )
       );
     }
+    const scopedPath = writeResult.value;
 
     resources.push({
       type: "resource",
@@ -373,7 +359,7 @@ export async function uploadAndFormatImageResponse(
 > {
   if (!toolContext?.runContext) {
     return new Err(
-      new MCPError("No conversation context available for file upload", {
+      new MCPError("No tool run context available for file upload", {
         tracked: false,
       })
     );

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
+  type AgentLoopRunContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -207,27 +208,15 @@ export function trackTokenUsage({
   );
 }
 
-export async function uploadAndFormatImageResponse(
+async function uploadAndFormatAgentLoopImageResponse(
   auth: Authenticator,
-  toolContext: ToolContext | undefined,
+  runContext: AgentLoopRunContext,
   images: Base64ImageData[],
   fileName: string
 ): Promise<
   Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
 > {
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-  if (!toolContext?.runContext) {
-    return new Err(
-      new MCPError("No conversation context available for file upload", {
-        tracked: false,
-      })
-    );
-  }
-
-  const conversationId = toolContext.runContext.conversation.sId;
+  const conversationId = runContext.conversation.sId;
   const baseFileName = stripFileExtension(fileName);
 
   const resources: Array<{
@@ -282,6 +271,34 @@ export async function uploadAndFormatImageResponse(
   }
 
   return new Ok(resources);
+}
+
+export async function uploadAndFormatImageResponse(
+  auth: Authenticator,
+  toolContext: ToolContext | undefined,
+  images: Base64ImageData[],
+  fileName: string
+): Promise<
+  Result<Array<{ type: "resource"; resource: ToolGeneratedFileType }>, MCPError>
+> {
+  assert(
+    isAgentLoopRunContext(toolContext?.runContext),
+    "AgentLoopRunContext expected"
+  );
+  if (!toolContext?.runContext) {
+    return new Err(
+      new MCPError("No conversation context available for file upload", {
+        tracked: false,
+      })
+    );
+  }
+
+  return uploadAndFormatAgentLoopImageResponse(
+    auth,
+    toolContext.runContext,
+    images,
+    fileName
+  );
 }
 
 async function processSingleImageFile(

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -49,7 +49,7 @@ async function getDustFileSystemForRunContext(
   }
 }
 
-export function getToolOutputsScopedPath(
+function getToolOutputsScopedPath(
   runContext: ToolRunContext,
   fileName: string
 ): string {

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -49,7 +49,7 @@ async function getDustFileSystemForRunContext(
   }
 }
 
-function getToolOutputsScopedPath(
+export function getToolOutputsScopedPath(
   runContext: ToolRunContext,
   fileName: string
 ): string {


### PR DESCRIPTION
## Description

`generate_image` currently asserts an agent-loop context when saving its output, so it cannot return generated files from a pod function invocation.

This PR writes pod-function outputs to `.tool_outputs/{function-slug}` through `DustFileSystem` and returns `FILE_PATH` resources. The agent-loop path remains unchanged and continues using conversation `FileResource`s so generated images go through the existing resize and rendering pipeline.

This follows the same output split as [#29390](https://github.com/dust-tt/dust/pull/29390) for tables query and data warehouse.

## Tests

- Added a focused test for pod-function image output.

## Risk

- Low.

## Deploy Plan

- Deploy front.
