### PR TITLE
[Workspace Deletion] Preserve safe data source cleanup

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -265,7 +265,8 @@ export async function softDeleteDataSourceAndLaunchScrubWorkflow(
  */
 export async function hardDeleteDataSource(
   auth: Authenticator,
-  dataSource: DataSourceResource
+  dataSource: DataSourceResource,
+  { warnAdmins = true }: { warnAdmins?: boolean } = {}
 ) {
   assert(auth.isBuilder(), "Only builders can delete data sources.");
 
@@ -415,7 +416,7 @@ export async function hardDeleteDataSource(
 
   await dataSource.delete(auth, { hardDelete: true });
 
-  if (dataSource.connectorProvider) {
+  if (dataSource.connectorProvider && warnAdmins) {
     await warnPostDeletion(auth, dataSource.connectorProvider);
   }
 }
@@ -433,14 +434,18 @@ async function warnPostDeletion(
         activeOnly: true,
       });
       const adminEmails = members.map((u) => u.email);
-      // send email to admins
-      for (const email of adminEmails) {
-        await sendGitHubDeletionEmail(email);
-      }
+      await sendGitHubDeletionEmails(adminEmails);
       break;
 
     default:
       break;
+  }
+}
+
+export async function sendGitHubDeletionEmails(adminEmails: string[]) {
+  // send email to admins
+  for (const email of adminEmails) {
+    await sendGitHubDeletionEmail(email);
   }
 }
 

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -4,12 +4,11 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { createZodSchemaFromArgs } from "@app/types/poke/plugins";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockDeleteWorkspace, mockEmitAuditLogEvent } = vi.hoisted(() => ({
+const { mockDeleteWorkspace } = vi.hoisted(() => ({
   mockDeleteWorkspace: vi.fn(),
-  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@app/lib/api/workspace", async (importOriginal) => {
@@ -18,17 +17,9 @@ vi.mock("@app/lib/api/workspace", async (importOriginal) => {
   return { ...actual, deleteWorkspace: mockDeleteWorkspace };
 });
 
-vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
-  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
-});
-
 beforeEach(() => {
   mockDeleteWorkspace.mockReset();
-  mockEmitAuditLogEvent.mockReset();
   mockDeleteWorkspace.mockResolvedValue(new Ok(undefined));
-  mockEmitAuditLogEvent.mockResolvedValue(undefined);
 });
 
 describe("deleteWorkspacePlugin.execute", () => {
@@ -92,6 +83,25 @@ describe("deleteWorkspacePlugin.execute", () => {
     expect(mockDeleteWorkspace).toHaveBeenCalledWith(workspace, {
       deleteDataSources: false,
     });
+  });
+
+  it("returns workspace deletion scheduling errors", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    mockDeleteWorkspace.mockResolvedValue(
+      new Err(new Error("Failed to start deletion workflow."))
+    );
+
+    const result = await deleteWorkspacePlugin.execute(auth, workspace, {
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+      deleteDataSources: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Failed to start deletion workflow.");
+    }
   });
 
   it("proceeds with data sources when explicitly requested", async () => {

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -3,6 +3,7 @@ import { Authenticator } from "@app/lib/auth";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { createZodSchemaFromArgs } from "@app/types/poke/plugins";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,6 +32,17 @@ beforeEach(() => {
 });
 
 describe("deleteWorkspacePlugin.execute", () => {
+  it("defaults data source deletion to false", () => {
+    const schema = createZodSchemaFromArgs(deleteWorkspacePlugin.manifest.args);
+
+    const args = schema.parse({
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+    });
+
+    expect(args.deleteDataSources).toBe(false);
+  });
+
   it("blocks deletion when the free-plan workspace still has an active Metronome contract", async () => {
     // Credit-priced free plan: `isFreePlan` is true, yet the active subscription
     // is Metronome-billed — the case the guard must catch.

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.test.ts
@@ -78,6 +78,22 @@ describe("deleteWorkspacePlugin.execute", () => {
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
+  it("keeps data source deletion disabled when the workspace has none", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await deleteWorkspacePlugin.execute(auth, workspace, {
+      confirmation: "DELETE",
+      workspaceHasBeenRelocated: false,
+      deleteDataSources: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockDeleteWorkspace).toHaveBeenCalledWith(workspace, {
+      deleteDataSources: false,
+    });
+  });
+
   it("proceeds with data sources when explicitly requested", async () => {
     const workspace = await WorkspaceFactory.byok();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -91,6 +107,8 @@ describe("deleteWorkspacePlugin.execute", () => {
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockDeleteWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockDeleteWorkspace).toHaveBeenCalledWith(workspace, {
+      deleteDataSources: true,
+    });
   });
 });

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -55,7 +55,9 @@ export const deleteWorkspacePlugin = createPlugin({
     }
 
     if (!deleteDataSources) {
-      const dataSources = await DataSourceResource.listByWorkspace(auth);
+      const dataSources = await DataSourceResource.listByWorkspace(auth, {
+        limit: 1,
+      });
       if (dataSources.length > 0) {
         return new Err(
           new Error(

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -1,8 +1,3 @@
-import {
-  buildAuditLogTarget,
-  emitAuditLogEvent,
-  getAuditLogContext,
-} from "@app/lib/api/audit/workos_audit";
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
   deleteWorkspace,
@@ -67,9 +62,7 @@ export const deleteWorkspacePlugin = createPlugin({
       }
     }
 
-    // If the workspace has been relocated, we can delete it immediately.
     if (workspaceHasBeenRelocated) {
-      // Ensure that the workspace has been relocated.
       if (!isWorkspaceRelocationDone(workspace)) {
         return new Err(
           new Error(
@@ -77,13 +70,7 @@ export const deleteWorkspacePlugin = createPlugin({
           )
         );
       }
-
-      await deleteWorkspace(workspace, {
-        deleteDataSources,
-        workspaceHasBeenRelocated,
-      });
     } else {
-      // If the workspace has not been relocated, we need to check its subscription.
       const subscription = auth.getNonNullableSubscription();
       if (!isFreePlan(subscription.plan.code)) {
         return new Err(
@@ -99,19 +86,17 @@ export const deleteWorkspacePlugin = createPlugin({
           )
         );
       }
-
-      await deleteWorkspace(workspace, { deleteDataSources });
     }
 
-    void emitAuditLogEvent({
-      auth,
-      action: "workspace.deleted",
-      targets: [buildAuditLogTarget("workspace", workspace)],
-      context: getAuditLogContext(auth),
-      metadata: {
-        relocated: String(workspaceHasBeenRelocated ?? false),
-      },
+    const deletedByUser = auth.user();
+    const deletionResult = await deleteWorkspace(workspace, {
+      deleteDataSources,
+      ...(deletedByUser ? { deletedByUserModelId: deletedByUser.id } : {}),
+      ...(workspaceHasBeenRelocated ? { workspaceHasBeenRelocated } : {}),
     });
+    if (deletionResult.isErr()) {
+      return new Err(deletionResult.error);
+    }
 
     return new Ok({
       display: "text",

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -33,6 +33,7 @@ export const deleteWorkspacePlugin = createPlugin({
       },
       deleteDataSources: {
         type: "boolean",
+        default: false,
         description:
           "Delete all data sources as part of the workspace deletion.",
         label: "Delete all data sources",

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -76,7 +76,10 @@ export const deleteWorkspacePlugin = createPlugin({
         );
       }
 
-      await deleteWorkspace(workspace, { workspaceHasBeenRelocated });
+      await deleteWorkspace(workspace, {
+        deleteDataSources,
+        workspaceHasBeenRelocated,
+      });
     } else {
       // If the workspace has not been relocated, we need to check its subscription.
       const subscription = auth.getNonNullableSubscription();
@@ -95,7 +98,7 @@ export const deleteWorkspacePlugin = createPlugin({
         );
       }
 
-      await deleteWorkspace(workspace);
+      await deleteWorkspace(workspace, { deleteDataSources });
     }
 
     void emitAuditLogEvent({

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -30,6 +30,7 @@ import type {
   MembershipRoleType,
 } from "@app/types/memberships";
 import type { SubscriptionType } from "@app/types/plan";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -494,12 +495,14 @@ export async function areAllSubscriptionsCanceled(
 export async function deleteWorkspace(
   owner: LightWorkspaceType,
   {
-    deleteDataSources = true,
+    deleteDataSources,
+    deletedByUserModelId,
     workspaceHasBeenRelocated = false,
   }: {
-    deleteDataSources?: boolean;
+    deleteDataSources: boolean;
+    deletedByUserModelId?: ModelId;
     workspaceHasBeenRelocated?: boolean;
-  } = {}
+  }
 ): Promise<Result<void, Error>> {
   // If the workspace has not been relocated, we expect all subscriptions to be canceled.
   if (!workspaceHasBeenRelocated) {
@@ -515,6 +518,7 @@ export async function deleteWorkspace(
 
   const res = await launchDeleteWorkspaceWorkflow({
     deleteDataSources,
+    deletedByUserModelId,
     workspaceId: owner.sId,
     workspaceHasBeenRelocated,
   });

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -494,8 +494,12 @@ export async function areAllSubscriptionsCanceled(
 export async function deleteWorkspace(
   owner: LightWorkspaceType,
   {
+    deleteDataSources = true,
     workspaceHasBeenRelocated = false,
-  }: { workspaceHasBeenRelocated?: boolean } = {}
+  }: {
+    deleteDataSources?: boolean;
+    workspaceHasBeenRelocated?: boolean;
+  } = {}
 ): Promise<Result<void, Error>> {
   // If the workspace has not been relocated, we expect all subscriptions to be canceled.
   if (!workspaceHasBeenRelocated) {
@@ -510,6 +514,7 @@ export async function deleteWorkspace(
   }
 
   const res = await launchDeleteWorkspaceWorkflow({
+    deleteDataSources,
     workspaceId: owner.sId,
     workspaceHasBeenRelocated,
   });

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -15,6 +15,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -25,6 +26,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import { formatUserFullName } from "@app/types/user";
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -87,9 +89,22 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       "editedAt" | "editedByUserId" | "vaultId"
     >,
     space: SpaceResource,
-    editedByUser?: UserType | null,
-    transaction?: Transaction
+    editedByUser: UserType | null | undefined,
+    transaction: Transaction
   ) {
+    // Serialize with workspace deletion so a data source cannot be inserted after its opt-in check.
+    assert(blob.workspaceId !== undefined, "Workspace id is required.");
+    const workspace = await WorkspaceResource.fetchForUpdate(
+      blob.workspaceId,
+      transaction
+    );
+    assert(workspace, "Workspace not found.");
+    assert(
+      workspace.metadata?.[WorkspaceResource.DELETION_METADATA_KEY] ===
+        undefined,
+      "Workspace deletion is in progress."
+    );
+
     const dataSource = await DataSourceModel.create(
       {
         ...blob,

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -24,6 +24,7 @@ import {
   invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/agent_loop/terminate";
@@ -333,10 +334,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   static async fetchForUpdate(
-    id: ModelId,
+    workspaceModelId: ModelId,
     transaction: Transaction
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findByPk(id, {
+    const workspace = await this.model.findByPk(workspaceModelId, {
       transaction,
       lock: transaction.LOCK.UPDATE,
     });
@@ -764,11 +765,46 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   static async updateMetadata(
-    id: ModelId,
-    metadata: Record<string, string | number | boolean | object> | null,
-    transaction?: Transaction
+    workspaceModelId: ModelId,
+    metadata: Record<string, string | number | boolean | object> | null
   ): Promise<Result<void, Error>> {
-    return this.updateByModelIdAndCheckExistence(id, { metadata }, transaction);
+    return withTransaction(async (transaction) => {
+      // Metadata updates may use stale snapshots, so serialize them to preserve deletion guards.
+      const workspace = await this.fetchForUpdate(
+        workspaceModelId,
+        transaction
+      );
+      if (!workspace) {
+        return new Err(new Error("Workspace not found."));
+      }
+
+      const deletionState =
+        workspace.metadata?.[WorkspaceResource.DELETION_METADATA_KEY];
+      const nextMetadata =
+        deletionState === undefined
+          ? metadata
+          : {
+              ...(metadata ?? {}),
+              [WorkspaceResource.DELETION_METADATA_KEY]: deletionState,
+              [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
+                WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
+            };
+
+      await workspace.update({ metadata: nextMetadata }, transaction);
+      return new Ok(undefined);
+    });
+  }
+
+  static async updateDeletionMetadata(
+    workspaceModelId: ModelId,
+    metadata: Record<string, string | number | boolean | object>,
+    transaction: Transaction
+  ): Promise<Result<void, Error>> {
+    return this.updateByModelIdAndCheckExistence(
+      workspaceModelId,
+      { metadata },
+      transaction
+    );
   }
 
   async removeMetadataKeys(keys: string[]): Promise<Result<void, Error>> {

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -118,6 +118,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static model: ModelStatic<WorkspaceModel> = WorkspaceModel;
   private static workspaceDomainModel: ModelStaticWorkspaceAware<WorkspaceHasDomainModel> =
     WorkspaceHasDomainModel;
+  static readonly DELETION_METADATA_KEY = "deletionInProgress";
   static readonly KILL_SWITCH_METADATA_KEY = "killSwitched";
   static readonly FULL_WORKSPACE_KILL_SWITCH_VALUE = "full";
 
@@ -329,6 +330,17 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       ...cached,
       whiteListedProviders: whiteListedProviders,
     });
+  }
+
+  static async fetchForUpdate(
+    id: ModelId,
+    transaction: Transaction
+  ): Promise<WorkspaceResource | null> {
+    const workspace = await this.model.findByPk(id, {
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    return workspace ? new this(this.model, workspace.get()) : null;
   }
 
   static async fetchByName(name: string): Promise<WorkspaceResource | null> {
@@ -753,9 +765,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
   static async updateMetadata(
     id: ModelId,
-    metadata: Record<string, string | number | boolean | object> | null
+    metadata: Record<string, string | number | boolean | object> | null,
+    transaction?: Transaction
   ): Promise<Result<void, Error>> {
-    return this.updateByModelIdAndCheckExistence(id, { metadata });
+    return this.updateByModelIdAndCheckExistence(id, { metadata }, transaction);
   }
 
   async removeMetadataKeys(keys: string[]): Promise<Result<void, Error>> {
@@ -1016,7 +1029,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
   static async updateByModelIdAndCheckExistence(
     id: ModelId,
-    updateValues: Partial<Attributes<WorkspaceModel>>
+    updateValues: Partial<Attributes<WorkspaceModel>>,
+    transaction?: Transaction
   ): Promise<Result<void, Error>> {
     if (updateValues.conversationsRetentionDays !== undefined) {
       const retentionDays = updateValues.conversationsRetentionDays;
@@ -1035,6 +1049,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
     const workspace = await this.model.findOne({
       where: { id },
+      transaction,
     });
 
     if (!workspace) {
@@ -1042,7 +1057,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     const workspaceResource = new this(this.model, workspace.get());
-    await workspaceResource.update(updateValues);
+    await workspaceResource.update(updateValues, transaction);
 
     return new Ok(undefined);
   }

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -1,22 +1,41 @@
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   deleteMembersActivity,
   deleteSpacesActivity,
   getGitHubAdminEmailsActivity,
+  scrubSpaceActivity,
+  sendGitHubNoticesActivity,
 } from "@app/poke/temporal/activities";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSendGitHubDeletionEmail } = vi.hoisted(() => ({
-  mockSendGitHubDeletionEmail: vi.fn(),
-}));
+const { mockHardDeleteDataSource, mockSendGitHubDeletionEmail } = vi.hoisted(
+  () => ({
+    mockHardDeleteDataSource: vi.fn(),
+    mockSendGitHubDeletionEmail: vi.fn(),
+  })
+);
+
+beforeEach(() => {
+  mockHardDeleteDataSource.mockReset();
+  mockHardDeleteDataSource.mockImplementation(
+    async (auth: Authenticator, dataSource: DataSourceResource) => {
+      const result = await dataSource.delete(auth, { hardDelete: true });
+      if (result.isErr()) {
+        throw result.error;
+      }
+    }
+  );
+  mockSendGitHubDeletionEmail.mockReset();
+});
 
 vi.mock("@app/lib/api/email", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@app/lib/api/email")>();
@@ -31,18 +50,34 @@ vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
     await importOriginal<typeof import("@app/lib/api/data_sources")>();
   return {
     ...actual,
-    hardDeleteDataSource: vi.fn(
-      async (auth: Authenticator, dataSource: DataSourceResource) => {
-        const result = await dataSource.delete(auth, { hardDelete: true });
-        if (result.isErr()) {
-          throw result.error;
-        }
-      }
-    ),
+    hardDeleteDataSource: mockHardDeleteDataSource,
   };
 });
 
 describe("deleteMembersActivity", () => {
+  it("deletes memberships for users who belong to another workspace", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const otherWorkspace = await WorkspaceFactory.byok();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await MembershipFactory.associate(otherWorkspace, user, { role: "user" });
+
+    await deleteMembersActivity({ workspaceId: workspace.sId });
+
+    await expect(
+      MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: otherWorkspace,
+      })
+    ).resolves.not.toBeNull();
+  });
+
   it("notifies admins after deleting a workspace with GitHub data", async () => {
     const workspace = await WorkspaceFactory.byok();
     const admin = await UserFactory.basic();
@@ -56,12 +91,46 @@ describe("deleteMembersActivity", () => {
     await deleteMembersActivity({ workspaceId: workspace.sId });
     expect(mockSendGitHubDeletionEmail).not.toHaveBeenCalled();
 
-    await deleteSpacesActivity({
-      githubAdminEmails,
+    await deleteSpacesActivity({ workspaceId: workspace.sId });
+    expect(mockSendGitHubDeletionEmail).not.toHaveBeenCalled();
+    expect(mockHardDeleteDataSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { warnAdmins: false }
+    );
+
+    await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
+
+    expect(mockSendGitHubDeletionEmail).toHaveBeenCalledWith(admin.email);
+  });
+});
+
+describe("scrubSpaceActivity", () => {
+  it("keeps GitHub admin warnings for standalone space deletion", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const space = await SpaceFactory.regular(workspace);
+    const view = await DataSourceViewFactory.fromConnector(
+      workspace,
+      space,
+      "github"
+    );
+
+    await view.delete(auth, { hardDelete: false });
+    await view.dataSource.delete(auth, { hardDelete: false });
+    const spaceDeleteResult = await space.delete(auth, { hardDelete: false });
+    expect(spaceDeleteResult.isOk()).toBe(true);
+
+    await scrubSpaceActivity({
+      spaceId: space.sId,
       workspaceId: workspace.sId,
     });
 
-    expect(mockSendGitHubDeletionEmail).toHaveBeenCalledWith(admin.email);
+    expect(mockHardDeleteDataSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { warnAdmins: true }
+    );
   });
 });
 
@@ -85,10 +154,7 @@ describe("deleteSpacesActivity", () => {
       );
     expect(sharedView.isOk()).toBe(true);
 
-    await deleteSpacesActivity({
-      githubAdminEmails: [],
-      workspaceId: workspace.sId,
-    });
+    await deleteSpacesActivity({ workspaceId: workspace.sId });
 
     await expect(
       DataSourceResource.fetchById(auth, defaultView.dataSource.sId, {

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -101,6 +101,73 @@ describe("prepareDeletionActivity", () => {
     ).toBe(true);
     expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeUndefined();
   });
+
+  it("restores conversation blocks when deletion is refused", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const previousKillSwitch = { conversationIds: ["conversation-1"] };
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      killSwitched: previousKillSwitch,
+    });
+    expect(updateResult.isOk()).toBe(true);
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.folder(workspace, globalSpace);
+
+    const preparation = await prepareDeletionActivity({
+      deleteDataSources: false,
+      workspaceId: workspace.sId,
+    });
+
+    expect(preparation.canDelete).toBe(false);
+    const reloadedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    expect(reloadedWorkspace?.metadata?.killSwitched).toEqual(
+      previousKillSwitch
+    );
+    expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeUndefined();
+  });
+
+  it("reapplies the workspace block when preparation is retried", async () => {
+    const workspace = await WorkspaceFactory.byok();
+
+    const firstPreparation = await prepareDeletionActivity({
+      deleteDataSources: true,
+      workspaceId: workspace.sId,
+    });
+    expect(firstPreparation.canDelete).toBe(true);
+
+    const preparedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    expect(preparedWorkspace).not.toBeNull();
+    const metadata = { ...(preparedWorkspace?.metadata ?? {}) };
+    delete metadata.killSwitched;
+    const updateResult = await WorkspaceResource.updateMetadata(
+      workspace.id,
+      metadata
+    );
+    expect(updateResult.isOk()).toBe(true);
+
+    const retryPreparation = await prepareDeletionActivity({
+      deleteDataSources: true,
+      workspaceId: workspace.sId,
+    });
+
+    expect(retryPreparation.canDelete).toBe(true);
+    const reloadedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    expect(reloadedWorkspace?.metadata?.killSwitched).toBe("full");
+  });
+
+  it("prevents data source insertion after preparation", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const globalSpace = await SpaceFactory.global(workspace);
+
+    const preparation = await prepareDeletionActivity({
+      deleteDataSources: true,
+      workspaceId: workspace.sId,
+    });
+    expect(preparation.canDelete).toBe(true);
+
+    await expect(
+      DataSourceViewFactory.folder(workspace, globalSpace)
+    ).rejects.toThrow("Workspace deletion is in progress.");
+  });
 });
 
 describe("deleteMembersActivity", () => {

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -5,6 +5,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   deleteMembersActivity,
   deleteSpacesActivity,
+  getGitHubAdminEmailsActivity,
 } from "@app/poke/temporal/activities";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -49,9 +50,10 @@ describe("deleteMembersActivity", () => {
     const globalSpace = await SpaceFactory.global(workspace);
     await DataSourceViewFactory.fromConnector(workspace, globalSpace, "github");
 
-    const githubAdminEmails = await deleteMembersActivity({
+    const githubAdminEmails = await getGitHubAdminEmailsActivity({
       workspaceId: workspace.sId,
     });
+    await deleteMembersActivity({ workspaceId: workspace.sId });
     expect(mockSendGitHubDeletionEmail).not.toHaveBeenCalled();
 
     await deleteSpacesActivity({

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -2,11 +2,28 @@ import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { deleteSpacesActivity } from "@app/poke/temporal/activities";
+import {
+  deleteMembersActivity,
+  deleteSpacesActivity,
+} from "@app/poke/temporal/activities";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it, vi } from "vitest";
+
+const { mockSendGitHubDeletionEmail } = vi.hoisted(() => ({
+  mockSendGitHubDeletionEmail: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/api/email")>();
+  return {
+    ...actual,
+    sendGitHubDeletionEmail: mockSendGitHubDeletionEmail,
+  };
+});
 
 vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
   const actual =
@@ -22,6 +39,28 @@ vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
       }
     ),
   };
+});
+
+describe("deleteMembersActivity", () => {
+  it("notifies admins after deleting a workspace with GitHub data", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.fromConnector(workspace, globalSpace, "github");
+
+    const githubAdminEmails = await deleteMembersActivity({
+      workspaceId: workspace.sId,
+    });
+    expect(mockSendGitHubDeletionEmail).not.toHaveBeenCalled();
+
+    await deleteSpacesActivity({
+      githubAdminEmails,
+      workspaceId: workspace.sId,
+    });
+
+    expect(mockSendGitHubDeletionEmail).toHaveBeenCalledWith(admin.email);
+  });
 });
 
 describe("deleteSpacesActivity", () => {
@@ -44,7 +83,10 @@ describe("deleteSpacesActivity", () => {
       );
     expect(sharedView.isOk()).toBe(true);
 
-    await deleteSpacesActivity({ workspaceId: workspace.sId });
+    await deleteSpacesActivity({
+      githubAdminEmails: [],
+      workspaceId: workspace.sId,
+    });
 
     await expect(
       DataSourceResource.fetchById(auth, defaultView.dataSource.sId, {

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -63,6 +63,7 @@ describe("prepareDeletionActivity", () => {
 
     const preparation = await prepareDeletionActivity({
       deleteDataSources: false,
+      notifyGitHubAdmins: false,
       workspaceId: workspace.sId,
     });
 
@@ -89,6 +90,7 @@ describe("prepareDeletionActivity", () => {
 
     const preparation = await prepareDeletionActivity({
       deleteDataSources: false,
+      notifyGitHubAdmins: false,
       workspaceId: workspace.sId,
     });
 
@@ -114,6 +116,7 @@ describe("prepareDeletionActivity", () => {
 
     const preparation = await prepareDeletionActivity({
       deleteDataSources: false,
+      notifyGitHubAdmins: false,
       workspaceId: workspace.sId,
     });
 
@@ -130,6 +133,7 @@ describe("prepareDeletionActivity", () => {
 
     const preparation = await prepareDeletionActivity({
       deleteDataSources: true,
+      notifyGitHubAdmins: false,
       workspaceId: workspace.sId,
     });
     expect(preparation.canDelete).toBe(true);
@@ -152,6 +156,7 @@ describe("prepareDeletionActivity", () => {
 
     const preparation = await prepareDeletionActivity({
       deleteDataSources: true,
+      notifyGitHubAdmins: false,
       workspaceId: workspace.sId,
     });
     expect(preparation.canDelete).toBe(true);
@@ -159,6 +164,22 @@ describe("prepareDeletionActivity", () => {
     await expect(
       DataSourceViewFactory.folder(workspace, globalSpace)
     ).rejects.toThrow("Workspace deletion is in progress.");
+  });
+
+  it("does not collect GitHub admins for relocation purges", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.fromConnector(workspace, globalSpace, "github");
+
+    const preparation = await prepareDeletionActivity({
+      deleteDataSources: true,
+      notifyGitHubAdmins: false,
+      workspaceId: workspace.sId,
+    });
+
+    expect(preparation.githubAdminModelIds).toEqual([]);
   });
 });
 
@@ -200,8 +221,9 @@ describe("deleteMembersActivity", () => {
     await githubView.delete(auth, { hardDelete: false });
     await githubView.dataSource.delete(auth, { hardDelete: false });
 
-    const { canDelete, githubAdminEmails } = await prepareDeletionActivity({
+    const { canDelete, githubAdminModelIds } = await prepareDeletionActivity({
       deleteDataSources: true,
+      notifyGitHubAdmins: true,
       workspaceId: workspace.sId,
     });
     expect(canDelete).toBe(true);
@@ -216,7 +238,7 @@ describe("deleteMembersActivity", () => {
       { warnAdmins: false }
     );
 
-    await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
+    await sendGitHubNoticesActivity({ githubAdminModelIds });
 
     expect(mockSendGitHubDeletionEmail).toHaveBeenCalledWith(admin.email);
   });

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -125,33 +125,25 @@ describe("prepareDeletionActivity", () => {
     expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeUndefined();
   });
 
-  it("reapplies the workspace block when preparation is retried", async () => {
+  it("preserves deletion state across workspace metadata updates", async () => {
     const workspace = await WorkspaceFactory.byok();
 
-    const firstPreparation = await prepareDeletionActivity({
+    const preparation = await prepareDeletionActivity({
       deleteDataSources: true,
       workspaceId: workspace.sId,
     });
-    expect(firstPreparation.canDelete).toBe(true);
+    expect(preparation.canDelete).toBe(true);
 
-    const preparedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
-    expect(preparedWorkspace).not.toBeNull();
-    const metadata = { ...(preparedWorkspace?.metadata ?? {}) };
-    delete metadata.killSwitched;
-    const updateResult = await WorkspaceResource.updateMetadata(
-      workspace.id,
-      metadata
-    );
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      ...(workspace.metadata ?? {}),
+      allowVoiceTranscription: true,
+    });
     expect(updateResult.isOk()).toBe(true);
 
-    const retryPreparation = await prepareDeletionActivity({
-      deleteDataSources: true,
-      workspaceId: workspace.sId,
-    });
-
-    expect(retryPreparation.canDelete).toBe(true);
     const reloadedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
     expect(reloadedWorkspace?.metadata?.killSwitched).toBe("full");
+    expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeDefined();
+    expect(reloadedWorkspace?.metadata?.allowVoiceTranscription).toBe(true);
   });
 
   it("prevents data source insertion after preparation", async () => {

--- a/front/poke/temporal/activities.test.ts
+++ b/front/poke/temporal/activities.test.ts
@@ -3,10 +3,11 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   deleteMembersActivity,
   deleteSpacesActivity,
-  getGitHubAdminEmailsActivity,
+  prepareDeletionActivity,
   scrubSpaceActivity,
   sendGitHubNoticesActivity,
 } from "@app/poke/temporal/activities";
@@ -54,6 +55,54 @@ vi.mock("@app/lib/api/data_sources", async (importOriginal) => {
   };
 });
 
+describe("prepareDeletionActivity", () => {
+  it("blocks deletion when data sources appeared without opt-in", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.folder(workspace, globalSpace);
+
+    const preparation = await prepareDeletionActivity({
+      deleteDataSources: false,
+      workspaceId: workspace.sId,
+    });
+
+    expect(preparation.canDelete).toBe(false);
+    const reloadedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    expect(
+      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+        reloadedWorkspace?.metadata?.killSwitched
+      )
+    ).toBe(false);
+    expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeUndefined();
+  });
+
+  it("preserves an existing workspace block when deletion is refused", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    expect(workspaceResource).not.toBeNull();
+    const blockResult = await workspaceResource?.updateWorkspaceKillSwitch({
+      operation: "block",
+    });
+    expect(blockResult?.isOk()).toBe(true);
+    const globalSpace = await SpaceFactory.global(workspace);
+    await DataSourceViewFactory.folder(workspace, globalSpace);
+
+    const preparation = await prepareDeletionActivity({
+      deleteDataSources: false,
+      workspaceId: workspace.sId,
+    });
+
+    expect(preparation.canDelete).toBe(false);
+    const reloadedWorkspace = await WorkspaceResource.fetchById(workspace.sId);
+    expect(
+      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+        reloadedWorkspace?.metadata?.killSwitched
+      )
+    ).toBe(true);
+    expect(reloadedWorkspace?.metadata?.deletionInProgress).toBeUndefined();
+  });
+});
+
 describe("deleteMembersActivity", () => {
   it("deletes memberships for users who belong to another workspace", async () => {
     const workspace = await WorkspaceFactory.byok();
@@ -83,11 +132,20 @@ describe("deleteMembersActivity", () => {
     const admin = await UserFactory.basic();
     await MembershipFactory.associate(workspace, admin, { role: "admin" });
     const globalSpace = await SpaceFactory.global(workspace);
-    await DataSourceViewFactory.fromConnector(workspace, globalSpace, "github");
+    const githubView = await DataSourceViewFactory.fromConnector(
+      workspace,
+      globalSpace,
+      "github"
+    );
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await githubView.delete(auth, { hardDelete: false });
+    await githubView.dataSource.delete(auth, { hardDelete: false });
 
-    const githubAdminEmails = await getGitHubAdminEmailsActivity({
+    const { canDelete, githubAdminEmails } = await prepareDeletionActivity({
+      deleteDataSources: true,
       workspaceId: workspace.sId,
     });
+    expect(canDelete).toBe(true);
     await deleteMembersActivity({ workspaceId: workspace.sId });
     expect(mockSendGitHubDeletionEmail).not.toHaveBeenCalled();
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -85,10 +85,14 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  type WorkspaceConversationKillSwitchValue,
+  WorkspaceResource,
+} from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { deleteActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
@@ -98,7 +102,24 @@ import assert from "assert";
 import { Op } from "sequelize";
 
 const hardDeleteLogger = logger.child({ activity: "hard-delete" });
-const WORKSPACE_DELETION_METADATA_KEY = "deletionInProgress";
+
+type PreviousKillSwitch =
+  | typeof WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE
+  | WorkspaceConversationKillSwitchValue
+  | null;
+
+function parsePreviousKillSwitch(value: unknown): PreviousKillSwitch {
+  if (value === null) {
+    return null;
+  }
+  if (WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(value)) {
+    return WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE;
+  }
+  if (WorkspaceResource.isWorkspaceConversationKillSwitchValue(value)) {
+    return value;
+  }
+  throw new Error("Invalid previous workspace kill switch.");
+}
 
 export async function scrubDataSourceActivity({
   dataSourceId,
@@ -638,57 +659,81 @@ export async function prepareDeletionActivity({
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  assert(workspace, "Workspace not found.");
-
-  // Remember the previous block state so retries can safely roll back an aborted deletion.
-  const existingDeletionState =
-    workspace.metadata?.[WORKSPACE_DELETION_METADATA_KEY];
-  let wasKillSwitched: boolean;
-  if (existingDeletionState === undefined) {
-    wasKillSwitched = WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
-      workspace.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY]
+  const canDelete = await withTransaction(async (transaction) => {
+    // This row lock is also taken by data source insertion, making the opt-in check atomic.
+    const workspace = await WorkspaceResource.fetchForUpdate(
+      auth.getNonNullableWorkspace().id,
+      transaction
     );
-    const blockResult = await WorkspaceResource.updateMetadata(workspace.id, {
+    assert(workspace, "Workspace not found.");
+
+    const existingDeletionState =
+      workspace.metadata?.[WorkspaceResource.DELETION_METADATA_KEY];
+    let previousKillSwitch: PreviousKillSwitch;
+    if (existingDeletionState === undefined) {
+      previousKillSwitch = parsePreviousKillSwitch(
+        workspace.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY] ?? null
+      );
+    } else {
+      assert(
+        typeof existingDeletionState === "object" &&
+          existingDeletionState !== null &&
+          "previousKillSwitch" in existingDeletionState,
+        "Invalid workspace deletion state."
+      );
+      previousKillSwitch = parsePreviousKillSwitch(
+        existingDeletionState.previousKillSwitch
+      );
+    }
+
+    const metadata: Record<string, string | number | boolean | object> = {
       ...(workspace.metadata ?? {}),
-      [WORKSPACE_DELETION_METADATA_KEY]: { wasKillSwitched },
+      [WorkspaceResource.DELETION_METADATA_KEY]: { previousKillSwitch },
       [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
         WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
-    });
+    };
+    const blockResult = await WorkspaceResource.updateMetadata(
+      workspace.id,
+      metadata,
+      transaction
+    );
     if (blockResult.isErr()) {
       throw blockResult.error;
     }
-  } else {
-    assert(
-      typeof existingDeletionState === "object" &&
-        existingDeletionState !== null &&
-        "wasKillSwitched" in existingDeletionState &&
-        typeof existingDeletionState.wasKillSwitched === "boolean",
-      "Invalid workspace deletion state."
-    );
-    wasKillSwitched = existingDeletionState.wasKillSwitched;
-  }
 
-  if (!deleteDataSources) {
-    const dataSources = await DataSourceResource.listByWorkspace(auth);
-    if (dataSources.length > 0) {
-      const blockedWorkspace = await WorkspaceResource.fetchById(workspaceId);
-      assert(blockedWorkspace, "Workspace not found.");
-      const metadata = { ...(blockedWorkspace.metadata ?? {}) };
-      delete metadata[WORKSPACE_DELETION_METADATA_KEY];
-      if (!wasKillSwitched) {
-        delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
-      }
-      const unblockResult = await WorkspaceResource.updateMetadata(
-        blockedWorkspace.id,
-        metadata
+    if (!deleteDataSources) {
+      const dataSources = await DataSourceResource.listByWorkspace(
+        auth,
+        undefined,
+        undefined,
+        transaction
       );
-      if (unblockResult.isErr()) {
-        throw unblockResult.error;
-      }
+      if (dataSources.length > 0) {
+        delete metadata[WorkspaceResource.DELETION_METADATA_KEY];
+        if (previousKillSwitch === null) {
+          delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+        } else {
+          metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY] =
+            previousKillSwitch;
+        }
+        const unblockResult = await WorkspaceResource.updateMetadata(
+          workspace.id,
+          metadata,
+          transaction
+        );
+        if (unblockResult.isErr()) {
+          throw unblockResult.error;
+        }
 
-      return { canDelete: false, githubAdminEmails: [] };
+        return false;
+      }
     }
+
+    return true;
+  });
+
+  if (!canDelete) {
+    return { canDelete: false, githubAdminEmails: [] };
   }
 
   // The workspace/provider index makes this existence check cheap.

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -574,21 +574,6 @@ export async function deleteMembersActivity({
     workspace,
   });
 
-  // The workspace/provider index makes this existence check cheap.
-  const githubDataSources = await DataSourceResource.listByConnectorProvider(
-    auth,
-    "github",
-    { limit: 1 }
-  );
-  let githubAdminEmails: string[] = [];
-  if (githubDataSources.length > 0) {
-    const { members } = await getMembers(auth, {
-      roles: ["admin"],
-      activeOnly: true,
-    });
-    githubAdminEmails = members.map((member) => member.email);
-  }
-
   for (const membership of memberships) {
     const user = await UserResource.fetchByModelId(membership.userId);
     if (user) {
@@ -634,6 +619,29 @@ export async function deleteMembersActivity({
       );
       await membership.delete(auth, {});
     }
+  }
+}
+
+export async function getGitHubAdminEmailsActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  // The workspace/provider index makes this existence check cheap.
+  const githubDataSources = await DataSourceResource.listByConnectorProvider(
+    auth,
+    "github",
+    { limit: 1 }
+  );
+  let githubAdminEmails: string[] = [];
+  if (githubDataSources.length > 0) {
+    const { members } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    githubAdminEmails = members.map((member) => member.email);
   }
 
   return githubAdminEmails;

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -692,7 +692,7 @@ export async function prepareDeletionActivity({
       [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
         WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
     };
-    const blockResult = await WorkspaceResource.updateMetadata(
+    const blockResult = await WorkspaceResource.updateDeletionMetadata(
       workspace.id,
       metadata,
       transaction
@@ -716,7 +716,7 @@ export async function prepareDeletionActivity({
           metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY] =
             previousKillSwitch;
         }
-        const unblockResult = await WorkspaceResource.updateMetadata(
+        const unblockResult = await WorkspaceResource.updateDeletionMetadata(
           workspace.id,
           metadata,
           transaction

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -98,6 +98,7 @@ import assert from "assert";
 import { Op } from "sequelize";
 
 const hardDeleteLogger = logger.child({ activity: "hard-delete" });
+const WORKSPACE_DELETION_METADATA_KEY = "deletionInProgress";
 
 export async function scrubDataSourceActivity({
   dataSourceId,
@@ -604,7 +605,6 @@ export async function deleteMembersActivity({
         ? "Deleting Membership and user data"
         : "Deleting Membership"
     );
-    await membership.delete(auth, {});
 
     // If the user we're removing the membership of only has one membership, we delete their
     // workspace data but keep the user row to avoid expensive FK constraint scans.
@@ -625,21 +625,77 @@ export async function deleteMembersActivity({
       // user in this workspace.
       await WakeUpResource.deleteAllForUser(auth, user.toJSON());
     }
+
+    await membership.delete(auth, {});
   }
 }
 
-export async function getGitHubAdminEmailsActivity({
+export async function prepareDeletionActivity({
+  deleteDataSources,
   workspaceId,
 }: {
+  deleteDataSources: boolean;
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  assert(workspace, "Workspace not found.");
+
+  // Remember the previous block state so retries can safely roll back an aborted deletion.
+  const existingDeletionState =
+    workspace.metadata?.[WORKSPACE_DELETION_METADATA_KEY];
+  let wasKillSwitched: boolean;
+  if (existingDeletionState === undefined) {
+    wasKillSwitched = WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+      workspace.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY]
+    );
+    const blockResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      ...(workspace.metadata ?? {}),
+      [WORKSPACE_DELETION_METADATA_KEY]: { wasKillSwitched },
+      [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
+        WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
+    });
+    if (blockResult.isErr()) {
+      throw blockResult.error;
+    }
+  } else {
+    assert(
+      typeof existingDeletionState === "object" &&
+        existingDeletionState !== null &&
+        "wasKillSwitched" in existingDeletionState &&
+        typeof existingDeletionState.wasKillSwitched === "boolean",
+      "Invalid workspace deletion state."
+    );
+    wasKillSwitched = existingDeletionState.wasKillSwitched;
+  }
+
+  if (!deleteDataSources) {
+    const dataSources = await DataSourceResource.listByWorkspace(auth);
+    if (dataSources.length > 0) {
+      const blockedWorkspace = await WorkspaceResource.fetchById(workspaceId);
+      assert(blockedWorkspace, "Workspace not found.");
+      const metadata = { ...(blockedWorkspace.metadata ?? {}) };
+      delete metadata[WORKSPACE_DELETION_METADATA_KEY];
+      if (!wasKillSwitched) {
+        delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+      }
+      const unblockResult = await WorkspaceResource.updateMetadata(
+        blockedWorkspace.id,
+        metadata
+      );
+      if (unblockResult.isErr()) {
+        throw unblockResult.error;
+      }
+
+      return { canDelete: false, githubAdminEmails: [] };
+    }
+  }
 
   // The workspace/provider index makes this existence check cheap.
   const githubDataSources = await DataSourceResource.listByConnectorProvider(
     auth,
     "github",
-    { limit: 1 }
+    { includeDeleted: true, limit: 1 }
   );
   let githubAdminEmails: string[] = [];
   if (githubDataSources.length > 0) {
@@ -650,7 +706,7 @@ export async function getGitHubAdminEmailsActivity({
     githubAdminEmails = members.map((member) => member.email);
   }
 
-  return githubAdminEmails;
+  return { canDelete: true, githubAdminEmails };
 }
 
 export async function sendGitHubNoticesActivity({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -704,7 +704,7 @@ export async function prepareDeletionActivity({
     if (!deleteDataSources) {
       const dataSources = await DataSourceResource.listByWorkspace(
         auth,
-        undefined,
+        { limit: 1 },
         undefined,
         transaction
       );

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -1,5 +1,9 @@
 import { hardDeleteApp } from "@app/lib/api/apps";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import {
   hardDeleteDataSource,
@@ -98,6 +102,7 @@ import logger from "@app/logger/logger";
 import { deleteActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 import { deleteAllConversations } from "@app/temporal/scrub_workspace/activities";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import { Op } from "sequelize";
 
@@ -653,9 +658,11 @@ export async function deleteMembersActivity({
 
 export async function prepareDeletionActivity({
   deleteDataSources,
+  notifyGitHubAdmins,
   workspaceId,
 }: {
   deleteDataSources: boolean;
+  notifyGitHubAdmins: boolean;
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -733,7 +740,12 @@ export async function prepareDeletionActivity({
   });
 
   if (!canDelete) {
-    return { canDelete: false, githubAdminEmails: [] };
+    return { canDelete: false, githubAdminModelIds: [] };
+  }
+
+  let githubAdminModelIds: ModelId[] = [];
+  if (!notifyGitHubAdmins) {
+    return { canDelete: true, githubAdminModelIds };
   }
 
   // The workspace/provider index makes this existence check cheap.
@@ -742,24 +754,66 @@ export async function prepareDeletionActivity({
     "github",
     { includeDeleted: true, limit: 1 }
   );
-  let githubAdminEmails: string[] = [];
   if (githubDataSources.length > 0) {
     const { members } = await getMembers(auth, {
       roles: ["admin"],
       activeOnly: true,
     });
-    githubAdminEmails = members.map((member) => member.email);
+    githubAdminModelIds = members.map((member) => member.id);
   }
 
-  return { canDelete: true, githubAdminEmails };
+  return { canDelete: true, githubAdminModelIds };
 }
 
 export async function sendGitHubNoticesActivity({
-  adminEmails,
+  githubAdminModelIds,
 }: {
-  adminEmails: string[];
+  githubAdminModelIds: ModelId[];
 }) {
-  await sendGitHubDeletionEmails(adminEmails);
+  const admins = await UserResource.fetchByModelIds(githubAdminModelIds);
+  await sendGitHubDeletionEmails(admins.map((admin) => admin.email));
+}
+
+export async function emitDeletionAuditActivity({
+  deletedByUserModelId,
+  relocated,
+  workspaceId,
+}: {
+  deletedByUserModelId?: ModelId;
+  relocated: boolean;
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspace = auth.getNonNullableWorkspace();
+  const deletedByUser =
+    deletedByUserModelId === undefined
+      ? null
+      : await UserResource.fetchByModelId(deletedByUserModelId);
+  assert(
+    deletedByUserModelId === undefined || deletedByUser,
+    "Workspace deletion actor not found."
+  );
+
+  void emitAuditLogEventDirect({
+    workspace,
+    action: "workspace.deleted",
+    actor: deletedByUser
+      ? {
+          type: "user",
+          id: deletedByUser.sId,
+          name: deletedByUser.fullName() ?? undefined,
+        }
+      : {
+          type: "system",
+          id: "temporal",
+          name: "Workspace deletion workflow",
+        },
+    targets: [buildAuditLogTarget("workspace", workspace)],
+    context: { location: "internal" },
+    metadata: {
+      relocated: String(relocated),
+    },
+  });
 }
 
 export async function deleteSkillsActivity({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -156,9 +156,11 @@ export async function scrubMCPServerViewActivity({
 
 export async function scrubSpaceActivity({
   spaceId,
+  warnAdmins = true,
   workspaceId,
 }: {
   spaceId: string;
+  warnAdmins?: boolean;
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -195,7 +197,7 @@ export async function scrubSpaceActivity({
   for (const ds of dataSources) {
     await scrubDataSourceActivity({
       dataSourceId: ds.sId,
-      warnAdmins: false,
+      warnAdmins,
       workspaceId,
     });
   }
@@ -576,41 +578,7 @@ export async function deleteMembersActivity({
 
   for (const membership of memberships) {
     const user = await UserResource.fetchByModelId(membership.userId);
-    if (user) {
-      const { memberships: membershipsOfUser } =
-        await MembershipResource.getLatestMemberships({
-          users: [user],
-        });
-
-      // If the user we're removing the membership of only has one membership, we delete their
-      // workspace data but keep the user row to avoid expensive FK constraint scans.
-      if (membershipsOfUser.length === 1) {
-        childLogger.info(
-          {
-            membershipId: membership.id,
-            userId: user.sId,
-          },
-          "Deleting Membership and user data"
-        );
-
-        // Delete the user's files.
-        await FileResource.deleteAllForUser(auth, user.toJSON());
-        await membership.delete(auth, {});
-
-        // Delete the user's agent memories.
-        await AgentMemoryModel.destroy({
-          where: {
-            workspaceId: workspace.id,
-            userId: user.id,
-          },
-        });
-        await OnboardingTaskResource.deleteAllForUser(auth, user.toJSON());
-
-        // Cancel any remaining Temporal workflows/schedules and delete wake-up rows owned by the
-        // user in this workspace.
-        await WakeUpResource.deleteAllForUser(auth, user.toJSON());
-      }
-    } else {
+    if (!user) {
       hardDeleteLogger.info(
         {
           membershipId: membership.id,
@@ -618,6 +586,44 @@ export async function deleteMembersActivity({
         "Deleting Membership"
       );
       await membership.delete(auth, {});
+      continue;
+    }
+
+    const { memberships: membershipsOfUser } =
+      await MembershipResource.getLatestMemberships({
+        users: [user],
+      });
+    const shouldDeleteUserData = membershipsOfUser.length === 1;
+
+    childLogger.info(
+      {
+        membershipId: membership.id,
+        userId: user.sId,
+      },
+      shouldDeleteUserData
+        ? "Deleting Membership and user data"
+        : "Deleting Membership"
+    );
+    await membership.delete(auth, {});
+
+    // If the user we're removing the membership of only has one membership, we delete their
+    // workspace data but keep the user row to avoid expensive FK constraint scans.
+    if (shouldDeleteUserData) {
+      // Delete the user's files.
+      await FileResource.deleteAllForUser(auth, user.toJSON());
+
+      // Delete the user's agent memories.
+      await AgentMemoryModel.destroy({
+        where: {
+          workspaceId: workspace.id,
+          userId: user.id,
+        },
+      });
+      await OnboardingTaskResource.deleteAllForUser(auth, user.toJSON());
+
+      // Cancel any remaining Temporal workflows/schedules and delete wake-up rows owned by the
+      // user in this workspace.
+      await WakeUpResource.deleteAllForUser(auth, user.toJSON());
     }
   }
 }
@@ -647,6 +653,14 @@ export async function getGitHubAdminEmailsActivity({
   return githubAdminEmails;
 }
 
+export async function sendGitHubNoticesActivity({
+  adminEmails,
+}: {
+  adminEmails: string[];
+}) {
+  await sendGitHubDeletionEmails(adminEmails);
+}
+
 export async function deleteSkillsActivity({
   workspaceId,
 }: {
@@ -673,10 +687,8 @@ export async function deleteWebhookSourcesActivity({
 }
 
 export async function deleteSpacesActivity({
-  githubAdminEmails,
   workspaceId,
 }: {
-  githubAdminEmails: string[];
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -759,11 +771,10 @@ export async function deleteSpacesActivity({
 
     await scrubSpaceActivity({
       spaceId: space.sId,
+      warnAdmins: false,
       workspaceId,
     });
   }
-
-  await sendGitHubDeletionEmails(githubAdminEmails);
 }
 
 export async function deletePluginRunsActivity({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -1,12 +1,18 @@
 import { hardDeleteApp } from "@app/lib/api/apps";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import config from "@app/lib/api/config";
-import { hardDeleteDataSource } from "@app/lib/api/data_sources";
+import {
+  hardDeleteDataSource,
+  sendGitHubDeletionEmails,
+} from "@app/lib/api/data_sources";
 import { deletePodStatePrefix } from "@app/lib/api/sandbox/db";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { deleteWebhookSource } from "@app/lib/api/webhook_source";
 import { deleteWorksOSOrganizationWithWorkspace } from "@app/lib/api/workos/organization";
-import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
+import {
+  areAllSubscriptionsCanceled,
+  getMembers,
+} from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
@@ -95,9 +101,11 @@ const hardDeleteLogger = logger.child({ activity: "hard-delete" });
 
 export async function scrubDataSourceActivity({
   dataSourceId,
+  warnAdmins = true,
   workspaceId,
 }: {
   dataSourceId: string;
+  warnAdmins?: boolean;
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -122,7 +130,7 @@ export async function scrubDataSourceActivity({
     throw new Error("Data source is not soft deleted.");
   }
 
-  await hardDeleteDataSource(auth, dataSource);
+  await hardDeleteDataSource(auth, dataSource, { warnAdmins });
 }
 
 export async function scrubMCPServerViewActivity({
@@ -187,6 +195,7 @@ export async function scrubSpaceActivity({
   for (const ds of dataSources) {
     await scrubDataSourceActivity({
       dataSourceId: ds.sId,
+      warnAdmins: false,
       workspaceId,
     });
   }
@@ -565,6 +574,21 @@ export async function deleteMembersActivity({
     workspace,
   });
 
+  // The workspace/provider index makes this existence check cheap.
+  const githubDataSources = await DataSourceResource.listByConnectorProvider(
+    auth,
+    "github",
+    { limit: 1 }
+  );
+  let githubAdminEmails: string[] = [];
+  if (githubDataSources.length > 0) {
+    const { members } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    githubAdminEmails = members.map((member) => member.email);
+  }
+
   for (const membership of memberships) {
     const user = await UserResource.fetchByModelId(membership.userId);
     if (user) {
@@ -611,6 +635,8 @@ export async function deleteMembersActivity({
       await membership.delete(auth, {});
     }
   }
+
+  return githubAdminEmails;
 }
 
 export async function deleteSkillsActivity({
@@ -639,8 +665,10 @@ export async function deleteWebhookSourcesActivity({
 }
 
 export async function deleteSpacesActivity({
+  githubAdminEmails,
   workspaceId,
 }: {
+  githubAdminEmails: string[];
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -726,6 +754,8 @@ export async function deleteSpacesActivity({
       workspaceId,
     });
   }
+
+  await sendGitHubDeletionEmails(githubAdminEmails);
 }
 
 export async function deletePluginRunsActivity({

--- a/front/poke/temporal/client.ts
+++ b/front/poke/temporal/client.ts
@@ -67,9 +67,11 @@ export async function launchScrubSpaceWorkflow(
 }
 
 export async function launchDeleteWorkspaceWorkflow({
+  deleteDataSources = true,
   workspaceId,
   workspaceHasBeenRelocated = false,
 }: {
+  deleteDataSources?: boolean;
   workspaceId: string;
   workspaceHasBeenRelocated?: boolean;
 }) {
@@ -79,6 +81,7 @@ export async function launchDeleteWorkspaceWorkflow({
     await client.workflow.start(deleteWorkspaceWorkflow, {
       args: [
         {
+          deleteDataSources,
           workspaceId,
           workspaceHasBeenRelocated,
         },

--- a/front/poke/temporal/client.ts
+++ b/front/poke/temporal/client.ts
@@ -3,6 +3,7 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -67,11 +68,13 @@ export async function launchScrubSpaceWorkflow(
 }
 
 export async function launchDeleteWorkspaceWorkflow({
-  deleteDataSources = true,
+  deleteDataSources,
+  deletedByUserModelId,
   workspaceId,
   workspaceHasBeenRelocated = false,
 }: {
-  deleteDataSources?: boolean;
+  deleteDataSources: boolean;
+  deletedByUserModelId?: ModelId;
   workspaceId: string;
   workspaceHasBeenRelocated?: boolean;
 }) {
@@ -82,6 +85,7 @@ export async function launchDeleteWorkspaceWorkflow({
       args: [
         {
           deleteDataSources,
+          deletedByUserModelId,
           workspaceId,
           workspaceHasBeenRelocated,
         },

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,5 +1,5 @@
 import type * as activities from "@app/poke/temporal/activities";
-import { proxyActivities } from "@temporalio/workflow";
+import { ApplicationFailure, proxyActivities } from "@temporalio/workflow";
 
 // Create a single proxy with all normal and long activities
 const normalActivityProxies = proxyActivities<typeof activities>({
@@ -77,7 +77,10 @@ export async function deleteWorkspaceWorkflow({
     workspaceId,
   });
   if (!canDelete) {
-    return;
+    throw ApplicationFailure.nonRetryable(
+      "Workspace deletion refused because data sources exist without explicit opt-in.",
+      "WORKSPACE_DELETION_REFUSED"
+    );
   }
 
   await deleteMembersActivity({ workspaceId });
@@ -91,7 +94,9 @@ export async function deleteWorkspaceWorkflow({
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });
-  await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
+  if (!workspaceHasBeenRelocated) {
+    await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
+  }
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -22,6 +22,7 @@ const {
   deleteTranscriptsActivity,
   deleteWorkOSOrganization,
   deleteWorkspaceUserMetadataActivity,
+  getGitHubAdminEmailsActivity,
   isWorkflowDeletableActivity,
   scrubDataSourceActivity,
   scrubSpaceActivity,
@@ -74,7 +75,8 @@ export async function deleteWorkspaceWorkflow({
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteAppsActivity({ workspaceId });
-  const githubAdminEmails = await deleteMembersActivity({ workspaceId });
+  const githubAdminEmails = await getGitHubAdminEmailsActivity({ workspaceId });
+  await deleteMembersActivity({ workspaceId });
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -1,4 +1,5 @@
 import type * as activities from "@app/poke/temporal/activities";
+import type { ModelId } from "@app/types/shared/model_id";
 import { ApplicationFailure, proxyActivities } from "@temporalio/workflow";
 
 // Create a single proxy with all normal and long activities
@@ -22,6 +23,7 @@ const {
   deleteTranscriptsActivity,
   deleteWorkOSOrganization,
   deleteWorkspaceUserMetadataActivity,
+  emitDeletionAuditActivity,
   isWorkflowDeletableActivity,
   prepareDeletionActivity,
   scrubDataSourceActivity,
@@ -56,11 +58,13 @@ export async function scrubSpaceWorkflow({
 }
 
 export async function deleteWorkspaceWorkflow({
-  deleteDataSources = true,
+  deleteDataSources,
+  deletedByUserModelId,
   workspaceId,
   workspaceHasBeenRelocated = false,
 }: {
-  deleteDataSources?: boolean;
+  deleteDataSources: boolean;
+  deletedByUserModelId?: ModelId;
   workspaceId: string;
   workspaceHasBeenRelocated?: boolean;
 }) {
@@ -72,8 +76,9 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
-  const { canDelete, githubAdminEmails } = await prepareDeletionActivity({
+  const { canDelete, githubAdminModelIds } = await prepareDeletionActivity({
     deleteDataSources,
+    notifyGitHubAdmins: !workspaceHasBeenRelocated,
     workspaceId,
   });
   if (!canDelete) {
@@ -83,6 +88,11 @@ export async function deleteWorkspaceWorkflow({
     );
   }
 
+  await emitDeletionAuditActivity({
+    deletedByUserModelId,
+    relocated: workspaceHasBeenRelocated,
+    workspaceId,
+  });
   await deleteMembersActivity({ workspaceId });
   await deleteConversationsActivity({ workspaceId });
   await deleteSkillsActivity({ workspaceId });
@@ -94,8 +104,8 @@ export async function deleteWorkspaceWorkflow({
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteSpacesActivity({ workspaceId });
-  if (!workspaceHasBeenRelocated) {
-    await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
+  if (githubAdminModelIds.length > 0) {
+    await sendGitHubNoticesActivity({ githubAdminModelIds });
   }
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -22,8 +22,8 @@ const {
   deleteTranscriptsActivity,
   deleteWorkOSOrganization,
   deleteWorkspaceUserMetadataActivity,
-  getGitHubAdminEmailsActivity,
   isWorkflowDeletableActivity,
+  prepareDeletionActivity,
   scrubDataSourceActivity,
   scrubSpaceActivity,
   sendGitHubNoticesActivity,
@@ -56,9 +56,11 @@ export async function scrubSpaceWorkflow({
 }
 
 export async function deleteWorkspaceWorkflow({
+  deleteDataSources = true,
   workspaceId,
   workspaceHasBeenRelocated = false,
 }: {
+  deleteDataSources?: boolean;
   workspaceId: string;
   workspaceHasBeenRelocated?: boolean;
 }) {
@@ -70,14 +72,21 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
+  const { canDelete, githubAdminEmails } = await prepareDeletionActivity({
+    deleteDataSources,
+    workspaceId,
+  });
+  if (!canDelete) {
+    return;
+  }
+
+  await deleteMembersActivity({ workspaceId });
   await deleteConversationsActivity({ workspaceId });
   await deleteSkillsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteAppsActivity({ workspaceId });
-  const githubAdminEmails = await getGitHubAdminEmailsActivity({ workspaceId });
-  await deleteMembersActivity({ workspaceId });
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -74,11 +74,11 @@ export async function deleteWorkspaceWorkflow({
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
   await deleteAppsActivity({ workspaceId });
+  const githubAdminEmails = await deleteMembersActivity({ workspaceId });
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
-  await deleteSpacesActivity({ workspaceId });
-  await deleteMembersActivity({ workspaceId });
+  await deleteSpacesActivity({ githubAdminEmails, workspaceId });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -26,6 +26,7 @@ const {
   isWorkflowDeletableActivity,
   scrubDataSourceActivity,
   scrubSpaceActivity,
+  sendGitHubNoticesActivity,
 } = normalActivityProxies;
 
 const {
@@ -80,7 +81,8 @@ export async function deleteWorkspaceWorkflow({
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
-  await deleteSpacesActivity({ githubAdminEmails, workspaceId });
+  await deleteSpacesActivity({ workspaceId });
+  await sendGitHubNoticesActivity({ adminEmails: githubAdminEmails });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -328,6 +328,7 @@ makeScript(
 
           // 2) Delete the workspace in the source region.
           const deleteWorkspaceRes = await deleteWorkspace(owner, {
+            deleteDataSources: true,
             workspaceHasBeenRelocated: true,
           });
           if (deleteWorkspaceRes.isErr()) {

--- a/front/scripts/scrub_workspaces_without_subscription.ts
+++ b/front/scripts/scrub_workspaces_without_subscription.ts
@@ -48,6 +48,7 @@ async function scrubWorkspaceBatch(
     toScrub,
     async (workspace) => {
       const res = await launchDeleteWorkspaceWorkflow({
+        deleteDataSources: true,
         workspaceId: workspace.sId,
       });
       if (res.isErr()) {

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -182,7 +182,10 @@ export function createZodSchemaFromArgs(
         break;
 
       case "boolean":
-        schemaProps[key] = z.boolean();
+        schemaProps[key] =
+          arg.default === undefined
+            ? z.boolean()
+            : z.boolean().default(arg.default);
         break;
 
       case "enum":


### PR DESCRIPTION
## Description

Fixes safety regressions introduced by https://github.com/dust-tt/dust/pull/29394, which
merged while this follow-up was being prepared.

The new "Delete all data sources" checkbox remains opt-in. Its manifest and server-side validation
default to `false`, and the choice is carried into the Temporal workflow instead of being checked
only in Poke. The destructive argument is required at every internal layer; relocation and
automatic scrub callers now pass `true` explicitly.

At workflow start, deletion blocks workspace API writes and rechecks for data sources. Deletion
preparation, data source insertion, and workspace metadata updates serialize on the workspace row,
so an in-flight insertion is either included in the check or refused after deletion starts, and
stale metadata writes cannot remove the deletion guard. If deletion was not authorized and a data
source exists, the workflow restores the workspace's exact previous block state and fails visibly
without deleting it.

Only after that recheck succeeds does the workflow emit the existing workspace deletion audit event
and start cleanup. It records GitHub administrator model IDs, not emails, before revoking every
membership; the notification activity resolves the emails later, keeping them out of Temporal
history. Scheduling errors are returned to Poke instead of reporting success.

Genuine workspace deletion suppresses per-data-source GitHub notices to avoid duplicates and sends
one separate notice activity after cleanup. Relocation purges neither collect recipients nor send
this uninstall notice because the connector remains active in the destination region. Ordinary data
source and space deletion keep their existing notification behavior.

## Risks

Blast radius: Poke workspace deletion, automatic and relocation deletion callers, data source
insertion, workspace metadata and API blocking, membership cleanup, audit timing, and post-deletion
GitHub administrator notifications.
Risk: standard

The workflow records new preparation, audit, and notification activities without `patched()`. This
is safe only under the deploy constraint below.

## Deploy Plan

- Confirm no workspace deletion workflows are running, and do not start one during the worker
  rollout.
- Deploy front.
- Resume workspace deletions after all workers are updated.

## Tests

- [x] Missing checkbox input defaults to `false`.
- [x] Poke carries both enabled and disabled choices into workflow launch.
- [x] Poke returns workspace deletion scheduling failures.
- [x] Workflow revalidation refuses new data sources without opt-in, restores the exact previous
  workspace block state, and fails non-retryably.
- [x] Data source insertion is refused after workspace deletion preparation.
- [x] Stale workspace metadata updates preserve the deletion marker and full workspace block.
- [x] Memberships are revoked for users who belong to other workspaces.
- [x] GitHub administrators are notified only after genuine workspace data source cleanup,
  including soft-deleted GitHub sources.
- [x] Relocation purges do not collect GitHub recipients or send uninstall notices.
- [x] Standalone space deletion retains GitHub administrator notices.
- [x] Data sources shared into a later space are deleted safely.
