### PR TITLE
[GitHub MCP] Skip inaccessible review requests on fallback

### DIFF
--- a/front/lib/api/actions/servers/github/tools/index.test.ts
+++ b/front/lib/api/actions/servers/github/tools/index.test.ts
@@ -74,10 +74,11 @@ describe("GitHub pull request tools", () => {
   it.each([
     ["search_advanced", { query: "is:pr" }, searchResponse],
     ["list_pull_requests", { owner: "dust-tt", repo: "dust" }, listResponse],
-  ])("retries %s without team details when GitHub denies them", async (toolName, params, response) => {
+  ])("uses partial %s data when GitHub denies team details", async (toolName, params, response) => {
     const reviewerAccessError = Object.assign(
       new Error("Resource not accessible by integration"),
       {
+        data: response,
         errors: [
           {
             type: "FORBIDDEN",
@@ -96,8 +97,7 @@ describe("GitHub pull request tools", () => {
         ],
       }
     );
-    graphqlMock.mockRejectedValueOnce(reviewerAccessError);
-    graphqlMock.mockResolvedValueOnce(response);
+    graphqlMock.mockRejectedValue(reviewerAccessError);
 
     const { authenticator } = await createResourceTest({ role: "admin" });
     const tool = createGithubTools(authenticator).find(
@@ -126,14 +126,9 @@ describe("GitHub pull request tools", () => {
     const result = await tool.handler(params, extra);
 
     expect(result.isOk()).toBe(true);
-    expect(graphqlMock).toHaveBeenNthCalledWith(
-      1,
+    expect(graphqlMock).toHaveBeenCalledOnce();
+    expect(graphqlMock).toHaveBeenCalledWith(
       expect.stringContaining("... on Team"),
-      expect.any(Object)
-    );
-    expect(graphqlMock).toHaveBeenNthCalledWith(
-      2,
-      expect.not.stringContaining("... on Team"),
       expect.any(Object)
     );
     if (result.isOk()) {

--- a/front/lib/api/actions/servers/github/tools/index.test.ts
+++ b/front/lib/api/actions/servers/github/tools/index.test.ts
@@ -36,7 +36,6 @@ const pullRequest = {
   changedFiles: 1,
   labels: { nodes: [] },
   assignees: { nodes: [] },
-  reviewRequests: { nodes: [{ requestedReviewer: null }] },
   comments: { totalCount: 0 },
   reviews: { totalCount: 0 },
 };
@@ -74,11 +73,10 @@ describe("GitHub pull request tools", () => {
   it.each([
     ["search_advanced", { query: "is:pr" }, searchResponse],
     ["list_pull_requests", { owner: "dust-tt", repo: "dust" }, listResponse],
-  ])("uses partial %s data when GitHub denies team details", async (toolName, params, response) => {
+  ])("retries %s without review requests when GitHub denies team details", async (toolName, params, response) => {
     const reviewerAccessError = Object.assign(
       new Error("Resource not accessible by integration"),
       {
-        data: response,
         errors: [
           {
             type: "FORBIDDEN",
@@ -97,7 +95,8 @@ describe("GitHub pull request tools", () => {
         ],
       }
     );
-    graphqlMock.mockRejectedValue(reviewerAccessError);
+    graphqlMock.mockRejectedValueOnce(reviewerAccessError);
+    graphqlMock.mockResolvedValueOnce(response);
 
     const { authenticator } = await createResourceTest({ role: "admin" });
     const tool = createGithubTools(authenticator).find(
@@ -126,10 +125,15 @@ describe("GitHub pull request tools", () => {
     const result = await tool.handler(params, extra);
 
     expect(result.isOk()).toBe(true);
-    expect(graphqlMock).toHaveBeenCalledOnce();
-    expect(graphqlMock).toHaveBeenCalledWith(
+    expect(graphqlMock).toHaveBeenNthCalledWith(
+      1,
       expect.stringContaining("... on Team"),
-      expect.any(Object)
+      expect.objectContaining({ includeReviewRequests: true })
+    );
+    expect(graphqlMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("... on Team"),
+      expect.objectContaining({ includeReviewRequests: false })
     );
     if (result.isOk()) {
       expect(result.value[1]).toMatchObject({

--- a/front/lib/api/actions/servers/github/tools/index.test.ts
+++ b/front/lib/api/actions/servers/github/tools/index.test.ts
@@ -127,12 +127,16 @@ describe("GitHub pull request tools", () => {
     expect(result.isOk()).toBe(true);
     expect(graphqlMock).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining("... on Team"),
+      expect.stringContaining(
+        "reviewRequests(first: 10) @include(if: $includeReviewRequests)"
+      ),
       expect.objectContaining({ includeReviewRequests: true })
     );
     expect(graphqlMock).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("... on Team"),
+      expect.stringContaining(
+        "reviewRequests(first: 10) @include(if: $includeReviewRequests)"
+      ),
       expect.objectContaining({ includeReviewRequests: false })
     );
     if (result.isOk()) {

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -23,12 +23,17 @@ const GITHUB_TEAM_REVIEWER_FRAGMENT = `... on Team {
   slug
 }`;
 
-function isTeamReviewerAccessError(error: unknown): boolean {
+function isTeamReviewerAccessError(
+  error: unknown
+): error is { data: object; errors: unknown[] } {
   if (
     typeof error !== "object" ||
     error === null ||
     !("errors" in error) ||
-    !Array.isArray(error.errors)
+    !Array.isArray(error.errors) ||
+    !("data" in error) ||
+    typeof error.data !== "object" ||
+    error.data === null
   ) {
     return false;
   }
@@ -48,8 +53,9 @@ function isTeamReviewerAccessError(error: unknown): boolean {
   );
 }
 
-// GitHub App tokens without organization Members access cannot resolve Team reviewers. Retry
-// without the Team fragment so valid pull request data is not discarded with the error.
+// GitHub App tokens without organization Members access cannot resolve Team reviewers. Octokit
+// throws on these field-level errors but keeps the valid GraphQL data on the error, with the
+// inaccessible nullable reviewer set to null. Return that data instead of retrying the union.
 async function graphqlWithReviewerFallback<T>(
   octokit: Octokit,
   query: string,
@@ -62,10 +68,7 @@ async function graphqlWithReviewerFallback<T>(
       throw error;
     }
 
-    return octokit.graphql<T>(
-      query.replace(GITHUB_TEAM_REVIEWER_FRAGMENT, ""),
-      variables
-    );
+    return error.data as T;
   }
 }
 

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -23,17 +23,12 @@ const GITHUB_TEAM_REVIEWER_FRAGMENT = `... on Team {
   slug
 }`;
 
-function isTeamReviewerAccessError(
-  error: unknown
-): error is { data: object; errors: unknown[] } {
+function isTeamReviewerAccessError(error: unknown): boolean {
   if (
     typeof error !== "object" ||
     error === null ||
     !("errors" in error) ||
-    !Array.isArray(error.errors) ||
-    !("data" in error) ||
-    typeof error.data !== "object" ||
-    error.data === null
+    !Array.isArray(error.errors)
   ) {
     return false;
   }
@@ -53,22 +48,28 @@ function isTeamReviewerAccessError(
   );
 }
 
-// GitHub App tokens without organization Members access cannot resolve Team reviewers. Octokit
-// throws on these field-level errors but keeps the valid GraphQL data on the error, with the
-// inaccessible nullable reviewer set to null. Return that data instead of retrying the union.
+// GitHub App tokens without organization Members access cannot resolve Team reviewers. Retry with
+// the entire reviewRequests field skipped: requestedReviewer can require that permission even if
+// the query no longer selects Team fields.
 async function graphqlWithReviewerFallback<T>(
   octokit: Octokit,
   query: string,
   variables: Record<string, unknown>
 ): Promise<T> {
   try {
-    return await octokit.graphql<T>(query, variables);
+    return await octokit.graphql<T>(query, {
+      ...variables,
+      includeReviewRequests: true,
+    });
   } catch (error) {
     if (!isTeamReviewerAccessError(error)) {
       throw error;
     }
 
-    return error.data as T;
+    return octokit.graphql<T>(query, {
+      ...variables,
+      includeReviewRequests: false,
+    });
   }
 }
 
@@ -2192,7 +2193,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
 
       try {
         const searchQuery = `
-          query($searchQuery: String!, $first: Int!, $after: String, $before: String) {
+          query($searchQuery: String!, $first: Int!, $after: String, $before: String, $includeReviewRequests: Boolean!) {
             search(query: $searchQuery, type: ISSUE_ADVANCED, first: $first, after: $after, before: $before) {
               issueCount
               pageInfo {
@@ -2272,7 +2273,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                       login
                     }
                   }
-                  reviewRequests(first: 10) {
+                  reviewRequests(first: 10) @include(if: $includeReviewRequests) {
                     nodes {
                       requestedReviewer {
                         ... on User {
@@ -2373,14 +2374,14 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                       login: string;
                     }>;
                   };
-                  reviewRequests: {
+                  reviewRequests?: {
                     nodes: Array<{
                       requestedReviewer: {
                         login?: string;
                         slug?: string;
                       } | null;
                     }>;
-                  };
+                  } | null;
                   comments: {
                     totalCount: number;
                   };
@@ -2427,11 +2428,13 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               additions: node.additions,
               deletions: node.deletions,
               changedFiles: node.changedFiles,
-              reviewRequests: removeNulls(
-                node.reviewRequests.nodes.map((request) =>
-                  getReviewerIdentifier(request.requestedReviewer)
-                )
-              ),
+              reviewRequests: node.reviewRequests
+                ? removeNulls(
+                    node.reviewRequests.nodes.map((request) =>
+                      getReviewerIdentifier(request.requestedReviewer)
+                    )
+                  )
+                : [],
               reviewCount: node.reviews.totalCount,
             };
           } else {
@@ -2495,7 +2498,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
 
       try {
         const query = `
-          query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [PullRequestState!], $after: String, $before: String) {
+          query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [PullRequestState!], $after: String, $before: String, $includeReviewRequests: Boolean!) {
             repository(owner: $owner, name: $repo) {
               pullRequests(first: $first, orderBy: $orderBy, states: $states, after: $after, before: $before) {
                 pageInfo {
@@ -2531,7 +2534,7 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                       login
                     }
                   }
-                  reviewRequests(first: 10) {
+                  reviewRequests(first: 10) @include(if: $includeReviewRequests) {
                     nodes {
                       requestedReviewer {
                         ... on User {
@@ -2599,14 +2602,14 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                     login: string;
                   }[];
                 };
-                reviewRequests: {
+                reviewRequests?: {
                   nodes: {
                     requestedReviewer: {
                       login?: string;
                       slug?: string;
                     } | null;
                   }[];
-                };
+                } | null;
                 comments: {
                   totalCount: number;
                 };
@@ -2649,11 +2652,13 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               color: label.color,
             })),
             assignees: pr.assignees.nodes.map((assignee) => assignee.login),
-            reviewRequests: removeNulls(
-              pr.reviewRequests.nodes.map((request) =>
-                getReviewerIdentifier(request.requestedReviewer)
-              )
-            ),
+            reviewRequests: pr.reviewRequests
+              ? removeNulls(
+                  pr.reviewRequests.nodes.map((request) =>
+                    getReviewerIdentifier(request.requestedReviewer)
+                  )
+                )
+              : [],
             commentCount: pr.comments.totalCount,
             reviewCount: pr.reviews.totalCount,
           }));


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9593
Follow-up to https://github.com/dust-tt/dust/pull/29326

The first fallback removed only the Team fragment, but still asked GitHub to resolve `requestedReviewer`. Resolving that union to a Team can require organization Members access, so the retry could fail with the same authorization error.

Add an `includeReviewRequests` GraphQL directive and retry reviewer-specific authorization failures with the entire `reviewRequests` field disabled. Pull request data still returns successfully; only review requests are empty on affected connections. Connections with team access keep the existing full response.

## Risks

Low. The fallback applies only when every GraphQL error is a `FORBIDDEN` error below `reviewRequests`. Other errors still propagate unchanged.

## Deploy plan

Deploy Front normally.

## Tests

- [x] `NODE_ENV=test npm test -- lib/api/actions/servers/github/tools/index.test.ts`
- [x] `npx biome ci lib/api/actions/servers/github/tools/index.ts lib/api/actions/servers/github/tools/index.test.ts`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npx tsgo --noEmit`