### PR TITLE
test(conversations): fix conversation test factories for resource refactor

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -75,7 +75,7 @@ async function createUserMessage(
     content,
     branchId = null,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     rank: number;
     content: string;
     branchId?: ModelId | null;
@@ -119,7 +119,7 @@ async function createAgentMessage(
     generatedFileId = null,
     branchId = null,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     rank: number;
     parentId: ModelId;
     status: "created" | "succeeded";
@@ -856,7 +856,7 @@ describe("createConversationFork", () => {
     });
 
     const upsertResult = await SkillResource.upsertConversationSkills(auth, {
-      conversation: parentConversation,
+      conversation: parentConversation.toJSON(),
       skills: [enabledSkill],
       enabled: true,
     });

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -846,12 +846,19 @@ describe("createAgentMessages", () => {
       );
       expect(restrictedSpaceModelId).not.toBeNull();
 
-      const restrictedConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const restrictedConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpaceModelId!],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpaceModelId!] },
+        { where: { id: restrictedConversationResource.id } }
+      );
+      const restrictedConversation = {
+        ...restrictedConversationResource.toJSON(),
+        requestedSpaceIds: [refreshedRestrictedSpace!.sId],
+      };
 
       // Verify the mentioned user cannot access the conversation
       const canAccess = await ConversationResource.canAccess(
@@ -1039,12 +1046,19 @@ describe("createAgentMessages", () => {
       );
       expect(restrictedSpaceModelId).not.toBeNull();
 
-      const restrictedConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const restrictedConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpaceModelId!],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpaceModelId!] },
+        { where: { id: restrictedConversationResource.id } }
+      );
+      const restrictedConversation = {
+        ...restrictedConversationResource.toJSON(),
+        requestedSpaceIds: [refreshedRestrictedSpace!.sId],
+      };
 
       // Add user as participant first (which would normally auto-approve)
       await ConversationResource.upsertParticipation(auth, {
@@ -1130,11 +1144,13 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedProjectSpace).not.toBeNull();
 
-      const projectConversation = await createConversation(userAuth, {
+      const projectConversationResource = await createConversation(userAuth, {
         title: "Project Conversation",
         visibility: "unlisted",
         spaceId: refreshedProjectSpace!.id,
       });
+
+      const projectConversation = projectConversationResource.toJSON();
 
       // Create an agent message
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
@@ -1207,11 +1223,13 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedProjectSpace).not.toBeNull();
 
-      const projectConversation = await createConversation(userAuth, {
+      const projectConversationResource = await createConversation(userAuth, {
         title: "Project Conversation",
         visibility: "unlisted",
         spaceId: refreshedProjectSpace!.id,
       });
+
+      const projectConversation = projectConversationResource.toJSON();
 
       // Create an agent message
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
@@ -1527,12 +1545,19 @@ describe("createAgentMessages", () => {
 
       // Create a conversation in a restricted space
       const restrictedSpace = await SpaceFactory.regular(workspace);
-      const regularConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const regularConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpace.id] },
+        { where: { id: regularConversationResource.id } }
+      );
+      const regularConversation = {
+        ...regularConversationResource.toJSON(),
+        requestedSpaceIds: [restrictedSpace.sId],
+      };
 
       const restrictedUserResource = await getUserForWorkspace(auth, {
         userId: restrictedUser.sId,
@@ -1858,7 +1883,7 @@ describe("createUserMessage", () => {
       const userJson = adminUser.toJSON();
       const userMessage = await withTransaction(async (transaction) => {
         return createUserMessage(userAuth, {
-          conversation: projectConversation,
+          conversation: projectConversation.toJSON(),
           content: `Hello @${mentionedUser.sId}`,
           metadata: {
             type: "create",

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1038,7 +1038,7 @@ describe("createAgentMessages", () => {
       ];
 
       const { agentMessages, richMentions } = await createAgentMessages(auth, {
-        conversation: spaceConversation,
+        conversation: spaceConversation.toJSON(),
         metadata: {
           type: "create",
           mentions,
@@ -1184,7 +1184,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1316,7 +1316,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1439,7 +1439,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1588,7 +1588,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,

--- a/front/lib/api/assistant/plan_mode.test.ts
+++ b/front/lib/api/assistant/plan_mode.test.ts
@@ -36,7 +36,7 @@ async function setup(): Promise<{
     visibility: "unlisted",
     spaceId: null,
   });
-  return { auth, conversation };
+  return { auth, conversation: conversation.toJSON() };
 }
 
 function lastPlanWrite(): string | null {

--- a/front/lib/reinforcement/selection.test.ts
+++ b/front/lib/reinforcement/selection.test.ts
@@ -11,6 +11,7 @@ import {
   findConversationsWithSkills,
   scoreAndSelectConversations,
 } from "@app/lib/reinforcement/selection";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -320,14 +321,16 @@ describe("findConversationsWithSkills", () => {
     const skillOff = await SkillFactory.create(auth, { name: "Skill Off" });
     await skillOff.updateReinforcement("off");
 
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
     // Conversation A uses all 3 skills. Has 2 user messages to pass the scoring filter.
     const convA = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date(), new Date()],
     });
     const agentMessageA = await AgentMessageModel.create({
       status: "created",
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       agentConfigurationVersion: 0,
       conversationId: convA.id,
       workspaceId: workspace.id,
@@ -347,12 +350,12 @@ describe("findConversationsWithSkills", () => {
 
     // Conversation B uses only the "off" skill. Has 2 user messages.
     const convB = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date(), new Date()],
     });
     const agentMessageB = await AgentMessageModel.create({
       status: "created",
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       agentConfigurationVersion: 0,
       conversationId: convB.id,
       workspaceId: workspace.id,


### PR DESCRIPTION
## Description

Follow-up to the `ConversationResource` refactor (PR #29396): `createConversation` now returns `ConversationResource` instead of `ConversationWithoutContentType`, breaking several test helpers that expected the plain type.

- Call `.toJSON()` on `ConversationResource` before passing to `createAgentMessages`, `createUserMessage`, `SkillResource.upsertConversationSkills`, and `plan_mode` setup — across `messages.test.ts`, `mentions.test.ts`, `forks.test.ts`, and `plan_mode.test.ts`.
- Replace `ConversationFactory.create(auth, { requestedSpaceIds: [...] })` with `createConversation` + direct `ConversationModel.update` to set `requestedSpaceIds`, since the resource API no longer accepts that field at creation time. The resulting plain object is constructed via `.toJSON()` with `requestedSpaceIds` spread in using the space `sId`.
- Fix `selection.test.ts` to use a real `AgentConfigurationFactory.createTestAgent` sId instead of the hardcoded `"test-agent"` string.

## Tests

All changes are in test files. Existing test suites cover the behaviour; this PR makes them pass again after the `ConversationResource` refactor.

## Risk

No production code changed. Test-only. Low risk, safe to rollback at any point.

## Deploy Plan

No deploy needed — test-only changes.
