### PR TITLE
[Slack MCP] Clarify footer-removal toggle description in settings

### DIFF
--- a/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
+++ b/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
@@ -6,7 +6,7 @@ import { ContextItem, SlackLogo, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = '"Sent via Agent" Slack footer';
 const DESCRIPTION =
-  'Control whether Slack messages posted with user credentials show the "Sent via Agent" footer.';
+  'Allow agents to remove the "Sent via Agent" footer on Slack messages posted with user credentials.';
 
 export function SlackPersonalFooterRemovalToggle({
   owner,

--- a/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
+++ b/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
@@ -6,7 +6,7 @@ import { ContextItem, SlackLogo, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = '"Sent via Agent" Slack footer';
 const DESCRIPTION =
-  'Allow agents to remove the "Sent via Agent" footer on Slack messages posted with user credentials.';
+  'Control whether agents can remove the "Sent via Agent" footer on Slack messages posted with user credentials.';
 
 export function SlackPersonalFooterRemovalToggle({
   owner,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9776
Follows https://github.com/dust-tt/dust/pull/29410

The governance settings row for the Slack footer toggle reads "Control whether Slack messages posted with user credentials show the 'Sent via Agent' footer", which implies toggle ON = footer shown. The actual semantics are the opposite: the toggle maps directly to `slackPersonalAllowFooterRemoval`, so ON = agents may remove the footer. This caused confusion when investigating the issue above (the toggle looked like it enforced the footer while the workspace actually allowed removal).

Reword the description to match the semantics, aligning with the non-governance variant of the same component ("Let agents remove the attribution footer...").

## Risks

Blast radius: one description string on the workspace settings page.
Risk: none

## Deploy Plan

- deploy front