### PR TITLE
Harden sandbox uid 1002 service boundary

### DIFF
--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -246,6 +246,10 @@ describe("GCS credential lifecycle", () => {
     expect(command).toContain(
       "/usr/local/bin/dust-gcs-token-firewall.sh; firewall_exit=$?"
     );
+    expect(command).toContain("/usr/sbin/runuser -u agent -- /usr/bin/curl");
+    expect(command).toContain(
+      "/usr/sbin/runuser -u agent-proxied -- /usr/bin/curl"
+    );
     expect(command).toContain("--connect-timeout 0.3 --max-time 1");
     expect(command).toContain("deny_check_exit -ne 28");
     expect(command.indexOf("exit $firewall_exit")).toBeLessThan(

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -29,6 +29,7 @@ const TOKEN_FIREWALL_PATH = "/usr/local/bin/dust-gcs-token-firewall.sh";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
+const TOKEN_BROKER_DENIED_USERS = ["agent", "agent-proxied"] as const;
 
 class GCSMountImageHelperUnavailableError extends Error {
   constructor(
@@ -108,9 +109,10 @@ export type GCSMountTarget = {
  *
  * Mounts one GCS prefix per target via gcsfuse using a per-target CAB-scoped downscoped token
  * served by a root-owned HTTP token server baked into the sandbox image. The server listens on a
- * privileged loopback port and a dedicated nftables table denies the untrusted workload UID access
- * to that port, including when dev-unrestricted egress removes the general egress table. The UID
- * firewall is the sole caller-authorization control; token ids are routing names, not secrets.
+ * privileged loopback port and a dedicated nftables table denies every Front-controlled non-root
+ * UID access to that port, including when dev-unrestricted egress removes the general egress table.
+ * The UID firewall is the sole caller-authorization control; token ids are routing names, not
+ * secrets.
  *
  * Each token has one unconditional rule plus two rules for its single prefix. The existing
  * four-target limit is retained as an operational guard on concurrent mounts.
@@ -181,6 +183,17 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     // 3-4. Start the root-owned token server and poll it ready in
     // ONE exec. Polling every 50ms returns the instant the server is listening
     // instead of a flat sleep 1, and folds three round-trips into one.
+    const tokenBrokerDenyChecks = TOKEN_BROKER_DENIED_USERS.map(
+      (user) =>
+        `/usr/sbin/runuser -u ${user} -- /usr/bin/curl -sf --connect-timeout 0.3 --max-time 1 ${tokenUrl(0)} > /dev/null 2>&1; ` +
+        `deny_check_exit=$?; ` +
+        `if [ $deny_check_exit -eq 0 ]; then ` +
+        `/usr/bin/printf 'GCS token firewall deny-check unexpectedly reached the broker as ${user}\\n' >&2; ` +
+        `exit 1; fi; ` +
+        `if [ $deny_check_exit -ne 28 ]; then ` +
+        `/usr/bin/printf 'GCS token firewall deny-check for ${user} could not be verified (exit code %s)\\n' "$deny_check_exit" >&2; ` +
+        `exit 1; fi; `
+    ).join("");
     const tokenServerResult = await traceSandboxStartupPhase(
       "gcs.token_server",
       () =>
@@ -199,14 +212,7 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
               `if ! /usr/bin/curl -sf ${TOKEN_SERVER_HEALTH_URL} > /dev/null 2>&1; then ` +
               `/usr/bin/sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; ` +
               `i=$((i+1)); continue; fi; ` +
-              `/usr/sbin/runuser -u agent-proxied -- /usr/bin/curl -sf --connect-timeout 0.3 --max-time 1 ${tokenUrl(0)} > /dev/null 2>&1; ` +
-              `deny_check_exit=$?; ` +
-              `if [ $deny_check_exit -eq 0 ]; then ` +
-              `/usr/bin/printf 'GCS token firewall deny-check unexpectedly reached the broker\\n' >&2; ` +
-              `exit 1; fi; ` +
-              `if [ $deny_check_exit -ne 28 ]; then ` +
-              `/usr/bin/printf 'GCS token firewall deny-check could not be verified (exit code %s)\\n' "$deny_check_exit" >&2; ` +
-              `exit 1; fi; ` +
+              tokenBrokerDenyChecks +
               `exit 0; ` +
               `done; ` +
               `/usr/bin/printf 'GCS token server readiness timed out\\n' >&2; exit 1`,

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -254,7 +254,12 @@ describe("sandbox egress helpers", () => {
     expect(healthCall).toContain("/opt/bin/dsbx healthcheck");
     expect(healthCall).toContain("--forwarder-listen 127.0.0.1:9990");
     expect(healthCall).toContain("--resolver-listen 127.0.0.1:1053");
+    expect(healthCall).toContain("--proxied-uid 1002");
     expect(healthCall).toContain("--proxied-uid 1003");
+    expect(healthCall).toContain("/usr/bin/jq -e '.forwarder_port_ok == true");
+    expect(healthCall).toContain(".nft_ipv6_drop_ok == true'");
+    expect(healthCall).not.toContain(".bundle_ok == true");
+    expect(healthCall).not.toContain(".ok == true");
     // The healthcheck inspects nftables, which requires CAP_NET_ADMIN, so it
     // must run as root. Pin the exec options to prevent silent regression.
     expect(sandbox.execRoot).toHaveBeenNthCalledWith(

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -7,7 +7,7 @@ import {
   writeEgressSecretsFile,
 } from "@app/lib/api/sandbox/egress_secrets";
 import { writeSandboxEnvManifestFile } from "@app/lib/api/sandbox/env_manifest";
-import { SANDBOX_AGENT_PROXIED_UID } from "@app/lib/api/sandbox/image/types";
+import { SANDBOX_EGRESS_CONTROLLED_UIDS } from "@app/lib/api/sandbox/image/types";
 import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import {
@@ -29,7 +29,6 @@ import { fromError } from "zod-validation-error";
 
 const EGRESS_FORWARDER_LISTEN_ADDR = "127.0.0.1:9990";
 const EGRESS_RESOLVER_LISTEN_ADDR = "127.0.0.1:1053";
-const EGRESS_PROXIED_UID = SANDBOX_AGENT_PROXIED_UID;
 const EGRESS_TOKEN_DIR = "/etc/dust";
 const EGRESS_TOKEN_PATH = "/etc/dust/egress-token";
 const EGRESS_DENY_LOG_PATH = "/tmp/dust-egress-denied.log";
@@ -195,6 +194,67 @@ const FAILED_EGRESS_HEALTH_STATE: EgressHealthState = {
   bundleOk: false,
 };
 
+function buildEgressHealthcheckCommand(): RootCommand {
+  const commands = SANDBOX_EGRESS_CONTROLLED_UIDS.map((uid) =>
+    rootCommand.exec("/opt/bin/dsbx", [
+      "healthcheck",
+      "--forwarder-listen",
+      EGRESS_FORWARDER_LISTEN_ADDR,
+      "--resolver-listen",
+      EGRESS_RESOLVER_LISTEN_ADDR,
+      "--proxied-uid",
+      uid,
+      "--ca-bundle",
+      MITM_CA_BUNDLE_PATH,
+      "--ca-bundle-marker",
+      MITM_CA_BUNDLE_MARKER_PATH,
+    ])
+  );
+  const finalCommand = commands[commands.length - 1];
+  if (!finalCommand) {
+    throw new Error("At least one sandbox egress-controlled UID is required.");
+  }
+
+  // The trust bundle is installed only after the first forwarder/nftables
+  // health pass. It is global rather than UID-specific, so prerequisite UIDs
+  // validate only the shared listeners and their own nftables enforcement.
+  // The final UID's full JSON is parsed below, where bundleOk remains a
+  // separate signal for the existing install/self-heal flow.
+  const jqEgressBoundaryOkCommand = renderRootCommand(
+    rootCommand.exec("/usr/bin/jq", [
+      "-e",
+      [
+        ".forwarder_port_ok == true",
+        ".resolver_udp_ok == true",
+        ".resolver_tcp_ok == true",
+        ".nft_dns_udp_redirect_ok == true",
+        ".nft_dns_tcp_redirect_ok == true",
+        ".nft_dns_udp_accept_ok == true",
+        ".nft_tcp_forward_redirect_ok == true",
+        ".nft_loopback_ssh_drop_ok == true",
+        ".nft_udp_drop_ok == true",
+        ".nft_icmp_drop_ok == true",
+        ".nft_ipv6_drop_ok == true",
+      ].join(" and "),
+    ])
+  );
+  const prerequisiteChecks = commands.slice(0, -1).map((command, index) => {
+    const resultVariable = `_dust_egress_health_${index}`;
+    return [
+      `${resultVariable}=$(${renderRootCommand(command)}) || exit $?;`,
+      `if ! /usr/bin/printf %s "$${resultVariable}" | ${jqEgressBoundaryOkCommand} >/dev/null; then`,
+      `/usr/bin/printf '%s\\n' "$${resultVariable}" >&2;`,
+      "exit 1;",
+      "fi;",
+    ].join(" ");
+  });
+
+  return rootCommand.unsafeShell(
+    [...prerequisiteChecks, renderRootCommand(finalCommand)].join(" "),
+    "validate the complete fixed set of sandbox egress-controlled UIDs in one healthcheck exec"
+  );
+}
+
 function parseEgressHealthcheckOutput(
   stdout: string,
   logContext: Record<string, unknown>
@@ -264,28 +324,15 @@ async function checkEgressForwarderHealth(
     event: "egress.healthcheck_parse",
     providerId: sandbox.providerId,
     sandboxId: sandbox.sId,
+    controlledUids: SANDBOX_EGRESS_CONTROLLED_UIDS,
   };
 
   // Root is required: `nft list table` needs CAP_NET_ADMIN, and the probe also
   // reads /proc/net/{tcp,udp} which is fine non-root but pointless to split.
   const result = await traceSandboxStartupPhase("egress.healthcheck", () =>
-    sandbox.execRoot(
-      auth,
-      rootCommand.exec("/opt/bin/dsbx", [
-        "healthcheck",
-        "--forwarder-listen",
-        EGRESS_FORWARDER_LISTEN_ADDR,
-        "--resolver-listen",
-        EGRESS_RESOLVER_LISTEN_ADDR,
-        "--proxied-uid",
-        EGRESS_PROXIED_UID,
-        "--ca-bundle",
-        MITM_CA_BUNDLE_PATH,
-        "--ca-bundle-marker",
-        MITM_CA_BUNDLE_MARKER_PATH,
-      ]),
-      { timeoutMs: 1_000 }
-    )
+    sandbox.execRoot(auth, buildEgressHealthcheckCommand(), {
+      timeoutMs: 1_000,
+    })
   );
 
   if (result.isErr()) {
@@ -443,7 +490,7 @@ export async function ensureSandboxEgressOnExec(
 }
 
 // Dev-only: tear down the in-sandbox nftables redirect baked into the image
-// (see egress-nftables.sh in the image registry) so agent-proxied traffic
+// (see egress-nftables.sh in the image registry) so controlled non-root traffic
 // flows direct out of the (now permissive) E2B network, instead of being
 // redirected to the local forwarder port that has no listener in this mode.
 // Keep the dedicated GCS broker drop in place: that credential boundary must

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -1,6 +1,18 @@
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 
 export const SANDBOX_ROOT_SAFE_PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin";
+export const SANDBOX_AGENT_SAFE_PATH = SANDBOX_ROOT_SAFE_PATH;
+export const SANDBOX_AGENT_SERVICE_HOME = "/var/empty";
+export const SANDBOX_AGENT_PROXIED_SAFE_PATH = [
+  "/opt/venv/bin",
+  "/opt/bin",
+  "/usr/local/sbin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/usr/bin",
+  "/sbin",
+  "/bin",
+].join(":");
 export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
   "/opt/bin",
   "/usr/local",
@@ -51,6 +63,46 @@ export const SANDBOX_ROOT_INVOKED_HELPERS = [
 const ROOT_SAFE_PATH_PROFILE = "/etc/profile.d/zz-dust-root-safe-path.sh";
 const STATIC_ROOT_CONSUMED_DIRS = SANDBOX_STATIC_ROOT_CONSUMED_DIRS.join(" ");
 const ROOT_INVOKED_HELPERS = SANDBOX_ROOT_INVOKED_HELPERS.join(" ");
+
+export function getSandboxServicePathHardeningCommand(): string {
+  const hardenAgentHome = [
+    `/usr/bin/install -d -o root -g root -m 755 ${SANDBOX_AGENT_SERVICE_HOME}`,
+    `/usr/sbin/usermod --home ${SANDBOX_AGENT_SERVICE_HOME} agent`,
+    "/bin/rm -f /home/agent/.bash_profile /home/agent/.bash_login /home/agent/.profile /home/agent/.bashrc",
+    "/usr/bin/chown -R root:agent /home/agent",
+    "/bin/chmod -R go-w /home/agent",
+    "/usr/bin/find /home/agent -type d -exec /bin/chmod 2750 {} +",
+  ].join(" && ");
+  const hardenPythonVenv = [
+    "/usr/bin/chown -R root:root /opt/venv",
+    "/bin/chmod -R go-w /opt/venv",
+    "/usr/bin/find /opt/venv -type d -exec /bin/chmod 755 {} +",
+  ].join(" && ");
+  const hardenDustProfiles = [
+    "/usr/bin/chown -R root:root /opt/dust/profile",
+    "/bin/chmod -R go-w /opt/dust/profile",
+    "/usr/bin/find /opt/dust/profile -type d -exec /bin/chmod 755 {} +",
+    "/bin/chmod 644 /opt/dust/profile/*.sh",
+    "/bin/chmod 755 /opt/dust/profile/dust-tools /opt/dust/profile/soffice/*.py",
+  ].join(" && ");
+  const assertPermissions = [
+    `if [ "$(/usr/bin/getent passwd agent | /usr/bin/cut -d: -f6)" != ${SANDBOX_AGENT_SERVICE_HOME} ]; then`,
+    "echo 'agent service account must use the root-owned empty home' >&2;",
+    "exit 1;",
+    "fi;",
+    "if /usr/bin/find /home/agent /opt/venv /opt/dust/profile \\( -type f -o -type d \\) -perm /022 -print -quit | /usr/bin/grep -q .; then",
+    "echo 'sandbox service paths must not be group/other writable' >&2;",
+    "exit 1;",
+    "fi",
+  ].join(" ");
+
+  return [
+    hardenAgentHome,
+    hardenPythonVenv,
+    hardenDustProfiles,
+    assertPermissions,
+  ].join(" && ");
+}
 
 export function getRootConsumedPathHardeningCommand(): string {
   const hardenStaticRootConsumedDirs = [

--- a/front/lib/api/sandbox/image/egress/dust-egress-nftables.service
+++ b/front/lib/api/sandbox/image/egress/dust-egress-nftables.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=Dust egress nftables rules for agent-proxied
-After=network.target
+Description=Dust egress nftables rules for sandbox-controlled accounts
+After=network.target systemd-resolved.service dust-egress-resolver.service
 
 [Service]
 Type=oneshot

--- a/front/lib/api/sandbox/image/egress/dust-egress-resolver.service
+++ b/front/lib/api/sandbox/image/egress/dust-egress-resolver.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Dust local DNS resolver for agent-proxied
-After=network.target
+Description=Dust synthetic DNS resolver for sandbox-controlled accounts
+Wants=systemd-resolved.service
+After=network.target systemd-resolved.service
 Before=dust-egress-nftables.service
 
 [Service]

--- a/front/lib/api/sandbox/image/egress/dust-resolve1.conf
+++ b/front/lib/api/sandbox/image/egress/dust-resolve1.conf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "https://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+  <!--
+    systemd-resolved's vendor policy allows every system-bus client to issue
+    resolver requests. These two accounts must use the synthetic DNS listener
+    selected by nftables instead of delegating real DNS to systemd-resolved.
+  -->
+  <policy user="agent">
+    <deny send_destination="org.freedesktop.resolve1"/>
+  </policy>
+  <policy user="agent-proxied">
+    <deny send_destination="org.freedesktop.resolve1"/>
+  </policy>
+</busconfig>

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 set -eu
 
-PROXIED_UID=1003
+CONTROLLED_UIDS="1002 1003"
 DNS_STUB_PORT=1053
 GCS_TOKEN_SERVER_PORT=987
+SYSTEM_RESOLV_CONF=/run/systemd/resolve/stub-resolv.conf
+
+# Keep the machine-wide resolver local. Service users not covered by the
+# sandbox egress boundary use systemd-resolved, while controlled UIDs are
+# redirected below to the synthetic resolver before reaching the local stub.
+test -s "$SYSTEM_RESOLV_CONF"
+/bin/ln -sfn "$SYSTEM_RESOLV_CONF" /etc/resolv.conf
 
 # Reinstall a single canonical ruleset on every sandbox boot.
 nft delete table ip dust-egress 2>/dev/null || true
@@ -14,36 +21,39 @@ nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; 
 nft add chain ip dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
 
 # nat/OUTPUT runs before filter/OUTPUT for locally generated packets.
-# DNS interception must run before loopback/private exemptions and before the
-# broad TCP redirect so every port-53 packet lands on the local stub.
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID udp dport 53 redirect to :$DNS_STUB_PORT
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport 53 redirect to :$DNS_STUB_PORT
-
-# Other exemptions must land in nat before the broad TCP redirect so filter
-# drops still see the original destination. The 127.0.0.0/8 return is
-# load-bearing for the loopback SSH drop below: without it the broad TCP
-# redirect would rewrite dport to 9990 before filter_output ever sees port 22.
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 return
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 return
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 10.0.0.0/8 return
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 172.16.0.0/12 return
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 192.168.0.0/16 return
-nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990
-
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
-# The GCS token broker serves live bearer credentials. Keep the untrusted workload UID out.
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
-# Loopback SSH kill switch: the image masks sshd, this drops uid 1003 to local
-# tcp/22 in case anything restores it. IPv6 ::1:22 is covered by the catch-all
-# ip6 drop below. Relies on the 127.0.0.0/8 return in nat_output above.
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 10.0.0.0/8 drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 172.16.0.0/12 drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 192.168.0.0/16 drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID meta l4proto udp drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID meta l4proto icmp drop
-
 nft add table ip6 dust-egress
 nft add chain ip6 dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
-nft add rule ip6 dust-egress filter_output meta skuid $PROXIED_UID drop
+
+for CONTROLLED_UID in $CONTROLLED_UIDS; do
+  # DNS interception must run before loopback/private exemptions and before
+  # the broad TCP redirect so every port-53 packet lands on the local stub.
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID udp dport 53 redirect to :$DNS_STUB_PORT
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport 53 redirect to :$DNS_STUB_PORT
+
+  # Other exemptions must land in nat before the broad TCP redirect so filter
+  # drops still see the original destination. The 127.0.0.0/8 return is
+  # load-bearing for the loopback SSH drop below: without it the broad TCP
+  # redirect would rewrite dport to 9990 before filter_output sees port 22.
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 return
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 return
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 return
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 return
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 return
+  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport != 0 redirect to :9990
+
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
+  # The GCS token broker serves live bearer credentials. Keep every
+  # Front-controlled non-root UID out.
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
+  # Loopback SSH kill switch: the image masks sshd, this drops controlled UIDs
+  # to local tcp/22 in case anything restores it. IPv6 ::1:22 is covered by
+  # the catch-all ip6 drop below.
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto udp drop
+  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto icmp drop
+  nft add rule ip6 dust-egress filter_output meta skuid $CONTROLLED_UID drop
+done

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -9,51 +9,51 @@ SYSTEM_RESOLV_CONF=/run/systemd/resolve/stub-resolv.conf
 # Keep the machine-wide resolver local. Service users not covered by the
 # sandbox egress boundary use systemd-resolved, while controlled UIDs are
 # redirected below to the synthetic resolver before reaching the local stub.
-test -s "$SYSTEM_RESOLV_CONF"
+[ -s "$SYSTEM_RESOLV_CONF" ]
 /bin/ln -sfn "$SYSTEM_RESOLV_CONF" /etc/resolv.conf
 
 # Reinstall a single canonical ruleset on every sandbox boot.
-nft delete table ip dust-egress 2>/dev/null || true
-nft delete table ip6 dust-egress 2>/dev/null || true
+/usr/sbin/nft delete table ip dust-egress 2>/dev/null || true
+/usr/sbin/nft delete table ip6 dust-egress 2>/dev/null || true
 
-nft add table ip dust-egress
-nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; policy accept ; }'
-nft add chain ip dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
+/usr/sbin/nft add table ip dust-egress
+/usr/sbin/nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; policy accept ; }'
+/usr/sbin/nft add chain ip dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
 
 # nat/OUTPUT runs before filter/OUTPUT for locally generated packets.
-nft add table ip6 dust-egress
-nft add chain ip6 dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
+/usr/sbin/nft add table ip6 dust-egress
+/usr/sbin/nft add chain ip6 dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'
 
 for CONTROLLED_UID in $CONTROLLED_UIDS; do
   # DNS interception must run before loopback/private exemptions and before
   # the broad TCP redirect so every port-53 packet lands on the local stub.
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID udp dport 53 redirect to :$DNS_STUB_PORT
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport 53 redirect to :$DNS_STUB_PORT
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID udp dport 53 redirect to :$DNS_STUB_PORT
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport 53 redirect to :$DNS_STUB_PORT
 
   # Other exemptions must land in nat before the broad TCP redirect so filter
   # drops still see the original destination. The 127.0.0.0/8 return is
   # load-bearing for the loopback SSH drop below: without it the broad TCP
   # redirect would rewrite dport to 9990 before filter_output sees port 22.
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 return
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 return
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 return
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 return
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 return
-  nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport != 0 redirect to :9990
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 return
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 return
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 return
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 return
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 return
+  /usr/sbin/nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport != 0 redirect to :9990
 
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
   # The GCS token broker serves live bearer credentials. Keep every
   # Front-controlled non-root UID out.
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
   # Loopback SSH kill switch: the image masks sshd, this drops controlled UIDs
   # to local tcp/22 in case anything restores it. IPv6 ::1:22 is covered by
   # the catch-all ip6 drop below.
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto udp drop
-  nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto icmp drop
-  nft add rule ip6 dust-egress filter_output meta skuid $CONTROLLED_UID drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 10.0.0.0/8 drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 172.16.0.0/12 drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 192.168.0.0/16 drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto udp drop
+  /usr/sbin/nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID meta l4proto icmp drop
+  /usr/sbin/nft add rule ip6 dust-egress filter_output meta skuid $CONTROLLED_UID drop
 done

--- a/front/lib/api/sandbox/image/egress/systemd-resolved-ipc.conf
+++ b/front/lib/api/sandbox/image/egress/systemd-resolved-ipc.conf
@@ -1,0 +1,4 @@
+[Service]
+# systemd-resolved creates its resolver Varlink socket as mode 0666. Keep it
+# available to root and the daemon itself, but not to egress-controlled users.
+ExecStartPost=/bin/chmod 0600 /run/systemd/resolve/io.systemd.Resolve

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -20,7 +20,7 @@ import {
 import { getSandboxImageFromRegistry } from "@app/lib/api/sandbox/image/registry";
 import {
   type Operation,
-  SANDBOX_UNTRUSTED_UIDS,
+  SANDBOX_EGRESS_CONTROLLED_UIDS,
 } from "@app/lib/api/sandbox/image/types";
 import { SANDBOX_TRUST_ENV_VARS } from "@app/lib/api/sandbox/trust_env";
 import { describe, expect, test } from "vitest";
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.64",
+      tag: "0.8.65",
     });
   });
 
@@ -106,28 +106,54 @@ describe("sandbox image registry", () => {
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
+        expect.stringContaining("groupadd --gid 1003 agent-proxied"),
         expect.stringContaining(
-          "install -d -o agent -g agent -m 2775 /home/agent/.local /home/agent/.local/bin"
+          "useradd --create-home --uid 1003 --gid agent-proxied --groups agent --shell /bin/bash agent-proxied"
         ),
-        expect.stringContaining(
-          "useradd --create-home --uid 1003 --gid agent --shell /bin/bash agent-proxied"
-        ),
-        expect.stringContaining(
-          "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files"
-        ),
-        expect.stringContaining(
-          "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files"
-        ),
-        expect.stringContaining(
-          "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files"
-        ),
-        expect.stringContaining(
-          "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files"
-        ),
+        expect.stringContaining("chgrp agent /files"),
+        expect.stringContaining("chmod 2775 /files"),
+        expect.stringContaining("setfacl -R -d -m g::rwx /files"),
+        expect.stringContaining("setfacl -R -m g::rwx /files"),
         expect.stringContaining(
           "useradd --system --no-create-home --gid dust-egress-resolver --shell /usr/sbin/nologin dust-egress-resolver"
         ),
       ])
+    );
+
+    expect(runCommands.join("\n")).not.toContain("chmod g+ws /home/agent");
+    expect(runCommands.join("\n")).not.toContain(
+      "setfacl -R -d -m g::rwx /home/agent"
+    );
+  });
+
+  test("locks service-owned runtime paths after all package installs", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const permissionCommand = runCommands.find((command) =>
+      command.includes("sandbox service paths must not be group/other writable")
+    );
+
+    expect(permissionCommand).toBeDefined();
+    expect(permissionCommand).toContain(
+      "/usr/bin/chown -R root:agent /home/agent"
+    );
+    expect(permissionCommand).toContain(
+      "/usr/sbin/usermod --home /var/empty agent"
+    );
+    expect(permissionCommand).toContain(
+      "/bin/rm -f /home/agent/.bash_profile /home/agent/.bash_login /home/agent/.profile /home/agent/.bashrc"
+    );
+    expect(permissionCommand).toContain(
+      "/usr/bin/find /home/agent -type d -exec /bin/chmod 2750 {} +"
+    );
+    expect(permissionCommand).toContain(
+      "/usr/bin/chown -R root:root /opt/venv"
+    );
+    expect(permissionCommand).toContain("/bin/chmod -R go-w /opt/venv");
+    expect(permissionCommand).toContain(
+      "/usr/bin/chown -R root:root /opt/dust/profile"
+    );
+    expect(permissionCommand).toContain(
+      "/bin/chmod 644 /opt/dust/profile/*.sh"
     );
   });
 
@@ -243,9 +269,13 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         "chmod 755 /etc/dust/egress-nftables.sh",
-        "systemctl daemon-reload && systemctl enable dust-egress-resolver.service dust-egress-nftables.service",
+        "systemctl daemon-reload && systemctl enable systemd-resolved.service dust-egress-resolver.service dust-egress-nftables.service",
       ])
     );
+    expect(runCommands.join("\n")).toContain(
+      "ln -sfn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf"
+    );
+    expect(runCommands.join("\n")).toContain("DNSStubListener=yes");
 
     expect(runCommands.join("\n")).not.toContain(
       "chmod 755 /etc/dust/egress-nftables.sh && /etc/dust/egress-nftables.sh"
@@ -253,7 +283,10 @@ describe("sandbox image registry", () => {
     expect(runCommands.join("\n")).not.toContain("iptables");
 
     expect(serviceUnit).toContain(
-      "Description=Dust egress nftables rules for agent-proxied"
+      "Description=Dust egress nftables rules for sandbox-controlled accounts"
+    );
+    expect(serviceUnit).toContain(
+      "After=network.target systemd-resolved.service"
     );
     expect(serviceUnit).toContain("Type=oneshot");
     expect(serviceUnit).toContain("RemainAfterExit=yes");
@@ -262,8 +295,9 @@ describe("sandbox image registry", () => {
     expect(serviceUnit).not.toContain("Requires=dust-egress-resolver.service");
 
     expect(resolverUnit).toContain(
-      "Description=Dust local DNS resolver for agent-proxied"
+      "Description=Dust synthetic DNS resolver for sandbox-controlled accounts"
     );
+    expect(resolverUnit).toContain("Wants=systemd-resolved.service");
     expect(resolverUnit).toContain("Before=dust-egress-nftables.service");
     expect(resolverUnit).toContain("User=dust-egress-resolver");
     expect(resolverUnit).toContain("Group=dust-egress-resolver");
@@ -279,8 +313,15 @@ describe("sandbox image registry", () => {
     expect(resolverUnit).toContain("MemoryDenyWriteExecute=yes");
 
     expect(nftablesScript).toContain("nft add table ip dust-egress");
+    expect(nftablesScript).toContain('CONTROLLED_UIDS="1002 1003"');
     expect(nftablesScript).toContain("DNS_STUB_PORT=1053");
     expect(nftablesScript).toContain("GCS_TOKEN_SERVER_PORT=987");
+    expect(nftablesScript).toContain(
+      "SYSTEM_RESOLV_CONF=/run/systemd/resolve/stub-resolv.conf"
+    );
+    expect(nftablesScript).toContain(
+      '/bin/ln -sfn "$SYSTEM_RESOLV_CONF" /etc/resolv.conf'
+    );
     expect(nftablesScript).toContain(
       "nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; policy accept ; }'"
     );
@@ -288,33 +329,32 @@ describe("sandbox image registry", () => {
       "nft add chain ip dust-egress filter_output '{ type filter hook output priority 0 ; policy accept ; }'"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 return"
+      "nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 return"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID udp dport 53 redirect to :$DNS_STUB_PORT"
+      "nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID udp dport 53 redirect to :$DNS_STUB_PORT"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport 53 redirect to :$DNS_STUB_PORT"
+      "nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport 53 redirect to :$DNS_STUB_PORT"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990"
+      "nft add rule ip dust-egress nat_output meta skuid $CONTROLLED_UID tcp dport != 0 redirect to :9990"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept"
+      "nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop"
+      "nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop"
+      "nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 drop"
+      "nft add rule ip dust-egress filter_output meta skuid $CONTROLLED_UID ip daddr 169.254.169.254 drop"
     );
     expect(nftablesScript).toContain(
-      "nft add rule ip6 dust-egress filter_output meta skuid $PROXIED_UID drop"
+      "nft add rule ip6 dust-egress filter_output meta skuid $CONTROLLED_UID drop"
     );
-    expect(nftablesScript).not.toContain("/etc/resolv.conf");
     expect(nftablesScript).not.toContain('ip daddr "$NS"');
 
     expectContentInOrder(
@@ -383,8 +423,11 @@ describe("sandbox image registry", () => {
     expect(writer).toContain("mv -f");
     expect(firewall).toContain("dust-gcs-token");
     expect(firewall).toContain("/usr/bin/flock -x 9");
-    expect(firewall).toContain("meta skuid 1003");
-    expect(firewall).toContain("tcp dport 987 drop");
+    expect(firewall).toContain('CONTROLLED_UIDS="1002 1003"');
+    expect(firewall).toContain("for CONTROLLED_UID in $CONTROLLED_UIDS");
+    expect(firewall).toContain(
+      'meta skuid "$CONTROLLED_UID" ip daddr 127.0.0.0/8 tcp dport 987 drop'
+    );
     expect(firewall).not.toContain("delete table ip dust-gcs-token");
   });
 
@@ -622,16 +665,31 @@ describe("sandbox image registry", () => {
     }
   });
 
-  test("keeps the nftables UID filter aligned with untrusted sandbox UIDs", () => {
+  test("keeps the nftables UID filter aligned with controlled sandbox UIDs", () => {
     const copyOperations = getCopyOperations(getDustBaseImageOperations());
     const nftablesScript = getCopiedContent(
       copyOperations,
       "/etc/dust/egress-nftables.sh"
     );
-    const proxiedUidMatch = /^PROXIED_UID=(\d+)$/m.exec(nftablesScript);
-    const configuredUids = proxiedUidMatch ? [Number(proxiedUidMatch[1])] : [];
+    const tokenFirewallScript = getCopiedContent(
+      copyOperations,
+      "/usr/local/bin/dust-gcs-token-firewall.sh"
+    );
+    const controlledUidsMatch = /^CONTROLLED_UIDS="([\d ]+)"$/m.exec(
+      nftablesScript
+    );
+    const tokenFirewallUidsMatch = /^CONTROLLED_UIDS="([\d ]+)"$/m.exec(
+      tokenFirewallScript
+    );
+    const configuredUids = controlledUidsMatch
+      ? controlledUidsMatch[1].split(" ").map(Number)
+      : [];
+    const tokenFirewallUids = tokenFirewallUidsMatch
+      ? tokenFirewallUidsMatch[1].split(" ").map(Number)
+      : [];
 
-    expect(configuredUids).toEqual([...SANDBOX_UNTRUSTED_UIDS]);
+    expect(configuredUids).toEqual([...SANDBOX_EGRESS_CONTROLLED_UIDS]);
+    expect(tokenFirewallUids).toEqual([...SANDBOX_EGRESS_CONTROLLED_UIDS]);
   });
 
   test("installs trust env defaults and the runtime trust helper", () => {

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.65",
+      tag: "0.8.66",
     });
   });
 
@@ -265,10 +265,19 @@ describe("sandbox image registry", () => {
       copyOperations,
       "/etc/systemd/system/dust-egress-resolver.service"
     );
+    const resolve1Policy = getCopiedContent(
+      copyOperations,
+      "/etc/dbus-1/system.d/dust-resolve1.conf"
+    );
+    const resolvedIpcDropIn = getCopiedContent(
+      copyOperations,
+      "/etc/systemd/system/systemd-resolved.service.d/dust-ipc.conf"
+    );
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
         "chmod 755 /etc/dust/egress-nftables.sh",
+        "mkdir -p /etc/dbus-1/system.d /etc/systemd/system/systemd-resolved.service.d",
         "systemctl daemon-reload && systemctl enable systemd-resolved.service dust-egress-resolver.service dust-egress-nftables.service",
       ])
     );
@@ -311,6 +320,19 @@ describe("sandbox image registry", () => {
     expect(resolverUnit).toContain("ProtectSystem=strict");
     expect(resolverUnit).toContain("RestrictAddressFamilies=AF_INET");
     expect(resolverUnit).toContain("MemoryDenyWriteExecute=yes");
+
+    for (const user of ["agent", "agent-proxied"]) {
+      expect(resolve1Policy).toContain(`<policy user="${user}">`);
+    }
+    expect(
+      resolve1Policy.match(
+        /<deny send_destination="org\.freedesktop\.resolve1"\/>/g
+      )
+    ).toHaveLength(2);
+    expect(resolvedIpcDropIn).toContain("[Service]");
+    expect(resolvedIpcDropIn).toContain(
+      "ExecStartPost=/bin/chmod 0600 /run/systemd/resolve/io.systemd.Resolve"
+    );
 
     expect(nftablesScript).toContain("nft add table ip dust-egress");
     expect(nftablesScript).toContain('CONTROLLED_UIDS="1002 1003"');

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.65";
+const DUST_BASE_IMAGE_VERSION = "0.8.66";
 const DSBX_CLI_VERSION = "0.1.41";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -692,6 +692,22 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .copy(
     getLocalContent(EGRESS_LOCAL_DIR, "dust-egress-resolver.service"),
     "/etc/systemd/system/dust-egress-resolver.service",
+    { user: "root" }
+  )
+  // The system resolver must remain available to root-owned services without
+  // becoming a DNS escape hatch for the two egress-controlled accounts.
+  .runCmd(
+    "mkdir -p /etc/dbus-1/system.d /etc/systemd/system/systemd-resolved.service.d",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "dust-resolve1.conf"),
+    "/etc/dbus-1/system.d/dust-resolve1.conf",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "systemd-resolved-ipc.conf"),
+    "/etc/systemd/system/systemd-resolved.service.d/dust-ipc.conf",
     { user: "root" }
   )
   .runCmd(

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -1,6 +1,7 @@
 import {
   getLocalAccountPrivilegeHardeningCommand,
   getRootConsumedPathHardeningCommand,
+  getSandboxServicePathHardeningCommand,
 } from "@app/lib/api/sandbox/hardening";
 import {
   buildPodPackage,
@@ -25,11 +26,11 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.64";
+const DUST_BASE_IMAGE_VERSION = "0.8.65";
 const DSBX_CLI_VERSION = "0.1.41";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
-// nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
-// list must not silently change this user's UID.
+// nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
+// the stable identity used when creating the workload account.
 const AGENT_PROXIED_UID = SANDBOX_AGENT_PROXIED_UID;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
@@ -196,17 +197,15 @@ function getLocalDirContent(
 }
 
 function getAgentProxiedSetupCommand(): string {
-  // setgid bit on shared dirs + default POSIX ACLs ensures files created
-  // by either agent or agent-proxied are group-owned by `agent` and
-  // group-writable, regardless of the creating process's umask - avoids
-  // a perms handoff footgun during the PR1→PR2 rollout window.
+  // agent-proxied has its own primary group. Supplementary membership in
+  // agent is limited to explicit shared state such as /files and pod DBs.
   return [
-    "install -d -o agent -g agent -m 2775 /home/agent/.local /home/agent/.local/bin",
-    `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent --shell /bin/bash agent-proxied`,
-    "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files",
-    "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files",
-    "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files",
-    "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files",
+    `groupadd --gid ${AGENT_PROXIED_UID} agent-proxied`,
+    `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent-proxied --groups agent --shell /bin/bash agent-proxied`,
+    "chgrp agent /files",
+    "chmod 2775 /files",
+    "setfacl -R -d -m g::rwx /files",
+    "setfacl -R -m g::rwx /files",
   ].join(" && ");
 }
 
@@ -221,8 +220,8 @@ function getDustStateUserSetupCommand(): string {
   // dust-state runs the litestream replication daemon (pod state). Primary
   // group dust-state owns the replica mount point; supplementary membership
   // in `agent` grants rw on the live databases dir shared with agent-proxied
-  // function code. Deliberately NOT in SANDBOX_UNTRUSTED_UIDS: it never
-  // executes workload code.
+  // function code. Deliberately not egress-controlled: it never executes
+  // workload code.
   return [
     "groupadd --system dust-state",
     "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state",
@@ -341,9 +340,12 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .runCmd(getDustStateUserSetupCommand(), { user: "root" })
   .runCmd(getPodStateSetupCommand(), { user: "root" })
   // Hidden tools: installed but not in manifest (back profile functions)
-  .runCmd("apt-get update && apt-get install -y ripgrep fd-find sd", {
-    user: "root",
-  })
+  .runCmd(
+    "apt-get update && apt-get install -y ripgrep fd-find sd systemd-resolved",
+    {
+      user: "root",
+    }
+  )
   // Create profile directory and copy profile scripts
   // The other tools are installed in bedrock
   // Bump LibreOffice past the distro's 24.2 to a current release so the
@@ -583,24 +585,29 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .runCmd(`chmod +x ${PROFILE_DIR}/dust-tools`, { user: "root" })
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "common.sh"),
-    `${PROFILE_DIR}/common.sh`
+    `${PROFILE_DIR}/common.sh`,
+    { user: "root" }
   )
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "shell.sh"),
-    `${PROFILE_DIR}/shell.sh`
+    `${PROFILE_DIR}/shell.sh`,
+    { user: "root" }
   )
   // Provider-specific profiles (sourced by common.sh based on DUST_PROFILE)
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "anthropic.sh"),
-    `${PROFILE_DIR}/anthropic.sh`
+    `${PROFILE_DIR}/anthropic.sh`,
+    { user: "root" }
   )
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "openai.sh"),
-    `${PROFILE_DIR}/openai.sh`
+    `${PROFILE_DIR}/openai.sh`,
+    { user: "root" }
   )
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "gemini.sh"),
-    `${PROFILE_DIR}/gemini.sh`
+    `${PROFILE_DIR}/gemini.sh`,
+    { user: "root" }
   )
   .copy(
     getLocalDirContent(PROFILE_LOCAL_DIR, "soffice"),
@@ -688,11 +695,18 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     { user: "root" }
   )
   .runCmd(
-    "systemctl daemon-reload && systemctl enable dust-egress-resolver.service dust-egress-nftables.service",
+    "mkdir -p /etc/systemd/resolved.conf.d && " +
+      "printf '%s\\n' '[Resolve]' 'DNS=8.8.8.8' 'FallbackDNS=' 'DNSStubListener=yes' > /etc/systemd/resolved.conf.d/dust-sandbox.conf && " +
+      "ln -sfn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf",
+    { user: "root" }
+  )
+  .runCmd(
+    "systemctl daemon-reload && systemctl enable systemd-resolved.service dust-egress-resolver.service dust-egress-nftables.service",
     { user: "root" }
   )
   // Run after all apt/npm installs as a final guard against a dependency
   // reintroducing sudo or privileged account state.
+  .runCmd(getSandboxServicePathHardeningCommand(), { user: "root" })
   .runCmd(getLocalAccountPrivilegeHardeningCommand(), { user: "root" })
   .runCmd(getRootConsumedPathHardeningCommand(), { user: "root" })
   // Profile functions (no install needed, provided by profile scripts)

--- a/front/lib/api/sandbox/image/token/dust-gcs-token-firewall.sh
+++ b/front/lib/api/sandbox/image/token/dust-gcs-token-firewall.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Keep the root-owned token broker inaccessible to the untrusted workload uid even when
-# dev-unrestricted egress tears down the regular dust-egress nftables table. The lock and
-# existence checks make concurrent lifecycle/mount setup calls converge without a gap.
+# Keep the root-owned token broker inaccessible to every Front-controlled
+# non-root uid even when dev-unrestricted egress tears down the regular
+# dust-egress nftables table. The lock and existence checks make concurrent
+# lifecycle/mount setup calls converge without a gap.
+CONTROLLED_UIDS="1002 1003"
+
 /usr/bin/install -d -o root -g root -m 700 /run/dust-gcs
 exec 9>/run/dust-gcs/firewall.lock
 /usr/bin/flock -x 9
@@ -15,6 +18,9 @@ if ! /usr/sbin/nft list chain ip dust-gcs-token filter_output >/dev/null 2>&1; t
   /usr/sbin/nft add chain ip dust-gcs-token filter_output '{ type filter hook output priority 0 ; policy accept ; }'
 fi
 rules="$(/usr/sbin/nft list chain ip dust-gcs-token filter_output 2>/dev/null || true)"
-if ! /usr/bin/grep -Fq 'meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 987 drop' <<<"$rules"; then
-  /usr/sbin/nft add rule ip dust-gcs-token filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 987 drop
-fi
+for CONTROLLED_UID in $CONTROLLED_UIDS; do
+  expected_rule="meta skuid $CONTROLLED_UID ip daddr 127.0.0.0/8 tcp dport 987 drop"
+  if ! /usr/bin/grep -Fq "$expected_rule" <<<"$rules"; then
+    /usr/sbin/nft add rule ip dust-gcs-token filter_output meta skuid "$CONTROLLED_UID" ip daddr 127.0.0.0/8 tcp dport 987 drop
+  fi
+done

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -21,17 +21,18 @@ export function formatSandboxImageId(id: SandboxImageId): string {
 // sandbox tool manifest by name when sandbox tools are off.
 export const DSBX_TOOL_NAME = "dsbx";
 
-// UID of the `agent-proxied` user that runs untrusted agent code. Egress
-// enforcement (nftables redirect to dsbx forward + DNS stub) is scoped to
-// this UID; every other process in the sandbox bypasses it.
+// Stable UIDs of the service account and the untrusted workload account.
+export const SANDBOX_AGENT_UID = 1002;
 export const SANDBOX_AGENT_PROXIED_UID = 1003;
 
-// UIDs that can execute untrusted workspace or model-driven code inside the
-// sandbox. Every UID in this list must be covered by the egress nftables
-// ruleset, otherwise it inherits provider DNS/networking. Today this is just
-// agent-proxied; if a future feature adds another untrusted UID, extend this
-// list AND update egress-nftables.sh so the new UID is covered there too.
-export const SANDBOX_UNTRUSTED_UIDS = [SANDBOX_AGENT_PROXIED_UID] as const;
+// Every non-root account reachable from a Front-triggered exec must stay
+// behind the same DNS and TCP egress boundary. `agent` is included even
+// though it only runs service commands: this keeps a future service-command
+// compromise from bypassing the workload policy.
+export const SANDBOX_EGRESS_CONTROLLED_UIDS = [
+  SANDBOX_AGENT_UID,
+  SANDBOX_AGENT_PROXIED_UID,
+] as const;
 
 // ---------------------------------------------------------------------------
 // Tool Runtime & Profile
@@ -109,9 +110,10 @@ export interface NetworkPolicy {
   readonly allowlist?: readonly string[];
 }
 
-// Agent commands run as agent-proxied (uid 1003) whose traffic is redirected
-// by nftables to the in-sandbox egress proxy. The E2B-level allowlist covers
-// services that root processes access directly (bypassing the proxy).
+// Front-triggered non-root commands run as agent (uid 1002) or agent-proxied
+// (uid 1003); both are redirected by nftables to the in-sandbox egress proxy.
+// The E2B-level allowlist covers services that root processes access directly
+// (bypassing the proxy).
 export const PROXY_ONLY_NETWORK_POLICY: NetworkPolicy = {
   mode: "deny_all",
   allowlist: [

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -108,11 +108,11 @@ async function ensureOwnerSandboxReady(
       if (freshlyCreated) {
         // The image seeds /etc/dust/ca-bundle.pem with system roots, and
         // gcsfuse runs as root to storage.googleapis.com, which the in-sandbox
-        // nftables ruleset never touches: every rule is scoped to the agent uid
-        // (1003) and the chains default to accept, so root egress is never
-        // dropped, even mid-setup. The dev-unrestricted branch tears down the
-        // general table but recreates the dedicated GCS broker drop, so it's
-        // safe to overlap too.
+        // nftables ruleset never touches: every rule is scoped to the
+        // non-root Front exec UIDs (1002 and 1003) and the chains default to
+        // accept, so root egress is never dropped, even mid-setup. The
+        // dev-unrestricted branch tears down the general table but recreates
+        // the dedicated GCS broker drops, so it's safe to overlap too.
         // Egress prep can therefore run alongside the GCS mount, with egress
         // errors still taking precedence.
         const [prepResult, mountResult] = await Promise.all([

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -77,7 +77,12 @@ vi.mock("e2b", () => {
 
 import { CommandExitError, NotFoundError } from "e2b";
 
-import { SANDBOX_ROOT_SAFE_PATH } from "../hardening";
+import {
+  SANDBOX_AGENT_PROXIED_SAFE_PATH,
+  SANDBOX_AGENT_SAFE_PATH,
+  SANDBOX_AGENT_SERVICE_HOME,
+  SANDBOX_ROOT_SAFE_PATH,
+} from "../hardening";
 import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
 
@@ -168,6 +173,11 @@ describe("E2BSandboxProvider", () => {
     expect(hardeningCommand).toContain(
       "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle"
     );
+    expect(hardeningCommand).toContain(
+      "/usr/bin/chown -R root:agent /home/agent"
+    );
+    expect(hardeningCommand).toContain("/usr/bin/chown -R root:root /opt/venv");
+    expect(hardeningCommand).toContain("/bin/chmod 644 /opt/dust/profile/*.sh");
     expect(hardeningCommand).toContain("privileged primary group");
     expect(mockKill).not.toHaveBeenCalled();
   });
@@ -264,7 +274,48 @@ describe("E2BSandboxProvider", () => {
     expect(mockRun).not.toHaveBeenCalled();
   });
 
-  it("does not wrap non-root commands", async () => {
+  it("runs default agent service commands without sourcing user dotfiles", async () => {
+    mockRun.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec("provider-id", "echo ok", undefined, {
+      workspaceId: "workspace-id",
+    });
+
+    expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    const command = mockRun.mock.calls[0][0];
+    if (typeof command !== "string") {
+      throw new Error("expected command to be a string");
+    }
+    expect(command).toContain(`PATH='${SANDBOX_AGENT_SAFE_PATH}'`);
+    expect(command).toContain(`HOME='${SANDBOX_AGENT_SERVICE_HOME}'`);
+    expect(command).toContain("BASH_ENV=/dev/null");
+    expect(command).toContain("ENV=/dev/null");
+    expect(command).toContain("/bin/bash --noprofile --norc -c 'echo ok'");
+    expect(command).not.toContain("/opt/venv/bin");
+    expect(command).not.toContain("/home/agent/.local/bin");
+    expect(mockRun).toHaveBeenCalledWith(
+      command,
+      expect.objectContaining({
+        envs: {
+          BASH_ENV: "/dev/null",
+          ENV: "/dev/null",
+          HOME: SANDBOX_AGENT_SERVICE_HOME,
+          PATH: SANDBOX_AGENT_SAFE_PATH,
+        },
+        user: "agent",
+      })
+    );
+  });
+
+  it("runs agent-proxied workload commands in a clean shell with its own home", async () => {
     mockRun.mockResolvedValueOnce({
       exitCode: 0,
       stdout: "ok",
@@ -278,14 +329,41 @@ describe("E2BSandboxProvider", () => {
     const result = await provider.exec(
       "provider-id",
       "echo ok",
-      { user: "agent-proxied" },
+      {
+        envVars: {
+          BASH_ENV: "/tmp/attacker/bash-env",
+          ENV: "/tmp/attacker/env",
+          HOME: "/home/agent-proxied",
+          PATH: "/tmp/attacker/bin",
+          SAFE_INPUT: "preserved",
+        },
+        user: "agent-proxied",
+      },
       { workspaceId: "workspace-id" }
     );
 
     expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    const command = mockRun.mock.calls[0][0];
+    if (typeof command !== "string") {
+      throw new Error("expected command to be a string");
+    }
+    expect(command).toContain(`PATH='${SANDBOX_AGENT_PROXIED_SAFE_PATH}'`);
+    expect(command).toContain("HOME='/home/agent-proxied'");
+    expect(command).toContain("BASH_ENV=/dev/null");
+    expect(command).toContain("ENV=/dev/null");
+    expect(command).toContain("/bin/bash --noprofile --norc -c 'echo ok'");
     expect(mockRun).toHaveBeenCalledWith(
-      "echo ok",
-      expect.objectContaining({ user: "agent-proxied" })
+      command,
+      expect.objectContaining({
+        envs: {
+          BASH_ENV: "/dev/null",
+          ENV: "/dev/null",
+          HOME: SANDBOX_AGENT_SERVICE_HOME,
+          PATH: SANDBOX_AGENT_SAFE_PATH,
+          SAFE_INPUT: "preserved",
+        },
+        user: "agent-proxied",
+      })
     );
   });
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,5 +1,9 @@
 import {
   getLocalAccountPrivilegeHardeningCommand,
+  getSandboxServicePathHardeningCommand,
+  SANDBOX_AGENT_PROXIED_SAFE_PATH,
+  SANDBOX_AGENT_SAFE_PATH,
+  SANDBOX_AGENT_SERVICE_HOME,
   SANDBOX_ROOT_SAFE_PATH,
 } from "@app/lib/api/sandbox/hardening";
 import {
@@ -13,6 +17,7 @@ import type {
   FileEntry,
   RootExecOptions,
   SandboxCreateConfig,
+  SandboxExecUser,
   SandboxHandle,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
@@ -59,6 +64,46 @@ function getRootSafeSandboxCommand(command: RootCommand): string {
     "/bin/bash --noprofile --norc -c",
     shellEscape(renderRootCommand(command)),
   ].join(" ");
+}
+
+function getNonRootSafeSandboxCommand(
+  command: string,
+  user: SandboxExecUser
+): string {
+  const { home, path } =
+    user === "agent"
+      ? {
+          home: SANDBOX_AGENT_SERVICE_HOME,
+          path: SANDBOX_AGENT_SAFE_PATH,
+        }
+      : {
+          home: "/home/agent-proxied",
+          path: SANDBOX_AGENT_PROXIED_SAFE_PATH,
+        };
+
+  return [
+    `PATH=${shellEscape(path)}`,
+    `HOME=${shellEscape(home)}`,
+    "BASH_ENV=/dev/null",
+    "ENV=/dev/null",
+    "/bin/bash --noprofile --norc -c",
+    shellEscape(command),
+  ].join(" ");
+}
+
+function getNonRootOuterEnvironment(
+  envVars: Record<string, string> | undefined
+): Record<string, string> {
+  return {
+    ...envVars,
+    // The E2B SDK starts an outer login shell before evaluating `command`.
+    // Keep that shell away from attacker-writable homes and startup hooks; the
+    // inner clean shell above restores the workload user's intended HOME/PATH.
+    PATH: SANDBOX_AGENT_SAFE_PATH,
+    HOME: SANDBOX_AGENT_SERVICE_HOME,
+    BASH_ENV: "/dev/null",
+    ENV: "/dev/null",
+  };
 }
 
 function getLocalAccountHardeningError(result: ExecResult): Error {
@@ -307,8 +352,11 @@ export class E2BSandboxProvider implements SandboxProvider {
               sandbox.commands.run(
                 getRootSafeSandboxCommand(
                   rootCommand.unsafeShell(
-                    getLocalAccountPrivilegeHardeningCommand(),
-                    "create-time sandbox local account hardening"
+                    [
+                      getLocalAccountPrivilegeHardeningCommand(),
+                      getSandboxServicePathHardeningCommand(),
+                    ].join(" && "),
+                    "create-time sandbox local account and service path hardening"
                   )
                 ),
                 {
@@ -482,15 +530,17 @@ export class E2BSandboxProvider implements SandboxProvider {
       );
     }
 
+    const execUser = execOpts?.user ?? "agent";
+
     return this.runCommand(
       providerId,
-      command,
+      getNonRootSafeSandboxCommand(command, execUser),
       {
         cwd: execOpts?.workingDirectory,
-        envs: execOpts?.envVars,
+        envs: getNonRootOuterEnvironment(execOpts?.envVars),
         timeoutMs: execOpts?.timeoutMs,
         stdin: execOpts?.stdin,
-        user: execOpts?.user,
+        user: execUser,
       },
       tracingOpts
     );

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -10,6 +10,7 @@ import {
   assertPodStateDirsSafe,
   assertRootInvokedHelpersSafe,
   assertRootPathSafe,
+  assertSshAndDnsHardening,
   assertStaticRootConsumedDirsSafe,
   assertSudoAbsent,
   assertSystemdUnitPathsSafe,
@@ -23,6 +24,40 @@ describe("sandbox security check assertions", () => {
     expect(buildBashCommand("echo 'ok'")).toBe(
       "/bin/bash -c 'echo '\\''ok'\\'''"
     );
+  });
+
+  test("requires system resolver IPC isolation evidence", () => {
+    const safeOutput = [
+      "SSH_PORT_22_LISTENING=0",
+      "PermitRootLogin no",
+      "PasswordAuthentication no",
+      "UsePAM no",
+      "AllowUsers agent",
+      "DenyUsers root agent-proxied",
+      "DNS_RESOLVER_ACTIVE=1",
+      "DNS_NFTABLES_ACTIVE=1",
+      "SYSTEM_RESOLVER_ACTIVE=1",
+      "SYSTEM_RESOLVER_VARLINK_PRIVATE=1",
+      "ROOT_RESOLVE1_DBUS_OK=1",
+      "ROOT_RESOLVE1_VARLINK_OK=1",
+      "RESOLV_CONF_LOCAL=1",
+      "ROOT_GCS_DNS_OK=1",
+      "ROOT_GCS_HTTPS_OK=1",
+      "udp dport 53 redirect",
+      "tcp dport 53 redirect",
+      "tcp dport 22 drop",
+      "meta l4proto",
+    ].join("\n");
+
+    expect(() => assertSshAndDnsHardening(safeOutput)).not.toThrow();
+    expect(() =>
+      assertSshAndDnsHardening(
+        safeOutput.replace(
+          "SYSTEM_RESOLVER_VARLINK_PRIVATE=1",
+          "SYSTEM_RESOLVER_VARLINK_PRIVATE=0"
+        )
+      )
+    ).toThrow("SYSTEM_RESOLVER_VARLINK_PRIVATE=1");
   });
 
   test("detects unrestricted passwordless sudo while ignoring comments", () => {

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -27,6 +27,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 const TRACE_OPTS = { workspaceId: "sandbox-image-security-check" };
+const AGENT_USER = "agent";
 const AGENT_PROXIED_USER = "agent-proxied";
 const COMMAND_TIMEOUT_MS = 15_000;
 const ROOT_ID_PATTERN = /\buid=0\(root\)\b/;
@@ -269,6 +270,9 @@ async function checkBasicSandboxFunctionality(
 set -euo pipefail
 echo "shell-ok"
 /opt/bin/dsbx version >/dev/null
+DUST_PROFILE=openai source /opt/dust/profile/common.sh
+declare -F shell >/dev/null
+/opt/venv/bin/python3 -c 'import requests'
 # /files/conversation and /files/pod no longer exist in the image. They are
 # created at runtime as mount points by the GCS mount adapter. Test /files
 # itself and verify that a subdirectory created there mimics the runtime
@@ -284,6 +288,190 @@ rm -rf "$tmpdir"
   );
 
   assertCommandSucceeded("basic shell and file operations", smoke);
+}
+
+async function checkAgentServiceBoundary(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  for (const user of [AGENT_USER, AGENT_PROXIED_USER] as const) {
+    const pathDenials = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+for dotfile in .bash_profile .bash_login .profile .bashrc; do
+  if [ -e "/home/agent/$dotfile" ]; then
+    echo "CRITICAL: agent dotfile unexpectedly exists: /home/agent/$dotfile"
+    exit 1
+  fi
+done
+if touch /home/agent/.bash_profile 2>/dev/null; then
+  echo "CRITICAL: workload can write /home/agent/.bash_profile"
+  exit 1
+fi
+if printf '\\n# security probe\\n' >> /usr/local/bin/dust-gcs-token-server.py 2>/dev/null; then
+  echo "CRITICAL: workload can modify the GCS token server"
+  exit 1
+fi
+site_packages=$(/opt/venv/bin/python3 -c 'import site; print(site.getsitepackages()[0])')
+if touch "$site_packages/dust-security-check.pth" 2>/dev/null; then
+  echo "CRITICAL: workload can plant a Python .pth file"
+  exit 1
+fi
+if printf '\\n# security probe\\n' >> /opt/dust/profile/common.sh 2>/dev/null; then
+  echo "CRITICAL: workload can modify the Dust tool profile"
+  exit 1
+fi
+`,
+      { user }
+    );
+    assertCommandSucceeded(`${user} service path denials`, pathDenials);
+  }
+
+  const marker = `/tmp/dust-agent-dotfile-proof-${Date.now()}`;
+  try {
+    const seed = await runRootBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+printf '%s\\n' '/usr/bin/touch ${marker}' > /home/agent/.bash_profile
+/usr/bin/chown root:agent /home/agent/.bash_profile
+/bin/chmod 640 /home/agent/.bash_profile
+printf '%s\\n' '/usr/bin/touch ${marker}' > /home/agent-proxied/.bash_profile
+/usr/bin/chown agent-proxied:agent-proxied /home/agent-proxied/.bash_profile
+/bin/chmod 600 /home/agent-proxied/.bash_profile
+/bin/rm -f ${marker}
+`
+    );
+    assertCommandSucceeded("agent dotfile non-execution seed", seed);
+
+    for (const [user, expectedHome] of [
+      [AGENT_USER, "/var/empty"],
+      [AGENT_PROXIED_USER, "/home/agent-proxied"],
+    ] as const) {
+      const cleanExec = await runCommand(
+        provider,
+        providerId,
+        `/usr/bin/test "$HOME" = ${expectedHome}`,
+        { user }
+      );
+      assertCommandSucceeded(`${user} clean exec`, cleanExec);
+    }
+
+    const verify = await runRootBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+test ! -e ${marker}
+test "$(/usr/bin/getent passwd agent | /usr/bin/cut -d: -f6)" = /var/empty
+test "$(/usr/bin/stat -c '%U:%G %a' /var/empty)" = "root:root 755"
+`
+    );
+    assertCommandSucceeded("agent dotfile non-execution proof", verify);
+  } finally {
+    await runRootBashScript(
+      provider,
+      providerId,
+      `/bin/rm -f /home/agent/.bash_profile /home/agent-proxied/.bash_profile ${marker}`
+    );
+  }
+}
+
+async function checkControlledUidEgress(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  for (const user of [AGENT_USER, AGENT_PROXIED_USER] as const) {
+    const result = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+if /usr/bin/curl -m 3 -sS http://169.254.169.254/ >/dev/null 2>&1; then
+  echo "CRITICAL: ${user} can reach the metadata service"
+  exit 1
+fi
+resolved=$(/usr/bin/getent ahostsv4 example.com | /usr/bin/awk 'NR == 1 { print $1 }')
+if [ "$resolved" != 240.0.0.1 ]; then
+  echo "CRITICAL: ${user} bypassed synthetic DNS: $resolved"
+  exit 1
+fi
+`,
+      { user }
+    );
+    assertCommandSucceeded(`${user} egress boundary`, result);
+  }
+}
+
+async function checkTokenBrokerDenied(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  for (const user of [AGENT_USER, AGENT_PROXIED_USER] as const) {
+    const result = await runCommand(
+      provider,
+      providerId,
+      "/usr/bin/curl -sf --connect-timeout 0.3 --max-time 1 http://127.0.0.1:987/token/mount-0",
+      { user }
+    );
+    if (result.exitCode !== 28) {
+      throw new Error(
+        `${user} GCS token broker denial returned exit code ${result.exitCode}, expected curl timeout 28:\n${combinedOutput(result)}`
+      );
+    }
+  }
+}
+
+async function checkRootTokenRefreshAcrossSleepWake(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const initialToken = '{"access_token":"before-sleep"}';
+  const refreshedToken = '{"access_token":"after-wake"}';
+  const start = await runRootBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+printf %s ${shellQuote(initialToken)} | /usr/local/bin/dust-gcs-write-token.sh /run/dust-gcs/mount-0.json
+/usr/local/bin/dust-gcs-token-firewall.sh
+/usr/bin/nohup /usr/local/bin/dust-gcs-token-server.py >/run/dust-gcs/security-check-server.log 2>&1 &
+for _attempt in $(/usr/bin/seq 1 100); do
+  if [ "$(/usr/bin/curl -sf http://127.0.0.1:987/token/mount-0)" = ${shellQuote(initialToken)} ]; then
+    exit 0
+  fi
+  /usr/bin/sleep 0.05
+done
+exit 1
+`
+  );
+  assertCommandSucceeded("root-owned GCS token server start", start);
+  await checkTokenBrokerDenied(provider, providerId);
+
+  const sleepResult = await provider.sleep(providerId, TRACE_OPTS);
+  if (sleepResult.isErr()) {
+    throw sleepResult.error;
+  }
+  const wakeResult = await provider.wake(providerId, TRACE_OPTS);
+  if (wakeResult.isErr()) {
+    throw wakeResult.error;
+  }
+
+  const refresh = await runRootBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+printf %s ${shellQuote(refreshedToken)} | /usr/local/bin/dust-gcs-write-token.sh /run/dust-gcs/mount-0.json
+test "$(/usr/bin/curl -sf http://127.0.0.1:987/token/mount-0)" = ${shellQuote(refreshedToken)}
+test ! -e /home/agent/.bash_profile
+`
+  );
+  assertCommandSucceeded("GCS token refresh after sleep/wake", refresh);
+  await checkTokenBrokerDenied(provider, providerId);
 }
 
 async function checkTargetUserState(
@@ -759,7 +947,11 @@ DUST_HIJACK_EOF
 `,
       { user: AGENT_PROXIED_USER }
     );
-    assertCommandSucceeded("root exec path hijack plant", plant);
+    if (plant.exitCode === 0) {
+      throw new Error(
+        `agent-proxied can plant an executable in the service venv at ${plantedPath}`
+      );
+    }
 
     const trigger = await runRootBashScript(
       provider,
@@ -968,6 +1160,10 @@ function assertSshAndDnsHardening(output: string): void {
   for (const expected of [
     "DNS_RESOLVER_ACTIVE=1",
     "DNS_NFTABLES_ACTIVE=1",
+    "SYSTEM_RESOLVER_ACTIVE=1",
+    "RESOLV_CONF_LOCAL=1",
+    "ROOT_GCS_DNS_OK=1",
+    "ROOT_GCS_HTTPS_OK=1",
     "udp dport 53 redirect",
     "tcp dport 53 redirect",
     "tcp dport 22 drop",
@@ -998,6 +1194,12 @@ fi
 echo "--- sshd-hardening ---"
 /usr/bin/cat /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf
 echo "--- dns-systemd ---"
+if /usr/bin/systemctl is-active --quiet systemd-resolved.service; then
+  echo "SYSTEM_RESOLVER_ACTIVE=1"
+else
+  /usr/bin/systemctl status systemd-resolved.service --no-pager || true
+  echo "SYSTEM_RESOLVER_ACTIVE=0"
+fi
 if /usr/bin/systemctl is-active --quiet dust-egress-resolver.service; then
   echo "DNS_RESOLVER_ACTIVE=1"
 else
@@ -1009,6 +1211,23 @@ if /usr/bin/systemctl is-active --quiet dust-egress-nftables.service; then
 else
   /usr/bin/systemctl status dust-egress-nftables.service --no-pager || true
   echo "DNS_NFTABLES_ACTIVE=0"
+fi
+if /usr/bin/grep -Eq '^nameserver 127\\.0\\.0\\.53$' /etc/resolv.conf; then
+  echo "RESOLV_CONF_LOCAL=1"
+else
+  /usr/bin/cat /etc/resolv.conf
+  echo "RESOLV_CONF_LOCAL=0"
+fi
+root_gcs_ip=$(/usr/bin/getent ahostsv4 storage.googleapis.com | /usr/bin/awk 'NR == 1 { print $1 }')
+if [ -n "$root_gcs_ip" ] && [ "$root_gcs_ip" != 240.0.0.1 ]; then
+  echo "ROOT_GCS_DNS_OK=1"
+else
+  echo "ROOT_GCS_DNS_OK=0"
+fi
+if /usr/bin/curl -m 10 -sS -o /dev/null https://storage.googleapis.com/; then
+  echo "ROOT_GCS_HTTPS_OK=1"
+else
+  echo "ROOT_GCS_HTTPS_OK=0"
 fi
 echo "--- nft-ip ---"
 /usr/sbin/nft -n list table ip dust-egress
@@ -1047,10 +1266,14 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkOriginalExploitPath(provider, providerId);
     await checkPamEscalationPaths(provider, providerId);
     await checkBasicSandboxFunctionality(provider, providerId);
+    await checkAgentServiceBoundary(provider, providerId);
     await checkTargetUserState(provider, providerId);
     await checkEquivalentAccountEscalation(provider, providerId);
     await checkSystemAccountAudit(provider, providerId);
     await checkSshAndDnsHardening(provider, providerId);
+    await checkControlledUidEgress(provider, providerId);
+    await checkRootTokenRefreshAcrossSleepWake(provider, providerId);
+    await checkControlledUidEgress(provider, providerId);
     await checkRootExecPathHijack(provider, providerId);
     await checkSystemdUnitSearchPathShadow(provider, providerId);
     await checkPodStateWorkloadAccess(provider, providerId);

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -399,6 +399,14 @@ if [ "$resolved" != 240.0.0.1 ]; then
   echo "CRITICAL: ${user} bypassed synthetic DNS: $resolved"
   exit 1
 fi
+if /usr/bin/resolvectl query example.com >/dev/null 2>&1; then
+  echo "CRITICAL: ${user} can delegate real DNS through resolve1 D-Bus"
+  exit 1
+fi
+if /usr/bin/python3 -c 'import socket; client = socket.socket(socket.AF_UNIX); client.connect("/run/systemd/resolve/io.systemd.Resolve")' >/dev/null 2>&1; then
+  echo "CRITICAL: ${user} can delegate real DNS through resolve1 Varlink"
+  exit 1
+fi
 `,
       { user }
     );
@@ -1138,7 +1146,7 @@ fi
   assertCommandSucceeded("pod-state workload denial probes", denials);
 }
 
-function assertSshAndDnsHardening(output: string): void {
+export function assertSshAndDnsHardening(output: string): void {
   if (!output.includes("SSH_PORT_22_LISTENING=0")) {
     throw new Error(`sshd appears to be listening on port 22:\n${output}`);
   }
@@ -1161,6 +1169,9 @@ function assertSshAndDnsHardening(output: string): void {
     "DNS_RESOLVER_ACTIVE=1",
     "DNS_NFTABLES_ACTIVE=1",
     "SYSTEM_RESOLVER_ACTIVE=1",
+    "SYSTEM_RESOLVER_VARLINK_PRIVATE=1",
+    "ROOT_RESOLVE1_DBUS_OK=1",
+    "ROOT_RESOLVE1_VARLINK_OK=1",
     "RESOLV_CONF_LOCAL=1",
     "ROOT_GCS_DNS_OK=1",
     "ROOT_GCS_HTTPS_OK=1",
@@ -1199,6 +1210,22 @@ if /usr/bin/systemctl is-active --quiet systemd-resolved.service; then
 else
   /usr/bin/systemctl status systemd-resolved.service --no-pager || true
   echo "SYSTEM_RESOLVER_ACTIVE=0"
+fi
+if [ "$(/usr/bin/stat -c '%a' /run/systemd/resolve/io.systemd.Resolve)" = 600 ]; then
+  echo "SYSTEM_RESOLVER_VARLINK_PRIVATE=1"
+else
+  /usr/bin/stat -c 'SYSTEM_RESOLVER_VARLINK_MODE=%a OWNER=%U:%G' /run/systemd/resolve/io.systemd.Resolve || true
+  echo "SYSTEM_RESOLVER_VARLINK_PRIVATE=0"
+fi
+if /usr/bin/resolvectl query storage.googleapis.com >/dev/null 2>&1; then
+  echo "ROOT_RESOLVE1_DBUS_OK=1"
+else
+  echo "ROOT_RESOLVE1_DBUS_OK=0"
+fi
+if /usr/bin/python3 -c 'import socket; client = socket.socket(socket.AF_UNIX); client.connect("/run/systemd/resolve/io.systemd.Resolve"); client.close()'; then
+  echo "ROOT_RESOLVE1_VARLINK_OK=1"
+else
+  echo "ROOT_RESOLVE1_VARLINK_OK=0"
 fi
 if /usr/bin/systemctl is-active --quiet dust-egress-resolver.service; then
   echo "DNS_RESOLVER_ACTIVE=1"


### PR DESCRIPTION
## Description

- Run every non-root E2B exec through a clean inner shell with pinned `PATH`/`HOME`, and pin E2B's outer login-shell environment to the root-owned `/var/empty` home so attacker-controlled profiles and shell hooks cannot run first.
- Move the `agent` service account's login home to `/var/empty`, give `agent-proxied` its own primary group, and lock `/home/agent`, `/opt/venv`, the GCS token broker, and Dust profile scripts against workload writes.
- Apply synthetic DNS, TCP forwarding, private-network drops, and runtime health checks to both controlled UIDs (`agent`/1002 and `agent-proxied`/1003).
- Keep the root-owned GCS FUSE token broker on real DNS through the local systemd-resolved stub while redirecting both controlled UIDs to the synthetic resolver.
- Deny both controlled UIDs access to systemd-resolved resolver IPC (D-Bus and Varlink), keeping real DNS reserved for root-owned services.
- Extend the live image security suite with service-path write denials, attacker-profile non-execution, metadata/DNS probes, root GCS connectivity, and GCS token refresh across E2B sleep/wake.

## Tests

- 69 focused Vitest tests passed across the E2B provider, image registry, egress setup, and GCS mount adapter.
- The broader sandbox suite passed: 334 tests passed and 8 provider-dependent tests were skipped.
- Full Front `tsgo --noEmit`, Biome formatting/lint checks, shell syntax validation, and `git diff --check` passed.
- Added live regression probes for resolve1 D-Bus and Varlink denial for both controlled UIDs before and after E2B sleep/wake, while verifying root resolver access and the private Varlink socket mode.
- The complete live security suite passed in EU and US on the pre-rebase `dust-base:0.8.60` build ([regional sandbox image workflow](https://github.com/dust-tt/dust/actions/runs/30453249458)). After rebasing onto `main`, the image is re-tagged **`0.8.66`** (`main` advanced the base to `0.8.64` with dbt/Snowflake CLIs and dsbx `0.1.41`, all now inherited); **`0.8.66` must be rebuilt and re-validated in both E2B regions before Front deploys.**

## Risk

Medium. This changes sandbox account ownership, shell startup behavior, DNS/egress boot services, and the base image tag. The regional live workflow fails if root GCS connectivity, controlled DNS/egress, resolver IPC isolation, service-path permissions, profile isolation, or sleep/wake token refresh regresses.

The compatibility tradeoff is intentional: workloads can no longer modify shared service paths such as `/opt/venv`; workload-owned packages and virtual environments must live under `/home/agent-proxied`.

## Deploy Plan

1. Confirm the validated `dust-base:0.8.66` templates remain available in both E2B regions before Front deploys. The existing deploy workflow gates Front on sandbox image availability.
2. Deploy Front using `dust-base:0.8.66`.
3. Immediately after the Front deploy, invoke `/poke/kill` for every `dust-base` version older than `0.8.66`. This is mandatory because sleeping sandboxes retain their original image.
4. Verify the kill requester completed successfully and that no non-deleted sandbox remains on an older `dust-base` version before closing the incident.