### PR TITLE
[front] refactor: surface agent loop context asserts in tool handlers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,8 +1,4 @@
-import {
-  type AgentLoopRunContext,
-  isAgentLoopRunContext,
-  type ToolContext,
-} from "@app/lib/actions/types";
+import type { ToolContext } from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,4 +1,8 @@
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -379,41 +383,6 @@ describe("resolveConversationFileRef", () => {
       expect(await result.value.getSignedUrl()).toBe(signedUrl);
     });
 
-    it("does not require toolContext", async () => {
-      const { authenticator: auth } = await createResourceTest({
-        role: "admin",
-      });
-
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      mockFromScopedPath.mockResolvedValue(
-        new Ok({
-          stat: vi
-            .fn()
-            .mockResolvedValue(
-              new Ok({ contentType: "text/plain", sizeBytes: 10 })
-            ),
-          read: vi.fn().mockResolvedValue(new Ok(makeReadableStream("hello"))),
-          getDownloadUrl: vi
-            .fn()
-            .mockResolvedValue(new Ok("https://example.com/url")),
-        })
-      );
-
-      // Pass undefined — should succeed for canonical paths.
-      const result = await resolveConversationFileRef(
-        auth,
-        `conversation-${conversation.sId}/file.txt`,
-        undefined
-      );
-
-      expect(result.isOk()).toBe(true);
-    });
-
     it("returns Err when the file is not found", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
@@ -507,7 +476,7 @@ describe("resolveConversationFileRef", () => {
       useCaseMetadata: { conversationId: conversationA.sId },
     });
 
-    // But toolContext points to conversation B.
+    // But the run context points to conversation B.
     const result = await resolveConversationFileRef(
       auth,
       file.sId,

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,7 +1,4 @@
-import {
-  isAgentLoopRunContext,
-  type ToolContext,
-} from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
   conversationAttachmentId,
@@ -23,7 +20,6 @@ import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
-import assert from "assert";
 import { PassThrough } from "stream";
 
 export function sanitizeFilename(filename: string): string {
@@ -53,10 +49,10 @@ export type ConversationFileRef = {
 export async function resolveConversationFileRef(
   auth: Authenticator,
   fileId: string,
-  toolContext: ToolContext | undefined
+  runContext: AgentLoopRunContext
 ): Promise<Result<ConversationFileRef, string>> {
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
-  // DustFileSystem layer. Resolved directly — no conversation context needed.
+  // DustFileSystem layer are resolved directly.
   if (isCanonicalScopedPath(fileId)) {
     const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
     if (fsResult.isErr()) {
@@ -104,14 +100,9 @@ export async function resolveConversationFileRef(
     });
   }
 
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
-    const conversation = toolContext.runContext.conversation;
+    const conversation = runContext.conversation;
     const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
@@ -126,7 +117,7 @@ export async function resolveConversationFileRef(
     });
   }
 
-  const conversation = toolContext.runContext.conversation;
+  const conversation = runContext.conversation;
   const fileResource = await FileResource.fetchById(auth, fileId);
   if (!fileResource) {
     return new Err(`File resource not found for fileId ${fileId}`);
@@ -161,7 +152,7 @@ export async function resolveConversationFileRef(
 export async function getFileFromConversationAttachment(
   auth: Authenticator,
   fileId: string,
-  toolContext: ToolContext
+  runContext: AgentLoopRunContext
 ): Promise<
   Result<
     {
@@ -172,11 +163,6 @@ export async function getFileFromConversationAttachment(
     string
   >
 > {
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-
   // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) — resolve via DustFileSystem.
   if (isCanonicalScopedPath(fileId)) {
     const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
@@ -217,7 +203,7 @@ export async function getFileFromConversationAttachment(
   // Scoped paths resolve through mount path.
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
-    const conversation = toolContext.runContext.conversation;
+    const conversation = runContext.conversation;
     const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
@@ -237,7 +223,7 @@ export async function getFileFromConversationAttachment(
   }
 
   // Legacy fileId path: scan the conversation to find the attachment.
-  const conversation = toolContext.runContext.conversation;
+  const conversation = runContext.conversation;
   let attachment: ConversationAttachmentType | null = null;
 
   for (const versions of conversation.content) {

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -63,8 +63,7 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     { auth, runContext }
   ) => {
     // This tool actually has 2 modes: you either pass an ID or an URL.
-    // TODO(2026-07-24 aubin): In the branch where we use an ID we need an agent loop context.
-    // Not a true requirement, but requires some work to support sandbox contexts.
+    // We currently only support file IDs in an agent loop context.
     const isInputUrl = validateUrl(file_id_or_url).valid;
     let inputFileRunContext: AgentLoopRunContext | undefined;
     if (!isInputUrl) {

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -62,6 +62,9 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     { file_id_or_url, source_format, output_format },
     { auth, runContext }
   ) => {
+    // This tool actually has 2 modes: you either pass an ID or an URL.
+    // TODO(2026-07-24 aubin): In the branch where we use an ID we need an agent loop context.
+    // Not a true requirement, but requires some work to support sandbox contexts.
     const isInputUrl = validateUrl(file_id_or_url).valid;
     let inputFileRunContext: AgentLoopRunContext | undefined;
     if (!isInputUrl) {

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -5,6 +5,10 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+} from "@app/lib/actions/types";
+import {
   getContentTypeFromOutputFormat,
   isBinaryFormat,
   isValidOutputType,
@@ -19,6 +23,7 @@ import { cacheWithRedis } from "@app/lib/utils/cache";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
+import assert from "assert";
 import ConvertAPI from "convertapi";
 import { marked } from "marked";
 
@@ -57,6 +62,13 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     { file_id_or_url, source_format, output_format },
     { auth, runContext }
   ) => {
+    const isInputUrl = validateUrl(file_id_or_url).valid;
+    let inputFileRunContext: AgentLoopRunContext | undefined;
+    if (!isInputUrl) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      inputFileRunContext = runContext;
+    }
+
     const convertAPIKey = config.getConvertAPIKey();
     const contentType = getContentTypeFromOutputFormat(output_format);
 
@@ -67,10 +79,12 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     // legacy `fil_` id or a canonical scoped path (e.g. `conversation-{id}/x.csv`)
     // as returned by generate_file for text outputs. Resolve it to a signed URL
     // that ConvertAPI can fetch.
-    if (!validateUrl(file_id_or_url).valid) {
-      const refResult = await resolveConversationFileRef(auth, file_id_or_url, {
-        runContext,
-      });
+    if (!isInputUrl && inputFileRunContext) {
+      const refResult = await resolveConversationFileRef(
+        auth,
+        file_id_or_url,
+        inputFileRunContext
+      );
       if (refResult.isErr()) {
         return new Err(
           new MCPError(`File not found: ${file_id_or_url}`, {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -13,6 +13,10 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+} from "@app/lib/actions/types";
 import type {
   GmailMessage,
   MessageDetail,
@@ -259,20 +263,15 @@ async function buildReplyContext(params: {
 
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
-  attachmentFilePath: string | undefined,
-  runContext: ToolHandlerExtra["runContext"]
+  attachmentFilePath: string,
+  runContext: AgentLoopRunContext
 ): Promise<
-  | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
-  | Err<MCPError>
+  Ok<{ buffer: Buffer; filename: string; contentType: string }> | Err<MCPError>
 > {
-  if (!attachmentFilePath) {
-    return new Ok(null);
-  }
-
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    { runContext }
+    runContext
   );
 
   if (fileResult.isErr()) {
@@ -368,6 +367,12 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -397,15 +402,18 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         }
       }
     }
-    const attachmentResult = await fetchAttachment(
-      auth,
-      attachmentFilePath,
-      runContext
-    );
-    if (attachmentResult.isErr()) {
-      return attachmentResult;
+    let attachment = null;
+    if (attachmentFilePath && attachmentRunContext) {
+      const attachmentResult = await fetchAttachment(
+        auth,
+        attachmentFilePath,
+        attachmentRunContext
+      );
+      if (attachmentResult.isErr()) {
+        return attachmentResult;
+      }
+      attachment = attachmentResult.value;
     }
-    const attachment = attachmentResult.value;
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
@@ -981,6 +989,12 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -1009,15 +1023,18 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         }
       }
     }
-    const attachmentResult = await fetchAttachment(
-      auth,
-      attachmentFilePath,
-      runContext
-    );
-    if (attachmentResult.isErr()) {
-      return attachmentResult;
+    let attachment = null;
+    if (attachmentFilePath && attachmentRunContext) {
+      const attachmentResult = await fetchAttachment(
+        auth,
+        attachmentFilePath,
+        attachmentRunContext
+      );
+      if (attachmentResult.isErr()) {
+        return attachmentResult;
+      }
+      attachment = attachmentResult.value;
     }
-    const attachment = attachmentResult.value;
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -367,6 +367,12 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -397,11 +403,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
     let attachment = null;
-    if (attachmentFilePath && isAgentLoopRunContext(runContext)) {
+    if (attachmentFilePath && attachmentRunContext) {
       const attachmentResult = await fetchAttachment(
         auth,
         attachmentFilePath,
-        runContext
+        attachmentRunContext
       );
       if (attachmentResult.isErr()) {
         return attachmentResult;
@@ -983,6 +989,12 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -1012,11 +1024,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
     let attachment = null;
-    if (attachmentFilePath && isAgentLoopRunContext(runContext)) {
+    if (attachmentFilePath && attachmentRunContext) {
       const attachmentResult = await fetchAttachment(
         auth,
         attachmentFilePath,
-        runContext
+        attachmentRunContext
       );
       if (attachmentResult.isErr()) {
         return attachmentResult;

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -266,7 +266,7 @@ async function fetchAttachment(
   attachmentFilePath: string,
   runContext: AgentLoopRunContext
 ): Promise<
-  Ok<{ buffer: Buffer; filename: string; contentType: string }> | Err<MCPError>
+  Result<{ buffer: Buffer; filename: string; contentType: string }, MCPError>
 > {
   const fileResult = await getFileFromConversationAttachment(
     auth,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -367,12 +367,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
-    let attachmentRunContext: AgentLoopRunContext | undefined;
-    if (attachmentFilePath) {
-      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-      attachmentRunContext = runContext;
-    }
-
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -403,11 +397,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
     let attachment = null;
-    if (attachmentFilePath && attachmentRunContext) {
+    if (attachmentFilePath && isAgentLoopRunContext(runContext)) {
       const attachmentResult = await fetchAttachment(
         auth,
         attachmentFilePath,
-        attachmentRunContext
+        runContext
       );
       if (attachmentResult.isErr()) {
         return attachmentResult;
@@ -989,12 +983,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
-    let attachmentRunContext: AgentLoopRunContext | undefined;
-    if (attachmentFilePath) {
-      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-      attachmentRunContext = runContext;
-    }
-
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -1024,11 +1012,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
     let attachment = null;
-    if (attachmentFilePath && attachmentRunContext) {
+    if (attachmentFilePath && isAgentLoopRunContext(runContext)) {
       const attachmentResult = await fetchAttachment(
         auth,
         attachmentFilePath,
-        attachmentRunContext
+        runContext
       );
       if (attachmentResult.isErr()) {
         return attachmentResult;

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -37,6 +37,7 @@ import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { isTextExtractionSupportedContentType } from "@app/types/shared/text_extraction";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 import { Common } from "googleapis";
 import { Readable } from "stream";
 
@@ -1770,6 +1771,8 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { fileId, parentId, fileName },
     { auth, authInfo, runContext }
   ) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
     const folderError = await ensureParentFolderWritable(parentId, authInfo);
     if (folderError) {
       return folderError;
@@ -1780,9 +1783,11 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
 
     try {
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        runContext
+      );
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -393,13 +393,13 @@ async function processSingleImageFile(
     maxImageSize,
     supportedContentTypes,
     providerId,
-    toolContext,
+    runContext,
   }: {
     imageFileId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
-    toolContext: ToolContext | undefined;
+    runContext: AgentLoopRunContext;
   }
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -407,7 +407,7 @@ async function processSingleImageFile(
   const refResult = await resolveConversationFileRef(
     auth,
     imageFileId,
-    toolContext
+    runContext
   );
   if (refResult.isErr()) {
     return new Err(
@@ -462,24 +462,16 @@ export async function processImageFileIds(
   auth: Authenticator,
   {
     imageFileIds,
-    toolContext,
+    runContext,
     supportedContentTypes,
     providerId,
   }: {
     imageFileIds: string[];
-    toolContext: ToolContext | undefined;
+    runContext: AgentLoopRunContext;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
   }
 ): Promise<Ok<ReferenceImageFile[]> | Err<MCPError>> {
-  if (!toolContext?.runContext) {
-    return new Err(
-      new MCPError("No conversation context available for file access", {
-        tracked: false,
-      })
-    );
-  }
-
   const maxImageSize = MAX_FILE_SIZES.image;
 
   const results = await concurrentExecutor(
@@ -490,7 +482,7 @@ export async function processImageFileIds(
         maxImageSize,
         supportedContentTypes,
         providerId,
-        toolContext,
+        runContext,
       }),
     { concurrency: 8 }
   );

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -4,7 +4,11 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import { getImageGenerationLLM } from "@app/lib/api/actions/servers/image_generation/getImageGenerationLLM";
 import {
   checkImageGenerationRateLimit,
@@ -25,6 +29,7 @@ import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { startObservation } from "@langfuse/tracing";
+import assert from "assert";
 
 export function createImageGenerationTools(
   auth: Authenticator,
@@ -35,6 +40,15 @@ export function createImageGenerationTools(
       { prompt, outputName, aspectRatio, referenceImages, quality },
       { sendNotification, _meta }
     ) => {
+      let referenceImagesRunContext: AgentLoopRunContext | undefined;
+      if (referenceImages?.length) {
+        assert(
+          isAgentLoopRunContext(toolContext?.runContext),
+          "AgentLoopRunContext expected"
+        );
+        referenceImagesRunContext = toolContext.runContext;
+      }
+
       const workspace = auth.getNonNullableWorkspace();
 
       await sendImageProgressNotification(
@@ -72,10 +86,10 @@ export function createImageGenerationTools(
 
       let referenceFiles: ReferenceImageFile[] = [];
 
-      if (referenceImages && referenceImages.length > 0) {
+      if (referenceImages && referenceImagesRunContext) {
         const processResult = await processImageFileIds(auth, {
           imageFileIds: referenceImages,
-          toolContext,
+          runContext: referenceImagesRunContext,
           supportedContentTypes: imageGenerationModel.supportedContentTypes,
           providerId,
         });

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -4,6 +4,10 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+} from "@app/lib/actions/types";
+import {
   createComment,
   createIssue,
   createIssueLink,
@@ -36,6 +40,7 @@ import { SEARCH_USERS_MAX_RESULTS } from "@app/lib/api/actions/servers/jira/type
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 
 const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
   get_issue_read_fields: async (_params, { authInfo }) => {
@@ -864,6 +869,12 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { issueKey, attachment },
     { auth, authInfo, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachment.type === "conversation_file") {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     return withAuth({
       action: async (baseUrl, _resourceInfo, accessToken) => {
         let fileToUpload: {
@@ -872,11 +883,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           contentType: string;
         };
 
-        if (attachment.type === "conversation_file") {
+        if (attachment.type === "conversation_file" && attachmentRunContext) {
           const fileResult = await getFileFromConversationAttachment(
             auth,
             attachment.fileId,
-            { runContext }
+            attachmentRunContext
           );
 
           if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -9,6 +9,7 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   downloadAndProcessMicrosoftFile,
   downloadDriveItemAsBuffer,
@@ -23,6 +24,7 @@ import { MICROSOFT_DRIVE_TOOLS_METADATA } from "@app/lib/api/actions/servers/mic
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
+import assert from "assert";
 import { z } from "zod";
 
 const driveChildItemSchema = z.object({
@@ -565,6 +567,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     { fileId, driveId, siteId, parentFolderId, fileName },
     { auth, authInfo, runContext }
   ) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
     const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
@@ -574,9 +578,11 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
     try {
       // Get the file from conversation attachment
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        runContext
+      );
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -20,6 +20,7 @@ import {
 import { getAllowedLabelsForMCPServer } from "@app/lib/api/actions/servers/microsoft/utils";
 import { OUTLOOK_TOOLS_METADATA } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
@@ -33,7 +34,7 @@ async function fetchAttachment(
   attachmentFilePath: string,
   runContext: AgentLoopRunContext
 ): Promise<
-  Ok<{ buffer: Buffer; filename: string; contentType: string }> | Err<MCPError>
+  Result<{ buffer: Buffer; filename: string; contentType: string }, MCPError>
 > {
   const fileResult = await getFileFromConversationAttachment(
     auth,

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -13,11 +13,16 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+} from "@app/lib/actions/types";
 import { getAllowedLabelsForMCPServer } from "@app/lib/api/actions/servers/microsoft/utils";
 import { OUTLOOK_TOOLS_METADATA } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
 import sanitizeHtml from "sanitize-html";
 import { z } from "zod";
 
@@ -25,20 +30,15 @@ const MAX_ATTACHMENT_SIZE_BYTES = 3 * 1024 * 1024; // 3MB — Graph API inline a
 
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
-  attachmentFilePath: string | undefined,
-  runContext: ToolHandlerExtra["runContext"]
+  attachmentFilePath: string,
+  runContext: AgentLoopRunContext
 ): Promise<
-  | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
-  | Err<MCPError>
+  Ok<{ buffer: Buffer; filename: string; contentType: string }> | Err<MCPError>
 > {
-  if (!attachmentFilePath) {
-    return new Ok(null);
-  }
-
   const fileResult = await getFileFromConversationAttachment(
     auth,
     attachmentFilePath,
-    { runContext }
+    runContext
   );
 
   if (fileResult.isErr()) {
@@ -1482,20 +1482,29 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
 
-    const attachmentResult = await fetchAttachment(
-      auth,
-      attachmentFilePath,
-      runContext
-    );
-    if (attachmentResult.isErr()) {
-      return attachmentResult;
+    let attachment = null;
+    if (attachmentFilePath && attachmentRunContext) {
+      const attachmentResult = await fetchAttachment(
+        auth,
+        attachmentFilePath,
+        attachmentRunContext
+      );
+      if (attachmentResult.isErr()) {
+        return attachmentResult;
+      }
+      attachment = attachmentResult.value;
     }
-    const attachment = attachmentResult.value;
 
     const validationError = validateMailParams({
       replyToMessageId,
@@ -1596,6 +1605,12 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     },
     { authInfo, auth, runContext }
   ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (attachmentFilePath) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
+
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -1611,15 +1626,18 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       return validationError;
     }
 
-    const attachmentResult = await fetchAttachment(
-      auth,
-      attachmentFilePath,
-      runContext
-    );
-    if (attachmentResult.isErr()) {
-      return attachmentResult;
+    let attachment = null;
+    if (attachmentFilePath && attachmentRunContext) {
+      const attachmentResult = await fetchAttachment(
+        auth,
+        attachmentFilePath,
+        attachmentRunContext
+      );
+      if (attachmentResult.isErr()) {
+        return attachmentResult;
+      }
+      attachment = attachmentResult.value;
     }
-    const attachment = attachmentResult.value;
 
     const basePath = getMailboxBasePath(sharedMailboxAddress);
 

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
+  type AgentLoopRunContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -759,7 +760,7 @@ export async function executePostMessage(
     to,
     message,
     threadTs,
-    fileId,
+    fileAttachment,
     unfurlLinks,
     unfurlMedia,
     showSentByFooter,
@@ -768,7 +769,9 @@ export async function executePostMessage(
     to: string | string[];
     message: string;
     threadTs: string | undefined;
-    fileId: string | undefined;
+    fileAttachment:
+      | { fileId: string; runContext: AgentLoopRunContext }
+      | undefined;
     unfurlLinks: boolean | undefined;
     unfurlMedia: boolean | undefined;
     showSentByFooter?: boolean;
@@ -809,16 +812,15 @@ export async function executePostMessage(
     message = slackifyMarkdown(originalMessage);
   }
 
-  if (!(await hasSlackScope(accessToken, "files:write"))) {
-    fileId = undefined;
-  }
+  const canUploadFile = await hasSlackScope(accessToken, "files:write");
 
   // If a file is provided, upload it as attachment of the original message.
-  if (fileId) {
+  if (fileAttachment && canUploadFile) {
+    const { fileId, runContext } = fileAttachment;
     const fileResult = await getFileFromConversationAttachment(
       auth,
       fileId,
-      toolContext
+      runContext
     );
     if (fileResult.isErr()) {
       return new Err(

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -4,7 +4,11 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
+import {
+  type AgentLoopRunContext,
+  isAgentLoopRunContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
 import {
   executeListPublicChannels,
   executePostMessage,
@@ -16,6 +20,7 @@ import { SLACK_BOT_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_bot
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 
 export function createSlackBotTools(
   auth: Authenticator,
@@ -35,6 +40,15 @@ export function createSlackBotTools(
       },
       { authInfo }
     ) => {
+      let attachmentRunContext: AgentLoopRunContext | undefined;
+      if (fileId) {
+        assert(
+          isAgentLoopRunContext(toolContext?.runContext),
+          "AgentLoopRunContext expected"
+        );
+        attachmentRunContext = toolContext.runContext;
+      }
+
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
@@ -49,7 +63,10 @@ export function createSlackBotTools(
           to,
           message,
           threadTs,
-          fileId,
+          fileAttachment:
+            fileId && attachmentRunContext
+              ? { fileId, runContext: attachmentRunContext }
+              : undefined,
           unfurlLinks,
           unfurlMedia,
           accessToken,

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -8,6 +8,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
+  type AgentLoopRunContext,
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
@@ -51,6 +52,7 @@ import {
   timeFrameFromNow,
 } from "@app/types/shared/utils/time_frame";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 import uniqBy from "lodash/uniqBy";
 
 const localLogger = logger.child({ module: "mcp_slack_personal" });
@@ -581,6 +583,15 @@ export function createSlackPersonalTools(
       },
       { authInfo }
     ) => {
+      let attachmentRunContext: AgentLoopRunContext | undefined;
+      if (fileId) {
+        assert(
+          isAgentLoopRunContext(toolContext?.runContext),
+          "AgentLoopRunContext expected"
+        );
+        attachmentRunContext = toolContext.runContext;
+      }
+
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
@@ -597,7 +608,10 @@ export function createSlackPersonalTools(
           to,
           message,
           threadTs,
-          fileId,
+          fileAttachment:
+            fileId && attachmentRunContext
+              ? { fileId, runContext: attachmentRunContext }
+              : undefined,
           unfurlLinks,
           unfurlMedia,
           accessToken,

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -54,6 +54,25 @@
 [+]     4  front/lib/api/actions/servers/web_search_browse/tools/index.ts:59
 [+]     1  front/lib/api/mcp/run_tool.ts:91
 
+## MCP servers with partial pod function support
+
+- `file_generation`: `convert_file_format` accepts URLs, but conversation file references still
+  require an agent loop context.
+- `gmail`: draft and send operations work in a pod function context; conversation attachments are
+  only resolved in an agent loop context and are omitted otherwise.
+- `google_drive`: `upload_file` still requires an agent loop context to read a conversation file.
+- `image_generation`: reference-image files still require an agent loop context.
+- `jira`: URL attachments work in a pod function context; conversation file attachments still
+  require an agent loop context.
+- `microsoft_drive`: `upload_file` still requires an agent loop context to read a conversation
+  file.
+- `outlook`: mail operations work in a pod function context without attachments; conversation
+  attachments still require an agent loop context.
+- `slack_bot`: message posting works in a pod function context without a file; conversation file
+  attachments still require an agent loop context.
+- `slack_personal`: message posting works in a pod function context without a file; conversation
+  file attachments still require an agent loop context.
+
 ## notes
 
 Ideally if createServer returns 0 tools we should not expose the server at all. Would be a nice way

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -59,7 +59,7 @@
 - `file_generation`: `convert_file_format` accepts URLs, but conversation file references still
   require an agent loop context.
 - `gmail`: draft and send operations work in a pod function context; conversation attachments are
-  only resolved in an agent loop context and are omitted otherwise.
+  require an agent loop context.
 - `google_drive`: `upload_file` still requires an agent loop context to read a conversation file.
 - `image_generation`: reference-image files still require an agent loop context.
 - `jira`: URL attachments work in a pod function context; conversation file attachments still

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -86,7 +86,7 @@ to dynamically express that a server is not usable.
   - [x] make processToolResults conversation-free
   - [x] make getExitOrPauseEvents conversation-free
 - [x] data_warehouse: flow to tool_outputs if in sandbox function
-- [ ] image_generation: flow to tool_outputs if in sandbox function
+- [x] image_generation: flow to tool_outputs if in sandbox function
 - [x] query_tables_v2: flow to tool_outputs if in sandbox function
 - [ ] interactive_content: allow conversation-less create and publish (big one, flavien has context) 
 - [x] timezone on invocation for:

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -23,20 +23,13 @@
 [-]     1  front/lib/api/actions/servers/helpers.ts:44
            // TODO: sidekick should be removed from list
 
-[~]     1  front/lib/api/actions/servers/data_warehouses/tools/index.ts:262
-           // TODO: end state is a migration of the whole system here but today it relies on table
-                    query. To re-enable likely different path when sandbox function that writes to
-                    the pod tool outputs. Will need to change the tool return (currently returns a
-                    file should now be a path for that flow). See TODOs below.
 [~]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
            // TODO: similar to data_warehouse, we need a specific flow to write to the pod
                     tool_outputs when in sandbox function. See TODOs below.
 [~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
            // We don't know how to create frames directly in pods for now.
            // Create still conversation tied. Will have to skip for now the server.
-[~]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:284
-           // TODO: similar to data_warehouse, relies on generateCSVFileAndSnippet.
-
+[+]     1  front/lib/api/actions/servers/data_warehouses/tools/index.ts:247
 [+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts:169
 [+]     1  front/lib/api/actions/servers/data_sources_file_system/tools/search.ts:55
 [+]     1  front/lib/api/actions/servers/common_utilities/tools/index.ts:100
@@ -52,6 +45,7 @@
            // TODO: create_conversation should have timezone
                     origin defaults to "web" which is fine for now
 [+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
+[+]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:262
 [+]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141
 [+]     2  front/lib/api/actions/servers/search/tools/index.ts:65
 [+]     3  front/lib/api/actions/servers/slack_personal/tools/index.ts:449
@@ -72,12 +66,11 @@ to dynamically express that a server is not usable.
   - [x] make processToolNotification conversation-free
   - [x] make processToolResults conversation-free
   - [x] make getExitOrPauseEvents conversation-free
-- [ ] data_warehouse: flow to tool_outputs if in sandbox function
+- [x] data_warehouse: flow to tool_outputs if in sandbox function
 - [ ] image_generation: flow to tool_outputs if in sandbox function
-- [ ] query_tables_v2: flow to tool_outputs if in sandbox function
-- [ ] interactive_content: allow conversation-less create and publish (big one, flavien has context)
-- [ ] pod_manager: filter add_message_to_conversation tool when in sandbox function 
-- [ ] timezone on invocation for:
+- [x] query_tables_v2: flow to tool_outputs if in sandbox function
+- [ ] interactive_content: allow conversation-less create and publish (big one, flavien has context) 
+- [x] timezone on invocation for:
       - google_calendar
       - pod_manager/create_conversation
 

--- a/x/spolu/tool_context/WORK.md
+++ b/x/spolu/tool_context/WORK.md
@@ -24,8 +24,6 @@
            // TODO: sidekick should be removed from list
 
 [~]     1  front/lib/api/actions/servers/image_generation/helpers.ts:217
-           // TODO: similar to data_warehouse, we need a specific flow to write to the pod
-                    tool_outputs when in sandbox function. See TODOs below.
 [~]     7  front/lib/api/actions/servers/interactive_content/tools/index.ts:52
            // We don't know how to create frames directly in pods for now.
            // Create still conversation tied. Will have to skip for now the server.
@@ -35,15 +33,12 @@
 [+]     1  front/lib/api/actions/servers/common_utilities/tools/index.ts:100
 [+]     3  front/lib/actions/mcp_internal_actions/wrappers.ts:141
 [+]     1  front/lib/api/actions/servers/google_calendar/helpers.ts:176
-           // TODO: user timezone for calendar, once we have it in invocations
 [+]     2  front/lib/api/actions/servers/google_drive/tools/index.ts:300
 [+]     4  front/lib/api/actions/servers/include_data/tools/index.ts:33
 [+]     3  front/lib/api/actions/servers/microsoft_teams/tools/index.ts:532
 [+]     2  front/lib/api/actions/servers/notion/tools/index.ts:118
 [+]     2  front/lib/api/actions/servers/pod_manager/helpers.ts:147
 [+]    11  front/lib/api/actions/servers/pod_manager/tools/index.ts:986
-           // TODO: create_conversation should have timezone
-                    origin defaults to "web" which is fine for now
 [+]     3  front/lib/api/actions/servers/pod_tasks/tools/index.ts:303
 [+]     1  front/lib/api/actions/servers/query_tables_v2/tools/index.ts:262
 [+]     3  front/lib/api/actions/servers/run_dust_app/index.ts:141


### PR DESCRIPTION
## Description

We have some asserts on `AgentLoopRunContext` buried deep down in some utils, making it hard to understand which tools need it vs which ones do not.

We could technically do a massive refactor to TypeScript our way out of this (no assert, no nothing).
This PR starts simple by moving the asserts to the tool handlers, at their very beginning to make them easy to spot.

This PR is a pure refactor to make the next step easier.
Next step is to remove all of these asserts by handling them in the context of a pod function (file paths will refer to paths on the pod in this case).

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
