### PR TITLE
[Conversations] Ignore deleted history when detecting active agents

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1178,6 +1178,7 @@ describe("softDeleteAgentMessage", () => {
       .filter((m) => m.type === "agent_message") as AgentMessageType[];
     expect(updatedAgentMessages.length).toBe(2);
     expect(updatedAgentMessages[0].rank).toBe(1);
+    expect(updatedAgentMessages[0].status).toBe("cancelled");
     expect(updatedAgentMessages[1].version).toBe(1);
     expect(updatedAgentMessages[1].visibility).toBe("deleted");
   });
@@ -1422,6 +1423,11 @@ describe("softDeleteUserMessageAndReplies", () => {
       throw new Error("No agent message found in conversation");
     }
 
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation,
+      isRunningAgentLoop: true,
+    });
+
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUserMessage,
       conversation,
@@ -1432,6 +1438,20 @@ describe("softDeleteUserMessageAndReplies", () => {
       messageIds: [firstAgentMessage.sId],
       conversationId: conversation.sId,
     });
+
+    const originalAgentMessage = await AgentMessageModel.findOne({
+      where: {
+        id: firstAgentMessage.agentMessageId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    expect(originalAgentMessage?.status).toBe("cancelled");
+
+    const updatedConversation = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(updatedConversation?.isRunningAgentLoop).toBe(false);
   });
 
   it("does not signal gracefullyStopAgentLoop when the cascaded agent reply already finished", async () => {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1178,7 +1178,6 @@ describe("softDeleteAgentMessage", () => {
       .filter((m) => m.type === "agent_message") as AgentMessageType[];
     expect(updatedAgentMessages.length).toBe(2);
     expect(updatedAgentMessages[0].rank).toBe(1);
-    expect(updatedAgentMessages[0].status).toBe("cancelled");
     expect(updatedAgentMessages[1].version).toBe(1);
     expect(updatedAgentMessages[1].visibility).toBe("deleted");
   });
@@ -1423,11 +1422,6 @@ describe("softDeleteUserMessageAndReplies", () => {
       throw new Error("No agent message found in conversation");
     }
 
-    await ConversationResource.setIsRunningAgentLoop(auth, {
-      conversation,
-      isRunningAgentLoop: true,
-    });
-
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUserMessage,
       conversation,
@@ -1438,20 +1432,58 @@ describe("softDeleteUserMessageAndReplies", () => {
       messageIds: [firstAgentMessage.sId],
       conversationId: conversation.sId,
     });
+  });
 
-    const originalAgentMessage = await AgentMessageModel.findOne({
-      where: {
-        id: firstAgentMessage.agentMessageId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
+  it("starts a follow-up after deleting the previous running reply", async () => {
+    const oneTurnConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
     });
-    expect(originalAgentMessage?.status).toBe("cancelled");
+    const fetched = await getConversation(auth, oneTurnConversation.sId);
+    if (fetched.isErr()) {
+      throw fetched.error;
+    }
+    const userMessage = fetched.value.content
+      .flat()
+      .find((message): message is UserMessageType =>
+        isUserMessageType(message)
+      );
+    if (!userMessage) {
+      throw new Error("No user message found in conversation");
+    }
 
-    const updatedConversation = await ConversationResource.fetchById(
-      auth,
-      conversation.sId
-    );
-    expect(updatedConversation?.isRunningAgentLoop).toBe(false);
+    const deleted = await softDeleteUserMessageAndReplies(auth, {
+      message: userMessage,
+      conversation: fetched.value,
+    });
+    expect(deleted.isOk()).toBe(true);
+
+    const afterDelete = await getConversation(auth, oneTurnConversation.sId);
+    if (afterDelete.isErr()) {
+      throw afterDelete.error;
+    }
+
+    const user = auth.getNonNullableUser().toJSON();
+    const followUp = await postUserMessage(auth, {
+      conversation: afterDelete.value,
+      content: "Follow-up",
+      mentions: [{ configurationId: agentConfig.sId }],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: user.email,
+        profilePictureUrl: user.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(followUp.isOk()).toBe(true);
+    if (followUp.isOk()) {
+      expect(followUp.value.userMessage.visibility).toBe("visible");
+      expect(followUp.value.agentMessages).toHaveLength(1);
+    }
   });
 
   it("does not signal gracefullyStopAgentLoop when the cascaded agent reply already finished", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -702,7 +702,7 @@ export async function postUserMessage(
   }
 
   let runningAgentMessage = conversation.content
-    .flat()
+    .map((versions) => versions[versions.length - 1])
     .find(
       (m): m is AgentMessageType =>
         isAgentMessageType(m) && m.status === "created"
@@ -2213,41 +2213,6 @@ function getAgentRepliesToCascadeOnUserDelete(
   return orphans;
 }
 
-async function stopDeletedAgentMessages(
-  auth: Authenticator,
-  conversation: ConversationType,
-  agentMessages: AgentMessageType[]
-): Promise<void> {
-  const runningAgentMessages = agentMessages.filter(
-    (message) => message.status === "created"
-  );
-  if (runningAgentMessages.length === 0) {
-    return;
-  }
-
-  await gracefullyStopAgentLoop(auth, {
-    messageIds: runningAgentMessages.map((message) => message.sId),
-    conversationId: conversation.sId,
-  });
-
-  let finalizedMessage = false;
-  for (const agentMessage of runningAgentMessages) {
-    const result = await updateAgentMessageWithFinalStatus(auth, {
-      conversation,
-      agentMessage,
-      status: "cancelled",
-    });
-    finalizedMessage ||= result.applied;
-  }
-
-  if (finalizedMessage) {
-    await ConversationResource.setIsRunningAgentLoop(auth, {
-      conversation,
-      isRunningAgentLoop: false,
-    });
-  }
-}
-
 /**
  * Soft-delete a user message and the agent replies that followed it.
  *
@@ -2355,9 +2320,18 @@ export async function softDeleteUserMessageAndReplies(
     await publishAgentMessagesEvents(conversation, cascadedAgentMessages);
   }
 
-  // Stop any still-running agent loops and finalize the hidden original versions. The workflow
-  // finalizer cannot load an agent message after its deleted v+1 becomes the latest version.
-  await stopDeletedAgentMessages(auth, conversation, orphanAgentMessages);
+  // Signal any still-running agent loops to stop. Orphans with status "created" have a live
+  // Temporal workflow that would otherwise keep streaming to a deleted message. The gracefully-
+  // stopped event also lets the client flip the message status and hide the Stop button.
+  const runningOrphans = orphanAgentMessages.filter(
+    (m) => m.status === "created"
+  );
+  if (runningOrphans.length > 0) {
+    await gracefullyStopAgentLoop(auth, {
+      messageIds: runningOrphans.map((m) => m.sId),
+      conversationId: conversation.sId,
+    });
+  }
 
   auditLog(
     {
@@ -2436,7 +2410,14 @@ export async function softDeleteAgentMessage(
 
   await publishAgentMessagesEvents(conversation, agentMessages);
 
-  await stopDeletedAgentMessages(auth, conversation, [message]);
+  // Stop the underlying agent loop if it's still running so the Temporal workflow doesn't keep
+  // streaming to a deleted message and the client sees the Stop button disappear.
+  if (message.status === "created") {
+    await gracefullyStopAgentLoop(auth, {
+      messageIds: [message.sId],
+      conversationId: conversation.sId,
+    });
+  }
 
   auditLog(
     {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -701,6 +701,7 @@ export async function postUserMessage(
     return canInteractRes;
   }
 
+  // Versions partition the message rows by rank, so this stays linear in conversation size.
   let runningAgentMessage = conversation.content
     .map((versions) =>
       versions.reduce((latest, message) =>

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -701,16 +701,19 @@ export async function postUserMessage(
     return canInteractRes;
   }
 
-  let runningAgentMessage = conversation.content
-    .map((versions) =>
-      versions.reduce((latest, message) =>
-        message.version > latest.version ? message : latest
-      )
-    )
-    .find(
-      (m): m is AgentMessageType =>
-        isAgentMessageType(m) && m.status === "created"
+  let runningAgentMessage: AgentMessageType | undefined;
+  for (const versions of conversation.content) {
+    const latestMessage = versions.reduce((latest, message) =>
+      message.version > latest.version ? message : latest
     );
+    if (
+      isAgentMessageType(latestMessage) &&
+      latestMessage.status === "created"
+    ) {
+      runningAgentMessage = latestMessage;
+      break;
+    }
+  }
 
   // Steering invariants: enforce single agent loop per conversation.
   if (explicitAgentMentions.length > 1) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -702,7 +702,11 @@ export async function postUserMessage(
   }
 
   let runningAgentMessage = conversation.content
-    .map((versions) => versions[versions.length - 1])
+    .map((versions) =>
+      versions.reduce((latest, message) =>
+        message.version > latest.version ? message : latest
+      )
+    )
     .find(
       (m): m is AgentMessageType =>
         isAgentMessageType(m) && m.status === "created"

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -701,19 +701,16 @@ export async function postUserMessage(
     return canInteractRes;
   }
 
-  let runningAgentMessage: AgentMessageType | undefined;
-  for (const versions of conversation.content) {
-    const latestMessage = versions.reduce((latest, message) =>
-      message.version > latest.version ? message : latest
+  let runningAgentMessage = conversation.content
+    .map((versions) =>
+      versions.reduce((latest, message) =>
+        message.version > latest.version ? message : latest
+      )
+    )
+    .find(
+      (m): m is AgentMessageType =>
+        isAgentMessageType(m) && m.status === "created"
     );
-    if (
-      isAgentMessageType(latestMessage) &&
-      latestMessage.status === "created"
-    ) {
-      runningAgentMessage = latestMessage;
-      break;
-    }
-  }
 
   // Steering invariants: enforce single agent loop per conversation.
   if (explicitAgentMentions.length > 1) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -701,7 +701,6 @@ export async function postUserMessage(
     return canInteractRes;
   }
 
-  // Versions partition the message rows by rank, so this stays linear in conversation size.
   let runningAgentMessage = conversation.content
     .map((versions) =>
       versions.reduce((latest, message) =>

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2213,6 +2213,41 @@ function getAgentRepliesToCascadeOnUserDelete(
   return orphans;
 }
 
+async function stopDeletedAgentMessages(
+  auth: Authenticator,
+  conversation: ConversationType,
+  agentMessages: AgentMessageType[]
+): Promise<void> {
+  const runningAgentMessages = agentMessages.filter(
+    (message) => message.status === "created"
+  );
+  if (runningAgentMessages.length === 0) {
+    return;
+  }
+
+  await gracefullyStopAgentLoop(auth, {
+    messageIds: runningAgentMessages.map((message) => message.sId),
+    conversationId: conversation.sId,
+  });
+
+  let finalizedMessage = false;
+  for (const agentMessage of runningAgentMessages) {
+    const result = await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "cancelled",
+    });
+    finalizedMessage ||= result.applied;
+  }
+
+  if (finalizedMessage) {
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation,
+      isRunningAgentLoop: false,
+    });
+  }
+}
+
 /**
  * Soft-delete a user message and the agent replies that followed it.
  *
@@ -2320,18 +2355,9 @@ export async function softDeleteUserMessageAndReplies(
     await publishAgentMessagesEvents(conversation, cascadedAgentMessages);
   }
 
-  // Signal any still-running agent loops to stop. Orphans with status "created" have a live
-  // Temporal workflow that would otherwise keep streaming to a deleted message. The gracefully-
-  // stopped event also lets the client flip the message status and hide the Stop button.
-  const runningOrphans = orphanAgentMessages.filter(
-    (m) => m.status === "created"
-  );
-  if (runningOrphans.length > 0) {
-    await gracefullyStopAgentLoop(auth, {
-      messageIds: runningOrphans.map((m) => m.sId),
-      conversationId: conversation.sId,
-    });
-  }
+  // Stop any still-running agent loops and finalize the hidden original versions. The workflow
+  // finalizer cannot load an agent message after its deleted v+1 becomes the latest version.
+  await stopDeletedAgentMessages(auth, conversation, orphanAgentMessages);
 
   auditLog(
     {
@@ -2410,14 +2436,7 @@ export async function softDeleteAgentMessage(
 
   await publishAgentMessagesEvents(conversation, agentMessages);
 
-  // Stop the underlying agent loop if it's still running so the Temporal workflow doesn't keep
-  // streaming to a deleted message and the client sees the Stop button disappear.
-  if (message.status === "created") {
-    await gracefullyStopAgentLoop(auth, {
-      messageIds: [message.sId],
-      conversationId: conversation.sId,
-    });
-  }
+  await stopDeletedAgentMessages(auth, conversation, [message]);
 
   auditLog(
     {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9777.

When a user deletes a turn, the deletion is stored as a newer deleted message version. The older agent-message version can legitimately remain in `created` while its workflow stops.

`postUserMessage` was flattening the full version history when looking for a running agent. It therefore found that hidden old version and stored every later user message as pending, even though the latest version said the agent reply was deleted.

This change checks only the latest version at each rank when deciding whether an agent is running. The existing deletion flow still signals a live workflow to stop, but historical versions no longer keep the queue blocked.

## Risks

Blast radius: steering detection in conversations containing multiple versions of the same message.
Risk: low. The latest version is the current conversation state; older versions are retained as history.

## Deploy Plan

- Deploy front.

## Tests

- [x] `front/lib/api/assistant/conversation.test.ts` (86 tests)