### PR TITLE
[LINT] forbid importing model_constructors outside llms

### DIFF
--- a/.grit/patterns/noModelConstructorsImport.grit
+++ b/.grit/patterns/noModelConstructorsImport.grit
@@ -1,0 +1,20 @@
+engine biome(1.0)
+language js
+
+// Forbids importing from the model_constructors folder. Scope (which files this
+// applies to) is controlled by the override `includes` in biome.json, which
+// excludes model_constructors itself and front/lib/llms.
+pattern model_constructors_import() {
+    or {
+        `"@app/lib/model_constructors"`,
+        `"@app/lib/model_constructors/$_"`,
+    }
+}
+
+model_constructors_import() as $source where {
+    register_diagnostic(
+        span = $source,
+        message = "Do not import from '@app/lib/model_constructors'. LLM calls must be provider-agnostic — go through '@app/lib/llms' instead.",
+        severity = "error"
+    )
+}

--- a/biome.json
+++ b/biome.json
@@ -144,6 +144,14 @@
       "plugins": ["./.grit/patterns/noSparkleClassInFront.grit"]
     },
     {
+      "includes": [
+        "front/**/*.{js,jsx,ts,tsx}",
+        "!front/lib/model_constructors/**",
+        "!front/lib/llms/**"
+      ],
+      "plugins": ["./.grit/patterns/noModelConstructorsImport.grit"]
+    },
+    {
       "includes": ["marketing/pages/**/*.{js,jsx,ts,tsx}"],
       "plugins": [
         "./.grit/patterns/nextjsPageComponentNaming.grit",


### PR DESCRIPTION
## Description

Adds a Biome grit lint rule that forbids importing `@app/lib/model_constructors`, scoped to `front/**` except `model_constructors/` and `front/lib/llms/` themselves.

## Tests

Not needed.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`