### PR TITLE
[front] add dust_app:admin governance capability and seeder

### DIFF
--- a/front/lib/api/permissions/governance_seeding.ts
+++ b/front/lib/api/permissions/governance_seeding.ts
@@ -59,6 +59,21 @@ export const CAPABILITY_SEEDERS: CapabilitySeeder[] = [
     capability: { grantType: "publish", resourceType: "frame" },
     resolveTarget: async (_auth) => "everyone",
   },
+  // Dust apps are a legacy feature gated by the `legacy_dust_apps` flag. Only workspaces that
+  // still have it should keep builder-level administration of apps; everywhere else it defaults to
+  // admins-only. The "builders" target degrades to "admins_only" when the workspace has no
+  // Builders group (i.e. no builder-role members), so this naturally lands on builders only for
+  // legacy workspaces that actually have builders.
+  {
+    capability: { grantType: "admin", resourceType: "dust_app" },
+    resolveTarget: async (auth) => {
+      const hasLegacyDustApps = await FeatureFlagResource.isEnabledForWorkspace(
+        auth.getNonNullableWorkspace(),
+        "legacy_dust_apps"
+      );
+      return hasLegacyDustApps ? "builders" : "admins_only";
+    },
+  },
   {
     capability: { grantType: "publish", resourceType: "agent" },
     resolveTarget: async (auth) => {

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -142,6 +142,7 @@ describe("Authenticator.getWorkspacePermissions", () => {
       billing: ["admin"],
       identity: ["admin"],
       audit_log: ["read"],
+      dust_app: ["admin"],
     });
   });
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -78,6 +78,9 @@ export const ROLE_REGISTRY: Record<
   models_tier: {
     use: { verbs: ["use"], levels: ["instance"] },
   },
+  dust_app: {
+    admin: { verbs: ["admin"], levels: ["type"] },
+  },
 };
 
 interface GrantSpec {
@@ -197,6 +200,7 @@ export function workspacePermissionsFromGrants(
     identity: new Set(),
     audit_log: new Set(),
     models_tier: new Set(),
+    dust_app: new Set(),
   };
 
   for (const { grantType, resourceType } of grants) {

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -47,6 +47,7 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "identity",
   "audit_log",
   "models_tier",
+  "dust_app",
   "*",
 ] as const;
 export type GroupPermissionResourceType =
@@ -130,6 +131,7 @@ export function emptyWorkspacePermissions(): WorkspacePermissions {
     identity: [],
     audit_log: [],
     models_tier: [],
+    dust_app: [],
   };
 }
 


### PR DESCRIPTION
## Description

Part 1 of moving Dust app administration off the deprecated builder role (dust-tt/tasks#9746). This PR **adds the `dust_app:admin` governance capability and prepares its backfill** — no enforcement yet. The follow-up PR #29469 switches the actual checks.

### Changes

- **New `dust_app:admin` capability**
  - `front/types/group_permissions.ts` — add `"dust_app"` to `GROUP_PERMISSION_RESOURCE_TYPES` and to `EMPTY_WORKSPACE_PERMISSIONS`.
  - `front/lib/resources/group_permission_registry.ts` — add `dust_app: { admin: { verbs: ["admin"], levels: ["type"] } }` (type-level singleton, matching `billing`/`identity`) and the `verbsByResource` entry. Registry invariant tests pass by construction (name == verb; `admin` already in `GRANT_TYPES`/`GRANT_VERBS`).
- **Seeder** (`governance_seeding.ts` → `CAPABILITY_SEEDERS`): targets the Builders group for workspaces with the `legacy_dust_apps` flag (degrading to admins_only when the workspace has no Builders group), admins_only otherwise. The existing backfill migration and new-workspace seeding pick it up automatically.

### No behavior change

Nothing reads `dust_app:admin` in this PR. Enforcement is in the stacked follow-up **#29469**.

### Testing

Verified zero TypeScript errors in the touched files (anchored). Full local `tsgo` is currently blocked by an unrelated `node_modules` drift in the dev workspace; CI's clean install runs the full typecheck + registry tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)