### PR TITLE
[front] Gate legacy Dust Apps behind legacy_dust_apps flag

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
@@ -4,6 +4,7 @@ import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_vie
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -19,6 +20,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/apps/:aId", () => {
   it("returns 409 when the app is used by an active agent", async () => {
     const { workspace, user, globalSpace, auth } =
       await createPrivateApiMockRequest({ role: "admin" });
+    await FeatureFlagFactory.basic(auth, "legacy_dust_apps");
 
     const app = await AppResource.makeNew(
       {
@@ -105,6 +107,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/apps/:aId", () => {
     const { workspace, globalSpace, auth } = await createPrivateApiMockRequest({
       role: "admin",
     });
+    await FeatureFlagFactory.basic(auth, "legacy_dust_apps");
 
     const app = await AppResource.makeNew(
       {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -12,6 +12,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 
@@ -24,6 +25,16 @@ const PostAppBodySchema = z.object({
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps.
 const app = workspaceApp();
+
+// Legacy Dust Apps are gated behind the `legacy_dust_apps` feature flag. This
+// gates the whole surface: listing, creation, and every per-app sub-route
+// (datasets, runs, state) mounted under /:aId below.
+app.use(
+  "*",
+  withFeatureFlag("legacy_dust_apps", {
+    message: "Dust Apps are not enabled for this workspace.",
+  })
+);
 
 // GET / — list apps in space.
 /** @ignoreswagger */

--- a/front-spa/src/app/layouts/RequireFeatureFlagLayout.tsx
+++ b/front-spa/src/app/layouts/RequireFeatureFlagLayout.tsx
@@ -1,0 +1,18 @@
+import Custom404 from "@dust-tt/front/components/pages/Custom404";
+import { useFeatureFlags } from "@dust-tt/front/lib/auth/AuthContext";
+import type { WhitelistableFeature } from "@dust-tt/front/types/shared/feature_flags";
+import { Outlet } from "react-router-dom";
+
+interface RequireFeatureFlagProps {
+  flag: WhitelistableFeature;
+}
+
+export function RequireFeatureFlagLayout({ flag }: RequireFeatureFlagProps) {
+  const { hasFeature } = useFeatureFlags();
+
+  if (!hasFeature(flag)) {
+    return <Custom404 />;
+  }
+
+  return <Outlet />;
+}

--- a/front-spa/src/app/routes/appsRoutes.tsx
+++ b/front-spa/src/app/routes/appsRoutes.tsx
@@ -1,4 +1,5 @@
 import { DustAppRouterLayout } from "@spa/app/layouts/DustAppRouterLayout";
+import { RequireFeatureFlagLayout } from "@spa/app/layouts/RequireFeatureFlagLayout";
 import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
 
@@ -38,20 +39,25 @@ const RunsPage = withSuspense(
 
 export const appsRoutes: RouteObject[] = [
   {
-    path: "spaces/:spaceId/apps/:aId",
-    element: <DustAppRouterLayout />,
+    element: <RequireFeatureFlagLayout flag="legacy_dust_apps" />,
     children: [
-      { index: true, element: <AppViewPage /> },
-      { path: "settings", element: <AppSettingsPage /> },
       {
-        path: "specification",
-        element: <AppSpecificationPage />,
+        path: "spaces/:spaceId/apps/:aId",
+        element: <DustAppRouterLayout />,
+        children: [
+          { index: true, element: <AppViewPage /> },
+          { path: "settings", element: <AppSettingsPage /> },
+          {
+            path: "specification",
+            element: <AppSpecificationPage />,
+          },
+          { path: "datasets", element: <DatasetsPage /> },
+          { path: "datasets/new", element: <NewDatasetPage /> },
+          { path: "datasets/:name", element: <DatasetPage /> },
+          { path: "runs", element: <RunsPage /> },
+          { path: "runs/:runId", element: <RunPage /> },
+        ],
       },
-      { path: "datasets", element: <DatasetsPage /> },
-      { path: "datasets/new", element: <NewDatasetPage /> },
-      { path: "datasets/:name", element: <DatasetPage /> },
-      { path: "runs", element: <RunsPage /> },
-      { path: "runs/:runId", element: <RunPage /> },
     ],
   },
 ];

--- a/front-spa/src/app/routes/spacesRoutes.tsx
+++ b/front-spa/src/app/routes/spacesRoutes.tsx
@@ -1,3 +1,4 @@
+import { RequireFeatureFlagLayout } from "@spa/app/layouts/RequireFeatureFlagLayout";
 import { SpaceRouterLayout } from "@spa/app/layouts/SpaceRouterLayout";
 import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
@@ -41,7 +42,10 @@ export const spacesRoutes: RouteObject[] = [
         path: "categories/actions",
         element: <SpaceActionsPage />,
       },
-      { path: "categories/apps", element: <SpaceAppsListPage /> },
+      {
+        element: <RequireFeatureFlagLayout flag="legacy_dust_apps" />,
+        children: [{ path: "categories/apps", element: <SpaceAppsListPage /> }],
+      },
       {
         path: "categories/triggers",
         element: <SpaceTriggersPage />,

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -176,12 +176,14 @@ export const SpaceCategoriesList = ({
             icon={Globe01}
             label="Scrape a website"
           />
-          <DropdownMenuItem
-            disabled={!isBuilder || !canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?modal=apps`}
-            icon={Terminal}
-            label="Create a Dust App"
-          />
+          {hasFeature("legacy_dust_apps") && (
+            <DropdownMenuItem
+              disabled={!isBuilder || !canWriteInSpace}
+              href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?modal=apps`}
+              icon={Terminal}
+              label="Create a Dust App"
+            />
+          )}
           <DropdownMenuItem
             disabled={!isAdmin}
             href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions?modal=tools`}


### PR DESCRIPTION
## Description

Dust apps were only **partially** gated by the `legacy_dust_apps` feature flag. Even with the flag off, a user could:

- See the **"Create a Dust App"** item under "Add data" (only builder/write permissions were checked, not the flag).
- Directly navigate to `/w/:wId/spaces/:spaceId/categories/apps` and the app editor route tree.
- Call the **private app API endpoints** (create/list/datasets/runs/state) — these had **no flag check at all**, so app creation worked even bypassing the UI.

### Changes

**Frontend UI**
- `SpaceCategoriesList.tsx`: hide the "Create a Dust App" dropdown item when `hasFeature("legacy_dust_apps")` is false (consistent with how the Apps category tile is already filtered).

**Frontend routes (`front-spa`)**
- New `RequireFeatureFlagLayout` route guard, mirroring the existing `RequireRoleLayout` (renders `Custom404` when the flag is missing, else `<Outlet/>`).
- Wrapped the `categories/apps` page and the entire `spaces/:spaceId/apps/:aId` editor route tree with it.

**Backend (`front-api`)**
- `app.use("*", withFeatureFlag("legacy_dust_apps"))` at the top of the private apps subrouter — gates **list, create, and every per-app sub-route** (datasets, runs, state). Same pattern as `sandbox-functions`; `auth` is already set upstream by the global `workspaceAuth()`.

**Tests**
- Enable the flag via `FeatureFlagFactory` in the affected endpoint test (it would otherwise 403).

### Scope / not included

Deliberately **did not** gate the public API (`/api/v1/.../apps/*`, incl. `import` and `runs`) or the poke admin endpoints:
- Gating the public v1 surface would be a breaking change for external consumers currently running Dust apps via API.
- Poke is internal support tooling.


## Tests

locally

## Risk

low

## Deploy Plan

front
