### PR TITLE
[front] fix: remove nested `<p>` in `ErrorDisplay`

### DIFF
--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -78,13 +78,13 @@ export function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
     <div className="flex h-dvh flex-col items-center justify-center gap-3">
       {icon && <Icon visual={icon} className="text-info-400" size="lg" />}
       <p className="heading-xl text-center text-foreground">{title}</p>
-      <p className="copy-sm text-center text-muted-foreground">
+      <div className="copy-sm text-center text-muted-foreground">
         {Array.isArray(message) ? (
           message.map((line, index) => <p key={index}>{line}</p>)
         ) : (
           <p>{message}</p>
         )}
-      </p>
+      </div>
       <LinkWrapper href="/">
         <Button variant="outline" label="Back to homepage" icon={LogIn01} />
       </LinkWrapper>


### PR DESCRIPTION
## Description

`ErrorDisplay` renders each message line as a paragraph inside another paragraph, producing invalid HTML.

Use a `div` for the message wrapper while keeping each message line as a paragraph. This preserves the existing layout and typography.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
