### PR TITLE
Admin governance: add parameter to bypass the editor visibility

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3437,7 +3437,7 @@
             "in": "query",
             "name": "availability",
             "required": false,
-            "description": "Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned to admin API keys.",
+            "description": "Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned when bypassEditorVisibility is set.",
             "schema": {
               "type": "array",
               "items": {
@@ -3451,6 +3451,15 @@
             },
             "style": "form",
             "explode": true
+          },
+          {
+            "in": "query",
+            "name": "bypassEditorVisibility",
+            "required": false,
+            "description": "When true, also return unpublished (editors) skills. Requires an admin API key.",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -223,7 +223,7 @@ describe("GET /api/v1/w/[wId]/skills", () => {
     expect(invalidResponse.status).toBe(400);
   });
 
-  it("exposes unpublished skills to admin API keys", async () => {
+  it("lets admin API keys bypass editor visibility to list unpublished skills", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
     });
@@ -245,23 +245,55 @@ describe("GET /api/v1/w/[wId]/skills", () => {
       availability: "editors",
     });
 
-    // Admin keys see unpublished skills, e.g. when exporting all workspace skills.
+    // The bypass is opt-in: without the param, admin keys don't see unpublished skills.
     const defaultResponse = await getSkills(workspace, key);
     expect(defaultResponse.status).toBe(200);
     const defaultSkillNames = (await defaultResponse.json()).skills.map(
       (skill: { name: string }) => skill.name
     );
     expect(defaultSkillNames).toContain("Workspace Skill");
-    expect(defaultSkillNames).toContain("Unpublished Skill");
+    expect(defaultSkillNames).not.toContain("Unpublished Skill");
+
+    // With the param, admin keys see unpublished skills, e.g. when exporting all
+    // workspace skills.
+    const bypassResponse = await getSkills(workspace, key, {
+      bypassEditorVisibility: "true",
+    });
+    expect(bypassResponse.status).toBe(200);
+    const bypassSkillNames = (await bypassResponse.json()).skills.map(
+      (skill: { name: string }) => skill.name
+    );
+    expect(bypassSkillNames).toContain("Workspace Skill");
+    expect(bypassSkillNames).toContain("Unpublished Skill");
 
     const editorsResponse = await getSkills(workspace, key, {
       availability: "editors",
+      bypassEditorVisibility: "true",
     });
     expect(editorsResponse.status).toBe(200);
     const editorsSkillNames = (await editorsResponse.json()).skills.map(
       (skill: { name: string }) => skill.name
     );
     expect(editorsSkillNames).toEqual(["Unpublished Skill"]);
+  });
+
+  it("rejects bypassEditorVisibility for non-admin API keys", async () => {
+    const { workspace, key } = await createPublicApiMockRequest();
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+
+    const response = await getSkills(workspace, key, {
+      bypassEditorVisibility: "true",
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only admins can bypass editor visibility.",
+      },
+    });
   });
 });
 

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -63,7 +63,7 @@ const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
  *       - in: query
  *         name: availability
  *         required: false
- *         description: Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned to admin API keys.
+ *         description: Filter skills by availability. Repeatable to match several values. Unpublished (editors) skills are only returned when bypassEditorVisibility is set.
  *         schema:
  *           type: array
  *           items:
@@ -71,6 +71,12 @@ const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
  *             enum: [editors, workspace_users, users_and_agents]
  *         style: form
  *         explode: true
+ *       - in: query
+ *         name: bypassEditorVisibility
+ *         required: false
+ *         description: When true, also return unpublished (editors) skills. Requires an admin API key.
+ *         schema:
+ *           type: boolean
  *     responses:
  *       200:
  *         description: Skills available in the workspace.
@@ -191,16 +197,30 @@ app.get(
         ? availabilityValidation.data
         : undefined;
 
+    const bypassEditorVisibility =
+      ctx.req.query("bypassEditorVisibility") === "true";
+
+    // Only admin keys may bypass editor visibility to list unpublished skills (e.g. for
+    // exporting all workspace skills).
+    if (bypassEditorVisibility && !auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins can bypass editor visibility.",
+        },
+      });
+    }
+
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status,
       onlyCustom: true,
       availability,
     });
 
-    // Unpublished (editors-only) skills are drafts: API keys have no editor-group
-    // membership to scope them by, so they are only exposed to admin keys (e.g. for
-    // exporting all workspace skills).
-    const skills = auth.isAdmin()
+    // API keys have no editor-group membership to scope them by, so they can't see
+    // editor restricted skills unless editor visibility is explicitly bypassed.
+    const skills = bypassEditorVisibility
       ? allSkills
       : allSkills.filter((skill) => skill.availability !== "editors");
 

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -148,6 +148,57 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).not.toContain("Someone Else's Unpublished Skill");
   });
 
+  it("lets admins bypass editor visibility to list unpublished skills they do not edit", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "builder",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    await SkillFactory.create(skillOwnerAuth, {
+      name: "Someone Else's Unpublished Skill",
+      availability: "editors",
+    });
+
+    // The requesting admin is not in the skill's editor group: without the param the
+    // unpublished skill stays hidden.
+    const withoutParamResponse = await getSkills(workspace);
+    expect(withoutParamResponse.status).toBe(200);
+    const withoutParamNames = (await withoutParamResponse.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(withoutParamNames).not.toContain("Someone Else's Unpublished Skill");
+
+    const response = await getSkills(workspace, {
+      bypassEditorVisibility: "true",
+    });
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Someone Else's Unpublished Skill");
+  });
+
+  it("rejects bypassEditorVisibility for non-admins", async () => {
+    const { workspace } = await setupTest("builder");
+
+    const response = await getSkills(workspace, {
+      bypassEditorVisibility: "true",
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only admins can bypass editor visibility.",
+      },
+    });
+  });
+
   it("filters by availability, with isDefault=true as a deprecated alias", async () => {
     const { workspace, user } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -131,6 +131,8 @@ app.get(
     const onlyCustom = ctx.req.query("onlyCustom");
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
+    const bypassEditorVisibility =
+      ctx.req.query("bypassEditorVisibility") === "true";
     // Repeatable: ?availability=workspace_users&availability=users_and_agents.
     const availabilityParams = ctx.req.queries("availability");
 
@@ -165,6 +167,17 @@ app.get(
           ? ["users_and_agents" as const]
           : undefined;
 
+    // Only admins may list unpublished skills they don't edit (e.g. for governance views).
+    if (bypassEditorVisibility && !auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins can bypass editor visibility.",
+        },
+      });
+    }
+
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
@@ -177,9 +190,11 @@ app.get(
 
     // Skills with editors-only availability (unpublished) are only listed for members of
     // their editor group.
-    const skills = allSkills.filter(
-      (skill) => skill.availability !== "editors" || skill.canWrite(auth)
-    );
+    const skills = bypassEditorVisibility
+      ? allSkills
+      : allSkills.filter(
+          (skill) => skill.availability !== "editors" || skill.canWrite(auth)
+        );
 
     if (withRelations === "true") {
       const usageMap = await SkillResource.batchFetchUsage(auth, skills);

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -101,6 +101,7 @@ export function useSkills({
   status,
   globalSpaceOnly,
   availability,
+  bypassEditorVisibility,
   swrOptions,
 }: {
   owner: LightWorkspaceType;
@@ -108,6 +109,9 @@ export function useSkills({
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
   availability?: SkillAvailability | SkillAvailability[];
+  // Admin-only: bypass the editor-visibility rule and also list unpublished
+  // (editors-only) skills the caller does not edit.
+  bypassEditorVisibility?: boolean;
   swrOptions?: SWRConfiguration;
 }): {
   skills: SkillWithoutInstructionsAndToolsType[];
@@ -131,6 +135,9 @@ export function useSkills({
     for (const value of availabilities) {
       queryParams.append("availability", value);
     }
+  }
+  if (bypassEditorVisibility) {
+    queryParams.set("bypassEditorVisibility", "true");
   }
   const queryString = queryParams.toString();
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9728

Change the private endpoint and V1 endpoint to support a new param `bypassEditorVisibility` which allows to list all skills, including the unpublished ones where the user is not editor.
This is only available to admin users.

## Tests

Added unit tests for both endpoints

## Risk

low

## Deploy Plan

deploy front 
