### PR TITLE
[front] remove loading check from useWorkspacePermissions

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -158,11 +158,7 @@ export function ShareFrameSheet({
   const externalSharingDisabledByPolicy =
     owner.sharingPolicy === "workspace_only";
 
-  // When the workspace policy forbids external sharing, we can skip the permission fetch entirely.
-  const { hasPermission, isWorkspacePermissionsLoading } =
-    useWorkspacePermissions(owner, {
-      disabled: externalSharingDisabledByPolicy,
-    });
+  const { hasPermission } = useWorkspacePermissions();
 
   const canInviteExternal =
     !externalSharingDisabledByPolicy && hasPermission("invite", "frame");
@@ -170,7 +166,7 @@ export function ShareFrameSheet({
     owner.sharingPolicy === "all_scopes" && hasPermission("publish", "frame");
 
   const lostPublishPermission =
-    currentScope === "public" && !canPublish && !isWorkspacePermissionsLoading;
+    currentScope === "public" && !canPublish;
 
   const availableScopeOptions = getAvailableScopeOptions({
     sharingPolicy: owner.sharingPolicy,


### PR DESCRIPTION
## Description
This PR is to fix failed ts check in main, permission is now read synchronously from useAuth() context so no loading state if i understand it correctly? 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
