### PR TITLE
[DX] rebuild sparkle on mprocs stop

### DIFF
--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -59,6 +59,7 @@ procs:
   sparkle:
     cwd: "<CONFIG_DIR>/../sparkle"
     shell: |
+      trap 'npm run build; exit' TERM INT
       npm run watch
 
   sdks-js:


### PR DESCRIPTION
## Description

Rebuild sparkle automatically when its mprocs `watch` process is stopped, so downstream consumers get an up-to-date build.

## Tests

Tested locally.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed. Local dev tooling only — no production impact.