### PR TITLE
feat(sandbox): conversation-scoped egress approvals with inherited pod policy layer

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -102,9 +102,9 @@ export const SANDBOX_TOOLS_METADATA = [
       "allowlist surface as denied entries in `<network_proxy_logs>` in " +
       "the bash tool output. Allowlist entries added through this tool " +
       "persist for the lifetime of the conversation (across sandbox " +
-      "restarts). In a Pod, approvals are Pod-wide: the domain is allowed " +
-      "for every conversation in the Pod and the Pod's shared sandbox, so " +
-      "make that scope clear when asking the user.",
+      "restarts) and are scoped to this conversation only — including " +
+      "inside a Pod, where Pod-wide domains are managed by admins in the " +
+      "Pod's network settings.",
     schema: {
       domain: z
         .string()

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -933,7 +933,7 @@ describe("addEgressDomainTool", () => {
     }
   });
 
-  it("writes Pod-scoped approvals to the Pod's policy file for pod conversations", async () => {
+  it("keeps approvals conversation-scoped for conversations inside a Pod", async () => {
     const sandbox = {
       providerId: "provider-id",
       sId: "sandbox-id",
@@ -951,17 +951,15 @@ describe("addEgressDomainTool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    // The approval lands in the POD's owner policy file — the same ownerId
-    // every sandbox in the Pod (conversations and the shared sandbox) carries
-    // in its egress JWT, so the domain is allowed Pod-wide.
+    // The approval lands in the CONVERSATION's own policy file, never the
+    // Pod's shared one — the Pod policy reaches the sandbox as a read-only
+    // inherited layer, and Pod-level additions go through the admin surface.
     expect(mockAddOwnerPolicyDomain).toHaveBeenCalledWith(expect.anything(), {
       domain: "example.org",
-      ownerId: "space-id",
+      ownerId: "conversation-id",
     });
     if (result.isOk()) {
-      expect(result.value[0].text).toContain(
-        "applies to this Pod (every conversation in it and the Pod's shared sandbox)"
-      );
+      expect(result.value[0].text).toContain("applies to this conversation");
     }
   });
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -574,14 +574,13 @@ export async function addEgressDomainTool(
     return new Err(new MCPError(parsed.error.message));
   }
 
-  // Approvals write to the sandbox's egress policy owner file. For a normal
-  // conversation that is the conversation itself (approvals persist for the
-  // conversation's lifetime, across sandbox destroy/recreate cycles). For a
-  // conversation inside a Pod it is the POD: pod network settings are shared,
-  // so the approval applies to every conversation in the Pod and the Pod's
-  // shared sandbox. Interim v0 behavior (internal-only, FF-gated) pending the
-  // approval-governance decision.
-  const egressPolicyOwnerId = conversation.spaceId ?? conversation.sId;
+  // Approvals write to the conversation's own egress policy file — inside or
+  // outside a Pod — persisting for the conversation's lifetime across sandbox
+  // destroy/recreate cycles. Pod network settings reach the sandbox as an
+  // inherited read-only layer instead (egressPolicyPodId), so an on-the-fly
+  // approval never widens the Pod's shared allowlist; Pod-level additions go
+  // through the Pod settings admin surface.
+  const egressPolicyOwnerId = conversation.sId;
   const result = await addOwnerPolicyDomain(auth, {
     ownerId: egressPolicyOwnerId,
     domain: parsed.value,
@@ -612,17 +611,12 @@ export async function addEgressDomainTool(
     },
   });
 
-  // Scope wording matches the tool description: pod approvals apply Pod-wide.
-  const scope =
-    conversation.spaceId !== null
-      ? "this Pod (every conversation in it and the Pod's shared sandbox)"
-      : "this conversation";
   const text =
     result.value.addedDomain !== null
       ? `Allowed: ${result.value.addedDomain}\n` +
-        `The change applies to ${scope} and persists across sandbox restarts.`
+        `The change applies to this conversation and persists across sandbox restarts.`
       : `Already allowed: ${parsed.value}\n` +
-        `No change made; this domain is already allowed for ${scope}.`;
+        `No change made; this domain is already allowed for this conversation.`;
 
   return new Ok([{ type: "text" as const, text }]);
 }

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -230,19 +230,18 @@ export async function destroyConversation(
     const owner = auth.getNonNullableWorkspace();
 
     // Delete the conversation's sandbox egress allowlist file (owner-keyed, so
-    // it is not deleted with individual sandboxes). Pod conversations never own
-    // a file (they share the Pod's policy file, which is scrubbed by
-    // hardDeleteSpace) so skip them. A GCS failure aborts the destroy before
-    // any row is touched; callers run in Temporal activities, whose retry
-    // policy retries the whole destroy.
-    if (conversation.spaceId === null) {
-      const deleteOwnerPolicyRes = await deleteOwnerPolicy(
-        auth,
-        conversation.sId
-      );
-      if (deleteOwnerPolicyRes.isErr()) {
-        return deleteOwnerPolicyRes;
-      }
+    // it is not deleted with individual sandboxes). Every conversation owns
+    // its own file — inside or outside a Pod (the Pod's own file is scrubbed
+    // by hardDeleteSpace) — and the delete ignores missing objects for
+    // conversations that never approved a domain. A GCS failure aborts the
+    // destroy before any row is touched; callers run in Temporal activities,
+    // whose retry policy retries the whole destroy.
+    const deleteOwnerPolicyRes = await deleteOwnerPolicy(
+      auth,
+      conversation.sId
+    );
+    if (deleteOwnerPolicyRes.isErr()) {
+      return deleteOwnerPolicyRes;
     }
 
     await ConversationForkResource.deleteForConversationModelId(auth, {

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -178,7 +178,27 @@ describe("sandbox egress helpers", () => {
     expect(payload.sbId).toBe("provider-sandbox-id");
     expect(payload.wId).toBe("workspace-id");
     expect(payload.ownerId).toBe("owner-id");
+    // Back-compat contract: no podId means the claim is absent from the
+    // payload entirely, not present with an empty value.
+    expect(payload).not.toHaveProperty("podId");
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
+  });
+
+  it("mints the podId claim for conversation sandboxes inside a pod", () => {
+    const token = mintEgressJwt({
+      providerId: "provider-sandbox-id",
+      workspaceId: "workspace-id",
+      ownerId: "conversation-id",
+      podId: "pod-space-id",
+    });
+    const payload = jwt.verify(token, "egress-secret", {
+      algorithms: ["HS256"],
+      audience: "dust-egress-proxy",
+      issuer: "dust-front",
+    }) as jwt.JwtPayload;
+
+    expect(payload.ownerId).toBe("conversation-id");
+    expect(payload.podId).toBe("pod-space-id");
   });
 
   it("writes the token, starts the forwarder, and waits for health", async () => {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -108,18 +108,23 @@ async function runSuccessfulRootCommand(
 
 // ownerId is the sandbox owner's stable sId (conversation sId for
 // conversation sandboxes, space sId for pod sandboxes); it selects the owner
-// policy file `w/{wId}/sandboxes/{ownerId}.json`. sbId stays for identity and
-// log tracing. Older proxy builds ignore the ownerId claim. Object params on
-// purpose: the values are look-alike sIds and transposed positional args
-// would compile fine and fail silently.
+// policy file `w/{wId}/sandboxes/{ownerId}.json`. podId is set for
+// conversation sandboxes running inside a pod and selects the pod's policy
+// file as an inherited layer — the proxy allows a domain if the workspace,
+// owner, or pod policy allows it. sbId stays for identity and log tracing.
+// Older proxy builds ignore unknown claims. Object params on purpose: the
+// values are look-alike sIds and transposed positional args would compile
+// fine and fail silently.
 export function mintEgressJwt({
   providerId,
   workspaceId,
   ownerId,
+  podId,
 }: {
   providerId: string;
   workspaceId: string;
   ownerId: string;
+  podId?: string;
 }): string {
   return jwt.sign(
     {
@@ -128,6 +133,7 @@ export function mintEgressJwt({
       sbId: providerId,
       wId: workspaceId,
       ownerId,
+      ...(podId ? { podId } : {}),
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -384,7 +390,12 @@ export async function prepareSandboxEgressBeforeMount(
   {
     runtimeOwner,
     egressPolicyOwnerId,
-  }: { runtimeOwner: SandboxRuntimeOwner; egressPolicyOwnerId: string }
+    egressPolicyPodId,
+  }: {
+    runtimeOwner: SandboxRuntimeOwner;
+    egressPolicyOwnerId: string;
+    egressPolicyPodId?: string;
+  }
 ): Promise<Result<void, Error>> {
   if (config.getSandboxDevUnrestrictedEgress()) {
     return teardownInSandboxEgressRedirect(auth, sandbox);
@@ -392,6 +403,7 @@ export async function prepareSandboxEgressBeforeMount(
   return setupEgressForwarder(auth, sandbox, {
     runtimeOwner,
     egressPolicyOwnerId,
+    egressPolicyPodId,
   });
 }
 
@@ -405,10 +417,12 @@ export async function ensureSandboxEgressOnExec(
   {
     runtimeOwner,
     egressPolicyOwnerId,
+    egressPolicyPodId,
     wokeFromSleep,
   }: {
     runtimeOwner: SandboxRuntimeOwner;
     egressPolicyOwnerId: string;
+    egressPolicyPodId?: string;
     wokeFromSleep: boolean;
   }
 ): Promise<Result<void, Error>> {
@@ -432,6 +446,7 @@ export async function ensureSandboxEgressOnExec(
       restartExisting: true,
       runtimeOwner,
       egressPolicyOwnerId,
+      egressPolicyPodId,
     });
   }
 
@@ -455,6 +470,7 @@ export async function ensureSandboxEgressOnExec(
       restartExisting: true,
       runtimeOwner,
       egressPolicyOwnerId,
+      egressPolicyPodId,
     });
   }
 
@@ -569,15 +585,19 @@ export async function setupEgressForwarder(
     restartExisting = false,
     runtimeOwner,
     egressPolicyOwnerId,
+    egressPolicyPodId,
   }: {
     restartExisting?: boolean;
     runtimeOwner: SandboxRuntimeOwner;
-    // The egress POLICY owner, distinct from runtimeOwner: conversations
-    // inside a Pod share the Pod's policy file, so their policy owner is the
-    // Pod space's sId while runtimeOwner (env vars, log context, file system
-    // selection) stays the conversation. Derived by the lifecycle ready
-    // helpers.
+    // The egress POLICY owner: every sandbox has its own policy file keyed
+    // by its owner's sId (conversation or pod space). Derived by the
+    // lifecycle ready helpers.
     egressPolicyOwnerId: string;
+    // The inherited pod policy layer, set for conversation sandboxes
+    // running inside a pod: the proxy also honors the pod's policy file, so
+    // pod network settings apply to every Computer in the Pod while
+    // on-the-fly approvals stay scoped to the conversation.
+    egressPolicyPodId?: string;
   }
 ): Promise<Result<void, Error>> {
   const logContext = {
@@ -601,6 +621,7 @@ export async function setupEgressForwarder(
     providerId: sandbox.providerId,
     workspaceId: auth.getNonNullableWorkspace().sId,
     ownerId: egressPolicyOwnerId,
+    podId: egressPolicyPodId,
   });
 
   // Token, secrets, and manifest are written in order, each gated on the

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -189,11 +189,9 @@ export async function readOwnerPolicy(
 // (Shared Computer) policies: like the workspace policy — and unlike the
 // agent tool's exact-domain appends — wildcard entries such as
 // `*.github.com` are supported, and there is no domain-count cap (also
-// mirroring the workspace policy). Note the asymmetry with
-// addOwnerPolicyDomain, which caps at SANDBOX_POLICY_MAX_DOMAINS and writes
-// the same pod files (tool approvals from a Pod's conversations are
-// Pod-scoped): an admin list over the cap makes every tool append in that
-// Pod fail its cap check.
+// mirroring the workspace policy). Tool approvals never touch pod files
+// (they land in the conversation's own policy file), so an over-cap admin
+// list does not interfere with addOwnerPolicyDomain's cap check.
 export async function writeOwnerPolicy(
   auth: Authenticator,
   { ownerId, policy }: { ownerId: string; policy: EgressPolicy }

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -222,7 +222,7 @@ describe("ensureConversationSandboxReady", () => {
     );
   });
 
-  it("scopes egress policy to the Pod for conversations inside a Pod", async () => {
+  it("keeps conversation-scoped policy with the Pod as an inherited layer", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
@@ -234,8 +234,9 @@ describe("ensureConversationSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    // The runtime owner stays the conversation but carries its pod, and the
-    // egress policy is scoped to the Pod's shared file.
+    // The runtime owner stays the conversation and carries its pod. The
+    // egress policy file stays conversation-scoped (on-the-fly approvals
+    // land there) while the Pod's policy applies as the inherited layer.
     const podConversationOwner = {
       ...conversationOwner,
       spaceId: "space-id",
@@ -243,11 +244,16 @@ describe("ensureConversationSandboxReady", () => {
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,
       sandbox,
-      { runtimeOwner: podConversationOwner, egressPolicyOwnerId: "space-id" }
+      {
+        runtimeOwner: podConversationOwner,
+        egressPolicyOwnerId: conversation.sId,
+        egressPolicyPodId: "space-id",
+      }
     );
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
       runtimeOwner: podConversationOwner,
-      egressPolicyOwnerId: "space-id",
+      egressPolicyOwnerId: conversation.sId,
+      egressPolicyPodId: "space-id",
       wokeFromSleep: false,
     });
     expect(mockForConversation).toHaveBeenCalledWith(auth, podConversation);

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -106,13 +106,16 @@ vi.mock("@app/logger/logger", () => {
   return { default: logger };
 });
 
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
 import {
   ensureConversationSandboxReady,
   ensurePodSandboxReady,
@@ -133,6 +136,7 @@ function createDeferred<T>() {
 
 describe("ensureConversationSandboxReady", () => {
   let auth: Authenticator;
+  let workspace: WorkspaceType;
   let conversation: ConversationType;
   let conversationOwner: {
     kind: "conversation";
@@ -155,6 +159,7 @@ describe("ensureConversationSandboxReady", () => {
     vi.clearAllMocks();
     const testSetup = await createResourceTest({ role: "admin" });
     auth = testSetup.authenticator;
+    workspace = testSetup.workspace;
     const agentConfiguration =
       await AgentConfigurationFactory.createTestAgent(auth);
     conversation = await ConversationFactory.create(auth, {
@@ -226,11 +231,46 @@ describe("ensureConversationSandboxReady", () => {
     mockEnsureSandboxActive.mockResolvedValue(
       new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
     );
-    const podConversation = { sId: conversation.sId, spaceId: "space-id" };
+    const project = await SpaceFactory.project(workspace);
+    // Space-scoped conversation fetches are permission-filtered, so the test
+    // user must be a member of the project before the authoritative re-read
+    // inside ensureConversationSandboxReady can see the moved conversation.
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const groupReference = project.groups.find((group) =>
+      group.isRegularAuto()
+    );
+    if (!groupReference) {
+      throw new Error("Project space regular group not found");
+    }
+    const [projectGroup] = await project.fetchGroupResources(
+      internalAdminAuth,
+      { groupReferences: [groupReference] }
+    );
+    const addRes = await projectGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: auth.getNonNullableUser().toJSON(),
+    });
+    if (addRes.isErr()) {
+      throw new Error(
+        `Failed to add user to project space group: ${addRes.error.message}`
+      );
+    }
+    await auth.refresh();
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    if (!conversationResource) {
+      throw new Error("Test conversation not found");
+    }
+    await conversationResource.updateSpaceId(auth, project);
 
+    // The caller's snapshot predates the move on purpose: the ready path must
+    // derive the pod scope from the database, not from the caller.
     const result = await ensureConversationSandboxReady(
       auth as never,
-      podConversation as never
+      conversation as never
     );
 
     expect(result.isOk()).toBe(true);
@@ -239,7 +279,7 @@ describe("ensureConversationSandboxReady", () => {
     // land there) while the Pod's policy applies as the inherited layer.
     const podConversationOwner = {
       ...conversationOwner,
-      spaceId: "space-id",
+      spaceId: project.sId,
     };
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,
@@ -247,16 +287,43 @@ describe("ensureConversationSandboxReady", () => {
       {
         runtimeOwner: podConversationOwner,
         egressPolicyOwnerId: conversation.sId,
-        egressPolicyPodId: "space-id",
+        egressPolicyPodId: project.sId,
       }
     );
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
       runtimeOwner: podConversationOwner,
       egressPolicyOwnerId: conversation.sId,
-      egressPolicyPodId: "space-id",
+      egressPolicyPodId: project.sId,
       wokeFromSleep: false,
     });
-    expect(mockForConversation).toHaveBeenCalledWith(auth, podConversation);
+    expect(mockForConversation).toHaveBeenCalledWith(auth, {
+      ...conversation,
+      spaceId: project.sId,
+    });
+  });
+
+  it("drops a stale pod scope from the caller's snapshot after a move out", async () => {
+    mockEnsureSandboxActive.mockResolvedValue(
+      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+    );
+    // The database says the conversation is standalone; only the caller's
+    // stale snapshot still carries a pod.
+    const staleSnapshot = { ...conversation, spaceId: "stale-pod-space-id" };
+
+    const result = await ensureConversationSandboxReady(
+      auth as never,
+      staleSnapshot as never
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      runtimeOwner: conversationOwner,
+      egressPolicyOwnerId: conversation.sId,
+      wokeFromSleep: false,
+    });
+    expect(
+      mockEnsureSandboxEgressOnExec.mock.calls[0][2].egressPolicyPodId
+    ).toBeUndefined();
   });
 
   it("starts GCS mount before initial egress prep resolves", async () => {

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -13,6 +13,7 @@ import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type {
@@ -23,7 +24,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const SANDBOX_RUNTIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -213,10 +214,28 @@ export async function ensureConversationSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
+  // The caller's conversation is typically a snapshot captured at agent-loop
+  // start, and a move — possibly issued by this very agent — can change
+  // spaceId while the loop runs. spaceId is an authorization input (egress
+  // scope, pod env vars, pod mounts), so it is re-read from the database
+  // here rather than trusted from the caller.
+  const freshResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!freshResource) {
+    return new Err(new Error(`Conversation ${conversation.sId} not found.`));
+  }
+  const freshConversation = {
+    ...conversation,
+    spaceId: freshResource.spaceSId,
+  };
+
   return ensureOwnerSandboxReady(auth, {
     ensureActive: () =>
-      ConversationSandboxAdapter.ensureSandboxActive(auth, conversation),
-    getFileSystem: () => DustFileSystem.forConversation(auth, conversation),
+      ConversationSandboxAdapter.ensureSandboxActive(auth, freshConversation),
+    getFileSystem: () =>
+      DustFileSystem.forConversation(auth, freshConversation),
     // Pod-level sandbox config applies to everything running in the Pod: a
     // conversation inside a Pod receives the Pod's env vars and HTTPS
     // secrets at creation, and inherits the Pod's egress policy as a
@@ -225,11 +244,11 @@ export async function ensureConversationSandboxReady(
     // like conversations outside a Pod.
     runtimeOwner: {
       kind: "conversation",
-      conversationId: conversation.sId,
-      spaceId: conversation.spaceId ?? null,
+      conversationId: freshConversation.sId,
+      spaceId: freshConversation.spaceId ?? null,
     },
-    egressPolicyOwnerId: conversation.sId,
-    egressPolicyPodId: conversation.spaceId ?? undefined,
+    egressPolicyOwnerId: freshConversation.sId,
+    egressPolicyPodId: freshConversation.spaceId ?? undefined,
   });
 }
 

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -37,9 +37,12 @@ type SandboxReadyConfig = {
   getFileSystem: () => Promise<Result<DustFileSystem, Error>>;
   runtimeOwner: SandboxRuntimeOwner;
   // Which owner policy file (`w/{wId}/sandboxes/{ownerId}.json`) this
-  // sandbox's egress is scoped to. Distinct from runtimeOwner: conversations
-  // inside a Pod share the Pod's policy file.
+  // sandbox's egress is scoped to — the owner's own sId (conversation or
+  // pod space).
   egressPolicyOwnerId: string;
+  // Inherited pod policy layer for conversation sandboxes running inside a
+  // pod; pod-owned sandboxes carry none (their ownerId already is the pod).
+  egressPolicyPodId?: string;
 };
 
 // /!\ All sandbox-touching tools must use the owner-specific ready helper rather than calling
@@ -52,6 +55,7 @@ async function ensureOwnerSandboxReady(
     getFileSystem,
     runtimeOwner,
     egressPolicyOwnerId,
+    egressPolicyPodId,
   }: SandboxReadyConfig
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   const startMs = performance.now();
@@ -121,6 +125,7 @@ async function ensureOwnerSandboxReady(
             prepareSandboxEgressBeforeMount(auth, sandbox, {
               runtimeOwner,
               egressPolicyOwnerId,
+              egressPolicyPodId,
             })
           ),
           traceSandboxStartupPhase("gcs_mount", async () => {
@@ -186,6 +191,7 @@ async function ensureOwnerSandboxReady(
           ensureSandboxEgressOnExec(auth, sandbox, {
             runtimeOwner,
             egressPolicyOwnerId,
+            egressPolicyPodId,
             wokeFromSleep,
           })
       );
@@ -212,14 +218,18 @@ export async function ensureConversationSandboxReady(
       ConversationSandboxAdapter.ensureSandboxActive(auth, conversation),
     getFileSystem: () => DustFileSystem.forConversation(auth, conversation),
     // Pod-level sandbox config applies to everything running in the Pod: a
-    // conversation inside a Pod uses the Pod's shared egress policy file and
-    // receives the Pod's env vars and HTTPS secrets at creation.
+    // conversation inside a Pod receives the Pod's env vars and HTTPS
+    // secrets at creation, and inherits the Pod's egress policy as a
+    // read-only layer (egressPolicyPodId). Its own policy file stays
+    // conversation-scoped — on-the-fly domain approvals land there, exactly
+    // like conversations outside a Pod.
     runtimeOwner: {
       kind: "conversation",
       conversationId: conversation.sId,
       spaceId: conversation.spaceId ?? null,
     },
-    egressPolicyOwnerId: conversation.spaceId ?? conversation.sId,
+    egressPolicyOwnerId: conversation.sId,
+    egressPolicyPodId: conversation.spaceId ?? undefined,
   });
 }
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -681,7 +681,7 @@ describe("destroyConversation", () => {
     expect(stillThere).not.toBeNull();
   });
 
-  it("does not scrub the Pod's egress policy file when destroying a pod conversation", async () => {
+  it("deletes the conversation's own policy file, never the Pod's, when destroying a pod conversation", async () => {
     mockDeleteOwnerPolicy.mockResolvedValue(new Ok(undefined));
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -715,9 +715,17 @@ describe("destroyConversation", () => {
 
     await destroyConversation(podAuth, { conversation });
 
-    // Pod conversations never own a policy file — the Pod's file is scrubbed
-    // by hardDeleteSpace, not conversation destruction.
-    expect(mockDeleteOwnerPolicy).not.toHaveBeenCalled();
+    // Pod conversations own their own policy file (on-the-fly approvals land
+    // there) — destroying the conversation deletes it. The Pod's own file is
+    // untouched: the delete targets the conversation sId, never the pod's.
+    expect(mockDeleteOwnerPolicy).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.sId
+    );
+    expect(mockDeleteOwnerPolicy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      pod.sId
+    );
   });
 
   it("should delete batched message resources chunk by chunk", async () => {


### PR DESCRIPTION
## Description

First step in bringing egress-approval behavior in line with [this Slack thread](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1784750813582049). In the first iteration we didn't give sandbox sessions inside a Pod their own policy file — on-the-fly domain approvals were routed straight into the Pod's shared file, so any pod member's tool click widened egress for the whole Pod.

This PR lands the agreed model: **every conversation sandbox gets its own conversation-scoped egress policy file — inside or outside a Pod — and on-the-fly approvals land there**, while Pod network settings apply to every Computer in the Pod as an inherited read-only layer. Pod-owned sandboxes (pod functions) are unchanged: their ownerId already is the Pod, so they see workspace + Pod allowances and get no per-session file. The proxy half (`podId` claim + inherited pod layer) is #30383, already merged; the move-recycling follow-up `30379` and the scope-fingerprint follow-up `30386` stack above.

**What this PR does:**

1. **Conversation-scoped policy owner.** `ensureConversationSandboxReady` sets `egressPolicyOwnerId` to the conversation sId always, and `egressPolicyPodId` to the Pod's space sId when the conversation lives in one — threaded through egress setup/wake/health-restart into the token.
2. **Approvals route to the conversation.** The `add_egress_domain` tool writes the conversation's own file in all cases; the tool description and agent-facing response copy now say conversation scope, dropping the "Pod-wide, make that clear to the user" framing.
3. **Cleanup on destroy.** Every conversation now owns a policy file, so `destroyConversation` deletes it for pod conversations too (the Pod's own file remains `hardDeleteSpace`'s job).
4. **Authoritative scope derivation.** `ensureConversationSandboxReady` re-reads the conversation's `spaceId` from the database instead of trusting the caller's object: the caller's conversation is typically an agent-loop snapshot, and a move (possibly issued by that very agent) can change the pod association mid-loop. `spaceId` is an authorization input (egress scope, pod env vars, pod mounts), so every sandbox create/wake derives it fresh.

Domains already written into Pod files under the v0 behavior stay honored (they're in the inherited layer) — no data migration.

Pod-level allowlist additions remain admin-only via Pod network settings; the request-manifest flow for pod-function domain requests is still to be built (`29347` carries its approval surface).

## Risk

Worst case, a conversation in a Pod loses the pod layer (falls back to workspace + own approvals — fail closed, no over-granting). Safe to rollback; rollback order mirrors the deploy order below.

Rollout: sandboxes already warm at deploy keep their pod-scoped token until they re-mint. The warm-fleet migration is the stacked `30386` (egress token scope fingerprint — split out for standalone design review): its NULL-mismatch check re-mints every pre-deploy sandbox on its next use. Until it deploys, the window closes at each sandbox's natural sleep/wake; nothing over-grants either way — Pod/workspace domains keep working and only new conversation-scoped approvals are inert on warm sandboxes.

Moves are handled across the stack: the authoritative fetch here means any sandbox create/wake derives scope from database state, and `30379` recycles the sandbox at move time so warm state (including pod env vars, which are injected only at creation) is rebuilt.

## Deploy Plan

- [x] Confirm the #30383 egress-proxy deploy is live in both regions (merged; old proxies ignore the `podId` claim, so if front ships first, conversations inside Pods fail closed to workspace + own approvals until the proxy catches up — no over-granting)
- [ ] Deploy front (ideally with the stacked `30386`, whose fingerprint migrates warm sandboxes to conversation-scoped tokens; without it, warm sandboxes converge at their natural sleep/wake)

## Tests

Proxy-side coverage (claim round-trip + the authorization matrix) lives in #30383. Front: lifecycle asserts conversation-scoped owner + inherited pod layer in both egress calls, with the pod case now moving the conversation in the database and passing a stale snapshot (pinning the authoritative fetch), plus the reverse direction (stale snapshot still carrying a pod the conversation left); `mintEgressJwt` asserts podId present when given and absent otherwise; conversation destroy deletes the conversation's own policy file and never the Pod's; tool test flipped to conversation-scope approvals and copy. Move-recycling tests live in the stacked `30379`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
