### PR TITLE
Refactor: listAttachments now fetch contentfragments directlyy

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -1,7 +1,6 @@
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
@@ -10,12 +9,12 @@ import {
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
 } from "@app/lib/api/sandbox/access_tokens";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
 import aId from "./[aId]";
 import call from "./call";
 
@@ -130,9 +129,8 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   );
 
   // Fetch conversation-jitted servers.
-  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
-  const conversationResult = await getConversation(auth, cId);
-  if (conversationResult.isErr()) {
+  const conversationResource = await ConversationResource.fetchById(auth, cId);
+  if (!conversationResource) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
@@ -141,9 +139,11 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
       },
     });
   }
+  const conversation = conversationResource.toJSON();
 
-  const conversation = conversationResult.value;
-  const attachments = await listAttachments(auth, { conversation });
+  const attachments = await listAttachments(auth, {
+    conversation: conversationResource,
+  });
   const jitServers = await getJITServers(auth, {
     agentConfiguration: agentConfig,
     conversation,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,6 +1,7 @@
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { GetConversationAttachmentsResponseBody } from "@app/types/api/assistant/conversation/attachments";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -22,14 +23,19 @@ app.get(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
+      );
     }
 
     const attachments = await listAttachments(auth, {
-      conversation: conversationRes.value,
+      conversation,
     });
 
     return ctx.json({ attachments });

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -33,7 +33,7 @@ import type {
   ContentNodeAttachmentType,
   ConversationAttachmentType,
 } from "@app/types/api/assistant/conversation/attachments";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type {
   ImageContent,
   TextContent,
@@ -341,7 +341,7 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 async function getFileFromConversation(
   auth: Authenticator,
   fileId: string,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   model: ModelConfigurationType
 ): Promise<
   Result<

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -1,5 +1,11 @@
-import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
+import {
+  fetchContentFragmentsForConversation,
+  getRelatedContentFragments,
+} from "@app/lib/api/assistant/content_fragments";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type {
   ConversationType,
   UserMessageType,
@@ -357,5 +363,111 @@ describe("getRelatedContentFragments", () => {
     expect(result).toHaveLength(1);
     expect(result[0].rank).toBe(4);
     expect(result[0].title).toBe("Fragment 3");
+  });
+});
+
+describe("fetchContentFragmentsForConversation", () => {
+  it("returns latest content fragments ordered by rank", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    await ConversationFactory.createContentFragmentMessage({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      title: "First",
+      fileName: "First",
+    });
+    await ConversationFactory.createContentFragmentMessage({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 2,
+      title: "Second",
+      fileName: "Second",
+    });
+
+    const fragments = await fetchContentFragmentsForConversation(auth, {
+      conversation,
+    });
+
+    expect(fragments).toHaveLength(2);
+    expect(fragments.map((f) => f.title)).toEqual(["First", "Second"]);
+    expect(fragments.every((f) => f.contentFragmentVersion === "latest")).toBe(
+      true
+    );
+  });
+
+  it("respects upToRank", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    await ConversationFactory.createContentFragmentMessage({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      title: "Early",
+      fileName: "Early",
+    });
+    await ConversationFactory.createContentFragmentMessage({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 3,
+      title: "Late",
+      fileName: "Late",
+    });
+
+    const fragments = await fetchContentFragmentsForConversation(auth, {
+      conversation,
+      upToRank: 2,
+    });
+
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0].title).toBe("Early");
+  });
+
+  it("excludes superseded content fragments", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    const message = await ConversationFactory.createContentFragmentMessage({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      title: "Original",
+      fileName: "Original",
+    });
+
+    await ContentFragmentModel.update(
+      { version: "superseded" },
+      {
+        where: {
+          id: message.contentFragmentId!,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const fragments = await fetchContentFragmentsForConversation(auth, {
+      conversation,
+    });
+
+    expect(fragments).toEqual([]);
   });
 });

--- a/front/lib/api/assistant/content_fragments.ts
+++ b/front/lib/api/assistant/content_fragments.ts
@@ -5,11 +5,13 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type {
   ConversationType,
+  ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import { Op, type Transaction } from "sequelize";
+import type { Transaction, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
 
 export function getRelatedContentFragments(
   conversation: ConversationType,
@@ -112,4 +114,62 @@ function collectConsecutivePrecedingContentFragments(
   }
 
   return relatedContentFragments;
+}
+
+/**
+ * Fetch content fragments for a conversation without loading full conversation content.
+ * Returns the latest message version per rank, only fragments with
+ * `contentFragmentVersion === "latest"`, optionally limited to `rank <= upToRank`.
+ * Main branch only (`branchId` null).
+ */
+export async function fetchContentFragmentsForConversation(
+  auth: Authenticator,
+  {
+    conversation,
+    upToRank,
+  }: {
+    conversation: Pick<ConversationWithoutContentType, "id" | "sId">;
+    upToRank?: number;
+  }
+): Promise<ContentFragmentType[]> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const where: WhereOptions<MessageModel> = {
+    conversationId: conversation.id,
+    workspaceId: owner.id,
+    branchId: null,
+    visibility: { [Op.ne]: "deleted" },
+    ...(upToRank !== undefined ? { rank: { [Op.lte]: upToRank } } : {}),
+  };
+
+  const messages = await MessageModel.findAll({
+    where,
+    include: [
+      {
+        model: ContentFragmentModel,
+        as: "contentFragment",
+        required: true,
+        where: {
+          version: "latest",
+        },
+      },
+    ],
+    order: [
+      ["rank", "ASC"],
+      ["version", "DESC"],
+    ],
+  });
+
+  // Keep only the latest message version per rank.
+  const latestPerRank = new Map<number, MessageModel>();
+  for (const m of messages) {
+    if (!latestPerRank.has(m.rank)) {
+      latestPerRank.set(m.rank, m);
+    }
+  }
+
+  return ContentFragmentResource.batchRenderFromMessages(auth, {
+    conversationId: conversation.sId,
+    messages: [...latestPerRank.values()],
+  });
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -37,10 +37,7 @@ import type {
   FileAttachmentType,
 } from "@app/types/api/assistant/conversation/attachments";
 import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
-import type {
-  ConversationType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isFileContentFragment } from "@app/types/content_fragment";
@@ -408,8 +405,8 @@ async function carryOverConversationAttachments(
     childConversation,
     sourceMessageRank,
   }: {
-    parentConversation: ConversationType;
-    childConversation: ConversationType;
+    parentConversation: ConversationWithoutContentType;
+    childConversation: ConversationWithoutContentType;
     sourceMessageRank: number;
   }
 ): Promise<CompactionAttachmentIdReplacements> {

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,5 +1,6 @@
 // Okay to use public API types because here front is talking to core API.
 
+import { fetchContentFragmentsForConversation } from "@app/lib/api/assistant/content_fragments";
 import {
   getAttachmentFromContentFragment,
   makeFileAttachment,
@@ -7,12 +8,12 @@ import {
 import { truncateLegacyPastedSnippet } from "@app/lib/api/files/snippet";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type {
   ContentNodeAttachmentType,
   ConversationAttachmentType,
 } from "@app/types/api/assistant/conversation/attachments";
-import type { ConversationType } from "@app/types/assistant/conversation";
-import { isContentFragmentType } from "@app/types/content_fragment";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
 
@@ -22,41 +23,35 @@ export async function listAttachments(
     conversation,
     upToRank,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType | ConversationResource;
     /** When set, only attachments from messages with `rank <= upToRank` are included. */
     upToRank?: number;
   }
 ): Promise<ConversationAttachmentType[]> {
-  // Using a map to avoid duplicated, order matters, project files should override directly attached files as they could have be moved from conversation to project.
+  // Using a map to avoid duplicated, order matters, project files should override directly
+  // attached files as they could have been moved from conversation to project.
   const attachments: Map<string, ConversationAttachmentType> = new Map();
-  for (const versions of conversation.content) {
-    const m = versions[versions.length - 1];
-    if (upToRank !== undefined && m.rank > upToRank) {
-      continue;
-    }
-    if (isContentFragmentType(m)) {
-      // Only list the latest version of a content fragment.
-      if (m.contentFragmentVersion !== "latest") {
-        continue;
-      }
 
-      const attachment = getAttachmentFromContentFragment(m);
-      if (attachment) {
-        attachments.set(
-          m.contentFragmentId,
-          truncateLegacyPastedSnippet(attachment)
-        );
-      }
-    }
-  }
-
-  // Agent-generated files are fetched independently of conversation.content so trimmed /
-  // paginated conversations still expose the full set of generated attachments.
-  const generatedFiles =
-    await AgentMCPActionResource.listGeneratedFilesForConversation(auth, {
+  const [contentFragments, generatedFiles] = await Promise.all([
+    fetchContentFragmentsForConversation(auth, {
+      conversation,
+      upToRank,
+    }),
+    AgentMCPActionResource.listGeneratedFilesForConversation(auth, {
       conversationId: conversation.id,
       upToRank,
-    });
+    }),
+  ]);
+
+  for (const m of contentFragments) {
+    const attachment = getAttachmentFromContentFragment(m);
+    if (attachment) {
+      attachments.set(
+        m.contentFragmentId,
+        truncateLegacyPastedSnippet(attachment)
+      );
+    }
+  }
 
   for (const f of generatedFiles) {
     attachments.set(


### PR DESCRIPTION
## Description

`listAttachments` previously iterated `conversation.content` to collect content fragments, which breaks for trimmed or paginated conversations (the same class of bug fixed for agent-generated files in PR29444). This PR replaces that walk with `fetchContentFragmentsForConversation`, a direct DB query joining `MessageModel` + `ContentFragmentModel` (main branch only, latest version per rank, optional `upToRank` boundary). Both content fragments and generated files are now fetched in parallel via `Promise.all`.

Callers in the sandbox and attachments routes are migrated from `getConversation` to `ConversationResource.fetchById`. `listAttachments` now accepts `ConversationWithoutContentType | ConversationResource` instead of `ConversationType`, and several other signatures (`carryOverConversationAttachments`, `resolveSkillMCPServers`, `getFileFromConversation`) are widened to `ConversationWithoutContentType`.

## Tests

Added Vitest integration tests for `fetchContentFragmentsForConversation` covering:
- ordered-by-rank, latest-only fetch
- `upToRank` boundary filtering
- exclusion of superseded content fragment versions

Tested locally.

## Risk

Low. Front-only, no DB schema changes. The behavioral change is replacing an in-memory walk of potentially incomplete `conversation.content` with a complete DB query — strictly more correct. Rollback is safe.

## Deploy Plan

Deploy front + front-api together.
