### PR TITLE
refactor(conversations): update get/compaction routes for ConversationResource

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,7 +9,7 @@ import {
 } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
@@ -204,27 +204,36 @@ app.patch(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const conversationRes = await getConversation(auth, cId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      cId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
 
     const data = ctx.req.valid("json");
     if ("read" in data) {
       if (data.read) {
         await ConversationResource.markAsReadForAuthUser(auth, {
-          conversation: conversationRes.value,
+          conversation: conversationResource,
         });
       } else {
         await ConversationResource.markAsUnreadForAuthUser(auth, {
-          conversation: conversationRes.value,
+          conversation: conversationResource,
         });
       }
       return ctx.json({ success: true });
     }
 
     const titleUpdateRes = await updateConversationTitle(auth, {
-      conversationId: conversationRes.value.sId,
+      conversationId: conversationResource.sId,
       title: data.title,
     });
     if (titleUpdateRes.isErr()) {
@@ -232,7 +241,7 @@ app.patch(
     }
 
     await ConversationResource.markAsReadForAuthUser(auth, {
-      conversation: conversationRes.value,
+      conversation: conversationResource,
     });
 
     return ctx.json({ success: true });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,9 +1,8 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -96,9 +95,18 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
 
     const { model } = ctx.req.valid("json");
@@ -123,7 +131,7 @@ app.post(
     }
 
     const result = await compactConversation(auth, {
-      conversation: conversationRes.value,
+      conversation: conversationResource.toJSON(),
       model,
     });
     if (result.isErr()) {

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -21,7 +21,7 @@ import { Err, Ok } from "@app/types/shared/result";
  */
 export async function resolveFilePathsInParentScope(
   auth: Authenticator,
-  mainConversation: ConversationType,
+  mainConversation: ConversationWithoutContentType,
   filePaths: string[]
 ): Promise<Result<string[], MCPError>> {
   const fsResult = await DustFileSystem.forConversation(auth, mainConversation);
@@ -85,7 +85,7 @@ export async function copyConversationFilesIntoSub(
     subConversationId,
     filePaths,
   }: {
-    parentConversation: ConversationType;
+    parentConversation: ConversationWithoutContentType;
     subConversationId: string;
     filePaths: string[];
   }


### PR DESCRIPTION
## Description

Completes the `ConversationResource` migration for the remaining front-api read routes. The `PATCH /v1/w/[wId]/assistant/conversations/[cId]` and `POST /w/[wId]/assistant/conversations/[cId]/compactions` routes both previously called `getConversation()` (full content load); they now use `ConversationResource.fetchById` instead, with inline 404 errors replacing `apiErrorForConversation`. The compaction route calls `conversationResource.toJSON()` to satisfy `compactConversation`'s existing interface. Also tightens `resolveFilePathsInParentScope` and `copyConversationFilesIntoSub` in `file_paths.ts` to accept `ConversationWithoutContentType` instead of the full `ConversationType`.

## Tests

Tested manually. No functional change to route behavior — same auth, same 404 semantics, same downstream calls.

## Risk

Low. No DB changes. The routes touch read/unread marking, title updates, and compaction triggers — none require full message content, so dropping to `fetchById` is safe. Rollback is straightforward.

## Deploy Plan

Deploy front-api and front.