### PR TITLE
Improve OpenAI prompt cache reuse across conversations

### DIFF
--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -33,6 +33,7 @@ import {
   responseToLLMEvents,
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
+import { getOpenAIPromptCacheKey } from "@app/lib/api/llm/utils/prompt_cache_key";
 import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/api/llm/utils/tool_search";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -146,7 +147,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
           ? ["reasoning.encrypted_content"]
           : [],
       tool_choice: toToolOption(specifications, streamParameters),
-      ...(metadata ? { prompt_cache_key: metadata.conversationId } : {}),
+      ...(metadata
+        ? { prompt_cache_key: getOpenAIPromptCacheKey(metadata) }
+        : {}),
     };
   }
 
@@ -185,9 +188,10 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     const lines = Array.from(conversations.entries()).map(
       ([customId, streamParams]) => {
         const body = {
-          ...this.buildRequestPayload(streamParams, {
-            conversationId: customId,
-          }),
+          ...this.buildRequestPayload(streamParams),
+          // Batch inputs do not carry agent configuration metadata, so preserve
+          // the existing per-conversation cache routing for this surface.
+          prompt_cache_key: customId,
           stream: false,
         };
         return JSON.stringify({

--- a/front/lib/api/llm/clients/openai/prompt_cache_key.test.ts
+++ b/front/lib/api/llm/clients/openai/prompt_cache_key.test.ts
@@ -1,0 +1,92 @@
+import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
+import { describe, expect, it, vi } from "vitest";
+
+const kit = vi.hoisted(() => {
+  const requests: Array<{ prompt_cache_key?: string }> = [];
+  const emptyStream = () => (async function* () {})();
+
+  class MockOpenAI {
+    responses = {
+      create: (request: { prompt_cache_key?: string }) => {
+        requests.push(request);
+        return emptyStream();
+      },
+    };
+  }
+
+  return { MockOpenAI, requests };
+});
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openai")>();
+  return { ...actual, OpenAI: kit.MockOpenAI };
+});
+
+function streamParameters(conversationId: string): LLMStreamParameters {
+  return {
+    conversation: {
+      messages: [
+        {
+          role: "user",
+          name: "User",
+          content: [{ type: "text", text: conversationId }],
+        },
+      ],
+    },
+    prompt: "You are a helpful assistant.",
+    specifications: [],
+  };
+}
+
+describe("OpenAI prompt cache key", () => {
+  it("reuses the key across conversations for the same workspace and agent", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const firstConversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const secondConversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const llm = new OpenAIResponsesLLM(authenticator, {
+      credentials: { OPENAI_API_KEY: "test-openai-key" },
+      modelId: GPT_5_6_LUNA_MODEL_ID,
+      bypassFeatureFlag: true,
+    });
+    const metadata = {
+      workspaceId: workspace.sId,
+      agentConfigurationId: agent.sId,
+    };
+
+    expect(firstConversation.sId).not.toBe(secondConversation.sId);
+
+    for await (const _ of llm.stream(
+      streamParameters(firstConversation.sId),
+      metadata
+    )) {
+      // Drain the mocked stream.
+    }
+    for await (const _ of llm.stream(
+      streamParameters(secondConversation.sId),
+      metadata
+    )) {
+      // Drain the mocked stream.
+    }
+
+    const expectedKey = `${workspace.sId}:${agent.sId}`;
+    expect(kit.requests.map((request) => request.prompt_cache_key)).toEqual([
+      expectedKey,
+      expectedKey,
+    ]);
+  });
+});

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -27,7 +27,10 @@ import {
   readEndpointInfo,
 } from "@app/lib/api/llm/tests/parity/providers";
 import { StreamEndpointTransition } from "@app/lib/api/llm/transitionLLM";
-import type { LLMParameters } from "@app/lib/api/llm/types/options";
+import type {
+  LLMParameters,
+  LLMStreamMetadata,
+} from "@app/lib/api/llm/types/options";
 import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
 import {
   AGENT_PLATFORM_HOST,
@@ -147,6 +150,10 @@ const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS)
       endpoint.host !== AGENT_PLATFORM_HOST
   );
 const MATRIX = buildParityMatrix();
+const STREAM_METADATA: LLMStreamMetadata = {
+  workspaceId: "workspace-123",
+  agentConfigurationId: "agent-456",
+};
 
 describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
   "LLM router request parity (legacy vs new)",
@@ -183,10 +190,10 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
             );
 
             const oldErr = await drain(
-              oldLLM.stream(testCase.streamParameters)
+              oldLLM.stream(testCase.streamParameters, STREAM_METADATA)
             );
             const newErr = await drain(
-              newLLM.stream(testCase.streamParameters)
+              newLLM.stream(testCase.streamParameters, STREAM_METADATA)
             );
 
             const oldReq = provider.selectOldRequest(

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -28,6 +28,7 @@ import {
   parseReasoningMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
+import { getOpenAIPromptCacheKey } from "@app/lib/api/llm/utils/prompt_cache_key";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
@@ -823,10 +824,13 @@ export class StreamEndpointTransition extends BaseTransition {
     // needs an explicit breakpoint on the conversation tail (legacy's isLast).
     const explicitTailBreakpoint = api === AGENT_PLATFORM_HOST;
     // Only OpenAI Responses consumes a prompt cache key (as `prompt_cache_key`);
-    // legacy sent the conversationId. Other surfaces guard `cacheKey` to
+    // use the workspace and agent configuration so requests can reuse cached
+    // prefixes across conversations. Other surfaces guard `cacheKey` to
     // undefined, so leave it unset for them.
     const cacheKey =
-      api === OPENAI_RESPONSES_HOST ? metadata?.conversationId : undefined;
+      api === OPENAI_RESPONSES_HOST && metadata
+        ? getOpenAIPromptCacheKey(metadata)
+        : undefined;
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters, { explicitTailBreakpoint }),
       this.buildConfig(

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -170,7 +170,8 @@ export type LLMStreamParameters = LLMStreamParametersBase &
   ExclusiveToolChoiceParameters;
 
 export interface LLMStreamMetadata {
-  conversationId: string;
+  agentConfigurationId: string;
+  workspaceId: string;
 }
 
 // Omit the base fields only and re-intersect the tool-choice union: a plain

--- a/front/lib/api/llm/utils/prompt_cache_key.ts
+++ b/front/lib/api/llm/utils/prompt_cache_key.ts
@@ -1,0 +1,8 @@
+import type { LLMStreamMetadata } from "@app/lib/api/llm/types/options";
+
+export function getOpenAIPromptCacheKey({
+  agentConfigurationId,
+  workspaceId,
+}: LLMStreamMetadata): string {
+  return `${workspaceId}:${agentConfigurationId}`;
+}

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -300,7 +300,8 @@ export async function getOutputFromLLMStream(
       previousMessageId,
     },
     {
-      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+      agentConfigurationId: agentConfiguration.sId,
     }
   );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
OpenAI prompt caching requires requests to share both an identical prompt prefix and a stable cache key. We
currently use the conversation identifier as that key, which prevents cache reuse between separate conversations
even when their instructions, tools, context, and explicit cache breakpoints are identical. See documentation [here](https://developers.openai.com/api/docs/guides/prompt-caching).

This was observable in two requests made minutes apart: their reusable prefixes were byte-for-byte identical, but
their cache keys differed because they originated from different conversations.

## Change

Streaming OpenAI requests now use `<workspaceId>:<agentConfigurationId>` as their cache key.

This allows conversations using the same agent in the same workspace to reuse cached prompt prefixes. Workspace
isolation is preserved, and partitioning by agent reduces.

> [!WARNING]
> OpenAI's recommendation is approximately 15 requests per minute for a single key. We will monitor cache usage for it.

The key does not permit incorrect cache reuse. OpenAI still requires an exact prefix match, including instructions,
messages, tools, schemas, ordering, and cache breakpoints.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
