### PR TITLE
[front] fix: Putback viewportRef to fix infinite scroll

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1515,7 +1515,11 @@ function NavigationListWithInbox({
   loadMore,
   isLoadingMore,
 }: NavigationListWithInboxProps) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // The Radix ScrollArea root never scrolls (overflow-hidden); the inner
+  // viewport does. Keep it in state so InfiniteScroll re-binds once mounted.
+  const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(
+    null
+  );
   const {
     readConversations,
     inboxConversations,
@@ -1556,7 +1560,7 @@ function NavigationListWithInbox({
         nextPage={loadMore}
         hasMore={hasMore}
         showLoader={isLoadingMore}
-        options={{ root: scrollContainerRef.current, rootMargin: "400px" }}
+        options={{ root: scrollViewport, rootMargin: "400px" }}
         loader={
           <div className="flex justify-center py-2">
             <Spinner size="sm" />
@@ -1568,7 +1572,7 @@ function NavigationListWithInbox({
 
   return (
     <ScrollArea
-      ref={scrollContainerRef}
+      viewportRef={setScrollViewport}
       className="dd-privacy-mask h-full w-full"
     >
       <div className="flex flex-col gap-4">

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -2917,6 +2917,92 @@ describe("listPrivateConversationsForUser", () => {
     expect(item?.nextWakeupAt).toBe(scheduledFireAt.getTime());
   });
 
+  it("keeps paginating when a full page window contains a filtered-out conversation", async () => {
+    const deletedSpace = await SpaceFactory.regular(workspace);
+
+    const createParticipatingConversation = async ({
+      updatedAt,
+      requestedSpaceIds,
+    }: {
+      updatedAt: Date;
+      requestedSpaceIds?: number[];
+    }) => {
+      const conversation = await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [new Date()],
+        requestedSpaceIds,
+      });
+      await ConversationResource.upsertParticipation(userAuth, {
+        conversation,
+        action: "posted",
+        user: userAuth.getNonNullableUser().toJSON(),
+      });
+      // Raw SQL: Sequelize refuses to write an explicit updatedAt.
+      await frontSequelize.query(
+        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        { replacements: { updatedAt, id: conversation.id } }
+      );
+      return conversation;
+    };
+
+    // updatedAt order: newest > poisoned > middle > oldest > the beforeEach
+    // conversation.
+    const baseMs = Date.now();
+    const hourMs = 60 * 60 * 1000;
+    const newest = await createParticipatingConversation({
+      updatedAt: new Date(baseMs + 4 * hourMs),
+    });
+    const poisoned = await createParticipatingConversation({
+      updatedAt: new Date(baseMs + 3 * hourMs),
+      requestedSpaceIds: [deletedSpace.id],
+    });
+    const middle = await createParticipatingConversation({
+      updatedAt: new Date(baseMs + 2 * hourMs),
+    });
+    const oldest = await createParticipatingConversation({
+      updatedAt: new Date(baseMs + 1 * hourMs),
+    });
+
+    const deleteRes = await deletedSpace.delete(adminAuth, {
+      hardDelete: false,
+    });
+    assert(deleteRes.isOk(), "Failed to soft-delete space");
+
+    // Page 1 scans limit+1 = 3 rows (newest, poisoned, middle). The poisoned
+    // row references a deleted space and is dropped in-memory, leaving exactly
+    // `limit` conversations: hasMore must not flip to false because of the
+    // drop.
+    const page1 =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 2 }
+      );
+
+    expect(page1.conversations.map((c) => c.sId)).toEqual([
+      newest.sId,
+      middle.sId,
+    ]);
+    expect(page1.hasMore).toBe(true);
+    assert(page1.lastValue, "Expected a pagination cursor");
+
+    const page2 =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 2, lastValue: page1.lastValue }
+      );
+
+    expect(page2.conversations.map((c) => c.sId)).toEqual([
+      oldest.sId,
+      conversationIds[0],
+    ]);
+    expect(page2.hasMore).toBe(false);
+
+    const returnedSIds = [...page1.conversations, ...page2.conversations].map(
+      (c) => c.sId
+    );
+    expect(returnedSIds).not.toContain(poisoned.sId);
+  });
+
   it("should return conversations with populated participation data", async () => {
     // First, get the raw participation data from the database to compare
     const { ConversationParticipantModel } = await import(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -72,6 +72,7 @@ import type {
   Attributes,
   CreationAttributes,
   InferAttributes,
+  Order,
   Transaction,
   WhereOptions,
 } from "sequelize";
@@ -1837,24 +1838,37 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     const fetchLimit = pagination.limit + 1;
+    const order: Order = [
+      ["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"],
+    ];
+
+    // baseFetchWithAuthorization filters rows after the SQL limit (deleted
+    // space references, ACLs), which corrupts the +1 sentinel: one dropped row
+    // makes a full window look like the last page. Scan the raw window first
+    // and derive hasMore and the cursor from the scan, not the filtered rows.
+    const rawRows = await ConversationModel.findAll({
+      where: { ...whereClause, workspaceId: auth.getNonNullableWorkspace().id },
+      order,
+      limit: fetchLimit,
+      attributes: ["id", "updatedAt"],
+    });
+
+    if (rawRows.length === 0) {
+      return emptyResult;
+    }
+
+    const hasMore = rawRows.length === fetchLimit;
 
     const conversations = await this.baseFetchWithAuthorization(
       auth,
       {},
       {
-        where: whereClause,
-        order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
-        limit: fetchLimit,
+        where: { id: { [Op.in]: rawRows.map((r) => r.id) } },
+        order,
       }
     );
 
-    let hasMore = false;
-    let resultConversations = conversations;
-
-    if (conversations.length > pagination.limit) {
-      hasMore = true;
-      resultConversations = conversations.slice(0, pagination.limit);
-    }
+    const resultConversations = conversations.slice(0, pagination.limit);
 
     resultConversations.forEach((c) => {
       const participation = participationMap.get(c.id);
@@ -1865,11 +1879,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     await this.enrichWithReadState(auth, resultConversations);
 
-    const lastConversation =
-      resultConversations[resultConversations.length - 1];
-    const lastValue = lastConversation
-      ? lastConversation.updatedAt.getTime().toString()
-      : null;
+    // Advance the cursor past the scanned window, unless accessible rows were
+    // cut by the limit — those must reappear on the next page.
+    const lastReturned = resultConversations[resultConversations.length - 1];
+    const lastValue =
+      conversations.length > pagination.limit && lastReturned
+        ? lastReturned.updatedAt.getTime().toString()
+        : rawRows[rawRows.length - 1].updatedAt.getTime().toString();
 
     return {
       conversations: resultConversations,


### PR DESCRIPTION
## Description

In some rare cases, we are not correctly inferring hasMore because we evaluate it after filtering some rows in JS 🤡 

It's not longer the case

side-🚗 : fix the viewport in the list itself


## Tests

Added tests
Tested locally

## Risk

Low

## Deploy Plan

Deploy front