### PR TITLE
Mark dust_agent_gpt_5_6_luna_default as on demand

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -49,7 +49,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   dust_agent_gpt_5_6_luna_default: {
     description:
       "Use GPT 5.6 Luna (high reasoning) as the default model for the @dust agent",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   dust_agent_sonnet_5_default: {
     description: "Use Claude Sonnet 5 as the default model for the @dust agent",


### PR DESCRIPTION
## Description

Flips the `dust_agent_gpt_5_6_luna_default` feature flag from `dust_only` to `on_demand` so it can be enabled for customer workspaces.


## Tests

Nothing beyond CI, this is a one-line metadata change. `global_agents.test.ts` already covers both flag paths including Sonnet 5 precedence, and no test asserts `stage` values.

## Risk
none

## Deploy Plan

Standard deploy.