### PR TITLE
fix(databricks-mcp): backport error-handling fixes from ServiceNow MCP review

### DIFF
--- a/front/lib/api/actions/servers/databricks/helpers.ts
+++ b/front/lib/api/actions/servers/databricks/helpers.ts
@@ -1,6 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { untrustedFetch } from "@app/lib/egress/server";
-import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
@@ -27,7 +26,7 @@ function getWorkspaceUrl(authInfo?: AuthInfo): string | null {
   if (!isString(databricksWorkspaceUrl)) {
     return null;
   }
-  return databricksWorkspaceUrl;
+  return databricksWorkspaceUrl.trim().replace(/\/$/, "");
 }
 
 async function databricksApiCall<T extends z.ZodTypeAny>(
@@ -46,8 +45,7 @@ async function databricksApiCall<T extends z.ZodTypeAny>(
     body?: Record<string, unknown>;
   } = {}
 ): Promise<Result<z.infer<T>, MCPError>> {
-  const baseUrl = workspaceUrl.trim().replace(/\/$/, "");
-  const url = `${baseUrl}${endpoint}`;
+  const url = `${workspaceUrl}${endpoint}`;
 
   const response = await untrustedFetch(url, {
     method: options.method ?? "GET",
@@ -67,11 +65,9 @@ async function databricksApiCall<T extends z.ZodTypeAny>(
     } catch {
       errorMessage = `${errorMessage} - ${errorBody}`;
     }
-    logger.error({
-      error: errorMessage,
-      message: `[Databricks MCP Server] ${errorMessage}`,
-    });
-    return new Err(new MCPError(errorMessage));
+    return new Err(
+      new MCPError(errorMessage, { tracked: response.status >= 500 })
+    );
   }
 
   const responseText = await response.text();
@@ -84,7 +80,6 @@ async function databricksApiCall<T extends z.ZodTypeAny>(
 
   if (!parseResult.success) {
     const msg = `Invalid Databricks response format: ${parseResult.error.message}`;
-    logger.error(`[Databricks MCP Server] ${msg}`);
     return new Err(new MCPError(msg));
   }
 
@@ -130,7 +125,8 @@ export async function withAuth({
   if (!workspaceUrl) {
     return new Err(
       new MCPError(
-        "Workspace URL not found in connection metadata. Please reconnect your Databricks account."
+        "Workspace URL not found in connection metadata. Please reconnect your Databricks account.",
+        { tracked: false }
       )
     );
   }


### PR DESCRIPTION
## Description

While reviewing the ServiceNow MCP incident CRUD PR (#29152), Aubin flagged a handful of issues in `front/lib/api/actions/servers/servicenow/client.ts` — but their root already existed one PR earlier, in the ServiceNow *skeleton* PR (#29135), because that server's client code was scaffolded off of the Databricks MCP server. The fixes landed in ServiceNow but were never backported to Databricks, where the same code still has the original issues.

This PR ports those same fixes to `front/lib/api/actions/servers/databricks/helpers.ts`:

- **Redundant logging**: `databricksApiCall` called `logger.error(...)` on failure, duplicating what `withToolLogging` already logs around every tool call. Removed (see Aubin's comment ["this log is redundant with what we have in `withToolLogging`"](https://github.com/dust-tt/dust/pull/29135) on the ServiceNow skeleton PR).
- **Error tracking not categorized by status code**: all API errors were tracked (`MCPError` defaults `tracked: true`) regardless of status, so routine 4xx errors (e.g. bad/expired credentials) paged the same as genuine 5xx failures. Now `tracked: response.status >= 500`, matching Aubin's request to ["categorize errors: 5xx -> tracked: true, 4xx -> tracked: false"](https://github.com/dust-tt/dust/pull/29135).
- **Workspace URL re-normalized on every request**: `workspaceUrl.trim().replace(/\/$/, "")` was recomputed inside `databricksApiCall` on every call instead of once when the URL is read from connection metadata. Moved into `getWorkspaceUrl`.
- **Untracked config error not marked as such**: the "Workspace URL not found in connection metadata" error is a user-facing reconnect prompt, not a system fault, so it should not be tracked. Added `{ tracked: false }`.

## Scope

Deliberately narrow — only the four issues above, matching the equivalent ServiceNow fixes one-for-one. No behavior change to `list_warehouses` itself, no architectural refactor (Databricks currently has a single tool, so the class-based client / structured-chaining feedback from the incident-CRUD PR doesn't apply here yet).

## Tests

- `npx tsgo --noEmit`: no new errors introduced by this change (verified against a clean `origin/main` baseline).
- `npx biome check`: clean.
- No dedicated Databricks MCP test file exists; behavior is unchanged aside from error tracking/logging, which isn't covered by the existing metadata snapshot test.

## Risk

Low. Internal-only error-handling/observability changes; no schema, tool, or API surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)