### PR TITLE
Admin governance: default skill availability value depending on feature flag

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,11 +1,12 @@
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
   SKILL_INSTRUCTIONS_LABEL,
   SKILL_INVOCATION_LABEL,
 } from "@app/lib/skills/labels";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
+import { getDefaultSkillAvailability } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -65,7 +66,7 @@ app.post(
         agentFacingDescription,
         instructions,
         icon: skillIcon,
-        availability: DEFAULT_SKILL_AVAILABILITY,
+        availability: getDefaultSkillAvailability(await getFeatureFlags(auth)),
       },
       {
         mcpServerViewIds,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -792,7 +792,7 @@ describe("POST /api/w/:wId/skills", () => {
     expect(response.status).toBe(400);
   });
 
-  it("keeps the default availability without requiring the publish permission when governance is on", async () => {
+  it("defaults new skills to unpublished, without requiring the publish permission, when governance is on", async () => {
     const { auth, workspace, user } = await setupTest("builder");
     await grantCreateSkillCapability(workspace, user);
     await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");
@@ -810,7 +810,7 @@ describe("POST /api/w/:wId/skills", () => {
 
     expect(response.status).toBe(200);
     const responseData = await response.json();
-    expect(responseData.skill.availability).toBe("workspace_users");
+    expect(responseData.skill.availability).toBe("editors");
   });
 
   it("requires the publish permission to create a published skill when governance is on", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -4,7 +4,7 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
-import { hasFeatureFlag } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -17,7 +17,7 @@ import type {
 } from "@app/types/api/skills";
 import {
   availabilityFromIsDefault,
-  DEFAULT_SKILL_AVAILABILITY,
+  getDefaultSkillAvailability,
   SKILL_AVAILABILITIES,
   SKILL_REINFORCEMENT_MODES,
   type SkillAvailability,
@@ -286,8 +286,8 @@ app.post(
       });
     }
 
-    const hasSkillPublicationGovernance = await hasFeatureFlag(
-      auth,
+    const featureFlags = await getFeatureFlags(auth);
+    const hasSkillPublicationGovernance = featureFlags.includes(
       "admin_governance_skill_publication"
     );
 
@@ -324,7 +324,8 @@ app.post(
       });
     }
 
-    const availability = requestedAvailability ?? DEFAULT_SKILL_AVAILABILITY;
+    const availability =
+      requestedAvailability ?? getDefaultSkillAvailability(featureFlags);
 
     const existingSkill = await SkillResource.fetchByName(auth, name);
 

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -29,6 +29,7 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { useAppRouter } from "@app/lib/platform";
 import { useSkillHistory } from "@app/lib/swr/skill_configurations";
@@ -62,6 +63,7 @@ interface SkillBuilderProps {
 
 export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
+  const { featureFlags } = useFeatureFlags();
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
@@ -107,8 +109,9 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
 
     return getDefaultSkillFormData({
       user,
+      featureFlags,
     });
-  }, [skill, user]);
+  }, [skill, user, featureFlags]);
 
   const form = useForm<SkillBuilderFormData>({
     disabled: isEditorLocked,

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -4,7 +4,8 @@ import type {
   SkillRelations,
   SkillType,
 } from "@app/types/assistant/skill_configuration";
-import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
+import { getDefaultSkillAvailability } from "@app/types/assistant/skill_configuration";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserType } from "@app/types/user";
 
 /**
@@ -42,8 +43,10 @@ export function transformSkillTypeToFormData(
  */
 export function getDefaultSkillFormData({
   user,
+  featureFlags,
 }: {
   user: UserType;
+  featureFlags: WhitelistableFeature[];
 }): SkillBuilderFormData {
   return {
     name: "",
@@ -55,7 +58,7 @@ export function getDefaultSkillFormData({
     tools: [],
     fileAttachments: [],
     icon: null,
-    availability: DEFAULT_SKILL_AVAILABILITY,
+    availability: getDefaultSkillAvailability(featureFlags),
     reinforcement: "on",
     additionalSpaces: [],
     referencedSkills: [],

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -19,6 +19,7 @@ import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -27,7 +28,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
 import { extractToolTags, serializeToolTag } from "@app/lib/tools/format";
 import logger from "@app/logger/logger";
-import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
+import { getDefaultSkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -310,6 +311,8 @@ export async function createSkill(
     }
   }
 
+  const featureFlags = await getFeatureFlags(auth);
+
   const skill = await SkillResource.makeNew(
     auth,
     {
@@ -324,7 +327,7 @@ export async function createSkill(
       icon: resolvedIcon,
       source: "agent",
       sourceMetadata: null,
-      availability: DEFAULT_SKILL_AVAILABILITY,
+      availability: getDefaultSkillAvailability(featureFlags),
       reinforcement: "on",
     },
     {

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -8,6 +8,7 @@ import {
 import type { ZipDetectedSkill } from "@app/lib/api/skills/detection/zip/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -16,7 +17,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
-import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
+import { getDefaultSkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -77,6 +78,8 @@ export async function importSkillsFromFiles(
   }
 
   const allSkills: ZipDetectedSkill[] = [];
+
+  const featureFlags = await getFeatureFlags(auth);
 
   // Readers are keyed by skill to avoid re-opening the same zip for each
   // attachment. Each zip buffer produces one reader shared across its skills.
@@ -249,7 +252,7 @@ export async function importSkillsFromFiles(
           icon,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
-          availability: DEFAULT_SKILL_AVAILABILITY,
+          availability: getDefaultSkillAvailability(featureFlags),
         },
         {
           mcpServerViews: suggestedMCPServerViews,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -16,13 +16,14 @@ import { suggestMCPServersForDetectedSkill } from "@app/lib/api/skills/detection
 import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
+import { getDefaultSkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -116,6 +117,8 @@ export async function importSkillsFromGitHub(
       message: "No matching importable skills found.",
     });
   }
+
+  const featureFlags = await getFeatureFlags(auth);
 
   const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
@@ -214,7 +217,7 @@ export async function importSkillsFromGitHub(
             repoUrl,
             filePath: skill.skillMdPath,
           },
-          availability: DEFAULT_SKILL_AVAILABILITY,
+          availability: getDefaultSkillAvailability(featureFlags),
         },
         {
           mcpServerViews: detectedMCPServerViews,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,5 +1,6 @@
 import { MCPServerViewSchema } from "@app/lib/api/mcp_schemas";
 import type { AgentsUsageType } from "@app/types/data_source";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
@@ -18,6 +19,16 @@ export const SKILL_AVAILABILITIES = [
 export type SkillAvailability = (typeof SKILL_AVAILABILITIES)[number];
 
 export const DEFAULT_SKILL_AVAILABILITY: SkillAvailability = "workspace_users";
+
+// With skill publication governance, new skills start unpublished (editors-only) and must be
+// explicitly published by a holder of the skill publish permission.
+export function getDefaultSkillAvailability(
+  featureFlags: WhitelistableFeature[]
+): SkillAvailability {
+  return featureFlags.includes("admin_governance_skill_publication")
+    ? "editors"
+    : DEFAULT_SKILL_AVAILABILITY;
+}
 
 // The DB column is availability; isDefault survives as a boolean alias in the API and
 // frontend. Remove these mappings once clients rely on availability directly.


### PR DESCRIPTION
## Description

Change the default value to be "editors" when the flag is activated. Skill always start as unpublished and need explicit publication.

The flag is not really usable until we have the UI to change the states


## Tests



## Risk

low, still behind Feature flag

## Deploy Plan
deploy front 
