### PR TITLE
test(file-system): update tests for ConversationResource tool context

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -1,3 +1,5 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -137,11 +139,15 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const restrictedSpace = await SpaceFactory.regular(workspace);
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
-      messagesCreatedAt: [new Date()],
-      requestedSpaceIds: [restrictedSpace.id],
+    const restrictedConversation = await createConversation(auth, {
+      title: "Restricted conversation",
+      visibility: "unlisted",
+      spaceId: null,
     });
+    await ConversationModel.update(
+      { requestedSpaceIds: [restrictedSpace.id] },
+      { where: { id: restrictedConversation.id } }
+    );
 
     const file = await FileFactory.create(auth, user, {
       contentType: "application/vnd.dust.frame",
@@ -149,7 +155,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
       fileSize: 1024,
       status: "ready",
       useCase: "conversation",
-      useCaseMetadata: { conversationId: conversation.sId },
+      useCaseMetadata: { conversationId: restrictedConversation.sId },
     });
 
     const response = await postEdit(workspace, file.sId, {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -3,13 +3,13 @@ import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { makeExtra } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import {
   getFileFromConversationAttachment,
   resolveConversationFileRef,
@@ -97,7 +97,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         canonicalPath,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isOk()).toBe(true);
@@ -130,7 +130,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/missing.pdf`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -158,7 +158,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -171,7 +171,7 @@ describe("getFileFromConversationAttachment", () => {
         role: "admin",
       });
 
-      const conversation = await createConversation(auth, {
+      const conversationResource = await createConversation(auth, {
         title: "Test",
         visibility: "unlisted",
         spaceId: null,
@@ -183,13 +183,13 @@ describe("getFileFromConversationAttachment", () => {
         fileSize: 100,
         status: "ready",
         useCase: "conversation",
-        useCaseMetadata: { conversationId: conversation.sId },
+        useCaseMetadata: { conversationId: conversationResource.sId },
       });
 
       await ConversationFactory.createContentFragmentMessage({
         auth,
         workspace,
-        conversationId: conversation.id,
+        conversationId: conversationResource.id,
         rank: 0,
         fileId: file.id,
         title: "Report",
@@ -197,11 +197,15 @@ describe("getFileFromConversationAttachment", () => {
         fileName: "report.pdf",
       });
 
-      const conversationResult = await getConversation(auth, conversation.sId);
-      if (conversationResult.isErr()) {
-        throw new Error("Failed to fetch conversation");
+      const conversationRes = await getConversation(
+        auth,
+        conversationResource.sId
+      );
+      if (conversationRes.isErr()) {
+        throw new Error(
+          `Failed to fetch conversation: ${conversationRes.error.type}`
+        );
       }
-      const fullConversation = conversationResult.value;
 
       const expectedContent = "pdf bytes";
       vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
@@ -211,7 +215,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         file.sId,
-        makeToolContext(fullConversation)
+        makeToolContext(conversationRes.value)
       );
 
       expect(result.isOk()).toBe(true);
@@ -229,21 +233,26 @@ describe("getFileFromConversationAttachment", () => {
         role: "admin",
       });
 
-      const conversation = await createConversation(auth, {
+      const conversationResource = await createConversation(auth, {
         title: "Test",
         visibility: "unlisted",
         spaceId: null,
       });
 
-      const conversationResult = await getConversation(auth, conversation.sId);
-      if (conversationResult.isErr()) {
-        throw new Error("Failed to fetch conversation");
+      const conversationRes = await getConversation(
+        auth,
+        conversationResource.sId
+      );
+      if (conversationRes.isErr()) {
+        throw new Error(
+          `Failed to fetch conversation: ${conversationRes.error.type}`
+        );
       }
 
       const result = await getFileFromConversationAttachment(
         auth,
         "fil_notfound",
-        makeToolContext(conversationResult.value)
+        makeToolContext(conversationRes.value)
       );
 
       expect(result.isErr()).toBe(true);
@@ -278,7 +287,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/notes.txt",
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isOk()).toBe(true);
@@ -308,7 +317,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/missing.pdf",
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -425,7 +434,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         `conversation-${conversation.sId}/missing.png`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -459,7 +468,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeToolContext({ ...conversation, content: [] })
+      makeExtra(auth, conversation)
     );
 
     expect(result.isOk()).toBe(true);
@@ -502,7 +511,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeToolContext({ ...conversationB, content: [] })
+      makeExtra(auth, conversationB)
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1,3 +1,4 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import {
   DustFileSystem,
   sanitizeFileSystemName,
@@ -595,17 +596,15 @@ describe("DustFileSystem.forAgentLoop", () => {
         )
       ).toBeNull();
 
-      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
-        userSessionAuth,
-        { name: "User Agent", description: "User Agent" }
-      );
-      const userConversation = await ConversationFactory.create(
+      const userConversationResource = await createConversation(
         userSessionAuth,
         {
-          agentConfigurationId: userAgentConfig.sId,
-          messagesCreatedAt: [],
+          title: "User Conversation",
+          visibility: "unlisted",
+          spaceId: null,
         }
       );
+      const userConversation = userConversationResource.toJSON();
 
       const result = await DustFileSystem.forAgentLoop(userSessionAuth, {
         conversation: userConversation,

--- a/front/lib/api/file_system/upload_from_url.test.ts
+++ b/front/lib/api/file_system/upload_from_url.test.ts
@@ -67,7 +67,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       spaceId: null,
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -92,7 +95,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       spaceId: null,
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -123,7 +129,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       contentLength: "15",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -158,7 +167,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: "ignored",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -196,7 +208,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: Readable.from(abortedBodyChunks()),
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -226,7 +241,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: "<html></html>",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;


### PR DESCRIPTION
## Description

Test-only follow-up to the `ConversationResource` refactor (PR #29396). `createConversation` now returns a `ConversationResource`, so:

- Replace `makeToolContext({ ...conversation, content: [] })` with `makeExtra(auth, conversation)` across `file_utils.test.ts` and `dust_file_system.test.ts` — `makeExtra` wraps the resource so it can lazily fetch full conversation content for legacy `fileId` resolution.
- Call `.toJSON()` on `ConversationResource` wherever `DustFileSystem.forConversation` / `forAgentLoop` expect a plain `ConversationType`.
- Replace `ConversationFactory.create` (which required a full agent config) with `createConversation` + a direct `ConversationModel.update` to set `requestedSpaceIds` in `edit-text.test.ts`.
- Improve error messages in `getConversation` failure guards to include `error.type`.

## Tests

Updated Vitest unit tests in `file_utils.test.ts`, `dust_file_system.test.ts`, `upload_from_url.test.ts`, and `edit-text.test.ts`. No new test cases — existing coverage is preserved with corrected test helpers.

## Risk

Test-only change. No production code modified. Zero rollback concern.

## Deploy Plan

No deploy needed.
