### PR TITLE
Update MCP sdk to latest 1.29

### DIFF
--- a/cli/dust-cli/package.json
+++ b/cli/dust-cli/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@dust-tt/client": "^1.2.6",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.4.1",
     "clipboardy": "^4.0.0",
     "diff": "^8.0.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -57,7 +57,7 @@
     "@mixmark-io/domino": "^2.2.0",
     "@dust-tt/sparkle": "^0.7.7",
     "@frontapp/plugin-sdk": "^1.8.1",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@tailwindcss/forms": "^0.5.9",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-blockquote": "^3.19.0",

--- a/front/package.json
+++ b/front/package.json
@@ -64,7 +64,7 @@
     "@metronome/sdk": "^3.4.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@mistralai/mistralai": "^2.2.1",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/blake-hash": "^1.3.6",
     "@notionhq/client": "^5.13.0",
     "@novu/api": "^3.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.2.6",
-        "@modelcontextprotocol/sdk": "^1.27.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.4.1",
         "clipboardy": "^4.0.0",
         "diff": "^8.0.2",
@@ -244,7 +244,7 @@
         "@dust-tt/sparkle": "^0.7.7",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@mixmark-io/domino": "^2.2.0",
-        "@modelcontextprotocol/sdk": "^1.27.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@tailwindcss/forms": "^0.5.9",
         "@tiptap/core": "^3.19.0",
         "@tiptap/extension-blockquote": "^3.19.0",
@@ -343,7 +343,7 @@
         "@metronome/sdk": "^3.4.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^2.2.1",
-        "@modelcontextprotocol/sdk": "^1.27.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/blake-hash": "^1.3.6",
         "@notionhq/client": "^5.13.0",
         "@novu/api": "^3.13.0",
@@ -994,18 +994,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "front/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "front/node_modules/hot-shots": {
@@ -7942,9 +7930,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -58318,7 +58306,7 @@
       "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/json-schema": "^7.0.15",
         "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     },
     "ajv": "^8.20.0",
     "@types/react": "^18.3.18",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^24.12.2",
     "dd-trace": "^5.87.0",
     "esbuild": "^0.27.3",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -41,7 +41,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/json-schema": "^7.0.15",
     "event-source-polyfill": "^1.0.31",
     "eventsource-parser": "^1.1.1",

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -8,14 +8,6 @@
     "lib": ["es2020", "dom"],
     "types": ["node"],
     "rootDir": "src",
-    "paths": {
-      "@modelcontextprotocol/sdk/*": [
-        // Workaround to fix invalid type mapping in @modelcontextprotocol/sdk, see https://github.com/modelcontextprotocol/typescript-sdk/pull/1623
-        "../../node_modules/@modelcontextprotocol/sdk/dist/esm/*",
-        // This path is needed to also support the same issue when using dust-hive under .hives folder
-        "../../../../node_modules/@modelcontextprotocol/sdk/dist/esm/*"
-      ]
-    },
     "outDir": "dist",
     "emitDeclarationOnly": true,
     "declaration": true,


### PR DESCRIPTION
## Description

Update MCP from 1.27.0 to 1.29.0, which includes the fix for the `tsc` path: https://github.com/modelcontextprotocol/typescript-sdk/pull/1623 — this is the motivation for the upgrade.

1.29.0 is the latest 1.x (anything newer is the `2.0.0-beta` prerelease line, which we deliberately avoid). Bumped in all workspaces that depend on it (`front`, `sdks/js`, `cli/dust-cli`, `extension`) plus the root `overrides` pin, and regenerated `package-lock.json`.

### Why this is safe

Every change between 1.27.0 and 1.29.0 is a bug fix or v1.x backport — no intentional breaking API changes:

- **1.28.0**: use `scopes_supported` from resource metadata by default; default to `client_secret_basic` when the server omits `token_endpoint_auth_methods_supported`; reject plain JSON Schema objects passed as `inputSchema` (#1596); timeout/abort cleanup fixes; RFC 8252 loopback port relaxation.
- **1.29.0**: disallow null (infinite) requested TTL; add missing `size` field to `ResourceSchema`; add typings exports / missing `package.json` types (the `tsc` path fix above, #1623); allow advertising extensions in the capability object; always set `windowsHide` on Windows for stdio.

The only behavior-narrowing change, **#1596 (`tool()`/`registerTool()` now throw if passed a plain JSON Schema instead of a Zod shape)**, does not affect us: every `registerTool` call site passes a Zod `ZodRawShape` (`register.ts`, `mcp_internal_actions/wrappers.ts`, `extension/shared/tools/index.ts`). The plain `{ type: "object", ... }` objects in the codebase are our own config types / mock wire-format `Tool` objects, never arguments to `registerTool`.

The auth-default changes are also no-ops for us: `remote_mcp_servers_resource.ts` already branches explicitly on `client_secret_post`/`client_secret_basic` and already prioritizes resource-metadata `scopes_supported`. No `StdioClientTransport` usage, so the Windows stdio change is irrelevant.

## Tests

`npx tsgo --noEmit` in `front` (type-check). No source changes required — dependency bump only.

## Risk

Low. Patch/minor bug-fix bump with no breaking API changes affecting our usage. Can be rolled back by reverting the version bump.

## Deploy Plan

deploy front
