### PR TITLE
Admin governance: availability in v1/w/[wId]/skills endpoint

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3437,12 +3437,13 @@
             "in": "query",
             "name": "availability",
             "required": false,
-            "description": "Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are never returned through the public API.",
+            "description": "Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned to admin API keys.",
             "schema": {
               "type": "array",
               "items": {
                 "type": "string",
                 "enum": [
+                  "editors",
                   "workspace_users",
                   "users_and_agents"
                 ]

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3432,6 +3432,24 @@
                 "suggested"
               ]
             }
+          },
+          {
+            "in": "query",
+            "name": "availability",
+            "required": false,
+            "description": "Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are never returned through the public API.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "workspace_users",
+                  "users_and_agents"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
         "responses": {

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -178,7 +178,7 @@ describe("GET /api/v1/w/[wId]/skills", () => {
       availability: "editors",
     });
 
-    // Unpublished (editors-only) skills are never exposed through the public API.
+    // Unpublished (editors-only) skills are only exposed to admin API keys.
     const defaultResponse = await getSkills(workspace, key);
     expect(defaultResponse.status).toBe(200);
     const defaultSkillNames = (await defaultResponse.json()).skills.map(
@@ -210,16 +210,58 @@ describe("GET /api/v1/w/[wId]/skills", () => {
     expect(multiSkillNames).toContain("Discoverable Skill");
     expect(multiSkillNames).not.toContain("Unpublished Skill");
 
-    // The unpublished availability is not accepted as a filter value.
+    // For non-admin keys, filtering on the unpublished availability returns nothing.
     const editorsResponse = await getSkills(workspace, key, {
       availability: "editors",
     });
-    expect(editorsResponse.status).toBe(400);
+    expect(editorsResponse.status).toBe(200);
+    expect((await editorsResponse.json()).skills).toEqual([]);
 
     const invalidResponse = await getSkills(workspace, key, {
       availability: "everyone",
     });
     expect(invalidResponse.status).toBe(400);
+  });
+
+  it("exposes unpublished skills to admin API keys", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const user = await UserFactory.basic();
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+
+    await SkillFactory.create(auth, {
+      name: "Workspace Skill",
+      availability: "workspace_users",
+    });
+    await SkillFactory.create(auth, {
+      name: "Unpublished Skill",
+      availability: "editors",
+    });
+
+    // Admin keys see unpublished skills, e.g. when exporting all workspace skills.
+    const defaultResponse = await getSkills(workspace, key);
+    expect(defaultResponse.status).toBe(200);
+    const defaultSkillNames = (await defaultResponse.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(defaultSkillNames).toContain("Workspace Skill");
+    expect(defaultSkillNames).toContain("Unpublished Skill");
+
+    const editorsResponse = await getSkills(workspace, key, {
+      availability: "editors",
+    });
+    expect(editorsResponse.status).toBe(200);
+    const editorsSkillNames = (await editorsResponse.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(editorsSkillNames).toEqual(["Unpublished Skill"]);
   });
 });
 

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -153,6 +153,74 @@ describe("GET /api/v1/w/[wId]/skills", () => {
     expect(skillNames).toContain("Archived API Skill");
     expect(skillNames).not.toContain("Active API Skill");
   });
+
+  it("filters skills by availability", async () => {
+    const { workspace, key } = await createPublicApiMockRequest();
+    const user = await UserFactory.basic();
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+
+    await SkillFactory.create(auth, {
+      name: "Workspace Skill",
+      availability: "workspace_users",
+    });
+    await SkillFactory.create(auth, {
+      name: "Discoverable Skill",
+      availability: "users_and_agents",
+    });
+    await SkillFactory.create(auth, {
+      name: "Unpublished Skill",
+      availability: "editors",
+    });
+
+    // Unpublished (editors-only) skills are never exposed through the public API.
+    const defaultResponse = await getSkills(workspace, key);
+    expect(defaultResponse.status).toBe(200);
+    const defaultSkillNames = (await defaultResponse.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(defaultSkillNames).toContain("Workspace Skill");
+    expect(defaultSkillNames).toContain("Discoverable Skill");
+    expect(defaultSkillNames).not.toContain("Unpublished Skill");
+
+    const response = await getSkills(workspace, key, {
+      availability: "users_and_agents",
+    });
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(skillNames).toEqual(["Discoverable Skill"]);
+
+    // Repeatable to match several availabilities.
+    const multiResponse = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/skills?availability=workspace_users&availability=users_and_agents`,
+      { headers: { authorization: `Bearer ${key.secret}` } }
+    );
+    expect(multiResponse.status).toBe(200);
+    const multiSkillNames = (await multiResponse.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(multiSkillNames).toContain("Workspace Skill");
+    expect(multiSkillNames).toContain("Discoverable Skill");
+    expect(multiSkillNames).not.toContain("Unpublished Skill");
+
+    // The unpublished availability is not accepted as a filter value.
+    const editorsResponse = await getSkills(workspace, key, {
+      availability: "editors",
+    });
+    expect(editorsResponse.status).toBe(400);
+
+    const invalidResponse = await getSkills(workspace, key, {
+      availability: "everyone",
+    });
+    expect(invalidResponse.status).toBe(400);
+  });
 });
 
 describe("POST /api/v1/w/[wId]/skills", () => {

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -6,6 +6,7 @@ import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/git
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
@@ -24,10 +25,8 @@ const GetSkillsQuerySchema = z.object({
   status: z.enum(["active", "archived", "suggested"]).optional(),
 });
 
-// Unpublished (editors) skills are never exposed through the public API, so the filter only
-// accepts the published availabilities.
 const SkillAvailabilitiesSchema = z
-  .array(z.enum(["workspace_users", "users_and_agents"]))
+  .array(z.enum(SKILL_AVAILABILITIES))
   .optional();
 
 // Mounted at /api/v1/w/:wId/skills.
@@ -64,12 +63,12 @@ const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
  *       - in: query
  *         name: availability
  *         required: false
- *         description: Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are never returned through the public API.
+ *         description: Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned to admin API keys.
  *         schema:
  *           type: array
  *           items:
  *             type: string
- *             enum: [workspace_users, users_and_agents]
+ *             enum: [editors, workspace_users, users_and_agents]
  *         style: form
  *         explode: true
  *     responses:
@@ -183,7 +182,7 @@ app.get(
         api_error: {
           type: "invalid_request_error",
           message:
-            'Invalid availability. Expected "workspace_users" or "users_and_agents".',
+            'Invalid availability. Expected "editors", "workspace_users", or "users_and_agents".',
         },
       });
     }
@@ -198,11 +197,12 @@ app.get(
       availability,
     });
 
-    // Unpublished (editors-only) skills are drafts and are never exposed through the
-    // public API: API keys have no editor-group membership to scope them by.
-    const skills = allSkills.filter(
-      (skill) => skill.availability !== "editors"
-    );
+    // Unpublished (editors-only) skills are drafts: API keys have no editor-group
+    // membership to scope them by, so they are only exposed to admin keys (e.g. for
+    // exporting all workspace skills).
+    const skills = auth.isAdmin()
+      ? allSkills
+      : allSkills.filter((skill) => skill.availability !== "editors");
 
     return ctx.json({
       skills: skills.map((skill) => skill.toJSON(auth)),

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -24,6 +24,12 @@ const GetSkillsQuerySchema = z.object({
   status: z.enum(["active", "archived", "suggested"]).optional(),
 });
 
+// Unpublished (editors) skills are never exposed through the public API, so the filter only
+// accepts the published availabilities.
+const SkillAvailabilitiesSchema = z
+  .array(z.enum(["workspace_users", "users_and_agents"]))
+  .optional();
+
 // Mounted at /api/v1/w/:wId/skills.
 //
 // We extend the public API context with `HttpBindings` so we can reach the
@@ -55,6 +61,17 @@ const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
  *         schema:
  *           type: string
  *           enum: [active, archived, suggested]
+ *       - in: query
+ *         name: availability
+ *         required: false
+ *         description: Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are never returned through the public API.
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum: [workspace_users, users_and_agents]
+ *         style: form
+ *         explode: true
  *     responses:
  *       200:
  *         description: Skills available in the workspace.
@@ -156,10 +173,36 @@ app.get(
     const auth = ctx.get("auth");
     const { status } = ctx.req.valid("query");
 
-    const skills = await SkillResource.listByWorkspace(auth, {
+    // Repeatable: ?availability=workspace_users&availability=users_and_agents.
+    const availabilityValidation = SkillAvailabilitiesSchema.safeParse(
+      ctx.req.queries("availability")
+    );
+    if (!availabilityValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            'Invalid availability. Expected "workspace_users" or "users_and_agents".',
+        },
+      });
+    }
+    const availability =
+      availabilityValidation.data && availabilityValidation.data.length > 0
+        ? availabilityValidation.data
+        : undefined;
+
+    const allSkills = await SkillResource.listByWorkspace(auth, {
       status,
       onlyCustom: true,
+      availability,
     });
+
+    // Unpublished (editors-only) skills are drafts and are never exposed through the
+    // public API: API keys have no editor-group membership to scope them by.
+    const skills = allSkills.filter(
+      (skill) => skill.availability !== "editors"
+    );
 
     return ctx.json({
       skills: skills.map((skill) => skill.toJSON(auth)),


### PR DESCRIPTION
## Description

Expose the availability as a filter in the public  v1/w/[wId]/skills API.
API do not cary the info about a user so it can never be an editor. 

## Tests

unit test added 

## Risk

low, the public API is retrocompatible

## Deploy Plan

deploy front
