### PR TITLE
refactor(conversations): migrate mutations and callers off conversation.content

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,7 +9,7 @@ import {
 } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
@@ -204,27 +204,36 @@ app.patch(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const conversationRes = await getConversation(auth, cId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      cId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
 
     const data = ctx.req.valid("json");
     if ("read" in data) {
       if (data.read) {
         await ConversationResource.markAsReadForAuthUser(auth, {
-          conversation: conversationRes.value,
+          conversation: conversationResource,
         });
       } else {
         await ConversationResource.markAsUnreadForAuthUser(auth, {
-          conversation: conversationRes.value,
+          conversation: conversationResource,
         });
       }
       return ctx.json({ success: true });
     }
 
     const titleUpdateRes = await updateConversationTitle(auth, {
-      conversationId: conversationRes.value.sId,
+      conversationId: conversationResource.sId,
       title: data.title,
     });
     if (titleUpdateRes.isErr()) {
@@ -232,7 +241,7 @@ app.patch(
     }
 
     await ConversationResource.markAsReadForAuthUser(auth, {
-      conversation: conversationRes.value,
+      conversation: conversationResource,
     });
 
     return ctx.json({ success: true });

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,5 +1,5 @@
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isUserMessageType } from "@app/types/assistant/conversation";
@@ -7,7 +7,6 @@ import {
   type PostMessagesResponseBody,
   PublicPostEditMessagesRequestBodySchema,
 } from "@dust-tt/client";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -130,24 +129,37 @@ app.post(
       });
     }
 
-    const branchId = messageRes.value.getBranchId() ?? null;
-
-    const conversationRes = await getConversation(
-      auth,
-      conversationId,
-      false,
-      branchId
-    );
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const messageModel = messageRes.value;
+    if (!messageModel.userMessage) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The message you're trying to edit does not exist or is not an user message.",
+        },
+      });
     }
 
-    const conversation = conversationRes.value;
+    const branchId = messageModel.getBranchId() ?? null;
 
-    const message = conversation.content
-      .flat()
-      .find((m) => m.sId === messageId);
+    const renderRes = await batchRenderMessages(
+      auth,
+      conversationResource,
+      [messageModel],
+      "full"
+    );
+    if (renderRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to render message.",
+        },
+      });
+    }
+
+    const message = renderRes.value[0];
     if (!message || !isUserMessageType(message)) {
       return apiError(ctx, {
         status_code: 400,
@@ -161,7 +173,8 @@ app.post(
     const { content, mentions, skipToolsValidation } = ctx.req.valid("json");
 
     const editedMessageRes = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
+      branchId,
       message,
       content,
       mentions,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,10 +1,9 @@
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { RetryMessageResponseType } from "@dust-tt/client";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { streamingTag } from "@front-api/middlewares/streaming";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -73,25 +72,8 @@ app.post(
       });
     }
 
-    const branchId = messageRes.value.getBranchId() ?? null;
-
-    const conversationRes = await getConversation(
-      auth,
-      conversationId,
-      false,
-      branchId
-    );
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
-    }
-
-    const conversation = conversationRes.value;
-
-    const message = conversation.content
-      .flat()
-      .find((m) => m.sId === messageId);
-    if (!message || !isAgentMessageType(message)) {
+    const messageModel = messageRes.value;
+    if (!messageModel.agentMessage) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -102,8 +84,38 @@ app.post(
       });
     }
 
+    const branchId = messageModel.getBranchId() ?? null;
+
+    const renderRes = await batchRenderMessages(
+      auth,
+      conversationResource,
+      [messageModel],
+      "full"
+    );
+    if (renderRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to render message.",
+        },
+      });
+    }
+
+    const message = renderRes.value[0];
+    if (!message || !isAgentMessageType(message)) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to render message.",
+        },
+      });
+    }
+
     const retriedMessageRes = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
+      branchId,
       message,
     });
     if (retriedMessageRes.isErr()) {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -3,7 +3,6 @@ import {
   isUserMessageContextValid,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isUserMessageContextOverflowing } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
@@ -16,7 +15,6 @@ import {
   type PostMessagesResponseBody,
   PublicPostMessagesRequestBodySchema,
 } from "@dust-tt/client";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { validatePublicModelSelection } from "@front-api/lib/api/assistant/conversation/model_selection";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -88,13 +86,19 @@ app.post(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const conversationRes = await getConversation(auth, cId);
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      cId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
-
-    const conversation = conversationRes.value;
 
     const {
       content,
@@ -191,7 +195,7 @@ app.post(
       );
 
       const upsertRes = await ConversationResource.upsertMCPServerViews(auth, {
-        conversation,
+        conversation: conversationResource,
         mcpServerViews,
         enabled: true,
         source: "conversation",
@@ -240,7 +244,7 @@ app.post(
             content,
             context: messageContext,
             agenticMessageData,
-            conversation,
+            conversationResource,
             mentions,
             modelSelection,
             skipToolsValidation: skipToolsValidation ?? false,
@@ -249,7 +253,7 @@ app.post(
             content,
             context: messageContext,
             agenticMessageData,
-            conversation,
+            conversationResource,
             mentions,
             modelSelection,
             skipToolsValidation: skipToolsValidation ?? false,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -36,10 +36,10 @@ import {
 } from "@app/types/api/assistant";
 import type {
   AgenticMessageData,
+  ConversationType,
   UserMessageContext,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
@@ -337,16 +337,23 @@ app.post(
       resolvedSpaceModelId = space.id;
     }
 
-    let conversation = await createConversation(auth, {
+    const conversationResource = await createConversation(auth, {
       title: title ?? null,
       visibility: normalizeConversationVisibility(visibility),
       depth,
       spaceId: resolvedSpaceModelId,
     });
 
-    if (conversation.depth === 0) {
+    let conversation: ConversationType = {
+      ...conversationResource.toJSON(),
+      owner: auth.getNonNullableWorkspace(),
+      visibility: conversationResource.visibility,
+      content: [],
+    };
+
+    if (conversationResource.depth === 0) {
       await ConversationResource.upsertParticipation(auth, {
-        conversation,
+        conversation: conversationResource,
         action: "subscribed",
         user: auth.user()?.toJSON() ?? null,
       });
@@ -361,7 +368,7 @@ app.post(
 
       if (isContentFragmentInputWithInlinedContent(cf)) {
         const contentFragmentRes = await toFileContentFragment(auth, {
-          conversation,
+          conversation: conversationResource,
           contentFragment: cf,
         });
         if (contentFragmentRes.isErr()) {
@@ -382,12 +389,17 @@ app.post(
         isContentFragmentInputWithFileId(cf) ||
         isContentFragmentInputWithContentNode(cf)
       ) {
-        const cfRes = await postNewContentFragment(auth, conversation, cf, {
-          username: context?.username ?? null,
-          fullName: context?.fullName ?? null,
-          email: context?.email?.toLowerCase() ?? null,
-          profilePictureUrl: context?.profilePictureUrl ?? null,
-        });
+        const cfRes = await postNewContentFragment(
+          auth,
+          conversationResource.toJSON(),
+          cf,
+          {
+            username: context?.username ?? null,
+            fullName: context?.fullName ?? null,
+            email: context?.email?.toLowerCase() ?? null,
+            profilePictureUrl: context?.profilePictureUrl ?? null,
+          }
+        );
         if (cfRes.isErr()) {
           return apiError(ctx, {
             status_code: 400,
@@ -398,25 +410,6 @@ app.post(
           });
         }
         newContentFragment = cfRes.value;
-      }
-
-      const updatedConversationRes = await getConversation(
-        auth,
-        conversation.sId
-      );
-
-      if (updatedConversationRes.isErr()) {
-        // Preserving former code in which if the conversation was not found here, we do not error
-        if (
-          !(
-            updatedConversationRes.error instanceof ConversationError &&
-            updatedConversationRes.error.type === "conversation_not_found"
-          )
-        ) {
-          return apiErrorForConversation(ctx, updatedConversationRes.error);
-        }
-      } else {
-        conversation = updatedConversationRes.value;
       }
     }
 
@@ -462,7 +455,7 @@ app.post(
         );
 
         const r = await ConversationResource.upsertMCPServerViews(auth, {
-          conversation,
+          conversation: conversationResource,
           mcpServerViews,
           enabled: true,
           source: "conversation",
@@ -505,7 +498,7 @@ app.post(
               content: message.content,
               context: messageContext,
               agenticMessageData,
-              conversation,
+              conversationResource,
               mentions: message.mentions,
               modelSelection,
               skipToolsValidation: skipToolsValidation ?? false,
@@ -514,7 +507,7 @@ app.post(
               content: message.content,
               context: messageContext,
               agenticMessageData,
-              conversation,
+              conversationResource,
               mentions: message.mentions,
               modelSelection,
               skipToolsValidation: skipToolsValidation ?? false,
@@ -533,7 +526,7 @@ app.post(
       // created as well, so pulling the conversation again will allow to have an up to date view
       // of the conversation with agent messages included so that the user of the API can start
       // streaming events from these agent messages directly.
-      const updatedRes = await getConversation(auth, conversation.sId);
+      const updatedRes = await getConversation(auth, conversationResource.sId);
 
       if (updatedRes.isErr()) {
         return apiErrorForConversation(ctx, updatedRes.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,9 +1,8 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -96,9 +95,18 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
 
     const { model } = ctx.req.valid("json");
@@ -123,7 +131,7 @@ app.post(
     }
 
     const result = await compactConversation(auth, {
-      conversation: conversationRes.value,
+      conversation: conversationResource.toJSON(),
       model,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,8 +1,7 @@
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isUserMessageType } from "@app/types/assistant/conversation";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -126,24 +125,37 @@ app.post(
       });
     }
 
-    const branchId = messageRes.value.getBranchId() ?? null;
-
-    const conversationRes = await getConversation(
-      auth,
-      conversationId,
-      false,
-      branchId
-    );
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const messageModel = messageRes.value;
+    if (!messageModel.userMessage) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The message you're trying to edit does not exist or is not an user message.",
+        },
+      });
     }
 
-    const conversation = conversationRes.value;
+    const branchId = messageModel.getBranchId() ?? null;
 
-    const message = conversation.content
-      .flat()
-      .find((m) => m.sId === messageId);
+    const renderRes = await batchRenderMessages(
+      auth,
+      conversationResource,
+      [messageModel],
+      "full"
+    );
+    if (renderRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to render message.",
+        },
+      });
+    }
+
+    const message = renderRes.value[0];
     if (!message || !isUserMessageType(message)) {
       return apiError(ctx, {
         status_code: 400,
@@ -158,7 +170,8 @@ app.post(
     const { content, mentions } = ctx.req.valid("json");
 
     const editedMessageRes = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
+      branchId,
       message,
       content,
       mentions,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -2,7 +2,6 @@ import {
   softDeleteAgentMessage,
   softDeleteUserMessageAndReplies,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type {
@@ -191,8 +190,8 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId, mId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
+  const conversationResource = await ConversationResource.fetchById(auth, cId);
+  if (!conversationResource) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
@@ -202,7 +201,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const messageRes = await conversation.getMessageById(auth, mId);
+  const messageRes = await conversationResource.getMessageById(auth, mId);
   if (messageRes.isErr()) {
     return apiError(ctx, {
       status_code: 404,
@@ -214,8 +213,6 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const message = messageRes.value;
-  const branchId = message.getBranchId() ?? null;
-
   if (!message.userMessage && !message.agentMessage) {
     return apiError(ctx, {
       status_code: 404,
@@ -226,28 +223,15 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const conversationRes = await getConversation(
-    auth,
-    conversation.sId,
-    false,
-    branchId
-  );
-
-  if (conversationRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Unable to get the conversation.",
-      },
-    });
-  }
-
-  const fullConversation = conversationRes.value;
+  const branchId = message.getBranchId() ?? null;
+  const conversation = {
+    ...conversationResource.toJSON(),
+    branchId,
+  };
 
   const renderRes = await batchRenderMessages(
     auth,
-    conversation,
+    conversationResource,
     [message],
     "full"
   );
@@ -266,7 +250,8 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   if (isUserMessageType(renderedMessage)) {
     const deleteResult = await softDeleteUserMessageAndReplies(auth, {
       message: renderedMessage,
-      conversation: fullConversation,
+      conversationResource,
+      branchId,
     });
     if (deleteResult.isErr()) {
       return apiError(ctx, {
@@ -280,7 +265,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   } else if (isAgentMessageType(renderedMessage)) {
     const deleteResult = await softDeleteAgentMessage(auth, {
       message: renderedMessage,
-      conversation: fullConversation,
+      conversation,
     });
     if (deleteResult.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,10 +1,9 @@
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -92,28 +91,47 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const branchId = messageRes.value.getBranchId() ?? null;
-
-  const conversationRes = await getConversation(
-    auth,
-    conversationId,
-    false,
-    branchId
-  );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
-  }
-
-  const conversation = conversationRes.value;
-
-  const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message || !isAgentMessageType(message)) {
+  const messageModel = messageRes.value;
+  if (!messageModel.agentMessage) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
         message:
           "The message you're trying to retry does not exist or is not an agent message.",
+      },
+    });
+  }
+
+  const branchId = messageModel.getBranchId() ?? null;
+  const conversation = {
+    ...conversationResource.toJSON(),
+    branchId,
+  };
+
+  const renderRes = await batchRenderMessages(
+    auth,
+    conversationResource,
+    [messageModel],
+    "full"
+  );
+  if (renderRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to render message.",
+      },
+    });
+  }
+
+  const message = renderRes.value[0];
+  if (!message || !isAgentMessageType(message)) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to render message.",
       },
     });
   }
@@ -156,7 +174,8 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const retriedMessageRes = await retryAgentMessage(auth, {
-    conversation,
+    conversationResource,
+    branchId,
     message,
   });
   if (retriedMessageRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,7 +1,7 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { isSidekickConversation } from "@app/lib/api/actions/servers/helpers";
+import { fetchPrecedingContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { addSelectedConversationSpaces } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
@@ -18,17 +18,12 @@ import type {
   LegacyLightMessageType,
   LightMessageType,
 } from "@app/types/assistant/conversation";
-import { isUserMessageType } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
-import { isContentFragmentType } from "@app/types/content_fragment";
-import { removeNulls } from "@app/types/shared/utils/general";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
 import { apiErrorForSelectedSpaces } from "../selected_spaces_errors";
 import message from "./[mId]";
 
@@ -293,11 +288,21 @@ app.post(
       }
     }
 
-    const conversationRes = await getConversation(auth, conversationId);
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
+
+    const conversation = conversationResource.toJSON();
 
     if (content.length === 0 && mentions.length === 0) {
       return apiError(ctx, {
@@ -309,8 +314,6 @@ app.post(
         },
       });
     }
-
-    let conversation = conversationRes.value;
 
     if (context.selectedSpaceIds?.length) {
       const selectedSpacesResult = await addSelectedConversationSpaces(auth, {
@@ -325,11 +328,6 @@ app.post(
       if (selectedSpacesResult.isErr()) {
         return apiErrorForSelectedSpaces(ctx, selectedSpacesResult.error);
       }
-
-      conversation = {
-        ...conversation,
-        requestedSpaceIds: selectedSpacesResult.value.effectiveAcl.spaceIds,
-      };
     }
 
     if (context.selectedMCPServerViewIds?.length) {
@@ -377,30 +375,6 @@ app.post(
       }
     }
 
-    // Find all the contentFragments that are above the user message.
-    // Messages may have multiple versions, so we need to return only the max
-    // version of each message.
-    const allMessages = removeNulls(
-      [...conversation.content].map((messages) => {
-        if (messages.length === 0) {
-          return null;
-        }
-        return messages.toSorted((a, b) => b.version - a.version)[0];
-      })
-    );
-
-    // Iterate over all messages sorted by rank descending and collect content
-    // fragments until we find a user message.
-    const contentFragments: ContentFragmentType[] = [];
-    for (const message of allMessages.toSorted((a, b) => b.rank - a.rank)) {
-      if (isUserMessageType(message)) {
-        break;
-      }
-      if (isContentFragmentType(message)) {
-        contentFragments.push(message);
-      }
-    }
-
     // Sidekick conversations always use "agent_sidekick" origin regardless of
     // what the client sends (follow-up messages default to "web" because
     // useClientType() doesn't know about sidekick context).
@@ -409,7 +383,7 @@ app.post(
       : (context.origin ?? "web");
 
     const messageRes = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content,
       mentions,
       context: {
@@ -429,6 +403,11 @@ app.post(
     if (messageRes.isErr()) {
       return apiError(ctx, messageRes.error);
     }
+
+    const contentFragments = await fetchPrecedingContentFragments(auth, {
+      conversationResource,
+      targetRank: messageRes.value.userMessage.rank,
+    });
 
     return ctx.json({
       message: messageRes.value.userMessage,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -1,11 +1,10 @@
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { buildOnboardingFollowUpPrompt } from "@app/lib/api/assistant/onboarding";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { isString } from "@app/types/shared/utils/general";
-import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -46,12 +45,19 @@ app.post(
       });
     }
 
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      });
     }
-
-    const conversation = conversationRes.value;
 
     // Extract user's preferred language from Accept-Language header.
     const acceptLanguage = ctx.req.header("accept-language");
@@ -60,7 +66,7 @@ app.post(
     const followUpPrompt = buildOnboardingFollowUpPrompt(toolId, language);
 
     const messageRes = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content: followUpPrompt,
       mentions: [
         {

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -22,7 +22,10 @@ import type {
   GetConversationsResponseBody,
   PostConversationsResponseBody,
 } from "@app/types/api/assistant/conversation/types";
-import type { UserMessageType } from "@app/types/assistant/conversation";
+import type {
+  ConversationType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
@@ -300,12 +303,19 @@ app.post(
       spaceModelId = space.id;
     }
 
-    let newConversation = await createConversation(auth, {
+    const newConversationResource = await createConversation(auth, {
       title,
       visibility,
       spaceId: spaceModelId,
       metadata,
     });
+
+    let newConversation: ConversationType = {
+      ...newConversationResource.toJSON(),
+      content: [],
+      owner: auth.getNonNullableWorkspace(),
+      visibility: visibility,
+    };
 
     if (allSelectedSpaceIds.length > 0) {
       const selectedSpacesResult = await addSelectedConversationSpaces(auth, {
@@ -369,14 +379,6 @@ app.post(
 
         newContentFragments.push(r.value);
       }
-
-      newConversation = {
-        ...newConversation,
-        content: [
-          ...newConversation.content,
-          ...newContentFragments.map((contentFragment) => [contentFragment]),
-        ],
-      };
     }
 
     if (message) {
@@ -442,7 +444,7 @@ app.post(
       // If a message was provided we do await for the message to be created
       // before returning the conversation along with the message.
       const messageRes = await postUserMessage(auth, {
-        conversation: newConversation,
+        conversationResource: newConversationResource,
         content: message.content,
         mentions: message.mentions,
         context: {

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -1,3 +1,5 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -137,11 +139,15 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const restrictedSpace = await SpaceFactory.regular(workspace);
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
-      messagesCreatedAt: [new Date()],
-      requestedSpaceIds: [restrictedSpace.id],
+    const restrictedConversation = await createConversation(auth, {
+      title: "Restricted conversation",
+      visibility: "unlisted",
+      spaceId: null,
     });
+    await ConversationModel.update(
+      { requestedSpaceIds: [restrictedSpace.id] },
+      { where: { id: restrictedConversation.id } }
+    );
 
     const file = await FileFactory.create(auth, user, {
       contentType: "application/vnd.dust.frame",
@@ -149,7 +155,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
       fileSize: 1024,
       status: "ready",
       useCase: "conversation",
-      useCaseMetadata: { conversationId: conversation.sId },
+      useCaseMetadata: { conversationId: restrictedConversation.sId },
     });
 
     const response = await postEdit(workspace, file.sId, {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -3,13 +3,13 @@ import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { makeExtra } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import {
   getFileFromConversationAttachment,
   resolveConversationFileRef,
@@ -97,7 +97,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         canonicalPath,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isOk()).toBe(true);
@@ -130,7 +130,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/missing.pdf`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -158,7 +158,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -171,7 +171,7 @@ describe("getFileFromConversationAttachment", () => {
         role: "admin",
       });
 
-      const conversation = await createConversation(auth, {
+      const conversationResource = await createConversation(auth, {
         title: "Test",
         visibility: "unlisted",
         spaceId: null,
@@ -183,13 +183,13 @@ describe("getFileFromConversationAttachment", () => {
         fileSize: 100,
         status: "ready",
         useCase: "conversation",
-        useCaseMetadata: { conversationId: conversation.sId },
+        useCaseMetadata: { conversationId: conversationResource.sId },
       });
 
       await ConversationFactory.createContentFragmentMessage({
         auth,
         workspace,
-        conversationId: conversation.id,
+        conversationId: conversationResource.id,
         rank: 0,
         fileId: file.id,
         title: "Report",
@@ -197,11 +197,15 @@ describe("getFileFromConversationAttachment", () => {
         fileName: "report.pdf",
       });
 
-      const conversationResult = await getConversation(auth, conversation.sId);
-      if (conversationResult.isErr()) {
-        throw new Error("Failed to fetch conversation");
+      const conversationRes = await getConversation(
+        auth,
+        conversationResource.sId
+      );
+      if (conversationRes.isErr()) {
+        throw new Error(
+          `Failed to fetch conversation: ${conversationRes.error.type}`
+        );
       }
-      const fullConversation = conversationResult.value;
 
       const expectedContent = "pdf bytes";
       vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
@@ -211,7 +215,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         file.sId,
-        makeToolContext(fullConversation)
+        makeToolContext(conversationRes.value)
       );
 
       expect(result.isOk()).toBe(true);
@@ -229,21 +233,26 @@ describe("getFileFromConversationAttachment", () => {
         role: "admin",
       });
 
-      const conversation = await createConversation(auth, {
+      const conversationResource = await createConversation(auth, {
         title: "Test",
         visibility: "unlisted",
         spaceId: null,
       });
 
-      const conversationResult = await getConversation(auth, conversation.sId);
-      if (conversationResult.isErr()) {
-        throw new Error("Failed to fetch conversation");
+      const conversationRes = await getConversation(
+        auth,
+        conversationResource.sId
+      );
+      if (conversationRes.isErr()) {
+        throw new Error(
+          `Failed to fetch conversation: ${conversationRes.error.type}`
+        );
       }
 
       const result = await getFileFromConversationAttachment(
         auth,
         "fil_notfound",
-        makeToolContext(conversationResult.value)
+        makeToolContext(conversationRes.value)
       );
 
       expect(result.isErr()).toBe(true);
@@ -278,7 +287,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/notes.txt",
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isOk()).toBe(true);
@@ -308,7 +317,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/missing.pdf",
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -425,7 +434,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         `conversation-${conversation.sId}/missing.png`,
-        makeToolContext({ ...conversation, content: [] })
+        makeExtra(auth, conversation)
       );
 
       expect(result.isErr()).toBe(true);
@@ -459,7 +468,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeToolContext({ ...conversation, content: [] })
+      makeExtra(auth, conversation)
     );
 
     expect(result.isOk()).toBe(true);
@@ -502,7 +511,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeToolContext({ ...conversationB, content: [] })
+      makeExtra(auth, conversationB)
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -1,67 +1,23 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
 import { describe, expect, it, vi } from "vitest";
 
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
-async function setupProjectConversation(
-  role: "admin" | "user" = "admin"
-): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-  spaceId: string;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({ role });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return {
-    auth: projectAuth,
-    conversation,
-    spaceId: space.sId,
-  };
-}
-
 describe("copyHandler", () => {
   it("copies a file from conversation to pod mount", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const result = await copyHandler(
       {
         source: `conversation-${conversation.sId}/report.pdf`,
-        dest: `pod-${spaceId}/report.pdf`,
+        dest: `pod-${projectId}/report.pdf`,
       },
       makeExtra(auth, conversation)
     );
@@ -73,17 +29,17 @@ describe("copyHandler", () => {
     expect(result.value[0]).toEqual({
       type: "text",
       text:
-        `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
+        `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${projectId}/report.pdf\`. ` +
         getFilePreviewDirectiveInstruction({
           contentType: "text/plain",
-          path: `pod-${spaceId}/report.pdf`,
+          path: `pod-${projectId}/report.pdf`,
           title: "report.pdf",
         }),
     });
     expect(result.value[1]).toMatchObject({
       type: "resource",
       resource: {
-        path: `pod-${spaceId}/report.pdf`,
+        path: `pod-${projectId}/report.pdf`,
         title: "report.pdf",
         contentType: "text/plain",
       },
@@ -91,11 +47,11 @@ describe("copyHandler", () => {
   });
 
   it("copies a file from pod to conversation mount", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const result = await copyHandler(
       {
-        source: `pod-${spaceId}/spec.md`,
+        source: `pod-${projectId}/spec.md`,
         dest: `conversation-${conversation.sId}/spec.md`,
       },
       makeExtra(auth, conversation)
@@ -105,7 +61,7 @@ describe("copyHandler", () => {
   });
 
   it("returns Err when the source file does not exist", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
@@ -117,7 +73,7 @@ describe("copyHandler", () => {
     const result = await copyHandler(
       {
         source: `conversation-${conversation.sId}/missing.pdf`,
-        dest: `pod-${spaceId}/missing.pdf`,
+        dest: `pod-${projectId}/missing.pdf`,
       },
       makeExtra(auth, conversation)
     );
@@ -130,7 +86,7 @@ describe("copyHandler", () => {
   });
 
   it("returns Err when the source is a frame file", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
@@ -146,7 +102,7 @@ describe("copyHandler", () => {
     const result = await copyHandler(
       {
         source: `conversation-${conversation.sId}/interactive.html`,
-        dest: `pod-${spaceId}/interactive.html`,
+        dest: `pod-${projectId}/interactive.html`,
       },
       makeExtra(auth, conversation)
     );
@@ -177,10 +133,10 @@ describe("copyHandler", () => {
   });
 
   it("returns Err for an invalid source path prefix", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "other/foo.md", dest: `pod-${spaceId}/foo.md` },
+      { source: "other/foo.md", dest: `pod-${projectId}/foo.md` },
       makeExtra(auth, conversation)
     );
 
@@ -208,7 +164,7 @@ describe("copyHandler", () => {
   });
 
   it("writes to the correct pod storage path when copying to a pod mount", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const copyFileMock = vi.fn().mockResolvedValue(undefined);
@@ -225,7 +181,7 @@ describe("copyHandler", () => {
     const result = await copyHandler(
       {
         source: `conversation-${conversation.sId}/report.pdf`,
-        dest: `pod-${spaceId}/report.pdf`,
+        dest: `pod-${projectId}/report.pdf`,
       },
       makeExtra(auth, conversation)
     );
@@ -233,7 +189,7 @@ describe("copyHandler", () => {
     assert(result.isOk());
 
     const sourcePath = `w/${workspaceId}/conversations/${conversation.sId}/files/report.pdf`;
-    const destPodsPath = `w/${workspaceId}/pods/${spaceId}/files/report.pdf`;
+    const destPodsPath = `w/${workspaceId}/pods/${projectId}/files/report.pdf`;
 
     expect(copyFileMock).toHaveBeenCalledWith(sourcePath, destPodsPath);
   });

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,53 +1,12 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
-import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
 import { beforeEach, describe, expect, it } from "vitest";
-
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
-async function setupProjectConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return { auth: projectAuth, conversation };
-}
 
 describe("createHandler", () => {
   beforeEach(() => {

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,12 +1,9 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
-import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,45 +13,6 @@ vi.mock("@app/lib/file_storage/config", () => ({
 vi.mock("@app/lib/api/config", () => ({
   default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
 }));
-
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
-async function setupProjectConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-  projectId: string;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return { auth: projectAuth, conversation, projectId: space.sId };
-}
 
 describe("deleteHandler", () => {
   let deleteMock: ReturnType<typeof vi.fn>;

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -1,14 +1,11 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { editHandler } from "@app/lib/api/actions/servers/files/tools/edit";
 import { FRAME_SOURCE_MAX_BYTES } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameContentType } from "@app/types/files";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,44 +16,6 @@ vi.mock("@app/lib/file_storage/config", () => ({
 vi.mock("@app/lib/api/config", () => ({
   default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
 }));
-
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
-async function setupProjectConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return { auth: projectAuth, conversation };
-}
 
 function mockStoredFile(content: string, contentType: string) {
   fileStorageMock.setFileMetadata(() => ({

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -1,16 +1,18 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
@@ -53,17 +55,6 @@ async function sessionAuthForUser(
   );
 }
 
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
 function makeStorageFile(
   name: string,
   contentType = "text/plain",
@@ -79,37 +70,9 @@ function makeStorageFile(
   };
 }
 
-async function setupProjectConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-  projectId: string;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return { auth: projectAuth, conversation, projectId: space.sId };
-}
-
 async function setupProjectWithRegularConversation(): Promise<{
   auth: Authenticator;
-  conversation: ConversationType;
+  conversation: ConversationResource;
   projectId: string;
   workspaceId: string;
 }> {

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -1,62 +1,17 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolRunContext } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
 import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
-import assert from "assert";
 import { describe, expect, it } from "vitest";
-
-function makeExtra(
-  auth: Authenticator,
-  conversation: ConversationType
-): ToolHandlerExtra {
-  const runContext = {
-    contextType: "agent_loop",
-    conversation,
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
-}
-
-async function setupProjectConversation(
-  role: "admin" | "user" = "admin"
-): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-  spaceId: string;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({ role });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return {
-    auth: projectAuth,
-    conversation,
-    spaceId: space.sId,
-  };
-}
 
 describe("moveHandler", () => {
   it("moves a file from conversation to pod mount", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     // Source (conversation) exists, destination (pod) does not.
     fileStorageMock.setFileExists((filePath) =>
@@ -66,7 +21,7 @@ describe("moveHandler", () => {
     const result = await moveHandler(
       {
         source: `conversation-${conversation.sId}/report.pdf`,
-        dest: `pod-${spaceId}/report.pdf`,
+        dest: `pod-${projectId}/report.pdf`,
       },
       makeExtra(auth, conversation)
     );
@@ -78,24 +33,24 @@ describe("moveHandler", () => {
     expect(result.value[0]).toEqual({
       type: "text",
       text:
-        `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
+        `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${projectId}/report.pdf\`. ` +
         getFilePreviewDirectiveInstruction({
           contentType: "text/plain",
-          path: `pod-${spaceId}/report.pdf`,
+          path: `pod-${projectId}/report.pdf`,
           title: "report.pdf",
         }),
     });
   });
 
   it("moves a file from pod to conversation mount", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     // Source (pod) exists, destination (conversation) does not.
     fileStorageMock.setFileExists((filePath) => filePath.includes("/pods/"));
 
     const result = await moveHandler(
       {
-        source: `pod-${spaceId}/spec.md`,
+        source: `pod-${projectId}/spec.md`,
         dest: `conversation-${conversation.sId}/spec.md`,
       },
       makeExtra(auth, conversation)
@@ -105,14 +60,14 @@ describe("moveHandler", () => {
   });
 
   it("returns Err when the source file does not exist", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     fileStorageMock.setFileExists(() => false);
 
     const result = await moveHandler(
       {
         source: `conversation-${conversation.sId}/missing.pdf`,
-        dest: `pod-${spaceId}/missing.pdf`,
+        dest: `pod-${projectId}/missing.pdf`,
       },
       makeExtra(auth, conversation)
     );
@@ -143,10 +98,10 @@ describe("moveHandler", () => {
   });
 
   it("returns Err for an invalid source path prefix", async () => {
-    const { auth, conversation, spaceId } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "other/foo.md", dest: `pod-${spaceId}/foo.md` },
+      { source: "other/foo.md", dest: `pod-${projectId}/foo.md` },
       makeExtra(auth, conversation)
     );
 

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -44,10 +44,7 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import {
-  getConversation,
-  getLightConversation,
-} from "@app/lib/api/assistant/conversation/fetch";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
 import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import {
@@ -1195,7 +1192,7 @@ export function createProjectManagerTools(
         }
 
         // Create conversation in the project space
-        const conversation = await createConversation(auth, {
+        const conversationResource = await createConversation(auth, {
           title: params.title,
           visibility: "unlisted",
           spaceId: pod.id,
@@ -1203,7 +1200,7 @@ export function createProjectManagerTools(
 
         // Post user message
         const messageRes = await postUserMessage(auth, {
-          conversation,
+          conversationResource,
           content: params.message,
           mentions,
           context: {
@@ -1235,7 +1232,7 @@ export function createProjectManagerTools(
 
         const conversationUrl = getConversationRoute(
           owner.sId,
-          conversation.sId,
+          conversationResource.sId,
           undefined,
           config.getAppUrl()
         );
@@ -1243,7 +1240,7 @@ export function createProjectManagerTools(
         return new Ok(
           makeSuccessResponse({
             success: true,
-            conversationId: conversation.sId,
+            conversationId: conversationResource.sId,
             conversationUrl,
             userMessageId: messageRes.value.userMessage.sId,
             message: `Conversation created successfully in Pod "${pod.name}"`,
@@ -1429,12 +1426,11 @@ export function createProjectManagerTools(
           );
         }
 
-        const conversationRes = await getConversation(
+        const conversationResource = await ConversationResource.fetchById(
           auth,
-          conversationId,
-          false
+          conversationId
         );
-        if (conversationRes.isErr()) {
+        if (!conversationResource) {
           return new Err(
             new MCPError(`Conversation not found: ${conversationId}`, {
               tracked: false,
@@ -1442,7 +1438,8 @@ export function createProjectManagerTools(
           );
         }
 
-        const conversation = conversationRes.value;
+        const conversation = conversationResource.toJSON();
+
         if (conversation.spaceId !== pod.sId) {
           return new Err(
             new MCPError("Conversation is not in this Pod", {
@@ -1492,7 +1489,7 @@ export function createProjectManagerTools(
         }
 
         const messageRes = await postUserMessage(auth, {
-          conversation,
+          conversationResource,
           content: params.message,
           mentions,
           context: {
@@ -1560,12 +1557,12 @@ export function createProjectManagerTools(
           );
         }
 
-        const conversationRes = await getConversation(
+        const conversationResource = await ConversationResource.fetchById(
           auth,
-          conversationId,
-          false
+          conversationId
         );
-        if (conversationRes.isErr()) {
+
+        if (!conversationResource) {
           return new Err(
             new MCPError(`Conversation not found: ${conversationId}`, {
               tracked: false,
@@ -1573,7 +1570,8 @@ export function createProjectManagerTools(
           );
         }
 
-        const conversation = conversationRes.value;
+        const conversation = conversationResource.toJSON();
+
         const conversationUrl = getConversationRoute(
           owner.sId,
           conversation.sId,

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -8,61 +8,24 @@ import {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system";
-import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import {
+  setupPlainConversation,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import assert from "assert";
 import { describe, expect, it, vi } from "vitest";
-
-async function setupProjectConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-  projectId: string;
-}> {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
-  });
-  const user = auth.getNonNullableUser();
-
-  const space = await SpaceFactory.project(workspace, user.id);
-  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
-  assert(addRes.isOk(), "Failed to add user to project space");
-
-  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
-  );
-
-  const conversation = await createConversation(projectAuth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: space.id,
-  });
-
-  return { auth: projectAuth, conversation, projectId: space.sId };
-}
-
-async function setupPlainConversation(): Promise<{
-  auth: Authenticator;
-  conversation: ConversationType;
-}> {
-  const { authenticator: auth } = await createResourceTest({ role: "admin" });
-  const conversation = await createConversation(auth, {
-    title: "Test",
-    visibility: "unlisted",
-    spaceId: null,
-  });
-  return { auth, conversation };
-}
 
 describe("resolveFilePathsInParentScope", () => {
   it("resolves a conversation-scoped path in a plain conversation", async () => {
     const { auth, conversation } = await setupPlainConversation();
     const path = `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/foo.md`;
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [path]);
+    const res = await resolveFilePathsInParentScope(
+      auth,
+      conversation.toJSON(),
+      [path]
+    );
 
     assert(res.isOk());
     expect(res.value).toEqual([path]);
@@ -71,10 +34,14 @@ describe("resolveFilePathsInParentScope", () => {
   it("resolves both conversation and Pod paths in a Pod conversation", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [
-      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/a.txt`,
-      `${SCOPED_PREFIX_POD}${projectId}/b.txt`,
-    ]);
+    const res = await resolveFilePathsInParentScope(
+      auth,
+      conversation.toJSON(),
+      [
+        `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/a.txt`,
+        `${SCOPED_PREFIX_POD}${projectId}/b.txt`,
+      ]
+    );
 
     assert(res.isOk());
     expect(res.value).toHaveLength(2);
@@ -83,9 +50,11 @@ describe("resolveFilePathsInParentScope", () => {
   it("returns Err for a path with no scope prefix", async () => {
     const { auth, conversation } = await setupPlainConversation();
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "other/foo.md",
-    ]);
+    const res = await resolveFilePathsInParentScope(
+      auth,
+      conversation.toJSON(),
+      ["other/foo.md"]
+    );
 
     expect(res.isErr()).toBe(true);
     if (res.isErr()) {
@@ -96,9 +65,11 @@ describe("resolveFilePathsInParentScope", () => {
   it("returns Err for a Pod path in a non-Pod conversation", async () => {
     const { auth, conversation } = await setupPlainConversation();
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [
-      `${SCOPED_PREFIX_POD}somepodid/spec.md`,
-    ]);
+    const res = await resolveFilePathsInParentScope(
+      auth,
+      conversation.toJSON(),
+      [`${SCOPED_PREFIX_POD}somepodid/spec.md`]
+    );
 
     expect(res.isErr()).toBe(true);
     if (res.isErr()) {
@@ -115,9 +86,11 @@ describe("resolveFilePathsInParentScope", () => {
       })),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [
-      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/missing.md`,
-    ]);
+    const res = await resolveFilePathsInParentScope(
+      auth,
+      conversation.toJSON(),
+      [`${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/missing.md`]
+    );
 
     expect(res.isErr()).toBe(true);
     if (res.isErr()) {
@@ -147,7 +120,7 @@ describe("copyConversationFilesIntoSub", () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
 
     const res = await copyConversationFilesIntoSub(auth, {
-      parentConversation: conversation,
+      parentConversation: conversation.toJSON(),
       subConversationId: "sub_sid",
       filePaths: [`${SCOPED_PREFIX_POD}${projectId}/spec.md`],
     });
@@ -164,7 +137,7 @@ describe("copyConversationFilesIntoSub", () => {
     });
 
     const res = await copyConversationFilesIntoSub(auth, {
-      parentConversation: conversation,
+      parentConversation: conversation.toJSON(),
       subConversationId: subConversation.sId,
       filePaths: [
         `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/a.md`,
@@ -191,7 +164,7 @@ describe("copyConversationFilesIntoSub", () => {
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const res = await copyConversationFilesIntoSub(auth, {
-      parentConversation: conversation,
+      parentConversation: conversation.toJSON(),
       subConversationId: subConversation.sId,
       filePaths: [
         `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/missing.md`,

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -21,7 +21,7 @@ import { Err, Ok } from "@app/types/shared/result";
  */
 export async function resolveFilePathsInParentScope(
   auth: Authenticator,
-  mainConversation: ConversationType,
+  mainConversation: ConversationWithoutContentType,
   filePaths: string[]
 ): Promise<Result<string[], MCPError>> {
   const fsResult = await DustFileSystem.forConversation(auth, mainConversation);
@@ -85,7 +85,7 @@ export async function copyConversationFilesIntoSub(
     subConversationId,
     filePaths,
   }: {
-    parentConversation: ConversationType;
+    parentConversation: ConversationWithoutContentType;
     subConversationId: string;
     filePaths: string[];
   }

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -106,6 +106,17 @@ const TEST_CREDIT_EXPIRATION_DELAY_MS =
   TEST_CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
 const TEST_DAILY_USAGE_TTL_SECONDS = 60 * 60;
 
+async function fetchConversationResource(
+  auth: Authenticator,
+  sId: string
+): Promise<ConversationResource> {
+  const resource = await ConversationResource.fetchById(auth, sId);
+  if (!resource) {
+    throw new Error(`Failed to fetch conversation resource: ${sId}`);
+  }
+  return resource;
+}
+
 async function fetchRegularAutoGroup(
   space: SpaceResource,
   auth: Authenticator
@@ -153,6 +164,7 @@ describe("retryAgentMessage", () => {
     ReturnType<typeof createResourceTest>
   >["globalGroup"];
   let conversation: ConversationType;
+  let conversationResource: ConversationResource;
   let agentConfig: LightAgentConfigurationType;
   let agentMessage: AgentMessageType;
 
@@ -184,6 +196,10 @@ describe("retryAgentMessage", () => {
       throw new Error("Failed to fetch conversation");
     }
     conversation = fetchedConversationResult.value;
+    conversationResource = await fetchConversationResource(
+      auth,
+      conversationWithoutContent.sId
+    );
 
     // Find the agent message in the conversation
     const agentMessages = conversation.content
@@ -212,7 +228,7 @@ describe("retryAgentMessage", () => {
     expect(userMessage).toBeDefined();
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -248,13 +264,9 @@ describe("retryAgentMessage", () => {
 
     expect(userMessage).toBeDefined();
 
-    const branchedConversation: ConversationType = {
-      ...conversation,
-      branchId,
-    };
-
     const result = await retryAgentMessage(auth, {
-      conversation: branchedConversation,
+      conversationResource,
+      branchId,
       message: agentMessage,
     });
 
@@ -274,7 +286,7 @@ describe("retryAgentMessage", () => {
 
   it("should call publishAgentMessagesEvents with correct arguments", async () => {
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -304,7 +316,7 @@ describe("retryAgentMessage", () => {
     const originalId = agentMessage.sId;
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -335,7 +347,7 @@ describe("retryAgentMessage", () => {
     };
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: nonExistentMessage,
     });
 
@@ -351,7 +363,7 @@ describe("retryAgentMessage", () => {
   it("should return error when message was already retried", async () => {
     // First retry
     const firstRetry = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
     expect(firstRetry.isOk()).toBe(true);
@@ -361,7 +373,7 @@ describe("retryAgentMessage", () => {
 
     // Try to retry again with the same original message
     const secondRetry = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -377,7 +389,7 @@ describe("retryAgentMessage", () => {
 
   it("should preserve agent message properties in the retry", async () => {
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -412,19 +424,15 @@ describe("retryAgentMessage", () => {
       }
     );
 
-    // Refresh conversation
-    const refreshedConversationResult = await getConversation(
+    // Refresh conversation resource
+    const refreshedConversationResource = await fetchConversationResource(
       auth,
       conversation.sId
     );
-    if (refreshedConversationResult.isErr()) {
-      throw new Error("Failed to fetch conversation");
-    }
-    const refreshedConversation = refreshedConversationResult.value;
-    expect(refreshedConversation.hasError).toBe(true);
+    expect(refreshedConversationResource.toJSON().hasError).toBe(true);
 
     const result = await retryAgentMessage(auth, {
-      conversation: refreshedConversation,
+      conversationResource: refreshedConversationResource,
       message: agentMessage,
     });
 
@@ -449,7 +457,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(0);
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -472,7 +480,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(100);
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -491,7 +499,7 @@ describe("retryAgentMessage", () => {
     };
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: messageWithInvalidParent,
     });
 
@@ -521,7 +529,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(100);
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -554,7 +562,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(100);
 
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -580,7 +588,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(0);
 
     const result = await retryAgentMessage(systemKeyAuth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -610,7 +618,7 @@ describe("retryAgentMessage", () => {
       .mockResolvedValue(100);
 
     const result = await retryAgentMessage(mixedAuth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -631,7 +639,7 @@ describe("retryAgentMessage", () => {
 
     // Try to retry the agent message
     const result = await retryAgentMessage(auth, {
-      conversation,
+      conversationResource,
       message: agentMessage,
     });
 
@@ -651,6 +659,7 @@ describe("retryAgentMessage", () => {
     let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let projectConversation: ConversationType;
+    let projectConversationResource: ConversationResource;
     let projectAgentMessage: AgentMessageType;
     let agentWithDifferentSpace: LightAgentConfigurationType;
 
@@ -765,6 +774,10 @@ describe("retryAgentMessage", () => {
         throw new Error("Failed to fetch conversation");
       }
       projectConversation = fetchedConversationResult.value;
+      projectConversationResource = await fetchConversationResource(
+        auth,
+        conversationWithoutContent.sId
+      );
 
       // Find the agent message in the conversation
       const agentMessages = projectConversation.content
@@ -780,7 +793,7 @@ describe("retryAgentMessage", () => {
 
     it("should return error when agent is restricted by space usage in project conversation with more than one manual member on that project", async () => {
       const result = await retryAgentMessage(auth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         message: projectAgentMessage,
       });
 
@@ -838,6 +851,10 @@ describe("retryAgentMessage", () => {
         throw new Error("Failed to fetch conversation");
       }
       const sameSpaceConversation = fetchedConversationResult.value;
+      const sameSpaceConversationResource = await fetchConversationResource(
+        auth,
+        conversationWithoutContent.sId
+      );
 
       const agentMessages = sameSpaceConversation.content
         .flat()
@@ -853,7 +870,7 @@ describe("retryAgentMessage", () => {
         .mockResolvedValue(100);
 
       const result = await retryAgentMessage(auth, {
-        conversation: sameSpaceConversation,
+        conversationResource: sameSpaceConversationResource,
         message: sameSpaceAgentMessage,
       });
 
@@ -905,6 +922,10 @@ describe("retryAgentMessage", () => {
         throw new Error("Failed to fetch conversation");
       }
       const globalSpaceConversation = fetchedConversationResult.value;
+      const globalSpaceConversationResource = await fetchConversationResource(
+        auth,
+        conversationWithoutContent.sId
+      );
 
       const agentMessages = globalSpaceConversation.content
         .flat()
@@ -920,7 +941,7 @@ describe("retryAgentMessage", () => {
         .mockResolvedValue(100);
 
       const result = await retryAgentMessage(auth, {
-        conversation: globalSpaceConversation,
+        conversationResource: globalSpaceConversationResource,
         message: globalSpaceAgentMessage,
       });
 
@@ -1265,6 +1286,7 @@ describe("softDeleteAgentMessage", () => {
 describe("softDeleteUserMessageAndReplies", () => {
   let auth: Authenticator;
   let conversation: ConversationType;
+  let conversationResource: ConversationResource;
   let agentConfig: LightAgentConfigurationType;
 
   beforeEach(async () => {
@@ -1292,6 +1314,10 @@ describe("softDeleteUserMessageAndReplies", () => {
       throw new Error("Failed to fetch conversation");
     }
     conversation = fetchedConversationResult.value;
+    conversationResource = await fetchConversationResource(
+      auth,
+      conversationWithoutContent.sId
+    );
   });
 
   it("cascade-deletes the agent message that replied to the deleted user message", async () => {
@@ -1304,7 +1330,7 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUserMessage,
-      conversation,
+      conversationResource,
     });
 
     expect(result.isOk()).toBe(true);
@@ -1348,7 +1374,7 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: lastUser,
-      conversation,
+      conversationResource,
     });
     expect(result.isOk()).toBe(true);
 
@@ -1371,7 +1397,7 @@ describe("softDeleteUserMessageAndReplies", () => {
     // Pre-delete the agent directly.
     const preDelete = await softDeleteAgentMessage(auth, {
       message: firstAgent,
-      conversation,
+      conversation: conversationResource.toJSON(),
     });
     expect(preDelete.isOk()).toBe(true);
 
@@ -1381,6 +1407,10 @@ describe("softDeleteUserMessageAndReplies", () => {
       throw new Error("Failed to refetch conversation");
     }
     const refetchedConversation = refetched.value;
+    const refetchedConversationResource = await fetchConversationResource(
+      auth,
+      conversation.sId
+    );
     const firstUser = refetchedConversation.content
       .flat()
       .find((m): m is UserMessageType => isUserMessageType(m));
@@ -1393,7 +1423,7 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUser,
-      conversation: refetchedConversation,
+      conversationResource: refetchedConversationResource,
     });
     expect(result.isOk()).toBe(true);
 
@@ -1424,7 +1454,7 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUserMessage,
-      conversation,
+      conversationResource,
     });
     expect(result.isOk()).toBe(true);
 
@@ -1454,7 +1484,10 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const deleted = await softDeleteUserMessageAndReplies(auth, {
       message: userMessage,
-      conversation: fetched.value,
+      conversationResource: await fetchConversationResource(
+        auth,
+        oneTurnConversation.sId
+      ),
     });
     expect(deleted.isOk()).toBe(true);
 
@@ -1465,7 +1498,10 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const user = auth.getNonNullableUser().toJSON();
     const followUp = await postUserMessage(auth, {
-      conversation: afterDelete.value,
+      conversationResource: await fetchConversationResource(
+        auth,
+        oneTurnConversation.sId
+      ),
       content: "Follow-up",
       mentions: [{ configurationId: agentConfig.sId }],
       context: {
@@ -1513,7 +1549,10 @@ describe("softDeleteUserMessageAndReplies", () => {
 
     const result = await softDeleteUserMessageAndReplies(auth, {
       message: firstUserMessage,
-      conversation: refetched.value,
+      conversationResource: await fetchConversationResource(
+        auth,
+        conversation.sId
+      ),
     });
     expect(result.isOk()).toBe(true);
 
@@ -1531,6 +1570,7 @@ describe("postUserMessage", () => {
     ReturnType<typeof createResourceTest>
   >["globalSpace"];
   let conversation: ConversationType;
+  let conversationResource: ConversationResource;
   let agentConfig1: LightAgentConfigurationType;
 
   beforeEach(async () => {
@@ -1560,6 +1600,10 @@ describe("postUserMessage", () => {
       throw new Error("Failed to fetch conversation");
     }
     conversation = fetchedConversationResult.value;
+    conversationResource = await fetchConversationResource(
+      auth,
+      conversationWithoutContent.sId
+    );
 
     vi.clearAllMocks();
   });
@@ -1598,7 +1642,10 @@ describe("postUserMessage", () => {
     const noCreditUserJson = noCreditUser.toJSON();
 
     const result = await postUserMessage(noCreditAuth, {
-      conversation: fetchedConversationResult.value,
+      conversationResource: await fetchConversationResource(
+        noCreditAuth,
+        fetchedConversationResult.value.sId
+      ),
       content: "Programmatic message",
       mentions: [],
       context: {
@@ -1634,7 +1681,10 @@ describe("postUserMessage", () => {
     const userJson = user.toJSON();
 
     const result = await postUserMessage(auth, {
-      conversation,
+      conversationResource: await fetchConversationResource(
+        auth,
+        conversation.sId
+      ),
       content: `Hello @claude-4-sonnet`,
       mentions: [
         {
@@ -1671,7 +1721,7 @@ describe("postUserMessage", () => {
     const userJson = user.toJSON();
 
     const result = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content: `Hello @${agentConfig1.name}`,
       mentions,
       context: {
@@ -1736,7 +1786,7 @@ describe("postUserMessage", () => {
     const userJson = user.toJSON();
 
     const result = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content: `Hello @${mentionedUser.username}`,
       mentions,
       context: {
@@ -1804,7 +1854,7 @@ describe("postUserMessage", () => {
     const userJson = user.toJSON();
 
     const result = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content: `Hello @${mentionedUser.username} and @${agentConfig1.name}`,
       mentions,
       context: {
@@ -1861,7 +1911,7 @@ describe("postUserMessage", () => {
     const userJson = user.toJSON();
 
     const result = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content: "Hello without mentions",
       mentions: [],
       context: {
@@ -1920,7 +1970,10 @@ describe("postUserMessage", () => {
       }
 
       const result = await postUserMessage(auth, {
-        conversation: fetched.value,
+        conversationResource: await fetchConversationResource(
+          auth,
+          fetched.value.sId
+        ),
         content: "should be blocked",
         mentions: [],
         context: {
@@ -1973,7 +2026,10 @@ describe("postUserMessage", () => {
       }
 
       const result = await postUserMessage(auth, {
-        conversation: fetched.value,
+        conversationResource: await fetchConversationResource(
+          auth,
+          fetched.value.sId
+        ),
         content: "should be allowed",
         mentions: [],
         context: {
@@ -2005,7 +2061,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "Hello without explicit mentions",
         mentions: [],
         context: {
@@ -2063,7 +2119,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const firstFromUser = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "first from A",
         mentions: [],
         context: {
@@ -2098,7 +2154,10 @@ describe("postUserMessage", () => {
       vi.clearAllMocks();
 
       const secondFromUser = await postUserMessage(auth, {
-        conversation: afterFirst.value,
+        conversationResource: await fetchConversationResource(
+          auth,
+          afterFirst.value.sId
+        ),
         content: "second from A",
         mentions: [],
         context: {
@@ -2145,7 +2204,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "From extension",
         mentions: [],
         context: {
@@ -2183,7 +2242,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "Hello without explicit mentions",
         mentions: [],
         context: {
@@ -2237,7 +2296,10 @@ describe("postUserMessage", () => {
         }
 
         resultWithOtherAgent = await postUserMessage(auth, {
-          conversation: afterFirstPostResult.value,
+          conversationResource: await fetchConversationResource(
+            auth,
+            afterFirstPostResult.value.sId
+          ),
           content: "Hello with explicit agent mention",
           mentions: [
             {
@@ -2307,7 +2369,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "API message",
         mentions: [],
         context: {
@@ -2351,7 +2413,7 @@ describe("postUserMessage", () => {
       const userBJson = userB.toJSON();
 
       const firstFromA = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: "first from A",
         mentions: [],
         context: {
@@ -2378,7 +2440,10 @@ describe("postUserMessage", () => {
       }
 
       const firstFromB = await postUserMessage(authB, {
-        conversation: afterA.value,
+        conversationResource: await fetchConversationResource(
+          authB,
+          afterA.value.sId
+        ),
         content: "first from B",
         mentions: [],
         context: {
@@ -2407,7 +2472,10 @@ describe("postUserMessage", () => {
       vi.clearAllMocks();
 
       const secondFromA = await postUserMessage(auth, {
-        conversation: afterB.value,
+        conversationResource: await fetchConversationResource(
+          auth,
+          afterB.value.sId
+        ),
         content: "second from A",
         mentions: [],
         context: {
@@ -2439,7 +2507,7 @@ describe("postUserMessage", () => {
     let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let nonMemberAuth: Authenticator;
     let memberAuth: Authenticator;
-    let projectConversation: ConversationType;
+    let projectConversationResource: ConversationResource;
 
     beforeEach(async () => {
       // Create a project space
@@ -2501,7 +2569,10 @@ describe("postUserMessage", () => {
       if (fetchedConversationResult.isErr()) {
         throw new Error("Failed to fetch conversation");
       }
-      projectConversation = fetchedConversationResult.value;
+      projectConversationResource = await fetchConversationResource(
+        memberAuth,
+        conversationWithoutContent.sId
+      );
     });
 
     it("should allow posting a message when user is a project member", async () => {
@@ -2509,7 +2580,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(memberAuth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         content: "Hello from a project member",
         mentions: [],
         context: {
@@ -2536,7 +2607,7 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(nonMemberAuth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         content: "Hello from a non-member",
         mentions: [],
         context: {
@@ -2578,7 +2649,7 @@ describe("postUserMessage", () => {
       expect(restrictedPod?.isOpen()).toBe(false);
 
       const result = await postUserMessage(apiKeyAuth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         content: "Hello from an integration",
         mentions: [],
         context: {
@@ -2627,7 +2698,7 @@ describe("postUserMessage", () => {
       expect(openPod?.isOpen()).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         content: "Hello from an integration",
         mentions: [],
         context: {
@@ -2675,7 +2746,7 @@ describe("postUserMessage", () => {
       expect(openPod?.isOpen()).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
-        conversation: projectConversation,
+        conversationResource: projectConversationResource,
         content: "Hello from an integration",
         mentions: [],
         context: {
@@ -2703,14 +2774,12 @@ describe("postUserMessage", () => {
       const user = memberAuth.getNonNullableUser();
       const userJson = user.toJSON();
 
-      // Create a conversation with a non-existent spaceId
-      const conversationWithInvalidSpace: ConversationType = {
-        ...projectConversation,
-        spaceId: "invalid-space-id",
-      };
+      const fetchPodSpy = vi
+        .spyOn(SpaceResource, "fetchById")
+        .mockResolvedValue(null);
 
       const result = await postUserMessage(memberAuth, {
-        conversation: conversationWithInvalidSpace,
+        conversationResource: projectConversationResource,
         content: "Hello",
         mentions: [],
         context: {
@@ -2723,6 +2792,8 @@ describe("postUserMessage", () => {
         },
         skipToolsValidation: false,
       });
+
+      fetchPodSpy.mockRestore();
 
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
@@ -2755,7 +2826,10 @@ describe("postUserMessage", () => {
       const userJson = user.toJSON();
 
       const result = await postUserMessage(nonMemberAuth, {
-        conversation: regularConversation,
+        conversationResource: await fetchConversationResource(
+          nonMemberAuth,
+          regularConversation.sId
+        ),
         content: "Hello from a non-member to regular conversation",
         mentions: [],
         context: {
@@ -2797,7 +2871,7 @@ describe("postUserMessage", () => {
       );
 
       const result = await postUserMessage(apiKeyAuth, {
-        conversation,
+        conversationResource,
         content: "Hello from API key",
         mentions: [],
         context: {
@@ -2822,6 +2896,7 @@ describe("postUserMessage", () => {
     let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let projectConversation: ConversationType;
+    let projectConversationResource: ConversationResource;
     let agentWithDifferentSpace: LightAgentConfigurationType;
 
     async function setupProjectWithRestrictedAgent({
@@ -2932,6 +3007,10 @@ describe("postUserMessage", () => {
         throw new Error("Failed to fetch conversation");
       }
       projectConversation = fetchedConversationResult.value;
+      projectConversationResource = await fetchConversationResource(
+        auth,
+        conversationWithoutContent.sId
+      );
     }
 
     describe("with projects feature flag enabled regarding branches", () => {
@@ -2955,7 +3034,7 @@ describe("postUserMessage", () => {
         expect(branchesBefore.length).toBe(0);
 
         const result = await postUserMessage(auth, {
-          conversation: projectConversation,
+          conversationResource: projectConversationResource,
           content: `Hello @${agentWithDifferentSpace.name}`,
           mentions: [{ configurationId: agentWithDifferentSpace.sId }],
           context: {
@@ -2981,7 +3060,6 @@ describe("postUserMessage", () => {
           );
         expect(branchesAfter.length).toBe(1);
         const branch = branchesAfter[0];
-        expect(projectConversation.branchId).toBe(branch.sId);
 
         const newUserMessageId = result.value.userMessage.id;
         const newUserMessageRow = await MessageModel.findOne({
@@ -3016,7 +3094,7 @@ describe("postUserMessage", () => {
           .mockResolvedValue(100);
 
         const firstPost = await postUserMessage(auth, {
-          conversation: projectConversation,
+          conversationResource: projectConversationResource,
           content: `First message @${agentWithDifferentSpace.name}`,
           mentions: [{ configurationId: agentWithDifferentSpace.sId }],
           context: {
@@ -3035,23 +3113,22 @@ describe("postUserMessage", () => {
           return;
         }
 
-        expect(projectConversation.branchId).toBeDefined();
-        const branchId = projectConversation.branchId!;
+        const branchesAfterFirstPost =
+          await ConversationBranchResource.listForConversation(
+            auth,
+            projectConversation.id
+          );
+        expect(branchesAfterFirstPost.length).toBe(1);
+        const branchId = branchesAfterFirstPost[0].sId;
 
-        const conversationWithBranch = await getConversation(
+        const convInBranchResource = await fetchConversationResource(
           auth,
-          projectConversation.sId,
-          false,
-          branchId
+          projectConversation.sId
         );
-        expect(conversationWithBranch.isOk()).toBe(true);
-        if (conversationWithBranch.isErr()) {
-          return;
-        }
-        const convInBranch = conversationWithBranch.value;
 
         const secondPost = await postUserMessage(auth, {
-          conversation: convInBranch,
+          conversationResource: convInBranchResource,
+          branchId,
           content: "Second message in branch",
           mentions: [],
           context: {
@@ -3104,7 +3181,7 @@ describe("postUserMessage", () => {
         expect(projectConversation.content.length).toBe(0);
 
         const result = await postUserMessage(auth, {
-          conversation: projectConversation,
+          conversationResource: projectConversationResource,
           content: `Hello @${agentWithDifferentSpace.name}`,
           mentions: [{ configurationId: agentWithDifferentSpace.sId }],
           context: {
@@ -3130,7 +3207,6 @@ describe("postUserMessage", () => {
           );
         expect(branchesAfter.length).toBe(1);
         const branch = branchesAfter[0];
-        expect(projectConversation.branchId).toBe(branch.sId);
 
         // Anchor message: rank 0, empty content, origin "branch_anchor".
         const anchorMessageRow = await MessageModel.findOne({
@@ -3241,7 +3317,7 @@ describe("postUserMessage", () => {
           .mockResolvedValue(100);
 
         const result = await postUserMessage(auth, {
-          conversation: projectConversation,
+          conversationResource: projectConversationResource,
           content: `Hello @${agentWithDifferentSpace.name}`,
           mentions: [{ configurationId: agentWithDifferentSpace.sId }],
           context: {
@@ -3267,7 +3343,6 @@ describe("postUserMessage", () => {
           );
         expect(branchesAfter.length).toBe(1);
         const branch = branchesAfter[0];
-        expect(projectConversation.branchId).toBe(branch.sId);
 
         const anchorMessageRow = await MessageModel.findOne({
           where: {
@@ -3432,7 +3507,7 @@ describe("compactConversation", () => {
 describe("editUserMessage", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
-  let conversation: ConversationType;
+  let conversationResource: ConversationResource;
   let agentConfig1: LightAgentConfigurationType;
   let agentConfig2: LightAgentConfigurationType;
   let originalUserMessage: UserMessageType;
@@ -3458,27 +3533,19 @@ describe("editUserMessage", () => {
       visibility: "unlisted",
     });
 
-    const fetchedConversationResult = await getConversation(
+    conversationResource = await fetchConversationResource(
       auth,
       conversationWithoutContent.sId
     );
-    if (fetchedConversationResult.isErr()) {
-      throw new Error("Failed to fetch conversation");
-    }
-    conversation = fetchedConversationResult.value;
 
-    // Create an original user message with agent mentions
+    // Create an original user message without mentions or agent replies.
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
     const postResult = await postUserMessage(auth, {
-      conversation,
-      content: `Original message with @${agentConfig1.name}`,
-      mentions: [
-        {
-          configurationId: agentConfig1.sId,
-        } satisfies AgentMention,
-      ],
+      conversationResource,
+      content: "Original message without mentions",
+      mentions: [],
       context: {
         username: userJson.username,
         timezone: "UTC",
@@ -3488,6 +3555,7 @@ describe("editUserMessage", () => {
         origin: "web",
       },
       skipToolsValidation: false,
+      skipDustAutoMention: true,
     });
 
     if (postResult.isErr()) {
@@ -3509,7 +3577,7 @@ describe("editUserMessage", () => {
     ];
 
     const result = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
       message: originalUserMessage,
       content: `Edited message with @${agentConfig1.name} and @${agentConfig2.name}`,
       mentions,
@@ -3570,7 +3638,7 @@ describe("editUserMessage", () => {
     ];
 
     const result = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
       message: originalUserMessage,
       content: `Edited message with @${mentionedUser.username}`,
       mentions,
@@ -3628,7 +3696,7 @@ describe("editUserMessage", () => {
     ];
 
     const result = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
       message: originalUserMessage,
       content: `Edited message with @${mentionedUser.username} and @${agentConfig2.name}`,
       mentions,
@@ -3675,7 +3743,7 @@ describe("editUserMessage", () => {
 
   it("should preserve empty mentions array when editing removes all mentions", async () => {
     const result = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
       message: originalUserMessage,
       content: "Edited message without mentions",
       mentions: [],
@@ -3722,7 +3790,7 @@ describe("editUserMessage", () => {
     ];
 
     const result = await editUserMessage(auth, {
-      conversation,
+      conversationResource,
       message: originalUserMessage,
       content: `Edited message with only user mention @${mentionedUser.username}`,
       mentions,
@@ -4899,7 +4967,10 @@ describe("postUserMessage no-seat gate", () => {
 
     const userJson = user.toJSON();
     const result = await postUserMessage(auth, {
-      conversation: fetched.value,
+      conversationResource: await fetchConversationResource(
+        auth,
+        fetched.value.sId
+      ),
       content: `Hello @${agent.name}`,
       mentions: [{ configurationId: agent.sId } satisfies AgentMention],
       context: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -4,7 +4,7 @@ import {
   getAgentConfiguration,
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration/agent";
-import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
+import { fetchPrecedingContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
 import { cleanupDeniedBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
@@ -95,7 +95,10 @@ import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import {
+  ConversationResource,
+  type RunningAgentMessageContext,
+} from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -132,9 +135,7 @@ import type {
   AgentMessageType,
   AgentMessageTypeWithoutMentions,
   CitationType,
-  CompactionMessageType,
   ConversationMetadata,
-  ConversationType,
   ConversationVisibility,
   ConversationWithoutContentType,
   MessageVisibility,
@@ -146,7 +147,6 @@ import type {
 import {
   ConversationError,
   isAgentMessageType,
-  isCompactionMessageType,
   isPodConversation,
   isUserMessageType,
   UNRESUMABLE_AGENT_MESSAGE_STATUSES,
@@ -162,7 +162,6 @@ import type {
   ContentFragmentContextType,
   ContentFragmentType,
 } from "@app/types/content_fragment";
-import { isContentFragmentType } from "@app/types/content_fragment";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -171,9 +170,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import assert from "assert";
 import type { IncomingHttpHeaders } from "http";
-import uniq from "lodash/uniq";
 import { col } from "sequelize";
 
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
@@ -230,8 +227,7 @@ export async function createConversation(
     spaceId: ModelId | null;
     metadata?: ConversationMetadata;
   }
-): Promise<ConversationType> {
-  const owner = auth.getNonNullableWorkspace();
+): Promise<ConversationResource> {
   let space: SpaceResource | null = null;
 
   if (spaceId) {
@@ -267,27 +263,7 @@ export async function createConversation(
     });
   }
 
-  return {
-    id: conversation.id,
-    owner,
-    created: conversation.createdAt.getTime(),
-    updated: conversation.updatedAt.getTime(),
-    sId: conversation.sId,
-    title: conversation.title,
-    depth: conversation.depth,
-    content: [],
-    lastReadMs: Date.now(),
-    unread: false,
-    actionRequired: false,
-    hasError: false,
-    visibility: conversation.visibility,
-    requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
-    spaceId: space?.sId ?? null,
-    triggerId: conversation.triggerSId,
-    metadata: conversation.metadata,
-    branchId: null,
-    isRunningAgentLoop: conversation.isRunningAgentLoop,
-  };
+  return conversation;
 }
 
 /**
@@ -546,7 +522,8 @@ export function isUserMessageContextValid(
 export async function postUserMessage(
   auth: Authenticator,
   {
-    conversation,
+    conversationResource,
+    branchId: initialBranchId = null,
     content,
     mentions,
     context,
@@ -556,7 +533,8 @@ export async function postUserMessage(
     doNotAssociateUser,
     modelSelection,
   }: {
-    conversation: ConversationType;
+    conversationResource: ConversationResource;
+    branchId?: string | null;
     content: string;
     mentions: MentionType[];
     context: UserMessageContext;
@@ -580,7 +558,12 @@ export async function postUserMessage(
   const subscription = auth.subscription();
   const plan = subscription?.plan;
 
-  if (!owner || owner.id !== conversation.owner.id || !subscription || !plan) {
+  const conversation: ConversationWithoutContentType = {
+    ...conversationResource.toJSON(),
+    branchId: initialBranchId,
+  };
+
+  if (!owner || !subscription || !plan) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -634,12 +617,10 @@ export async function postUserMessage(
     (context.origin === "web" || context.origin === "extension")
   ) {
     const hasOtherHumans =
-      uniq(
-        conversation.content
-          .map((versions) => versions[versions.length - 1])
-          .filter(isUserMessageType)
-          .filter((m) => m.user?.sId && m.user.sId !== auth.user()?.sId)
-      ).length >= 1;
+      await conversationResource.hasUserMessageFromOtherUser(auth, {
+        excludeUserId: user?.id,
+        branchId: conversation.branchId,
+      });
 
     if (!hasOtherHumans) {
       const dustAgent = await getAgentConfiguration(auth, {
@@ -677,12 +658,10 @@ export async function postUserMessage(
   // we don't currently re-check the existence of a compaction message inside the critical section
   // below which means an agent loop could be triggered whle a compaction is running. This is not
   // that problematic if it happens (agent message after the compaction message).
-  const runningCompactionMessage = conversation.content
-    .flat()
-    .find(
-      (m): m is CompactionMessageType =>
-        isCompactionMessageType(m) && m.status === "created"
-    );
+  const { runningAgentMessage: runningAgentContext, runningCompactionMessage } =
+    await conversationResource.getInFlightMessages(auth, {
+      branchId: conversation.branchId,
+    });
   if (runningCompactionMessage) {
     return new Err({
       status_code: 409,
@@ -702,16 +681,8 @@ export async function postUserMessage(
     return canInteractRes;
   }
 
-  let runningAgentMessage = conversation.content
-    .map((versions) =>
-      versions.reduce((latest, message) =>
-        message.version > latest.version ? message : latest
-      )
-    )
-    .find(
-      (m): m is AgentMessageType =>
-        isAgentMessageType(m) && m.status === "created"
-    );
+  let runningAgentMessage: RunningAgentMessageContext | undefined =
+    runningAgentContext ?? undefined;
 
   // Steering invariants: enforce single agent loop per conversation.
   if (explicitAgentMentions.length > 1) {
@@ -733,7 +704,7 @@ export async function postUserMessage(
     runningAgentMessage &&
     explicitAgentMentions.length > 0 &&
     explicitAgentMentions[0].configurationId !==
-      runningAgentMessage.configuration.sId &&
+      runningAgentMessage.agentConfigurationId &&
     !isHandover
   ) {
     return new Err({
@@ -870,21 +841,20 @@ export async function postUserMessage(
           "Message has user mentions, for now we do not support branching with user mentions."
         );
       } else {
-        const latestMessages = removeNulls(
-          conversation.content.map((versions) => versions.at(-1))
-        );
+        const branchContext =
+          await conversationResource.getBranchCreationContext(auth, {
+            branchId: conversation.branchId,
+            transaction: t,
+          });
         const shouldCreateAnchorMessage =
-          latestMessages.length === 0 ||
-          latestMessages.every(isContentFragmentType);
+          branchContext.isEmpty || branchContext.onlyContentFragments;
 
         if (shouldCreateAnchorMessage) {
           // Create an invisible anchor message so the branch has a previousMessageId
           // to reference. If the conversation only contains content fragments, keep
           // them before the anchor so they remain attached to the branch context.
           const anchorMessageRank =
-            latestMessages.length > 0
-              ? Math.max(...latestMessages.map((m) => m.rank)) + 1
-              : 0;
+            branchContext.maxRank !== null ? branchContext.maxRank + 1 : 0;
           const anchorMessage = await createUserMessage(auth, {
             conversation,
             content: "",
@@ -915,8 +885,7 @@ export async function postUserMessage(
           conversation.branchId = branch.sId;
           nextMessageRank = anchorMessageRank + 1;
         } else {
-          // Get the last message in the conversation.
-          const previousMessage = latestMessages.at(-1);
+          const previousMessage = branchContext.lastMessage;
           if (!previousMessage) {
             logger.error(
               "Last message in conversation has no content, cannot create branch."
@@ -1074,14 +1043,7 @@ export async function postUserMessage(
   // If a user is mentioned, we want to make sure the conversation has a title.
   // This ensures that mentioned users receive a notification with a conversation title.
   if (mentions.some(isUserMention)) {
-    await ensureConversationTitle(auth, {
-      conversation,
-      userMessage: {
-        ...userMessage,
-        richMentions: [],
-        mentions: [],
-      },
-    });
+    await ensureConversationTitle(auth, { conversation });
   }
 
   await triggerConversationUnreadNotifications(auth, {
@@ -1091,7 +1053,7 @@ export async function postUserMessage(
 
   void ServerSideTracking.trackUserMessage({
     userMessage,
-    workspace: conversation.owner,
+    workspace: owner,
     userId: user ? `user-${user.id}` : `api-${context.username}`,
     conversationId: conversation.sId,
     agentMessages,
@@ -1112,7 +1074,7 @@ export async function postUserMessage(
       auth,
       action: "agent.executed",
       targets: [
-        buildAuditLogTarget("workspace", conversation.owner),
+        buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("agent", agentMessage.configuration),
       ],
       metadata: {
@@ -1155,7 +1117,11 @@ export async function postUserMessage(
       conversation,
       {
         ...userMessage,
-        contentFragments: getRelatedContentFragments(conversation, userMessage),
+        contentFragments: await fetchPrecedingContentFragments(auth, {
+          conversationResource,
+          targetRank: userMessage.rank,
+          branchId: conversation.branchId,
+        }),
       },
       agentMessages
     ),
@@ -1164,7 +1130,6 @@ export async function postUserMessage(
     userMessage.rank >= 3
       ? ensureConversationTitle(auth, {
           conversation,
-          userMessage,
         })
       : Promise.resolve(undefined),
   ]);
@@ -1205,13 +1170,15 @@ class UserMessageError extends Error {}
 export async function editUserMessage(
   auth: Authenticator,
   {
-    conversation,
+    conversationResource,
+    branchId: initialBranchId = null,
     message,
     content,
     mentions,
     skipToolsValidation,
   }: {
-    conversation: ConversationType;
+    conversationResource: ConversationResource;
+    branchId?: string | null;
     message: UserMessageType;
     content: string;
     mentions: MentionType[];
@@ -1226,7 +1193,7 @@ export async function editUserMessage(
   const user = auth.user();
   const owner = auth.workspace();
 
-  if (!owner || owner.id !== conversation.owner.id) {
+  if (!owner) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -1245,6 +1212,11 @@ export async function editUserMessage(
       },
     });
   }
+
+  const conversation: ConversationWithoutContentType = {
+    ...conversationResource.toJSON(),
+    branchId: initialBranchId,
+  };
 
   const canInteractRes = await WakeUpResource.canUserInteract(
     auth,
@@ -1378,16 +1350,11 @@ export async function editUserMessage(
       const hasAgentMentions = mentions.some(isAgentMention);
 
       if (hasAgentMentions) {
-        // Check if there are any agent messages after the edited user message
-        // by checking conversation.content (which is indexed by rank)
-        const hasAgentMessagesAfter = conversation.content
-          .slice(messageRow.rank + 1)
-          .some((versions) => {
-            if (versions.length === 0) {
-              return false;
-            }
-            const latestVersion = versions[versions.length - 1];
-            return isAgentMessageType(latestVersion);
+        const hasAgentMessagesAfter =
+          await conversationResource.hasAgentMessageAfterRank(auth, {
+            afterRank: messageRow.rank,
+            branchId: conversation.branchId,
+            transaction: t,
           });
 
         const agentMessages: AgentMessageType[] = [];
@@ -1487,7 +1454,11 @@ export async function editUserMessage(
     conversation,
     {
       ...userMessage,
-      contentFragments: getRelatedContentFragments(conversation, userMessage),
+      contentFragments: await fetchPrecedingContentFragments(auth, {
+        conversationResource,
+        targetRank: userMessage.rank,
+        branchId: conversation.branchId,
+      }),
     },
     agentMessages
   );
@@ -1554,7 +1525,7 @@ export async function createAgentMessageFromText(
     skipToolsValidation = true,
     citationsAndFilesFromOutputItems,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     parentId: ModelId;
     rank: number;
     content: string;
@@ -1779,23 +1750,67 @@ export async function createAgentMessageFromText(
 export async function retryAgentMessage(
   auth: Authenticator,
   {
-    conversation,
+    conversationResource,
+    branchId: initialBranchId = null,
     message,
   }: {
-    conversation: ConversationType;
+    conversationResource: ConversationResource;
+    branchId?: string | null;
     message: AgentMessageType;
   }
 ): Promise<Result<AgentMessageType, APIErrorWithContentfulStatusCode>> {
-  // Find the parent user message to get the original context for rate limiting.
-  // This ensures retries are counted with the same origin (web vs programmatic) as the original.
-  const parentUserMessage = conversation.content
-    .flat()
-    .find(
-      (m): m is UserMessageType =>
-        isUserMessageType(m) && m.sId === message.parentMessageId
-    );
+  const conversation: ConversationWithoutContentType = {
+    ...conversationResource.toJSON(),
+    branchId: initialBranchId,
+  };
 
-  if (!parentUserMessage) {
+  const parentMessageRes = await conversationResource.getMessageById(
+    auth,
+    message.parentMessageId
+  );
+  if (parentMessageRes.isErr() || !parentMessageRes.value.userMessage) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Could not find the parent user message for this retry.",
+      },
+    });
+  }
+
+  const latestParentMessageModel =
+    await conversationResource.getLatestUserMessageModelAtRank(auth, {
+      rank: parentMessageRes.value.rank,
+      branchId: message.branchId,
+    });
+  if (!latestParentMessageModel) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Could not find the parent user message for this retry.",
+      },
+    });
+  }
+
+  const parentUserMessageRenderRes = await batchRenderMessages(
+    auth,
+    conversationResource,
+    [latestParentMessageModel],
+    "full"
+  );
+  if (parentUserMessageRenderRes.isErr()) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Could not find the parent user message for this retry.",
+      },
+    });
+  }
+
+  const parentUserMessage = parentUserMessageRenderRes.value[0];
+  if (!parentUserMessage || !isUserMessageType(parentUserMessage)) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -1948,34 +1963,6 @@ export async function retryAgentMessage(
 
   const { agentMessage } = agentMessageResult;
 
-  // First, find the array of the parent message in conversation.content.
-  const parentMessageIndex = conversation.content.findIndex((messages) => {
-    return messages.some((m) => m.sId === agentMessage.parentMessageId);
-  });
-  if (parentMessageIndex === -1) {
-    throw new Error(
-      `Parent message ${agentMessage.parentMessageId} not found in conversation`
-    );
-  }
-
-  const userMessage =
-    conversation.content[parentMessageIndex][
-      conversation.content[parentMessageIndex].length - 1
-    ];
-  if (!isUserMessageType(userMessage)) {
-    throw new Error("Unreachable: parent message must be a user message");
-  }
-
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: agentMessage.configuration.sId,
-    variant: "light",
-  });
-
-  assert(
-    agentConfiguration,
-    "Unreachable: could not find detailed configuration for agent"
-  );
-
   void launchAgentLoopWorkflow({
     auth,
     agentLoopArgs: {
@@ -1984,9 +1971,9 @@ export async function retryAgentMessage(
       conversationId: conversation.sId,
       conversationTitle: conversation.title,
       conversationBranchId: conversation.branchId,
-      userMessageId: userMessage.sId,
-      userMessageVersion: userMessage.version,
-      userMessageOrigin: userMessage.context.origin,
+      userMessageId: parentUserMessage.sId,
+      userMessageVersion: parentUserMessage.version,
+      userMessageOrigin: parentUserMessage.context.origin,
     },
     startStep: 0,
   });
@@ -2197,42 +2184,6 @@ export async function postNewContentFragment(
 }
 
 /**
- * Returns the agent replies that follow `userMessage` in the conversation and would be orphaned
- * by soft-deleting it. These are agent messages at subsequent ranks up to (but not including) the
- * next non-agent rank. Already-deleted agent messages are skipped.
- *
- * Invariant: agent replies are immediately contiguous to the user message they respond to (no
- * compaction, content fragment, or another user message inserted in between). If that ever
- * changes, this walk will stop short and leave orphans that re-introduce the trailing-assistant
- * bug this cascade is meant to fix.
- *
- * New conversations are capped at one mention per user message (enforced in postUserMessage) so
- * in practice there's at most one, but legacy conversations can have multiple agent replies in a
- * single turn, which is why the return type is an array.
- */
-function getAgentRepliesToCascadeOnUserDelete(
-  conversation: ConversationType,
-  userMessage: UserMessageType
-): AgentMessageType[] {
-  const orphans: AgentMessageType[] = [];
-  let sawUserMessage = false;
-  for (const versions of conversation.content) {
-    const latest = versions[versions.length - 1];
-    if (!sawUserMessage) {
-      sawUserMessage = latest.sId === userMessage.sId;
-      continue;
-    }
-    if (!isAgentMessageType(latest)) {
-      break;
-    }
-    if (latest.visibility !== "deleted") {
-      orphans.push(latest);
-    }
-  }
-  return orphans;
-}
-
-/**
  * Soft-delete a user message and the agent replies that followed it.
  *
  * Both deletions are represented as new v+1 `messages` rows with `visibility: "deleted"` rather
@@ -2249,15 +2200,22 @@ export async function softDeleteUserMessageAndReplies(
   auth: Authenticator,
   {
     message,
-    conversation,
+    conversationResource,
+    branchId: initialBranchId = null,
   }: {
     message: UserMessageType;
-    conversation: ConversationType;
+    conversationResource: ConversationResource;
+    branchId?: string | null;
   }
 ): Promise<Result<{ success: true }, ConversationError>> {
   if (message.visibility === "deleted") {
     return new Ok({ success: true });
   }
+
+  const conversation: ConversationWithoutContentType = {
+    ...conversationResource.toJSON(),
+    branchId: initialBranchId,
+  };
 
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
@@ -2267,22 +2225,45 @@ export async function softDeleteUserMessageAndReplies(
     return new Err(new ConversationError("message_deletion_not_authorized"));
   }
 
-  // Known small race: this snapshot of `conversation.content` is taken before the rank lock
-  // below. A concurrent retry/edit that takes the lock first and writes a v+1 at the same rank
-  // could cause the cascade insert to hit the (rank, version) unique constraint.
-  const orphanAgentMessages = getAgentRepliesToCascadeOnUserDelete(
-    conversation,
-    message
+  const branchId = message.branchId ?? initialBranchId;
+
+  // Known small race: this snapshot is taken before the rank lock below. A concurrent retry/edit
+  // that takes the lock first and writes a v+1 at the same rank could cause the cascade insert to
+  // hit the (rank, version) unique constraint.
+  const orphanAgentMessageModels =
+    await conversationResource.getConsecutiveAgentReplyModelsAfterRank(auth, {
+      afterRank: message.rank,
+      branchId,
+    });
+
+  const orphanModelsToCascade = orphanAgentMessageModels.filter(
+    (m) => m.visibility !== "deleted"
   );
+
+  let orphanAgentMessages: AgentMessageType[] = [];
+  if (orphanModelsToCascade.length > 0) {
+    const orphanRenderRes = await batchRenderMessages(
+      auth,
+      conversationResource,
+      orphanModelsToCascade,
+      "full"
+    );
+    if (orphanRenderRes.isErr()) {
+      throw new Error("Failed to render agent replies to cascade on delete");
+    }
+    orphanAgentMessages = orphanRenderRes.value.filter(isAgentMessageType);
+  }
 
   const cascadedAgentMessages: AgentMessageType[] = [];
   const userMessage = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    const relatedContentFragments = getRelatedContentFragments(
-      conversation,
-      message
-    );
+    const relatedContentFragments = await fetchPrecedingContentFragments(auth, {
+      conversationResource,
+      targetRank: message.rank,
+      branchId,
+      transaction: t,
+    });
 
     const userMessage = await createUserMessage(auth, {
       conversation,
@@ -2380,7 +2361,7 @@ export async function softDeleteAgentMessage(
     conversation,
   }: {
     message: AgentMessageType;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
   }
 ): Promise<Result<{ success: true }, ConversationError>> {
   if (message.visibility === "deleted") {

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -3,7 +3,6 @@ import {
   createAgentMessageFromText,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -154,11 +153,11 @@ export async function mergeConversationBranch(
 > {
   const owner = auth.getNonNullableWorkspace();
 
-  const conversation = await ConversationResource.fetchById(
+  const conversationResource = await ConversationResource.fetchById(
     auth,
     conversationId
   );
-  if (!conversation) {
+  if (!conversationResource) {
     return new Err(
       new DustError("conversation_not_found", "Conversation not found.")
     );
@@ -174,7 +173,7 @@ export async function mergeConversationBranch(
     return new Err(new DustError("branch_not_found", "Branch not found."));
   }
 
-  if (branch.conversationId !== conversation.id) {
+  if (branch.conversationId !== conversationResource.id) {
     return new Err(new DustError("branch_not_found", "Branch not found."));
   }
 
@@ -193,11 +192,9 @@ export async function mergeConversationBranch(
 
   const branchMessages = await branch.fetchAllMessages(auth);
 
-  const effectiveConversation = conversation;
-
   const renderedRes = await batchRenderMessages(
     auth,
-    effectiveConversation,
+    conversationResource,
     branchMessages,
     "light"
   );
@@ -261,19 +258,8 @@ export async function mergeConversationBranch(
     authMethod: src.userContextAuthMethod,
   };
 
-  const fullConversationRes = await getConversation(
-    auth,
-    conversationId,
-    false
-  );
-  if (fullConversationRes.isErr()) {
-    return new Err(
-      new DustError("conversation_not_found", "Conversation not found.")
-    );
-  }
-
   const postRes = await postUserMessage(auth, {
-    conversation: fullConversationRes.value,
+    conversationResource,
     content: src.content,
     mentions: [],
     context,
@@ -337,7 +323,7 @@ export async function mergeConversationBranch(
         : undefined;
 
     const created = await createAgentMessageFromText(auth, {
-      conversation: fullConversationRes.value,
+      conversation: conversationResource?.toJSON(),
       parentId: mergedUserMessage.id,
       rank: rankCursor++,
       content: contentOnly,

--- a/front/lib/api/assistant/conversation/compaction.ts
+++ b/front/lib/api/assistant/conversation/compaction.ts
@@ -5,24 +5,15 @@ import {
 import { createCompactionMessage } from "@app/lib/api/assistant/conversation/messages";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  AgentMessageModel,
-  CompactionMessageModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
+import { CompactionMessageModel } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { launchCompactionWorkflow } from "@app/temporal/agent_loop/client";
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type {
-  AgentMessageType,
   CompactionMessageType,
-  ConversationType,
   ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
-import {
-  isAgentMessageType,
-  isCompactionMessageType,
 } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -43,7 +34,7 @@ export async function compactConversation(
     model,
     sourceConversation,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     model: SupportedModel;
     sourceConversation?: CompactionSourceConversation;
   }
@@ -53,22 +44,23 @@ export async function compactConversation(
     APIErrorWithContentfulStatusCode
   >
 > {
-  const owner = auth.getNonNullableWorkspace();
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!conversationResource) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "The conversation does not exist.",
+      },
+    });
+  }
 
-  // Block compaction while an agent message is running or a compaction is running.
-  const runningAgentMessage = conversation.content
-    .flat()
-    .find(
-      (m): m is AgentMessageType =>
-        isAgentMessageType(m) && m.status === "created"
-    );
-  const runningCompaction = conversation.content
-    .flat()
-    .find(
-      (m): m is CompactionMessageType =>
-        isCompactionMessageType(m) && m.status === "created"
-    );
-  const lastMessage = conversation.content.at(-1)?.at(-1);
+  const { runningAgentMessage, runningCompactionMessage } =
+    await conversationResource.getInFlightMessages(auth);
+  const lastMessage = await conversationResource.getLatestMessageSummary(auth);
 
   if (runningAgentMessage) {
     return new Err({
@@ -80,7 +72,7 @@ export async function compactConversation(
     });
   }
 
-  if (runningCompaction) {
+  if (runningCompactionMessage) {
     return new Err({
       status_code: 409,
       api_error: {
@@ -90,11 +82,7 @@ export async function compactConversation(
     });
   }
 
-  if (
-    lastMessage &&
-    isCompactionMessageType(lastMessage) &&
-    lastMessage.status === "succeeded"
-  ) {
+  if (lastMessage && lastMessage.compactionStatus === "succeeded") {
     return new Err({
       status_code: 409,
       api_error: {
@@ -108,43 +96,11 @@ export async function compactConversation(
   const { compactionMessage } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Re-check the existence of a compaction message or running agent message inside the critical
-    // section of the advisory lock to avoid stacking compaction with other compaction or running
-    // agent loop.
-    const [runningCompactionMessage, runningAgentMessage] = await Promise.all([
-      MessageModel.findOne({
-        where: {
-          conversationId: conversation.id,
-          workspaceId: owner.id,
-        },
-        include: [
-          {
-            model: CompactionMessageModel,
-            as: "compactionMessage",
-            required: true,
-            where: { status: "created", conversationId: conversation.id },
-          },
-        ],
-        transaction: t,
-      }),
-      MessageModel.findOne({
-        where: {
-          conversationId: conversation.id,
-          workspaceId: owner.id,
-        },
-        include: [
-          {
-            model: AgentMessageModel,
-            as: "agentMessage",
-            required: true,
-            where: { status: "created", conversationId: conversation.id },
-          },
-        ],
-        transaction: t,
-      }),
-    ]);
+    const inFlight = await conversationResource.getInFlightMessages(auth, {
+      transaction: t,
+    });
 
-    if (runningCompactionMessage || runningAgentMessage) {
+    if (inFlight.runningCompactionMessage || inFlight.runningAgentMessage) {
       return { compactionMessage: null };
     }
 

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -6,6 +6,7 @@ import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/processing";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -65,7 +66,7 @@ export async function toFileContentFragment(
     fileName,
     skipDataSourceIndexing,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     contentFragment: ContentFragmentInputWithInlinedContent;
     fileName?: string;
     skipDataSourceIndexing?: boolean;

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -75,7 +75,7 @@ async function createUserMessage(
     content,
     branchId = null,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     rank: number;
     content: string;
     branchId?: ModelId | null;
@@ -119,7 +119,7 @@ async function createAgentMessage(
     generatedFileId = null,
     branchId = null,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     rank: number;
     parentId: ModelId;
     status: "created" | "succeeded";
@@ -856,7 +856,7 @@ describe("createConversationFork", () => {
     });
 
     const upsertResult = await SkillResource.upsertConversationSkills(auth, {
-      conversation: parentConversation,
+      conversation: parentConversation.toJSON(),
       skills: [enabledSkill],
       enabled: true,
     });

--- a/front/lib/api/assistant/conversation/lock.ts
+++ b/front/lib/api/assistant/conversation/lock.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { MessageModel } from "@app/lib/models/agent/conversation";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -15,7 +16,7 @@ import type { Transaction } from "sequelize";
  */
 export async function getConversationRankVersionLock(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType,
+  conversation: ConversationWithoutContentType | ConversationResource,
   t: Transaction
 ) {
   const now = new Date();

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -846,12 +846,19 @@ describe("createAgentMessages", () => {
       );
       expect(restrictedSpaceModelId).not.toBeNull();
 
-      const restrictedConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const restrictedConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpaceModelId!],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpaceModelId!] },
+        { where: { id: restrictedConversationResource.id } }
+      );
+      const restrictedConversation = {
+        ...restrictedConversationResource.toJSON(),
+        requestedSpaceIds: [refreshedRestrictedSpace!.sId],
+      };
 
       // Verify the mentioned user cannot access the conversation
       const canAccess = await ConversationResource.canAccess(
@@ -1039,12 +1046,19 @@ describe("createAgentMessages", () => {
       );
       expect(restrictedSpaceModelId).not.toBeNull();
 
-      const restrictedConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const restrictedConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpaceModelId!],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpaceModelId!] },
+        { where: { id: restrictedConversationResource.id } }
+      );
+      const restrictedConversation = {
+        ...restrictedConversationResource.toJSON(),
+        requestedSpaceIds: [refreshedRestrictedSpace!.sId],
+      };
 
       // Add user as participant first (which would normally auto-approve)
       await ConversationResource.upsertParticipation(auth, {
@@ -1130,11 +1144,13 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedProjectSpace).not.toBeNull();
 
-      const projectConversation = await createConversation(userAuth, {
+      const projectConversationResource = await createConversation(userAuth, {
         title: "Project Conversation",
         visibility: "unlisted",
         spaceId: refreshedProjectSpace!.id,
       });
+
+      const projectConversation = projectConversationResource.toJSON();
 
       // Create an agent message
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
@@ -1207,11 +1223,13 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedProjectSpace).not.toBeNull();
 
-      const projectConversation = await createConversation(userAuth, {
+      const projectConversationResource = await createConversation(userAuth, {
         title: "Project Conversation",
         visibility: "unlisted",
         spaceId: refreshedProjectSpace!.id,
       });
+
+      const projectConversation = projectConversationResource.toJSON();
 
       // Create an agent message
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
@@ -1527,12 +1545,19 @@ describe("createAgentMessages", () => {
 
       // Create a conversation in a restricted space
       const restrictedSpace = await SpaceFactory.regular(workspace);
-      const regularConversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: "test-agent",
-        messagesCreatedAt: [],
+      const regularConversationResource = await createConversation(auth, {
+        title: "Test Conversation",
         visibility: "unlisted",
-        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: null,
       });
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpace.id] },
+        { where: { id: regularConversationResource.id } }
+      );
+      const regularConversation = {
+        ...regularConversationResource.toJSON(),
+        requestedSpaceIds: [restrictedSpace.sId],
+      };
 
       const restrictedUserResource = await getUserForWorkspace(auth, {
         userId: restrictedUser.sId,
@@ -1858,7 +1883,7 @@ describe("createUserMessage", () => {
       const userJson = adminUser.toJSON();
       const userMessage = await withTransaction(async (transaction) => {
         return createUserMessage(userAuth, {
-          conversation: projectConversation,
+          conversation: projectConversation.toJSON(),
           content: `Hello @${mentionedUser.sId}`,
           metadata: {
             type: "create",

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -299,8 +299,8 @@ export async function validateUserMention(
     });
   }
   if (isApproval) {
-    const auditMessage = conversation.spaceId
-      ? "User approved a mention and added user to project"
+    const auditMessage = isPodConversation(conversation)
+      ? "User approved a mention and added user to Pod"
       : "User approved a mention";
     auditLog(
       {

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1038,7 +1038,7 @@ describe("createAgentMessages", () => {
       ];
 
       const { agentMessages, richMentions } = await createAgentMessages(auth, {
-        conversation: spaceConversation,
+        conversation: spaceConversation.toJSON(),
         metadata: {
           type: "create",
           mentions,
@@ -1184,7 +1184,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1316,7 +1316,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1439,7 +1439,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,
@@ -1588,7 +1588,7 @@ describe("createAgentMessages", () => {
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
-          conversation: spaceConversation,
+          conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
             mentions,

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -16,7 +16,8 @@ import {
 } from "@app/types/assistant/agent_run";
 import type {
   ConversationType,
-  UserMessageType,
+  ConversationWithoutContentType,
+  LightConversationType,
 } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
@@ -26,6 +27,7 @@ import { GPT_5_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { getLightConversation } from "./fetch";
 
 export async function updateConversationTitle(
   auth: Authenticator,
@@ -79,27 +81,42 @@ export async function ensureConversationTitleFromAgentLoop(
     throw runAgentDataRes.error;
   }
 
-  const { conversation, userMessage, auth } = runAgentDataRes.value;
+  const { conversation, auth } = runAgentDataRes.value;
 
-  return ensureConversationTitle(auth, { conversation, userMessage });
+  return ensureConversationTitle(auth, { conversation });
 }
 
 export async function ensureConversationTitle(
   auth: Authenticator,
   {
     conversation,
-    userMessage,
-  }: { conversation: ConversationType; userMessage: UserMessageType }
+  }: { conversation: ConversationResource | ConversationWithoutContentType }
 ): Promise<string | null> {
   // If the conversation has a title, return early.
   if (conversation.title) {
     return conversation.title;
   }
 
-  const titleRes = await generateConversationTitle(auth, {
-    ...conversation,
-    content: [...conversation.content, [userMessage]],
-  });
+  const conversationLightRes = await getLightConversation(
+    auth,
+    conversation.sId
+  );
+  if (conversationLightRes.isErr()) {
+    logger.error(
+      {
+        conversationId: conversation.sId,
+        error: conversationLightRes.error,
+      },
+      "[ensureConversationTitle] Failed to get light conversation"
+    );
+
+    return null;
+  }
+
+  const titleRes = await generateConversationTitle(
+    auth,
+    conversationLightRes.value
+  );
 
   if (titleRes.isErr()) {
     logger.error(
@@ -107,7 +124,7 @@ export async function ensureConversationTitle(
         conversationId: conversation.sId,
         error: titleRes.error,
       },
-      "Conversation title generation error"
+      "[ensureConversationTitle] Conversation title generation error"
     );
     return null;
   }
@@ -123,7 +140,7 @@ export async function ensureConversationTitle(
         conversationId: conversation.sId,
         error: updateRes.error,
       },
-      "Failed to update conversation title"
+      "[ensureConversationTitle] Failed to update conversation title"
     );
     return null;
   }
@@ -152,7 +169,7 @@ const specifications: AgentActionSpecification[] = [
 
 async function generateConversationTitle(
   auth: Authenticator,
-  conversation: ConversationType
+  conversation: ConversationType | LightConversationType
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -21,7 +21,10 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import {
+  createConversation,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
 import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
@@ -41,6 +44,7 @@ import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
+  ConversationModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -142,13 +146,20 @@ describe("dismissMention", () => {
       if (!conversationRes.isOk()) {
         throw new Error("Failed to fetch conversation");
       }
-      const conversation = conversationRes.value;
 
       // Use postUserMessage to create the message with the full flow
       const user = refreshedAuth.getNonNullableUser();
       const userJson = user.toJSON();
       const postResult = await postUserMessage(refreshedAuth, {
-        conversation,
+        conversationResource: await ConversationResource.fetchById(
+          refreshedAuth,
+          restrictedConversation.sId
+        ).then((resource) => {
+          if (!resource) {
+            throw new Error("Failed to fetch conversation resource");
+          }
+          return resource;
+        }),
         content: `Hello @${mentionedUser.username}`,
         mentions: [
           {
@@ -290,13 +301,20 @@ describe("dismissMention", () => {
       if (!conversationRes1.isOk()) {
         throw new Error("Failed to fetch conversation");
       }
-      const conversation1 = conversationRes1.value;
 
       // Use postUserMessage to create the first message with the full flow
       const user = refreshedAuth.getNonNullableUser();
       const userJson = user.toJSON();
       const postResult1 = await postUserMessage(refreshedAuth, {
-        conversation: conversation1,
+        conversationResource: await ConversationResource.fetchById(
+          refreshedAuth,
+          restrictedConversation.sId
+        ).then((resource) => {
+          if (!resource) {
+            throw new Error("Failed to fetch conversation resource");
+          }
+          return resource;
+        }),
         content: `Hello @${mentionedUser.username}`,
         mentions: [
           {
@@ -330,11 +348,18 @@ describe("dismissMention", () => {
       if (!conversationRes2.isOk()) {
         throw new Error("Failed to refresh conversation");
       }
-      const conversation2 = conversationRes2.value;
 
       // Use postUserMessage to create the second message with the full flow
       const postResult2 = await postUserMessage(refreshedAuth, {
-        conversation: conversation2,
+        conversationResource: await ConversationResource.fetchById(
+          refreshedAuth,
+          restrictedConversation.sId
+        ).then((resource) => {
+          if (!resource) {
+            throw new Error("Failed to fetch conversation resource");
+          }
+          return resource;
+        }),
         content: `Hello again @${mentionedUser.username}`,
         mentions: [
           {
@@ -468,10 +493,6 @@ describe("dismissMention", () => {
       await MembershipFactory.associate(workspace, otherUser, {
         role: "user",
       });
-      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        otherUser.sId,
-        workspace.sId
-      );
 
       // Create a user who is NOT a member of the restricted space
       const mentionedUser = await UserFactory.basic();
@@ -484,21 +505,33 @@ describe("dismissMention", () => {
         userIds: [otherUser.sId],
       });
 
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
       // Create a conversation with requestedSpaceIds that includes the restricted space
       const restrictedSpaceModelId = getResourceIdFromSId(
         refreshedRestrictedSpace!.sId
       );
       expect(restrictedSpaceModelId).not.toBeNull();
 
-      const restrictedConversation = await ConversationFactory.create(
+      const restrictedConversationResource = await createConversation(
         otherUserAuth,
         {
-          agentConfigurationId: "test-agent",
-          messagesCreatedAt: [],
+          title: "Restricted Conversation",
           visibility: "unlisted",
-          requestedSpaceIds: [restrictedSpaceModelId!],
+          spaceId: null,
         }
       );
+      await ConversationModel.update(
+        { requestedSpaceIds: [restrictedSpaceModelId!] },
+        { where: { id: restrictedConversationResource.id } }
+      );
+      const restrictedConversation = {
+        ...restrictedConversationResource.toJSON(),
+        requestedSpaceIds: [refreshedRestrictedSpace!.sId],
+      };
 
       // Note: auth (the user trying to dismiss) doesn't have access to this conversation
       // because they're not in the restricted space, so they'll get a 404

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -4,7 +4,6 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/constants";
 import config from "@app/lib/api/config";
 import { sendEmail, sendEmailToRecipients } from "@app/lib/api/email";
@@ -16,6 +15,7 @@ import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -26,7 +26,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -37,7 +37,6 @@ import fs from "fs";
 import sanitizeHtml from "sanitize-html";
 import { Op } from "sequelize";
 import { Readable } from "stream";
-
 import { toFileContentFragment } from "../conversation/content_fragment";
 import type { InboundEmailDkimResult } from "./inbound_auth";
 
@@ -779,7 +778,7 @@ export async function triggerFromEmail(
 ): Promise<
   Result<
     {
-      conversation: ConversationType;
+      conversation: ConversationWithoutContentType;
     },
     EmailTriggerError
   >
@@ -802,28 +801,32 @@ export async function triggerFromEmail(
     email.threadingHeaders
   );
 
-  let conversation: ConversationType | null = null;
+  let conversationResource: ConversationResource | null = null;
   if (threadConversationId) {
-    const conversationRes = await getConversation(auth, threadConversationId);
-    if (conversationRes.isOk()) {
-      conversation = conversationRes.value;
+    const threadConversation = await ConversationResource.fetchById(
+      auth,
+      threadConversationId
+    );
+    if (threadConversation) {
+      conversationResource = threadConversation;
     } else {
       localLogger.warn(
         {
           conversationId: threadConversationId,
-          errorType: conversationRes.error.type,
         },
         "[email] Cannot access conversation matching inbound email, creating a new one."
       );
     }
   }
-  if (!conversation) {
-    conversation = await createConversation(auth, {
+  if (!conversationResource) {
+    conversationResource = await createConversation(auth, {
       title: `Email: ${email.subject}`,
       visibility: "unlisted",
       spaceId: null,
     });
   }
+
+  const conversation = conversationResource.toJSON();
 
   // Map this email's Message-ID to the conversation (on create and on continue) so any later
   // reply in the thread keeps routing to it.
@@ -872,21 +875,6 @@ export async function triggerFromEmail(
           `Error creating file for content fragment: ` +
           contentFragmentRes.error.message,
       });
-    }
-
-    const updatedConversationRes = await getConversation(
-      auth,
-      conversation.sId
-    );
-    if (updatedConversationRes.isErr()) {
-      if (updatedConversationRes.error.type !== "conversation_not_found") {
-        return new Err({
-          type: "unexpected_error",
-          message: "Failed to update conversation with email thread.",
-        });
-      }
-    } else {
-      conversation = updatedConversationRes.value;
     }
   }
 
@@ -967,17 +955,6 @@ export async function triggerFromEmail(
     }
   }
 
-  // Refresh conversation after adding attachments.
-  if (email.attachments.length > 0) {
-    const updatedConversationRes = await getConversation(
-      auth,
-      conversation.sId
-    );
-    if (updatedConversationRes.isOk()) {
-      conversation = updatedConversationRes.value;
-    }
-  }
-
   const content =
     agentConfigurations
       .map((agent) => {
@@ -999,7 +976,7 @@ export async function triggerFromEmail(
   // Post message WITHOUT waiting for completion - the reply will be sent
   // by the agent loop finalization activity.
   const messageRes = await postUserMessage(auth, {
-    conversation,
+    conversationResource,
     content,
     mentions,
     context: {

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -556,7 +556,7 @@ export async function createOnboardingConversationIfNeeded(
     .map((v) => getInternalMCPServerNameFromSId(v.internalMCPServerId))
     .filter((name): name is InternalMCPServerNameType => name !== null);
 
-  const conversation = await createConversation(auth, {
+  const conversationResource = await createConversation(auth, {
     title: "Welcome to Dust",
     visibility: "unlisted",
     spaceId: null,
@@ -582,7 +582,7 @@ export async function createOnboardingConversationIfNeeded(
   };
 
   const postRes = await postUserMessage(auth, {
-    conversation,
+    conversationResource,
     content: onboardingSystemMessage,
     mentions: [
       {
@@ -597,7 +597,11 @@ export async function createOnboardingConversationIfNeeded(
     return postRes;
   }
 
-  await user.setMetadata("onboarding:conversation", conversation.sId, owner.id);
+  await user.setMetadata(
+    "onboarding:conversation",
+    conversationResource.sId,
+    owner.id
+  );
 
-  return new Ok(conversation.sId);
+  return new Ok(conversationResource.sId);
 }

--- a/front/lib/api/assistant/plan_mode.test.ts
+++ b/front/lib/api/assistant/plan_mode.test.ts
@@ -36,7 +36,7 @@ async function setup(): Promise<{
     visibility: "unlisted",
     spaceId: null,
   });
-  return { auth, conversation };
+  return { auth, conversation: conversation.toJSON() };
 }
 
 function lastPlanWrite(): string | null {

--- a/front/lib/api/assistant/reaction_update.ts
+++ b/front/lib/api/assistant/reaction_update.ts
@@ -1,3 +1,4 @@
+import { fetchPrecedingContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import {
   publishAgentMessagesEvents,
@@ -10,17 +11,14 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { Op } from "sequelize";
 
 export type ReactionTargetMessageType =
   | "user"
@@ -162,7 +160,7 @@ export async function publishReactionUpdate(
     // attachments from the UI. A dedicated `reactions_updated` event carrying
     // just { messageId, reactions } would remove the need for this fetch.
     const contentFragments = await fetchPrecedingContentFragments(auth, {
-      conversation,
+      conversationResource: conversation,
       targetRank: message.rank,
     });
     await publishMessageEventsOnMessagePostOrEdit(
@@ -179,61 +177,4 @@ export async function publishReactionUpdate(
   }
 
   return new Err(new Error("Unexpected message type for reaction update."));
-}
-
-// Fetch the contiguous content fragments that immediately precede the given
-// rank in the conversation (main branch). Mirrors the behavior of
-// getRelatedContentFragments but avoids loading the full conversation content.
-async function fetchPrecedingContentFragments(
-  auth: Authenticator,
-  {
-    conversation,
-    targetRank,
-  }: { conversation: ConversationResource; targetRank: number }
-): Promise<ContentFragmentType[]> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const messages = await MessageModel.findAll({
-    where: {
-      conversationId: conversation.id,
-      workspaceId: owner.id,
-      branchId: null,
-      rank: { [Op.lt]: targetRank },
-    },
-    include: [
-      { model: ContentFragmentModel, as: "contentFragment", required: true },
-    ],
-    order: [
-      ["rank", "DESC"],
-      ["version", "DESC"],
-    ],
-  });
-
-  // Keep only the latest version per rank.
-  const latestPerRank = new Map<number, MessageModel>();
-  for (const m of messages) {
-    if (!latestPerRank.has(m.rank)) {
-      latestPerRank.set(m.rank, m);
-    }
-  }
-
-  const fragments = await ContentFragmentResource.batchRenderFromMessages(
-    auth,
-    {
-      conversationId: conversation.sId,
-      messages: [...latestPerRank.values()],
-    }
-  );
-
-  const related: ContentFragmentType[] = [];
-  let lastRank = targetRank;
-  for (const cf of fragments) {
-    if (cf.rank === lastRank - 1) {
-      related.push(cf);
-      lastRank = cf.rank;
-    } else {
-      break;
-    }
-  }
-  return related;
 }

--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -5,11 +5,11 @@ import {
 } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { wakeLock } from "@app/lib/wake_lock";
 import type {
   AgenticMessageData,
   AgentMessageType,
-  ConversationType,
   UserMessageContext,
   UserMessageType,
 } from "@app/types/assistant/conversation";
@@ -150,7 +150,7 @@ export async function postUserMessageAndWaitForCompletion(
     content,
     context,
     agenticMessageData,
-    conversation,
+    conversationResource,
     mentions,
     modelSelection,
     skipToolsValidation,
@@ -158,7 +158,7 @@ export async function postUserMessageAndWaitForCompletion(
     content: string;
     context: UserMessageContext;
     agenticMessageData?: AgenticMessageData;
-    conversation: ConversationType;
+    conversationResource: ConversationResource;
     mentions: MentionType[];
     modelSelection?: ModelSelectionType;
     skipToolsValidation: boolean;
@@ -178,7 +178,7 @@ export async function postUserMessageAndWaitForCompletion(
         content,
         context,
         agenticMessageData,
-        conversation,
+        conversationResource,
         mentions,
         modelSelection,
         skipToolsValidation,
@@ -203,8 +203,8 @@ export async function postUserMessageAndWaitForCompletion(
       });
     },
     {
-      workspaceId: conversation.owner.sId,
-      conversationId: conversation.sId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId: conversationResource.sId,
       operation: "postUserMessageAndWaitForCompletion",
     }
   );

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1,3 +1,4 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import {
   DustFileSystem,
   sanitizeFileSystemName,
@@ -595,17 +596,15 @@ describe("DustFileSystem.forAgentLoop", () => {
         )
       ).toBeNull();
 
-      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
-        userSessionAuth,
-        { name: "User Agent", description: "User Agent" }
-      );
-      const userConversation = await ConversationFactory.create(
+      const userConversationResource = await createConversation(
         userSessionAuth,
         {
-          agentConfigurationId: userAgentConfig.sId,
-          messagesCreatedAt: [],
+          title: "User Conversation",
+          visibility: "unlisted",
+          spaceId: null,
         }
       );
+      const userConversation = userConversationResource.toJSON();
 
       const result = await DustFileSystem.forAgentLoop(userSessionAuth, {
         conversation: userConversation,

--- a/front/lib/api/file_system/upload_from_url.test.ts
+++ b/front/lib/api/file_system/upload_from_url.test.ts
@@ -67,7 +67,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       spaceId: null,
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -92,7 +95,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       spaceId: null,
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -123,7 +129,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       contentLength: "15",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -158,7 +167,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: "ignored",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -196,7 +208,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: Readable.from(abortedBodyChunks()),
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;
@@ -226,7 +241,10 @@ describe("uploadFileFromUrlToFileSystem", () => {
       body: "<html></html>",
     });
 
-    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
     expect(fsResult.isOk()).toBe(true);
     if (!fsResult.isOk()) {
       return;

--- a/front/lib/api/mcp_server/tools/conversations/create.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create.ts
@@ -58,7 +58,7 @@ export function registerConversationsCreateTool(server: McpServer) {
         podName = pod.name;
       }
 
-      let conversation;
+      let conversation: ConversationResource | null = null;
       try {
         conversation = await createConversation(auth, {
           title,
@@ -106,7 +106,7 @@ export function registerConversationsCreateTool(server: McpServer) {
         }
 
         const messageRes = await postUserMessage(auth, {
-          conversation,
+          conversationResource: conversation,
           content: message,
           mentions,
           context: {

--- a/front/lib/api/mcp_server/tools/conversations/create_message.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create_message.ts
@@ -1,9 +1,8 @@
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
 import config from "@app/lib/api/config";
 import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -36,13 +35,13 @@ export function registerConversationsCreateMessageTool(server: McpServer) {
     async (auth, { conversationId, message, agentName }) => {
       const user = auth.user();
 
-      const conversationRes = await getConversation(auth, conversationId);
-      if (conversationRes.isErr()) {
-        const apiError = getConversationApiError(conversationRes.error);
-        return mcpError(apiError.api_error.message);
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversationId
+      );
+      if (!conversationResource) {
+        return mcpError("Conversation not found");
       }
-
-      const conversation = conversationRes.value;
 
       let mentions: { configurationId: string }[] = [];
       if (agentName !== null) {
@@ -57,7 +56,7 @@ export function registerConversationsCreateMessageTool(server: McpServer) {
       }
 
       const messageRes = await postUserMessage(auth, {
-        conversation,
+        conversationResource,
         content: message,
         mentions,
         context: {
@@ -81,11 +80,11 @@ export function registerConversationsCreateMessageTool(server: McpServer) {
       const owner = auth.workspace();
       const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
         owner.sId,
-        conversation.sId
+        conversationResource.sId
       )}`;
 
       return mcpJsonResponse({
-        conversationId: conversation.sId,
+        conversationId: conversationResource.sId,
         conversationUrl,
         userMessageId: messageRes.value.userMessage.sId,
         agentMessageIds: messageRes.value.agentMessages.map(

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -9,7 +9,6 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { serializeProjectTaskDirective } from "@app/lib/project_task/format";
@@ -24,6 +23,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { resolveDefaultAgentId } from "@app/types/user";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { toFileContentFragment } from "../api/assistant/conversation/content_fragment";
+import { ConversationResource } from "../resources/conversation_resource";
 
 type StartProjectTaskAgentError = {
   statusCode: ContentfulStatusCode;
@@ -224,11 +224,11 @@ export async function startAgentForProjectTask(
   });
 
   let conversationId = await task.getLatestConversationId(auth);
-  let conversation;
+  let conversationResource: ConversationResource | null = null;
   let action: "created" | "appended" = "appended";
 
   if (!conversationId) {
-    conversation = await createConversation(auth, {
+    conversationResource = await createConversation(auth, {
       title: `Task · ${task.text.slice(0, 80)}`,
       visibility: "unlisted",
       spaceId: space.id,
@@ -238,27 +238,27 @@ export async function startAgentForProjectTask(
     });
 
     await task.addConversation(auth, {
-      conversationModelId: conversation.id,
+      conversationModelId: conversationResource.id,
     });
-    conversationId = conversation.sId;
+    conversationId = conversationResource.sId;
     action = "created";
   } else {
-    const conversationRes = await getConversation(auth, conversationId, false);
-    if (conversationRes.isErr()) {
-      const conversationErrorType = conversationRes.error.type;
+    conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
       return new Err({
-        statusCode:
-          conversationErrorType === "conversation_not_found" ? 404 : 403,
-        type: conversationErrorType,
-        message: conversationRes.error.message,
+        statusCode: 404,
+        type: "conversation_not_found",
+        message: "Conversation not found",
       });
     }
-    conversation = conversationRes.value;
   }
 
   // Add the prompt as a file attachment to the conversation.
   const contentFragmentRes = await toFileContentFragment(auth, {
-    conversation,
+    conversation: conversationResource,
     contentFragment: {
       title: "How to complete the task",
       content: prompt,
@@ -276,7 +276,7 @@ export async function startAgentForProjectTask(
 
   const contentFragmentMsgRes = await postNewContentFragment(
     auth,
-    conversation,
+    conversationResource.toJSON(),
     contentFragmentRes.value,
     null
   );
@@ -288,18 +288,6 @@ export async function startAgentForProjectTask(
       message: contentFragmentMsgRes.error.message,
     });
   }
-
-  // Get the updated conversation with the new content fragment.
-  const conversationRes = await getConversation(auth, conversationId);
-  if (conversationRes.isErr()) {
-    return new Err({
-      statusCode: 400,
-      type: "invalid_request_error",
-      message: conversationRes.error.message,
-    });
-  }
-
-  conversation = conversationRes.value;
 
   const taskDirective = serializeProjectTaskDirective({
     label: task.text,
@@ -320,7 +308,7 @@ export async function startAgentForProjectTask(
     agentConfigurationId ?? (await resolveDefaultAgentIdForTask(auth, space));
 
   const messageRes = await postUserMessage(auth, {
-    conversation,
+    conversationResource,
     content,
     mentions: [
       {

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -4,7 +4,6 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
@@ -311,7 +310,7 @@ export async function createSkillSuggestionsConversation(
   );
 
   const conversationTitle = `Reinforced suggestions for ${skillType.name} skill`;
-  const conversation = await createConversation(auth, {
+  const conversationResource = await createConversation(auth, {
     title: conversationTitle,
     visibility: "unlisted",
     spaceId: null,
@@ -326,11 +325,11 @@ export async function createSkillSuggestionsConversation(
   await SkillSuggestionResource.bulkSetNotificationConversation(
     auth,
     pendingSuggestions,
-    conversation.id
+    conversationResource.id
   );
 
   const contentFragmentRes = await toFileContentFragment(auth, {
-    conversation,
+    conversation: conversationResource,
     contentFragment: {
       title: `${pendingSuggestions.length} pending suggestions for ${skillType.name} skill`,
       content: formattedSuggestions,
@@ -356,7 +355,7 @@ export async function createSkillSuggestionsConversation(
 
   const contentFragmentPostRes = await postNewContentFragment(
     auth,
-    conversation,
+    conversationResource.toJSON(),
     contentFragmentRes.value,
     {
       username: author.username,
@@ -385,7 +384,7 @@ export async function createSkillSuggestionsConversation(
   );
 
   const messageRes = await postUserMessage(auth, {
-    conversation,
+    conversationResource,
     content,
     mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
     context: {
@@ -414,7 +413,7 @@ export async function createSkillSuggestionsConversation(
     editors,
     (editor) =>
       ConversationResource.upsertParticipation(auth, {
-        conversation,
+        conversation: conversationResource,
         action: "posted",
         user: editor,
         lastReadAt: null,
@@ -469,18 +468,20 @@ export async function postSkillSuggestionStatusUpdate(
   };
 
   for (const [conversationId, items] of byConversation) {
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
       logger.warn(
         {
           conversationId,
-          error: conversationRes.error.message,
+          error: "Conversation not found",
         },
         "ReinforcedSkills: failed to fetch notification conversation for status update"
       );
       continue;
     }
-    const conversation = conversationRes.value;
 
     const titles = items.map((s) => s.title ?? s.sId);
     const content =
@@ -489,7 +490,7 @@ export async function postSkillSuggestionStatusUpdate(
         : `${actorName} ${verb}:\n${titles.map((t) => `${marker} ${t}`).join("\n")}`;
 
     const postRes = await postUserMessage(auth, {
-      conversation,
+      conversationResource,
       content,
       mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
       context: messageContext,
@@ -513,7 +514,7 @@ export async function postSkillSuggestionStatusUpdate(
     // future so the ack holds through the imminent agent completion — the
     // NOOP reply lands within milliseconds.
     await ConversationResource.markAsReadForAuthUser(auth, {
-      conversation,
+      conversation: conversationResource,
       lastReadAt: new Date(Date.now() + 60_000),
     });
   }

--- a/front/lib/reinforcement/selection.test.ts
+++ b/front/lib/reinforcement/selection.test.ts
@@ -11,6 +11,7 @@ import {
   findConversationsWithSkills,
   scoreAndSelectConversations,
 } from "@app/lib/reinforcement/selection";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -320,14 +321,16 @@ describe("findConversationsWithSkills", () => {
     const skillOff = await SkillFactory.create(auth, { name: "Skill Off" });
     await skillOff.updateReinforcement("off");
 
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
     // Conversation A uses all 3 skills. Has 2 user messages to pass the scoring filter.
     const convA = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date(), new Date()],
     });
     const agentMessageA = await AgentMessageModel.create({
       status: "created",
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       agentConfigurationVersion: 0,
       conversationId: convA.id,
       workspaceId: workspace.id,
@@ -347,12 +350,12 @@ describe("findConversationsWithSkills", () => {
 
     // Conversation B uses only the "off" skill. Has 2 user messages.
     const convB = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date(), new Date()],
     });
     const agentMessageB = await AgentMessageModel.create({
       status: "created",
-      agentConfigurationId: "test-agent",
+      agentConfigurationId: agentConfig.sId,
       agentConfigurationVersion: 0,
       conversationId: convB.id,
       workspaceId: workspace.id,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -195,7 +195,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       conversation,
       stepContent,
     }: {
-      conversation: ConversationWithoutContentType;
+      conversation: ConversationWithoutContentType | ConversationResource;
       stepContent: AgentStepContentResource;
     },
     blob: Omit<CreationAttributes<AgentMCPActionModel>, "workspaceId">,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -2919,15 +2919,27 @@ describe("listPrivateConversationsForUser", () => {
 
   it("keeps paginating when a full page window contains a filtered-out conversation", async () => {
     const deletedSpace = await SpaceFactory.regular(workspace);
+    // Admin must be a space member (with a refreshed authenticator) before
+    // ConversationFactory.create can fetch a conversation that references it.
+    const addMembersRes = await deletedSpace.addMembers(adminAuth, {
+      userIds: [adminAuth.getNonNullableUser().sId],
+    });
+    assert(addMembersRes.isOk(), "Failed to add admin to space");
+    const adminWithSpaceAccess = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
 
     const createParticipatingConversation = async ({
       updatedAt,
       requestedSpaceIds,
+      auth = adminAuth,
     }: {
       updatedAt: Date;
       requestedSpaceIds?: number[];
+      auth?: Authenticator;
     }) => {
-      const conversation = await ConversationFactory.create(adminAuth, {
+      const conversation = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[0].sId,
         messagesCreatedAt: [new Date()],
         requestedSpaceIds,
@@ -2955,6 +2967,7 @@ describe("listPrivateConversationsForUser", () => {
     const poisoned = await createParticipatingConversation({
       updatedAt: new Date(baseMs + 3 * hourMs),
       requestedSpaceIds: [deletedSpace.id],
+      auth: adminWithSpaceAccess,
     });
     const middle = await createParticipatingConversation({
       updatedAt: new Date(baseMs + 2 * hourMs),
@@ -2963,7 +2976,7 @@ describe("listPrivateConversationsForUser", () => {
       updatedAt: new Date(baseMs + 1 * hourMs),
     });
 
-    const deleteRes = await deletedSpace.delete(adminAuth, {
+    const deleteRes = await deletedSpace.delete(adminWithSpaceAccess, {
       hardDelete: false,
     });
     assert(deleteRes.isOk(), "Failed to soft-delete space");

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3418,6 +3418,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
   }
 
+  /**
+   * Finds an in-flight agent reply using only the latest message version at each
+   * rank. Soft-delete writes a newer `visibility: "deleted"` placeholder while the
+   * older row can remain `status: "created"`; scanning historical versions would
+   * incorrectly treat that deleted turn as still running (see #29418).
+   */
   async getRunningAgentMessage(
     auth: Authenticator,
     {
@@ -3428,46 +3434,62 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction?: Transaction;
     } = {}
   ): Promise<RunningAgentMessageContext | null> {
-    const { scopeWhere } = await this.resolveMessageViewScope(auth, {
-      branchId,
-      transaction,
-    });
-
     const owner = auth.getNonNullableWorkspace();
-    const message = await MessageModel.findOne({
-      attributes: ["sId", "rank"],
-      where: {
-        ...scopeWhere,
-        visibility: { [Op.ne]: "deleted" },
+    const { branchFilterSql, sqlReplacements } =
+      await this.resolveMessageViewScope(auth, { branchId, transaction });
+
+    const query = `
+      SELECT
+        latest."sId",
+        latest.rank,
+        am.id AS "agentMessageId",
+        am."agentConfigurationId"
+      FROM (
+        SELECT DISTINCT ON (m.rank)
+          m."sId",
+          m.rank,
+          m.visibility,
+          m."agentMessageId"
+        FROM messages m
+        WHERE m."workspaceId" = :workspaceId
+          AND m."conversationId" = :conversationId
+          AND ${branchFilterSql}
+        ORDER BY m.rank DESC, m.version DESC
+      ) latest
+      INNER JOIN agent_messages am
+        ON am.id = latest."agentMessageId"
+        AND am."workspaceId" = :workspaceId
+        AND am."conversationId" = :conversationId
+      WHERE latest.visibility != 'deleted'
+        AND am.status = 'created'
+      ORDER BY latest.rank DESC
+      LIMIT 1
+    `;
+
+    // biome-ignore lint/plugin/noRawSql: DISTINCT ON latest version per rank
+    const [message] = await frontSequelize.query<{
+      sId: string;
+      rank: number;
+      agentMessageId: number;
+      agentConfigurationId: string;
+    }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceId: owner.id,
+        conversationId: this.id,
+        ...sqlReplacements,
       },
-      include: [
-        {
-          model: AgentMessageModel,
-          as: "agentMessage",
-          required: true,
-          attributes: ["id", "agentConfigurationId"],
-          where: {
-            status: "created",
-            conversationId: this.id,
-            workspaceId: owner.id,
-          },
-        },
-      ],
-      order: [
-        ["rank", "DESC"],
-        ["version", "DESC"],
-      ],
       transaction,
     });
 
-    if (!message?.agentMessage) {
+    if (!message) {
       return null;
     }
 
     return {
       sId: message.sId,
-      agentMessageId: message.agentMessage.id,
-      agentConfigurationId: message.agentMessage.agentConfigurationId,
+      agentMessageId: message.agentMessageId,
+      agentConfigurationId: message.agentConfigurationId,
       rank: message.rank,
     };
   }

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -8,7 +8,6 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -715,8 +714,8 @@ describe("SkillSuggestionResource", () => {
   });
 
   describe("visibleSourceConversationIds", () => {
-    let conversation1: ConversationType;
-    let conversation2: ConversationType;
+    let conversation1: ConversationResource;
+    let conversation2: ConversationResource;
 
     beforeEach(async () => {
       conversation1 = await createConversation(authenticator, {

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -4,7 +4,7 @@ import {
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
@@ -25,10 +25,7 @@ import {
   retrieveGoogleTranscriptContent,
   retrieveGoogleTranscripts,
 } from "@app/temporal/labs/transcripts/utils/google";
-import type {
-  AgentMessageType,
-  UserMessageContext,
-} from "@app/types/assistant/conversation";
+import type { UserMessageContext } from "@app/types/assistant/conversation";
 import { CoreAPI } from "@app/types/core/core_api";
 import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/lib";
 import { Err } from "@app/types/shared/result";
@@ -515,11 +512,13 @@ export async function processTranscriptActivity(
       return new Err(new Error("username must be a non-empty string"));
     }
 
-    const initialConversation = await createConversation(auth, {
+    const conversationResource = await createConversation(auth, {
       title: transcriptTitle,
       visibility: "unlisted",
       spaceId: null,
     });
+
+    const conversation = conversationResource.toJSON();
 
     const baseContext: UserMessageContext = {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
@@ -531,7 +530,7 @@ export async function processTranscriptActivity(
     };
 
     const cfRes = await toFileContentFragment(auth, {
-      conversation: initialConversation,
+      conversation,
       contentFragment: {
         title: transcriptTitle,
         content: transcriptContent,
@@ -543,7 +542,7 @@ export async function processTranscriptActivity(
     if (cfRes.isErr()) {
       localLogger.error(
         {
-          conversationId: initialConversation.sId,
+          conversationId: conversation.sId,
           error: cfRes.error,
         },
         "[processTranscriptActivity] Error creating file for content fragment. Stopping."
@@ -553,7 +552,7 @@ export async function processTranscriptActivity(
 
     const contentFragmentRes = await postNewContentFragment(
       auth,
-      initialConversation,
+      conversation,
       cfRes.value,
       baseContext
     );
@@ -562,7 +561,7 @@ export async function processTranscriptActivity(
       localLogger.error(
         {
           agentConfigurationId,
-          conversationId: initialConversation.sId,
+          conversationId: conversation.sId,
           error: contentFragmentRes.error,
         },
         "[processTranscriptActivity] Error creating content fragment. Stopping."
@@ -570,30 +569,8 @@ export async function processTranscriptActivity(
       return;
     }
 
-    // Initial conversation is stale, so we need to reload it.
-    const conversationRes = await getConversation(
-      auth,
-      initialConversation.sId
-    );
-
-    if (conversationRes.isErr()) {
-      localLogger.error(
-        {
-          agentConfigurationId,
-          conversationId: initialConversation.sId,
-          panic: true,
-          error: conversationRes.error,
-        },
-        "[processTranscriptActivity] Unreachable: Error getting conversation after creation."
-      );
-
-      return;
-    }
-
-    let conversation = conversationRes.value;
-
     const messageRes = await postUserMessageAndWaitForCompletion(auth, {
-      conversation,
+      conversationResource,
       content: `Transcript: ${transcriptTitle}`,
       mentions: [{ configurationId: agentConfigurationId }],
       context: baseContext,
@@ -615,22 +592,6 @@ export async function processTranscriptActivity(
       return;
     }
 
-    const updatedRes = await getConversation(auth, conversation.sId);
-
-    if (updatedRes.isErr()) {
-      localLogger.error(
-        {
-          agentConfigurationId,
-          conversationId: conversation.sId,
-          error: updatedRes.error,
-        },
-        "[processTranscriptActivity] Error getting conversation after creation. Stopping."
-      );
-      return;
-    }
-
-    conversation = updatedRes.value;
-
     localLogger.info(
       {
         agentConfigurationId,
@@ -640,16 +601,29 @@ export async function processTranscriptActivity(
     );
 
     // Get first from array with type='agent_message' in conversation.content;
-    const agentMessage = <AgentMessageType[]>conversation.content.find(
-      (innerArray) => {
-        return innerArray.find((item) => item.type === "agent_message");
-      }
+    const lightConversationRes = await getLightConversation(
+      auth,
+      conversation.sId
+    );
+    if (lightConversationRes.isErr()) {
+      localLogger.error(
+        {
+          agentConfigurationId,
+          conversationId: conversation.sId,
+          error: lightConversationRes.error,
+        },
+        "[processTranscriptActivity] Error getting light conversation. Stopping."
+      );
+      return;
+    }
+    const agentMessage = lightConversationRes.value.content.find(
+      (item) => item.type === "agent_message"
     );
 
     // Usage
     const markDownAnswer =
-      agentMessage && agentMessage[0].content
-        ? convertCitationsToLinks(agentMessage[0].content, conversation)
+      agentMessage && agentMessage.content
+        ? convertCitationsToLinks(agentMessage.content, conversation)
         : "";
 
     const htmlAnswer = sanitizeHtml(await marked.parse(markDownAnswer), {

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -5,7 +5,6 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -22,10 +21,7 @@ import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import {
-  type ConversationType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -49,7 +45,9 @@ async function createConversationForAgentConfiguration({
   trigger: TriggerType;
   lastRunAt: Date | null;
   webhookRequest: WebhookRequestResource | null;
-}): Promise<Result<ConversationType, APIErrorWithContentfulStatusCode>> {
+}): Promise<
+  Result<ConversationWithoutContentType, APIErrorWithContentfulStatusCode>
+> {
   let spaceModelId: ModelId | null = null;
   if (trigger.spaceId) {
     const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
@@ -142,14 +140,14 @@ async function createConversationForAgentConfiguration({
 
     await postNewContentFragment(
       auth,
-      newConversation,
+      newConversation.toJSON(),
       contentFragmentRes.value,
       null
     );
   }
 
   const messageRes = await postUserMessage(auth, {
-    conversation: newConversation,
+    conversationResource: newConversation,
     content:
       serializeMention(agentConfiguration) +
       (trigger.customPrompt ? `\n\n${trigger.customPrompt}` : ""),
@@ -172,7 +170,7 @@ async function createConversationForAgentConfiguration({
     return messageRes;
   }
 
-  return new Ok(newConversation);
+  return new Ok(newConversation.toJSON());
 }
 
 export async function runTriggeredAgentsActivity({
@@ -378,27 +376,6 @@ function buildWakeUpMessageContent(wakeUp: WakeUpType): string {
   return content;
 }
 
-function getWakeUpClientSideMCPServerIds(
-  conversation: ConversationType
-): string[] {
-  const previousUserMessageVersions = conversation.content.findLast(
-    (versions) => {
-      const message = versions.at(-1);
-      return (
-        !!message &&
-        isUserMessageType(message) &&
-        message.context.origin !== "wakeup"
-      );
-    }
-  );
-
-  const previousUserMessage = previousUserMessageVersions?.at(-1);
-
-  return previousUserMessage && isUserMessageType(previousUserMessage)
-    ? (previousUserMessage.context.clientSideMCPServerIds ?? [])
-    : [];
-}
-
 export async function runWakeUpActivity({
   workspaceId,
   wakeUpId,
@@ -442,14 +419,17 @@ export async function runWakeUpActivity({
     return;
   }
 
-  const conversationRes = await getConversation(auth, c.sId);
-  if (conversationRes.isErr()) {
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    c.sId
+  );
+  if (!conversationResource) {
     logger.info(
       {
         status: wakeUp.status,
         wakeUpId,
         workspaceId,
-        error: normalizeError(conversationRes.error),
+        error: "Conversation not found",
       },
       "Cancelling wake-up: conversation not accessible."
     );
@@ -457,11 +437,13 @@ export async function runWakeUpActivity({
     return;
   }
 
-  const conversation = conversationRes.value;
-  const clientSideMCPServerIds = getWakeUpClientSideMCPServerIds(conversation);
+  const clientSideMCPServerIds =
+    await conversationResource.getClientSideMCPServerIdsFromLatestNonWakeUpUserMessage(
+      auth
+    );
 
   const postMessageResult = await postUserMessage(auth, {
-    conversation,
+    conversationResource: conversationResource,
     content: buildWakeUpMessageContent(wakeUp.toJSON()),
     mentions: [{ configurationId: wakeUp.agentConfigurationId }],
     context: {

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -1,6 +1,8 @@
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import type { Authenticator } from "@app/lib/auth";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -10,10 +12,14 @@ import {
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageStatus,
@@ -28,6 +34,53 @@ import type { SupportedContentFragmentType } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
+
+async function authForConversationFetch(
+  auth: Authenticator,
+  t?: Transaction
+): Promise<Authenticator> {
+  if (auth.isUser()) {
+    return auth;
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return auth;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const role = await MembershipResource.getActiveRoleForUserInWorkspace({
+    user,
+    workspace,
+    transaction: t,
+  });
+
+  if (role === "none") {
+    await MembershipFactory.associate(workspace, user, { role: "user" }, t);
+  }
+
+  return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId, {
+    transaction: t,
+  });
+}
+
+async function resolveAgentConfigurationId(
+  auth: Authenticator,
+  agentConfigurationId: string,
+  t?: Transaction
+): Promise<string> {
+  const fetchAuth = await authForConversationFetch(auth, t);
+  const existing = await getAgentConfiguration(fetchAuth, {
+    agentId: agentConfigurationId,
+    variant: "extra_light",
+  });
+  if (existing) {
+    return agentConfigurationId;
+  }
+
+  const agent = await AgentConfigurationFactory.createTestAgent(fetchAuth);
+  return agent.sId;
+}
 
 export class ConversationFactory {
   static async create(
@@ -73,6 +126,11 @@ export class ConversationFactory {
       );
     }
 
+    const resolvedAgentConfigurationId =
+      messagesCreatedAt.length > 0
+        ? await resolveAgentConfigurationId(auth, agentConfigurationId, t)
+        : agentConfigurationId;
+
     // Note: fetchConversationParticipants rely on the existence of UserMessage even if we have a table for ConversationParticipant.
     for (let i = 0; i < messagesCreatedAt.length; i++) {
       const createdAt = messagesCreatedAt[i];
@@ -87,7 +145,7 @@ export class ConversationFactory {
       await createMessageAndAgentMessage({
         workspace,
         conversationModelId: conversation.id,
-        agentConfigurationId,
+        agentConfigurationId: resolvedAgentConfigurationId,
         createdAt,
         rank: i * 2 + 1,
         parentId: userMessageRow.id,
@@ -95,7 +153,16 @@ export class ConversationFactory {
       });
     }
 
-    return conversation;
+    const fetchAuth = await authForConversationFetch(auth, t);
+    const res = await getConversation(
+      fetchAuth,
+      conversation.sId,
+      visibility === "deleted"
+    );
+    if (res.isErr()) {
+      throw new Error(`Failed to fetch conversation: ${res.error.type}`);
+    }
+    return res.value;
   }
 
   static async setTriggerIdForTest(
@@ -179,7 +246,7 @@ export class ConversationFactory {
   }: {
     auth: Authenticator;
     workspace: WorkspaceType;
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     content: string;
     origin?: UserMessageOrigin;
     rank?: number;
@@ -359,7 +426,10 @@ export class ConversationFactory {
       mcpAction,
     }: {
       workspace: WorkspaceType;
-      conversation: ConversationType | ConversationWithoutContentType;
+      conversation:
+        | ConversationType
+        | ConversationWithoutContentType
+        | ConversationResource;
       agentConfig: LightAgentConfigurationType;
       mcpAction?: {
         toolConfiguration: LightServerSideMCPToolConfigurationType;

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -1,5 +1,10 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type { ToolRunContext } from "@app/lib/actions/types";
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentMessageType,
@@ -11,6 +16,69 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { UserType } from "@app/types/user";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
+import { createResourceTest } from "./generic_resource_tests";
+import { SpaceFactory } from "./SpaceFactory";
+
+export function makeExtra(
+  auth: Authenticator,
+  conversation: ConversationResource
+): ToolHandlerExtra {
+  const runContext = {
+    contextType: "agent_loop",
+    conversation: {
+      ...conversation.toJSON(),
+      visibility: conversation.visibility,
+      owner: auth.getNonNullableWorkspace(),
+    },
+  } as unknown as ToolRunContext;
+  return { auth, runContext } as unknown as ToolHandlerExtra;
+}
+
+export async function setupPlainConversation(
+  role: "admin" | "user" = "admin"
+): Promise<{
+  auth: Authenticator;
+  conversation: ConversationResource;
+}> {
+  const { authenticator: auth } = await createResourceTest({ role });
+  const conversation = await createConversation(auth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+  return { auth, conversation };
+}
+
+export async function setupProjectConversation(
+  role: "admin" | "user" = "admin"
+): Promise<{
+  auth: Authenticator;
+  conversation: ConversationResource;
+  projectId: string;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role,
+  });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: space.id,
+  });
+
+  return { auth: projectAuth, conversation, projectId: space.sId };
+}
 
 function mockUser(username: string): UserType {
   return {


### PR DESCRIPTION
## Summary
- Migrates `postUserMessage`, `editUserMessage`, `retryAgentMessage`, and `softDeleteUserMessageAndReplies` off `conversation.content` onto `ConversationResource` query methods.
- Updates remaining front-api routes (get conversation patch, compaction, mutation callers) to use `ConversationResource.fetchById` instead of full content hydration.
- Fixes conversation/file-system/file-tool tests and factories for the resource-based APIs, including deleted-space setup and running-agent detection after soft-delete.

This consolidates the former stack (#29421–#29424 + tip) into a single PR so intermediate typing/test breakage is not landable on its own, and so the change can be reverted in one shot if needed.

## Test plan
- [ ] `front` conversation mutation / soft-delete tests (`conversation.test.ts`)
- [ ] `front` `conversation_resource.test.ts` (incl. pagination with filtered-out conversation)
- [ ] file tool + file-system tests that use conversation factories
- [ ] Smoke: post / edit / retry / soft-delete user message via web + API