### PR TITLE
chore(sandbox): remove legacy GCS token broker

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -235,10 +235,9 @@ describe("GCS credential lifecycle", () => {
     expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
   });
 
-  test("refreshes both firewall generations in one root exec", async () => {
+  test("refreshes the broker firewall before writing tokens", async () => {
     const sandbox = {
       sId: "sandbox-id",
-      exec: vi.fn(),
       execRoot: vi.fn().mockResolvedValue(successfulExec()),
       requestKill: vi.fn(),
     };
@@ -253,40 +252,23 @@ describe("GCS credential lifecycle", () => {
     expect(result.isOk()).toBe(true);
     expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
     const firewallCommand = getRootCommandCall(sandbox.execRoot, 0);
-    expect(firewallCommand).toContain("dust-gcs-token-legacy");
-    expect(firewallCommand).toContain(
-      "/usr/local/bin/dust-gcs-token-firewall.sh"
-    );
-    expect(spawnSync("/bin/bash", ["-n", "-c", firewallCommand]).status).toBe(
-      0
-    );
-    expect(sandbox.exec).not.toHaveBeenCalled();
+    expect(firewallCommand).toBe("/usr/local/bin/dust-gcs-token-firewall.sh");
     expect(sandbox.requestKill).not.toHaveBeenCalled();
   });
 
-  test("refreshes the legacy token before recreating an old-image sandbox", async () => {
+  test("requests recreation when the image firewall helper is unavailable", async () => {
     const sandbox = {
       sId: "sandbox-id",
-      exec: vi.fn().mockResolvedValue(successfulExec()),
       execRoot: vi.fn().mockResolvedValue(
         new Ok({
           exitCode: 127,
           stdout: "",
-          stderr: "dust-gcs-current-firewall-failed",
+          stderr: "helper not found",
         })
       ),
       requestKill: vi.fn().mockResolvedValue(undefined),
     };
-    const targets = [
-      workloadTarget(),
-      workloadTarget({
-        gcsPrefix: "w/ws1/pods/spc1/state",
-        sandboxMountPoint: "/pod-state/replica",
-        legacySandboxMountPoint: null,
-        mountProfile: "pod_state_replica",
-      }),
-    ];
-    const adapter = new GCSSandboxMountAdapter("bucket-x", targets);
+    const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
     const result = await adapter.refreshCredential(
       auth,
@@ -294,33 +276,15 @@ describe("GCS credential lifecycle", () => {
       image
     );
 
-    expect(result.isOk()).toBe(true);
+    expect(result.isErr()).toBe(true);
     expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
-    expect(mockMintDownscopedGcsToken).toHaveBeenCalledWith({
-      bucket: "bucket-x",
-      prefixes: targets.map((target) => ({
-        prefix: target.gcsPrefix,
-        readOnly: target.readOnly,
-      })),
-    });
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      auth,
-      "/usr/bin/tee /tmp/token.json >/dev/null",
-      {
-        stdin: JSON.stringify({
-          access_token: "token",
-          token_type: "Bearer",
-          expires_in: 3600,
-        }),
-      }
-    );
+    expect(mockMintDownscopedGcsToken).not.toHaveBeenCalled();
     expect(sandbox.requestKill).toHaveBeenCalledTimes(1);
   });
 
   test("does not recreate a sandbox after a transient firewall exec error", async () => {
     const sandbox = {
       sId: "sandbox-id",
-      exec: vi.fn(),
       execRoot: vi
         .fn()
         .mockResolvedValue(new Err(new Error("transient E2B error"))),
@@ -336,7 +300,6 @@ describe("GCS credential lifecycle", () => {
 
     expect(result.isErr()).toBe(true);
     expect(mockMintDownscopedGcsToken).not.toHaveBeenCalled();
-    expect(sandbox.exec).not.toHaveBeenCalled();
     expect(sandbox.requestKill).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -26,10 +26,6 @@ const TOKEN_DIRECTORY = "/run/dust-gcs";
 const TOKEN_SERVER_PATH = "/usr/local/bin/dust-gcs-token-server.py";
 const TOKEN_WRITER_PATH = "/usr/local/bin/dust-gcs-write-token.sh";
 const TOKEN_FIREWALL_PATH = "/usr/local/bin/dust-gcs-token-firewall.sh";
-const LEGACY_TOKEN_PATH = "/tmp/token.json";
-const LEGACY_TOKEN_FIREWALL_FAILURE_MARKER = "dust-gcs-legacy-firewall-failed";
-const CURRENT_TOKEN_FIREWALL_FAILURE_MARKER =
-  "dust-gcs-current-firewall-failed";
 const TOKEN_SERVER_POLL_ATTEMPTS = 100;
 const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
 const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
@@ -332,22 +328,12 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       return new Ok(undefined);
     }
 
-    // Re-establish both broker UID drops in one sandbox round-trip before replacing any token
-    // files. This protects old 9876 servers during the image rollout and closes the wake window
-    // where systemd/nftables state may have been reset before the lifecycle egress check runs.
-    const firewallResult = await ensureTokenFirewalls(auth, sandbox);
+    // Re-establish the dedicated broker UID drop before replacing any token files. This closes
+    // the wake window where systemd/nftables state may have been reset before the lifecycle
+    // egress check runs.
+    const firewallResult = await ensureTokenFirewall(auth, sandbox);
     if (firewallResult.isErr()) {
       if (firewallResult.error instanceof GCSMountImageHelperUnavailableError) {
-        if (firewallResult.error.helperPath === TOKEN_FIREWALL_PATH) {
-          const legacyRefreshResult = await mintAndWriteLegacyToken({
-            auth,
-            sandbox,
-            bucket: this.bucket,
-            targets: this.targets,
-          });
-          await sandbox.requestKill();
-          return legacyRefreshResult;
-        }
         await sandbox.requestKill();
       }
       return firewallResult;
@@ -372,16 +358,9 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       if (writeError.error instanceof GCSMountTokenWriterUnavailableError) {
         logger.warn(
           { sandboxId: sandbox.sId, error: writeError.error },
-          "GCS token writer is unavailable; refreshing the legacy token and requesting sandbox recreation"
+          "GCS token writer is unavailable; requesting sandbox recreation"
         );
-        const legacyRefreshResult = await mintAndWriteLegacyToken({
-          auth,
-          sandbox,
-          bucket: this.bucket,
-          targets: this.targets,
-        });
         await sandbox.requestKill();
-        return legacyRefreshResult;
       }
       return writeError;
     }
@@ -565,112 +544,29 @@ async function mintAndWriteToken({
   return new Ok(undefined);
 }
 
-async function mintAndWriteLegacyToken({
-  auth,
-  sandbox,
-  bucket,
-  targets,
-}: {
-  auth: Authenticator;
-  sandbox: SandboxResource;
-  bucket: string;
-  targets: ReadonlyArray<GCSMountTarget>;
-}): Promise<Result<void, Error>> {
-  const tokenResult = await traceSandboxStartupPhase(
-    "gcs.mint_token",
-    () =>
-      mintDownscopedGcsToken({
-        bucket,
-        prefixes: targets.map((target) => ({
-          prefix: target.gcsPrefix,
-          readOnly: target.readOnly,
-        })),
-      }),
-    { credential_format: "legacy" }
-  );
-  if (tokenResult.isErr()) {
-    return tokenResult;
-  }
-
-  // Old images serve this file from the already-running agent-owned broker on port 9876. Keep
-  // this compatibility write for one image rollout so a pod's pre-destroy litestream flush can
-  // complete before the requested recreation.
-  const writeResult = await sandbox.exec(
-    auth,
-    `/usr/bin/tee ${LEGACY_TOKEN_PATH} >/dev/null`,
-    { stdin: buildTokenJson(tokenResult.value) }
-  );
-  if (writeResult.isErr()) {
-    return writeResult;
-  }
-  if (writeResult.value.exitCode !== 0) {
-    return new Err(
-      new Error(
-        `Legacy GCS token write failed: ${writeResult.value.stderr || writeResult.value.stdout}`
-      )
-    );
-  }
-
-  logger.warn(
-    {
-      sandboxId: sandbox.sId,
-      prefixes: targets.map((target) => target.gcsPrefix),
-    },
-    "GCS sandbox mount: refreshed legacy credential before sandbox recreation"
-  );
-
-  return new Ok(undefined);
-}
-
-async function ensureTokenFirewalls(
+async function ensureTokenFirewall(
   auth: Authenticator,
   sandbox: SandboxResource
 ): Promise<Result<void, Error>> {
   const result = await sandbox.execRoot(
     auth,
-    rootCommand.unsafeShell(
-      "install_legacy_firewall() { " +
-        "if ! /usr/sbin/nft list table ip dust-gcs-token-legacy >/dev/null 2>&1; then " +
-        "/usr/sbin/nft add table ip dust-gcs-token-legacy || return $?; fi; " +
-        "if ! /usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output >/dev/null 2>&1; then " +
-        "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }' || return $?; fi; " +
-        "legacy_rules=$(/usr/sbin/nft list chain ip dust-gcs-token-legacy filter_output 2>/dev/null || true); " +
-        "if ! /usr/bin/grep -Fq 'meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop' <<<\"$legacy_rules\"; then " +
-        "/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 9876 drop || return $?; fi; " +
-        "return 0; }; " +
-        "install_legacy_firewall; legacy_firewall_exit=$?; " +
-        "if [ $legacy_firewall_exit -ne 0 ]; then " +
-        `/usr/bin/printf '${LEGACY_TOKEN_FIREWALL_FAILURE_MARKER}\\n' >&2; ` +
-        "exit $legacy_firewall_exit; fi; " +
-        `${TOKEN_FIREWALL_PATH}; current_firewall_exit=$?; ` +
-        "if [ $current_firewall_exit -ne 0 ]; then " +
-        `/usr/bin/printf '${CURRENT_TOKEN_FIREWALL_FAILURE_MARKER}\\n' >&2; ` +
-        "fi; exit $current_firewall_exit",
-      "Protect legacy and current GCS token brokers during image rollout"
-    )
+    rootCommand.exec(TOKEN_FIREWALL_PATH)
   );
   if (result.isErr()) {
     return result;
   }
   if (result.value.exitCode === 126 || result.value.exitCode === 127) {
-    const helperPath = result.value.stderr.includes(
-      LEGACY_TOKEN_FIREWALL_FAILURE_MARKER
-    )
-      ? "/usr/sbin/nft"
-      : TOKEN_FIREWALL_PATH;
     return new Err(
-      new GCSMountImageHelperUnavailableError(helperPath, result.value.exitCode)
+      new GCSMountImageHelperUnavailableError(
+        TOKEN_FIREWALL_PATH,
+        result.value.exitCode
+      )
     );
   }
   if (result.value.exitCode !== 0) {
-    const firewall = result.value.stderr.includes(
-      CURRENT_TOKEN_FIREWALL_FAILURE_MARKER
-    )
-      ? "Current"
-      : "Legacy";
     return new Err(
       new Error(
-        `${firewall} GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
+        `GCS token firewall setup failed: ${result.value.stderr || result.value.stdout}`
       )
     );
   }

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -861,7 +861,7 @@ describe("sandbox egress helpers", () => {
       expect(command).toContain("/usr/sbin/nft delete table ip dust-egress");
       expect(command).toContain("/usr/sbin/nft delete table ip6 dust-egress");
       expect(command).toContain("/usr/local/bin/dust-gcs-token-firewall.sh");
-      expect(command).toContain("tcp dport 9876 drop");
+      expect(command).not.toContain("tcp dport 9876 drop");
       expect(sandbox.execRoot).toHaveBeenCalledWith(auth, expect.any(Object));
     });
 

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -447,8 +447,7 @@ export async function ensureSandboxEgressOnExec(
 // flows direct out of the (now permissive) E2B network, instead of being
 // redirected to the local forwarder port that has no listener in this mode.
 // Keep the dedicated GCS broker drop in place: that credential boundary must
-// survive dev-unrestricted mode. The legacy rule protects existing sandboxes
-// during the application cutover. Idempotent: safe to call on every fresh sandbox.
+// survive dev-unrestricted mode. Idempotent: safe to call on every fresh sandbox.
 export async function teardownInSandboxEgressRedirect(
   auth: Authenticator,
   sandbox: SandboxResource
@@ -465,11 +464,7 @@ export async function teardownInSandboxEgressRedirect(
     "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service >/dev/null 2>&1 || true; " +
       "/usr/sbin/nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
       "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true; " +
-      "if [ -x /usr/local/bin/dust-gcs-token-firewall.sh ]; then " +
-      "/usr/local/bin/dust-gcs-token-firewall.sh; fi; " +
-      "/usr/sbin/nft add table ip dust-gcs-token-legacy >/dev/null 2>&1 || true; " +
-      "/usr/sbin/nft add chain ip dust-gcs-token-legacy filter_output '{ type filter hook output priority 0 ; policy accept ; }' >/dev/null 2>&1 || true; " +
-      `/usr/sbin/nft add rule ip dust-gcs-token-legacy filter_output meta skuid ${EGRESS_PROXIED_UID} ip daddr 127.0.0.0/8 tcp dport 9876 drop >/dev/null 2>&1 || true`,
+      "/usr/local/bin/dust-gcs-token-firewall.sh",
     "dev-only teardown needs best-effort shell fallbacks and must retain the GCS broker UID drop"
   );
 

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -4,7 +4,6 @@ set -eu
 PROXIED_UID=1003
 DNS_STUB_PORT=1053
 GCS_TOKEN_SERVER_PORT=987
-LEGACY_GCS_TOKEN_SERVER_PORT=9876
 
 # Reinstall a single canonical ruleset on every sandbox boot.
 nft delete table ip dust-egress 2>/dev/null || true
@@ -32,10 +31,8 @@ nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 192.168.
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990
 
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
-# The GCS token broker serves live bearer credentials. Keep the untrusted workload UID out of
-# both the staged root-owned broker and the legacy broker during the application cutover.
+# The GCS token broker serves live bearer credentials. Keep the untrusted workload UID out.
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop
-nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $LEGACY_GCS_TOKEN_SERVER_PORT drop
 # Loopback SSH kill switch: the image masks sshd, this drops uid 1003 to local
 # tcp/22 in case anything restores it. IPv6 ::1:22 is covered by the catch-all
 # ip6 drop below. Relies on the 127.0.0.0/8 return in nat_output above.

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.58",
+      tag: "0.8.59",
     });
   });
 
@@ -281,7 +281,6 @@ describe("sandbox image registry", () => {
     expect(nftablesScript).toContain("nft add table ip dust-egress");
     expect(nftablesScript).toContain("DNS_STUB_PORT=1053");
     expect(nftablesScript).toContain("GCS_TOKEN_SERVER_PORT=987");
-    expect(nftablesScript).toContain("LEGACY_GCS_TOKEN_SERVER_PORT=9876");
     expect(nftablesScript).toContain(
       "nft add chain ip dust-egress nat_output '{ type nat hook output priority -100 ; policy accept ; }'"
     );
@@ -305,9 +304,6 @@ describe("sandbox image registry", () => {
     );
     expect(nftablesScript).toContain(
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $GCS_TOKEN_SERVER_PORT drop"
-    );
-    expect(nftablesScript).toContain(
-      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport $LEGACY_GCS_TOKEN_SERVER_PORT drop"
     );
     expect(nftablesScript).toContain(
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop"
@@ -348,7 +344,7 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("stages the root-owned GCS token broker without removing the compatibility broker", () => {
+  test("installs the root-owned GCS token broker without the compatibility broker", () => {
     const operations = getDustBaseImageOperations();
     const runCommands = getRunCommands(operations);
     const copyOperations = getCopyOperations(operations);
@@ -370,12 +366,12 @@ describe("sandbox image registry", () => {
         "apt-get update && apt-get install -y python3",
         "mkdir -p /usr/local/bin",
         expect.stringContaining(
-          "tee /home/agent/.bin/token-server.sh > /dev/null"
-        ),
-        expect.stringContaining(
           "chown root:root /usr/local/bin/dust-gcs-token-server.py /usr/local/bin/dust-gcs-write-token.sh /usr/local/bin/dust-gcs-token-firewall.sh"
         ),
       ])
+    );
+    expect(runCommands.join("\n")).not.toContain(
+      "/home/agent/.bin/token-server.sh"
     );
     expect(server).toMatch(/^#!\/usr\/bin\/python3$/m);
     expect(server).toContain('self.path == "/token/mount-0"');
@@ -398,7 +394,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.37/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.38/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.58";
-const DSBX_CLI_VERSION = "0.1.37";
+const DUST_BASE_IMAGE_VERSION = "0.8.59";
+const DSBX_CLI_VERSION = "0.1.38";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -305,53 +305,10 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .runCmd(getLocalAccountPrivilegeHardeningCommand(), { user: "root" })
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
   .runCmd(getSshHardeningCommand(), { user: "root" })
-  // Both the compatibility broker and the new root-owned broker require /usr/bin/python3.
+  // The root-owned token broker requires /usr/bin/python3.
   .runCmd("apt-get update && apt-get install -y python3", { user: "root" })
-  // Keep the legacy token server until the application cutover and kill sweep have completed.
-  // Threaded on purpose: gcsfuse fetches the
-  // token on EVERY GCS request (--reuse-token-from-url=false), and a
-  // single-connection nc loop drops concurrent fetches (connection reset →
-  // gcsfuse retry backoff), starving call-dense consumers like the pod-state
-  // litestream restore.
-  .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
-  // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.
-  .runCmd(
-    `tee /home/agent/.bin/token-server.sh > /dev/null << 'SHELLEOF'
-#!/bin/bash
-exec python3 - << 'PYEOF'
-import http.server
-import socketserver
-
-
-class Handler(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        try:
-            body = open("/tmp/token.json", "rb").read()
-        except OSError:
-            body = b"{}"
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, *args):
-        pass
-
-
-class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
-    daemon_threads = True
-    allow_reuse_address = True
-
-
-Server(("127.0.0.1", 9876), Handler).serve_forever()
-PYEOF
-SHELLEOF`,
-    { user: "root" }
-  )
-  .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
-  // Stage the root-owned per-mount broker used by the application cutover. These helpers live
-  // outside the agent's group-writable home and serve mode-0600 tokens from /run/dust-gcs.
+  // The per-mount broker helpers live outside the agent's group-writable home and serve
+  // mode-0600 tokens from /run/dust-gcs.
   .runCmd("mkdir -p /usr/local/bin", { user: "root" })
   .copy(
     getLocalContent(TOKEN_LOCAL_DIR, "dust-gcs-token-server.py"),

--- a/front/lib/api/sandbox/image/scripts/token-server.sh
+++ b/front/lib/api/sandbox/image/scripts/token-server.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-while true; do
-  (echo -ne "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: $(stat -c %s /tmp/token.json 2>/dev/null || echo 0)\r\n\r\n"; cat /tmp/token.json 2>/dev/null) | nc -l -p 9876 -q 1
-done


### PR DESCRIPTION
## Description

Remove the one-release `/tmp/token.json` fallback, port 9876 firewall rules, and compatibility token server after the protected broker rollout is complete. Refresh then requires the root-owned image helpers and only requests recreation when those helpers are unavailable.

Draft only. Do not merge until #29447 and #29371 are deployed and the old-image kill sweep has completed.

## Tests

Updated refresh, image registry, and egress coverage to verify the compatibility broker and legacy port are gone.

## Risk

High if merged early: old-image pod sandboxes would lose the credential refresh needed for their pre-destroy flush. Keep this draft until no pre-cutover sandboxes remain.

## Deploy Plan

1. Complete the deploy and kill sweep from #29447 and #29371.
2. Confirm no pre-cutover sandbox images remain and recheck the proposed image versions.
3. Publish dust-base `0.8.59` and dsbx `0.1.38`.
4. Deploy this application change, then sweep dust-base `0.8.58` sandboxes.
