### PR TITLE
Admin governance: add query param to filter by availability

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -148,6 +148,66 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).not.toContain("Someone Else's Unpublished Skill");
   });
 
+  it("filters by availability, with isDefault=true as a deprecated alias", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await SkillFactory.create(auth, {
+      name: "Workspace Skill",
+      availability: "workspace_users",
+    });
+    await SkillFactory.create(auth, {
+      name: "Discoverable Skill",
+      availability: "users_and_agents",
+    });
+
+    const equivalentQueries: Record<string, string>[] = [
+      { availability: "users_and_agents" },
+      { isDefault: "true" },
+    ];
+    for (const query of equivalentQueries) {
+      const response = await getSkills(workspace, query);
+      expect(response.status).toBe(200);
+      const skillNames = (await response.json()).skills.map(
+        (s: SkillWithoutInstructionsAndToolsType) => s.name
+      );
+      expect(skillNames).toContain("Discoverable Skill");
+      expect(skillNames).not.toContain("Workspace Skill");
+    }
+
+    // An explicit availability takes priority over the deprecated alias.
+    const response = await getSkills(workspace, {
+      availability: "workspace_users",
+      isDefault: "true",
+    });
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Workspace Skill");
+    expect(skillNames).not.toContain("Discoverable Skill");
+
+    // Several availabilities can be requested at once (repeated query param).
+    const multiResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/skills?availability=workspace_users&availability=users_and_agents&onlyCustom=true`
+    );
+    expect(multiResponse.status).toBe(200);
+    const multiSkillNames = (await multiResponse.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(multiSkillNames).toContain("Workspace Skill");
+    expect(multiSkillNames).toContain("Discoverable Skill");
+
+    const invalidResponse = await getSkills(workspace, {
+      availability: "everyone",
+    });
+    expect(invalidResponse.status).toBe(400);
+  });
+
   it("should only return active skills", async () => {
     const { workspace, user } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -40,6 +40,10 @@ const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])
   .optional();
 
+const SkillAvailabilitiesSchema = z
+  .array(z.enum(SKILL_AVAILABILITIES))
+  .optional();
+
 // Request body schema for POST.
 const PostSkillRequestBodySchema = z.intersection(
   z.object({
@@ -125,7 +129,10 @@ app.get(
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
     const onlyCustom = ctx.req.query("onlyCustom");
+    // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
+    // Repeatable: ?availability=workspace_users&availability=users_and_agents.
+    const availabilityParams = ctx.req.queries("availability");
 
     const statusValidation = SkillStatusSchema.safeParse(status);
     if (!statusValidation.success) {
@@ -139,11 +146,30 @@ app.get(
     }
     const skillStatus = statusValidation.data;
 
+    const availabilityValidation =
+      SkillAvailabilitiesSchema.safeParse(availabilityParams);
+    if (!availabilityValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid availability: ${availabilityParams}. Expected "editors", "workspace_users", or "users_and_agents".`,
+        },
+      });
+    }
+    // An explicit availability takes priority over the deprecated isDefault alias.
+    const availability =
+      availabilityValidation.data && availabilityValidation.data.length > 0
+        ? availabilityValidation.data
+        : isDefault === "true"
+          ? ["users_and_agents" as const]
+          : undefined;
+
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
       onlyCustom: onlyCustom === "true",
-      isDefault: isDefault === "true" ? true : undefined,
+      availability,
       withInstructions: false,
       withTools: false,
       withFileAttachments: false,

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -50,7 +50,7 @@ export function SkillInfoTab({
     useSkills({
       owner,
       status: "active",
-      isDefault: true,
+      availability: "users_and_agents",
       disabled: !showDiscoverableSkills,
     });
 

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -141,7 +141,7 @@ export async function filterSkillDefinitions<T extends SkillDefinition>(
 
     if (
       where.availability !== undefined &&
-      where.availability !== availability
+      !matchesFilter(availability, where.availability)
     ) {
       return false;
     }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -87,10 +87,7 @@ import type {
   SkillType,
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
-import {
-  availabilityFromIsDefault,
-  isDefaultFromAvailability,
-} from "@app/types/assistant/skill_configuration";
+import { isDefaultFromAvailability } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -1439,7 +1436,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       limit,
       globalSpaceOnly,
       onlyCustom,
-      isDefault,
+      availability,
       updatedAfter,
       reinforcementNotOff,
       withInstructions = true,
@@ -1450,7 +1447,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       limit?: number;
       globalSpaceOnly?: boolean;
       onlyCustom?: boolean;
-      isDefault?: boolean;
+      availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
       reinforcementNotOff?: boolean;
       withInstructions?: boolean;
@@ -1461,10 +1458,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const skills = await this.baseFetch(auth, {
       where: {
         status,
-        // isDefault is a legacy alias kept at the interface level; the column is availability.
-        ...(isDefault !== undefined
-          ? { availability: availabilityFromIsDefault(isDefault) }
-          : {}),
+        ...(availability !== undefined ? { availability } : {}),
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
         ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
       },

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -15,7 +15,7 @@ export type AllSkillConfigurationFindOptions = Omit<
     sId?: string | string[];
     id?: number | number[];
     status?: SkillStatus | SkillStatus[];
-    availability?: SkillAvailability;
+    availability?: SkillAvailability | SkillAvailability[];
   };
   onlyCustom?: false; // Default: include global skills.
 };

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -16,6 +16,7 @@ import type {
 } from "@app/types/api/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/types/api/skills/existing_skill_checker";
 import type {
+  SkillAvailability,
   SkillReinforcementMode,
   SkillStatus,
   SkillType,
@@ -99,14 +100,14 @@ export function useSkills({
   disabled,
   status,
   globalSpaceOnly,
-  isDefault,
+  availability,
   swrOptions,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
-  isDefault?: boolean;
+  availability?: SkillAvailability | SkillAvailability[];
   swrOptions?: SWRConfiguration;
 }): {
   skills: SkillWithoutInstructionsAndToolsType[];
@@ -123,8 +124,13 @@ export function useSkills({
   if (globalSpaceOnly) {
     queryParams.set("globalSpaceOnly", "true");
   }
-  if (isDefault) {
-    queryParams.set("isDefault", "true");
+  if (availability) {
+    const availabilities = Array.isArray(availability)
+      ? availability
+      : [availability];
+    for (const value of availabilities) {
+      queryParams.append("availability", value);
+    }
   }
   const queryString = queryParams.toString();
 


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9728

replace the isDefault filtering by the new availability one.
keep isDefault for legacy reason (old clients), to be removed later

## Tests

added tests

## Risk

low, non breaking change

## Deploy Plan

deploy front
