### PR TITLE
[LLM] Remove use_new_llm_router feature flag

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -267,7 +267,7 @@ export async function getStreamLLM(
     llmParameters
   );
 
-  if (featureFlags.includes("use_new_llm_router") && streamEndpointLLM) {
+  if (streamEndpointLLM) {
     return streamEndpointLLM;
   }
 
@@ -302,7 +302,7 @@ export async function getBatchLLM(
     llmParameters
   );
 
-  if (featureFlags.includes("use_new_llm_router") && batchEndpointLLM) {
+  if (batchEndpointLLM) {
     return batchEndpointLLM;
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -295,10 +295,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Admin Governance: govern skill publication. Shows the skill state (availability) dropdown in the UI, defaults new skills to unpublished (editors-only), and allows unpublishing a skill.",
     stage: "dust_only",
   },
-  use_new_llm_router: {
-    description: "Use the new LLM router for model selection and routing",
-    stage: "dust_only",
-  },
   pod_default_agent: {
     description:
       "Per-pod default agent: pre-select an agent for new conversations started in a project (pod).",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -799,7 +799,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_vertex_for_supported_models"
   | "admin_governance"
   | "admin_governance_skill_publication"
-  | "use_new_llm_router"
   | "live_speech_to_text"
   | "workspace_default_agent"
   | "whitelabel_frames"


### PR DESCRIPTION
## Description

Removes the `use_new_llm_router` feature flag so the new LLM router endpoints are always used when available.

## Tests

Not needed.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`