### PR TITLE
Fix: pod editors correctly show in UI

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -308,8 +308,7 @@ app.get(
             const groupMemberships = membershipMap.get(group.id);
             return groupMembers.map((member) => ({
               ...member.toJSON(),
-              // group_vaults tells us if the group is an editor group.
-              isEditor: group.group_vaults?.kind === "project_editor",
+              isEditor: group.kind === "space_editors",
               joinedAt: groupMemberships?.get(member.id),
             }));
           },


### PR DESCRIPTION
## Description

`isEditor` in the pod members endpoint was derived from `group.group_vaults?.kind === "project_editor"` — a stale reference to the old `group_vaults` join that no longer reflects the current data model. Replaced with `group.kind === "space_editors"`, which is the canonical field. Pod editors now correctly surface in the UI.

## Tests

Tested manually: pod editor members now display with the editor role in the UI.

## Risk

Low. Single-line change replacing a broken optional-chain lookup with the correct group kind check. No schema or API contract change.

## Deploy Plan

Deploy front-api.
