### PR TITLE
[front] fix: converge Stripe-backed subs to ended on contract swap

### DIFF
--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -695,10 +695,14 @@ describe("processMetronomeWebhook — swap webhook ordering", () => {
     expect(oldSub!.status).toBe("ended");
   });
 
-  it("keeps a shadow-billed (Stripe-backed) old sub as ended_backend_only so Stripe converges it", async () => {
-    // The fix is scoped to Metronome-only subs. A sub with a Stripe
-    // subscription must still wait for Stripe's customer.subscription.deleted
-    // webhook, so it ends as ended_backend_only.
+  it("converges a shadow-billed (Stripe-backed) old sub to ended on activation (does not strand in ended_backend_only)", async () => {
+    // A pending-row cutover races Stripe's customer.subscription.deleted (the
+    // scheduled cancel_at). When the Stripe event lands first it is consumed by
+    // the "active + pending → skip" branch, leaving contract.start's
+    // activatePending as the only handler that can finalize the old sub. It must
+    // therefore end directly as `ended` rather than waiting on a Stripe webhook
+    // that already fired, otherwise the old sub is stranded in
+    // `ended_backend_only`.
     const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID, {
       stripeSubscriptionId: "sub_shadow_xxx",
     });
@@ -719,7 +723,7 @@ describe("processMetronomeWebhook — swap webhook ordering", () => {
       refreshed!,
       OLD_CONTRACT_ID
     );
-    expect(oldSub!.status).toBe("ended_backend_only");
+    expect(oldSub!.status).toBe("ended");
   });
 });
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -171,8 +171,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   }
 
   /**
-   * Terminal status to use when ending this subscription as part of a contract
-   * swap (`activatePending` / `swapMetronomeContract`).
+   * Terminal status to use when `swapMetronomeContract` ends this subscription
+   * (the in-place swap path, with no pre-staged pending row). `activatePending`
+   * does NOT use this — it finalizes directly to `ended` (see the note there).
    *
    * A subscription backed by a Stripe subscription converges via Stripe's
    * `customer.subscription.deleted` webhook, so it is ended as
@@ -793,6 +794,28 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return subscriptions.map((s) => s.workspaceId);
   }
 
+  static async internalListEndedBackendOnly(): Promise<SubscriptionResource[]> {
+    const subscriptions = await this.model.findAll({
+      where: {
+        status: "ended_backend_only",
+      },
+      // WORKSPACE_ISOLATION_BYPASS: Internal maintenance script that reconciles
+      // stranded subscriptions across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      include: [PlanModel],
+    });
+
+    return subscriptions.map(
+      (sub) =>
+        new SubscriptionResource(
+          this.model,
+          sub.get(),
+          renderPlanFromModel({ plan: sub.plan })
+        )
+    );
+  }
+
   /**
    * Internal function to subscribe to the FREE_NO_PLAN.
    * This is the only plan without a database entry: no need to create a subscription, we just end the active one if any.
@@ -1381,7 +1404,16 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           t
         );
       if (currentActive && !currentActive.isLegacyFreeNoPlan()) {
-        await currentActive.markAsEnded(currentActive.swapEndedStatus, t);
+        // Finalize directly to `ended`, even for a Stripe-backed (shadow-billed)
+        // sub. This `contract.start` and Stripe's `customer.subscription.deleted`
+        // (the scheduled `cancel_at` reaching the cutover) fire at the same
+        // instant. When the Stripe event is processed first it takes the
+        // "active + pending → skip" branch (see lib/api/stripe/webhook_handler.ts)
+        // and is ack'd without converging, so no later webhook is left to flip an
+        // `ended_backend_only` sub to `ended` — stranding it. The deleted
+        // handler's pending guard and the Metronome `contract.end` shadow guard
+        // already prevent a scrub in every ordering, so ending directly is safe.
+        await currentActive.markAsEnded("ended", t);
       }
       await this.update({ status: "active" }, t);
       const workspaceId = this.workspaceId;

--- a/front/scripts/backfill_stranded_ended_backend_only_subscriptions.ts
+++ b/front/scripts/backfill_stranded_ended_backend_only_subscriptions.ts
@@ -1,0 +1,157 @@
+/**
+ * Backfill subscriptions stranded in `ended_backend_only`.
+ *
+ * During a Stripe → Metronome contract swap (e.g. the legacy Pro → Business
+ * migration via `migrate_legacy_pro_monthly_to_business.ts`) the old
+ * Stripe-backed subscription used to be marked `ended_backend_only`, relying on
+ * Stripe's `customer.subscription.deleted` webhook to flip it to `ended`. But
+ * that webhook and the Metronome `contract.start` fire at the same cutover
+ * instant; when the Stripe event is processed first it is consumed by the
+ * "active + pending → skip" branch of the webhook handler and never converges
+ * the sub — leaving no later webhook to finalize it. The sub is then stranded
+ * in `ended_backend_only` forever.
+ *
+ * The code fix (subscription_resource.ts `activatePending`) finalizes directly
+ * to `ended`, so new swaps no longer strand. This script reconciles the
+ * already-stranded rows: for each `ended_backend_only` subscription whose Stripe
+ * subscription is confirmed `canceled` in Stripe, flip it to `ended`.
+ *
+ * A subscription without a `stripeSubscriptionId`, or whose Stripe subscription
+ * cannot be retrieved or is not `canceled`, is left untouched and logged for
+ * manual review (we only converge what Stripe confirms is actually gone).
+ *
+ * Dry run by default. Run with:
+ *   npx tsx scripts/backfill_stranded_ended_backend_only_subscriptions.ts \
+ *     [--workspaceId <sId>] [--concurrency 4] [--execute]
+ */
+
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+    concurrency: {
+      type: "number" as const,
+      description: "Number of subscriptions to reconcile in parallel",
+      default: 4,
+    },
+  },
+  async ({ workspaceId, concurrency, execute }, logger) => {
+    const stranded = await SubscriptionResource.internalListEndedBackendOnly();
+
+    // Resolve workspace sIds for logging (batched — no per-sub DB call).
+    const workspaceModelIds = [...new Set(stranded.map((s) => s.workspaceId))];
+    const workspaces =
+      await WorkspaceResource.fetchByModelIds(workspaceModelIds);
+    const workspaceIdByModelId = new Map(workspaces.map((w) => [w.id, w.sId]));
+
+    let subscriptions = stranded;
+    if (workspaceId) {
+      subscriptions = subscriptions.filter(
+        (s) => workspaceIdByModelId.get(s.workspaceId) === workspaceId
+      );
+    }
+
+    logger.info(
+      { candidates: subscriptions.length },
+      `[backfill-ended-backend-only] ${execute ? "Executing" : "[DRY RUN]"} over ${subscriptions.length} stranded subscription(s)`
+    );
+
+    let converged = 0;
+    let skipped = 0;
+
+    await concurrentExecutor(
+      subscriptions,
+      async (subscription) => {
+        const wId = workspaceIdByModelId.get(subscription.workspaceId) ?? null;
+
+        if (!subscription.stripeSubscriptionId) {
+          skipped++;
+          logger.warn(
+            { workspaceId: wId, subscriptionId: subscription.sId },
+            "[backfill-ended-backend-only] Skipping: no Stripe subscription to confirm cancellation against (needs manual review)"
+          );
+          return;
+        }
+
+        let stripeSubscription;
+        try {
+          stripeSubscription = await getStripeSubscription(
+            subscription.stripeSubscriptionId
+          );
+        } catch (err) {
+          skipped++;
+          logger.error(
+            {
+              workspaceId: wId,
+              subscriptionId: subscription.sId,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+              error: normalizeError(err).message,
+            },
+            "[backfill-ended-backend-only] Skipping: failed to retrieve Stripe subscription"
+          );
+          return;
+        }
+
+        if (!stripeSubscription || stripeSubscription.status !== "canceled") {
+          skipped++;
+          logger.warn(
+            {
+              workspaceId: wId,
+              subscriptionId: subscription.sId,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+              stripeStatus: stripeSubscription?.status ?? "not_found",
+            },
+            "[backfill-ended-backend-only] Skipping: Stripe subscription is not canceled (needs manual review)"
+          );
+          return;
+        }
+
+        if (!execute) {
+          logger.info(
+            {
+              workspaceId: wId,
+              subscriptionId: subscription.sId,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+            },
+            "[backfill-ended-backend-only] [DRY RUN] Would converge to ended"
+          );
+          converged++;
+          return;
+        }
+
+        await subscription.markAsEnded("ended");
+        converged++;
+        logger.info(
+          {
+            workspaceId: wId,
+            subscriptionId: subscription.sId,
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
+          },
+          "[backfill-ended-backend-only] Converged to ended"
+        );
+      },
+      { concurrency }
+    );
+
+    logger.info(
+      {
+        total: subscriptions.length,
+        converged,
+        skipped,
+      },
+      `[backfill-ended-backend-only] ${execute ? "Done" : "[DRY RUN] Done"}: ${converged} ${execute ? "converged" : "would converge"}, ${skipped} skipped`
+    );
+  }
+);


### PR DESCRIPTION
## Problem

Legacy Pro → Business migrated workspaces (via `migrate_legacy_pro_monthly_to_business.ts` → `switchContract` → pending row → `contract.start`) were left stranded in **`ended_backend_only`** instead of `ended`, even though Stripe had correctly ended the subscription — permanently, not transiently.

## Root cause — a mutual-deferral race

At the cutover instant two webhooks fire for the same workspace:

- **Metronome `contract.start`** → `activatePending()` marks the legacy Stripe-backed sub `ended_backend_only`, deferring the final `ended` flip to Stripe (`swapEndedStatus`).
- **Stripe `customer.subscription.deleted`** (the scheduled `cancel_at` reaching the cutover) — the event that is *supposed* to converge `ended_backend_only` → `ended`.

Convergence only works if `deleted` is processed **after** `activatePending`. When the Stripe event wins the race:

1. The deleted handler hits `case "active"` + the pending-sub guard → logs *"raced ahead… contract.start will finalize the swap"* and **skips without converging**.
2. Then `activatePending` sets the sub to `ended_backend_only`, expecting Stripe's `deleted` — which already fired and was consumed.
3. No webhook is left to finalize it → stranded forever.

Shadow-billed legacy subs (both `stripeSubscriptionId` + `metronomeContractId`) can't be rescued by Metronome `contract.end` either — it breaks early on `isMetronomeShadowBilled`. So Stripe's `deleted` was the sole converger, and it lost the race.

## Fix

`activatePending()` now ends the old sub **directly as `ended`** rather than via `swapEndedStatus`. This is scrub-safe in every ordering:

- `deleted` first → `case "active"` + pending guard skips the scrub, then `activatePending` sets `ended`. ✅
- `deleted` later → finds `ended` → `case "ended"` no-op. ✅

`swapEndedStatus` is retained for the in-place `swapMetronomeContract` path (where `contract.start` reliably precedes the Stripe cancel).

## Backfill

Adds `backfill_stranded_ended_backend_only_subscriptions.ts` to reconcile already-stranded rows: for each `ended_backend_only` sub whose Stripe subscription is **confirmed `canceled`**, flip it to `ended`. Subs without a Stripe ID / not confirmed canceled are left untouched and logged for manual review. Dry-run by default.

```
npx tsx scripts/backfill_stranded_ended_backend_only_subscriptions.ts            # dry run
npx tsx scripts/backfill_stranded_ended_backend_only_subscriptions.ts --execute
```

## Test

Updated the `process_webhook` test that encoded the old (buggy) behavior — it now asserts a shadow-billed (Stripe-backed) sub converges to `ended` on activation.

## Notes / reviewer callout

- Scoped the code fix to `activatePending` (the path the migration uses). `swapMetronomeContract` converges in its normal ordering, so it's left on `swapEndedStatus`; happy to harden it the same way for consistency if preferred.
- CI will run the full test suite + eslint — those could not be run locally (this workspace's `node_modules` can't build the `@dust-tt/client` SDK and is missing `ajv` for eslint). `tsgo --noEmit` and `biome check` pass locally, and the pre-commit typecheck hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)