### PR TITLE
admin governance: only list unpublished skills to their editors

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -15,9 +15,11 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
   SkillWithoutInstructionsAndToolsType,
   SkillWithoutInstructionsAndToolsWithRelationsType,
@@ -100,6 +102,50 @@ describe("GET /api/w/:wId/skills", () => {
     );
     expect(skillNames).toContain("Test Skill 1");
     expect(skillNames).toContain("Test Skill 2");
+  });
+
+  it("only lists editors-only skills to members of their editor group", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // Skill whose editor group the requester belongs to (creator is an editor).
+    await SkillFactory.create(auth, {
+      name: "My Unpublished Skill",
+      availability: "editors",
+    });
+
+    // Skills created by another user: the requester is not in their editor groups.
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, {
+      role: "builder",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    await SkillFactory.create(otherAuth, {
+      name: "Someone Else's Unpublished Skill",
+      availability: "editors",
+    });
+    await SkillFactory.create(otherAuth, {
+      name: "Someone Else's Published Skill",
+      availability: "workspace_users",
+    });
+
+    const response = await getSkills(workspace);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("My Unpublished Skill");
+    expect(skillNames).toContain("Someone Else's Published Skill");
+    expect(skillNames).not.toContain("Someone Else's Unpublished Skill");
   });
 
   it("should only return active skills", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -139,7 +139,7 @@ app.get(
     }
     const skillStatus = statusValidation.data;
 
-    const skills = await SkillResource.listByWorkspace(auth, {
+    const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
       onlyCustom: onlyCustom === "true",
@@ -148,6 +148,12 @@ app.get(
       withTools: false,
       withFileAttachments: false,
     });
+
+    // Skills with editors-only availability (unpublished) are only listed for members of
+    // their editor group.
+    const skills = allSkills.filter(
+      (skill) => skill.availability !== "editors" || skill.canWrite(auth)
+    );
 
     if (withRelations === "true") {
       const usageMap = await SkillResource.batchFetchUsage(auth, skills);

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -7,12 +7,16 @@ import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_reso
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SKILL_ICON } from "@app/lib/skill";
 import { serializeSkillTag } from "@app/lib/skills/format";
-import type { SkillStatus } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillAvailability,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
 import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
 type CreateSkillOverrides = Partial<{
+  availability: SkillAvailability;
   name: string;
   agentFacingDescription: string;
   userFacingDescription: string;
@@ -58,7 +62,7 @@ export class SkillFactory {
         requestedSpaceIds,
         status,
         icon: SKILL_ICON.name,
-        availability: DEFAULT_SKILL_AVAILABILITY,
+        availability: overrides.availability ?? DEFAULT_SKILL_AVAILABILITY,
       },
       {
         mcpServerViews,


### PR DESCRIPTION
## Description

`GET /w/{wId}/skills` now filters out unpublished skills (`editors` availability) for callers who are not members of their editor group.
Published skills (`workspace_users`, `users_and_agents`) are listed for everyone as before.
No need for flag check, only workspaces with the flag on can create unpublished skills anyway.

Issue: https://github.com/dust-tt/tasks/issues/9728

## Tests

unit testes added

## Risk

Low, PR is easy to revert.

## Deploy Plan

Deploy front.