### PR TITLE
[front] Add ActivationNextSteps component to conversation home

### DIFF
--- a/front/components/assistant/conversation/ActivationNextSteps.tsx
+++ b/front/components/assistant/conversation/ActivationNextSteps.tsx
@@ -1,0 +1,133 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import type { ActivationRecommendationForUserType } from "@app/lib/api/activation/recommendations";
+import { useAppRouter } from "@app/lib/platform";
+import {
+  useActivationRecommendations,
+  useUpdateActivationRecommendation,
+} from "@app/lib/swr/activation";
+import { classNames } from "@app/lib/utils";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ActionSparklesIcon,
+  Button,
+  ChevronDown,
+  CornerDownLeft,
+  Icon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  XClose,
+} from "@dust-tt/sparkle";
+import { useContext, useState } from "react";
+
+interface ActivationNextStepsProps {
+  owner: LightWorkspaceType;
+}
+
+export function ActivationNextSteps({ owner }: ActivationNextStepsProps) {
+  const router = useAppRouter();
+  const { setPendingInputText, setShouldFocusInput } =
+    useContext(InputBarContext);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { recommendations, isRecommendationsLoading, mutateRecommendations } =
+    useActivationRecommendations({ workspaceId: owner.sId });
+  const { updateRecommendation } = useUpdateActivationRecommendation({
+    workspaceId: owner.sId,
+  });
+
+  if (isRecommendationsLoading || recommendations.length === 0) {
+    return null;
+  }
+
+  const handleSelect = (rec: ActivationRecommendationForUserType) => {
+    setIsOpen(false);
+
+    if (rec.conversationId) {
+      void router.push(getConversationRoute(owner.sId, rec.conversationId));
+      return;
+    }
+
+    setPendingInputText(rec.content, { replace: true });
+    setShouldFocusInput(true);
+  };
+
+  const handleDismiss = async (
+    e: React.MouseEvent,
+    rec: ActivationRecommendationForUserType
+  ) => {
+    e.stopPropagation();
+
+    await mutateRecommendations(
+      (current) => ({
+        recommendations: (current?.recommendations ?? []).filter(
+          (r) => r.sId !== rec.sId
+        ),
+      }),
+      { revalidate: false }
+    );
+
+    await updateRecommendation(rec.sId, { status: "dismissed" });
+    void mutateRecommendations();
+  };
+
+  return (
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={classNames(
+            "flex items-center gap-1.5 rounded-full px-3 py-1.5",
+            "bg-highlight-50 text-sm font-medium text-highlight-600",
+            "transition-colors hover:bg-highlight-100"
+          )}
+        >
+          <Icon visual={ActionSparklesIcon} size="xs" />
+          <span>Your next steps</span>
+          <span className="flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-highlight-500 px-1 text-xs font-semibold text-white">
+            {recommendations.length}
+          </span>
+          <Icon visual={ChevronDown} size="xs" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="center" className="w-[420px] p-0">
+        <div className="flex flex-col">
+          {recommendations.map((rec) => (
+            <div
+              key={rec.sId}
+              className={classNames(
+                "flex w-full items-center gap-2 px-3 py-2.5",
+                "border-b border-border last:border-b-0",
+                "hover:bg-muted-background"
+              )}
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="truncate text-sm font-semibold text-foreground">
+                  {rec.title}
+                </span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {rec.content}
+                </span>
+              </div>
+              <Button
+                icon={XClose}
+                size="mini"
+                variant="ghost-secondary"
+                tooltip="Dismiss"
+                onClick={(e) => void handleDismiss(e, rec)}
+              />
+              <Button
+                icon={CornerDownLeft}
+                size="mini"
+                variant="ghost-secondary"
+                tooltip="Try this"
+                onClick={() => handleSelect(rec)}
+              />
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -3,6 +3,7 @@ import {
   getWorkspaceLimitForSubmitError,
   ReachedLimitPopup,
 } from "@app/components/app/ReachedLimitPopup";
+import { ActivationNextSteps } from "@app/components/assistant/conversation/ActivationNextSteps";
 import { AgentBrowserContainer } from "@app/components/assistant/conversation/AgentBrowserContainer";
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -269,9 +270,12 @@ export function ConversationContainerVirtuoso({
         <>
           <div
             id="agent-input-header"
-            className="flex h-fit w-full max-w-conversation flex-col justify-end gap-8 py-4 md:min-h-[20vh]"
+            className="flex h-fit w-full max-w-conversation flex-col items-center justify-end gap-4 py-4 md:min-h-[20vh]"
             ref={startConversationRef}
           >
+            <div className="flex w-full justify-center">
+              <ActivationNextSteps owner={owner} />
+            </div>
             <Page.Header title={greeting} />
           </div>
           <div

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -1,0 +1,83 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetActivationRecommendationsResponseBody } from "@app/lib/api/activation/recommendations";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+export function useActivationRecommendations({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const recommendationsFetcher: Fetcher<GetActivationRecommendationsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/action-recommendations`,
+    recommendationsFetcher,
+    { disabled }
+  );
+
+  return {
+    recommendations: data?.recommendations ?? emptyArray(),
+    isRecommendationsLoading: disabled ? false : isLoading,
+    isRecommendationsError: !!error,
+    mutateRecommendations: mutate,
+  };
+}
+
+export function useUpdateActivationRecommendation({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const updateRecommendation = useCallback(
+    async (
+      recommendationId: string,
+      body: { status: "executed" | "dismissed" }
+    ): Promise<boolean> => {
+      try {
+        const res = await clientFetch(
+          `/api/w/${workspaceId}/action-recommendations/${recommendationId}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Failed to update action recommendation",
+            description: errorData.message,
+          });
+          return false;
+        }
+
+        return true;
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to update action recommendation",
+        });
+        return false;
+      }
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { updateRecommendation };
+}


### PR DESCRIPTION
## Summary
- Following design - https://app.dust.tt/share/frame/8afb4896-9522-437a-b25f-a22dd0a278c5
- This will show on the home page, but only if you have activation recommendations in your account (behind FF right now)
- The only real for non-activation users is it centers the welcome greeting
- Can decline recommendations directly or deep link you to pod conversation

## Testing

<img width="711" height="299" alt="Screenshot 2026-07-23 at 1 49 07 PM" src="https://github.com/user-attachments/assets/f4ea77ad-ae61-472f-8ecd-ec0e78e3798d" />
<img width="338" height="246" alt="Screenshot 2026-07-23 at 1 49 21 PM" src="https://github.com/user-attachments/assets/74291aeb-af3b-4efd-b6fb-f6747deffbc9" />


## Risk

Low, behind FF for activaiton right now

## Deploy
1. Deploy front