### PR TITLE
[front] feat(activation): add get_tool_execution_modes tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -7,6 +7,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "get_tool_execution_modes": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "list_recommendations": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -2586,6 +2590,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
 {
   "activation_recommendations": {
     "create_recommendation": "never_ask",
+    "get_tool_execution_modes": "never_ask",
     "list_recommendations": "never_ask",
     "update_recommendation": "never_ask",
   },

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -57,20 +57,22 @@ async function buildConnectedServerIdsByType(
     workspace: new Set(),
   };
 
-  await Promise.all(
-    [...neededTypes].map(async (connectionType) => {
-      if (connectionType === "personal" && !auth.user()) {
-        return;
-      }
-      const connections = await MCPServerConnectionResource.listByWorkspace(
-        auth,
-        { connectionType }
-      );
-      connectedByType[connectionType] = new Set(
-        connections.map((c) => c.mcpServerId)
-      );
-    })
-  );
+  if (neededTypes.has("personal") && auth.user()) {
+    const connections = await MCPServerConnectionResource.listByWorkspace(
+      auth,
+      { connectionType: "personal" }
+    );
+    connectedByType["personal"] = new Set(connections.map((c) => c.mcpServerId));
+  }
+  if (neededTypes.has("workspace")) {
+    const connections = await MCPServerConnectionResource.listByWorkspace(
+      auth,
+      { connectionType: "workspace" }
+    );
+    connectedByType["workspace"] = new Set(
+      connections.map((c) => c.mcpServerId)
+    );
+  }
 
   return connectedByType;
 }

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -1,8 +1,10 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
@@ -11,10 +13,108 @@ import {
 } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type ToolExecutionMode = "auto" | "requires_approval" | "not_connected";
+
+function connectionTypeForOAuthUseCase(
+  oAuthUseCase: MCPOAuthUseCase
+): MCPServerConnectionConnectionType {
+  switch (oAuthUseCase) {
+    case "personal_actions":
+      return "personal";
+    case "platform_actions":
+      return "workspace";
+    default:
+      assertNever(oAuthUseCase);
+  }
+}
+
+async function buildConnectedServerIdsByType(
+  auth: Authenticator,
+  serverViews: MCPServerViewResource[]
+): Promise<Record<MCPServerConnectionConnectionType, Set<string>>> {
+  const neededTypes = new Set<MCPServerConnectionConnectionType>();
+  for (const view of serverViews) {
+    if (view.oAuthUseCase) {
+      neededTypes.add(connectionTypeForOAuthUseCase(view.oAuthUseCase));
+    }
+  }
+
+  const connectedByType: Record<
+    MCPServerConnectionConnectionType,
+    Set<string>
+  > = {
+    personal: new Set(),
+    workspace: new Set(),
+  };
+
+  await Promise.all(
+    [...neededTypes].map(async (connectionType) => {
+      if (connectionType === "personal" && !auth.user()) {
+        return;
+      }
+      const connections = await MCPServerConnectionResource.listByWorkspace(
+        auth,
+        { connectionType }
+      );
+      connectedByType[connectionType] = new Set(
+        connections.map((c) => c.mcpServerId)
+      );
+    })
+  );
+
+  return connectedByType;
+}
+
+function isServerConnected(
+  view: MCPServerViewResource,
+  connectedByType: Record<MCPServerConnectionConnectionType, Set<string>>
+): boolean {
+  if (!view.oAuthUseCase) {
+    return true;
+  }
+  return connectedByType[
+    connectionTypeForOAuthUseCase(view.oAuthUseCase)
+  ].has(view.mcpServerId);
+}
+
+async function resolveToolExecutionMode(
+  auth: Authenticator,
+  {
+    view,
+    toolName,
+    permission,
+    serverConnected,
+  }: {
+    view: MCPServerViewResource;
+    toolName: string;
+    permission: MCPToolStakeLevelType;
+    serverConnected: boolean;
+  }
+): Promise<ToolExecutionMode> {
+  if (!serverConnected) {
+    return "not_connected";
+  }
+
+  const { status } = await getExecutionStatusFromConfig(auth, {
+    actionConfiguration: {
+      permission,
+      toolServerId: view.mcpServerId,
+      name: toolName,
+    },
+  });
+
+  return status === "ready_allowed_implicitly" ? "auto" : "requires_approval";
+}
 
 const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
   {
@@ -121,6 +221,76 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         {
           type: "text" as const,
           text: `Previous recommendations (${recs.length}):\n${lines.join("\n")}`,
+        },
+      ]);
+    },
+
+    get_tool_execution_modes: async (
+      { executionModes: executionModeFilter },
+      { auth, runContext }
+    ) => {
+      if (!isAgentLoopRunContext(runContext)) {
+        return new Err(
+          new MCPError(
+            "get_tool_execution_modes is only available in agent loop runs."
+          )
+        );
+      }
+
+      const { conversation } = runContext;
+      const spaceIds = conversation.spaceId ? [conversation.spaceId] : [];
+
+      const serverViews =
+        await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
+          auth,
+          spaceIds,
+          { includeGlobalSpace: true, includeHeavyAttributes: ["cachedTools"] }
+        );
+
+      const connectedByType = await buildConnectedServerIdsByType(
+        auth,
+        serverViews
+      );
+
+      const lines: string[] = [];
+
+      for (const view of serverViews) {
+        const serverName = view.getDisplayName();
+        const serverConnected = isServerConnected(view, connectedByType);
+
+        for (const toolMeta of view.getToolPermissions) {
+          const executionMode = await resolveToolExecutionMode(auth, {
+            view,
+            toolName: toolMeta.toolName,
+            permission: toolMeta.permission,
+            serverConnected,
+          });
+
+          if (
+            !executionModeFilter ||
+            executionModeFilter.length === 0 ||
+            executionModeFilter.includes(executionMode)
+          ) {
+            lines.push(`${serverName}__${toolMeta.toolName}: ${executionMode}`);
+          }
+        }
+      }
+
+      if (lines.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: executionModeFilter?.length
+              ? `No tools with execution mode in [${executionModeFilter.join(", ")}].`
+              : "No tools found.",
+          },
+        ]);
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Tool execution modes:\n${lines.join("\n")}`,
         },
       ]);
     },

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -86,6 +86,30 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
       done: "Recommendation history fetched",
     },
   },
+  {
+    name: "get_tool_execution_modes",
+    description:
+      "Get the resolved execution mode for each tool available in the current run. " +
+      "Returns one of three modes for each tool: " +
+      "'auto' — runs silently without user approval; " +
+      "'requires_approval' — pauses execution until the user approves; " +
+      "'not_connected' — the user has not connected to this server yet (OAuth required).",
+    schema: {
+      executionModes: z
+        .array(z.enum(["auto", "requires_approval", "not_connected"]))
+        .optional()
+        .describe(
+          "When set, only return tools whose execution mode is one of these values. Omit to return all tools."
+        ),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Checking tool execution modes",
+      done: "Tool execution modes ready",
+    },
+  },
 ] as const;
 
 export const ACTIVATION_RECOMMENDATIONS_SERVER = {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -2,7 +2,10 @@ import type {
   CustomResourceIconType,
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icons";
-import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
+import {
+  DEFAULT_MCP_ACTION_DESCRIPTION,
+  type MCPToolStakeLevelType,
+} from "@app/lib/actions/constants";
 import {
   autoInternalMCPServerNameToSId,
   getMcpServerViewDisplayName,
@@ -17,6 +20,7 @@ import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getAvailabilityOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerByName,
+  getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
   isAutoInternalMCPServerName,
   isValidInternalMCPServerId,
@@ -1689,6 +1693,37 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ...(this.internalToolsMetadata ?? []),
       ...(this.remoteToolsMetadata ?? []),
     ];
+  }
+
+  get getToolPermissions(): {
+    toolName: string;
+    permission: MCPToolStakeLevelType;
+    enabled: boolean;
+  }[] {
+    if (this.serverType === "internal" && this.internalMCPServerId) {
+      const nameResult = getInternalMCPServerNameAndWorkspaceId(
+        this.internalMCPServerId
+      );
+      if (nameResult.isOk()) {
+        const tools = INTERNAL_MCP_SERVERS[nameResult.value.name].metadata.tools;
+        const overrides = new Map(
+          this.allToolsMetadata.map((m) => [m.toolName, m])
+        );
+        return tools.map((tool) => {
+          const override = overrides.get(tool.name);
+          return {
+            toolName: tool.name,
+            permission: override?.permission ?? tool.stake,
+            enabled: override?.enabled ?? true,
+          };
+        });
+      }
+    }
+    return this.allToolsMetadata.map((t) => ({
+      toolName: t.toolName,
+      permission: t.permission,
+      enabled: t.enabled,
+    }));
   }
 
   // Serialization.

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -1,8 +1,5 @@
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
-import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ACTIVATION_POD_FRAME_TEMPLATE } from "@app/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
@@ -55,13 +52,21 @@ If the skill is used outside of a pod, you still leverage the recommendation ste
 
 Every conversation follows the same arc:
 
+The first set of steps below will result in a single user message to start the activation flow.
+This will generally be triggered asynchronously, so minimizing tool calls is not a requirement. Accuracy and strict adherence to the defined workflow is critical.
+
 1. Research — Gather context about the user and their workspace.
-2. [Only If First Ever Session In This Pod] Define Pod Goal
-3. [Only If First Ever Session In This Pod] Set-up the Pod & Welcome the User
-4. Recommend — Always present exactly one high-value recommendation as a card. Follow the strict decision procedure below to generate the recommendation.
-5. Execute — Once accepted, run it for real. Make the result fully visible inline.
-6. Make it Recurring — If applicable, offer to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
-7. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 3.
+2. [Only If First Ever Session In This Pod] Set-up the Pod - Create the AGENTS.md file and the pinned Frame
+3. Recommend — Create exactly one high-value recommendation
+4. Create Execution Plan - Create a plan to execute the recommendation. Prefetch all required information to mitigate tool calls during execution.
+5. Present the Recommendation to the User
+
+The following steps will be synchronous for the user and require multiple turns to complete.
+A goal is to minimize the number of tool calls during this phase but NEVER compromise the interaction quality or deviate from the defined workflow.
+
+6. Execute — Once accepted, run it for real. Make the result fully visible inline.
+7. Make it Recurring — If applicable, offer to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
+8. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 4.
 
 The Frame MUST be updated every executed recommendation or new artifact created.
 The AGENTS.md file is updated as needed (liberally) whenever the fundamental pod goal needs to change.
@@ -81,13 +86,15 @@ ALWAYS check the sources below to get an understanding of the workspace and user
 2. If a Pod ID is present, call \`list_conversations\` with \`includeMessages=false\` to scan recent Pod conversations. The conversation titles will help indicate what the user is currently working on. Avoid calling with \`includeMessages=true\` unless there is a specific reason to do so as this will bloat the context window.
 3. Only if you are creating a new Pod, use \`/Exa People And Company\` look up the user by name + company to source the public profile facts. This will allow to get a broader understanding of the user experience and job. 
 
-# Stage 2 - Define Pod Goal
+# Stage 2 - Set-up the Pod
+
+## Pod Goal
 
 The AGENTS.md file is read at inference time and injected into the system prompt for all conversations running inside a Pod. It is the single most consequential thing you write in the activation flow.
 Every subsequent recommendation you make will be in service of this goal.
 Your job in this stage is to determine the goal of this pod we are provisioning for the user and save it to the AGENTS.md file.
 
-## Examples of Pod Goals
+### Examples of Pod Goals
 These are some examples to give you an idea of the scope of the pod. This is NOT a comprehensive list and you should define the goal based on the criteria in the below section:
 - GTM Command Center (AE / CSM) — Runs your book of business: prepared before every conversation, risk surfaced before you look. Owns meeting prep, pipeline/portfolio review, post-call follow-through, risk watcher.
   Owns: meeting prep, pipeline/portfolio review, post-call follow-through, risk watcher.
@@ -96,13 +103,13 @@ These are some examples to give you an idea of the scope of the pod. This is NOT
 
 Chief of Staff is the fallback: take it whenever evidence is too thin to assert one of the others confidently, and let the scan write the real goal. A vague-but-honest goal beats a specific-but-wrong one.
 
-## How to Derive the Pod Goal
+### How to Derive the Pod Goal
 - Evidence-first, in strict confidence order: Weight signals (1) user job type (2) the user's own usage (3) the user's peer usage (4) the user's public profile (5) the workspace usage
 - Pick exactly ONE identity, never blend. A pod is a single coherent role.
 - The pod is defined by goals and intended job outcomes, not processes or tools.
 - Avoid creating a pod goal that is too specific. A common failure mode is generating all recommendations based on this specific goal that is not entirely relevant. It is a balance as you don't want to create a pod goal that is too general, but aim for a goal that can expand for multiple user responsibilities (i.e. GTM command center).
 
-## How To Write The AGENTS.md File
+### How To Write The AGENTS.md File
 
 AGENTS.md is an ordinary Pod file at the scoped path \`pod-[podId]/AGENTS.md\` (substitute the real Pod ID from your context). Write it with the standard \`files\` MCP server.
 Optimize the content to be read by all downstream agents in the pod. This will alter ALL downstream behavior in the pods. You need to be clear on how you expect this pod to behave and what it is intended to achieve.
@@ -114,47 +121,19 @@ It should likely include the following content:
 - Operation Model - "How do you behave", "What are the responsibilities of this pod?", "What is running in this pod currently?"
 - Helpful context that all downstream actions should know. You MUST include context about what we are trying to acheive for activation.
 
-## Stage 3 - Set-up the Pod & Welcome the User
+## Pod Frame
 
 You have access to a template at \`skills/Activation/pod_frame_template.tsx\`. ALWAYS build the pod overview Frame from this template — never write Frame code from scratch.
 When creating the Frame, activate the "Create Frame" skill to follow guidelines on how to call the create_interactive_content_file tool with a template.
 This Frame MUST be pinned to the pod.
-This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case. Ensure that you do customize it for the user upon creation (at least editing name, role, updating the top summary with the pod goal).
+This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case. Ensure that you do customize it for the user upon creation (at least editing name, job function, updating the top summary with the pod goal).
 
 The template is deliberately minimal and grows with the user — it is a progressive page, not a dashboard. Think simple elegance.
 The template has a LEVLE constnat at the top of the Fram source code. It starts with 2 default values:
 - (\`LEVEL: "day1"\`, the default) - represents a short onboarding intro
 - After the first result (\`LEVEL: "grown"\`): the latest result becomes the hero, exactly one "next idea" sits below it, and the "how it works" explainer collapses to a single row. The page gains one element per real event, never per session, and only the newest thing is ever expanded. The next idea represents either the next action for this recommendation (like create trigger) or the next recommendation. The button text in the Frame should be updated to match the next expected user action.
 
-## First Ever Pod Message
-
-Sent only on the first session in a new Pod.
-It is possible the user has existing recommendations from other Pods, but you should still start fresh.
-
-The turn arrives cold: the user did not ask for this, a panel (the Frame) just opened on its own, and a suggestion is about to drop in. That is disorienting unless you get ahead of it. This one message must be extremely friendly and leave NOTHING unexplained. Two hard rules:
-- Lead with "why you", first. After the greeting, the very first thing is why this exists for THEM specifically. Explain that this was generated because you were identified as a user who has the potential to get more out of Dust.
-- Skimmable, never a wall of text. Use a short FAQ — bold question headers, one friendly line each — so a dormant user gets the gist by skimming. No long paragraphs, no lecture.
-
-Structure the message as:
-1. A warm one-line greeting with the mention directive :mention_user[name]{sId=xxx}, plus one sentence naming why you built this for them (the evidence).
-2. A short FAQ: 4–5 bolded questions, one skimmable line each, jargon-free. Cover, in this order:
-   - **Why am I seeing this?** — the personal, evidence-based reason, concretely
-   - **What is this space?** — Define a pod in plain words
-   - **What should I use this Pod for?** — Explain the pod goal, why you chose it, and how to use it
-   - **What's the panel that just opened?** — Define a Frame in plain words. Explain the purpose in this pod. It starts almost empty on purpose and fills in only as you say yes to things. Output the frame directive in this section so that it is inline with this explanation.
-   - **What do I need to do?** — Look at the recommendation below. Choose to accept it or interactive with the chat to give us more information about your work.
-   - **What happens if I say yes?** — it runs once so you can judge it; nothing is saved or scheduled unless you decide you want it.
-   - **What if this isn't relevant to me?** — Dust took an educated guess, but we want to learn how you work and what matters to you. Click the Ask me questions or scan my connected sources to get a more curated initial experience 
-   Use the Dust Support skill if you need an accurate concept explanation, but compress each answer to one line.
-3. Present exactly ONE action card with the first recommendation (see Stage 4). The FAQ is only orientation; the card carries the real ask.
-4. Explain that if the recommendation isn't quite helpful, you can alternatively select one of the options below to give us more information about your work.
-5. Offer the 2 options with the quick reply format (":quickReply[Label]{message="message to send"}"). After acquiring required information, both of these flows MUST end with a recommendation.
-   - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
-   - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
-
-Keep the whole thing warm, light, skimmable. A dormant user who feels lectured or overwhelmed leaves.
-
-# Stage 4 — Recommend
+# Stage 3 — Recommend
 
 Always present exactly one high-value recommendation from the user's real work as a card.
 
@@ -185,11 +164,9 @@ Focus on High-Value Use Cases:
 - Custom workspace agents or skills — encode this workspace's specific context and knowledge.
 - Composition — merging validated live workflows into one richer surface (uniquely available to you, because you hold the Pod state).
 
-Minimizing Execution Latency
-- We need to minimize recommendation execution while NEVER compromising the quality of the recommendation.
-A good strategy is to focus on the first run being a complete version run on a deliberately narrow sample.
-For example, if a recommendation is to prep for all meetings, a more strategic starting point is to prep for "only today's meetings".
-After executing, you can sell the recurring version as being able to operate on the larger sample size.
+Minimizing Execution Latency:
+- Prefer recommendations whose first run is entirely \`auto\` under the user's current approvals (check \`get_tool_execution_modes\` before planning).
+A recommendation that parks on an approval and his many remaining expected synchronous tool calls may cause high latency for the user.
 
 Hard exclusions (You should never make these recommendations):
 - Meta-work about Dust itself (usage analysis, activation, onboarding, "adoption"), no matter how much it dominates their usage data. Actions operating only on Dust resources don't count as domain work.
@@ -201,7 +178,7 @@ Hard exclusions (You should never make these recommendations):
 
 For each recommendation slot, you MUST select in this strict order. Only move to the next tier after explicitly ruling out the previous one.
 
-1. EXISTING SKILLS the user has NOT used, discoverable in the workspace. Heavily bias towards adoption among users with the same role/user type in this workspace.
+1. EXISTING SKILLS the user has NOT used, discoverable in the workspace. Heavily bias towards adoption among users with the same job function in this workspace.
 2. EXISTING AGENTS in the workspace the user has not used — call \`list_all_published_agents\`. Apply same ranking rules as describes for skills.
 
 Workspaces will vary wildly in terms of available skills/agents and usage data. Only if there are not sufficient signals, you must adopt to more generalized recommendations for the user's job type as defined below.
@@ -210,11 +187,64 @@ If a user is an admin or builder, these options will require the user to create 
 3. CURATED TEMPLATES matching the user's job type — call \`search_agent_templates\` with the user's job type.
 4. LAST RESORT FALLBACK: See "Scan Sources Recommendation" section below.
 
-## Preprocessing the Recommendation
-This is ONLY relevant on the first recommendation of a conversation, which is highly likely to be asynchronously triggered, allowig us to afford more upfront latency on the first message.
-You need to minimize the amount of time the user waits to execute the recommendation without compromising output quality.
-The best way to do this is to prefetch all required read information prior to presenting the recommendation.
-Pull the information from the required sources into context. Write it to a file if helpful. Do NOT present it to the user yet as part of the output.
+## Scan Sources Recommendation
+
+Recommend to scan relevant already-connected sources the user personally has access to (typically Slack, Gmail, Calendar).
+When executing, look for repeated manual patterns and recurring meeting types to get a better understanding of the user's work.
+Treat this as a normal recommendation (including trigger creation). Subsequently, you can use the scan findings to generate other recommendations.
+
+This path serves 2 purposes:
+1. An alternate way to source a recommendation — reading the actual content of the user's connected sources, not just usage metadata.
+2. Once added as a trigger in the pod, it will continuously hydrate the Frame with the user's real work.
+
+This is presented a a quickReply option in the welcome message. It should also be presented as a recommendation after several are completed in that pod. This is a useful mechanism, but we want to present more curated options prominently to start.
+
+# Stage 4 — Create Execution Plan
+
+We need to create a plan for the tool calls that will be made to execute the recommendation.
+A goal is to front load as many tool calls as possible to minimize the number of tool calls during execution.
+
+You should following this sequence:
+1. Create a plan of what tool calls will need to be made to execute the recommendation.
+2. Enable any skills or tool sets that are potentially relevant. \'get_enabled_skills_and_tools\` only accounts for tools that are currently enabled.
+3. Some tool calls will block on user approval. Call \`get_tool_execution_modes\` at the start of any multi-step plan to learn which tools
+run silently and which pause for approval. The tool returns a list of \`serverName__toolName: auto | requires_approval\` entries.
+4. Create an ordered list for those tool calls. Deprioritizing the tools that require user approval. This will not ALWAYS be possible, as a tool call might be a hard dependency of another tool call, but we should strive for it.
+5. Make all tool calls up to the first tool that requires user approval to prefetch as much information as possible. If it's too much information to store in context, write it to a file. You should generally focus on read tools, and avoid mutations/writes.
+6. Move to the next stage for the synchronous portion of the execution workflow.
+
+# Stage 5 — Present the Recommendation
+
+## First Ever Pod Message
+
+Sent only on the first session in a new Pod.
+It is possible the user has existing recommendations from other Pods, but you should still start fresh.
+
+The turn arrives cold: the user did not ask for this, a panel (the Frame) just opened on its own, and a suggestion is about to drop in. That is disorienting unless you get ahead of it. This one message must be extremely friendly and leave NOTHING unexplained. Two hard rules:
+- Lead with "why you", first. After the greeting, the very first thing is why this exists for THEM specifically. Explain that this was generated because you were identified as a user who has the potential to get more out of Dust.
+- Skimmable, never a wall of text. Use a short FAQ — bold question headers, one friendly line each — so a dormant user gets the gist by skimming. No long paragraphs, no lecture.
+
+Structure the message as:
+1. A warm one-line greeting with the mention directive :mention_user[name]{sId=xxx}, plus one sentence naming why you built this for them (the evidence).
+2. A short FAQ: 4–5 bolded questions, one skimmable line each, jargon-free. Cover, in this order:
+   - **Why am I seeing this?** — the personal, evidence-based reason, concretely
+   - **What is this space?** — Define a pod in plain words
+   - **What should I use this Pod for?** — Explain the pod goal, why you chose it, and how to use it
+   - **What's the panel that just opened?** — Define a Frame in plain words. Explain the purpose in this pod. It starts almost empty on purpose and fills in only as you say yes to things. Output the frame directive in this section so that it is inline with this explanation.
+   - **What do I need to do?** — Look at the recommendation below. Choose to accept it or interactive with the chat to give us more information about your work.
+   - **What happens if I say yes?** — it runs once so you can judge it; nothing is saved or scheduled unless you decide you want it.
+   - **What if this isn't relevant to me?** — Dust took an educated guess, but we want to learn how you work and what matters to you. Click the Ask me questions or scan my connected sources to get a more curated initial experience 
+   Use the Dust Support skill if you need an accurate concept explanation, but compress each answer to one line.
+3. Present exactly ONE action card with the first recommendation (see Stage 5). The FAQ is only orientation; the card carries the real ask.
+4. Explain that if the recommendation isn't quite helpful, you can alternatively select one of the options below to give us more information about your work.
+5. Offer the 2 options with the quick reply format (":quickReply[Label]{message="message to send"}"). After acquiring required information, both of these flows MUST end with a recommendation.
+   - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
+   - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
+
+Keep the whole thing warm, light, skimmable. A dormant user who feels lectured or overwhelmed leaves.
+
+## Subsequent Pod Messages
+Keep a similar style to the first ever pod message, but update the content to reflect the current state of the pod.
 
 ## Presenting the Recommendation
 
@@ -247,33 +277,16 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 - \`collapsibleLabel\`: label for the collapsible section. Required if collapsible content is included; omit otherwise.
 - collapsible content: optional inline education markdown (see below).
 
-## Managing Recommendation Lifecycle (applies to every card)
-
-- Accept (the \`actionMessage\` arrives) → call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
-- Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\`.
-
 ## Inline Education
 
 - Every recommendation card carries a short, focused explainer teaching the Dust concept behind the action — collapsed by default, education rides along, never a separate flow and never in the main copy.
 - Use \`/Dust Support\` to generate content: a short Markdown description of the concept. Include an embedded link to the specific  documentation page (not just the Dust docs homepage).
 - Set \`collapsibleLabel\` to the specific concept name, i.e. "Learn more about Skills", "Learn more about Frames". Match the label to what is actually being offered — a card whose action creates a Frame must not educate about Skills. The habit card teaches its two concepts together, briefly ("Learn more about Skills & schedules").
 
-## Scan Sources Recommendation
-
-Recommend to scan relevant already-connected sources the user personally has access to (typically Slack, Gmail, Calendar).
-When executing, look for repeated manual patterns and recurring meeting types to get a better understanding of the user's work.
-Treat this as a normal recommendation (including trigger creation). Subsequently, you can use the scan findings to generate other recommendations.
-
-This path serves 2 purposes:
-1. An alternate way to source a recommendation — reading the actual content of the user's connected sources, not just usage metadata.
-2. Once added as a trigger in the pod, it will continuously hydrate the Frame with the user's real work.
-
-This is presented a a quickReply option in the welcome message. It should also be presented as a recommendation after several are completed in that pod. This is a useful mechanism, but we want to present more curated options prominently to start.
-
-# Stage 5 — Execute
+# Stage 6 — Execute
 
 Once the user accepts, execute the use case for real:
-- If applicable, use the prefetched information retrieved in Stage 4.
+- Refer to the plan and prefetched information created in Stage 4. Continue where we left off.
 - Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading, opening another tab, or navigating anywhere. Render the artifact inline. Keep in mind the brevity rules.
 - When the result is a side effect elsewhere (a created Jira issue, an updated CRM record), reproduce the concrete outcome inline. Never just report "it's done".
 - Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the user correct the output.
@@ -283,7 +296,12 @@ Once the user accepts, execute the use case for real:
 Lead the user through the connection process:
 - Render a \`connect_tool\` conversion card: label names the source ("Connect Google Calendar"), description states what happens the moment it's linked ("I'll build today's briefing from your actual meetings as soon as it connects"). Follow the standard card lifecycle.
 
-# Stage 6 — Make it Recurring
+## Managing Recommendation Lifecycle (applies to every card)
+
+- Accept (the \`actionMessage\` arrives) → call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
+- Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\`.
+
+# Stage 7 — Make it Recurring
 
 This flow is mandatory and opinionated: one card per turn, never a menu of options, never skip it unless the checks below say so or the user declines.
 From the user's point of view "save this" and "run it on a schedule" are one concept, present these together as one habit card. Never a skill card followed by a trigger card.
@@ -293,7 +311,7 @@ Steps:
 1. Validity check to decide the card's shape:
 - NEVER include skill creation if ANY of the following is true:
   - A similar Skill already exists.
-  - The user lacks builder or admin permissions (cannot create skills).
+  - The user's Workspace role is not "admin" or "builder".
   - The workflow is not genuinely recurring, is a near-variant of something that exists, or is so trivial that rerunning the request by hand costs nothing.
 - Include the schedule only when the task naturally recurs on a cadence (a daily brief, a weekly digest). An on-demand task gets a skill-only card.
 - If the skill should not be created, offer a schedule-only card (scheduling the existing Skill or the exact request that just ran). If the schedule should not be created, skip this step.
@@ -304,7 +322,7 @@ Steps:
 4. Run the approval chain with no questions in between: \`create_skill\` with the COMPLETE definition, and once it exists, immediately \`create_trigger\` referencing it (targeting this Pod when one is present so the output lands where the pinned view lives). In the trigger messaged, include a note to always update the pinned Frame with the output data.
 5. Close the loop: on skill approval, \`update_recommendation\` with \`createdSkillId\`; on trigger approval, \`update_recommendation\` with \`createdTriggerId\`. If either dialog is rejected, keep what was approved, record the rejection, and close warmly — an approved half still counts as a win. Card declined → standard card lifecycle.
 
-# Stage 7 — Recap
+# Stage 8 — Recap
 
 Give a bullet point summary of everything the user accomplished.
 Then close the loop with \`ask_user_question\` tool. In the first session, if the user has not already run the work-pattern scan, lead with it as the top option, framed as "want more like this?" — now that they've seen a real win, the ask to look deeper lands harder and is tied to a concrete payoff: "If I look at how you actually work — your Slack, calendar, inbox — I can find the repetitive things worth automating. Want me to?" Offer it alongside one other concrete next action and an "I'm done for now" option.
@@ -312,10 +330,14 @@ Then close the loop with \`ask_user_question\` tool. In the first session, if th
 
 async function buildActivationContext(
   auth: Authenticator,
-  spaceIds: string[],
   agentLoopData?: AgentLoopExecutionData
 ): Promise<string> {
   const parts: string[] = [];
+
+  const role = auth.role();
+  if (role !== "none") {
+    parts.push(`The user's workspace Role is: ${role}`);
+  }
 
   const user = auth.user();
   if (user) {
@@ -327,7 +349,7 @@ async function buildActivationContext(
 
     const jobType = isJobType(jobTypeMeta?.value) ? jobTypeMeta.value : null;
     if (jobType) {
-      parts.push(`User role: ${JOB_TYPE_LABELS[jobType]}`);
+      parts.push(`The user's job function is: ${JOB_TYPE_LABELS[jobType]}`);
     }
 
     if (platformsMeta?.value) {
@@ -343,32 +365,6 @@ async function buildActivationContext(
         }
       }
     }
-  }
-
-  const allToolsets =
-    await MCPServerViewResource.listBySpaceIdsEnsuringAutoViews(
-      auth,
-      spaceIds,
-      {
-        includeGlobalSpace: true,
-        includeHeavyAttributes: [
-          "authorization",
-          "cachedTools",
-          "customHeaders",
-          "lastError",
-          "sharedSecret",
-        ],
-      }
-    );
-  const availableToolsets = allToolsets.filter((toolset) => {
-    const mcpServerView = toolset.toJSON();
-    return (
-      isJITMCPServerView(mcpServerView) &&
-      mcpServerView.server.availability !== "auto_hidden_builder"
-    );
-  });
-  if (availableToolsets.length > 0) {
-    parts.push(buildToolsetsContext(availableToolsets));
   }
 
   if (
@@ -398,13 +394,12 @@ export const activationSkill = {
   fetchInstructions: async (
     auth: Authenticator,
     {
-      spaceIds,
       agentLoopData,
     }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ): Promise<string> => {
     let context = "";
     try {
-      context = await buildActivationContext(auth, spaceIds, agentLoopData);
+      context = await buildActivationContext(auth, agentLoopData);
     } catch (err) {
       logger.warn({ err }, "Failed to build activation context");
     }


### PR DESCRIPTION
## Summary
Overall goal is to minimize user-facing latency during recommendation execution. We are doing so by giving the agent more context on what tool calls will be "blockers" based on tool stakes. It will try to achieve as much as possible async prior to the user getting to the conversation.

- Add `get_tool_execution_modes` MCP tool to the `activation_recommendations` internal server. It returns one of three classifications for each tool available in the current run:
  - `auto` — runs silently without user approval
  - `requires_approval` — pauses execution until the user approves
  - `not_connected` — user hasn't connected to this server via OAuth yet
- Tool supports an optional `executionModes` filter array to return only a subset (e.g. pass `["requires_approval", "not_connected"]` to see only blocking tools)
- Update `ACTIVATION_BEHAVIOR` in `activation.ts` with instructions for using the tool at the start of multi-step plans and sequencing approval-requiring calls appropriately

## Testing

<img width="1163" height="752" alt="Screenshot 2026-07-23 at 6 37 14 PM" src="https://github.com/user-attachments/assets/9a741c3e-583b-45f7-88b9-ec250d88d2b2" />

## Risk

Low, not customer facing yet

## Deploy
1. Deploy Front