### PR TITLE
[front] enh: allow publish-permission users to view manage agents page

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -497,6 +497,10 @@ export function AgentSidebarMenu({
     useStarredPodsSectionCollapsed();
 
   const canCreateAgent = hasPermission("create", "agent");
+  const canPublishAgent = hasPermission("publish", "agent");
+  // Users who can publish agents can reach the manage agents page to discover
+  // existing agents and edit the ones they can, even without create permission.
+  const canManageAgents = canCreateAgent || canPublishAgent;
   const canCreateSkill = hasPermission("create", "skill");
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
@@ -990,66 +994,68 @@ export function AgentSidebarMenu({
                         />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {canCreateAgent && (
+                        {canManageAgents && (
                           <>
                             <DropdownMenuLabel>Agents</DropdownMenuLabel>
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger
-                                icon={Plus}
-                                label="New agent"
-                                disabled={noHealthyProviders}
-                              />
-                              <DropdownMenuPortal>
-                                <DropdownMenuSubContent className="pointer-events-auto">
-                                  <DropdownMenuItem
-                                    href={getAgentBuilderRoute(
-                                      owner.sId,
-                                      "new"
-                                    )}
-                                    icon={File02}
-                                    label="From scratch"
-                                    data-gtm-label="assistantCreationButton"
-                                    data-gtm-location="sidebarMenu"
-                                    onClick={withTracking(
-                                      TRACKING_AREAS.BUILDER,
-                                      "create_from_scratch"
-                                    )}
-                                  />
-                                  <DropdownMenuItem
-                                    href={getAgentBuilderRoute(
-                                      owner.sId,
-                                      "create"
-                                    )}
-                                    icon={MagicWand02}
-                                    label="From template"
-                                    data-gtm-label="assistantCreationButton"
-                                    data-gtm-location="sidebarMenu"
-                                    onClick={withTracking(
-                                      TRACKING_AREAS.BUILDER,
-                                      "create_from_template"
-                                    )}
-                                  />
-                                  <DropdownMenuItem
-                                    icon={
-                                      isUploadingYAML ? (
-                                        <Spinner size="xs" />
-                                      ) : (
-                                        Brackets
-                                      )
-                                    }
-                                    label={
-                                      isUploadingYAML
-                                        ? "Uploading..."
-                                        : "From YAML"
-                                    }
-                                    disabled={isUploadingYAML}
-                                    onClick={triggerYAMLUpload}
-                                    data-gtm-label="yamlUploadButton"
-                                    data-gtm-location="sidebarMenu"
-                                  />
-                                </DropdownMenuSubContent>
-                              </DropdownMenuPortal>
-                            </DropdownMenuSub>
+                            {canCreateAgent && (
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger
+                                  icon={Plus}
+                                  label="New agent"
+                                  disabled={noHealthyProviders}
+                                />
+                                <DropdownMenuPortal>
+                                  <DropdownMenuSubContent className="pointer-events-auto">
+                                    <DropdownMenuItem
+                                      href={getAgentBuilderRoute(
+                                        owner.sId,
+                                        "new"
+                                      )}
+                                      icon={File02}
+                                      label="From scratch"
+                                      data-gtm-label="assistantCreationButton"
+                                      data-gtm-location="sidebarMenu"
+                                      onClick={withTracking(
+                                        TRACKING_AREAS.BUILDER,
+                                        "create_from_scratch"
+                                      )}
+                                    />
+                                    <DropdownMenuItem
+                                      href={getAgentBuilderRoute(
+                                        owner.sId,
+                                        "create"
+                                      )}
+                                      icon={MagicWand02}
+                                      label="From template"
+                                      data-gtm-label="assistantCreationButton"
+                                      data-gtm-location="sidebarMenu"
+                                      onClick={withTracking(
+                                        TRACKING_AREAS.BUILDER,
+                                        "create_from_template"
+                                      )}
+                                    />
+                                    <DropdownMenuItem
+                                      icon={
+                                        isUploadingYAML ? (
+                                          <Spinner size="xs" />
+                                        ) : (
+                                          Brackets
+                                        )
+                                      }
+                                      label={
+                                        isUploadingYAML
+                                          ? "Uploading..."
+                                          : "From YAML"
+                                      }
+                                      disabled={isUploadingYAML}
+                                      onClick={triggerYAMLUpload}
+                                      data-gtm-label="yamlUploadButton"
+                                      data-gtm-location="sidebarMenu"
+                                    />
+                                  </DropdownMenuSubContent>
+                                </DropdownMenuPortal>
+                              </DropdownMenuSub>
+                            )}
                             {editableAgents.length > 0 && (
                               <DropdownMenuSub>
                                 <DropdownMenuSubTrigger

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -58,6 +58,10 @@ export function WebAgentBrowser({
   const { hasPermission } = useWorkspacePermissions(owner);
 
   const canCreateAgent = hasPermission("create", "agent");
+  const canPublishAgent = hasPermission("publish", "agent");
+  // Users who can publish agents can reach the manage agents page to discover
+  // existing agents and edit the ones they can, even without create permission.
+  const canManageAgents = canCreateAgent || canPublishAgent;
   const canCreateSkill = hasPermission("create", "skill");
 
   const sortTypeLabel = useMemo(() => {
@@ -108,9 +112,9 @@ export function WebAgentBrowser({
                 <CreateDropdown owner={owner} dataGtmLocation="homepage" />
               </div>
             )}
-            {canCreateAgent && canCreateSkill ? (
+            {canManageAgents && canCreateSkill ? (
               <ManageDropdownMenu owner={owner} />
-            ) : canCreateAgent ? (
+            ) : canManageAgents ? (
               <Button
                 href={getAgentBuilderRoute(owner.sId, "manage")}
                 variant="primary"

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -83,7 +83,11 @@ export function ManageAgentsPage() {
   const { hasPermission } = useWorkspacePermissions(owner);
 
   const canCreateAgent = hasPermission("create", "agent");
-  const shouldDisableAgentFetching = !canCreateAgent;
+  const canPublishAgent = hasPermission("publish", "agent");
+  // Users who can publish agents can view the page to discover existing agents
+  // and identify the ones they can edit, even without create permission.
+  const canManageAgents = canCreateAgent || canPublishAgent;
+  const shouldDisableAgentFetching = !canManageAgents;
   const isSearchActive = assistantSearch.trim() !== "";
 
   const activeTab = useMemo(() => {
@@ -215,7 +219,7 @@ export function ManageAgentsPage() {
   }, []);
 
   useEffect(() => {
-    if (!canCreateAgent) {
+    if (!canManageAgents) {
       return;
     }
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -229,7 +233,7 @@ export function ManageAgentsPage() {
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [canCreateAgent]);
+  }, [canManageAgents]);
 
   const navChildren = useMemo(
     () => <AgentSidebarMenu owner={owner} />,
@@ -241,7 +245,7 @@ export function ManageAgentsPage() {
 
   return (
     <>
-      {!canCreateAgent ? (
+      {!canManageAgents ? (
         <Custom404 />
       ) : (
         <>


### PR DESCRIPTION
## Description

Resolves dust-tt/tasks#9742.

Currently the manage agents page is only visible to users with the **create agent** permission. Users who can only **publish** agents cannot see it, even though browsing the page is useful to discover existing agents and identify the ones they can edit.

This relaxes the frontend gate from `create` to `create OR publish`:

- **`ManageAgentsPage.tsx`** — the page now renders (instead of `Custom404`), fetches agents, and enables the `/` search shortcut when the user can create **or** publish. The "Create" dropdown and the "Create an agent" empty-state CTA remain gated on `create`.
- **`SidebarMenu.tsx`** — the "Agents" section and its "Manage agents" link now show for publish-capable users. The "New agent" (scratch / template / YAML) submenu stays gated on `create`. "Edit agent" was already gated on having editable agents, which works for publish-only users.

No backend change is needed: the `"manage"` agents view already returns workspace/published/visible agents plus the user's own private and editable agents for any user.

## Test plan

- [ ] As a user with only `publish:agent` (no `create:agent`): the "Manage agents" sidebar entry appears, the page loads, agents are listed, and the "Editable by me" tab shows editable agents. No "New agent" / "Create" actions are shown.
- [ ] As a user with `create:agent`: behavior unchanged (create actions present).
- [ ] As a user with neither permission: page still 404s and no sidebar entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)