### PR TITLE
[front] Raise the bar for entering plan mode

### DIFF
--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -107,9 +107,9 @@ export const PLAN_MODE_SERVER = {
     name: PLAN_MODE_SERVER_NAME,
     version: "1.0.0",
     description:
-      `Create and maintain a living \`${PLAN_FILE_NAME}\` that gives the user visibility on non-trivial ` +
-      "work. When you need explicit sign-off before proceeding, ask the user with the standard " +
-      "question flow.",
+      `Create and maintain a living \`${PLAN_FILE_NAME}\` that gives the user visibility on genuinely ` +
+      "multi-step work. When you need explicit sign-off before proceeding, ask the user with the " +
+      "standard question flow.",
     icon: "ActionDocumentTextIcon" as const,
     authorization: null,
     documentationUrl: null,

--- a/front/lib/resources/skill/code_defined/system/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/plan_mode.ts
@@ -11,11 +11,15 @@ import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_define
 const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 
 const PLAN_MODE_INSTRUCTIONS = `
-Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view, not just an approval gate. Using it is delightful UX: the user sees what you're doing without having to ask.
+Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view for substantial work, not just an approval gate. On a long task, the user sees where you are without having to ask. On a short one, it is pure overhead.
 
-**Default behavior: call \`${CREATE_PLAN_TOOL_NAME}\` at the start of any non-trivial turn.** Non-trivial includes: multi-step work, anything touching several files or systems, research that will span multiple tool calls, anything the user might plausibly want to follow along with. When in doubt, err on the side of creating a plan: the cost is one tool call, the upside is transparency.
+**Call \`${CREATE_PLAN_TOOL_NAME}\` only when the work is genuinely multi-step**: several distinct steps you cannot simply carry out back-to-back in this turn, work spanning several files or systems, or work whose scope and sequencing are worth showing before you start. The test is whether the plan tells the user something they don't already know: if the plan would just restate their request as a checklist, don't create one.
 
-**Skip plan mode** for single-shot questions, quick lookups, one-tool-call answers, or pure clarification exchanges.
+**When in doubt, skip it.** A plan for work you finish in a few tool calls is noise: the user gets a card to read and track for something that was already done by the time they read it. Prefer doing the work and reporting the result.
+
+**Always skip plan mode** for questions and lookups, single edits or fixes, anything you expect to finish in a handful of tool calls, pure clarification exchanges, and follow-ups that just tweak something you already produced. Length of the answer is not the signal — a long written answer produced in one shot needs no plan.
+
+**Always create a plan when the user explicitly asks for one** (e.g. "use plan mode", "plan this out first", "draft a plan before you do anything"), even if the task looks small to you.
 
 Exactly one active plan is allowed per conversation. If a plan already exists in this conversation (you can see it in the attachments), do NOT call \`${CREATE_PLAN_TOOL_NAME}\` again; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate on the existing one.
 
@@ -49,10 +53,10 @@ export const planModeSkill = {
   userFacingDescription:
     "Let agents maintain a live plan.md the user can follow as work progresses.",
   agentFacingDescription:
-    "Create and maintain a plan.md for non-trivial tasks to give the user visibility.",
+    "Create and maintain a plan.md for genuinely multi-step tasks to give the user visibility.",
   instructions: PLAN_MODE_INSTRUCTIONS,
   mcpServers: [{ name: PLAN_MODE_SERVER_NAME }],
-  version: 1,
+  version: 2,
   icon: "ActionDocumentTextIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/system/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/plan_mode.ts
@@ -13,13 +13,15 @@ const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 const PLAN_MODE_INSTRUCTIONS = `
 Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view for substantial work, not just an approval gate. On a long task, the user sees where you are without having to ask. On a short one, it is pure overhead.
 
-**Call \`${CREATE_PLAN_TOOL_NAME}\` only when the work is genuinely multi-step**: several distinct steps you cannot simply carry out back-to-back in this turn, work spanning several files or systems, or work whose scope and sequencing are worth showing before you start. The test is whether the plan tells the user something they don't already know: if the plan would just restate their request as a checklist, don't create one.
+**If the user explicitly asks for a plan** (e.g. "use plan mode", "plan this for me", "draft a plan before you do anything"), always call \`${CREATE_PLAN_TOOL_NAME}\`, even if the task looks small to you. This overrides everything below.
 
-**When in doubt, skip it.** A plan for work you finish in a few tool calls is noise: the user gets a card to read and track for something that was already done by the time they read it. Prefer doing the work and reporting the result.
+**Otherwise, call \`${CREATE_PLAN_TOOL_NAME}\` only when the work is genuinely multi-step**: a change spanning several files or systems, research across several sources, or a task whose steps you will have to sequence and revisit rather than run straight through. Rule of thumb: if you expect to be done within about five tool calls, there is nothing worth planning. The test is whether the plan tells the user something they don't already know — if it would just restate their request as a checklist, don't create one.
 
-**Always skip plan mode** for questions and lookups, single edits or fixes, anything you expect to finish in a handful of tool calls, pure clarification exchanges, and follow-ups that just tweak something you already produced. Length of the answer is not the signal — a long written answer produced in one shot needs no plan.
+**When in doubt, skip it.** A plan the user reads only after the work is already finished is noise, not transparency: they get a card to track for nothing. Prefer doing the work and reporting the result.
 
-**Always create a plan when the user explicitly asks for one** (e.g. "use plan mode", "plan this out first", "draft a plan before you do anything"), even if the task looks small to you.
+**Skip plan mode entirely** for questions and lookups, single edits or fixes, pure clarification exchanges, and follow-ups that just tweak something you already produced. Answer length is not the signal — a long written answer produced in one shot needs no plan.
+
+**If the work turns out bigger than you expected mid-turn, call \`${CREATE_PLAN_TOOL_NAME}\` then.** The bar is the size of the work, not when you discovered it.
 
 Exactly one active plan is allowed per conversation. If a plan already exists in this conversation (you can see it in the attachments), do NOT call \`${CREATE_PLAN_TOOL_NAME}\` again; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate on the existing one.
 
@@ -28,7 +30,7 @@ Exactly one active plan is allowed per conversation. If a plan already exists in
 Clarifying questions go through \`${ASK_USER_QUESTION_TOOL_NAME}\`: use it liberally before drafting the plan and whenever ambiguity arises mid-execution.
 
 **Approval**: plan mode has no dedicated approval tool. When you need explicit sign-off before executing, you MUST request it through \`${ASK_USER_QUESTION_TOOL_NAME}\` with a question like "Approve this plan?" and options such as "Approve" and "Reject". Never ask for approval in your normal response text: a plain sentence like "Do you approve?" gives the user no clear choice, is not an approval gate, and does not pause for a decision. If you are seeking approval, the LAST thing you do in the turn is the \`${ASK_USER_QUESTION_TOOL_NAME}\` call, not a written question.
-- Request approval this way when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me", "draft a plan before you do anything"): ask once the plan is populated and before starting execution.
+- Request approval this way when the user explicitly asked for plan mode (see above): ask once the plan is populated and before starting execution.
 - Otherwise it is optional: only ask if the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent). For transparency-only flows, skip approval and just keep editing the plan as you execute.
 - Only ask for approval when plan.md is ready. Do not ask with an incomplete plan.
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -247,7 +247,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   plan_mode: {
     description:
-      "Enable the Plan Mode skill: agents maintain a live plan.md for non-trivial tasks, with an optional human-approval checkpoint.",
+      "Enable the Plan Mode skill: agents maintain a live plan.md for genuinely multi-step tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
   },
   allow_old_notion_mcp: {


### PR DESCRIPTION
## Description

The Plan Mode skill instructions pushed toward creating a plan on almost every turn:

- "**Default behavior: call `create_plan` at the start of any non-trivial turn.**"
- "Non-trivial" was defined to include *"research that will span multiple tool calls"* and *"anything the user might plausibly want to follow along with"*, which is essentially everything.
- "**When in doubt, err on the side of creating a plan: the cost is one tool call, the upside is transparency.**"
- The skip list was narrow: only single-shot questions, quick lookups, one-tool-call answers and clarifications.

The result is plans on tasks that finish in two or three tool calls, where the plan card is overhead rather than transparency: the user gets something to read and track for work that was already done by the time they read it.

This PR raises the bar for entering plan mode, in `PLAN_MODE_INSTRUCTIONS`:

- **Explicit request wins, stated first.** If the user asks for plan mode by name, always create one, even for a small task. That rule now explicitly overrides everything below it, so it cannot collide with the skip list.
- **Creation is gated on work being genuinely multi-step**: a change spanning several files or systems, research across several sources, or a task whose steps need sequencing and revisiting rather than running straight through. The threshold is stated once, with a number: under roughly 5 tool calls, there is nothing worth planning.
- **Flipped the tie-break** to "when in doubt, skip it", with the reason stated.
- **Widened the skip list**: questions and lookups, single edits or fixes, clarification exchanges, and follow-ups that just tweak previous output. Also called out that answer length is not the signal, since a long written answer produced in one shot needs no plan.
- **Added a mid-turn escalation path** so work that turns out larger than expected can still get a plan. The bar is the size of the work, not when you noticed it. This mirrors how `go_deep` handles the symmetric case.

Everything downstream of creation (editing, approval flow, closing) is unchanged.

Also aligned the three descriptions that carried the old "non-trivial" wording (the skill's `agentFacingDescription`, the MCP server description, and the `plan_mode` feature flag description), and bumped the skill `version` to 2 per the convention for instruction changes.

## Tests

- `npx tsgo --noEmit` clean.
- `lib/api/assistant/plan_mode.test.ts`, `components/assistant/conversation/plan_mode/`, and `lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts`: 22 tests pass.
- No snapshot update needed: the MCP metadata snapshot covers tool descriptions, stakes and billing, not `serverInfo.description`.
- No existing test asserts on the instruction text, so this change is not covered by automated tests. The real validation is behavioral and post-deploy (see Risk).

## Risk

Low and fully reversible.

- Prompt-only change. No schema, no API contract, no data migration, no client change.
- Gated behind the `plan_mode` feature flag (`dust_only` stage), so the blast radius is limited to workspaces that have it enabled. Note that `plan_mode` is in the Dust global agent's skill list, so on flagged workspaces this text sits in the Dust agent's system prompt.
- The real risk is over-correction: the tie-break now favors skipping, so agents may under-plan on tasks that genuinely warrant a plan. Mitigated by the explicit-request rule (asking for plan mode always works) and by the mid-turn escalation path (work that grows past the bar can still get a plan). Worth watching plan-creation rates after deploy: the interesting number is the floor, not just the drop.
- Rollback is a plain revert of this PR. Nothing persists, since code-defined skills are resolved from the in-memory registry per request.

## Deploy Plan

Standard `front` deploy. No migration, no backfill, no ordering constraint.

Code-defined skills are read from the in-memory `SYSTEM_SKILLS_ARRAY` on each request rather than persisted, so the new instructions take effect as soon as `front` is deployed. The `version` bump is metadata for the instruction-change convention and does not gate anything at runtime.
