### PR TITLE
[core] fix: qdrant_reshard watch never stops on transfer inactivity

### DIFF
--- a/core/bin/qdrant/qdrant_reshard.rs
+++ b/core/bin/qdrant/qdrant_reshard.rs
@@ -645,17 +645,6 @@ async fn wait_for_no_resharding(
                 }
                 if !info.shard_transfers.is_empty() {
                     last_transfer_seen = std::time::Instant::now();
-                } else if last_transfer_seen.elapsed() > Duration::from_secs(600) {
-                    // The operation exists but nothing has moved it in 10 minutes: whatever was
-                    // supposed to drive it is not doing so. Stop instead of polling forever; the
-                    // operation stays registered server-side.
-                    return Err(anyhow!(
-                        "[{}] resharding is registered but no shard transfer happened for 10 \
-                         minutes: nothing is driving it. Re-run with --drive to drive it \
-                         (self-hosted/OSS), re-run as-is to resume watching (managed cluster \
-                         mid-cleanup), or cancel with --abort.",
-                        shard_key
-                    ));
                 }
                 let topology = KeyTopology::from_cluster_info(&info, shard_key);
                 let transfers = info
@@ -668,14 +657,20 @@ async fn wait_for_no_resharding(
                     })
                     .collect::<Vec<_>>()
                     .join("; ");
+                // This watch never gives up on its own: the operation belongs to whoever drives
+                // it (the cloud operator on managed clusters) and only a human decides to stop
+                // (ctrl-c, --abort). Transfer inactivity is surfaced as data on the poll line.
                 println!(
                     "[{}] [{}elapsed] resharding: {} | {}{}",
                     shard_key,
                     format_elapsed(started.elapsed()),
                     describe_resharding_ops(ops),
                     topology.describe(),
-                    if transfers.is_empty() {
-                        "".to_string()
+                    if info.shard_transfers.is_empty() {
+                        format!(
+                            " | no transfer for {}",
+                            format_elapsed(last_transfer_seen.elapsed()).trim_end()
+                        )
                     } else {
                         format!(" | transfers: {}", transfers)
                     }


### PR DESCRIPTION
Follow-up to #29363, from the first prod run (EU, `key_6`): the 10-minute no-transfer hard error fired on a managed cluster while the operation was legitimately parked waiting for the cloud operator.

Once an operation is in flight, the watch now never stops on its own — the operation belongs to whoever drives it, and only a human decides to interrupt (ctrl-c, `--abort`). Transfer inactivity is surfaced as data on every poll line instead:

```
[key_6] [0h23m00s elapsed] resharding: up shard 49 on peer … | shard 13 [Active@… 16668324 pts]; … | no transfer for 0h23m00s
```

The case the hard error was protecting against (OSS/self-hosted cluster where nothing will ever drive the operation) is already covered upfront: `--execute` without `--drive` on a non-managed cluster is refused before anything starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)