### PR TITLE
[front] perf: pipeline recent-authors reads, single-query agent editors, parallel enrichments

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -176,6 +176,74 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     expect(data.agentConfigurations[0].feedbacks).toBeDefined();
   });
 
+  it("returns agent configurations with recent authors (cold then warm cache)", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    await setupTestAgents(workspace, user);
+
+    // First call: Redis is cold, authors are backfilled from the DB.
+    const coldResponse = await listAgents(workspace, {
+      view: "list",
+      withAuthors: "true",
+    });
+
+    expect(coldResponse.status).toBe(200);
+    const coldData: { agentConfigurations: LightAgentConfigurationType[] } =
+      await coldResponse.json();
+    const coldAgents = coldData.agentConfigurations.filter(
+      (a) => a.scope !== "global"
+    );
+    expect(coldAgents.length).toBe(testAgents.length);
+    for (const agent of coldAgents) {
+      // The requester authored all test agents, rendered as "Me".
+      expect(agent.lastAuthors).toEqual(["Me"]);
+    }
+
+    // Second call: authors are read back from Redis.
+    const warmResponse = await listAgents(workspace, {
+      view: "list",
+      withAuthors: "true",
+    });
+
+    expect(warmResponse.status).toBe(200);
+    const warmData: { agentConfigurations: LightAgentConfigurationType[] } =
+      await warmResponse.json();
+    const warmAgents = warmData.agentConfigurations.filter(
+      (a) => a.scope !== "global"
+    );
+    expect(warmAgents.length).toBe(testAgents.length);
+    for (const agent of warmAgents) {
+      expect(agent.lastAuthors).toEqual(["Me"]);
+    }
+  });
+
+  it("returns agent configurations with editors", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    await setupTestAgents(workspace, user);
+
+    const response = await listAgents(workspace, {
+      view: "list",
+      withEditors: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      await response.json();
+    const nonGlobalAgents = data.agentConfigurations.filter(
+      (a) => a.scope !== "global"
+    );
+    expect(nonGlobalAgents.length).toBe(testAgents.length);
+    for (const agent of nonGlobalAgents) {
+      // The creating user is the sole member of each agent's editor group.
+      expect(agent.editors?.map((editor) => editor.sId)).toEqual([user.sId]);
+    }
+  });
+
   it("returns 400 for invalid query parameters", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,3 +1,4 @@
+import type { AgentUsageCount } from "@app/lib/api/assistant/agent_usage";
 import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -6,6 +7,7 @@ import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { runOnRedis } from "@app/lib/api/redis";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   GetAgentConfigurationsQuerySchema,
   PostOrPatchAgentConfigurationRequestBodySchema,
@@ -14,6 +16,9 @@ import type {
   GetAgentConfigurationsResponseBody,
   PostAgentConfigurationResponseBody,
 } from "@app/types/api/assistant/configuration";
+import type { AgentRecentAuthors } from "@app/types/assistant/agent";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { UserType } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -35,6 +40,21 @@ import webhookFilterGenerator from "./webhook_filter_generator";
 // Mounted at /api/w/:wId/assistant/agent_configurations. workspaceAuth is
 // applied by the parent workspace sub-app.
 const app = workspaceApp();
+
+// One optional enrichment of the agent list, fetched concurrently with the
+// others and merged into the response after all of them resolved.
+type AgentListEnrichment =
+  | { kind: "usage"; usage: AgentUsageCount[] }
+  | { kind: "authors"; authors: AgentRecentAuthors[] }
+  | { kind: "editors"; editors: Record<string, UserType[]> }
+  | {
+      kind: "feedbacks";
+      feedbacks: Awaited<
+        ReturnType<
+          typeof AgentMessageFeedbackResource.getFeedbackCountForAssistants
+        >
+      >;
+    };
 
 /**
  * @swagger
@@ -212,77 +232,112 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
     // Stripped to stay under Next.js' 4MB API response limit.
     omitInstructions: true,
   });
+  // The enrichments below only depend on the base agent list; fetch them
+  // concurrently, then merge sequentially.
+  const enrichments: (() => Promise<AgentListEnrichment>)[] = [];
   if (withUsage === "true") {
-    const mentionCounts = await runOnRedis(
-      { origin: "agent_usage" },
-      async (redis) => {
-        return getAgentsUsage({
+    enrichments.push(async () => ({
+      kind: "usage",
+      usage: await runOnRedis({ origin: "agent_usage" }, (redis) =>
+        getAgentsUsage({
           providedRedis: redis,
           workspaceId: owner.sId,
           limit:
             typeof rawQuery.limit === "string"
               ? parseInt(rawQuery.limit, 10)
               : -1,
-        });
-      }
-    );
-    const usageMap = keyBy(mentionCounts, "agentId");
-    agentConfigurations = agentConfigurations.map((agentConfiguration) =>
-      usageMap[agentConfiguration.sId]
-        ? {
-            ...agentConfiguration,
-            usage: omit(usageMap[agentConfiguration.sId], ["agentId"]),
-          }
-        : agentConfiguration
-    );
+        })
+      ),
+    }));
   }
   if (withAuthors === "true") {
-    const recentAuthors = await getAgentsRecentAuthors({
-      auth,
-      agents: agentConfigurations,
-    });
-    agentConfigurations = agentConfigurations.map(
-      (agentConfiguration, index) => ({
-        ...agentConfiguration,
-        lastAuthors: recentAuthors[index],
-      })
-    );
-  }
-
-  if (withEditors === "true") {
-    const editors = await getAgentsEditors(auth, agentConfigurations);
-    agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
-      ...agentConfiguration,
-      editors: editors[agentConfiguration.sId],
-    }));
-  }
-
-  if (withFeedbacks === "true") {
-    const feedbacks =
-      await AgentMessageFeedbackResource.getFeedbackCountForAssistants(
+    enrichments.push(async () => ({
+      kind: "authors",
+      authors: await getAgentsRecentAuthors({
         auth,
-        agentConfigurations
-          .filter((agent) => agent.scope !== "global")
-          .map((agent) => agent.sId),
-        30
-      );
-    agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
-      ...agentConfiguration,
-      feedbacks: {
-        up:
-          feedbacks.find(
-            (f) =>
-              f.agentConfigurationId === agentConfiguration.sId &&
-              f.thumbDirection === "up"
-          )?.count ?? 0,
-        down:
-          feedbacks.find(
-            (f) =>
-              f.agentConfigurationId === agentConfiguration.sId &&
-              f.thumbDirection === "down"
-          )?.count ?? 0,
-      },
+        agents: agentConfigurations,
+      }),
     }));
+  }
+  if (withEditors === "true") {
+    enrichments.push(async () => ({
+      kind: "editors",
+      editors: await getAgentsEditors(auth, agentConfigurations),
+    }));
+  }
+  if (withFeedbacks === "true") {
+    enrichments.push(async () => ({
+      kind: "feedbacks",
+      feedbacks:
+        await AgentMessageFeedbackResource.getFeedbackCountForAssistants(
+          auth,
+          agentConfigurations
+            .filter((agent) => agent.scope !== "global")
+            .map((agent) => agent.sId),
+          30
+        ),
+    }));
+  }
+  const enrichmentResults = await concurrentExecutor(
+    enrichments,
+    (task) => task(),
+    { concurrency: 4 }
+  );
+
+  for (const enrichment of enrichmentResults) {
+    switch (enrichment.kind) {
+      case "usage": {
+        const usageMap = keyBy(enrichment.usage, "agentId");
+        agentConfigurations = agentConfigurations.map((agentConfiguration) =>
+          usageMap[agentConfiguration.sId]
+            ? {
+                ...agentConfiguration,
+                usage: omit(usageMap[agentConfiguration.sId], ["agentId"]),
+              }
+            : agentConfiguration
+        );
+        break;
+      }
+      case "authors": {
+        const { authors } = enrichment;
+        agentConfigurations = agentConfigurations.map(
+          (agentConfiguration, index) => ({
+            ...agentConfiguration,
+            lastAuthors: authors[index],
+          })
+        );
+        break;
+      }
+      case "editors": {
+        const { editors } = enrichment;
+        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
+          ...agentConfiguration,
+          editors: editors[agentConfiguration.sId],
+        }));
+        break;
+      }
+      case "feedbacks": {
+        const feedbackCounts = new Map<string, { up: number; down: number }>();
+        for (const feedback of enrichment.feedbacks) {
+          const counts = feedbackCounts.get(feedback.agentConfigurationId) ?? {
+            up: 0,
+            down: 0,
+          };
+          counts[feedback.thumbDirection] = feedback.count;
+          feedbackCounts.set(feedback.agentConfigurationId, counts);
+        }
+        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
+          ...agentConfiguration,
+          feedbacks: feedbackCounts.get(agentConfiguration.sId) ?? {
+            up: 0,
+            down: 0,
+          },
+        }));
+        break;
+      }
+      default:
+        assertNever(enrichment);
+    }
   }
 
   return ctx.json({ agentConfigurations });

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -134,6 +134,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       : Promise.resolve([]),
   ]);
 
+  const editorIdsSet = new Set(editorIds);
+
   const agentConfigurationTypes: AgentConfigurationType[] = [];
   for (const agent of agentConfigurations) {
     const actions =
@@ -144,8 +146,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const model = getModelForAgentConfiguration(agent);
     const tags: TagResource[] = tagsPerAgent[agent.id] ?? [];
 
-    const isAuthor = agent.authorId === auth.user()?.id;
-    const isMember = editorIds.includes(agent.id);
+    const isAuthor = agent.authorId === user?.id;
+    const isMember = editorIdsSet.has(agent.id);
 
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,

--- a/front/lib/api/assistant/editors.ts
+++ b/front/lib/api/assistant/editors.ts
@@ -38,31 +38,18 @@ export const getAgentsEditors = async (
   auth: Authenticator,
   agentConfigurations: LightAgentConfigurationType[]
 ): Promise<Record<string, UserType[]>> => {
-  const editorGroups = await GroupResource.findEditorGroupsForAgents(
+  const editorUsers = await GroupResource.listAgentEditorUsers(
     auth,
     agentConfigurations
   );
-  if (editorGroups.isErr()) {
+  if (editorUsers.isErr()) {
     return {};
   }
 
-  const activeMemberships = await GroupResource.getActiveMembershipsForGroups(
-    auth,
-    Object.values(editorGroups.value)
-  );
-
-  const users = await UserResource.fetchByModelIds([
-    ...new Set(Object.values(activeMemberships).flat()),
-  ]);
-
-  // Create a map from userId to UserType for quick lookup
-  const userMap = new Map(users.map((u) => [u.id, u.toJSON()]));
-
   // Build the result map: { agentId: [editors] }
   const result: Record<string, UserType[]> = {};
-  for (const [agentId, group] of Object.entries(editorGroups.value)) {
-    const userIds = activeMemberships[group.id] || [];
-    result[agentId] = removeNulls(userIds.map((userId) => userMap.get(userId)));
+  for (const [agentId, users] of Object.entries(editorUsers.value)) {
+    result[agentId] = users.map((user) => user.toJSON());
   }
 
   return result;

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -2,13 +2,12 @@ import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentRecentAuthors,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { getGlobalAgentAuthorName } from "@app/types/assistant/assistant";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isStringArray, removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import { Op, Sequelize } from "sequelize";
 
@@ -125,21 +124,34 @@ async function populateAuthorIdsFromDbForAgents(
     (agentId) => (recentAuthorsByAgentId.get(agentId) ?? []).length > 0
   );
 
-  await concurrentExecutor(
-    agentsWithAuthors,
-    async (agentId) => {
-      const authors = recentAuthorsByAgentId.get(agentId) ?? [];
-      await setAuthorIdsWithVersionInRedis(auth, {
-        agentId,
-        authorIdsWithScore: authors.map((a) => ({
-          // Redis only supports strings.
-          value: a.authorId.toString(),
-          score: a.version,
-        })),
-      });
-    },
-    { concurrency: 8 }
-  );
+  if (agentsWithAuthors.length > 0) {
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    // Backfill all cold-cache agents in a single pipeline (one round trip
+    // instead of two per agent).
+    await runOnRedis({ origin: "update_authors" }, async (redis) => {
+      const pipeline = redis.multi();
+      for (const agentId of agentsWithAuthors) {
+        const agentRecentAuthorIdsKey = _getRecentAuthorIdsKey({
+          agentId,
+          workspaceId,
+        });
+        const authors = recentAuthorsByAgentId.get(agentId) ?? [];
+        // Add <authorId:version> pairs to the sorted set, only if the version
+        // is greater than the one stored.
+        pipeline.zAdd(
+          agentRecentAuthorIdsKey,
+          authors.map((a) => ({
+            // Redis only supports strings.
+            value: a.authorId.toString(),
+            score: a.version,
+          })),
+          { GT: true }
+        );
+        pipeline.expire(agentRecentAuthorIdsKey, recentAuthorIdsKeyTTL);
+      }
+      await pipeline.exec();
+    });
+  }
 
   return result;
 }
@@ -174,23 +186,29 @@ export async function getAgentsRecentAuthors({
 
   const nonGlobalAgents = agents.filter((agent) => agent.scope !== "global");
 
-  // First pass: read Redis for all non-global agents concurrently.
-  const redisResults = await concurrentExecutor(
-    nonGlobalAgents,
-    async (agent): Promise<[string, string[]]> => {
-      const { sId: agentId } = agent;
-      const agentRecentAuthorIdsKey = _getRecentAuthorIdsKey({
-        agentId,
-        workspaceId: owner.sId,
+  // First pass: read Redis for all non-global agents in a single pipeline (one
+  // round trip instead of one per agent).
+  const redisResults = await runOnRedis(
+    { origin: "agent_recent_authors" },
+    async (redis) => {
+      const pipeline = redis.multi();
+      for (const agent of nonGlobalAgents) {
+        pipeline.zRange(
+          _getRecentAuthorIdsKey({
+            agentId: agent.sId,
+            workspaceId: owner.sId,
+          }),
+          0,
+          2,
+          { REV: true }
+        );
+      }
+      const replies = await pipeline.exec();
+      return nonGlobalAgents.map((agent, i): [string, string[]] => {
+        const reply = replies[i];
+        return [agent.sId, isStringArray(reply) ? reply : []];
       });
-      const recentAuthorIds = await runOnRedis(
-        { origin: "agent_recent_authors" },
-        async (redis) =>
-          redis.zRange(agentRecentAuthorIdsKey, 0, 2, { REV: true })
-      );
-      return [agentId, recentAuthorIds];
-    },
-    { concurrency: 8 }
+    }
   );
 
   // Collect cold-cache agent IDs and batch-fetch them in a single SQL query.

--- a/front/lib/models/agent/group_agent.ts
+++ b/front/lib/models/agent/group_agent.ts
@@ -7,6 +7,7 @@ import type {
   BelongsToGetAssociationMixin,
   CreationOptional,
   ForeignKey,
+  NonAttribute,
 } from "sequelize";
 
 export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
@@ -17,6 +18,9 @@ export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
   // workspaceId is inherited from WorkspaceAwareModel
+
+  // Present when fetched with the group include.
+  declare group?: NonAttribute<GroupModel>;
 
   declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
   declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfigurationModel>;

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -10,6 +10,7 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
@@ -644,6 +645,79 @@ export class GroupResource extends BaseResource<GroupModel> {
           r[agentConfiguration.sId] = group;
         }
       }
+    }
+
+    return new Ok(r);
+  }
+
+  /**
+   * Fetches the active members of the editor groups for a set of agents in a
+   * single query (group_agents → groups → group_memberships → users).
+   */
+  static async listAgentEditorUsers(
+    auth: Authenticator,
+    agents: LightAgentConfigurationType[]
+  ): Promise<Result<Record<string, UserResource[]>, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+    if (agents.length === 0) {
+      return new Ok({});
+    }
+
+    const now = new Date();
+    const groupAgents = await GroupAgentModel.findAll({
+      where: {
+        agentConfigurationId: { [Op.in]: agents.map((a) => a.id) },
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: GroupModel,
+          required: true,
+          include: [
+            {
+              model: GroupMembershipModel,
+              as: "memberships",
+              // `required: false` with `where` keeps the LEFT OUTER join (the
+              // conditions land in the ON clause), so editor groups with no
+              // active member still come back, with an empty editors list.
+              required: false,
+              where: {
+                workspaceId: owner.id,
+                status: "active",
+                startAt: { [Op.lte]: now },
+                [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+              },
+              include: [{ model: UserModel, required: true }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const agentIdByModelId = new Map(agents.map((a) => [a.id, a.sId]));
+
+    const r: Record<string, UserResource[]> = {};
+    for (const groupAgent of groupAgents) {
+      const agentId = agentIdByModelId.get(groupAgent.agentConfigurationId);
+      const groupModel = groupAgent.group;
+      if (!agentId || !groupModel) {
+        continue;
+      }
+      if (groupModel.kind !== "agent_editors") {
+        return new Err(
+          new DustError(
+            "group_not_found",
+            "Associated group is not an agent_editors group."
+          )
+        );
+      }
+      const group = new this(GroupModel, groupModel.get());
+      if (!group.canRead(auth)) {
+        continue;
+      }
+      r[agentId] = (groupModel.memberships ?? []).map(
+        (membership) => new UserResource(UserModel, membership.user.get())
+      );
     }
 
     return new Ok(r);

--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -3,7 +3,7 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 export class GroupMembershipModel extends WorkspaceAwareModel<GroupMembershipModel> {
   declare createdAt: CreationOptional<Date>;
@@ -15,6 +15,8 @@ export class GroupMembershipModel extends WorkspaceAwareModel<GroupMembershipMod
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
   declare status: "active" | "suspended";
+
+  declare user: NonAttribute<UserModel>;
 }
 GroupMembershipModel.init(
   {
@@ -67,6 +69,7 @@ UserModel.hasMany(GroupMembershipModel, {
   onDelete: "RESTRICT",
 });
 GroupModel.hasMany(GroupMembershipModel, {
+  as: "memberships",
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -3,7 +3,9 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { GroupKind } from "@app/types/groups";
 import { isGlobalGroupKind, isSystemGroupKind } from "@app/types/groups";
-import type { CreationOptional, Transaction } from "sequelize";
+import type { CreationOptional, NonAttribute, Transaction } from "sequelize";
+
+import type { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 
 export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   declare createdAt: CreationOptional<Date>;
@@ -18,6 +20,9 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   // Per-group usage spend limit (excluding seat allowance), applied per member.
   // null means the group carries no cap (falls back to the workspace default).
   declare poolCapAwuCredits: CreationOptional<number | null>;
+
+  // Present when fetched with the "memberships" include.
+  declare memberships?: NonAttribute<GroupMembershipModel[]>;
 }
 
 GroupModel.init(

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -13,8 +13,54 @@ import { afterEach, beforeEach, vi } from "vitest";
 // runOnRedis uses a shared in-memory store so that set/get/del/ttl persist across calls
 // (needed for OTP challenge generate → validate flows). runOnRedisCache stays stateless.
 const redisStore = new Map<string, { value: string; expiresAtMs: number }>();
+// Sorted sets for the stateful client, key → (member → score).
+const redisZStore = new Map<string, Map<string, number>>();
 
 function createStatefulMockRedisClient() {
+  const zAdd = vi.fn(
+    async (
+      key: string,
+      members:
+        | { score: number; value: string }
+        | { score: number; value: string }[],
+      opts?: { GT?: boolean }
+    ) => {
+      const entries = Array.isArray(members) ? members : [members];
+      const zset = redisZStore.get(key) ?? new Map<string, number>();
+      for (const { score, value } of entries) {
+        const existing = zset.get(value);
+        if (opts?.GT && existing !== undefined && existing >= score) {
+          continue;
+        }
+        zset.set(value, score);
+      }
+      redisZStore.set(key, zset);
+      return entries.length;
+    }
+  );
+  const zRange = vi.fn(
+    async (
+      key: string,
+      start: number,
+      stop: number,
+      opts?: { REV?: boolean }
+    ) => {
+      const zset = redisZStore.get(key);
+      if (!zset) {
+        return [];
+      }
+      const values = [...zset.entries()]
+        .sort((a, b) => a[1] - b[1] || a[0].localeCompare(b[0]))
+        .map(([value]) => value);
+      if (opts?.REV) {
+        values.reverse();
+      }
+      const end = stop === -1 ? values.length - 1 : stop;
+      return values.slice(start, end + 1);
+    }
+  );
+  const expire = vi.fn(async (_key: string, _seconds: number) => true);
+
   return {
     get: vi.fn(async (key: string) => {
       const entry = redisStore.get(key);
@@ -42,9 +88,35 @@ function createStatefulMockRedisClient() {
       const remainingMs = entry.expiresAtMs - Date.now();
       return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : -2;
     }),
-    zAdd: vi.fn(),
-    expire: vi.fn(),
-    zRange: vi.fn(),
+    zAdd,
+    expire,
+    zRange,
+    // Minimal MULTI support: queue commands, run them in order on exec.
+    multi: vi.fn(() => {
+      const queued: (() => Promise<unknown>)[] = [];
+      const multi = {
+        zAdd(...args: Parameters<typeof zAdd>) {
+          queued.push(async () => zAdd(...args));
+          return multi;
+        },
+        zRange(...args: Parameters<typeof zRange>) {
+          queued.push(async () => zRange(...args));
+          return multi;
+        },
+        expire(...args: Parameters<typeof expire>) {
+          queued.push(async () => expire(...args));
+          return multi;
+        },
+        async exec() {
+          const results: unknown[] = [];
+          for (const run of queued) {
+            results.push(await run());
+          }
+          return results;
+        },
+      };
+      return multi;
+    }),
     zCount: vi.fn().mockResolvedValue(0),
     hGetAll: vi.fn().mockResolvedValue([]),
     hGet: vi.fn(),
@@ -228,6 +300,7 @@ beforeEach(async (c) => {
   vi.clearAllMocks();
   fileStorageMock.reset();
   redisStore.clear();
+  redisZStore.clear();
 
   const namespace = createNamespace("test-namespace");
 


### PR DESCRIPTION
## Problem

`GET /api/w/:wId/assistant/agent_configurations` (agent picker hot path, `view=list&withUsage=true&withAuthors=true`) has a heavy tail: 7-day median 191ms but p90 1.28s and p99 ~20s.

APM shows where slow requests go ([sample 8.95s trace](https://app.datadoghq.eu/apm/trace/6a62366900000000292671b34950e301)): **168 Redis ZRANGE calls (one per agent) totaling 9.8s of span time**, while all Postgres queries combined cost ~130ms. `getAgentsRecentAuthors` issued one `zRange` per non-global agent over the single shared node-redis connection.

The base list query itself needs no work (pganalyze 12470698029, avg 26.6ms, partial active-agent indexes, ~100% cache hit).

## Changes

- `recent_authors.ts`: all ZRANGE reads issued in a single `multi()` pipeline (1 round trip instead of N); cold-cache backfill writes (`zAdd` + `expire`) likewise batched (1 round trip instead of 2 per agent).
- `GroupResource.listAgentEditorUsers` + `editors.ts`: agent editors fetched in **one joined query** instead of 3 sequential ones (`group_agents` INNER JOIN `groups` LEFT OUTER JOIN (`group_memberships` INNER JOIN `users`), active-membership conditions in the ON clause so editor groups with no active member still return; `canRead` still enforced through GroupResource in memory). Verified Sequelize emits a single SELECT.
- `agent_configurations/index.ts` (front-api): the four enrichments (usage/authors/editors/feedbacks) fetched concurrently via `concurrentExecutor` over task thunks returning a typed discriminated union, merged sequentially after; feedback counts keyed by `agentConfigurationId` instead of two `.find()` scans per agent.
- `helpers.ts`: `Set` lookup for editor ids instead of `Array.includes` per agent.
- `vite.setup.ts`: the stateful redis mock gains real sorted-set semantics (`zAdd`/`zRange` with `GT`/`REV`) and minimal `MULTI` support — it previously had no `multi` at all, so the recent-authors path was untestable.

## Tests

- New endpoint tests: `withAuthors=true` cold (DB backfill + pipelined writes) then warm (pipelined ZRANGE reads); `withEditors=true` asserting the single-query path returns the editor group members.
- `front-api` agent_configurations suite 14/14 + editors suite 17/17, `front` group_resource 34/34, rate_limiter + configuration/agent 38/38, conversation_resource + messages 202/202. `tsgo --noEmit` clean on both workspaces.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

