### PR TITLE
[front] switch dust app administration to dust_app:admin capability

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -59,13 +59,16 @@ app.post(
     const space = ctx.get("space");
     const owner = auth.getNonNullableWorkspace();
 
-    if (!space.canWrite(auth) || !auth.isBuilder()) {
+    if (
+      !space.canWrite(auth) ||
+      !(await auth.hasWorkspacePermission("admin", "dust_app"))
+    ) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "app_auth_error",
           message:
-            "Only the users that are `builders` for the current workspace can create an app.",
+            "You do not have permission to administrate apps in the current workspace.",
         },
       });
     }

--- a/front/components/apps/DustAppPageLayout.tsx
+++ b/front/components/apps/DustAppPageLayout.tsx
@@ -11,6 +11,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { useApp } from "@app/lib/swr/apps";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
@@ -40,6 +41,8 @@ export function DustAppPageLayout({ children }: DustAppPageLayoutProps) {
   const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
 
   const { app } = useApp({
     workspaceId: owner.sId,
@@ -78,7 +81,12 @@ export function DustAppPageLayout({ children }: DustAppPageLayoutProps) {
     <div className="flex w-full flex-col">
       <Tabs value={currentTab} className="sticky top-0 z-10 bg-background pt-4">
         <TabsList>
-          {subNavigationApp({ owner, app, current: currentTab }).map((item) => (
+          {subNavigationApp({
+            owner,
+            app,
+            current: currentTab,
+            canAdministrateApps,
+          }).map((item) => (
             <TabsTrigger
               key={item.value}
               value={item.value}

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -7,7 +7,7 @@ import {
   type WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder, isManager } from "@app/types/user";
+import { isAdmin, isManager } from "@app/types/user";
 import {
   BarChart01,
   Brackets,
@@ -453,10 +453,12 @@ export const subNavigationApp = ({
   owner,
   app,
   current,
+  canAdministrateApps,
 }: {
   owner: WorkspaceType;
   app: AppType;
   current: SubNavigationAppId;
+  canAdministrateApps: boolean;
 }) => {
   let nav = [
     {
@@ -475,7 +477,7 @@ export const subNavigationApp = ({
     },
   ];
 
-  if (isAdmin(owner) || isBuilder(owner)) {
+  if (canAdministrateApps) {
     nav = nav.concat([
       {
         value: "runs",

--- a/front/components/pages/spaces/SpaceAppsListPage.tsx
+++ b/front/components/pages/spaces/SpaceAppsListPage.tsx
@@ -1,7 +1,8 @@
 import { SpaceAppsList } from "@app/components/spaces/SpaceAppsList";
 import { SpaceSearchInput } from "@app/components/spaces/SpaceSearchLayout";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { Spinner } from "@dust-tt/sparkle";
 
@@ -9,7 +10,8 @@ export function SpaceAppsListPage() {
   const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
 
   const {
     spaceInfo: space,
@@ -42,7 +44,7 @@ export function SpaceAppsListPage() {
       <SpaceAppsList
         owner={owner}
         space={space}
-        isBuilder={isBuilder}
+        canAdministrateApps={canAdministrateApps}
         onSelect={(sId) => {
           void router.push(`/w/${owner.sId}/spaces/${space.sId}/apps/${sId}`);
         }}

--- a/front/components/pages/spaces/SpacePage.tsx
+++ b/front/components/pages/spaces/SpacePage.tsx
@@ -14,7 +14,7 @@ export function SpacePage() {
   const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
-  const { subscription, isAdmin, isBuilder } = useAuth();
+  const { subscription, isAdmin } = useAuth();
   const plan = subscription.plan;
 
   const {
@@ -75,7 +75,6 @@ export function SpacePage() {
             );
           }}
           isAdmin={isAdmin}
-          isBuilder={isBuilder}
           onButtonClick={() => setShowSpaceEditionModal(true)}
         />
         <CreateOrEditSpaceModal

--- a/front/components/pages/spaces/apps/AppSettingsPage.tsx
+++ b/front/components/pages/spaces/apps/AppSettingsPage.tsx
@@ -1,10 +1,11 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import Custom404 from "@app/components/pages/Custom404";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { useApp } from "@app/lib/swr/apps";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import { APP_NAME_REGEXP } from "@app/types/app";
@@ -17,7 +18,8 @@ export function AppSettingsPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
 
   const { spaceInfo: space, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -135,12 +137,12 @@ export function AppSettingsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appName]);
 
-  // Redirect non-builders
+  // Redirect users without app administration permission.
   useEffect(() => {
-    if (!isBuilder && app && space) {
+    if (!canAdministrateApps && app && space) {
       void router.push(`/w/${owner.sId}/spaces/${space.sId}/apps/${app.sId}`);
     }
-  }, [isBuilder, app, space, router, owner.sId]);
+  }, [canAdministrateApps, app, space, router, owner.sId]);
 
   const isLoading = isSpaceInfoLoading || isAppLoading;
 

--- a/front/components/pages/spaces/apps/AppViewPage.tsx
+++ b/front/components/pages/spaces/apps/AppViewPage.tsx
@@ -13,6 +13,7 @@ import {
   moveBlockUp,
 } from "@app/lib/specification";
 import { useApp, useCancelRun, useSavedRunStatus } from "@app/lib/swr/apps";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type {
   BlockRunConfig,
   SpecificationBlockType,
@@ -99,8 +100,9 @@ export function AppViewPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { isAdmin, isBuilder } = useAuth();
-  const readOnly = !isBuilder;
+  const { isAdmin } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const readOnly = !hasPermission("admin", "dust_app");
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -3,11 +3,12 @@ import "@uiw/react-textarea-code-editor/dist.css";
 import DatasetView from "@app/components/app/DatasetView";
 import Custom404 from "@app/components/pages/Custom404";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { useApp } from "@app/lib/swr/apps";
 import { useDataset } from "@app/lib/swr/datasets";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { DatasetSchema, DatasetType } from "@app/types/dataset";
 import { Button, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
@@ -18,8 +19,8 @@ export function DatasetPage() {
   const aId = useRequiredPathParam("aId");
   const name = useRequiredPathParam("name");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
-  const readOnly = !isBuilder;
+  const { hasPermission } = useWorkspacePermissions();
+  const readOnly = !hasPermission("admin", "dust_app");
 
   const { app, isAppLoading } = useApp({
     workspaceId: owner.sId,

--- a/front/components/pages/spaces/apps/DatasetsPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetsPage.tsx
@@ -1,6 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import Custom404 from "@app/components/pages/Custom404";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   LinkWrapper,
@@ -9,6 +9,7 @@ import {
 } from "@app/lib/platform";
 import { useApp } from "@app/lib/swr/apps";
 import { useDatasets } from "@app/lib/swr/datasets";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { classNames } from "@app/lib/utils";
 import { Button, Chip, Plus, Spinner, Trash01 } from "@dust-tt/sparkle";
 import { useContext } from "react";
@@ -18,7 +19,7 @@ export function DatasetsPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -32,7 +33,7 @@ export function DatasetsPage() {
   });
 
   const confirm = useContext(ConfirmContext);
-  const readOnly = !isBuilder;
+  const readOnly = !hasPermission("admin", "dust_app");
 
   const handleDelete = async (datasetName: string) => {
     if (!app) {

--- a/front/components/pages/spaces/apps/NewDatasetPage.tsx
+++ b/front/components/pages/spaces/apps/NewDatasetPage.tsx
@@ -3,11 +3,12 @@ import "@uiw/react-textarea-code-editor/dist.css";
 import DatasetView from "@app/components/app/DatasetView";
 import Custom404 from "@app/components/pages/Custom404";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { useApp } from "@app/lib/swr/apps";
 import { useDatasets } from "@app/lib/swr/datasets";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { DatasetSchema, DatasetType } from "@app/types/dataset";
 import { Button, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
@@ -17,7 +18,8 @@ export function NewDatasetPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -40,14 +42,14 @@ export function NewDatasetPage() {
 
   useNavigationLock(editorDirty);
 
-  // Redirect non-builders
+  // Redirect users without app administration permission.
   useEffect(() => {
-    if (!isBuilder && app) {
+    if (!canAdministrateApps && app) {
       void router.push(
         `/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`
       );
     }
-  }, [isBuilder, app, router, owner.sId]);
+  }, [canAdministrateApps, app, router, owner.sId]);
 
   // This is a little wonky, but in order to redirect to the dataset's main page and not pop up the
   // "You have unsaved changes" dialog, we need to set editorDirty to false and then do the router

--- a/front/components/pages/spaces/apps/RunPage.tsx
+++ b/front/components/pages/spaces/apps/RunPage.tsx
@@ -7,6 +7,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { cleanSpecificationFromCore } from "@app/lib/specification";
 import { useApp, useRunWithSpec } from "@app/lib/swr/apps";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { Button, CheckCircle, Clock, Spinner } from "@dust-tt/sparkle";
 import { useContext, useState } from "react";
 
@@ -15,7 +16,9 @@ export function RunPage() {
   const aId = useRequiredPathParam("aId");
   const runId = useRequiredPathParam("runId");
   const owner = useWorkspace();
-  const { isAdmin, isBuilder } = useAuth();
+  const { isAdmin } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -40,7 +43,7 @@ export function RunPage() {
   }
 
   const restore = async () => {
-    if (!isBuilder || !app || !run || !spec) {
+    if (!canAdministrateApps || !app || !run || !spec) {
       return;
     }
 
@@ -157,7 +160,7 @@ export function RunPage() {
           app={app}
           isAdmin={isAdmin}
           readOnly={true}
-          showOutputs={isBuilder}
+          showOutputs={canAdministrateApps}
           spec={spec}
           run={run}
           runRequested={false}

--- a/front/components/pages/spaces/apps/RunsPage.tsx
+++ b/front/components/pages/spaces/apps/RunsPage.tsx
@@ -1,11 +1,12 @@
 import Custom404 from "@app/components/pages/Custom404";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   LinkWrapper,
   useRequiredPathParam,
   useSearchParam,
 } from "@app/lib/platform";
 import { useApp, useRuns } from "@app/lib/swr/apps";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import type { RunRunType, RunStatus } from "@app/types/run";
 import { Button, Spinner } from "@dust-tt/sparkle";
@@ -32,9 +33,9 @@ export function RunsPage() {
   const aId = useRequiredPathParam("aId");
   const wIdTarget = useSearchParam("wIdTarget");
   const owner = useWorkspace();
-  const { isBuilder } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
 
-  const readOnly = !isBuilder;
+  const readOnly = !hasPermission("admin", "dust_app");
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -61,7 +61,7 @@ const hasAppsModalQuery = (
   isString(query.modal) && query.modal === "apps";
 
 interface SpaceAppsListProps {
-  isBuilder: boolean;
+  canAdministrateApps: boolean;
   onSelect: (sId: string) => void;
   owner: LightWorkspaceType;
   space: SpaceType;
@@ -69,7 +69,7 @@ interface SpaceAppsListProps {
 
 export const SpaceAppsList = ({
   owner,
-  isBuilder,
+  canAdministrateApps,
   space,
   onSelect,
 }: SpaceAppsListProps) => {
@@ -103,7 +103,7 @@ export const SpaceAppsList = ({
 
   React.useEffect(() => {
     // Extract modal=apps query param to open modal on first render and remove it from URL
-    if (!router.isReady || !isBuilder) {
+    if (!router.isReady || !canAdministrateApps) {
       return;
     }
     const { query } = router;
@@ -112,7 +112,7 @@ export const SpaceAppsList = ({
     }
     setIsCreateAppModalOpened(true);
     void removeParamFromRouter(router, "modal");
-  }, [router.isReady, router.query.modal, isBuilder, router]);
+  }, [router.isReady, router.query.modal, canAdministrateApps, router]);
 
   const { portalToHeader } = useActionButtonsPortal({
     containerId: ACTION_BUTTONS_CONTAINER_ID,
@@ -131,7 +131,7 @@ export const SpaceAppsList = ({
 
   const actionButtons = (
     <>
-      {isBuilder && (
+      {canAdministrateApps && (
         <Button
           label="New App"
           variant="primary"
@@ -152,7 +152,7 @@ export const SpaceAppsList = ({
         <div className="flex h-36 w-full items-center justify-center gap-2 rounded-lg bg-muted-background">
           <Button
             label="Create App"
-            disabled={!isBuilder}
+            disabled={!canAdministrateApps}
             onClick={() => {
               setIsCreateAppModalOpened(true);
             }}

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -6,6 +6,7 @@ import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils_ui";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
 import type { AgentsUsageType } from "@app/types/data_source";
@@ -77,7 +78,6 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
 
 type SpaceCategoriesListProps = {
   isAdmin: boolean;
-  isBuilder: boolean;
   canWriteInSpace: boolean;
   onButtonClick?: () => void;
   onSelect: (category: string) => void;
@@ -87,7 +87,6 @@ type SpaceCategoriesListProps = {
 
 export const SpaceCategoriesList = ({
   isAdmin,
-  isBuilder,
   onButtonClick,
   canWriteInSpace,
   onSelect,
@@ -101,6 +100,8 @@ export const SpaceCategoriesList = ({
 
   const { user } = useAuth();
   const { hasFeature } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAdministrateApps = hasPermission("admin", "dust_app");
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
   const [assistantId, setAssistantId] = React.useState<string | null>(null);
@@ -178,7 +179,7 @@ export const SpaceCategoriesList = ({
           />
           {hasFeature("legacy_dust_apps") && (
             <DropdownMenuItem
-              disabled={!isBuilder || !canWriteInSpace}
+              disabled={!canAdministrateApps || !canWriteInSpace}
               href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?modal=apps`}
               icon={Terminal}
               label="Create a Dust App"


### PR DESCRIPTION
## Description

Part 2 of moving Dust app administration off the deprecated builder role (dust-tt/tasks#9746). **Enforces the `dust_app:admin` capability** added in #29460, replacing `auth.isBuilder()` / `useAuth().isBuilder` for Dust apps — server and client.

Stacked on #29460 (the capability + seeder). Merge that first.

### Server
- App creation (`front-api .../spaces/[spaceId]/apps`) now checks `auth.hasWorkspacePermission("admin", "dust_app")` instead of `auth.isBuilder()`.

### Client (`apps/*` pages)
Swapped `useAuth().isBuilder` → `useWorkspacePermissions().hasPermission("admin", "dust_app")`. The permission is served synchronously from the auth context (same as `isBuilder` was), so it's a 1:1 swap with no loading changes:
- `SpaceAppsList` / `SpaceAppsListPage` — the "New App" button (prop renamed `isBuilder` → `canAdministrateApps`)
- `AppViewPage`, `RunsPage`, `RunPage`, `DatasetPage`, `DatasetsPage` — read-only gating
- `AppSettingsPage`, `NewDatasetPage` — redirects for users without the permission

### Behavior

For workspaces with the `legacy_dust_apps` flag, #29460's seeder grants `dust_app:admin` to the Builders group, so builders/admins keep app access; other members lose the (previously builder-gated) app administration surface — as intended by the builder-role deprecation.

### Testing

Verified zero TypeScript errors in the touched files (anchored). Full local `tsgo`/tests blocked by unrelated `node_modules` drift in the dev workspace; CI's clean install runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)