### PR TITLE
[Poke] Show actual group member counts

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -37,7 +37,7 @@ app.get(
 
     return ctx.json({
       members,
-      group: await group.toJSONWithMemberCount(auth),
+      group: { ...group.toJSON(), memberCount: members.length },
     });
   }
 );

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -37,7 +37,7 @@ app.get(
 
     return ctx.json({
       members,
-      group: group.toJSON(),
+      group: await group.toJSONWithMemberCount(auth),
     });
   }
 );

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
@@ -1,5 +1,8 @@
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -12,16 +15,28 @@ async function createGroupWithMember() {
     workspace,
     "Poke member count group"
   );
-  const addMemberResult = await GroupFactory.withMembers(auth, group, [user]);
+  const revokedUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, revokedUser, { role: "user" });
+  const addMemberResult = await GroupFactory.withMembers(auth, group, [
+    user,
+    revokedUser,
+  ]);
   if (addMemberResult.isErr()) {
     throw addMemberResult.error;
+  }
+  const revokeResult = await MembershipResource.revokeMembership({
+    user: revokedUser,
+    workspace,
+  });
+  if (revokeResult.isErr()) {
+    throw new Error(revokeResult.error.type);
   }
 
   return { workspace, group };
 }
 
 describe("GET /api/poke/workspaces/:wId/groups", () => {
-  it("returns actual member counts", async () => {
+  it("excludes revoked workspace members from group counts", async () => {
     const { workspace, group } = await createGroupWithMember();
 
     const response = await honoApp.request(
@@ -38,7 +53,7 @@ describe("GET /api/poke/workspaces/:wId/groups", () => {
 });
 
 describe("GET /api/poke/workspaces/:wId/groups/:groupId/details", () => {
-  it("returns the actual member count", async () => {
+  it("excludes revoked workspace members from the group count", async () => {
     const { workspace, group } = await createGroupWithMember();
 
     const response = await honoApp.request(

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
@@ -1,0 +1,52 @@
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function createGroupWithMember() {
+  const { workspace, auth, user } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+  const group = await GroupFactory.regularManual(
+    workspace,
+    "Poke member count group"
+  );
+  const addMemberResult = await GroupFactory.withMembers(auth, group, [user]);
+  if (addMemberResult.isErr()) {
+    throw addMemberResult.error;
+  }
+
+  return { workspace, group };
+}
+
+describe("GET /api/poke/workspaces/:wId/groups", () => {
+  it("returns actual member counts", async () => {
+    const { workspace, group } = await createGroupWithMember();
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/groups`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const responseGroup = data.groups.find(
+      (g: { sId: string }) => g.sId === group.sId
+    );
+    expect(responseGroup?.memberCount).toBe(1);
+  });
+});
+
+describe("GET /api/poke/workspaces/:wId/groups/:groupId/details", () => {
+  it("returns the actual member count", async () => {
+    const { workspace, group } = await createGroupWithMember();
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/groups/${group.sId}/details`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.group.memberCount).toBe(1);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -26,8 +26,17 @@ app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
         !isSkillEditorGroupKind(kind)
     ),
   });
+  const memberCounts = await GroupResource.getMemberCountsForGroups(
+    auth,
+    groups
+  );
 
-  return ctx.json({ groups: groups.map((g) => g.toJSON()) });
+  return ctx.json({
+    groups: groups.map((group) => ({
+      ...group.toJSON(),
+      memberCount: memberCounts.get(group.id) ?? 0,
+    })),
+  });
 });
 
 app.route("/:groupId", groupId);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1376,16 +1376,21 @@ export class GroupResource extends BaseResource<GroupModel> {
   ): Promise<Map<ModelId, number>> {
     const owner = auth.getNonNullableWorkspace();
     const counts = new Map<ModelId, number>();
+    if (groups.length === 0) {
+      return counts;
+    }
 
     const globalGroup = groups.find((g) => g.isGlobal());
     const regularGroups = groups.filter((g) => !g.isGlobal());
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getActiveMemberships({ workspace: owner });
+    const activeUserIds = new Set(
+      workspaceMemberships.map((membership) => membership.userId)
+    );
 
     // Global group count comes from workspace active memberships.
     if (globalGroup) {
-      const { total } = await MembershipResource.getActiveMemberships({
-        workspace: owner,
-      });
-      counts.set(globalGroup.id, total);
+      counts.set(globalGroup.id, workspaceMemberships.length);
     }
 
     // All regular group counts in one query, reusing the existing method.
@@ -1393,7 +1398,10 @@ export class GroupResource extends BaseResource<GroupModel> {
       const membershipsByGroup =
         await GroupResource.getActiveMembershipsForGroups(auth, regularGroups);
       for (const [groupId, userIds] of Object.entries(membershipsByGroup)) {
-        counts.set(Number(groupId), userIds.length);
+        counts.set(
+          Number(groupId),
+          userIds.filter((userId) => activeUserIds.has(userId)).length
+        );
       }
     }
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9773

Poke group list and detail endpoints serialized groups with the default `memberCount` value, which is always zero. Return the number of active workspace members so Poke diagnostics agree with the displayed member rows.

The shared batched count now filters out revoked workspace members. The details endpoint reuses the length of its already-filtered member list.

## Risks

Blast radius: Member counts displayed in Poke and workspace group views.
Risk: very low, resource method getMemberCountsForGroups was not called before this PR

## Deploy Plan

- deploy front-api

## Test

- [x] Poke group list excludes revoked workspace members from its count
- [x] Poke group details exclude revoked workspace members from their count
- [x] Existing workspace group endpoint tests pass