### PR TITLE
build(sandbox): stage protected GCS token broker

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -860,6 +860,8 @@ describe("sandbox egress helpers", () => {
       );
       expect(command).toContain("/usr/sbin/nft delete table ip dust-egress");
       expect(command).toContain("/usr/sbin/nft delete table ip6 dust-egress");
+      expect(command).toContain("/usr/local/bin/dust-gcs-token-firewall.sh");
+      expect(command).toContain("tcp dport 9876 drop");
       expect(sandbox.execRoot).toHaveBeenCalledWith(auth, expect.any(Object));
     });
 

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -446,7 +446,9 @@ export async function ensureSandboxEgressOnExec(
 // (see egress-nftables.sh in the image registry) so agent-proxied traffic
 // flows direct out of the (now permissive) E2B network, instead of being
 // redirected to the local forwarder port that has no listener in this mode.
-// Idempotent: safe to call on every fresh sandbox.
+// Keep the dedicated GCS broker drop in place: that credential boundary must
+// survive dev-unrestricted mode. The legacy rule protects existing sandboxes
+// during the application cutover. Idempotent: safe to call on every fresh sandbox.
 export async function teardownInSandboxEgressRedirect(
   auth: Authenticator,
   sandbox: SandboxResource
@@ -462,8 +464,13 @@ export async function teardownInSandboxEgressRedirect(
   const command = rootCommand.unsafeShell(
     "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service >/dev/null 2>&1 || true; " +
       "/usr/sbin/nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
-      "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true",
-    "dev-only teardown needs best-effort shell fallbacks"
+      "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true; " +
+      "if [ -x /usr/local/bin/dust-gcs-token-firewall.sh ]; then " +
+      "/usr/local/bin/dust-gcs-token-firewall.sh; fi; " +
+      "/usr/sbin/nft add table ip dust-gcs-token-legacy >/dev/null 2>&1 || true; " +
+      "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }' >/dev/null 2>&1 || true; " +
+      `/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid ${EGRESS_PROXIED_UID} ip daddr 127.0.0.0/8 tcp dport 9876 drop >/dev/null 2>&1 || true`,
+    "dev-only teardown needs best-effort shell fallbacks and must retain the GCS broker UID drop"
   );
 
   return runSuccessfulRootCommand(auth, sandbox, command);

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -40,6 +40,9 @@ export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
 export const SANDBOX_ROOT_INVOKED_HELPERS = [
   "/opt/bin/dsbx",
   "/usr/local/bin/dust-install-trust-bundle",
+  "/usr/local/bin/dust-gcs-token-server.py",
+  "/usr/local/bin/dust-gcs-write-token.sh",
+  "/usr/local/bin/dust-gcs-token-firewall.sh",
   // Root invokes litestream on the pod-state pre-sleep sync (`litestream sync
   // -wait`) and cold-start restore, so it must stay root-owned/non-writable.
   "/opt/bin/litestream",

--- a/front/lib/api/sandbox/image/egress/dust-run-dust.tmpfiles
+++ b/front/lib/api/sandbox/image/egress/dust-run-dust.tmpfiles
@@ -1,1 +1,2 @@
 d /run/dust 0755 root root -
+d /run/dust-gcs 0700 root root -

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -3,6 +3,8 @@ set -eu
 
 PROXIED_UID=1003
 DNS_STUB_PORT=1053
+GCS_TOKEN_SERVER_PORT=987
+LEGACY_GCS_TOKEN_SERVER_PORT=9876
 
 # Reinstall a single canonical ruleset on every sandbox boot.
 nft delete table ip dust-egress 2>/dev/null || true
@@ -30,6 +32,10 @@ nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 192.168.
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990
 
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
+# The GCS token broker serves live bearer credentials. Keep the untrusted workload UID out of
+# both the staged root-owned broker and the legacy broker during the application cutover.
+nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
+nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $LEGACY_GCS_TOKEN_SERVER_PORT drop
 # Loopback SSH kill switch: the image masks sshd, this drops uid 1003 to local
 # tcp/22 in case anything restores it. IPv6 ::1:22 is covered by the catch-all
 # ip6 drop below. Relies on the 127.0.0.0/8 return in nat_output above.

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.57",
+      tag: "0.8.58",
     });
   });
 
@@ -167,7 +167,7 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/systemd-analyze unit-paths");
       expect(command).toContain("systemd unit path must be absolute");
       expect(command).toContain(
-        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle /opt/bin/litestream"
+        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle /usr/local/bin/dust-gcs-token-server.py /usr/local/bin/dust-gcs-write-token.sh /usr/local/bin/dust-gcs-token-firewall.sh /opt/bin/litestream"
       );
       expect(command).toContain("empty-password local accounts must not exist");
       expect(command).toContain("privileged primary group");
@@ -280,6 +280,8 @@ describe("sandbox image registry", () => {
 
     expect(nftablesScript).toContain("nft add table ip dust-egress");
     expect(nftablesScript).toContain("DNS_STUB_PORT=1053");
+    expect(nftablesScript).toContain("GCS_TOKEN_SERVER_PORT=987");
+    expect(nftablesScript).toContain("LEGACY_GCS_TOKEN_SERVER_PORT=9876");
     expect(nftablesScript).toContain(
       "nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; policy accept ; }'"
     );
@@ -300,6 +302,12 @@ describe("sandbox image registry", () => {
     );
     expect(nftablesScript).toContain(
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept"
+    );
+    expect(nftablesScript).toContain(
+      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop"
+    );
+    expect(nftablesScript).toContain(
+      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $LEGACY_GCS_TOKEN_SERVER_PORT drop"
     );
     expect(nftablesScript).toContain(
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop"
@@ -326,6 +334,11 @@ describe("sandbox image registry", () => {
     expectContentInOrder(
       nftablesScript,
       "udp dport $DNS_STUB_PORT accept",
+      "tcp dport $GCS_TOKEN_SERVER_PORT drop"
+    );
+    expectContentInOrder(
+      nftablesScript,
+      "tcp dport $GCS_TOKEN_SERVER_PORT drop",
       "tcp dport 22 drop"
     );
     expectContentInOrder(
@@ -335,13 +348,57 @@ describe("sandbox image registry", () => {
     );
   });
 
+  test("stages the root-owned GCS token broker without removing the compatibility broker", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const server = getCopiedContent(
+      copyOperations,
+      "/usr/local/bin/dust-gcs-token-server.py"
+    );
+    const writer = getCopiedContent(
+      copyOperations,
+      "/usr/local/bin/dust-gcs-write-token.sh"
+    );
+    const firewall = getCopiedContent(
+      copyOperations,
+      "/usr/local/bin/dust-gcs-token-firewall.sh"
+    );
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        "apt-get update && apt-get install -y python3",
+        "mkdir -p /usr/local/bin",
+        expect.stringContaining(
+          "tee /home/agent/.bin/token-server.sh > /dev/null"
+        ),
+        expect.stringContaining(
+          "chown root:root /usr/local/bin/dust-gcs-token-server.py /usr/local/bin/dust-gcs-write-token.sh /usr/local/bin/dust-gcs-token-firewall.sh"
+        ),
+      ])
+    );
+    expect(server).toMatch(/^#!\/usr\/bin\/python3$/m);
+    expect(server).toContain('self.path == "/token/mount-0"');
+    expect(server).toContain('self.path == "/healthz"');
+    expect(server).toContain('Server(("127.0.0.1", 987), Handler)');
+    expect(server).not.toContain("/tmp/token.json");
+    expect(writer).toContain("^/run/dust-gcs/mount-[0-9]+\\.json$");
+    expect(writer).toContain("chmod 600");
+    expect(writer).toContain("mv -f");
+    expect(firewall).toContain("dust-gcs-token");
+    expect(firewall).toContain("/usr/bin/flock -x 9");
+    expect(firewall).toContain("meta skuid 1003");
+    expect(firewall).toContain("tcp dport 987 drop");
+    expect(firewall).not.toContain("delete table ip dust-gcs-token");
+  });
+
   test("installs the current dsbx CLI release", () => {
     const runCommands = getRunCommands(getDustBaseImageOperations());
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.36/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.37/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"
@@ -586,7 +643,9 @@ describe("sandbox image registry", () => {
       `export JAVA_TOOL_OPTIONS='${SANDBOX_TRUST_ENV_VARS.JAVA_TOOL_OPTIONS}'\n`
     );
 
-    expect(tmpfilesConfig).toBe("d /run/dust 0755 root root -\n");
+    expect(tmpfilesConfig).toBe(
+      "d /run/dust 0755 root root -\nd /run/dust-gcs 0700 root root -\n"
+    );
     expect(installer).toContain(
       '/usr/bin/openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM'
     );

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.57";
-const DSBX_CLI_VERSION = "0.1.36";
+const DUST_BASE_IMAGE_VERSION = "0.8.58";
+const DSBX_CLI_VERSION = "0.1.37";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -52,6 +52,7 @@ const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
 const LITESTREAM_LOCAL_DIR = path.resolve(__dirname, "litestream");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
+const TOKEN_LOCAL_DIR = path.resolve(__dirname, "token");
 
 interface PythonLibrary {
   name: string;
@@ -304,7 +305,10 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .runCmd(getLocalAccountPrivilegeHardeningCommand(), { user: "root" })
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
   .runCmd(getSshHardeningCommand(), { user: "root" })
-  // Create the token server script. Threaded on purpose: gcsfuse fetches the
+  // Both the compatibility broker and the new root-owned broker require /usr/bin/python3.
+  .runCmd("apt-get update && apt-get install -y python3", { user: "root" })
+  // Keep the legacy token server until the application cutover and kill sweep have completed.
+  // Threaded on purpose: gcsfuse fetches the
   // token on EVERY GCS request (--reuse-token-from-url=false), and a
   // single-connection nc loop drops concurrent fetches (connection reset →
   // gcsfuse retry backoff), starving call-dense consumers like the pod-state
@@ -346,6 +350,29 @@ SHELLEOF`,
     { user: "root" }
   )
   .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
+  // Stage the root-owned per-mount broker used by the application cutover. These helpers live
+  // outside the agent's group-writable home and serve mode-0600 tokens from /run/dust-gcs.
+  .runCmd("mkdir -p /usr/local/bin", { user: "root" })
+  .copy(
+    getLocalContent(TOKEN_LOCAL_DIR, "dust-gcs-token-server.py"),
+    "/usr/local/bin/dust-gcs-token-server.py",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(TOKEN_LOCAL_DIR, "dust-gcs-write-token.sh"),
+    "/usr/local/bin/dust-gcs-write-token.sh",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(TOKEN_LOCAL_DIR, "dust-gcs-token-firewall.sh"),
+    "/usr/local/bin/dust-gcs-token-firewall.sh",
+    { user: "root" }
+  )
+  .runCmd(
+    "chown root:root /usr/local/bin/dust-gcs-token-server.py /usr/local/bin/dust-gcs-write-token.sh /usr/local/bin/dust-gcs-token-firewall.sh && " +
+      "chmod 755 /usr/local/bin/dust-gcs-token-server.py /usr/local/bin/dust-gcs-write-token.sh /usr/local/bin/dust-gcs-token-firewall.sh",
+    { user: "root" }
+  )
   .runCmd(getEgressResolverUserSetupCommand(), { user: "root" })
   .runCmd(getDustStateUserSetupCommand(), { user: "root" })
   .runCmd(getPodStateSetupCommand(), { user: "root" })

--- a/front/lib/api/sandbox/image/token/dust-gcs-token-firewall.sh
+++ b/front/lib/api/sandbox/image/token/dust-gcs-token-firewall.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Keep the root-owned token broker inaccessible to the untrusted workload uid even when
+# dev-unrestricted egress tears down the regular dust-egress nftables table. The lock and
+# existence checks make concurrent lifecycle/mount setup calls converge without a gap.
+/usr/bin/install -d -o root -g root -m 700 /run/dust-gcs
+exec 9>/run/dust-gcs/firewall.lock
+/usr/bin/flock -x 9
+
+if ! /usr/sbin/nft list table ip dust-gcs-token >/dev/null 2>&1; then
+  /usr/sbin/nft add table ip dust-gcs-token
+fi
+if ! /usr/sbin/nft list chain ip dust-gcs-token filter_output >/dev/null 2>&1; then
+  /usr/sbin/nft add chain ip dust-gcs-token filter_output '{ type filter hook output priority 0 ; policy accept ; }'
+fi
+rules="$(/usr/sbin/nft list chain ip dust-gcs-token filter_output 2>/dev/null || true)"
+if ! /usr/bin/grep -Fq 'meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 987 drop' <<<"$rules"; then
+  /usr/sbin/nft add rule ip dust-gcs-token filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 987 drop
+fi

--- a/front/lib/api/sandbox/image/token/dust-gcs-token-server.py
+++ b/front/lib/api/sandbox/image/token/dust-gcs-token-server.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+"""Serve root-owned, per-mount GCS tokens to trusted gcsfuse processes."""
+
+import http.server
+import socketserver
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/healthz":
+            body = b'{"status":"ok"}'
+        elif self.path == "/token/mount-0":
+            token_path = "/run/dust-gcs/mount-0.json"
+            body = self._read_token(token_path)
+        elif self.path == "/token/mount-1":
+            token_path = "/run/dust-gcs/mount-1.json"
+            body = self._read_token(token_path)
+        elif self.path == "/token/mount-2":
+            token_path = "/run/dust-gcs/mount-2.json"
+            body = self._read_token(token_path)
+        elif self.path == "/token/mount-3":
+            token_path = "/run/dust-gcs/mount-3.json"
+            body = self._read_token(token_path)
+        else:
+            self.send_error(404)
+            return
+
+        if body is None:
+            self.send_error(404)
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_token(self, token_path):
+        try:
+            with open(token_path, "rb") as token_file:
+                return token_file.read()
+        except OSError:
+            return None
+
+    def log_message(self, *args):
+        # Token URLs and request metadata must not enter sandbox logs.
+        pass
+
+
+class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+Server(("127.0.0.1", 987), Handler).serve_forever()

--- a/front/lib/api/sandbox/image/token/dust-gcs-write-token.sh
+++ b/front/lib/api/sandbox/image/token/dust-gcs-write-token.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: dust-gcs-write-token.sh PATH" >&2
+  exit 2
+fi
+
+token_path="$1"
+token_directory="$(/usr/bin/dirname -- "$token_path")"
+
+if [[ ! "$token_path" =~ ^/run/dust-gcs/mount-[0-9]+\.json$ ]]; then
+  echo "token path must be a mount token under /run/dust-gcs" >&2
+  exit 2
+fi
+
+/usr/bin/install -d -o root -g root -m 700 "$token_directory"
+umask 077
+temporary_path="$(/usr/bin/mktemp "$token_directory/.token.XXXXXX")"
+cleanup() {
+  /usr/bin/rm -f -- "$temporary_path"
+}
+trap cleanup EXIT
+
+/usr/bin/cat >"$temporary_path"
+/usr/bin/chown root:root "$temporary_path"
+/usr/bin/chmod 600 "$temporary_path"
+/usr/bin/mv -f -- "$temporary_path" "$token_path"
+trap - EXIT

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -147,7 +147,7 @@ describe("sandbox security check assertions", () => {
   test("detects unsafe root-invoked helper ownership or modes", () => {
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-token-server.py root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-write-token.sh root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-token-firewall.sh root:root 755 -rwxr-xr-x\n/opt/bin/litestream root:root 755 -rwxr-xr-x"
       )
     ).not.toThrow();
     expect(() =>
@@ -164,7 +164,7 @@ describe("sandbox security check assertions", () => {
     );
     expect(() =>
       assertRootInvokedHelpersSafe(
-        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-token-server.py root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-write-token.sh root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-gcs-token-firewall.sh root:root 755 -rwxr-xr-x"
       )
     ).toThrow("missing root-invoked helper audit for /opt/bin/litestream");
   });


### PR DESCRIPTION
## Description

Stage the root-owned per-mount GCS token broker, atomic token writer, dedicated nftables boundary, and explicit Python runtime in dust-base. Keep the existing broker installed so the current application remains compatible until #29371 deploys and the sandbox kill sweep completes.

The dev-unrestricted teardown now restores both the new broker firewall and the legacy port 9876 drop.

## Tests

Added image and security coverage for helper ownership, token file modes, the Python interpreter, both broker ports, and compatibility broker retention.

## Risk

Image-only rollout foundation. Existing application behavior is retained. Roll back by publishing the previous dust-base and dsbx versions.

## Deploy Plan

1. Publish dust-base `0.8.58` and dsbx `0.1.37`.
2. Merge and deploy #29371 after the new image is available.
3. Run the sandbox kill sweep as documented in #29371.
