### PR TITLE
[front] Seed default governance capabilities in dust-hive dev seed

### DIFF
--- a/front/lib/dev/dust_hive_seed.sql
+++ b/front/lib/dev/dust_hive_seed.sql
@@ -140,6 +140,27 @@ link_conversations AS (
   RETURNING "vaultId"
 ),
 
+-- Step 5d: Seed default governance capabilities (type-wide -1 grants on the global group).
+-- Mirrors seedWorkspaceCapabilities (front/lib/api/permissions/governance_seeding.ts), which
+-- workspace provisioning runs but this raw-SQL seed bypasses. A fresh workspace has no feature
+-- flags and no Builders group, so every "everyone" capability resolves to the global group;
+-- "create skill" resolves to admins_only (no row). Keep in sync with CAPABILITY_SEEDERS.
+inserted_group_permissions AS (
+  INSERT INTO group_permissions (
+    "workspaceId", "groupId", "grantType", "resourceType", "resourceId", "createdAt", "updatedAt"
+  )
+  SELECT gg."workspaceId", gg.id, capability.grant_type, capability.resource_type, -1, NOW(), NOW()
+  FROM inserted_global_group gg
+  CROSS JOIN (
+    VALUES
+      ('create', 'agent'),
+      ('publish', 'agent'),
+      ('invite', 'frame'),
+      ('publish', 'frame')
+  ) AS capability(grant_type, resource_type)
+  RETURNING id
+),
+
 -- Step 6: Create membership
 inserted_membership AS (
   INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "firstUsedAt", "createdAt", "updatedAt")

--- a/front/lib/dev/dust_hive_seed_schema.test.ts
+++ b/front/lib/dev/dust_hive_seed_schema.test.ts
@@ -83,6 +83,13 @@ describe("dust-hive seed SQL schema compatibility", () => {
         }
       );
       await frontSequelize.query(
+        `DELETE FROM group_permissions WHERE "workspaceId" = :workspaceId`,
+        {
+          replacements: { workspaceId: createdWorkspaceId },
+          type: QueryTypes.DELETE,
+        }
+      );
+      await frontSequelize.query(
         `DELETE FROM group_vaults WHERE "workspaceId" = :workspaceId`,
         {
           replacements: { workspaceId: createdWorkspaceId },


### PR DESCRIPTION
## Problem

The dust-hive raw-SQL seed (`front/lib/dev/dust_hive_seed.sql`) mirrors workspace provisioning (`front/lib/iam/workspaces.ts`) — user, workspace, groups, spaces, membership, subscription — but it skips the `seedWorkspaceCapabilities(auth)` step that provisioning runs (`workspaces.ts:102`). As a result, a freshly-created dust-hive dev env has **no `group_permissions` rows**, so every governance capability (create agent, publish agent, invite/publish frame, …) resolves to `admins_only`.

## Fix

Add a CTE to the SQL seed that reproduces exactly what `CAPABILITY_SEEDERS` (`front/lib/api/permissions/governance_seeding.ts`) produces for a brand-new workspace (no feature flags, no Builders group): four type-wide (`-1`) "everyone" grants on the global group —

- `create` / `agent`
- `publish` / `agent`
- `invite` / `frame`
- `publish` / `frame`

`create` / `skill` correctly gets **no row** (it resolves to `builders` → degrades to `admins_only` with no Builders group present).

Chose the SQL-seed route over running the `20260721_backfill_governance_capabilities.ts` migration from the seed process: it's consistent with how the seed already replicates provisioning in SQL, stays fast/self-contained, and avoids coupling the seed to a one-time migration file that will eventually be archived.

Also clears `group_permissions` in the schema-validation test teardown, since the new rows hold `ON DELETE RESTRICT` FKs to both `groups` and `workspaces`.

## Notes

- **Existing** dust-hive envs are not backfilled by this change (new seeds only); re-seed or run the migration against `DevWkSpace` once for those.
- This SQL mirror can drift from `CAPABILITY_SEEDERS`; a "keep in sync" comment is added. The schema test validates SQL/schema compatibility, not seeder parity.

## Test plan

- [x] `npm run test -- dust_hive_seed_schema` passes (SQL valid against current schema; FK-ordered teardown works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)