### PR TITLE
dedup slack threads messages

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -560,6 +560,40 @@ export async function getChannelById(
   return res.channel;
 }
 
+// Memoized channel lookup (mirrors `getSlackUserInfoMemoized` for users) so a thread
+// mentioning the same channel across many messages does not refetch it.
+const getChannelByIdMemoized = cacheWithRedis(
+  (connectorId: ModelId, slackClient: WebClient, channelId: string) =>
+    getChannelById(slackClient, connectorId, channelId),
+  (connectorId, _slackClient, channelId) =>
+    `slack-channel-info-${connectorId}-${channelId}`,
+  { ttlMs: 60 * 60 * 1000 }
+);
+
+// Resolves a channel id to its name (mirrors `getUserInfo`: a thin wrapper over the memoized
+// lookup). Returns `null` when the channel cannot be read, so the caller can fall back to the
+// raw id.
+export async function getChannelNameById(
+  connectorId: ModelId,
+  slackClient: WebClient,
+  channelId: string
+): Promise<string | null> {
+  try {
+    const channel = await getChannelByIdMemoized(
+      connectorId,
+      slackClient,
+      channelId
+    );
+    return channel.name ?? null;
+  } catch (err) {
+    logger.info(
+      { connectorId, channelId, err: normalizeError(err) },
+      "Could not resolve Slack channel mention."
+    );
+    return null;
+  }
+}
+
 export async function migrateChannelsFromLegacyBotToNewBot(
   slackConnector: ConnectorResource,
   slackBotConnector: ConnectorResource

--- a/connectors/src/connectors/slack/lib/message_formatter.test.ts
+++ b/connectors/src/connectors/slack/lib/message_formatter.test.ts
@@ -86,7 +86,7 @@ describe("formatSlackMessageForLLM", () => {
     expect(result.blocks).toContain("Service B healthy");
   });
 
-  it("renders rich_text blocks including links and mentions", () => {
+  it("renders rich_text blocks, leaving mention tokens intact for downstream resolution", () => {
     const result = formatSlackMessageForLLM({
       text: "",
       blocks: [
@@ -125,8 +125,10 @@ describe("formatSlackMessageForLLM", () => {
       ],
     });
 
+    // The user mention is emitted as a `<@U…>` token (resolved to a name later, in
+    // `messages.ts`), not as a bare `@id`.
     expect(result.blocks).toContain(
-      "See the report (https://example.com) cc @U123"
+      "See the report (https://example.com) cc <@U123>"
     );
     expect(result.blocks).toContain("- first item");
     expect(result.blocks).toContain("- second item");
@@ -156,12 +158,16 @@ describe("formatSlackMessageForLLM", () => {
     expect(result.attachments).toContain("Assignee: Jane");
   });
 
-  it("cleans Slack mrkdwn links and user mentions in plain text", () => {
+  it("cleans Slack mrkdwn links but leaves mention tokens for downstream resolution", () => {
     const result = formatSlackMessageForLLM({
       text: "Ping <@U050CALAKFD|someone> see <https://dust.tt|docs>",
     });
 
-    expect(result.text).toBe("Ping @someone see docs (https://dust.tt)");
+    // The link is rendered, but the mention token is left intact (mentions are resolved to
+    // names later, in `messages.ts`, not by the formatter).
+    expect(result.text).toBe(
+      "Ping <@U050CALAKFD|someone> see docs (https://dust.tt)"
+    );
   });
 
   it("exposes file info in the files field", () => {

--- a/connectors/src/connectors/slack/lib/message_formatter.ts
+++ b/connectors/src/connectors/slack/lib/message_formatter.ts
@@ -139,14 +139,17 @@ function renderRichTextLeaf(element: RichTextElement): string {
         ? `${element.text} (${element.url ?? ""})`
         : (element.url ?? "");
 
+    // Emit the token form (not a bare `@id`/`#id`) so the downstream pass in `messages.ts`
+    // resolves user/channel ids to names the same way it does for the mrkdwn `<@…>`/`<#…>`.
     case "user":
-      return element.user_id ? `@${element.user_id}` : "";
+      return element.user_id ? `<@${element.user_id}>` : "";
 
+    // Usergroups are not resolved yet (missing scope); render the raw id.
     case "usergroup":
       return element.usergroup_id ? `@${element.usergroup_id}` : "";
 
     case "channel":
-      return element.channel_id ? `#${element.channel_id}` : "";
+      return element.channel_id ? `<#${element.channel_id}>` : "";
 
     case "emoji":
       return element.name ? `:${element.name}:` : "";

--- a/connectors/src/connectors/slack/lib/message_mentions.ts
+++ b/connectors/src/connectors/slack/lib/message_mentions.ts
@@ -1,0 +1,46 @@
+import { getUserInfo } from "@connectors/connectors/slack/lib/bot_user_helpers";
+import { getChannelNameById } from "@connectors/connectors/slack/lib/channels";
+import type { ModelId } from "@connectors/types";
+import type { WebClient } from "@slack/web-api";
+
+// `<@U123>` and `<#C123>`: Slack sends mentions as bare ids (no label) in both rich_text and
+// mrkdwn, and the formatter leaves these tokens intact for us to resolve here.
+const USER_MENTION_RE = /<@[UW][A-Z0-9]+>/g;
+const CHANNEL_MENTION_RE = /<#[A-Z0-9]+>/g;
+
+// Resolves a single mention token to its display form via the Slack API: `<@U123>` -> `@name`,
+// `<#C123>` -> `#name`, falling back to the raw id when it does not resolve.
+async function resolveMentionToken(
+  token: string,
+  connectorId: ModelId,
+  slackClient: WebClient
+): Promise<string> {
+  const id = token.replace(/[<@#>]/g, "");
+  if (token.startsWith("<@")) {
+    const { name } = await getUserInfo(id, connectorId, slackClient);
+    return `@${name ?? id}`;
+  }
+  const name = await getChannelNameById(connectorId, slackClient, id);
+  return `#${name ?? id}`;
+}
+
+// Resolves every user/channel mention token the formatter left in the rendered body.
+export async function processMessageForMentions(
+  body: string,
+  connectorId: ModelId,
+  slackClient: WebClient
+): Promise<string> {
+  const tokens = new Set([
+    ...(body.match(USER_MENTION_RE) ?? []),
+    ...(body.match(CHANNEL_MENTION_RE) ?? []),
+  ]);
+
+  let resolved = body;
+  for (const token of tokens) {
+    resolved = resolved.replaceAll(
+      token,
+      await resolveMentionToken(token, connectorId, slackClient)
+    );
+  }
+  return resolved;
+}

--- a/connectors/src/connectors/slack/lib/messages.test.ts
+++ b/connectors/src/connectors/slack/lib/messages.test.ts
@@ -3,14 +3,20 @@ import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetBotOrUserName, mockGetUserInfo } = vi.hoisted(() => ({
-  mockGetBotOrUserName: vi.fn(),
-  mockGetUserInfo: vi.fn(),
-}));
+const { mockGetBotOrUserName, mockGetUserInfo, mockGetChannelNameById } =
+  vi.hoisted(() => ({
+    mockGetBotOrUserName: vi.fn(),
+    mockGetUserInfo: vi.fn(),
+    mockGetChannelNameById: vi.fn(),
+  }));
 
 vi.mock("@connectors/connectors/slack/lib/bot_user_helpers", () => ({
   getBotOrUserName: mockGetBotOrUserName,
   getUserInfo: mockGetUserInfo,
+}));
+
+vi.mock("@connectors/connectors/slack/lib/channels", () => ({
+  getChannelNameById: mockGetChannelNameById,
 }));
 
 // Keep everything real except `renderDocumentTitleAndContent`, which tokenizes
@@ -196,22 +202,23 @@ describe("formatMessagesForUpsert", () => {
     vi.clearAllMocks();
     mockGetBotOrUserName.mockResolvedValue("grafana");
     mockGetUserInfo.mockResolvedValue({ name: "bob", email: null });
+    mockGetChannelNameById.mockResolvedValue("general");
   });
 
-  it("renders a human link message once, without duplicating it into blocks or leaking the link unfurl", async () => {
-    // `text` and the `rich_text` block carry the same content, and a link-unfurl
-    // attachment previews the URL. We render `text` alone.
+  it("renders a human link message once (from blocks) and keeps the successful link preview", async () => {
+    // `text` and the `rich_text` block carry the same content; we render the blocks (not
+    // both), and the link-unfurl attachment resolved to a real preview we keep as content.
     const text = sectionFullText(await upsert([LINK_MESSAGE]));
 
-    // The title comes through exactly once (not once from text + once from the block).
+    // The content comes through exactly once (from the blocks, not duplicated by `text`).
     expect(text.match(/Multiplayer AI/g)).toHaveLength(1);
 
     // The URL the user typed is preserved.
     expect(text).toContain("example.com/rfs#multiplayer-ai");
 
-    // The link-unfurl attachment (Slack's URL preview) never leaks in.
-    expect(text).not.toContain("Example is looking for startups");
-    expect(text).not.toContain("Requests for Startups");
+    // The successful preview is useful content, so it is kept.
+    expect(text).toContain("Example is looking for startups");
+    expect(text).toContain("Requests for Startups");
   });
 
   it("renders a forwarded message once and resolves the author's mention", async () => {
@@ -233,26 +240,37 @@ describe("formatMessagesForUpsert", () => {
     expect(text.match(/I built a few things today/g)).toHaveLength(1);
   });
 
-  it("drops a failed link preview ([no preview available]) when text is present", async () => {
-    // Slack could not build the preview, so the attachment's only content is the
-    // "[no preview available]" fallback. With `text` present, it must not leak.
+  it("resolves a channel mention in a rich_text block to its name", async () => {
+    mockGetChannelNameById.mockResolvedValue("general");
+
+    // A human message mentioning a channel: the bare channel id lives in a typed
+    // `rich_text` element, which the formatter emits as a `<#C…>` token.
     const message = makeSlackMessage({
       user: "U1",
-      ts: "1720000000.000300",
-      text: "look at this https://example.com/x",
-      attachments: [
+      ts: "1720000000.000600",
+      blocks: [
         {
-          from_url: "https://example.com/x",
-          original_url: "https://example.com/x",
-          fallback: "[no preview available]",
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "ping " },
+                { type: "channel", channel_id: "C0GENERAL01" },
+                { type: "text", text: " please" },
+              ],
+            },
+          ],
         },
       ],
     });
 
     const text = sectionFullText(await upsert([message]));
 
-    expect(text).toContain("look at this https://example.com/x");
-    expect(text).not.toContain("[no preview available]");
+    // Resolved to `#name`; neither the raw id nor the token leaks.
+    expect(text).toContain("ping #general please");
+    expect(text).not.toContain("C0GENERAL01");
+    expect(text).not.toContain("<#");
   });
 
   it("reconstructs a block-only bot alert whose top-level text is empty", async () => {

--- a/connectors/src/connectors/slack/lib/messages.test.ts
+++ b/connectors/src/connectors/slack/lib/messages.test.ts
@@ -224,7 +224,7 @@ describe("formatMessagesForUpsert", () => {
           fallback: "[no preview available]",
         },
       ],
-    } as unknown as MessageElement;
+    } as MessageElement;
 
     const text = sectionFullText(await upsert([message]));
 
@@ -250,7 +250,7 @@ describe("formatMessagesForUpsert", () => {
           text: { type: "mrkdwn", text: "*Summary*: service is down" },
         },
       ],
-    } as unknown as MessageElement;
+    } as MessageElement;
 
     const text = sectionFullText(await upsert([message]));
 
@@ -275,7 +275,7 @@ describe("formatMessagesForUpsert", () => {
           fallback: "CPU alert",
         },
       ],
-    } as unknown as MessageElement;
+    } as MessageElement;
 
     const text = sectionFullText(await upsert([message]));
 

--- a/connectors/src/connectors/slack/lib/messages.test.ts
+++ b/connectors/src/connectors/slack/lib/messages.test.ts
@@ -1,0 +1,285 @@
+import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
+import type { WebClient } from "@slack/web-api";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetBotOrUserName, mockGetUserInfo } = vi.hoisted(() => ({
+  mockGetBotOrUserName: vi.fn(),
+  mockGetUserInfo: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors/slack/lib/bot_user_helpers", () => ({
+  getBotOrUserName: mockGetBotOrUserName,
+  getUserInfo: mockGetUserInfo,
+}));
+
+// Keep everything real except `renderDocumentTitleAndContent`, which tokenizes
+// the title over the network. Stub it to return the section tree it is handed,
+// so we can assert on the content we assembled with `sectionFullText`.
+vi.mock("@connectors/lib/data_sources", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@connectors/lib/data_sources")>();
+  return {
+    ...actual,
+    renderDocumentTitleAndContent: vi.fn(
+      async ({
+        content,
+      }: {
+        content: CoreAPIDataSourceDocumentSection | null;
+      }) => content ?? { prefix: null, content: null, sections: [] }
+    ),
+  };
+});
+
+import { sectionFullText } from "@connectors/lib/data_sources";
+
+import { formatMessagesForUpsert } from "./messages";
+
+function upsert(messages: MessageElement[]) {
+  return formatMessagesForUpsert({
+    dataSourceConfig: {} as DataSourceConfig,
+    channelName: "alerts",
+    messages,
+    isThread: true,
+    connectorId: 1 as ModelId,
+    slackClient: {} as WebClient,
+  });
+}
+
+// Structure taken from a real `conversations.replies` payload, with all
+// identifiable content replaced. A human posts a public link: the URL lives in
+// `text`, a `rich_text` block repeats the exact same content, and Slack adds a
+// link-unfurl attachment (from_url/original_url) previewing the URL.
+const LINK_MESSAGE = {
+  type: "message",
+  user: "U0POSTER0001",
+  ts: "1720000000.000100",
+  text: "*« Multiplayer AI » in the Fall 2026 RFS*\n<https://www.example.com/rfs#multiplayer-ai|https://www.example.com/rfs#multiplayer-ai> ",
+  attachments: [
+    {
+      image_url: "https://static.example.com/assets/rfs/preview-image.jpg",
+      from_url: "https://www.example.com/rfs#multiplayer-ai",
+      id: 1,
+      original_url: "https://www.example.com/rfs#multiplayer-ai",
+      fallback: "Example: Requests for Startups | Example",
+      text: "Example is looking for startups working on these ideas. If you're working on something we're interested in, we'd love to hear from you.",
+      title: "Requests for Startups | Example",
+      title_link: "https://www.example.com/rfs#multiplayer-ai",
+      service_name: "Example",
+    },
+  ],
+  blocks: [
+    {
+      type: "rich_text",
+      block_id: "b0000",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            {
+              type: "text",
+              text: "« Multiplayer AI » in the Fall 2026 RFS",
+              style: { bold: true, italic: false },
+            },
+            { type: "text", text: "\n" },
+            {
+              type: "link",
+              url: "https://www.example.com/rfs#multiplayer-ai",
+              text: "https://www.example.com/rfs#multiplayer-ai",
+            },
+            { type: "text", text: " " },
+          ],
+        },
+      ],
+    },
+  ],
+} as unknown as MessageElement;
+
+// Structure taken from a real `conversations.replies` payload, with all
+// identifiable content replaced. The author writes text (with a user mention), a
+// `rich_text` block repeats it, and the shared message rides along as an
+// `is_msg_unfurl` attachment.
+const FORWARDED_MESSAGE = {
+  type: "message",
+  user: "U0POSTER0002",
+  ts: "1720000000.000200",
+  text: ":wave: <@U0MENTION001> saw this and was wondering:\n=&gt; not sure, but I sense that:\n• either there's a good reason we did it\n• or it's an easy fix\nright?",
+  attachments: [
+    {
+      fallback: "[Jan 1st, 2026 3:15 PM] a.author: Hi again (encore)",
+      ts: "1719990000.000100",
+      author_id: "U0FWDAUTHOR",
+      author_subname: "A. Author",
+      is_msg_unfurl: true,
+      text: "Hi again (encore) :slightly_smiling_face:\n\nI built a few things today.\n\nBut when I try to use them in another setup, it doesn't work unless the helper is also attached.",
+      author_name: "A. Author",
+      color: "D0D0D0",
+      from_url:
+        "https://example.slack.com/archives/C0000000001/p1719990000000100",
+      is_share: true,
+      id: 1,
+      footer: "Slack conversation",
+    },
+  ],
+  blocks: [
+    {
+      type: "rich_text",
+      block_id: "b0001",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "emoji", name: "wave", unicode: "1f44b" },
+            { type: "text", text: " " },
+            { type: "user", user_id: "U0MENTION001" },
+            {
+              type: "text",
+              text: " saw this and was wondering:\n=> not sure, but I sense that:\n",
+            },
+          ],
+        },
+        {
+          type: "rich_text_list",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "text",
+                  text: "either there's a good reason we did it",
+                },
+              ],
+            },
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "or it's an easy fix" }],
+            },
+          ],
+          style: "bullet",
+        },
+        {
+          type: "rich_text_section",
+          elements: [{ type: "text", text: "right?" }],
+        },
+      ],
+    },
+  ],
+} as unknown as MessageElement;
+
+describe("formatMessagesForUpsert", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBotOrUserName.mockResolvedValue("grafana");
+    mockGetUserInfo.mockResolvedValue({ name: "bob", email: null });
+  });
+
+  it("renders a human link message once, without duplicating it into blocks or leaking the link unfurl", async () => {
+    // `text` and the `rich_text` block carry the same content, and a link-unfurl
+    // attachment previews the URL. We render `text` alone.
+    const text = sectionFullText(await upsert([LINK_MESSAGE]));
+
+    // The title comes through exactly once (not once from text + once from the block).
+    expect(text.match(/Multiplayer AI/g)).toHaveLength(1);
+
+    // The URL the user typed is preserved.
+    expect(text).toContain("example.com/rfs#multiplayer-ai");
+
+    // The link-unfurl attachment (Slack's URL preview) never leaks in.
+    expect(text).not.toContain("Example is looking for startups");
+    expect(text).not.toContain("Requests for Startups");
+  });
+
+  it("renders a forwarded message once and resolves the author's mention", async () => {
+    // The author's own message (with a `<@U…>` mention echoed as a raw id in the
+    // block) plus a forwarded (`is_msg_unfurl`) message.
+    const text = sectionFullText(await upsert([FORWARDED_MESSAGE]));
+
+    // The author's text comes through once, from `text` (not duplicated by the block).
+    expect(text.match(/easy fix/g)).toHaveLength(1);
+    expect(text).toContain("right?");
+
+    // The mention is resolved to a name (from `text`), and the raw id from the
+    // block is never rendered.
+    expect(text).toContain("@bob");
+    expect(text).not.toContain("U0MENTION001");
+
+    // The forwarded message is rendered once, attributed to its author.
+    expect(text).toContain("Forwarded from @A. Author:");
+    expect(text.match(/I built a few things today/g)).toHaveLength(1);
+  });
+
+  it("drops a failed link preview ([no preview available]) when text is present", async () => {
+    // Slack could not build the preview, so the attachment's only content is the
+    // "[no preview available]" fallback. With `text` present, it must not leak.
+    const message = {
+      type: "message",
+      user: "U1",
+      ts: "1720000000.000300",
+      text: "look at this https://example.com/x",
+      attachments: [
+        {
+          from_url: "https://example.com/x",
+          original_url: "https://example.com/x",
+          fallback: "[no preview available]",
+        },
+      ],
+    } as unknown as MessageElement;
+
+    const text = sectionFullText(await upsert([message]));
+
+    expect(text).toContain("look at this https://example.com/x");
+    expect(text).not.toContain("[no preview available]");
+  });
+
+  it("reconstructs a block-only bot alert whose top-level text is empty", async () => {
+    // The original bug: empty `text`, content lives entirely in the blocks. With
+    // no `text` fallback to fall back on, we reconstruct from the blocks.
+    const message = {
+      type: "message",
+      bot_id: "B1",
+      ts: "1720000000.000400",
+      text: "",
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: "[FIRING] tax-service" },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "*Summary*: service is down" },
+        },
+      ],
+    } as unknown as MessageElement;
+
+    const text = sectionFullText(await upsert([message]));
+
+    expect(text).toContain("[FIRING] tax-service");
+    expect(text).toContain("Summary");
+    expect(text).toContain("service is down");
+    expect(text).not.toContain("(empty)");
+  });
+
+  it("reconstructs a block-only bot alert's content from a legacy attachment when text is empty", async () => {
+    // Some alerts (e.g. Grafana/Zendesk) carry their content in a legacy
+    // attachment card rather than blocks. With empty `text`, it must surface.
+    const message = {
+      type: "message",
+      bot_id: "B1",
+      ts: "1720000000.000500",
+      text: "",
+      attachments: [
+        {
+          title: "Grafana",
+          text: "CPU above 90% on api-1",
+          fallback: "CPU alert",
+        },
+      ],
+    } as unknown as MessageElement;
+
+    const text = sectionFullText(await upsert([message]));
+
+    expect(text).toContain("Grafana");
+    expect(text).toContain("CPU above 90% on api-1");
+  });
+});

--- a/connectors/src/connectors/slack/lib/messages.test.ts
+++ b/connectors/src/connectors/slack/lib/messages.test.ts
@@ -1,5 +1,4 @@
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
-import type { DataSourceConfig, ModelId } from "@connectors/types";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -38,21 +37,47 @@ import { formatMessagesForUpsert } from "./messages";
 
 function upsert(messages: MessageElement[]) {
   return formatMessagesForUpsert({
-    dataSourceConfig: {} as DataSourceConfig,
+    dataSourceConfig: {
+      workspaceAPIKey: "test",
+      workspaceId: "test",
+      dataSourceId: "test",
+    },
     channelName: "alerts",
     messages,
     isThread: true,
-    connectorId: 1 as ModelId,
+    connectorId: 1,
+    // getUserInfo/getBotOrUserName are mocked, so the client is never used; it is
+    // only a placeholder for the (large, external) WebClient type.
     slackClient: {} as WebClient,
   });
+}
+
+interface SlackMessageFixture {
+  type?: "message";
+  user?: string;
+  bot_id?: string;
+  ts?: string;
+  text?: string;
+  blocks?: unknown[];
+  attachments?: unknown[];
+  files?: unknown[];
+}
+
+// Build fixtures through this factory so the single cast lives here, not at every
+// call site. `MessageElement` is a generated Slack response type whose block and
+// attachment element types are narrower than real payloads (the block `type` union
+// has no "rich_text"/"header"/"section", `Attachment` has no `is_share`), so a real
+// fixture can't be written against it. `SlackMessageFixture` accepts the literals
+// via `unknown[]`, then we assert the result back to `MessageElement`.
+function makeSlackMessage(fields: SlackMessageFixture): MessageElement {
+  return { type: "message", ...fields } as MessageElement;
 }
 
 // Structure taken from a real `conversations.replies` payload, with all
 // identifiable content replaced. A human posts a public link: the URL lives in
 // `text`, a `rich_text` block repeats the exact same content, and Slack adds a
 // link-unfurl attachment (from_url/original_url) previewing the URL.
-const LINK_MESSAGE = {
-  type: "message",
+const LINK_MESSAGE = makeSlackMessage({
   user: "U0POSTER0001",
   ts: "1720000000.000100",
   text: "*« Multiplayer AI » in the Fall 2026 RFS*\n<https://www.example.com/rfs#multiplayer-ai|https://www.example.com/rfs#multiplayer-ai> ",
@@ -94,14 +119,13 @@ const LINK_MESSAGE = {
       ],
     },
   ],
-} as unknown as MessageElement;
+});
 
 // Structure taken from a real `conversations.replies` payload, with all
 // identifiable content replaced. The author writes text (with a user mention), a
 // `rich_text` block repeats it, and the shared message rides along as an
 // `is_msg_unfurl` attachment.
-const FORWARDED_MESSAGE = {
-  type: "message",
+const FORWARDED_MESSAGE = makeSlackMessage({
   user: "U0POSTER0002",
   ts: "1720000000.000200",
   text: ":wave: <@U0MENTION001> saw this and was wondering:\n=&gt; not sure, but I sense that:\n• either there's a good reason we did it\n• or it's an easy fix\nright?",
@@ -165,7 +189,7 @@ const FORWARDED_MESSAGE = {
       ],
     },
   ],
-} as unknown as MessageElement;
+});
 
 describe("formatMessagesForUpsert", () => {
   beforeEach(() => {
@@ -212,8 +236,7 @@ describe("formatMessagesForUpsert", () => {
   it("drops a failed link preview ([no preview available]) when text is present", async () => {
     // Slack could not build the preview, so the attachment's only content is the
     // "[no preview available]" fallback. With `text` present, it must not leak.
-    const message = {
-      type: "message",
+    const message = makeSlackMessage({
       user: "U1",
       ts: "1720000000.000300",
       text: "look at this https://example.com/x",
@@ -224,7 +247,7 @@ describe("formatMessagesForUpsert", () => {
           fallback: "[no preview available]",
         },
       ],
-    } as MessageElement;
+    });
 
     const text = sectionFullText(await upsert([message]));
 
@@ -235,8 +258,7 @@ describe("formatMessagesForUpsert", () => {
   it("reconstructs a block-only bot alert whose top-level text is empty", async () => {
     // The original bug: empty `text`, content lives entirely in the blocks. With
     // no `text` fallback to fall back on, we reconstruct from the blocks.
-    const message = {
-      type: "message",
+    const message = makeSlackMessage({
       bot_id: "B1",
       ts: "1720000000.000400",
       text: "",
@@ -250,7 +272,7 @@ describe("formatMessagesForUpsert", () => {
           text: { type: "mrkdwn", text: "*Summary*: service is down" },
         },
       ],
-    } as MessageElement;
+    });
 
     const text = sectionFullText(await upsert([message]));
 
@@ -263,8 +285,7 @@ describe("formatMessagesForUpsert", () => {
   it("reconstructs a block-only bot alert's content from a legacy attachment when text is empty", async () => {
     // Some alerts (e.g. Grafana/Zendesk) carry their content in a legacy
     // attachment card rather than blocks. With empty `text`, it must surface.
-    const message = {
-      type: "message",
+    const message = makeSlackMessage({
       bot_id: "B1",
       ts: "1720000000.000500",
       text: "",
@@ -275,7 +296,7 @@ describe("formatMessagesForUpsert", () => {
           fallback: "CPU alert",
         },
       ],
-    } as MessageElement;
+    });
 
     const text = sectionFullText(await upsert([message]));
 

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -42,8 +42,8 @@ async function processMessageForMentions(
 }
 
 // Single entry point to turn a Slack message into its upsert body text: resolves
-// mentions, splits forwarded (unfurl) attachments from regular ones, reconstructs
-// the content from text/blocks/attachments/files, and appends forwarded messages.
+// mentions, uses the top-level `text` when present (else reconstructs the content
+// from its Block Kit blocks/attachments), and appends forwarded (unfurl) messages.
 async function formatSlackMessageBody(
   message: MessageElement,
   connectorId: ModelId,
@@ -66,14 +66,19 @@ async function formatSlackMessageBody(
     files: message.files,
   });
 
-  // `content` has a single text slot, so flatten the reconstructed sections into
-  // one string, dropping the ones the formatter marked empty.
-  const body = [
-    formatted.text,
-    formatted.blocks,
-    formatted.attachments,
-    formatted.files,
-  ]
+  // `text` is Slack's fallback for `blocks`: a message typed in Slack repeats its
+  // content in both, so rendering both would duplicate it. When `text` is present
+  // it is also the better-rendered version (mentions resolved to names), so we use
+  // it alone. Only when `text` is empty (bot alerts whose content lives entirely in
+  // Block Kit) do we reconstruct from blocks/attachments.
+  const messageContent =
+    formatted.text !== EMPTY_SECTION
+      ? [formatted.text]
+      : [formatted.blocks, formatted.attachments];
+
+  // `content` has a single text slot, so flatten the sections into one string,
+  // dropping the ones the formatter marked empty.
+  const body = [...messageContent, formatted.files]
     .filter((s) => s !== EMPTY_SECTION)
     .join("\n");
 

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -2,6 +2,7 @@ import {
   getBotOrUserName,
   getUserInfo,
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
+import { getChannelNameById } from "@connectors/connectors/slack/lib/channels";
 import { splitSlackAttachments } from "@connectors/connectors/slack/lib/message_attachments";
 import {
   EMPTY_SECTION,
@@ -15,74 +16,85 @@ import { safeSubstring } from "@connectors/types";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 
-async function processMessageForMentions(
-  message: string,
+// `<@U123>` and `<#C123>`: Slack sends mentions as bare ids (no label) in both rich_text and
+// mrkdwn, and the formatter leaves these tokens intact for us to resolve here.
+const USER_MENTION_RE = /<@[UW][A-Z0-9]+>/g;
+const CHANNEL_MENTION_RE = /<#[A-Z0-9]+>/g;
+
+// Resolves a single mention token to its display form via the Slack API: `<@U123>` -> `@name`,
+// `<#C123>` -> `#name`, falling back to the raw id when it does not resolve.
+async function resolveMentionToken(
+  token: string,
   connectorId: ModelId,
   slackClient: WebClient
 ): Promise<string> {
-  const matches = message.match(/<@[A-Z-0-9]+>/g);
-  if (!matches) {
-    return message;
+  const id = token.replace(/[<@#>]/g, "");
+  if (token.startsWith("<@")) {
+    const { name } = await getUserInfo(id, connectorId, slackClient);
+    return `@${name ?? id}`;
   }
-  for (const m of matches) {
-    const userId = m.replace(/<|@|>/g, "");
-    const { name: userName } = await getUserInfo(
-      userId,
-      connectorId,
-      slackClient
-    );
-    if (!userName) {
-      continue;
-    }
-
-    message = message.replace(m, `@${userName}`);
-  }
-
-  return message;
+  const name = await getChannelNameById(connectorId, slackClient, id);
+  return `#${name ?? id}`;
 }
 
-// Single entry point to turn a Slack message into its upsert body text: resolves
-// mentions, uses the top-level `text` when present (else reconstructs the content
-// from its Block Kit blocks/attachments), and appends forwarded (unfurl) messages.
+// Resolves every user/channel mention token the formatter left in the rendered body.
+async function processMessageForMentions(
+  body: string,
+  connectorId: ModelId,
+  slackClient: WebClient
+): Promise<string> {
+  const tokens = new Set([
+    ...(body.match(USER_MENTION_RE) ?? []),
+    ...(body.match(CHANNEL_MENTION_RE) ?? []),
+  ]);
+
+  let resolved = body;
+  for (const token of tokens) {
+    resolved = resolved.replaceAll(
+      token,
+      await resolveMentionToken(token, connectorId, slackClient)
+    );
+  }
+  return resolved;
+}
+
+// Single entry point to turn a Slack message into its upsert body text: renders the
+// content (blocks first, top-level `text` as a fallback), appends forwarded (unfurl)
+// messages, then resolves the mention tokens left in the assembled body.
 async function formatSlackMessageBody(
   message: MessageElement,
   connectorId: ModelId,
   slackClient: WebClient
 ): Promise<string> {
-  const text = await processMessageForMentions(
-    message.text ?? "",
-    connectorId,
-    slackClient
-  );
-
   const { nonUnfurlAttachments, forwardedMessagesText } = splitSlackAttachments(
     message.attachments
   );
 
   const formatted = formatSlackMessageForLLM({
-    text,
+    text: message.text,
     blocks: message.blocks,
     attachments: nonUnfurlAttachments,
     files: message.files,
   });
 
-  // `text` is Slack's fallback for `blocks`: a message typed in Slack repeats its
-  // content in both, so rendering both would duplicate it. When `text` is present
-  // it is also the better-rendered version (mentions resolved to names), so we use
-  // it alone. Only when `text` is empty (bot alerts whose content lives entirely in
-  // Block Kit) do we reconstruct from blocks/attachments.
-  const messageContent =
-    formatted.text !== EMPTY_SECTION
-      ? [formatted.text]
-      : [formatted.blocks, formatted.attachments];
+  // `blocks` is the authoritative content of a Slack message; the top-level `text` is
+  // Slack's fallback rendering of the same thing, so rendering both would duplicate it.
+  // We render the blocks and only fall back to `text` when the message has none (rare bot
+  // alerts). Attachments (content cards, link previews) render alongside either way.
+  const mainContent =
+    formatted.blocks !== EMPTY_SECTION ? formatted.blocks : formatted.text;
 
   // `content` has a single text slot, so flatten the sections into one string,
   // dropping the ones the formatter marked empty.
-  const body = [...messageContent, formatted.files]
+  const body = [mainContent, formatted.attachments, formatted.files]
     .filter((s) => s !== EMPTY_SECTION)
     .join("\n");
 
-  return forwardedMessagesText ? `${body}\n${forwardedMessagesText}` : body;
+  const assembled = forwardedMessagesText
+    ? `${body}\n${forwardedMessagesText}`
+    : body;
+
+  return processMessageForMentions(assembled, connectorId, slackClient);
 }
 
 export async function formatMessagesForUpsert({

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -2,12 +2,12 @@ import {
   getBotOrUserName,
   getUserInfo,
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
-import { getChannelNameById } from "@connectors/connectors/slack/lib/channels";
 import { splitSlackAttachments } from "@connectors/connectors/slack/lib/message_attachments";
 import {
   EMPTY_SECTION,
   formatSlackMessageForLLM,
 } from "@connectors/connectors/slack/lib/message_formatter";
+import { processMessageForMentions } from "@connectors/connectors/slack/lib/message_mentions";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
 import { formatDateForUpsert } from "@connectors/lib/formatting";
@@ -15,48 +15,6 @@ import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { safeSubstring } from "@connectors/types";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
-
-// `<@U123>` and `<#C123>`: Slack sends mentions as bare ids (no label) in both rich_text and
-// mrkdwn, and the formatter leaves these tokens intact for us to resolve here.
-const USER_MENTION_RE = /<@[UW][A-Z0-9]+>/g;
-const CHANNEL_MENTION_RE = /<#[A-Z0-9]+>/g;
-
-// Resolves a single mention token to its display form via the Slack API: `<@U123>` -> `@name`,
-// `<#C123>` -> `#name`, falling back to the raw id when it does not resolve.
-async function resolveMentionToken(
-  token: string,
-  connectorId: ModelId,
-  slackClient: WebClient
-): Promise<string> {
-  const id = token.replace(/[<@#>]/g, "");
-  if (token.startsWith("<@")) {
-    const { name } = await getUserInfo(id, connectorId, slackClient);
-    return `@${name ?? id}`;
-  }
-  const name = await getChannelNameById(connectorId, slackClient, id);
-  return `#${name ?? id}`;
-}
-
-// Resolves every user/channel mention token the formatter left in the rendered body.
-async function processMessageForMentions(
-  body: string,
-  connectorId: ModelId,
-  slackClient: WebClient
-): Promise<string> {
-  const tokens = new Set([
-    ...(body.match(USER_MENTION_RE) ?? []),
-    ...(body.match(CHANNEL_MENTION_RE) ?? []),
-  ]);
-
-  let resolved = body;
-  for (const token of tokens) {
-    resolved = resolved.replaceAll(
-      token,
-      await resolveMentionToken(token, connectorId, slackClient)
-    );
-  }
-  return resolved;
-}
 
 // Single entry point to turn a Slack message into its upsert body text: renders the
 // content (blocks first, top-level `text` as a fallback), appends forwarded (unfurl)

--- a/connectors/src/connectors/slack/lib/slack_mrkdwn.ts
+++ b/connectors/src/connectors/slack/lib/slack_mrkdwn.ts
@@ -32,21 +32,10 @@ function slackInlineToken(
 }
 
 // Patterns are anchored (`^`): marked feeds the tokenizer the source from the match start.
+// User (`<@U123>`) and channel (`<#C123>`) tokens are intentionally NOT handled here: their
+// ids are resolved to names against the Slack API downstream (`processMessageForMentions` in
+// `messages.ts`), so we let them pass through untouched for that pass to pick up.
 const SLACK_EXTENSIONS: TokenizerAndRendererExtension[] = [
-  // <@U123> or <@U123|name> -> @name (falls back to the id when no label).
-  slackInlineToken(
-    "slackUser",
-    "<@",
-    /^<@([UW][A-Z0-9]+)(?:\|([^>]+))?>/,
-    (m) => `@${m[2] ?? m[1]}`
-  ),
-  // <#C123> or <#C123|name> -> #name.
-  slackInlineToken(
-    "slackChannel",
-    "<#",
-    /^<#([A-Z0-9]+)(?:\|([^>]+))?>/,
-    (m) => `#${m[2] ?? m[1]}`
-  ),
   // <!subteam^S123|@group> -> @group ; <!subteam^S123> -> @S123.
   slackInlineToken(
     "slackSubteam",


### PR DESCRIPTION
## Description
takes care of a regression which I introduced in [#28893](https://github.com/dust-tt/dust/pull/28893).

Some messages written by people showed up twice in the context agents receive. Because, to read block-only bot alerts (Grafana/Datadog/Zendesk), that PR started rendering `text`, `blocks` and `attachments` together. But `text` is Slack's *fallback* for `blocks`: the same content is carried in both, so rendering both is redundant.

## Fix
When `blocks` is not present we fall back to `text`.

Edit: while implementing, I looked at real Slack payloads and realized that mentions in text don't come with a label after the id giving the name, it's <@ U123>, not <@ U123|bob> (same for <#C123> channels). So we can't parse text to output the username/channel name. We have to resolve the id through the API either way. The parsing would have been the only advantage text had over blocks (one fewer API call per user/channel mention).

Conclusion: Since `getUserInfo` was already being used I had nothing to do for user mentions. I just added `getChannelNameById` which wraps `getChannelById` (pre-existed) to solve channel mentions through their ids. This way, outputting `blocks` is even better because we don't solve channel mentions in `text`.

## Tests

added connectors/src/connectors/slack/lib/messages.test.ts and tested locally:
--> no deduped messages in connectors logs.

PS: I could not confirm against a real payload, but the "[no preview available]" is probably from Slack, in case the unfurl link can't be solved (it doesn't come from us at least). 

## Risk

Low. Safe to revert

## Deploy Plan
