### PR TITLE
Admin governance: add endpoint to bulk edit skill availability

### DIFF
--- a/front-api/routes/w/[wId]/skills/availability.test.ts
+++ b/front-api/routes/w/[wId]/skills/availability.test.ts
@@ -1,0 +1,197 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupTest(role: MembershipRoleType = "admin") {
+  const { workspace, user: requestUser } = await createPrivateApiMockRequest({
+    role,
+  });
+
+  // Skills are created by another user so the requester is never in their
+  // editor group: the batch endpoint relies on the publish permission alone.
+  const skillOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, skillOwner, {
+    role: "builder",
+  });
+  const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    skillOwner.sId,
+    workspace.sId
+  );
+
+  const requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    requestUser.sId,
+    workspace.sId
+  );
+
+  return {
+    workspace,
+    requestUser,
+    requestUserAuth,
+    skillOwner,
+    skillOwnerAuth,
+  };
+}
+
+function patchSkillsAvailability(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/availability`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/w/:wId/skills/availability", () => {
+  it("rejects the request when skill publication governance is off", async () => {
+    const { workspace, skillOwnerAuth } = await setupTest();
+    const skill = await SkillFactory.create(skillOwnerAuth);
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [skill.sId],
+      availability: "users_and_agents",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("updates the availability of several skills at once", async () => {
+    const {
+      workspace,
+      requestUser,
+      requestUserAuth,
+      skillOwner,
+      skillOwnerAuth,
+    } = await setupTest();
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const firstSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "First Unpublished Skill",
+      availability: "editors",
+    });
+    const secondSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Second Unpublished Skill",
+      availability: "editors",
+    });
+    // Already at the requested availability: the update is a no-op.
+    const unchangedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Already Published Skill",
+      availability: "workspace_users",
+    });
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [firstSkill.sId, secondSkill.sId, unchangedSkill.sId],
+      availability: "workspace_users",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(
+      data.skills.map((s: { availability: string }) => s.availability)
+    ).toEqual(["workspace_users", "workspace_users", "workspace_users"]);
+
+    for (const sId of [firstSkill.sId, secondSkill.sId]) {
+      const updatedSkill = await SkillResource.fetchById(requestUserAuth, sId);
+      expect(updatedSkill?.availability).toBe("workspace_users");
+      // Publishing counts as an edit: editedBy is stamped with the acting user.
+      expect(updatedSkill?.editedBy).toBe(requestUser.id);
+    }
+
+    // The no-op skill is untouched: editedBy still points to its creator.
+    const untouchedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      unchangedSkill.sId
+    );
+    expect(untouchedSkill?.availability).toBe("workspace_users");
+    expect(untouchedSkill?.editedBy).toBe(skillOwner.id);
+  });
+
+  it("snapshots a version of each updated skill", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const skill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Versioned Skill",
+      availability: "editors",
+    });
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [skill.sId],
+      availability: "users_and_agents",
+    });
+    expect(response.status).toBe(200);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    const versions = (await updatedSkill?.listVersions(requestUserAuth)) ?? [];
+    expect(versions.length).toBe(1);
+  });
+
+  it("denies a caller without the publish permission", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } =
+      await setupTest("builder");
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+    const skill = await SkillFactory.create(skillOwnerAuth);
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [skill.sId],
+      availability: "users_and_agents",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when a skill is missing, without updating the others", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+    const skill = await SkillFactory.create(skillOwnerAuth, {
+      availability: "editors",
+    });
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [skill.sId, "skl_0000000000"],
+      availability: "users_and_agents",
+    });
+
+    expect(response.status).toBe(404);
+    const unchangedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(unchangedSkill?.availability).toBe("editors");
+  });
+
+  it("rejects an empty batch", async () => {
+    const { workspace, requestUserAuth } = await setupTest();
+    await FeatureFlagFactory.basic(
+      requestUserAuth,
+      "admin_governance_skill_publication"
+    );
+
+    const response = await patchSkillsAvailability(workspace, {
+      skillIds: [],
+      availability: "workspace_users",
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/skills/availability.ts
+++ b/front-api/routes/w/[wId]/skills/availability.ts
@@ -1,0 +1,99 @@
+import { hasFeatureFlag } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import uniq from "lodash/uniq";
+import { z } from "zod";
+
+const MAX_SKILLS_PER_BATCH = 1000;
+
+const PatchSkillsAvailabilityBodySchema = z.object({
+  skillIds: z.array(z.string()).min(1).max(MAX_SKILLS_PER_BATCH),
+  availability: z.enum(SKILL_AVAILABILITIES),
+});
+
+export type PatchSkillsAvailabilityResponseBody = {
+  skills: SkillType[];
+};
+
+// Mounted at /api/w/:wId/skills/availability.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  validate("json", PatchSkillsAvailabilityBodySchema),
+  async (ctx): HandlerResult<PatchSkillsAvailabilityResponseBody> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+    const { availability } = body;
+    const skillIds = uniq(body.skillIds);
+
+    if (!(await hasFeatureFlag(auth, "admin_governance_skill_publication"))) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Changing skill availability requires skill publication governance to be enabled.",
+        },
+      });
+    }
+
+    if (!(await auth.hasWorkspacePermission("publish", "skill"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "You don't have permission to change skill availability.",
+        },
+      });
+    }
+
+    // Code-defined skills have a fixed availability.
+    const invalidSkillIds = skillIds.filter(
+      (skillId) => !isResourceSId("skill", skillId)
+    );
+    if (invalidSkillIds.length > 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Only custom skills can have their availability changed: ${invalidSkillIds.join(", ")}.`,
+        },
+      });
+    }
+
+    const skills = await SkillResource.fetchByIds(auth, skillIds);
+
+    const foundSkillIds = new Set(skills.map((skill) => skill.sId));
+    const missingSkillIds = skillIds.filter(
+      (skillId) => !foundSkillIds.has(skillId)
+    );
+    if (missingSkillIds.length > 0) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: `Skills not found: ${missingSkillIds.join(", ")}.`,
+        },
+      });
+    }
+
+    await SkillResource.updateAvailabilities(auth, skills, availability);
+
+    // Re-fetch: the bulk update does not refresh the in-memory resources.
+    const updatedSkills = await SkillResource.fetchByIds(auth, skillIds);
+
+    return ctx.json({
+      skills: updatedSkills.map((skill) => skill.toJSON(auth)),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -30,6 +30,7 @@ import { validate } from "@front-api/middlewares/validator";
 import uniq from "lodash/uniq";
 import { z } from "zod";
 import skill from "./[sId]";
+import availability from "./availability";
 import detect from "./detect";
 import importRoute from "./import";
 import reinforcementDailySpend from "./reinforcement_daily_spend";
@@ -107,6 +108,7 @@ function resolveRequestedAvailability({
 const app = workspaceApp();
 
 // Static sub-paths must be registered before the param sub-app.
+app.route("/availability", availability);
 app.route("/detect", detect);
 app.route("/import", importRoute);
 app.route("/reinforcement_daily_spend", reinforcementDailySpend);

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1276,25 +1276,36 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("updateAvailability", () => {
-    it("updates the availability for a caller with the publish permission", async () => {
+  describe("updateAvailabilities", () => {
+    it("updates the availability in bulk for a caller with the publish permission", async () => {
       // Admins hold every workspace-level capability, including publish on skills.
-      const skillResource = await SkillFactory.create(
-        testContext.authenticator,
-        { name: "Publishable Skill" }
-      );
+      const firstSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "First Publishable Skill",
+      });
+      const secondSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Second Publishable Skill",
+      });
 
-      await skillResource.updateAvailability(
+      await SkillResource.updateAvailabilities(
         testContext.authenticator,
+        [firstSkill, secondSkill],
         "editors"
       );
 
-      const updatedSkill = await SkillResource.fetchById(
-        testContext.authenticator,
-        skillResource.sId
-      );
-      expect(updatedSkill?.availability).toBe("editors");
-      expect(updatedSkill?.editedBy).toBe(skillResource.editedBy);
+      for (const skill of [firstSkill, secondSkill]) {
+        const updatedSkill = await SkillResource.fetchById(
+          testContext.authenticator,
+          skill.sId
+        );
+        expect(updatedSkill?.availability).toBe("editors");
+        // The availability change counts as an edit by the acting user.
+        expect(updatedSkill?.editedBy).toBe(testContext.user.id);
+        // A version of the previous state was snapshotted.
+        const versions =
+          (await updatedSkill?.listVersions(testContext.authenticator)) ?? [];
+        expect(versions.length).toBe(1);
+        expect(versions[0]?.availability).toBe("workspace_users");
+      }
     });
 
     it("rejects a caller without the publish permission, even an editor", async () => {
@@ -1314,10 +1325,12 @@ describe("SkillResource", () => {
       });
 
       await expect(
-        skillResource.updateAvailability(builderAuth, "users_and_agents")
-      ).rejects.toThrow(
-        "User is not authorized to update this skill's availability"
-      );
+        SkillResource.updateAvailabilities(
+          builderAuth,
+          [skillResource],
+          "users_and_agents"
+        )
+      ).rejects.toThrow("User is not authorized to update skill availability");
     });
 
     it("requires the publish permission to change availability through updateSkill when governance is on", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2946,19 +2946,44 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * permission on skills — being an editor is neither required nor sufficient. Does not
    * touch editedBy.
    */
-  async updateAvailability(
+  static async updateAvailabilities(
     auth: Authenticator,
+    skills: SkillResource[],
     availability: SkillAvailability
   ): Promise<void> {
     assert(
       await auth.hasWorkspacePermission("publish", "skill"),
-      "User is not authorized to update this skill's availability"
+      "User is not authorized to update skill availability"
     );
 
+    const changedSkills = skills.filter(
+      (skill) => skill.availability !== availability
+    );
+    if (changedSkills.length === 0) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.user();
+
     await withTransaction(async (transaction) => {
-      // Save the current version before updating.
-      await this.saveVersion(auth, { transaction });
-      await this.update({ availability }, transaction);
+      // Save the current version of each skill before updating.
+      await this.bulkSaveVersions(auth, changedSkills, { transaction });
+
+      await SkillConfigurationModel.update(
+        {
+          availability,
+          // Publishing counts as an edit even when the caller is not in the editor group.
+          ...(user ? { editedBy: user.id } : {}),
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            id: { [Op.in]: changedSkills.map((skill) => skill.id) },
+          },
+          transaction,
+        }
+      );
     });
   }
 
@@ -4075,69 +4100,96 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
-    const workspace = auth.getNonNullableWorkspace();
+    await SkillResource.bulkSaveVersions(auth, [this], { transaction });
+  }
 
-    // Fetch current MCP server configuration IDs for this skill.
+  /**
+   * Snapshot the current state of several skills as new version entries, with batched
+   * queries (one per satellite table) instead of per-skill round trips.
+   */
+  private static async bulkSaveVersions(
+    auth: Authenticator,
+    skills: SkillResource[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+    const skillIds = skills.map((skill) => skill.id);
+
+    // Fetch current MCP server configuration IDs for all skills.
     const mcpServerConfigurations =
       await SkillMCPServerConfigurationModel.findAll({
         where: {
           workspaceId: workspace.id,
-          skillConfigurationId: this.id,
+          skillConfigurationId: { [Op.in]: skillIds },
         },
         transaction,
       });
-
-    const mcpServerViewIds = mcpServerConfigurations.map(
-      (config) => config.mcpServerViewId
+    const mcpServerConfigsBySkillId = groupBy(
+      mcpServerConfigurations,
+      "skillConfigurationId"
     );
 
-    // Fetch current file attachment IDs for this skill.
+    // Fetch current file attachment IDs for all skills.
     const fileAttachments = await SkillFileAttachmentModel.findAll({
       where: {
         workspaceId: workspace.id,
-        skillConfigurationId: this.id,
+        skillConfigurationId: { [Op.in]: skillIds },
       },
       transaction,
     });
+    const fileAttachmentsBySkillId = groupBy(
+      fileAttachments,
+      "skillConfigurationId"
+    );
 
-    const fileAttachmentIds = fileAttachments.map((a) => a.fileId);
-
-    // Calculate the next version number by counting existing versions.
-    const where: WhereOptions<SkillVersionModel> = {
-      workspaceId: this.workspaceId,
-      skillConfigurationId: this.id,
+    // Compute the next version number per skill. Only (skillConfigurationId, version)
+    // pairs are loaded; skills have a bounded number of versions.
+    const versionWhere: WhereOptions<SkillVersionModel> = {
+      workspaceId: workspace.id,
+      skillConfigurationId: { [Op.in]: skillIds },
     };
-
-    const existingVersionsCount = await SkillVersionModel.count({
-      where,
+    const versionRows = await SkillVersionModel.findAll({
+      attributes: ["skillConfigurationId", "version"],
+      where: versionWhere,
       transaction,
     });
+    const maxVersionBySkillId = new Map<ModelId, number>();
+    for (const row of versionRows) {
+      const currentMax = maxVersionBySkillId.get(row.skillConfigurationId) ?? 0;
+      if (row.version > currentMax) {
+        maxVersionBySkillId.set(row.skillConfigurationId, row.version);
+      }
+    }
 
-    const versionNumber = existingVersionsCount + 1;
+    // Create the new version entries with the current state of each skill.
+    const versionData: SkillVersionCreationAttributes[] = skills.map(
+      (skill) => ({
+        workspaceId: skill.workspaceId,
+        skillConfigurationId: skill.id,
+        version: (maxVersionBySkillId.get(skill.id) ?? 0) + 1,
+        status: skill.status,
+        name: skill.name,
+        agentFacingDescription: skill.agentFacingDescription,
+        userFacingDescription: skill.userFacingDescription,
+        instructions: skill.instructions,
+        instructionsHtml: skill.instructionsHtml,
+        requestedSpaceIds: skill.requestedSpaceIds,
+        editedBy: skill.editedBy,
+        mcpServerViewIds: (mcpServerConfigsBySkillId[skill.id] ?? []).map(
+          (config) => config.mcpServerViewId
+        ),
+        fileAttachmentIds: (fileAttachmentsBySkillId[skill.id] ?? []).map(
+          (attachment) => attachment.fileId
+        ),
+        source: skill.source,
+        sourceMetadata: skill.sourceMetadata,
+        createdAt: skill.createdAt,
+        updatedAt: skill.updatedAt,
+        availability: skill.availability,
+      })
+    );
 
-    // Create a new version entry with the current state.
-    const versionData: SkillVersionCreationAttributes = {
-      workspaceId: this.workspaceId,
-      skillConfigurationId: this.id,
-      version: versionNumber,
-      status: this.status,
-      name: this.name,
-      agentFacingDescription: this.agentFacingDescription,
-      userFacingDescription: this.userFacingDescription,
-      instructions: this.instructions,
-      instructionsHtml: this.instructionsHtml,
-      requestedSpaceIds: this.requestedSpaceIds,
-      editedBy: this.editedBy,
-      mcpServerViewIds,
-      fileAttachmentIds,
-      source: this.source,
-      sourceMetadata: this.sourceMetadata,
-      createdAt: this.createdAt,
-      updatedAt: this.updatedAt,
-      availability: this.availability,
-    };
-
-    await SkillVersionModel.create(versionData, {
+    await SkillVersionModel.bulkCreate(versionData, {
       transaction,
     });
   }


### PR DESCRIPTION
## Description

The endpoint takes a list of skill ids and an availability.
Add an resource method to be able to create the old versions by bulk, which is required to efficiently change the availability by bulk.
Note that this do create a new version of each skill and set the "editedBy" field even if the caller is not actually an editor (but an admin changing availability).

This endpoint will be used to bulk edit the available skills page and change several availability at once.

## Tests

unit tests added

## Risk

low, easy to revert 

## Deploy Plan

deploy front 