### PR TITLE
Admin governance: only suggest similar skill among published skills

### DIFF
--- a/front-api/routes/w/[wId]/skills/similar.test.ts
+++ b/front-api/routes/w/[wId]/skills/similar.test.ts
@@ -103,6 +103,24 @@ describe("POST /api/w/:wId/skills/similar", () => {
     expect(runMultiActionsAgent).not.toHaveBeenCalled();
   });
 
+  it("ignores unpublished (editors-only) skills", async () => {
+    const { workspace, auth } = await setup();
+
+    await SkillFactory.create(auth, {
+      name: "Unpublished Skill",
+      availability: "editors",
+    });
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ similar_skills: [] });
+    // Never calls runMultiActionsAgent because there is no published skill to check
+    expect(runMultiActionsAgent).not.toHaveBeenCalled();
+  });
+
   it("batches skills into multiple LLM calls and merges deduplicated results", async () => {
     const { workspace, auth } = await setup();
     await createSkills(auth, SKILLS_PER_LLM_CALL + 1);

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -195,9 +195,11 @@ export async function getSimilarSkills(
     );
   }
 
-  // Retrieve all existing custom skills.
+  // Retrieve all existing published custom skills: unpublished (editors-only) skills
+  // should not prevent someone else from creating a similar skill.
   const allSkills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
     onlyCustom: true,
+    availability: ["workspace_users", "users_and_agents"],
   });
 
   const skills = inputs.excludeSkillId


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9732

Only compare the skills to the published ones, 2 users can have the same duplicate unpublished skills.

## Tests

added a unit test.

## Risk

low, easy to revert

## Deploy Plan

deploy front