### PR TITLE
[front] Retry Anthropic file download failures

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/errors.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/errors.ts
@@ -5,9 +5,8 @@ import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { isAnthropicFileDownloadError } from "@app/lib/model_constructors/sdk/anthropic_ai/errors";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-
-const ANTHROPIC_FILE_DOWNLOAD_ERROR = "Unable to download the file";
 
 // https://github.com/anthropics/anthropic-sdk-typescript#handling-errors
 export const handleError = (
@@ -64,7 +63,7 @@ function categorizeAnthropicError(
   const statusCode = originalError.status ?? 500;
   const isRetryable = shouldRetry(originalError);
 
-  if (normalized.message.includes(ANTHROPIC_FILE_DOWNLOAD_ERROR)) {
+  if (isAnthropicFileDownloadError(originalError)) {
     return {
       type: "server_error",
       message: `Server error from ${metadata.clientId}. ${normalized.message}`,

--- a/front/lib/api/llm/clients/anthropic/utils/errors.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/errors.ts
@@ -7,6 +7,8 @@ import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+const ANTHROPIC_FILE_DOWNLOAD_ERROR = "Unable to download the file";
+
 // https://github.com/anthropics/anthropic-sdk-typescript#handling-errors
 export const handleError = (
   err: APIError,
@@ -61,6 +63,15 @@ function categorizeAnthropicError(
 
   const statusCode = originalError.status ?? 500;
   const isRetryable = shouldRetry(originalError);
+
+  if (normalized.message.includes(ANTHROPIC_FILE_DOWNLOAD_ERROR)) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      originalError,
+    };
+  }
 
   // With eager_input_streaming enabled, the model may produce invalid tool parameter JSON.
   // The Anthropic API sometimes detects this server-side and aborts the stream with an SSE

--- a/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
@@ -54,9 +54,16 @@ describe("handleError (Anthropic)", () => {
   it("retries Anthropic file download failures", () => {
     const err = new BadRequestError(
       400,
-      { message: "Unable to download the file. Please verify the URL." },
+      {
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Unable to download the file. Please verify the URL.",
+        },
+      },
       undefined,
-      makeHeaders()
+      makeHeaders(),
+      "invalid_request_error"
     );
     const event = handleError(err, metadata) as EventError;
     expect(event.content.type).toBe("server_error");

--- a/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
@@ -47,6 +47,20 @@ describe("handleError (Anthropic)", () => {
     );
     const event = handleError(err, metadata) as EventError;
     expect(event.content.message.toLowerCase()).toContain("invalid request");
+    expect(event.content.type).toBe("invalid_request_error");
+    expect(event.content.isRetryable).toBe(false);
+  });
+
+  it("retries Anthropic file download failures", () => {
+    const err = new BadRequestError(
+      400,
+      { message: "Unable to download the file. Please verify the URL." },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as EventError;
+    expect(event.content.type).toBe("server_error");
+    expect(event.content.isRetryable).toBe(true);
   });
 
   it("maps AuthenticationError (401)", () => {

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -514,6 +514,25 @@ describe("streamErrorToErrorEvent", () => {
     expect(result.content.originalError).toBe(err);
   });
 
+  it("maps file download failures to server_error", () => {
+    const err = new APIError(
+      400,
+      {
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Unable to download the file. Please verify the URL.",
+        },
+      },
+      "Unable to download the file. Please verify the URL.",
+      undefined,
+      "invalid_request_error"
+    );
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      "server_error"
+    );
+  });
+
   it.each([
     [400, "invalid_request_error"],
     [422, "invalid_request_error"],

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -53,6 +53,7 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
 const INVALID_JSON_MARKER = "JSON: ";
 const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
+const FILE_DOWNLOAD_ERROR = "Unable to download the file";
 
 // Type guard: APIError carrying the server-side invalid-tool-JSON diagnostic.
 function isApiInvalidToolJsonError(
@@ -437,6 +438,15 @@ function apiErrorToErrorEvent(
   metadata: EndpointMetadata,
   error: APIError
 ): ErrorEvent {
+  if (error.message.includes(FILE_DOWNLOAD_ERROR)) {
+    return buildErrorEvent({
+      metadata,
+      type: "server_error",
+      message: `Server error from Anthropic: ${error.message}`,
+      originalError: error,
+    });
+  }
+
   // Mid-stream SSE `error` events surface as an `APIError` with no HTTP status;
   // the old router defaulted those to 500, so mirror that here.
   const status = error.status ?? 500;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -20,6 +20,7 @@ import {
   logToolSearchQuery,
   logToolSearchResult,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/tool_search_logging";
+import { isAnthropicFileDownloadError } from "@app/lib/model_constructors/sdk/anthropic_ai/errors";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import { ANTHROPIC_LAB } from "@app/lib/model_constructors/types/labs";
 import type {
@@ -53,7 +54,6 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
 const INVALID_JSON_MARKER = "JSON: ";
 const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
-const FILE_DOWNLOAD_ERROR = "Unable to download the file";
 
 // Type guard: APIError carrying the server-side invalid-tool-JSON diagnostic.
 function isApiInvalidToolJsonError(
@@ -438,7 +438,7 @@ function apiErrorToErrorEvent(
   metadata: EndpointMetadata,
   error: APIError
 ): ErrorEvent {
-  if (error.message.includes(FILE_DOWNLOAD_ERROR)) {
+  if (isAnthropicFileDownloadError(error)) {
     return buildErrorEvent({
       metadata,
       type: "server_error",

--- a/front/lib/model_constructors/sdk/anthropic_ai/errors.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/errors.ts
@@ -1,0 +1,29 @@
+import type { APIError } from "@anthropic-ai/sdk";
+
+import { isRecord } from "@app/types/shared/utils/general";
+
+const FILE_DOWNLOAD_ERROR = "Unable to download the file";
+
+export function isAnthropicFileDownloadError(error: APIError): boolean {
+  const body = error.error;
+  if (
+    error.status !== 400 ||
+    error.type !== "invalid_request_error" ||
+    typeof body !== "object" ||
+    body === null ||
+    !isRecord(body) ||
+    body.type !== "error"
+  ) {
+    return false;
+  }
+
+  const details = body.error;
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    isRecord(details) &&
+    details.type === "invalid_request_error" &&
+    typeof details.message === "string" &&
+    details.message.startsWith(FILE_DOWNLOAD_ERROR)
+  );
+}


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/9712

## Description

Anthropic can intermittently fail to download a signed image URL included in a long agent run and returns HTTP 400 with "Unable to download the file". We classified every such 400 as a permanent invalid request, so the agent loop stopped instead of retrying the failed model step.

Classify only this exact Anthropic diagnostic as a retryable server error in both the current model-constructor path and the legacy client path. Other HTTP 400 responses remain non-retryable.

This is a narrower alternative to https://github.com/dust-tt/dust/pull/26541, which base64-inlined every direct Anthropic image and was reverted by https://github.com/dust-tt/dust/pull/26553.

## Risks

Low. The behavior change is limited to Anthropic requests carrying the known file-download diagnostic. A persistent failure will still surface after the existing Temporal retry limit.

## Deploy Plan

Deploy front normally. No migration or configuration change is required.

## Tests

- Anthropic legacy error classification tests
- Anthropic model-constructor output conversion tests
- Front TypeScript type-check