### PR TITLE
[Conversation Files] Fix audio transcript previews

### DIFF
--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -123,6 +123,7 @@ export function FilePreviewPanel({
             isFullWidth
             markdownContent={processedContent?.text}
             markdownViewMode="preview"
+            owner={owner}
             processedContent={processedContent}
           />
         )}

--- a/front/components/file_explorer/FilePreviewContent.tsx
+++ b/front/components/file_explorer/FilePreviewContent.tsx
@@ -8,9 +8,10 @@ import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
 import { processFileContent } from "@app/lib/file_content_utils";
-import { useFileContentByUrl } from "@app/lib/swr/files";
+import { getFileProcessedUrl, useFileContentByUrl } from "@app/lib/swr/files";
 import { stripMimeParameters } from "@app/types/files";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   CodeBlock,
   cn,
@@ -138,11 +139,12 @@ function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
 interface AudioPreviewProps {
   fileUrl: string;
   fileId: string | null;
+  owner?: LightWorkspaceType;
 }
 
-function AudioPreview({ fileUrl, fileId }: AudioPreviewProps) {
-  const sep = fileUrl.includes("?") ? "&" : "?";
-  const transcriptUrl = fileId ? `${fileUrl}${sep}version=processed` : null;
+function AudioPreview({ fileUrl, fileId, owner }: AudioPreviewProps) {
+  const transcriptUrl =
+    fileId && owner ? getFileProcessedUrl(owner, fileId) : null;
   const { fileContent: transcript } = useFileContentByUrl({
     url: transcriptUrl,
     disabled: !transcriptUrl,
@@ -254,6 +256,7 @@ interface FilePreviewContentProps {
   markdownViewMode?: MarkdownFilePreviewViewMode;
   onMarkdownContentChange?: (content: string) => void;
   onMarkdownViewModeChange?: (mode: MarkdownFilePreviewViewMode) => void;
+  owner?: LightWorkspaceType;
   processedContent: ProcessedContent | null;
 }
 
@@ -269,6 +272,7 @@ export function FilePreviewContent({
   markdownViewMode,
   onMarkdownContentChange,
   onMarkdownViewModeChange,
+  owner,
   processedContent,
 }: FilePreviewContentProps) {
   if (isContentLoading) {
@@ -316,7 +320,9 @@ export function FilePreviewContent({
     }
 
     case "audio":
-      return <AudioPreview fileUrl={fileUrl} fileId={entry.fileId} />;
+      return (
+        <AudioPreview fileUrl={fileUrl} fileId={entry.fileId} owner={owner} />
+      );
 
     case "delimited":
       if (fileContent) {

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -289,6 +289,7 @@ export function FilePreviewDialog({
                 onMarkdownViewModeChange={
                   canEditMarkdown ? setMarkdownViewMode : undefined
                 }
+                owner={owner}
                 processedContent={processedContent}
               />
             )}
@@ -326,6 +327,7 @@ export function FilePreviewDialog({
                 onMarkdownViewModeChange={
                   canEditMarkdown ? setMarkdownViewMode : undefined
                 }
+                owner={owner}
                 processedContent={processedContent}
               />
             )}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9726

Audio previews use a canonical-path URL. The transcript request appended `version=processed` to that same URL, but the canonical-path endpoint ignores file versions and therefore returned the original binary audio bytes.

Load the transcript from the linked file resource’s processed-content endpoint while keeping audio playback on the canonical-path URL.

## Risks

Blast radius: transcript rendering for audio files in file previews.
Risk: low

## Deploy Plan

- deploy front