### PR TITLE
[Activation] Email notification text portion

### DIFF
--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -18,6 +18,7 @@ interface LLMTraceContextBase {
     | "agent_builder_emoji_suggestion"
     | "agent_builder_name_suggestion"
     | "agent_builder_tags_suggestion"
+    | "activation_recommendation"
     | "agent_conversation"
     | "compaction"
     | "agent_observability_summary"

--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -32,7 +32,7 @@ const ActivationNewConversationEmailTemplate = ({
   return (
     <EmailLayout workspace={workspace}>
       <p style={{ fontSize: "15px", color: "#111418", margin: "0 0 4px 0" }}>
-        Hi {name},
+        Hi {name}!
       </p>
       <p
         style={{
@@ -43,8 +43,8 @@ const ActivationNewConversationEmailTemplate = ({
         }}
       >
         {purpose
-          ? `We put something together to help ${purpose}. Take a look:`
-          : `We put something together for you in ${podName}. Take a look:`}
+          ? `We put something together to ${purpose}. Take a look:`
+          : `We put something together for you. Take a look:`}
       </p>
 
       {/* Text hyperlink into the activation conversation */}

--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -8,9 +8,9 @@ export const ActivationNewConversationEmailTemplatePropsSchema = z.object({
     id: z.string(),
     name: z.string(),
   }),
-  title: z.string(),
+  podName: z.string(),
+  purpose: z.string().nullable(),
   summary: z.string().nullable(),
-  previewImageUrl: z.string().optional(),
   action: z.object({
     label: z.string(),
     url: z.string(),
@@ -24,9 +24,9 @@ type ActivationNewConversationEmailTemplateProps = z.infer<
 const ActivationNewConversationEmailTemplate = ({
   name,
   workspace,
-  title,
+  podName,
+  purpose,
   summary,
-  previewImageUrl,
   action,
 }: ActivationNewConversationEmailTemplateProps) => {
   return (
@@ -37,91 +37,39 @@ const ActivationNewConversationEmailTemplate = ({
       <p
         style={{
           fontSize: "15px",
-          color: "#64707D",
+          color: "#111418",
           margin: "0 0 20px 0",
           lineHeight: "1.5",
         }}
       >
-        We put something together for you in {workspace.name}. Take a look:
+        {purpose
+          ? `We put something together to help ${purpose}. Take a look:`
+          : `We put something together for you in ${podName}. Take a look:`}
       </p>
 
-      {/* Card: headline + optional preview image + summary, all clickable. */}
-      <a
-        href={action.url}
-        target="_blank"
-        style={{ textDecoration: "none", color: "inherit" }}
-      >
-        <div
-          style={{
-            border: "1px solid #E4E7EB",
-            borderRadius: "12px",
-            overflow: "hidden",
-            backgroundColor: "#ffffff",
-          }}
-        >
-          {/* Preview image slot. Rendered only when an image is available. */}
-          {previewImageUrl && (
-            <img
-              alt={title}
-              src={previewImageUrl}
-              width="100%"
-              style={{
-                display: "block",
-                width: "100%",
-                maxWidth: "100%",
-                height: "auto",
-                borderBottom: "1px solid #E4E7EB",
-              }}
-            />
-          )}
-
-          <div style={{ padding: "20px" }}>
-            <h2
-              style={{
-                fontSize: "18px",
-                fontWeight: 600,
-                color: "#111418",
-                margin: "0 0 8px 0",
-                lineHeight: "1.35",
-              }}
-            >
-              {title}
-            </h2>
-            {summary && (
-              <p
-                style={{
-                  fontSize: "14px",
-                  color: "#64707D",
-                  margin: 0,
-                  lineHeight: "1.55",
-                }}
-              >
-                {summary}
-              </p>
-            )}
-          </div>
-        </div>
-      </a>
-
-      {/* Single, clear call-to-action into the conversation. */}
-      <div style={{ marginTop: "24px" }}>
+      {/* Text hyperlink into the activation conversation */}
+      <p style={{ fontSize: "15px", margin: "0 0 20px 0" }}>
         <a
           href={action.url}
           target="_blank"
-          style={{
-            display: "inline-block",
-            backgroundColor: "#1C91FF",
-            color: "#ffffff",
-            fontSize: "15px",
-            fontWeight: 600,
-            textDecoration: "none",
-            padding: "12px 24px",
-            borderRadius: "10px",
-          }}
+          style={{ color: "#1C91FF", textDecoration: "underline" }}
         >
           {action.label}
         </a>
-      </div>
+      </p>
+
+      {summary && (
+        <p
+          style={{
+            fontSize: "14px",
+            color: "#64707D",
+            margin: "0 0 20px 0",
+            lineHeight: "1.55",
+          }}
+        >
+          {summary}
+        </p>
+      )}
     </EmailLayout>
   );
 };

--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -1,0 +1,131 @@
+import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
+import { render } from "@react-email/render";
+import { z } from "zod";
+
+export const ActivationNewConversationEmailTemplatePropsSchema = z.object({
+  name: z.string(),
+  workspace: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  title: z.string(),
+  summary: z.string().nullable(),
+  previewImageUrl: z.string().optional(),
+  action: z.object({
+    label: z.string(),
+    url: z.string(),
+  }),
+});
+
+type ActivationNewConversationEmailTemplateProps = z.infer<
+  typeof ActivationNewConversationEmailTemplatePropsSchema
+>;
+
+const ActivationNewConversationEmailTemplate = ({
+  name,
+  workspace,
+  title,
+  summary,
+  previewImageUrl,
+  action,
+}: ActivationNewConversationEmailTemplateProps) => {
+  return (
+    <EmailLayout workspace={workspace}>
+      <p style={{ fontSize: "15px", color: "#111418", margin: "0 0 4px 0" }}>
+        Hi {name},
+      </p>
+      <p
+        style={{
+          fontSize: "15px",
+          color: "#64707D",
+          margin: "0 0 20px 0",
+          lineHeight: "1.5",
+        }}
+      >
+        We put something together for you in {workspace.name}. Take a look:
+      </p>
+
+      {/* Card: headline + optional preview image + summary, all clickable. */}
+      <a
+        href={action.url}
+        target="_blank"
+        style={{ textDecoration: "none", color: "inherit" }}
+      >
+        <div
+          style={{
+            border: "1px solid #E4E7EB",
+            borderRadius: "12px",
+            overflow: "hidden",
+            backgroundColor: "#ffffff",
+          }}
+        >
+          {/* Preview image slot. Rendered only when an image is available. */}
+          {previewImageUrl && (
+            <img
+              alt={title}
+              src={previewImageUrl}
+              width="100%"
+              style={{
+                display: "block",
+                width: "100%",
+                maxWidth: "100%",
+                height: "auto",
+                borderBottom: "1px solid #E4E7EB",
+              }}
+            />
+          )}
+
+          <div style={{ padding: "20px" }}>
+            <h2
+              style={{
+                fontSize: "18px",
+                fontWeight: 600,
+                color: "#111418",
+                margin: "0 0 8px 0",
+                lineHeight: "1.35",
+              }}
+            >
+              {title}
+            </h2>
+            {summary && (
+              <p
+                style={{
+                  fontSize: "14px",
+                  color: "#64707D",
+                  margin: 0,
+                  lineHeight: "1.55",
+                }}
+              >
+                {summary}
+              </p>
+            )}
+          </div>
+        </div>
+      </a>
+
+      {/* Single, clear call-to-action into the conversation. */}
+      <div style={{ marginTop: "24px" }}>
+        <a
+          href={action.url}
+          target="_blank"
+          style={{
+            display: "inline-block",
+            backgroundColor: "#1C91FF",
+            color: "#ffffff",
+            fontSize: "15px",
+            fontWeight: 600,
+            textDecoration: "none",
+            padding: "12px 24px",
+            borderRadius: "10px",
+          }}
+        >
+          {action.label}
+        </a>
+      </div>
+    </EmailLayout>
+  );
+};
+
+export function renderEmail(args: ActivationNewConversationEmailTemplateProps) {
+  return render(<ActivationNewConversationEmailTemplate {...args} />);
+}

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -38,6 +38,7 @@ import { isRichUserMention } from "@app/types/assistant/mentions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 import {
   decodeHtmlEntities,
   stripMarkdown,
@@ -503,7 +504,7 @@ const generateUnreadMessagesSummary = async ({
 
   // Extract summary from function call result.
   const summary = res.value.conversation_summary;
-  if (typeof summary === "string" && summary.length > 0) {
+  if (isString(summary) && summary.length > 0) {
     return new Ok(stripMarkdown(summary));
   }
 

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -1,8 +1,19 @@
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
+import {
+  countConversationMessages,
+  renderConversationAsText,
+} from "@app/lib/api/assistant/conversation/render_as_text";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import { Authenticator } from "@app/lib/auth";
 import {
   getAgentsDataRetention,
   getConversationsDataRetention,
 } from "@app/lib/data_retention";
+import { DustError } from "@app/lib/error";
 import {
   conversationUsesAgentsWithRetention,
   conversationWithoutContentForResource,
@@ -11,8 +22,10 @@ import {
   fetchUserMessageOriginBySId,
   getUnreadNotificationFlags,
 } from "@app/lib/notifications/conversation_fetch";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import {
   ConversationError,
   getConversationDisplayTitle,
@@ -25,7 +38,10 @@ import { isRichUserMention } from "@app/types/assistant/mentions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { decodeHtmlEntities } from "@app/types/shared/utils/markdown";
+import {
+  decodeHtmlEntities,
+  stripMarkdown,
+} from "@app/types/shared/utils/markdown";
 import { z } from "zod";
 
 // When isNewProjectConversation is true, messageId is not required (the first
@@ -246,4 +262,502 @@ export const getConversationDetails = async ({
     isNewProjectConversation,
     projectName,
   });
+};
+
+const MAX_CONVERSATION_SNIPPET_LENGTH = 12_000;
+//Shared by the unread-summary and activation-recommendation generators.
+const runConversationSummaryToolCall = async (
+  auth: Authenticator,
+  {
+    userFullName,
+    conversationId,
+    conversationSnippet,
+    prompt,
+    specification,
+    functionName,
+    operationType,
+  }: {
+    userFullName: string;
+    conversationId: string;
+    conversationSnippet: string;
+    prompt: string;
+    specification: AgentActionSpecification;
+    functionName: string;
+    operationType: LLMTraceContext["operationType"];
+  }
+): Promise<
+  Result<
+    Record<string, unknown>,
+    DustError<"no_whitelisted_model_found" | "generation_failed">
+  >
+> => {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = await getSmallWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new DustError("no_whitelisted_model_found", "No whitelisted model found")
+    );
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: functionName,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            name: userFullName,
+            content: [
+              {
+                type: "text",
+                text: `This is the content of the conversation to summarize:\n\n${conversationSnippet}`,
+              },
+            ],
+          },
+        ],
+      },
+      prompt,
+      specifications: [specification],
+      forceToolCall: functionName,
+    },
+    {
+      context: {
+        operationType,
+        conversationId,
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(new DustError("generation_failed", res.error.message));
+  }
+
+  const args = res.value.actions?.[0]?.arguments;
+  if (!args) {
+    return new Err(
+      new DustError("generation_failed", "No tool call result generated")
+    );
+  }
+
+  return new Ok(args);
+};
+
+const UNREAD_SUMMARY_FUNCTION_NAME = "write_summary";
+
+const unreadSummarySpecification: AgentActionSpecification = {
+  name: UNREAD_SUMMARY_FUNCTION_NAME,
+  description: "Write a summary of the conversation",
+  inputSchema: {
+    type: "object",
+    properties: {
+      conversation_summary: {
+        type: "string",
+        description: "A short summary of the conversation.",
+      },
+    },
+    required: ["conversation_summary"],
+  },
+};
+
+const generateUnreadMessagesSummary = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string;
+  payload: ConversationDetailsPayload;
+}): Promise<
+  Result<
+    string,
+    DustError<
+      | "conversation_not_found"
+      | "no_unread_messages_found"
+      | "no_whitelisted_model_found"
+      | "internal_error"
+      | "generation_failed"
+      | "user_not_found"
+    >
+  >
+> => {
+  if (!subscriberId) {
+    return new Ok("");
+  }
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    payload.workspaceId
+  );
+
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: message content is needed to compute unread messages.
+  const conversationRes = await getLightConversation(
+    auth,
+    payload.conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    return new Err(
+      new DustError("conversation_not_found", "Failed to get conversation")
+    );
+  }
+
+  const conversation = conversationRes.value;
+
+  const unreadMessages = conversation.content.filter((msg) =>
+    isMessageUnread(msg, conversation.lastReadMs)
+  );
+
+  if (unreadMessages.length === 0) {
+    return new Err(
+      new DustError("no_unread_messages_found", "No unread messages")
+    );
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const userFullName = auth.user()?.fullName();
+
+  if (!userFullName) {
+    return new Err(
+      new DustError("user_not_found", "User not found for summary generation")
+    );
+  }
+  // Generate LLM summary
+  const prompt =
+    `# Task\n` +
+    `Write a 1-2 sentence summary of unread messages for ${userFullName} to quickly understand what happened while they were away and what action (if any) is needed from them.\n\n` +
+    `CRITICAL RULE: You are writing to ${userFullName}. NEVER write their name "${userFullName}" in the summary. Always use "you/your/yours" instead.\n\n` +
+    `# Input Format\n` +
+    `You'll receive a JSON array of UNREAD messages (not the full conversation history, only what ${userFullName} hasn't seen yet). Each message has:\n` +
+    `- "role": "user" (human) or "assistant" (AI agent)\n` +
+    `- "name": sender's display name (e.g., "Sarah Chen", "dust")\n` +
+    `- "content": message text (human messages start with <dust_system> block with sender details)\n\n` +
+    `Use "role", "name", and <dust_system> to attribute senders correctly. Use message text for what happened. Never guess.\n\n` +
+    `# Writing Rules\n` +
+    `1. **Length**: 1-2 sentences maximum\n` +
+    `2. **Second person**: Use "you/your/yours" when referring to ${userFullName} - NEVER write "${userFullName}"\n` +
+    `3. **Action-first**: If someone needs something from ${userFullName}, lead with that: "[Name] needs you to [action] [details]"\n` +
+    `4. **Outcome-first for updates**: If no action needed from ${userFullName}, lead with what's ready/decided: "Draft is ready", "Meeting scheduled"\n` +
+    `5. **No chat narration**: NEVER write "X asked", "assistant provided", "then Y replied"\n` +
+    `6. **Result phrasing**: Use neutral outcomes - "Draft is ready", "Meeting scheduled", "Sarah needs..."\n` +
+    `7. **Use names**: Refer to other participants by name, never "the user"\n` +
+    `8. **Accurate attribution**: Only include information actually in the messages\n\n` +
+    `# Examples\n\n` +
+    `## Action Needed (someone waiting on the recipient)\n` +
+    `"Sarah needs your approval on the Q1 hiring budget ($450K) by end of week to finalize headcount."\n` +
+    `"Alex needs you to choose between the three homepage designs by Tuesday for the product launch."\n` +
+    `"Jordan needs your technical review of the migration plan—specifically whether the 2-week timeline is feasible."\n\n` +
+    `## Updates (no specific action needed)\n` +
+    `"Three design mockups are ready with Sarah's feedback for the homepage redesign."\n` +
+    `"Q4 budget approved at $2.5M. Implementation timeline set for March."\n` +
+    `"David shared the customer research findings—80% want mobile-first experience."\n\n` +
+    `## Mixed (update + action)\n` +
+    `"Hiring budget spreadsheet is ready for Q1. Emily needs your review by Wednesday."\n` +
+    `"Three design mockups are ready with Sarah's feedback. She's waiting on your approval to move forward."\n\n` +
+    `# Your Task\n` +
+    `Read the UNREAD messages below and write a 1-2 sentence summary following ALL rules above.\n` +
+    `Prioritize any actions needed from the recipient first, then updates. Include key specifics.\n` +
+    `Remember: Use "you/your" - NEVER write "${userFullName}".\n` +
+    `Write in a natural, engaging tone that makes someone want to read it.`;
+
+  const renderedMessages = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    includeEmail: true,
+    includeUnread: true,
+    truncateTotalChars: MAX_CONVERSATION_SNIPPET_LENGTH,
+  });
+
+  const preamble = [
+    `Conversation: ${conversation.sId}`,
+    `Title: ${getConversationDisplayTitle(conversation)}`,
+    `Created: ${new Date(conversation.created).toISOString()}`,
+    `Updated: ${new Date(conversation.updated).toISOString()}`,
+    `Unread: ${conversation.unread}`,
+    `Action Required: ${conversation.actionRequired}`,
+    `Has Error: ${conversation.hasError}`,
+    `Message Count: ${countConversationMessages(conversation)}`,
+    `URL: /w/${owner.sId}/assistant/${conversation.sId}`,
+  ].join("\n");
+
+  const conversationSnippet = `${preamble}\n\n${renderedMessages}`;
+
+  const res = await runConversationSummaryToolCall(auth, {
+    userFullName,
+    conversationId: conversation.sId,
+    conversationSnippet,
+    prompt,
+    specification: unreadSummarySpecification,
+    functionName: UNREAD_SUMMARY_FUNCTION_NAME,
+    operationType: "conversation_unread_summary",
+  });
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  // Extract summary from function call result.
+  const summary = res.value.conversation_summary;
+  if (typeof summary === "string" && summary.length > 0) {
+    return new Ok(stripMarkdown(summary));
+  }
+
+  return new Err(
+    new DustError("generation_failed", "No conversation summary generated")
+  );
+};
+
+export const getEmailSummary = async ({
+  details,
+  subscriberId,
+  payload,
+}: {
+  details: ConversationDetailsType;
+  subscriberId: string;
+  payload: ConversationDetailsPayload;
+}): Promise<string | null> => {
+  if (details.hasConversationRetentionPolicy) {
+    return "Summary not generated due to data retention policy on conversations in this workspace.";
+  }
+
+  if (details.hasAgentRetentionPolicies) {
+    return "Summary not generated due to data retention policy on agents in this conversation.";
+  }
+
+  // Generate summary of unread messages
+  const summaryResult = await generateUnreadMessagesSummary({
+    subscriberId,
+    payload,
+  });
+
+  if (summaryResult.isErr()) {
+    switch (summaryResult.error.code) {
+      case "generation_failed":
+      case "conversation_not_found":
+      case "no_unread_messages_found":
+      case "internal_error":
+      case "no_whitelisted_model_found":
+      case "user_not_found":
+        break;
+      default:
+        assertNever(summaryResult.error.code);
+    }
+    return null;
+  }
+  return summaryResult.value;
+};
+
+const ACTIVATION_RECOMMENDATION_FUNCTION_NAME = "write_recommendation";
+
+const activationRecommendationSpecification: AgentActionSpecification = {
+  name: ACTIVATION_RECOMMENDATION_FUNCTION_NAME,
+  description:
+    "Write the intro purpose phrase and summary for a proactive recommendation email",
+  inputSchema: {
+    type: "object",
+    properties: {
+      purpose: {
+        type: "string",
+        description:
+          'A short phrase completing the sentence " We put something together to help ...". Start with a lowercase verb, no trailing period, at most ~12 words. Example: "help your team simplify weekly reporting".',
+      },
+      summary: {
+        type: "string",
+        description:
+          "A 1-2 sentence summary of what the recommendation covers and what the reader can try first.",
+      },
+    },
+    required: ["purpose", "summary"],
+  },
+};
+
+// A proactive recommendation email surfaces a conversation a Dust agent
+// prepared for the user. We generate two pieces in a single LLM call: a short
+// "purpose" phrase for the intro line and a 1-2 sentence "summary" of the
+// recommendation content.
+const generateActivationRecommendation = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string;
+  payload: ConversationDetailsPayload;
+}): Promise<
+  Result<
+    { purpose: string; summary: string },
+    DustError<
+      | "conversation_not_found"
+      | "no_whitelisted_model_found"
+      | "generation_failed"
+      | "user_not_found"
+    >
+  >
+> => {
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId ?? "",
+    payload.workspaceId
+  );
+
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: message content is needed to render the conversation for summary generation.
+  const conversationRes = await getLightConversation(
+    auth,
+    payload.conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    return new Err(
+      new DustError("conversation_not_found", "Failed to get conversation")
+    );
+  }
+
+  const conversation = conversationRes.value;
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const userFullName = auth.user()?.fullName();
+
+  if (!userFullName) {
+    return new Err(
+      new DustError("user_not_found", "User not found for summary generation")
+    );
+  }
+
+  const recommendations =
+    await ActivationRecommendationResource.fetchByConversationSId(
+      auth,
+      conversation.sId
+    );
+
+  const recommendationCardSection =
+    recommendations.length > 0
+      ? `# Recommendation card shown to the user\n` +
+        `Base the purpose and summary primarily on this card; use the conversation below only for supporting context.\n` +
+        recommendations
+          .map((rec) => `- ${rec.title}: ${rec.content}`)
+          .join("\n") +
+        `\n\n`
+      : "";
+
+  const prompt =
+    `# Task\n` +
+    `A Dust agent proactively prepared a recommendation for ${userFullName}. Based on the recommendation card and conversation below, produce two things: a short "purpose" phrase and a 1-2 sentence "summary".\n\n` +
+    `# purpose\n` +
+    `- Completes the sentence: "We put something together to help ___."\n` +
+    `- Start with a lowercase verb, no trailing period, at most ~12 words.\n` +
+    `- Example: "your team simplify weekly reporting".\n\n` +
+    `# summary\n` +
+    `- 1-2 sentences describing what the recommendation covers and what ${userFullName} can try first.\n` +
+    `- Write in second person ("you/your"); NEVER write "${userFullName}".\n` +
+    `- No chat narration ("the agent said", "it then explained"). Describe the content directly.\n` +
+    `- Only include information actually present in the conversation.\n\n` +
+    `# Example\n` +
+    `purpose: "help your team simplify weekly reporting"\n` +
+    `summary: "It covers three practical workflows you can try first, including where Dust can gather information, summarize updates, and prepare a report for review."`;
+
+  const renderedMessages = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    includeEmail: true,
+    includeUnread: false,
+    truncateTotalChars: MAX_CONVERSATION_SNIPPET_LENGTH,
+  });
+
+  const preamble = [
+    `Conversation: ${conversation.sId}`,
+    `Title: ${getConversationDisplayTitle(conversation)}`,
+    `Created: ${new Date(conversation.created).toISOString()}`,
+    `Message Count: ${countConversationMessages(conversation)}`,
+    `URL: /w/${owner.sId}/assistant/${conversation.sId}`,
+  ].join("\n");
+
+  const conversationSnippet = `${preamble}\n\n${recommendationCardSection}${renderedMessages}`;
+
+  const res = await runConversationSummaryToolCall(auth, {
+    userFullName,
+    conversationId: conversation.sId,
+    conversationSnippet,
+    prompt,
+    specification: activationRecommendationSpecification,
+    functionName: ACTIVATION_RECOMMENDATION_FUNCTION_NAME,
+    operationType: "activation_recommendation",
+  });
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const { purpose, summary } = res.value;
+  if (
+    typeof purpose === "string" &&
+    purpose.length > 0 &&
+    typeof summary === "string" &&
+    summary.length > 0
+  ) {
+    return new Ok({
+      purpose: stripMarkdown(purpose),
+      summary: stripMarkdown(summary),
+    });
+  }
+
+  return new Err(
+    new DustError("generation_failed", "No recommendation content generated")
+  );
+};
+
+export const getActivationRecommendation = async ({
+  details,
+  subscriberId,
+  payload,
+}: {
+  details: ConversationDetailsType;
+  subscriberId: string;
+  payload: ConversationDetailsPayload;
+}): Promise<{ purpose: string | null; summary: string | null }> => {
+  if (
+    details.hasConversationRetentionPolicy ||
+    details.hasAgentRetentionPolicies
+  ) {
+    logger.info(
+      {
+        conversationId: payload.conversationId,
+        workspaceId: payload.workspaceId,
+        hasConversationRetentionPolicy: details.hasConversationRetentionPolicy,
+        hasAgentRetentionPolicies: details.hasAgentRetentionPolicies,
+      },
+      "[activation] Skipping recommendation generation due to data retention policy; email falls back to static copy."
+    );
+    return { purpose: null, summary: null };
+  }
+
+  const result = await generateActivationRecommendation({
+    subscriberId,
+    payload,
+  });
+
+  if (result.isErr()) {
+    switch (result.error.code) {
+      case "generation_failed":
+      case "conversation_not_found":
+      case "no_whitelisted_model_found":
+      case "user_not_found":
+        break;
+      default:
+        assertNever(result.error.code);
+    }
+    logger.warn(
+      {
+        conversationId: payload.conversationId,
+        workspaceId: payload.workspaceId,
+        code: result.error.code,
+        message: result.error.message,
+      },
+      "[activation] Recommendation generation failed; email falls back to static copy."
+    );
+    return { purpose: null, summary: null };
+  }
+
+  return result.value;
 };

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -7,8 +7,11 @@ import {
   getUserNotificationDelay,
 } from "@app/lib/notifications";
 import { hasUnreadSucceededAgentReply } from "@app/lib/notifications/conversation_fetch";
-import { renderEmail } from "@app/lib/notifications/email-templates/default";
-import { getConversationDetails } from "@app/lib/notifications/helpers";
+import { renderEmail } from "@app/lib/notifications/email-templates/activation-new-conversation";
+import {
+  getConversationDetails,
+  getEmailSummary,
+} from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -41,6 +44,8 @@ export type activationNewConversationPayloadType = z.infer<
 const activationNewConversationDetailsSchema = z.object({
   subject: z.string(),
   workspaceName: z.string(),
+  // Short, human summary of what's inside; null when none could be generated.
+  summary: z.string().nullable(),
 });
 
 export type activationNewConversationDetailsType = z.infer<
@@ -90,12 +95,23 @@ const getActivationNewConversationDetails = async ({
   if (detailsResult.isErr()) {
     // Only reached for a deleted conversation, in which case the email step is
     // already skipped, so this value is never actually delivered.
-    return { subject: "A new conversation", workspaceName: "your workspace" };
+    return {
+      subject: "A new conversation",
+      workspaceName: "your workspace",
+      summary: null,
+    };
   }
+
+  const summary = await getEmailSummary({
+    details: detailsResult.value,
+    subscriberId: subscriberId ?? "",
+    payload,
+  });
 
   return {
     subject: detailsResult.value.subject,
     workspaceName: detailsResult.value.workspaceName,
+    summary,
   };
 };
 
@@ -144,7 +160,9 @@ export const activationNewConversationWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          content: `There's something new waiting for you: "${details.subject}".`,
+          title: details.subject,
+          summary: details.summary,
+          previewImageUrl: undefined,
           action: {
             label: "Open conversation",
             url:
@@ -154,7 +172,7 @@ export const activationNewConversationWorkflow = workflow(
         });
 
         return {
-          subject: `[Dust] ${details.subject}`,
+          subject: details.subject,
           body,
         };
       },

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -9,8 +9,8 @@ import {
 import { hasUnreadSucceededAgentReply } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/activation-new-conversation";
 import {
+  getActivationRecommendation,
   getConversationDetails,
-  getEmailSummary,
 } from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -30,8 +30,6 @@ import { z } from "zod";
 // to the target user as a dedicated, standalone email. It has no digest step, so a
 // conversation sent this way is never also bundled into the unread digest for the same activity.
 
-// For the email UI itself, right now it reuses and says something basic, will be fleshed out later.
-
 const activationNewConversationPayloadSchema = z.object({
   workspaceId: z.string(),
   conversationId: z.string(),
@@ -44,7 +42,8 @@ export type activationNewConversationPayloadType = z.infer<
 const activationNewConversationDetailsSchema = z.object({
   subject: z.string(),
   workspaceName: z.string(),
-  // Short, human summary of what's inside; null when none could be generated.
+  podName: z.string(),
+  purpose: z.string().nullable(),
   summary: z.string().nullable(),
 });
 
@@ -98,11 +97,13 @@ const getActivationNewConversationDetails = async ({
     return {
       subject: "A new conversation",
       workspaceName: "your workspace",
+      podName: "your pod",
+      purpose: null,
       summary: null,
     };
   }
 
-  const summary = await getEmailSummary({
+  const { purpose, summary } = await getActivationRecommendation({
     details: detailsResult.value,
     subscriberId: subscriberId ?? "",
     payload,
@@ -111,6 +112,8 @@ const getActivationNewConversationDetails = async ({
   return {
     subject: detailsResult.value.subject,
     workspaceName: detailsResult.value.workspaceName,
+    podName: detailsResult.value.projectName ?? "your pod",
+    purpose,
     summary,
   };
 };
@@ -160,11 +163,11 @@ export const activationNewConversationWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          title: details.subject,
+          podName: details.podName,
+          purpose: details.purpose,
           summary: details.summary,
-          previewImageUrl: undefined,
           action: {
-            label: "Open conversation",
+            label: details.subject,
             url:
               config.getAppUrl() +
               getConversationRoute(payload.workspaceId, payload.conversationId),
@@ -172,7 +175,7 @@ export const activationNewConversationWorkflow = workflow(
         });
 
         return {
-          subject: details.subject,
+          subject: `[Dust] ${details.subject}`,
           body,
         };
       },

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -4,11 +4,13 @@ import {
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
-import type { ConversationDetailsType } from "@app/lib/notifications/helpers";
+import {
+  type ConversationDetailsType,
+  getEmailSummary,
+} from "@app/lib/notifications/helpers";
 import {
   type ConversationUnreadPayloadType,
   filterParticipantsByNotifyCondition,
-  getEmailSummary,
   getMessagePreviewSlack,
   getMessagePreviewText,
   shouldSendNotificationForAgentAnswer,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -1,20 +1,12 @@
-import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import {
-  countConversationMessages,
-  renderConversationAsText,
-} from "@app/lib/api/assistant/conversation/render_as_text";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
+import type { DustError } from "@app/lib/error";
 import {
   ensureSlackNotificationsReady,
   getNovuClient,
   getUserNotificationDelay,
   type NotificationAllowedTags,
 } from "@app/lib/notifications";
-import { fetchUnreadLightConversation } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/conversations-unread";
 import {
   type ConversationDetailsPayload,
@@ -22,6 +14,7 @@ import {
   ConversationDetailsSchema,
   type ConversationDetailsType,
   getConversationDetails,
+  getEmailSummary,
 } from "@app/lib/notifications/helpers";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -30,10 +23,7 @@ import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
-import {
-  getConversationDisplayTitle,
-  isPodConversation,
-} from "@app/types/assistant/conversation";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import type { NotificationCondition } from "@app/types/notification_preferences";
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
@@ -251,239 +241,6 @@ export const shouldSkipConversation = async ({
     triggerShouldSkip,
     hasUnreadMessages,
   });
-};
-
-const FUNCTION_NAME = "write_summary";
-
-const specification: AgentActionSpecification = {
-  name: FUNCTION_NAME,
-  description: "Write a summary of the conversation",
-  inputSchema: {
-    type: "object",
-    properties: {
-      conversation_summary: {
-        type: "string",
-        description: "A short summary of the conversation.",
-      },
-    },
-    required: ["conversation_summary"],
-  },
-};
-
-const MAX_CONVERSATION_SNIPPET_LENGTH = 12_000;
-
-const generateUnreadMessagesSummary = async ({
-  subscriberId,
-  payload,
-}: {
-  subscriberId?: string;
-  payload: ConversationUnreadPayloadType;
-}): Promise<
-  Result<
-    string,
-    DustError<
-      | "conversation_not_found"
-      | "no_unread_messages_found"
-      | "no_whitelisted_model_found"
-      | "internal_error"
-      | "generation_failed"
-      | "user_not_found"
-    >
-  >
-> => {
-  if (!subscriberId) {
-    return new Ok("");
-  }
-
-  const auth = await Authenticator.fromUserIdAndWorkspaceId(
-    subscriberId,
-    payload.workspaceId
-  );
-
-  const conversationRes = await fetchUnreadLightConversation(
-    auth,
-    payload.conversationId
-  );
-
-  if (conversationRes.isErr()) {
-    return new Err(
-      new DustError("conversation_not_found", "Failed to get conversation")
-    );
-  }
-
-  const conversation = conversationRes.value;
-
-  if (conversation.content.length === 0) {
-    return new Err(
-      new DustError("no_unread_messages_found", "No unread messages")
-    );
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  const model = await getSmallWhitelistedModel(auth);
-
-  if (!model) {
-    return new Err(
-      new DustError("no_whitelisted_model_found", "No whitelisted model found")
-    );
-  }
-
-  const userFullName = auth.user()?.fullName();
-
-  if (!userFullName) {
-    return new Err(
-      new DustError("user_not_found", "User not found for summary generation")
-    );
-  }
-  // Generate LLM summary
-  const prompt =
-    `# Task\n` +
-    `Write a 1-2 sentence summary of unread messages for ${userFullName} to quickly understand what happened while they were away and what action (if any) is needed from them.\n\n` +
-    `CRITICAL RULE: You are writing to ${userFullName}. NEVER write their name "${userFullName}" in the summary. Always use "you/your/yours" instead.\n\n` +
-    `# Input Format\n` +
-    `You'll receive a JSON array of UNREAD messages (not the full conversation history, only what ${userFullName} hasn't seen yet). Each message has:\n` +
-    `- "role": "user" (human) or "assistant" (AI agent)\n` +
-    `- "name": sender's display name (e.g., "Sarah Chen", "dust")\n` +
-    `- "content": message text (human messages start with <dust_system> block with sender details)\n\n` +
-    `Use "role", "name", and <dust_system> to attribute senders correctly. Use message text for what happened. Never guess.\n\n` +
-    `# Writing Rules\n` +
-    `1. **Length**: 1-2 sentences maximum\n` +
-    `2. **Second person**: Use "you/your/yours" when referring to ${userFullName} - NEVER write "${userFullName}"\n` +
-    `3. **Action-first**: If someone needs something from ${userFullName}, lead with that: "[Name] needs you to [action] [details]"\n` +
-    `4. **Outcome-first for updates**: If no action needed from ${userFullName}, lead with what's ready/decided: "Draft is ready", "Meeting scheduled"\n` +
-    `5. **No chat narration**: NEVER write "X asked", "assistant provided", "then Y replied"\n` +
-    `6. **Result phrasing**: Use neutral outcomes - "Draft is ready", "Meeting scheduled", "Sarah needs..."\n` +
-    `7. **Use names**: Refer to other participants by name, never "the user"\n` +
-    `8. **Accurate attribution**: Only include information actually in the messages\n\n` +
-    `# Examples\n\n` +
-    `## Action Needed (someone waiting on the recipient)\n` +
-    `"Sarah needs your approval on the Q1 hiring budget ($450K) by end of week to finalize headcount."\n` +
-    `"Alex needs you to choose between the three homepage designs by Tuesday for the product launch."\n` +
-    `"Jordan needs your technical review of the migration plan—specifically whether the 2-week timeline is feasible."\n\n` +
-    `## Updates (no specific action needed)\n` +
-    `"Three design mockups are ready with Sarah's feedback for the homepage redesign."\n` +
-    `"Q4 budget approved at $2.5M. Implementation timeline set for March."\n` +
-    `"David shared the customer research findings—80% want mobile-first experience."\n\n` +
-    `## Mixed (update + action)\n` +
-    `"Hiring budget spreadsheet is ready for Q1. Emily needs your review by Wednesday."\n` +
-    `"Three design mockups are ready with Sarah's feedback. She's waiting on your approval to move forward."\n\n` +
-    `# Your Task\n` +
-    `Read the UNREAD messages below and write a 1-2 sentence summary following ALL rules above.\n` +
-    `Prioritize any actions needed from the recipient first, then updates. Include key specifics.\n` +
-    `Remember: Use "you/your" - NEVER write "${userFullName}".\n` +
-    `Write in a natural, engaging tone that makes someone want to read it.`;
-
-  const renderedMessages = renderConversationAsText(conversation, {
-    includeTimestamps: true,
-    includeEmail: true,
-    includeUnread: true,
-    truncateTotalChars: MAX_CONVERSATION_SNIPPET_LENGTH,
-  });
-
-  const preamble = [
-    `Conversation: ${conversation.sId}`,
-    `Title: ${getConversationDisplayTitle(conversation)}`,
-    `Created: ${new Date(conversation.created).toISOString()}`,
-    `Updated: ${new Date(conversation.updated).toISOString()}`,
-    `Unread: ${conversation.unread}`,
-    `Action Required: ${conversation.actionRequired}`,
-    `Has Error: ${conversation.hasError}`,
-    `Message Count: ${countConversationMessages(conversation)}`,
-    `URL: /w/${owner.sId}/assistant/${conversation.sId}`,
-  ].join("\n");
-
-  const conversationSnippet = `${preamble}\n\n${renderedMessages}`;
-
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      providerId: model.providerId,
-      modelId: model.modelId,
-      functionCall: FUNCTION_NAME,
-    },
-    {
-      conversation: {
-        messages: [
-          {
-            role: "user",
-            name: userFullName,
-            content: [
-              {
-                type: "text",
-                text: `This is the content of the conversation to summarize:\n\n${conversationSnippet}`,
-              },
-            ],
-          },
-        ],
-      },
-      prompt,
-      specifications: [specification],
-      forceToolCall: FUNCTION_NAME,
-    },
-    {
-      context: {
-        operationType: "conversation_unread_summary",
-        conversationId: conversation.sId,
-        userId: auth.user()?.sId,
-        workspaceId: owner.sId,
-      },
-    }
-  );
-
-  if (res.isErr()) {
-    return new Err(new DustError("generation_failed", res.error.message));
-  }
-
-  // Extract summary from function call result.
-  if (res.value.actions?.[0]?.arguments?.conversation_summary) {
-    const summary = res.value.actions[0].arguments.conversation_summary;
-    return new Ok(stripMarkdown(summary));
-  }
-
-  return new Err(
-    new DustError("generation_failed", "No conversation summary generated")
-  );
-};
-
-export const getEmailSummary = async ({
-  details,
-  subscriberId,
-  payload,
-}: {
-  details: ConversationDetailsType;
-  subscriberId: string;
-  payload: ConversationUnreadPayloadType;
-}): Promise<string | null> => {
-  if (details.hasConversationRetentionPolicy) {
-    return "Summary not generated due to data retention policy on conversations in this workspace.";
-  }
-
-  if (details.hasAgentRetentionPolicies) {
-    return "Summary not generated due to data retention policy on agents in this conversation.";
-  }
-
-  // Generate summary of unread messages
-  const summaryResult = await generateUnreadMessagesSummary({
-    subscriberId,
-    payload,
-  });
-
-  if (summaryResult.isErr()) {
-    switch (summaryResult.error.code) {
-      case "generation_failed":
-      case "conversation_not_found":
-      case "no_unread_messages_found":
-      case "internal_error":
-      case "no_whitelisted_model_found":
-      case "user_not_found":
-        break;
-      default:
-        assertNever(summaryResult.error.code);
-    }
-    return null;
-  }
-  return summaryResult.value;
 };
 
 const getEmailSubject = (

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -96,6 +96,32 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     return new this(this.model, rec.get());
   }
 
+  // Fetches the recommendation records surfaced in a given conversation.
+  // Used to feed the actual recommendation card content into downstream
+  // generation (e.g. the activation email summary), rather than relying only
+  // on the rendered conversation messages.
+  static async fetchByConversationSId(
+    auth: Authenticator,
+    conversationSId: string
+  ): Promise<ActivationRecommendationResource[]> {
+    const recs = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [
+        {
+          model: ConversationModel,
+          attributes: [],
+          required: true,
+          where: { sId: conversationSId },
+        },
+      ],
+      order: [["createdAt", "DESC"]],
+    });
+
+    return recs.map((rec) => new this(this.model, rec.get()));
+  }
+
   static async fetchByUser(
     auth: Authenticator,
     { limit = 100 }: { limit?: number } = {}


### PR DESCRIPTION
## Description
Creates the text portion of the email notification:
- subject: [Dust] + "conversation title"
- Introduction message which includes an AI generated `purpose` --> short phrase to explain what the recommendation is.
- Hyperlink to the conversation
- A 1-2 sentence AI generated `summary` for more context about this recommendation.
- Fallback to a generic message if the AI generated parts fail.
<img width="714" height="440" alt="Screenshot 2026-07-27 at 12 07 35" src="https://github.com/user-attachments/assets/1deec9d4-31ad-4998-965b-02619d79fe35" />

Frame capabilities to be added in another PR.

## Tests
Local tests. 

## Risk
Low risk. Only triggered for people with new activation nudge convos who don't read the conversation.

## Deploy Plan
Deploy front.