### PR TITLE
Add cached query and mutation hooks for Frame Pod Functions

### DIFF
--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -170,29 +170,60 @@ return inline is written to a pod file whose path it reports), and \`${toolName(
 
 #### Calling a function from a Frame
 
-A Frame calls a published function through the injected \`@dust/react-hooks\` module, not the
-\`call\` tool. Unlike \`call\`/\`get\`/\`list\`/\`publish\`, which take the bare slug because they
-already operate within the current Pod, a Frame has no implicit Pod context and must address the
-function by its fully qualified slug: \`<podId>/<slug>\`, where \`podId\` is the same id that appears
-in Pod file paths as \`pod-<podId>/...\`, with the \`pod-\` prefix dropped. Neither the bare slug nor
-the mount-path form \`pod-<podId>/<slug>\` resolves from a Frame.
+A Frame calls published functions through the injected \`@dust/react-hooks\` module, not the
+\`call\` tool. Always pass the fully qualified \`<podId>/<slug>\` reference reported by
+\`${toolName("get")}\`. Never pass a bare slug or infer the function from the Frame's current Pod.
+This keeps the reference stable if the Frame is moved.
 
-\`\`\`ts
-import { callFunction } from "@dust/react-hooks";
+Use \`usePodFunction\` for idempotent reads. It caches identical calls, deduplicates calls already
+in flight, and keeps previous data visible while revalidating. Pass \`null\` as the reference to
+disable the query.
 
-const output = await callFunction("<podId>/<slug>", input);
+\`\`\`tsx
+import { usePodFunction } from "@dust/react-hooks"
+
+const { data, error, isLoading, isValidating, mutate } = usePodFunction(
+  "<podId>/list-comments",
+  { threadId }
+)
 \`\`\`
 
-\`input\` must match the function's declared input schema (see \`get\`). The promise resolves to
-the parsed and validated \`schema.output\`. It rejects with a \`SandboxFunctionCallError\` (also
-exported by \`@dust/react-hooks\`) carrying a \`message\`, an optional HTTP \`status\`, and a
-\`code\`; render loading and error states like for any other network call. Treat \`code\` as an
-open string: it is whatever classified the failure, so branch on the ones you handle and fall
-back to a generic message for the rest. The ones worth branching on are \`invalid_input\` and
-\`invalid_output\` (the value does not match the declared schema), \`threw\` (the function threw),
-\`http_error\` (the function's own request failed, with \`status\`), \`sandbox_function_not_found\`
-(no such function), and \`not_supported\` (the Frame is public or shared). Pod functions are only
-reachable from authenticated Pod Frames, not from public or shared Frames.`,
+Use \`usePodFunctionMutation\` for writes and other side effects. Mutations only run when
+\`trigger\` is called. They are not deduplicated and do not guess which cached queries they affect.
+Revalidate the affected read explicitly after the mutation succeeds.
+
+\`\`\`tsx
+import { usePodFunction, usePodFunctionMutation } from "@dust/react-hooks"
+
+const comments = usePodFunction("<podId>/list-comments", { threadId })
+const addComment = usePodFunctionMutation("<podId>/post-comment")
+
+async function handleAddComment(body: string) {
+  await addComment.trigger({ threadId, body })
+  await comments.mutate()
+}
+\`\`\`
+
+Call mutation handlers from a button or another supported in-Frame interaction. Do not model this
+as HTML form submission because forms cannot run inside the Frame iframe.
+
+Inspect each function with \`${toolName("get")}\` before writing the Frame and follow both reported
+schemas. Before success, hook \`data\` is \`undefined\`. After success, it contains the parsed JSON
+value described by \`schema.output\`. Mutation \`trigger\` accepts \`schema.input\` and resolves to
+the parsed and validated value described by \`schema.output\`.
+
+Function call failures are normalized as \`SandboxFunctionCallError\` instances, also exported by
+\`@dust/react-hooks\`. Query failures are exposed through \`error\`. Mutation failures update
+\`error\` and reject \`trigger\`. Each error carries a \`message\`, an optional HTTP \`status\`, and
+a \`code\`. Render loading and error states like for any other network call. Treat \`code\` as an
+open string because it is whatever classified the failure. Branch on the codes you handle and
+fall back to a generic message for the rest. The ones worth branching on are \`invalid_input\` and
+\`invalid_output\` for schema mismatches, \`threw\` when the function threw, \`http_error\` when the
+function's own request failed, \`sandbox_function_not_found\`, and \`not_supported\`.
+
+The existing imperative \`callFunction\` remains available unchanged for explicit calls and also
+takes \`<podId>/<slug>\` or a function id. Pod functions are only reachable from authenticated Pod
+Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
   version: 4,
   icon: "PuzzleIcon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58616,6 +58616,7 @@
         "react-runner": "^1.0.5",
         "recharts": "2.15.4",
         "sonner": "^2.0.7",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.3.6",
@@ -58624,6 +58625,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.1.0",
         "@types/node": "^24.12.2",
         "@types/papaparse": "^5.3.14",
         "@types/react": "^18.3.18",

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -5,6 +5,11 @@ import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
 import { VizContext } from "@viz/app/components/VizContext";
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
+import {
+  PodFunctionHooksProvider,
+  usePodFunction,
+  usePodFunctionMutation,
+} from "@viz/app/lib/pod-function-hooks";
 import { transformEditableText } from "@viz/app/lib/transformEditableText";
 import type {
   VisualizationAPI,
@@ -468,6 +473,8 @@ export function VisualizationWrapper({
             captureScreenshot: handleScreenshotDownload,
             triggerUserFileDownload: memoizedDownloadFile,
             useFile: (fileId: string) => useFile(fileId, api.data),
+            usePodFunction,
+            usePodFunctionMutation,
           },
         };
 
@@ -643,7 +650,9 @@ export function VisualizationWrapper({
         </div>
       )}
       <VizContext.Provider value={vizContextValue}>
-        {isEditable ? <EditableFrame>{runner}</EditableFrame> : runner}
+        <PodFunctionHooksProvider dataAPI={api.data}>
+          {isEditable ? <EditableFrame>{runner}</EditableFrame> : runner}
+        </PodFunctionHooksProvider>
       </VizContext.Provider>
     </div>
   );

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -1,0 +1,401 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  PodFunctionHooksProvider,
+  usePodFunction,
+  usePodFunctionMutation,
+} from "@viz/app/lib/pod-function-hooks";
+import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
+import { createElement, type PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function makeDataAPI(
+  callFunction: VisualizationDataAPI["callFunction"]
+): VisualizationDataAPI {
+  return {
+    callFunction,
+    fetchCode: vi.fn(),
+    fetchFile: vi.fn(),
+  };
+}
+
+function makeWrapper(dataAPI: VisualizationDataAPI) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return createElement(PodFunctionHooksProvider, { dataAPI }, children);
+  };
+}
+
+describe("usePodFunction", () => {
+  it("calls a qualified slug and returns the direct function output", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1, body: "Hello" }]);
+    const dataAPI = makeDataAPI(callFunction);
+    const { result } = renderHook(
+      () => usePodFunction("vlt_123/list-comments", { threadId: "thread-1" }),
+      { wrapper: makeWrapper(dataAPI) }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isValidating).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: 1, body: "Hello" }]);
+    });
+    expect(callFunction).toHaveBeenCalledWith("vlt_123/list-comments", {
+      threadId: "thread-1",
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+
+    window.dispatchEvent(new Event("focus"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(callFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call the function when disabled", async () => {
+    const callFunction = vi.fn();
+    const { result } = renderHook(
+      () => usePodFunction(null, { ignored: true }),
+      {
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+
+    expect(result.current).toMatchObject({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+    });
+    await expect(result.current.mutate()).resolves.toBeUndefined();
+    expect(callFunction).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unqualified function slug", () => {
+    const callFunction = vi.fn();
+    const { result } = renderHook(
+      () => usePodFunction("list-comments", { threadId: "thread-1" }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    expect(result.current.error).toEqual(
+      new Error(
+        "Pod Function hooks require a fully qualified <podId>/<slug> reference."
+      )
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(callFunction).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent calls with structurally identical inputs", async () => {
+    const request = deferred<unknown>();
+    const callFunction = vi.fn().mockReturnValue(request.promise);
+    const { result } = renderHook(
+      () => ({
+        first: usePodFunction("vlt_123/list-comments", {
+          filters: { author: "flavien", resolved: false },
+        }),
+        second: usePodFunction("vlt_123/list-comments", {
+          filters: { resolved: false, author: "flavien" },
+        }),
+      }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    await waitFor(() => expect(callFunction).toHaveBeenCalledTimes(1));
+    request.resolve([{ id: 1 }]);
+    await waitFor(() => {
+      expect(result.current.first.data).toEqual([{ id: 1 }]);
+      expect(result.current.second.data).toEqual([{ id: 1 }]);
+    });
+  });
+
+  it("keeps cached data visible while mutate revalidates", async () => {
+    const revalidation = deferred<unknown>();
+    const callFunction = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }])
+      .mockReturnValueOnce(revalidation.promise);
+    const { result } = renderHook(
+      () => usePodFunction("vlt_123/list-comments", { threadId: "thread-1" }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+
+    let mutatePromise: Promise<unknown> | undefined;
+    act(() => {
+      mutatePromise = result.current.mutate();
+    });
+    await waitFor(() => expect(result.current.isValidating).toBe(true));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+
+    revalidation.resolve([{ id: 1 }, { id: 2 }]);
+    await act(async () => mutatePromise);
+    expect(result.current.data).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it("keeps previous data visible when the input changes", async () => {
+    const nextRequest = deferred<unknown>();
+    const callFunction = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }])
+      .mockReturnValueOnce(nextRequest.promise);
+    const { result, rerender } = renderHook(
+      ({ page }: { page: number }) =>
+        usePodFunction("vlt_123/list-comments", { page }),
+      {
+        initialProps: { page: 1 },
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+    rerender({ page: 2 });
+
+    await waitFor(() => expect(callFunction).toHaveBeenCalledTimes(2));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+    expect(result.current.isValidating).toBe(true);
+
+    nextRequest.resolve([{ id: 2 }]);
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 2 }]));
+  });
+
+  it("keeps mutate stable across rerenders", async () => {
+    const callFunction = vi.fn().mockResolvedValue([]);
+    const { result, rerender } = renderHook(
+      ({ input }: { input: { page: number } }) =>
+        usePodFunction("vlt_123/list-comments", input),
+      {
+        initialProps: { input: { page: 1 } },
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+    const mutate = result.current.mutate;
+
+    rerender({ input: { page: 1 } });
+
+    expect(result.current.mutate).toBe(mutate);
+  });
+
+  it("shows cached data while revalidating when a query remounts", async () => {
+    const remountRequest = deferred<unknown>();
+    const callFunction = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }])
+      .mockReturnValueOnce(remountRequest.promise);
+    const { result, rerender } = renderHook(
+      ({ slug }: { slug: string | null }) =>
+        usePodFunction(slug, { threadId: "thread-1" }),
+      {
+        initialProps: { slug: "vlt_123/list-comments" as string | null },
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    rerender({ slug: null });
+    rerender({ slug: "vlt_123/list-comments" });
+
+    await waitFor(() => expect(callFunction).toHaveBeenCalledTimes(2));
+    expect(result.current.data).toEqual([{ id: 1 }]);
+    expect(result.current.isValidating).toBe(true);
+
+    remountRequest.resolve([{ id: 1 }, { id: 2 }]);
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{ id: 1 }, { id: 2 }])
+    );
+  });
+
+  it("normalizes function failures without retrying", async () => {
+    const callFunction = vi.fn().mockRejectedValue({
+      code: "http_error",
+      message: "Function returned HTTP 503.",
+      status: 503,
+    });
+    const { result } = renderHook(
+      () => usePodFunction("vlt_123/list-comments", { threadId: "thread-1" }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error).toMatchObject({
+      code: "http_error",
+      message: "Function returned HTTP 503.",
+      status: 503,
+    });
+    expect(callFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates identical cache keys between Frame providers", async () => {
+    const firstCall = vi.fn().mockResolvedValue([{ frame: 1 }]);
+    const secondCall = vi.fn().mockResolvedValue([{ frame: 2 }]);
+    const first = renderHook(
+      () => usePodFunction("vlt_123/list-comments", { threadId: "same" }),
+      { wrapper: makeWrapper(makeDataAPI(firstCall)) }
+    );
+    const second = renderHook(
+      () => usePodFunction("vlt_123/list-comments", { threadId: "same" }),
+      { wrapper: makeWrapper(makeDataAPI(secondCall)) }
+    );
+
+    await waitFor(() =>
+      expect(first.result.current.data).toEqual([{ frame: 1 }])
+    );
+    await waitFor(() =>
+      expect(second.result.current.data).toEqual([{ frame: 2 }])
+    );
+    expect(firstCall).toHaveBeenCalledTimes(1);
+    expect(secondCall).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("usePodFunctionMutation", () => {
+  it("runs only when triggered and does not deduplicate writes", async () => {
+    const firstRequest = deferred<unknown>();
+    const secondRequest = deferred<unknown>();
+    const callFunction = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const { result } = renderHook(
+      () => usePodFunctionMutation("vlt_123/post-comment"),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    expect(callFunction).not.toHaveBeenCalled();
+
+    let firstPromise: Promise<unknown> | undefined;
+    let secondPromise: Promise<unknown> | undefined;
+    act(() => {
+      firstPromise = result.current.trigger({ body: "First" });
+      secondPromise = result.current.trigger({ body: "Second" });
+    });
+    expect(callFunction).toHaveBeenCalledTimes(2);
+    expect(callFunction).toHaveBeenNthCalledWith(1, "vlt_123/post-comment", {
+      body: "First",
+    });
+    expect(callFunction).toHaveBeenNthCalledWith(2, "vlt_123/post-comment", {
+      body: "Second",
+    });
+
+    firstRequest.resolve({ id: 1 });
+    secondRequest.resolve({ id: 2 });
+    await act(async () => {
+      await firstPromise;
+      await secondPromise;
+    });
+    expect(result.current.data).toEqual({ id: 2 });
+  });
+
+  it("normalizes mutation errors", async () => {
+    const callFunction = vi.fn().mockRejectedValue(new Error("Write failed"));
+    const { result } = renderHook(
+      () => usePodFunctionMutation("vlt_123/post-comment"),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    await act(async () => {
+      await expect(result.current.trigger({ body: "Hello" })).rejects.toThrow(
+        "Write failed"
+      );
+    });
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("Write failed");
+  });
+
+  it("clears stale mutation state when the function changes", async () => {
+    const firstRequest = deferred<unknown>();
+    const callFunction = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockResolvedValueOnce({ id: 2 });
+    const { result, rerender } = renderHook(
+      ({ slug }: { slug: string }) => usePodFunctionMutation(slug),
+      {
+        initialProps: { slug: "vlt_123/first-comment" },
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+
+    let firstPromise: Promise<unknown> | undefined;
+    act(() => {
+      firstPromise = result.current.trigger({ body: "First" });
+    });
+    rerender({ slug: "vlt_123/second-comment" });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+
+    firstRequest.resolve({ id: 1 });
+    await act(async () => firstPromise);
+    expect(result.current.data).toBeUndefined();
+
+    await act(async () => {
+      await result.current.trigger({ body: "Second" });
+    });
+    expect(result.current.data).toEqual({ id: 2 });
+  });
+
+  it("keeps trigger stable and rejects disabled mutations", async () => {
+    const callFunction = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ slug }: { slug: string | null }) => usePodFunctionMutation(slug),
+      {
+        initialProps: { slug: "vlt_123/post-comment" as string | null },
+        wrapper: makeWrapper(makeDataAPI(callFunction)),
+      }
+    );
+    const trigger = result.current.trigger;
+
+    rerender({ slug: "vlt_123/post-comment" });
+    expect(result.current.trigger).toBe(trigger);
+
+    rerender({ slug: null });
+    await expect(result.current.trigger({ body: "Ignored" })).rejects.toThrow(
+      "Cannot trigger a disabled Pod Function mutation."
+    );
+    expect(callFunction).not.toHaveBeenCalled();
+  });
+
+  it("supports explicit query revalidation after a successful write", async () => {
+    const comments = [[{ id: 1 }], [{ id: 1 }, { id: 2 }]];
+    const callFunction = vi.fn(async (functionId: string) => {
+      if (functionId.endsWith("/post-comment")) {
+        return { id: 2 };
+      }
+      return comments.shift();
+    });
+    const { result } = renderHook(
+      () => ({
+        list: usePodFunction("vlt_123/list-comments", {
+          threadId: "thread-1",
+        }),
+        post: usePodFunctionMutation("vlt_123/post-comment"),
+      }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
+    await waitFor(() => expect(result.current.list.data).toEqual([{ id: 1 }]));
+    await act(async () => {
+      await result.current.post.trigger({
+        threadId: "thread-1",
+        body: "Second",
+      });
+      await result.current.list.mutate();
+    });
+    expect(result.current.list.data).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+});

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -21,7 +21,7 @@ interface PodFunctionContextValue {
 }
 
 interface PodFunctionHooksProviderProps extends PodFunctionContextValue {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export interface UsePodFunctionResult {
@@ -44,6 +44,10 @@ type PodFunctionQueryKey = readonly ["pod-function", string, unknown];
 type PodFunctionMutationKey = readonly ["pod-function-mutation", string];
 
 const PodFunctionContext = createContext<PodFunctionContextValue | null>(null);
+
+async function noopMutate(): Promise<undefined> {
+  return undefined;
+}
 
 function resolvePodFunction(slug: string | null): {
   functionId: string | null;
@@ -118,15 +122,7 @@ export function usePodFunction(
       shouldRetryOnError: false,
     }
   );
-  const revalidate = result.mutate;
-
-  const mutate = useCallback(async () => {
-    if (!functionId) {
-      return undefined;
-    }
-
-    return revalidate();
-  }, [functionId, revalidate]);
+  const mutate = functionId ? result.mutate : noopMutate;
 
   return {
     data: key === null ? undefined : result.data,
@@ -162,29 +158,28 @@ export function usePodFunctionMutation(
     },
     { populateCache: false, revalidate: false, throwOnError: true }
   );
-  const runMutation = result.trigger;
   const mutationFunctionIdRef = useRef(functionId);
   const mutationKeyChanged = mutationFunctionIdRef.current !== functionId;
 
   useEffect(() => {
-    if (mutationFunctionIdRef.current !== functionId) {
-      mutationFunctionIdRef.current = functionId;
+    if (mutationFunctionIdRef.current !== resolution.functionId) {
+      mutationFunctionIdRef.current = resolution.functionId;
       result.reset();
     }
-  }, [functionId, result.reset]);
+  }, [resolution.functionId, result.reset]);
 
   const trigger = useCallback(
     async (input: unknown) => {
       if (resolution.error) {
         throw resolution.error;
       }
-      if (!functionId) {
+      if (!resolution.functionId) {
         throw new Error("Cannot trigger a disabled Pod Function mutation.");
       }
 
-      return runMutation(input);
+      return result.trigger(input);
     },
-    [functionId, resolution.error, runMutation]
+    [resolution.error, resolution.functionId, result.trigger]
   );
 
   return {

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
+import {
+  createContext,
+  createElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import useSWR, { SWRConfig } from "swr";
+import useSWRMutation from "swr/mutation";
+
+interface PodFunctionContextValue {
+  dataAPI: VisualizationDataAPI;
+}
+
+interface PodFunctionHooksProviderProps extends PodFunctionContextValue {
+  children: ReactNode;
+}
+
+export interface UsePodFunctionResult {
+  data: unknown;
+  error: Error | undefined;
+  isLoading: boolean;
+  isValidating: boolean;
+  mutate: () => Promise<unknown>;
+}
+
+export interface UsePodFunctionMutationResult {
+  data: unknown;
+  error: Error | undefined;
+  isMutating: boolean;
+  reset: () => void;
+  trigger: (input: unknown) => Promise<unknown>;
+}
+
+type PodFunctionQueryKey = readonly ["pod-function", string, unknown];
+type PodFunctionMutationKey = readonly ["pod-function-mutation", string];
+
+const PodFunctionContext = createContext<PodFunctionContextValue | null>(null);
+
+function resolvePodFunction(slug: string | null): {
+  functionId: string | null;
+  error?: Error;
+} {
+  if (slug === null) {
+    return { functionId: null };
+  }
+  if (!/^[^/]+\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+    return {
+      functionId: null,
+      error: new Error(
+        "Pod Function hooks require a fully qualified <podId>/<slug> reference."
+      ),
+    };
+  }
+
+  return { functionId: slug };
+}
+
+export function PodFunctionHooksProvider({
+  children,
+  dataAPI,
+}: PodFunctionHooksProviderProps) {
+  const [cache] = useState(() => new Map());
+  const swrConfig = useMemo(() => ({ provider: () => cache }), [cache]);
+  const contextValue = useMemo(() => ({ dataAPI }), [dataAPI]);
+
+  return createElement(
+    PodFunctionContext.Provider,
+    { value: contextValue },
+    createElement(SWRConfig, { value: swrConfig }, children)
+  );
+}
+
+function usePodFunctionContext(): PodFunctionContextValue {
+  const context = useContext(PodFunctionContext);
+  if (!context) {
+    throw new Error("Pod Function hooks must run inside a Frame wrapper.");
+  }
+
+  return context;
+}
+
+export function usePodFunction(
+  slug: string | null,
+  input: unknown
+): UsePodFunctionResult {
+  const { dataAPI } = usePodFunctionContext();
+  const resolution = useMemo(() => resolvePodFunction(slug), [slug]);
+  const functionId = resolution.functionId;
+  const key: PodFunctionQueryKey | null = functionId
+    ? ["pod-function", functionId, input]
+    : null;
+  const result = useSWR<unknown, Error, PodFunctionQueryKey | null>(
+    key,
+    async ([, functionId, functionInput]) => {
+      try {
+        return await dataAPI.callFunction(functionId, functionInput);
+      } catch (error) {
+        throw normalizeSandboxFunctionCallError(error);
+      }
+    },
+    {
+      dedupingInterval: 0,
+      errorRetryCount: 0,
+      keepPreviousData: true,
+      refreshInterval: 0,
+      revalidateIfStale: true,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    }
+  );
+  const revalidate = result.mutate;
+
+  const mutate = useCallback(async () => {
+    if (!functionId) {
+      return undefined;
+    }
+
+    return revalidate();
+  }, [functionId, revalidate]);
+
+  return {
+    data: key === null ? undefined : result.data,
+    error: resolution.error ?? (key === null ? undefined : result.error),
+    isLoading: key !== null && result.isLoading,
+    isValidating: key !== null && result.isValidating,
+    mutate,
+  };
+}
+
+export function usePodFunctionMutation(
+  slug: string | null
+): UsePodFunctionMutationResult {
+  const { dataAPI } = usePodFunctionContext();
+  const resolution = useMemo(() => resolvePodFunction(slug), [slug]);
+  const functionId = resolution.functionId;
+  const key: PodFunctionMutationKey | null = functionId
+    ? ["pod-function-mutation", functionId]
+    : null;
+  const result = useSWRMutation<
+    unknown,
+    Error,
+    PodFunctionMutationKey | null,
+    unknown
+  >(
+    key,
+    async ([, functionId], { arg }) => {
+      try {
+        return await dataAPI.callFunction(functionId, arg);
+      } catch (error) {
+        throw normalizeSandboxFunctionCallError(error);
+      }
+    },
+    { populateCache: false, revalidate: false, throwOnError: true }
+  );
+  const runMutation = result.trigger;
+  const mutationFunctionIdRef = useRef(functionId);
+  const mutationKeyChanged = mutationFunctionIdRef.current !== functionId;
+
+  useEffect(() => {
+    if (mutationFunctionIdRef.current !== functionId) {
+      mutationFunctionIdRef.current = functionId;
+      result.reset();
+    }
+  }, [functionId, result.reset]);
+
+  const trigger = useCallback(
+    async (input: unknown) => {
+      if (resolution.error) {
+        throw resolution.error;
+      }
+      if (!functionId) {
+        throw new Error("Cannot trigger a disabled Pod Function mutation.");
+      }
+
+      return runMutation(input);
+    },
+    [functionId, resolution.error, runMutation]
+  );
+
+  return {
+    data: mutationKeyChanged ? undefined : result.data,
+    error: resolution.error ?? (mutationKeyChanged ? undefined : result.error),
+    isMutating: key !== null && !mutationKeyChanged && result.isMutating,
+    reset: result.reset,
+    trigger,
+  };
+}

--- a/viz/package.json
+++ b/viz/package.json
@@ -65,6 +65,7 @@
     "react-runner": "^1.0.5",
     "recharts": "2.15.4",
     "sonner": "^2.0.7",
+    "swr": "^2.4.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.6",
@@ -73,6 +74,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
     "@types/node": "^24.12.2",
     "@types/papaparse": "^5.3.14",
     "@types/react": "^18.3.18",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Frames often use the same Pod Function data across several slides or views.

Using `callFunction` imperatively requires each component to manage loading state, errors, request races, caching, and refreshes. It can also cause identical requests when several slides need the same data.

This PR adds two React hooks to the Frame wrapper:
- `usePodFunction` for read-only queries
- `usePodFunctionMutation` for explicit writes

Queries are cached by their fully qualified function path and input. Components within the same Frame can reuse cached results, including across slides. Identical in-flight requests are deduplicated, and previous data remains visible during revalidation.

Mutations remain explicit and do not automatically invalidate queries. After a write, callers revalidate the affected query with `mutate()`.

The existing imperative `callFunction` API remains unchanged.

This first PR excluisvely includes Frame-side plumbing and model guidance.

Publish-time validation of function references, inputs, and outputs will be done in a follow-up PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
