### PR TITLE
[front] Keep Frame side panel open when a message also writes regular files

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1388,13 +1388,19 @@ function AgentMessageContent({
   );
 
   // Auto-open interactive content drawer when interactive files are available.
-  const { interactiveFiles } = useAutoOpenInteractiveContent({
+  const { interactiveFiles, willOpenInteractiveContent } =
+    useAutoOpenInteractiveContent({
+      agentMessage,
+      isLastMessage,
+    });
+
+  // Auto-open file explorer panel when regular generated files are available,
+  // unless the same message is opening a Frame in the side panel.
+  useAutoOpenFilesPanel({
     agentMessage,
     isLastMessage,
+    deferToInteractiveContent: willOpenInteractiveContent,
   });
-
-  // Auto-open file explorer panel when regular generated files are available.
-  useAutoOpenFilesPanel({ agentMessage, isLastMessage });
 
   const blockedActionElement = blockedAction ? (
     <BlockedAction

--- a/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
+++ b/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
@@ -7,6 +7,11 @@ import React from "react";
 interface UseAutoOpenFilesPanelProps {
   isLastMessage: boolean;
   agentMessage: AgentMessageWithStreaming;
+  // When the same message is opening an interactive content file (a Frame) in
+  // the side panel, defer to it instead of stealing the panel for the file
+  // explorer. Owned by useAutoOpenInteractiveContent, the single source of
+  // truth for that decision.
+  deferToInteractiveContent: boolean;
 }
 
 /**
@@ -16,6 +21,7 @@ interface UseAutoOpenFilesPanelProps {
 export function useAutoOpenFilesPanel({
   isLastMessage,
   agentMessage,
+  deferToInteractiveContent,
 }: UseAutoOpenFilesPanelProps) {
   const { openPanel, currentPanel } = useConversationSidePanelContext();
   const isMobile = useIsMobile();
@@ -38,7 +44,8 @@ export function useAutoOpenFilesPanel({
       regularGeneratedFiles.length === 0 ||
       !isLastMessage ||
       autoOpenedForRef.current === agentMessage.sId ||
-      currentPanel === "files"
+      currentPanel === "files" ||
+      deferToInteractiveContent
     ) {
       return;
     }
@@ -47,6 +54,7 @@ export function useAutoOpenFilesPanel({
     openPanel({ type: "files" });
   }, [
     regularGeneratedFiles,
+    deferToInteractiveContent,
     isLastMessage,
     agentMessage.sId,
     openPanel,

--- a/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
+++ b/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
@@ -113,7 +113,17 @@ export function useAutoOpenInteractiveContent({
     lastOpenedFileIdRef.current = null;
   }, [agentMessage.sId]);
 
+  // Mirrors the open conditions in the effect above: a Frame opens from
+  // streaming progress at any time, or from a completed file on the last
+  // message. Consumers (e.g. the files panel) use this to defer to the Frame
+  // instead of opening a competing panel for the same message.
+  const willOpenInteractiveContent =
+    !isMobile &&
+    (interactiveFilesFromProgress.length > 0 ||
+      (completedInteractiveFiles.length > 0 && isLastMessage));
+
   return {
     interactiveFiles: completedInteractiveFiles,
+    willOpenInteractiveContent,
   };
 }


### PR DESCRIPTION
## Summary

When an activation-flow agent message writes an interactive content file (a Frame) **and** a regular file (e.g. `AGENTS.md`) in the same turn, the Frame side panel would flash open and then get replaced by the file explorer.

Root cause: two auto-open hooks fire on the same message. `useAutoOpenInteractiveContent` opens the Frame in the side panel, then `useAutoOpenFilesPanel` runs and clobbers it with the file explorer.

Fix: `useAutoOpenInteractiveContent` now exposes `willOpenInteractiveContent` — the single source of truth for whether a Frame is opening for this message (covering both the streaming-progress and completed-file paths). `useAutoOpenFilesPanel` defers to that flag instead of re-deriving its own guess from `generatedFiles`. This keeps the Frame panel in front and also handles the streaming-progress window (where the Frame is opening from progress notifications before the file lands in `generatedFiles`).

## Testing

- `npx tsgo --noEmit`: no new errors introduced (the 4 pre-existing errors are in `lib/api/llm/.../test/fixtures/` and unrelated to this change).
- `biome check --changed`: no fixes applied, no warnings.

## Risk

Low. The behavior only changes for messages that open a Frame: the files panel now defers to the Frame instead of taking over. Messages that produce only regular files still auto-open the files panel exactly as before. `useAutoOpenFilesPanel` is used across all conversations (not just activation Pods), so the defer applies anywhere a single message emits both a Frame and regular files — which is the intended behavior.

## Testing Plan

- In an activation Pod, send a message that produces both a Frame and a regular file (e.g. `AGENTS.md`); confirm the Frame stays open in the side panel and the file explorer does not take over.
- Send a message that produces only regular files; confirm the files panel still auto-opens.
- Confirm the Frame still auto-opens while streaming (progress) and on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)