### PR TITLE
[Slack MCP] Strengthen footer-removal guardrail in tool descriptions

### DIFF
--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -479,6 +479,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "post a message to a slack channel as the workspace bot",
     expected: "slack_bot.post_message",
+    maxRank: 2, // showSentByFooter guardrail wording lengthens the doc, add_reaction edges it out
   },
   {
     query: "edit a message the slack bot posted",

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -57,7 +57,7 @@ export const SLACK_BOT_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
+          "Include the 'Sent via [AgentName] on Dust' footer. Set false only when explicitly asked to remove the footer, never for formatting or brevity."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -57,7 +57,7 @@ export const SLACK_BOT_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Set to false only when explicitly asked to omit it."
+          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -138,7 +138,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Set to false only when explicitly asked to omit it."
+          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
         ),
     },
     stake: "medium",
@@ -196,7 +196,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Set to false only when explicitly asked to omit it."
+          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
         ),
     },
     stake: "medium",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -138,7 +138,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
+          "Include the 'Sent via [AgentName] on Dust' footer. Set false only when explicitly asked to remove the footer, never for formatting or brevity."
         ),
     },
     stake: "medium",
@@ -196,7 +196,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = [
         .optional()
         .default(true)
         .describe(
-          "Include the 'Sent via [AgentName] on Dust' footer. Keep true unless the user or your instructions explicitly ask to remove the footer or attribution itself. General formatting, brevity, or 'no metadata' guidelines are NOT a reason to set false."
+          "Include the 'Sent via [AgentName] on Dust' footer. Set false only when explicitly asked to remove the footer, never for formatting or brevity."
         ),
     },
     stake: "medium",


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9776
Context: [slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1784806109976979?thread_ts=1784806109.976979&cid=C050A0S2Z7F)

Investigation of the missing "Sent via [Agent] on Dust" footer showed the footer logic itself works. The affected message ("Docs audit: No new candidate today ✅" in #documentation) was posted by the `dust` agent which **explicitly passed `show_sent_by_footer: false`** (visible in the stored tool inputs), even though nothing in the trigger prompt or skill asked to remove the footer. The workspace has `slackPersonalAllowFooterRemoval` enabled, so the parameter was exposed to the model.

The trigger prompt required the parent message to be "a single line containing only the suggestion title... No links, no metadata" — the model treated the footer as "metadata" and dropped it on its own. The current parameter description ("Set to false only when explicitly asked to omit it") is too weak to prevent this.

This PR strengthens the parameter description on both Slack MCP servers (`slack_personal` `post_message`/`schedule_message`, `slack_bot` `post_message`, the latter added in https://github.com/dust-tt/dust/pull/29341) so that only an explicit request to remove the footer itself qualifies, and formatting/brevity instructions do not.

The slightly longer description dilutes the BM25 tool-search score of `slack_bot.post_message` just enough for `slack_bot.add_reaction` to edge it out on one ranking assertion; that expectation is relaxed to rank ≤ 2 with a comment (precedent exists in the test file).

Follows https://github.com/dust-tt/dust/pull/28203 and https://github.com/dust-tt/dust/pull/29341.

## Risks

Blast radius: agent-facing tool descriptions of the Slack MCP post/schedule message tools; no behavior change in code paths.
Risk: none

## Deploy Plan

- deploy front