### PR TITLE
feat(front): expand agent builder model picker inline on mobile

### DIFF
--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -141,7 +141,7 @@ export function AdvancedSettings() {
                     Auto
                     <Chip size="xs" color="highlight" label="Recommended" />
                   </span>
-                  <span className="text-xs font-normal text-muted-foreground">
+                  <span className="whitespace-normal text-xs font-normal text-muted-foreground">
                     Switches model depending on current availability for
                     balanced performance.
                   </span>

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -8,12 +8,18 @@ import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   getModelMaker,
   getModelMakerDisplayName,
 } from "@app/types/assistant/models/providers";
+import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
@@ -21,8 +27,10 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  Icon,
 } from "@dust-tt/sparkle";
 import type React from "react";
+import { Fragment, useState } from "react";
 import { useController } from "react-hook-form";
 
 interface ModelSelectionSubmenuProps {
@@ -90,6 +98,14 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const { hasFeature } = useFeatureFlags();
   const { subscription } = useAuth();
 
+  // On mobile there is no room for flyout submenus, so "Custom model" and each
+  // maker group expand inline within the same dropdown instead.
+  const isMobile = useIsMobile();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [expandedMaker, setExpandedMaker] = useState<ModelMakerIdType | null>(
+    null
+  );
+
   const showRegionalFlag =
     hasFeature("use_vertex_for_supported_models") && !subscription.plan.isByok;
 
@@ -127,117 +143,156 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
     modelConfig.modelId === modelField.value?.modelId &&
     modelConfig.providerId === modelField.value?.providerId;
 
+  const regionalComponentFor = (modelConfig: EnabledModelConfigurationType) =>
+    modelConfig.regionalAvailability[regionInfo.name] && showRegionalFlag ? (
+      <RegionalFlag region={regionInfo.name} />
+    ) : null;
+
+  const renderRadioItem = (
+    modelConfig: EnabledModelConfigurationType,
+    isSelected: boolean
+  ) => (
+    <ModelRadioItem
+      key={getModelKey(modelConfig)}
+      modelConfig={modelConfig}
+      isDark={isDark}
+      isSelected={isSelected}
+      onModelSelection={handleModelSelection}
+      regionalComponent={regionalComponentFor(modelConfig)}
+    />
+  );
+
+  const selectedModelSection = showSelectedModelSection && selectedModel && (
+    <>
+      <DropdownMenuLabel label="Selected model" />
+      <DropdownMenuRadioGroup value={currentModelKey}>
+        {renderRadioItem(selectedModel, true)}
+      </DropdownMenuRadioGroup>
+    </>
+  );
+
+  const bestModelsSection = (
+    <>
+      <DropdownMenuLabel label="Best performing models by providers" />
+      <DropdownMenuRadioGroup value={currentModelKey}>
+        {bestGeneralModels.map((modelConfig) =>
+          renderRadioItem(modelConfig, isModelSelected(modelConfig))
+        )}
+      </DropdownMenuRadioGroup>
+    </>
+  );
+
+  const renderMakerModels = (models: {
+    recent: EnabledModelConfigurationType[];
+    older: EnabledModelConfigurationType[];
+  }) => {
+    const hasRecentModels = models.recent.length > 0;
+    const hasOlderModels = models.older.length > 0;
+    return (
+      <>
+        {hasRecentModels && (
+          <>
+            <DropdownMenuLabel label="Recent models" />
+            <DropdownMenuRadioGroup value={currentModelKey}>
+              {models.recent.map((modelConfig) =>
+                renderRadioItem(modelConfig, isModelSelected(modelConfig))
+              )}
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+        {hasOlderModels && (
+          <>
+            <DropdownMenuLabel
+              label={hasRecentModels ? "Older models" : "All models"}
+            />
+            <DropdownMenuRadioGroup value={currentModelKey}>
+              {models.older.map((modelConfig) =>
+                renderRadioItem(modelConfig, isModelSelected(modelConfig))
+              )}
+            </DropdownMenuRadioGroup>
+          </>
+        )}
+      </>
+    );
+  };
+
+  const selectedModelMaker = selectedModel
+    ? getModelMaker(selectedModel)
+    : null;
+
+  if (isMobile) {
+    return (
+      <>
+        <DropdownMenuItem
+          label="Custom model"
+          endComponent={
+            <Icon visual={isExpanded ? ChevronDown : ChevronRight} size="xs" />
+          }
+          onClick={() => setIsExpanded((v) => !v)}
+          onSelect={(e) => e.preventDefault()}
+        />
+        {isExpanded && (
+          <>
+            {selectedModelSection}
+            {bestModelsSection}
+            <DropdownMenuLabel label="Other models" />
+            {Array.from(makerGroups.entries()).map(([makerId, models]) => (
+              <Fragment key={makerId}>
+                <DropdownMenuItem
+                  label={`From ${getModelMakerDisplayName(makerId)}`}
+                  endComponent={
+                    <div className="flex items-center gap-1">
+                      {selectedModelMaker === makerId && (
+                        <Icon
+                          visual={Check}
+                          size="sm"
+                          className="text-muted-foreground"
+                        />
+                      )}
+                      <Icon
+                        visual={
+                          expandedMaker === makerId ? ChevronDown : ChevronRight
+                        }
+                        size="xs"
+                      />
+                    </div>
+                  }
+                  onClick={() =>
+                    setExpandedMaker((current) =>
+                      current === makerId ? null : makerId
+                    )
+                  }
+                  onSelect={(e) => e.preventDefault()}
+                />
+                {expandedMaker === makerId && renderMakerModels(models)}
+              </Fragment>
+            ))}
+          </>
+        )}
+      </>
+    );
+  }
+
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger label="Custom model" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
-          {showSelectedModelSection && selectedModel && (
-            <>
-              <DropdownMenuLabel label="Selected model" />
-              <DropdownMenuRadioGroup value={currentModelKey}>
-                <ModelRadioItem
-                  key={getModelKey(selectedModel)}
-                  modelConfig={selectedModel}
-                  isDark={isDark}
-                  isSelected={true}
-                  onModelSelection={handleModelSelection}
-                  regionalComponent={
-                    selectedModel.regionalAvailability[regionInfo.name] &&
-                    showRegionalFlag ? (
-                      <RegionalFlag region={regionInfo.name} />
-                    ) : null
-                  }
-                />
-              </DropdownMenuRadioGroup>
-            </>
-          )}
-
-          <DropdownMenuLabel label="Best performing models by providers" />
-          <DropdownMenuRadioGroup value={currentModelKey}>
-            {bestGeneralModels.map((modelConfig) => (
-              <ModelRadioItem
-                key={getModelKey(modelConfig)}
-                modelConfig={modelConfig}
-                isDark={isDark}
-                isSelected={isModelSelected(modelConfig)}
-                onModelSelection={handleModelSelection}
-                regionalComponent={
-                  modelConfig.regionalAvailability[regionInfo.name] &&
-                  showRegionalFlag ? (
-                    <RegionalFlag region={regionInfo.name} />
-                  ) : null
-                }
-              />
-            ))}
-          </DropdownMenuRadioGroup>
-
+          {selectedModelSection}
+          {bestModelsSection}
           <DropdownMenuLabel label="Other models" />
-          {Array.from(makerGroups.entries()).map(([makerId, models]) => {
-            const makerDisplayName = getModelMakerDisplayName(makerId);
-            const hasRecentModels = models.recent.length > 0;
-            const hasOlderModels = models.older.length > 0;
-
-            return (
-              <DropdownMenuSub key={makerId}>
-                <DropdownMenuSubTrigger label={`From ${makerDisplayName}`} />
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent className="w-80">
-                    {hasRecentModels && (
-                      <>
-                        <DropdownMenuLabel label="Recent models" />
-                        <DropdownMenuRadioGroup value={currentModelKey}>
-                          {models.recent.map((modelConfig) => (
-                            <ModelRadioItem
-                              key={getModelKey(modelConfig)}
-                              modelConfig={modelConfig}
-                              isDark={isDark}
-                              isSelected={isModelSelected(modelConfig)}
-                              onModelSelection={handleModelSelection}
-                              regionalComponent={
-                                modelConfig.regionalAvailability[
-                                  regionInfo.name
-                                ] && showRegionalFlag ? (
-                                  <RegionalFlag region={regionInfo.name} />
-                                ) : null
-                              }
-                            />
-                          ))}
-                        </DropdownMenuRadioGroup>
-                      </>
-                    )}
-                    {hasOlderModels && (
-                      <>
-                        <DropdownMenuLabel
-                          label={
-                            hasRecentModels ? "Older models" : "All models"
-                          }
-                        />
-                        <DropdownMenuRadioGroup value={currentModelKey}>
-                          {models.older.map((modelConfig) => (
-                            <ModelRadioItem
-                              key={getModelKey(modelConfig)}
-                              modelConfig={modelConfig}
-                              isDark={isDark}
-                              isSelected={isModelSelected(modelConfig)}
-                              onModelSelection={handleModelSelection}
-                              regionalComponent={
-                                modelConfig.regionalAvailability[
-                                  regionInfo.name
-                                ] && showRegionalFlag ? (
-                                  <RegionalFlag region={regionInfo.name} />
-                                ) : null
-                              }
-                            />
-                          ))}
-                        </DropdownMenuRadioGroup>
-                      </>
-                    )}
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
-            );
-          })}
+          {Array.from(makerGroups.entries()).map(([makerId, models]) => (
+            <DropdownMenuSub key={makerId}>
+              <DropdownMenuSubTrigger
+                label={`From ${getModelMakerDisplayName(makerId)}`}
+              />
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent className="w-80">
+                  {renderMakerModels(models)}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          ))}
         </DropdownMenuSubContent>
       </DropdownMenuPortal>
     </DropdownMenuSub>

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -1,4 +1,5 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   getAvailableReasoningEfforts,
@@ -6,6 +7,9 @@ import {
 } from "@app/types/assistant/models/types";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import {
+  ChevronDown,
+  ChevronRight,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
@@ -13,10 +17,11 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  Icon,
 } from "@dust-tt/sparkle";
 import isEqual from "lodash/isEqual";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useController, useWatch } from "react-hook-form";
 
 const REASONING_EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
@@ -46,6 +51,9 @@ export function ReasoningEffortSubmenu({
   >({
     name: "generationSettings.reasoningEffort",
   });
+
+  const isMobile = useIsMobile();
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const modelConfig = useMemo(
     () =>
@@ -86,23 +94,45 @@ export function ReasoningEffortSubmenu({
     return <></>;
   }
 
+  const effortItems = (
+    <>
+      <DropdownMenuLabel label="Select reasoning effort" />
+      <DropdownMenuRadioGroup value={field.value ?? undefined}>
+        {availableEfforts.map((effort) => (
+          <DropdownMenuRadioItem
+            key={effort}
+            value={effort}
+            label={asDisplayName(effort)}
+            description={REASONING_EFFORT_DESCRIPTIONS[effort]}
+            onClick={() => field.onChange(effort)}
+          />
+        ))}
+      </DropdownMenuRadioGroup>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        <DropdownMenuItem
+          label="Custom reasoning effort"
+          endComponent={
+            <Icon visual={isExpanded ? ChevronDown : ChevronRight} size="xs" />
+          }
+          onClick={() => setIsExpanded((v) => !v)}
+          onSelect={(e) => e.preventDefault()}
+        />
+        {isExpanded && effortItems}
+      </>
+    );
+  }
+
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger label="Custom reasoning effort" />
       <DropdownMenuPortal>
         <DropdownMenuSubContent className="w-80">
-          <DropdownMenuLabel label="Select reasoning effort" />
-          <DropdownMenuRadioGroup value={field.value ?? undefined}>
-            {availableEfforts.map((effort) => (
-              <DropdownMenuRadioItem
-                key={effort}
-                value={effort}
-                label={asDisplayName(effort)}
-                description={REASONING_EFFORT_DESCRIPTIONS[effort]}
-                onClick={() => field.onChange(effort)}
-              />
-            ))}
-          </DropdownMenuRadioGroup>
+          {effortItems}
         </DropdownMenuSubContent>
       </DropdownMenuPortal>
     </DropdownMenuSub>


### PR DESCRIPTION
## Description
Not perfect but will hold the fort until we rework the picker!
<img width="519" height="815" alt="Screenshot 2026-07-24 at 10 09 31" src="https://github.com/user-attachments/assets/728a05ed-a899-450d-aa33-9720c523f94a" />

In the agent builder's **Advanced** dropdown, "Custom model" and "Custom reasoning effort" were rendered as flyout submenus (`DropdownMenuSub`), which are awkward and hard to use on mobile/touch.

On mobile (`useIsMobile()`, viewport < 768px) these now **expand inline within the same dropdown** instead of opening a flyout, mirroring the input-bar model picker's existing `isWidthConstrained` pattern:

- "Custom model" becomes an inline toggle; the selected/best-performing sections render inline, and each maker group ("From …") expands inline with its own state (plus a check mark on the maker holding the current selection).
- "Custom reasoning effort" expands its options inline.
- The shared rendering was refactored into `renderRadioItem` / `bestModelsSection` / `renderMakerModels` so desktop and mobile share one source of truth.

Also let the "Auto" model description wrap (`whitespace-normal`) instead of being clipped by the item's default `whitespace-nowrap`.

Desktop behavior is unchanged (flyout submenus preserved).

## Tests

Manually verified on desktop (submenus unchanged) and at a mobile-width viewport (inline expansion for model + effort, maker groups expand inline, Auto subtitle wraps). `tsgo --noEmit` and biome pass clean.
