### PR TITLE
Activation nudge notif novu workflow

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -1,3 +1,4 @@
+import { activationNewConversationWorkflow } from "@app/lib/notifications/workflows/activation-new-conversation";
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
@@ -67,6 +68,7 @@ const options: ServeHandlerOptions = {
     agentSuggestionsReadyWorkflow,
     skillSuggestionsReadyWorkflow,
     podAddedAsMemberWorkflow,
+    activationNewConversationWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -1,0 +1,255 @@
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { Authenticator } from "@app/lib/auth";
+import {
+  getAgentsDataRetention,
+  getConversationsDataRetention,
+} from "@app/lib/data_retention";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import {
+  ConversationError,
+  getConversationDisplayTitle,
+  isCompactionMessageType,
+  isLightAgentMessageType,
+  isPodConversation,
+  isUserMessageType,
+  isVisibleMessage,
+} from "@app/types/assistant/conversation";
+import { isRichUserMention } from "@app/types/assistant/mentions";
+import { isContentFragmentType } from "@app/types/content_fragment";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { decodeHtmlEntities } from "@app/types/shared/utils/markdown";
+import { z } from "zod";
+
+// When isNewProjectConversation is true, messageId is not required (the first
+// message is resolved from conversation content). Otherwise messageId is required.
+export const ConversationDetailsPayloadSchema = z.object({
+  workspaceId: z.string(),
+  conversationId: z.string(),
+  messageId: z.string().optional(),
+  isNewProjectConversation: z.boolean().optional(),
+});
+
+export type ConversationDetailsPayload = z.infer<
+  typeof ConversationDetailsPayloadSchema
+>;
+
+export const ConversationDetailsSchema = z.object({
+  subject: z.string(),
+  author: z.string(),
+  authorIsAgent: z.boolean(),
+  authorUserId: z.string().optional(),
+  isFromTrigger: z.boolean(),
+  isFromEmailAgentConversation: z.boolean(),
+  isFromSlackAgentConversation: z.boolean(),
+  workspaceName: z.string(),
+  mentionedUserIds: z.array(z.string()),
+  hasUnreadMessages: z.boolean(),
+  hasUnreadMentions: z.boolean(),
+  hasConversationRetentionPolicy: z.boolean(),
+  hasAgentRetentionPolicies: z.boolean(),
+  newMessageContent: z.string().nullable(),
+  isNewProjectConversation: z.boolean().optional(),
+  projectName: z.string().optional(),
+});
+
+export type ConversationDetailsType = z.infer<typeof ConversationDetailsSchema>;
+
+export const getConversationDetails = async ({
+  payload,
+  auth: providedAuth,
+  subscriberId,
+}: { payload: ConversationDetailsPayload } & (
+  | { auth: Authenticator; subscriberId?: never }
+  | { auth?: never; subscriberId: string }
+)): Promise<Result<ConversationDetailsType, ConversationError>> => {
+  if (!payload.isNewProjectConversation && !payload.messageId) {
+    throw new Error(
+      "messageId is required when isNewProjectConversation is false"
+    );
+  }
+
+  // Get or create auth from the discriminated union.
+  let auth: Authenticator;
+  if (providedAuth) {
+    auth = providedAuth;
+  } else {
+    // subscriberId may be empty when previewing the workflow step.
+    if (!subscriberId) {
+      return new Ok({
+        subject: "Deleted conversation",
+        author: "Deleted conversation",
+        authorIsAgent: false,
+        isFromTrigger: false,
+        isFromEmailAgentConversation: false,
+        isFromSlackAgentConversation: false,
+        workspaceName: "Deleted conversation",
+        mentionedUserIds: [],
+        avatarUrl: undefined,
+        hasUnreadMessages: false,
+        hasUnreadMentions: false,
+        hasConversationRetentionPolicy: false,
+        hasAgentRetentionPolicies: false,
+        newMessageContent: null,
+        isNewProjectConversation: false,
+      });
+    }
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      subscriberId,
+      payload.workspaceId
+    );
+  }
+
+  const conversationRes = await getLightConversation(
+    auth,
+    payload.conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    // Check if the conversation was deleted (expected during workflow delay).
+    const deletedConversation = await ConversationResource.fetchById(
+      auth,
+      payload.conversationId,
+      { includeDeleted: true }
+    );
+    if (deletedConversation) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+    // Conversation never existed - unexpected.
+    throw new Error(`Conversation not found: ${payload.conversationId}`);
+  }
+
+  const conversation = conversationRes.value;
+
+  const workspaceName = auth.getNonNullableWorkspace().name;
+  // Decode HTML entities in conversation title (e.g. from email subjects
+  // that may contain &amp;, &lt;, etc.) so notification subjects/bodies
+  // display clean text.
+  const subject = decodeHtmlEntities(getConversationDisplayTitle(conversation));
+  const isFromTrigger = !!conversation.triggerId;
+
+  // Retrieve the message that triggered the notification.
+  // For new project conversations, use the first visible message
+  const message = !payload.isNewProjectConversation
+    ? conversation.content.find((msg) => msg.sId === payload.messageId)
+    : conversation.content.find(isVisibleMessage);
+  if (!message) {
+    // Message doesn't exist at all - could be true if it's in a branch.
+    return new Err(new ConversationError("message_not_found"));
+  }
+  if (message.visibility === "deleted") {
+    // Message was deleted during workflow delay - expected.
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  let author: string;
+  let authorIsAgent: boolean;
+  let authorUserId: string | undefined;
+  let mentionedUserIds: string[] = [];
+  const messageContent =
+    message.type === "agent_message" || message.type === "user_message"
+      ? message.content
+      : "";
+  const parentUserMessage = isLightAgentMessageType(message)
+    ? conversation.content
+        .flat()
+        .find((msg) => msg.sId === message.parentMessageId)
+    : undefined;
+  const isFromEmailAgentConversation =
+    (isUserMessageType(message) && message.context.origin === "email") ||
+    (parentUserMessage !== undefined &&
+      isUserMessageType(parentUserMessage) &&
+      parentUserMessage.context.origin === "email");
+
+  const isFromSlackAgentConversation =
+    (isUserMessageType(message) && message.context.origin === "slack") ||
+    (parentUserMessage !== undefined &&
+      isUserMessageType(parentUserMessage) &&
+      parentUserMessage.context.origin === "slack");
+
+  if (isCompactionMessageType(message)) {
+    // Compaction messages don't trigger notifications.
+    return new Err(new ConversationError("message_not_found"));
+  } else if (isContentFragmentType(message)) {
+    // Content fragments don't have author info.
+    author = "Someone else";
+    authorIsAgent = false;
+  } else if (isUserMessageType(message)) {
+    author =
+      message.user?.fullName ?? message.context.fullName ?? "Someone else";
+    authorUserId = message.user?.sId ?? undefined;
+    authorIsAgent = false;
+
+    // Extract approved user mentions from the rendered message.
+    mentionedUserIds = message.richMentions
+      .filter((m) => isRichUserMention(m) && m.status === "approved")
+      .map((m) => m.id);
+  } else if (isLightAgentMessageType(message)) {
+    author = message.configuration.name
+      ? `@${message.configuration.name}`
+      : "An agent";
+    authorIsAgent = true;
+  } else {
+    assertNever(message);
+  }
+
+  const unreadMessages = conversation.content.filter((msg) =>
+    isMessageUnread(msg, conversation.lastReadMs)
+  );
+
+  const hasUnreadMessages = unreadMessages.length > 0;
+
+  const hasUnreadMentions = unreadMessages.some((msg) => {
+    if (isContentFragmentType(msg) || isCompactionMessageType(msg)) {
+      return false;
+    }
+    return msg.richMentions.some(
+      (m) => isRichUserMention(m) && m.id === subscriberId
+    );
+  });
+
+  const conversationsRetention = await getConversationsDataRetention(auth);
+  const hasConversationRetentionPolicy = conversationsRetention !== null;
+
+  const agentsRetention = await getAgentsDataRetention(auth);
+  const hasAgentRetentionPolicies = conversation.content.some((msg) => {
+    if (msg.type !== "agent_message") {
+      return false;
+    }
+
+    return msg.configuration.sId in agentsRetention;
+  });
+
+  // Fetch project-specific details when this is a new project conversation notification.
+  let projectName: string | undefined;
+  const isNewProjectConversation = !!payload.isNewProjectConversation;
+
+  if (isNewProjectConversation && isPodConversation(conversation)) {
+    const project = await SpaceResource.fetchById(auth, conversation.spaceId);
+    if (project) {
+      projectName = project.name;
+    }
+  }
+
+  return new Ok({
+    subject,
+    author,
+    authorIsAgent,
+    authorUserId,
+    isFromTrigger,
+    isFromEmailAgentConversation,
+    isFromSlackAgentConversation,
+    workspaceName,
+    mentionedUserIds,
+    hasUnreadMessages,
+    hasUnreadMentions,
+    hasConversationRetentionPolicy,
+    hasAgentRetentionPolicies,
+    newMessageContent: messageContent,
+    isNewProjectConversation,
+    projectName,
+  });
+};

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -1,7 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
+import { triggerActivationNewConversationEmail } from "@app/lib/notifications/workflows/activation-new-conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
@@ -127,6 +129,15 @@ const triggerProjectNewConversationNotifications = async (
     return new Err(new DustError("space_not_found", "Space not found"));
   }
 
+  // Activation pods send a dedicated email to the target user after the agent has replied.
+  const projectMetadata = await ProjectMetadataResource.fetchBySpace(
+    auth,
+    space
+  );
+  if (projectMetadata?.provisioningSource === "activation") {
+    return new Ok(undefined);
+  }
+
   const { groupsToProcess } = await space.fetchManualGroupsMemberships(auth);
 
   const projectMembers = uniqBy(
@@ -224,4 +235,70 @@ export function notifyNewProjectConversation(
       );
     }
   });
+}
+
+/**
+ * Send the dedicated activation email once the agent has replied in an
+ * activation-pod conversation. Called from the agent-loop completion path so
+ * the notification (and its per-user delay) starts only after the reply exists.
+ *
+ * Runs only if the conversation belongs to an activation pod and was started
+ * by the activation nudge workflow. Respects the target user's notification
+ * settings.
+ */
+export async function notifyActivationConversationAgentReplied(
+  auth: Authenticator,
+  { conversationId }: { conversationId: string }
+): Promise<void> {
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversationId,
+    { excludeTest: true }
+  );
+  if (!conversationResource) {
+    return;
+  }
+
+  const conversation = conversationResource.toJSON();
+  if (!isPodConversation(conversation)) {
+    return;
+  }
+
+  const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+  if (!space) {
+    return;
+  }
+
+  const projectMetadata = await ProjectMetadataResource.fetchBySpace(
+    auth,
+    space
+  );
+  if (projectMetadata?.provisioningSource !== "activation") {
+    return;
+  }
+
+  const userToNotify = auth.user();
+  if (!userToNotify) {
+    return;
+  }
+
+  const [allowedUser] = await filterMembersByNotifyCondition(
+    auth,
+    [userToNotify],
+    space.id
+  );
+  if (!allowedUser) {
+    return;
+  }
+
+  const res = await triggerActivationNewConversationEmail(auth, {
+    conversation,
+    userToNotify: allowedUser,
+  });
+  if (res.isErr()) {
+    logger.error(
+      { error: res.error, conversationId },
+      "Failed to trigger activation new conversation email"
+    );
+  }
 }

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -9,7 +9,7 @@ import {
   getUserNotificationDelay,
 } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
-import { getConversationDetails } from "@app/lib/notifications/workflows/conversation-unread";
+import { getConversationDetails } from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -157,8 +157,7 @@ export const activationNewConversationWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          content: `Test test test! Hi you are recieving a secret message from Phoebe :)
-          There's something new waiting for you: "${details.subject}".`,
+          content: `There's something new waiting for you: "${details.subject}".`,
           action: {
             label: "Open conversation",
             url:

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -157,8 +157,8 @@ export const activationNewConversationWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          content: `Test test test! Hi you are recieving a secret message from Phoebe :)" +
-          "There's something new waiting for you: "${details.subject}".`,
+          content: `Test test test! Hi you are recieving a secret message from Phoebe :)
+          There's something new waiting for you: "${details.subject}".`,
           action: {
             label: "Open conversation",
             url:

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -1,0 +1,244 @@
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import type { NotificationAllowedTags } from "@app/lib/notifications";
+import {
+  getNovuClient,
+  getUserNotificationDelay,
+} from "@app/lib/notifications";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getConversationDetails } from "@app/lib/notifications/workflows/conversation-unread";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isLightAgentMessageType } from "@app/types/assistant/conversation";
+import {
+  ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
+  NOTIFICATION_DELAY_OPTIONS,
+  NOTIFICATION_PREFERENCES_DELAYS,
+} from "@app/types/notification_preferences";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workflow } from "@novu/framework";
+import { z } from "zod";
+
+// An unread activation conversation created through the activation nudge flow are sent
+// to the target user as a dedicated, standalone email. It has no digest step, so a
+// conversation sent this way is never also bundled into the unread digest for the same activity.
+
+// For the email UI itself, right now it reuses and says something basic, will be fleshed out later.
+
+const activationNewConversationPayloadSchema = z.object({
+  workspaceId: z.string(),
+  conversationId: z.string(),
+});
+
+export type activationNewConversationPayloadType = z.infer<
+  typeof activationNewConversationPayloadSchema
+>;
+
+const activationNewConversationDetailsSchema = z.object({
+  subject: z.string(),
+  workspaceName: z.string(),
+});
+
+export type activationNewConversationDetailsType = z.infer<
+  typeof activationNewConversationDetailsSchema
+>;
+
+const userNotificationDelaySchema = z.object({
+  delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
+});
+
+const shouldSkipActivationNewConversation = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string | null;
+  payload: activationNewConversationPayloadType;
+}): Promise<boolean> => {
+  if (!subscriberId) {
+    return true;
+  }
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    payload.workspaceId
+  );
+
+  const conversationRes = await getLightConversation(
+    auth,
+    payload.conversationId
+  );
+  if (conversationRes.isErr()) {
+    return true;
+  }
+  const conversation = conversationRes.value;
+
+  // Send only when the agent has actually finished replying and that reply is still unread for this user.
+  const hasUnreadAgentReply = conversation.content.some(
+    (msg) =>
+      isLightAgentMessageType(msg) &&
+      msg.status === "succeeded" &&
+      isMessageUnread(msg, conversation.lastReadMs)
+  );
+
+  return !hasUnreadAgentReply;
+};
+
+const getActivationNewConversationDetails = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string | null;
+  payload: activationNewConversationPayloadType;
+}): Promise<activationNewConversationDetailsType> => {
+  const detailsResult = await getConversationDetails({
+    subscriberId: subscriberId ?? "",
+    payload: { ...payload, isNewProjectConversation: true },
+  });
+  if (detailsResult.isErr()) {
+    // Only reached for a deleted conversation, in which case the email step is
+    // already skipped, so this value is never actually delivered.
+    return { subject: "A new conversation", workspaceName: "your workspace" };
+  }
+
+  return {
+    subject: detailsResult.value.subject,
+    workspaceName: detailsResult.value.workspaceName,
+  };
+};
+
+export const activationNewConversationWorkflow = workflow(
+  ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    const details = await step.custom(
+      "get-conversation-details",
+      async () => {
+        return getActivationNewConversationDetails({
+          subscriberId: subscriber.subscriberId,
+          payload,
+        });
+      },
+      {
+        outputSchema: activationNewConversationDetailsSchema,
+      }
+    );
+
+    // Respect all the user's email notification preferences.
+    const { delay } = await step.custom(
+      "get-user-notification-delay",
+      async () => {
+        const userNotificationDelay = await getUserNotificationDelay({
+          subscriberId: subscriber.subscriberId,
+          workspaceId: payload.workspaceId,
+          channel: "email",
+        });
+        return { delay: userNotificationDelay };
+      },
+      {
+        outputSchema: userNotificationDelaySchema,
+      }
+    );
+
+    await step.delay("apply-user-delay", async () => {
+      return { type: "regular", ...NOTIFICATION_PREFERENCES_DELAYS[delay] };
+    });
+
+    await step.email(
+      "send-email",
+      async () => {
+        const body = await renderEmail({
+          name: subscriber.firstName ?? "You",
+          workspace: {
+            id: payload.workspaceId,
+            name: details.workspaceName,
+          },
+          content: `Test test test! Hi you are recieving a secret message from Phoebe :)" +
+          "There's something new waiting for you: "${details.subject}".`,
+          action: {
+            label: "Open conversation",
+            url:
+              config.getAppUrl() +
+              getConversationRoute(payload.workspaceId, payload.conversationId),
+          },
+        });
+
+        return {
+          subject: `[Dust] ${details.subject}`,
+          body,
+        };
+      },
+      {
+        skip: async () =>
+          shouldSkipActivationNewConversation({
+            subscriberId: subscriber.subscriberId,
+            payload,
+          }),
+      }
+    );
+  },
+  {
+    payloadSchema: activationNewConversationPayloadSchema,
+    tags: ["conversations"] as NotificationAllowedTags,
+  }
+);
+
+export const triggerActivationNewConversationEmail = async (
+  auth: Authenticator,
+  {
+    conversation,
+    userToNotify,
+  }: {
+    conversation: ConversationWithoutContentType;
+    userToNotify: UserResource;
+  }
+): Promise<Result<void, DustError<"internal_error">>> => {
+  try {
+    const novuClient = await getNovuClient();
+
+    const payload: activationNewConversationPayloadType = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId: conversation.sId,
+    };
+
+    const r = await novuClient.triggerBulk({
+      events: [
+        {
+          workflowId: ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
+          to: {
+            subscriberId: userToNotify.sId,
+            email: userToNotify.email,
+            firstName: userToNotify.firstName ?? undefined,
+            lastName: userToNotify.lastName ?? undefined,
+          },
+          payload,
+        },
+      ],
+    });
+
+    if (r.result.some((event) => !!event.error?.length)) {
+      const eventErrors = r.result
+        .filter((res) => !!res.error?.length)
+        .map(({ error }) => error?.join("; "))
+        .join("; ");
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: `Failed to trigger activation new conversation email: ${eventErrors}`,
+      });
+    }
+  } catch (err) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: "Failed to trigger activation new conversation email",
+      cause: normalizeError(err),
+    });
+  }
+
+  return new Ok(undefined);
+};

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -4,8 +4,8 @@ import {
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
+import type { ConversationDetailsType } from "@app/lib/notifications/helpers";
 import {
-  type ConversationDetailsType,
   type ConversationUnreadPayloadType,
   filterParticipantsByNotifyCondition,
   getEmailSummary,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -9,10 +9,6 @@ import {
 import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import {
-  getAgentsDataRetention,
-  getConversationsDataRetention,
-} from "@app/lib/data_retention";
 import { DustError } from "@app/lib/error";
 import {
   ensureSlackNotificationsReady,
@@ -21,6 +17,13 @@ import {
   type NotificationAllowedTags,
 } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/conversations-unread";
+import {
+  type ConversationDetailsPayload,
+  ConversationDetailsPayloadSchema,
+  ConversationDetailsSchema,
+  type ConversationDetailsType,
+  getConversationDetails,
+} from "@app/lib/notifications/helpers";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
@@ -29,16 +32,9 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import {
-  ConversationError,
   getConversationDisplayTitle,
-  isCompactionMessageType,
-  isLightAgentMessageType,
   isPodConversation,
-  isUserMessageType,
-  isVisibleMessage,
 } from "@app/types/assistant/conversation";
-import { isRichUserMention } from "@app/types/assistant/mentions";
-import { isContentFragmentType } from "@app/types/content_fragment";
 import type { NotificationCondition } from "@app/types/notification_preferences";
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
@@ -54,10 +50,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import {
-  decodeHtmlEntities,
-  stripMarkdown,
-} from "@app/types/shared/utils/markdown";
+import { stripMarkdown } from "@app/types/shared/utils/markdown";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { UserType } from "@app/types/user";
 import { workflow } from "@novu/framework";
@@ -65,18 +58,8 @@ import assert from "assert";
 import { Op } from "sequelize";
 import z from "zod";
 
-// When isNewProjectConversation is true, messageId is not required (the first
-// message is resolved from conversation content). Otherwise messageId is required.
-const ConversationUnreadPayloadSchema = z.object({
-  workspaceId: z.string(),
-  conversationId: z.string(),
-  messageId: z.string().optional(),
-  isNewProjectConversation: z.boolean().optional(),
-});
-
-export type ConversationUnreadPayloadType = z.infer<
-  typeof ConversationUnreadPayloadSchema
->;
+// The unread workflow operates on the shared conversation-details payload.
+export type ConversationUnreadPayloadType = ConversationDetailsPayload;
 
 export const shouldSendNotificationForAgentAnswer = (
   userMessageOrigin?: UserMessageOrigin | null
@@ -120,28 +103,6 @@ export const shouldSendNotificationForAgentAnswer = (
   }
 };
 
-const ConversationDetailsSchema = z.object({
-  subject: z.string(),
-  author: z.string(),
-  authorIsAgent: z.boolean(),
-  authorUserId: z.string().optional(),
-  isFromTrigger: z.boolean(),
-  isFromEmailAgentConversation: z.boolean(),
-  isFromSlackAgentConversation: z.boolean(),
-  workspaceName: z.string(),
-  mentionedUserIds: z.array(z.string()),
-  hasUnreadMessages: z.boolean(),
-  hasUnreadMentions: z.boolean(),
-  hasConversationRetentionPolicy: z.boolean(),
-  hasAgentRetentionPolicies: z.boolean(),
-  newMessageContent: z.string().nullable(),
-  // Fields for new project conversation notifications.
-  isNewProjectConversation: z.boolean().optional(),
-  projectName: z.string().optional(),
-});
-
-export type ConversationDetailsType = z.infer<typeof ConversationDetailsSchema>;
-
 // Wrapper for workflow step that may fail when conversation is deleted.
 const ConversationDetailsResultSchema = z.discriminatedUnion("success", [
   z.object({
@@ -156,202 +117,6 @@ const ConversationDetailsResultSchema = z.discriminatedUnion("success", [
 const UserNotificationDelaySchema = z.object({
   delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
 });
-
-export const getConversationDetails = async ({
-  payload,
-  auth: providedAuth,
-  subscriberId,
-}: { payload: ConversationUnreadPayloadType } & (
-  | { auth: Authenticator; subscriberId?: never }
-  | { auth?: never; subscriberId: string }
-)): Promise<Result<ConversationDetailsType, ConversationError>> => {
-  if (!payload.isNewProjectConversation && !payload.messageId) {
-    throw new Error(
-      "messageId is required when isNewProjectConversation is false"
-    );
-  }
-
-  // Get or create auth from the discriminated union.
-  let auth: Authenticator;
-  if (providedAuth) {
-    auth = providedAuth;
-  } else {
-    // subscriberId may be empty when previewing the workflow step.
-    if (!subscriberId) {
-      return new Ok({
-        subject: "Deleted conversation",
-        author: "Deleted conversation",
-        authorIsAgent: false,
-        isFromTrigger: false,
-        isFromEmailAgentConversation: false,
-        isFromSlackAgentConversation: false,
-        workspaceName: "Deleted conversation",
-        mentionedUserIds: [],
-        avatarUrl: undefined,
-        hasUnreadMessages: false,
-        hasUnreadMentions: false,
-        hasConversationRetentionPolicy: false,
-        hasAgentRetentionPolicies: false,
-        newMessageContent: null,
-        isNewProjectConversation: false,
-      });
-    }
-    auth = await Authenticator.fromUserIdAndWorkspaceId(
-      subscriberId,
-      payload.workspaceId
-    );
-  }
-
-  const conversationRes = await getLightConversation(
-    auth,
-    payload.conversationId
-  );
-
-  if (conversationRes.isErr()) {
-    // Check if the conversation was deleted (expected during workflow delay).
-    const deletedConversation = await ConversationResource.fetchById(
-      auth,
-      payload.conversationId,
-      { includeDeleted: true }
-    );
-    if (deletedConversation) {
-      return new Err(new ConversationError("conversation_not_found"));
-    }
-    // Conversation never existed - unexpected.
-    throw new Error(`Conversation not found: ${payload.conversationId}`);
-  }
-
-  const conversation = conversationRes.value;
-
-  const workspaceName = auth.getNonNullableWorkspace().name;
-  // Decode HTML entities in conversation title (e.g. from email subjects
-  // that may contain &amp;, &lt;, etc.) so notification subjects/bodies
-  // display clean text.
-  const subject = decodeHtmlEntities(getConversationDisplayTitle(conversation));
-  const isFromTrigger = !!conversation.triggerId;
-
-  // Retrieve the message that triggered the notification.
-  // For new project conversations, use the first visible message
-  const message = !payload.isNewProjectConversation
-    ? conversation.content.find((msg) => msg.sId === payload.messageId)
-    : conversation.content.find(isVisibleMessage);
-  if (!message) {
-    // Message doesn't exist at all - could be true if it's in a branch.
-    return new Err(new ConversationError("message_not_found"));
-  }
-  if (message.visibility === "deleted") {
-    // Message was deleted during workflow delay - expected.
-    return new Err(new ConversationError("message_not_found"));
-  }
-
-  let author: string;
-  let authorIsAgent: boolean;
-  let authorUserId: string | undefined;
-  let mentionedUserIds: string[] = [];
-  const messageContent =
-    message.type === "agent_message" || message.type === "user_message"
-      ? message.content
-      : "";
-  const parentUserMessage = isLightAgentMessageType(message)
-    ? conversation.content
-        .flat()
-        .find((msg) => msg.sId === message.parentMessageId)
-    : undefined;
-  const isFromEmailAgentConversation =
-    (isUserMessageType(message) && message.context.origin === "email") ||
-    (parentUserMessage !== undefined &&
-      isUserMessageType(parentUserMessage) &&
-      parentUserMessage.context.origin === "email");
-
-  const isFromSlackAgentConversation =
-    (isUserMessageType(message) && message.context.origin === "slack") ||
-    (parentUserMessage !== undefined &&
-      isUserMessageType(parentUserMessage) &&
-      parentUserMessage.context.origin === "slack");
-
-  if (isCompactionMessageType(message)) {
-    // Compaction messages don't trigger notifications.
-    return new Err(new ConversationError("message_not_found"));
-  } else if (isContentFragmentType(message)) {
-    // Content fragments don't have author info.
-    author = "Someone else";
-    authorIsAgent = false;
-  } else if (isUserMessageType(message)) {
-    author =
-      message.user?.fullName ?? message.context.fullName ?? "Someone else";
-    authorUserId = message.user?.sId ?? undefined;
-    authorIsAgent = false;
-
-    // Extract approved user mentions from the rendered message.
-    mentionedUserIds = message.richMentions
-      .filter((m) => isRichUserMention(m) && m.status === "approved")
-      .map((m) => m.id);
-  } else if (isLightAgentMessageType(message)) {
-    author = message.configuration.name
-      ? `@${message.configuration.name}`
-      : "An agent";
-    authorIsAgent = true;
-  } else {
-    assertNever(message);
-  }
-
-  const unreadMessages = conversation.content.filter((msg) =>
-    isMessageUnread(msg, conversation.lastReadMs)
-  );
-
-  const hasUnreadMessages = unreadMessages.length > 0;
-
-  const hasUnreadMentions = unreadMessages.some((msg) => {
-    if (isContentFragmentType(msg) || isCompactionMessageType(msg)) {
-      return false;
-    }
-    return msg.richMentions.some(
-      (m) => isRichUserMention(m) && m.id === subscriberId
-    );
-  });
-
-  const conversationsRetention = await getConversationsDataRetention(auth);
-  const hasConversationRetentionPolicy = conversationsRetention !== null;
-
-  const agentsRetention = await getAgentsDataRetention(auth);
-  const hasAgentRetentionPolicies = conversation.content.some((msg) => {
-    if (msg.type !== "agent_message") {
-      return false;
-    }
-
-    return msg.configuration.sId in agentsRetention;
-  });
-
-  // Fetch project-specific details when this is a new project conversation notification.
-  let projectName: string | undefined;
-  const isNewProjectConversation = !!payload.isNewProjectConversation;
-
-  if (isNewProjectConversation && isPodConversation(conversation)) {
-    const project = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (project) {
-      projectName = project.name;
-    }
-  }
-
-  return new Ok({
-    subject,
-    author,
-    authorIsAgent,
-    authorUserId,
-    isFromTrigger,
-    isFromEmailAgentConversation,
-    isFromSlackAgentConversation,
-    workspaceName,
-    mentionedUserIds,
-    hasUnreadMessages,
-    hasUnreadMentions,
-    hasConversationRetentionPolicy,
-    hasAgentRetentionPolicies,
-    newMessageContent: messageContent,
-    isNewProjectConversation,
-    projectName,
-  });
-};
 
 const shouldSkipUnreadConversation = async ({
   subscriberId,
@@ -1081,7 +846,7 @@ export const conversationUnreadWorkflow = workflow(
     );
   },
   {
-    payloadSchema: ConversationUnreadPayloadSchema,
+    payloadSchema: ConversationDetailsPayloadSchema,
     tags: ["conversations"] as NotificationAllowedTags,
   }
 );

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -157,7 +157,7 @@ const UserNotificationDelaySchema = z.object({
   delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
 });
 
-const getConversationDetails = async ({
+export const getConversationDetails = async ({
   payload,
   auth: providedAuth,
   subscriberId,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -14,7 +14,10 @@ import {
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
-import { conversationUnreadNotification } from "@app/temporal/agent_loop/activities/notification";
+import {
+  activationNewConversationNotification,
+  conversationUnreadNotification,
+} from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import {
   launchEmitMetronomeUsageEvents,
@@ -35,6 +38,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
     computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     conversationUnreadNotification(auth, agentLoopArgs),
+    activationNewConversationNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
     sendEmailReplyOnCompletion(auth, agentLoopArgs),
   ]);

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { notifyActivationConversationAgentReplied } from "@app/lib/notifications/triggers/project-new-conversation";
 import logger from "@app/logger/logger";
 import { launchConversationUnreadNotificationWorkflow } from "@app/temporal/notifications_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -25,4 +26,17 @@ export async function conversationUnreadNotification(
       "Failed to launch conversation unread notification workflow"
     );
   }
+}
+
+/**
+ * Send the activation-pod dedicated email after the agent has finished
+ * replying. No-op for non-activation conversations.
+ */
+export async function activationNewConversationNotification(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  await notifyActivationConversationAgentReplied(auth, {
+    conversationId: agentLoopArgs.conversationId,
+  });
 }

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -129,8 +129,12 @@ export const MANUAL_ACTION_REQUIRED_TRIGGER_ID =
   "manual-action-required" as const;
 export const MANUAL_ACTION_REQUIRED_TAG = "manual-action-required" as const;
 
+export const ACTIVATION_NEW_CONVERSATION_TRIGGER_ID =
+  "activation-new-conversation" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
+  | typeof ACTIVATION_NEW_CONVERSATION_TRIGGER_ID
   | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID


### PR DESCRIPTION
## Description
Adds a general email notification capability specific to activation nudge conversations. It is a standalone Novu workflow (activation-new-conversation) for easier iteration and to prevent the normal conversation-unread workflow from running in parallel (creating duplicate email notifs).

The workflow's steps: resolve conversation details → read the user's email delay preference → step.delay for that interval → send one email, whose skip re-checks after the delay and only sends when there's an unread, succeeded agent reply. It respects existing user settings throughout and introduces no new preferences.

This adds all the plumbing to make the email notification. Email UI changes coming later.

## Tests
Tested on local development (dust, novu, email).

## Risk
Low risk, only used when there is an unread activation nudge convo.

## Deploy Plan
Deploy front.
