### PR TITLE
[front] enh: support pod files in MCP tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,22 +1,28 @@
-import type { ToolContext } from "@app/lib/actions/types";
+import type {
+  SandboxFunctionRunContext,
+  ToolContext,
+  ToolRunContext,
+} from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { makeExtra } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  getFileFromConversationAttachment,
-  resolveConversationFileRef,
-} from "./file_utils";
+import { getFileFromToolFileRef, resolveToolFileRef } from "./file_utils";
 
-const { mockResolveFile, mockFromScopedPath } = vi.hoisted(() => ({
+const { mockResolveFile, mockForPod, mockFromScopedPath } = vi.hoisted(() => ({
   mockResolveFile: vi.fn(),
+  mockForPod: vi.fn(),
   mockFromScopedPath: vi.fn(),
 }));
 
@@ -41,6 +47,7 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
     ...actual,
     DustFileSystem: {
       ...actual.DustFileSystem,
+      forPod: mockForPod,
       fromScopedPath: mockFromScopedPath,
     },
   };
@@ -52,6 +59,13 @@ function makeToolContext(conversation: ConversationType): ToolContext {
   } as unknown as ToolContext;
 }
 
+function getRunContext(toolContext: ToolContext): ToolRunContext {
+  if (!toolContext.runContext) {
+    throw new Error("Tool run context expected");
+  }
+  return toolContext.runContext;
+}
+
 function makeReadableStream(content: string): Readable {
   return new Readable({
     read() {
@@ -61,7 +75,42 @@ function makeReadableStream(content: string): Readable {
   });
 }
 
-describe("getFileFromConversationAttachment", () => {
+async function makeSandboxRunContext(): Promise<{
+  auth: Awaited<
+    ReturnType<typeof createPersistedSandboxFunctionInvocationTokenTestContext>
+  >["auth"];
+  podId: string;
+  runContext: SandboxFunctionRunContext;
+}> {
+  const { auth, workspace, invocation, globalSpace, podSpace } =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    server.id,
+    globalSpace
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(auth, {
+    invocation,
+    mcpServerView: view,
+  });
+
+  return {
+    auth,
+    podId: podSpace.sId,
+    runContext: {
+      contextType: "sandbox_function",
+      action,
+      invocation,
+      toolConfiguration: action.toolConfiguration,
+    },
+  };
+}
+
+describe("getFileFromToolFileRef", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -94,10 +143,10 @@ describe("getFileFromConversationAttachment", () => {
         })
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         canonicalPath,
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isOk()).toBe(true);
@@ -127,10 +176,10 @@ describe("getFileFromConversationAttachment", () => {
         })
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         `conversation-${conversation.sId}/missing.pdf`,
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isErr()).toBe(true);
@@ -155,13 +204,48 @@ describe("getFileFromConversationAttachment", () => {
         new Err({ message: "Conversation not found" })
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("sandbox function path", () => {
+    it("reads an absolute path from the invoking function's pod", async () => {
+      const { auth, podId, runContext } = await makeSandboxRunContext();
+      const expectedContent = "col1,col2\nval1,val2";
+      const stat = vi
+        .fn()
+        .mockResolvedValue(new Ok({ contentType: "text/csv", sizeBytes: 19 }));
+      const read = vi
+        .fn()
+        .mockResolvedValue(new Ok(makeReadableStream(expectedContent)));
+
+      mockForPod.mockResolvedValue(new Ok({ stat, read }));
+
+      const result = await getFileFromToolFileRef(
+        auth,
+        `/files/pod-${podId}/reports/data.csv`,
+        runContext
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.buffer.toString()).toBe(expectedContent);
+      expect(result.value.filename).toBe("data.csv");
+      expect(mockForPod).toHaveBeenCalledWith(
+        auth,
+        runContext.invocation.sandboxFunction.space
+      );
+      expect(stat).toHaveBeenCalledWith(`pod-${podId}/reports/data.csv`);
+      expect(read).toHaveBeenCalledWith(`pod-${podId}/reports/data.csv`);
+      expect(mockFromScopedPath).not.toHaveBeenCalled();
     });
   });
 
@@ -212,10 +296,10 @@ describe("getFileFromConversationAttachment", () => {
         makeReadableStream(expectedContent)
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         file.sId,
-        makeToolContext(conversationRes.value)
+        getRunContext(makeToolContext(conversationRes.value))
       );
 
       expect(result.isOk()).toBe(true);
@@ -249,10 +333,10 @@ describe("getFileFromConversationAttachment", () => {
         );
       }
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         "fil_notfound",
-        makeToolContext(conversationRes.value)
+        getRunContext(makeToolContext(conversationRes.value))
       );
 
       expect(result.isErr()).toBe(true);
@@ -284,10 +368,10 @@ describe("getFileFromConversationAttachment", () => {
         })
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         "conversation/notes.txt",
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isOk()).toBe(true);
@@ -314,10 +398,10 @@ describe("getFileFromConversationAttachment", () => {
         new Err({ message: "GCS object not found" })
       );
 
-      const result = await getFileFromConversationAttachment(
+      const result = await getFileFromToolFileRef(
         auth,
         "conversation/missing.pdf",
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isErr()).toBe(true);
@@ -329,7 +413,7 @@ describe("getFileFromConversationAttachment", () => {
   });
 });
 
-describe("resolveConversationFileRef", () => {
+describe("resolveToolFileRef", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -363,10 +447,10 @@ describe("resolveConversationFileRef", () => {
         })
       );
 
-      const result = await resolveConversationFileRef(
+      const result = await resolveToolFileRef(
         auth,
         canonicalPath,
-        undefined // canonical paths do not need toolContext
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isOk()).toBe(true);
@@ -379,7 +463,7 @@ describe("resolveConversationFileRef", () => {
       expect(await result.value.getSignedUrl()).toBe(signedUrl);
     });
 
-    it("does not require toolContext", async () => {
+    it("resolves a canonical path from the agent loop", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -404,11 +488,10 @@ describe("resolveConversationFileRef", () => {
         })
       );
 
-      // Pass undefined — should succeed for canonical paths.
-      const result = await resolveConversationFileRef(
+      const result = await resolveToolFileRef(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        undefined
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isOk()).toBe(true);
@@ -431,10 +514,10 @@ describe("resolveConversationFileRef", () => {
         })
       );
 
-      const result = await resolveConversationFileRef(
+      const result = await resolveToolFileRef(
         auth,
         `conversation-${conversation.sId}/missing.png`,
-        makeExtra(auth, conversation)
+        getRunContext(makeExtra(auth, conversation))
       );
 
       expect(result.isErr()).toBe(true);
@@ -442,6 +525,43 @@ describe("resolveConversationFileRef", () => {
         return;
       }
       expect(result.error).toContain("not found");
+    });
+  });
+
+  describe("sandbox function path", () => {
+    it("resolves a scoped path from the invoking function's pod", async () => {
+      const { auth, podId, runContext } = await makeSandboxRunContext();
+      const signedUrl = "https://storage.example.com/signed";
+      const stat = vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ contentType: "image/png", sizeBytes: 512 })
+        );
+      const getDownloadUrl = vi.fn().mockResolvedValue(new Ok(signedUrl));
+
+      mockForPod.mockResolvedValue(
+        new Ok({
+          stat,
+          getDownloadUrl,
+        })
+      );
+
+      const scopedPath = `pod-${podId}/images/reference.png`;
+      const result = await resolveToolFileRef(auth, scopedPath, runContext);
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.fileName).toBe("reference.png");
+      expect(await result.value.getSignedUrl()).toBe(signedUrl);
+      expect(mockForPod).toHaveBeenCalledWith(
+        auth,
+        runContext.invocation.sandboxFunction.space
+      );
+      expect(stat).toHaveBeenCalledWith(scopedPath);
+      expect(getDownloadUrl).toHaveBeenCalledWith(scopedPath);
+      expect(mockFromScopedPath).not.toHaveBeenCalled();
     });
   });
 
@@ -465,10 +585,10 @@ describe("resolveConversationFileRef", () => {
       useCaseMetadata: { conversationId: conversation.sId },
     });
 
-    const result = await resolveConversationFileRef(
+    const result = await resolveToolFileRef(
       auth,
       file.sId,
-      makeExtra(auth, conversation)
+      getRunContext(makeExtra(auth, conversation))
     );
 
     expect(result.isOk()).toBe(true);
@@ -508,10 +628,10 @@ describe("resolveConversationFileRef", () => {
     });
 
     // But toolContext points to conversation B.
-    const result = await resolveConversationFileRef(
+    const result = await resolveToolFileRef(
       auth,
       file.sId,
-      makeExtra(auth, conversationB)
+      getRunContext(makeExtra(auth, conversationB))
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,6 +1,6 @@
-import {
-  isAgentLoopRunContext,
-  type ToolContext,
+import type {
+  AgentLoopRunContext,
+  ToolRunContext,
 } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
@@ -9,7 +9,7 @@ import {
   isFileAttachmentType,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import {
   isCanonicalScopedPath,
   parseScopedFilePath,
@@ -21,9 +21,9 @@ import { streamToBuffer } from "@app/lib/utils/streams";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
-import assert from "assert";
 import { PassThrough } from "stream";
 
 export function sanitizeFilename(filename: string): string {
@@ -35,7 +35,7 @@ export function sanitizeFilename(filename: string): string {
     .substring(0, 255);
 }
 
-export type ConversationFileRef = {
+export type ToolFileRef = {
   contentType: string;
   sizeBytes: number;
   fileName: string;
@@ -43,44 +43,106 @@ export type ConversationFileRef = {
   createReadStream: () => NodeJS.ReadableStream;
 };
 
-/**
- * Resolve a conversation file (scoped path or legacy fileId) to its metadata
- * and lazy GCS accessors, without reading its content.
- *
- * Scoped paths are resolved via GCS mount path.
- * Legacy fileIds are resolved via FileResource with a conversation ownership check.
- */
-export async function resolveConversationFileRef(
-  auth: Authenticator,
-  fileId: string,
-  toolContext: ToolContext | undefined
-): Promise<Result<ConversationFileRef, string>> {
-  // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
-  // DustFileSystem layer. Resolved directly — no conversation context needed.
-  if (isCanonicalScopedPath(fileId)) {
-    const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
-    if (fsResult.isErr()) {
-      return new Err(fsResult.error.message);
+type ToolFileResolution =
+  | {
+      kind: "dust_file_system";
+      fileSystem: DustFileSystem;
+      scopedPath: string;
     }
-    const fs = fsResult.value;
+  | {
+      kind: "agent_loop_legacy";
+      runContext: AgentLoopRunContext;
+    };
 
-    const statResult = await fs.stat(fileId);
+async function getDustFileSystemFileRef(
+  auth: Authenticator,
+  fileRef: string,
+  runContext: ToolRunContext
+): Promise<Result<ToolFileResolution, string>> {
+  switch (runContext.contextType) {
+    case "agent_loop": {
+      if (!isCanonicalScopedPath(fileRef)) {
+        return new Ok({ kind: "agent_loop_legacy", runContext });
+      }
+
+      const fsResult = await DustFileSystem.fromScopedPath(auth, fileRef);
+      if (fsResult.isErr()) {
+        return new Err(fsResult.error.message);
+      }
+
+      return new Ok({
+        kind: "dust_file_system",
+        fileSystem: fsResult.value,
+        scopedPath: fileRef,
+      });
+    }
+
+    case "sandbox_function": {
+      const space = runContext.invocation.sandboxFunction.space;
+      const scopedPrefix = `${SCOPED_PREFIX_POD}${space.sId}`;
+      const sandboxMountPoint = `/files/${scopedPrefix}`;
+      const scopedPath = fileRef.startsWith(`${sandboxMountPoint}/`)
+        ? fileRef.slice("/files/".length)
+        : fileRef;
+
+      const fsResult = await DustFileSystem.forPod(auth, space);
+      if (fsResult.isErr()) {
+        return new Err(fsResult.error.message);
+      }
+
+      return new Ok({
+        kind: "dust_file_system",
+        fileSystem: fsResult.value,
+        scopedPath,
+      });
+    }
+
+    default:
+      return assertNever(runContext);
+  }
+}
+
+/**
+ * Resolve a file from the current tool run to its metadata and lazy GCS
+ * accessors, without reading its content.
+ *
+ * Agent-loop runs accept scoped paths and legacy conversation file IDs.
+ * Sandbox-function runs accept paths in the invoking function's pod mount.
+ */
+export async function resolveToolFileRef(
+  auth: Authenticator,
+  fileRef: string,
+  runContext: ToolRunContext
+): Promise<Result<ToolFileRef, string>> {
+  const dustFileSystemRefResult = await getDustFileSystemFileRef(
+    auth,
+    fileRef,
+    runContext
+  );
+  if (dustFileSystemRefResult.isErr()) {
+    return dustFileSystemRefResult;
+  }
+
+  if (dustFileSystemRefResult.value.kind === "dust_file_system") {
+    const { fileSystem, scopedPath } = dustFileSystemRefResult.value;
+
+    const statResult = await fileSystem.stat(scopedPath);
     if (statResult.isErr()) {
       return new Err(statResult.error.message);
     }
     if (!statResult.value) {
-      return new Err(`File not found: \`${fileId}\`.`);
+      return new Err(`File not found: \`${fileRef}\`.`);
     }
 
     const { contentType, sizeBytes } = statResult.value;
-    const filename = fileId.split("/").pop() ?? fileId;
+    const filename = scopedPath.split("/").pop() ?? scopedPath;
 
     return new Ok({
       contentType,
       sizeBytes,
       fileName: sanitizeFilename(filename),
       getSignedUrl: async () => {
-        const urlResult = await fs.getDownloadUrl(fileId);
+        const urlResult = await fileSystem.getDownloadUrl(scopedPath);
         if (urlResult.isErr()) {
           throw new Error(urlResult.error.message);
         }
@@ -88,12 +150,12 @@ export async function resolveConversationFileRef(
       },
       createReadStream: () => {
         const pass = new PassThrough();
-        void fs.read(fileId).then((result) => {
+        void fileSystem.read(scopedPath).then((result) => {
           if (result.isErr() || !result.value) {
             pass.destroy(
               result.isErr()
                 ? new Error(result.error.message)
-                : new Error(`File not found: \`${fileId}\``)
+                : new Error(`File not found: \`${fileRef}\``)
             );
           } else {
             result.value.pipe(pass);
@@ -104,15 +166,11 @@ export async function resolveConversationFileRef(
     });
   }
 
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
-  );
-
-  const parsed = parseScopedFilePath(fileId);
+  const { runContext: agentLoopRunContext } = dustFileSystemRefResult.value;
+  const parsed = parseScopedFilePath(fileRef);
   if (parsed) {
-    const conversation = toolContext.runContext.conversation;
-    const resolvedRes = await resolveFile(auth, conversation, fileId);
+    const conversation = agentLoopRunContext.conversation;
+    const resolvedRes = await resolveFile(auth, conversation, fileRef);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }
@@ -126,15 +184,15 @@ export async function resolveConversationFileRef(
     });
   }
 
-  const conversation = toolContext.runContext.conversation;
-  const fileResource = await FileResource.fetchById(auth, fileId);
+  const conversation = agentLoopRunContext.conversation;
+  const fileResource = await FileResource.fetchById(auth, fileRef);
   if (!fileResource) {
-    return new Err(`File resource not found for fileId ${fileId}`);
+    return new Err(`File resource not found for fileId ${fileRef}`);
   }
 
   const belongsResult = fileResource.belongsToConversation(conversation.sId);
   if (belongsResult.isErr() || !belongsResult.value) {
-    return new Err(`File ${fileId} does not belong to this conversation`);
+    return new Err(`File ${fileRef} does not belong to this conversation`);
   }
 
   return new Ok({
@@ -148,20 +206,15 @@ export async function resolveConversationFileRef(
 }
 
 /**
- * Get file data from a conversation attachment, including images.
- * Accepts either a scoped file path (e.g. "conversation/report.pdf") or a
- * legacy fileId (e.g. "fil_xxx").
+ * Read a file from the current tool run, including images.
  *
- * Scoped paths are resolved via GCS mount path (workspace + conversation scoped).
- * When no FileResource record exists for the GCS path (e.g. tool-written outputs),
- * content is read directly from GCS.
- *
- * Legacy fileIds are resolved by scanning conversation content.
+ * Agent-loop runs accept scoped paths and legacy conversation file IDs.
+ * Sandbox-function runs accept paths in the invoking function's pod mount.
  */
-export async function getFileFromConversationAttachment(
+export async function getFileFromToolFileRef(
   auth: Authenticator,
-  fileId: string,
-  toolContext: ToolContext
+  fileRef: string,
+  runContext: ToolRunContext
 ): Promise<
   Result<
     {
@@ -172,33 +225,32 @@ export async function getFileFromConversationAttachment(
     string
   >
 > {
-  assert(
-    isAgentLoopRunContext(toolContext?.runContext),
-    "AgentLoopRunContext expected"
+  const dustFileSystemRefResult = await getDustFileSystemFileRef(
+    auth,
+    fileRef,
+    runContext
   );
+  if (dustFileSystemRefResult.isErr()) {
+    return dustFileSystemRefResult;
+  }
 
-  // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) — resolve via DustFileSystem.
-  if (isCanonicalScopedPath(fileId)) {
-    const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
-    if (fsResult.isErr()) {
-      return new Err(fsResult.error.message);
-    }
-    const fs = fsResult.value;
+  if (dustFileSystemRefResult.value.kind === "dust_file_system") {
+    const { fileSystem, scopedPath } = dustFileSystemRefResult.value;
 
-    const statResult = await fs.stat(fileId);
+    const statResult = await fileSystem.stat(scopedPath);
     if (statResult.isErr()) {
       return new Err(statResult.error.message);
     }
     if (!statResult.value) {
-      return new Err(`File not found: \`${fileId}\`.`);
+      return new Err(`File not found: \`${fileRef}\`.`);
     }
 
-    const readResult = await fs.read(fileId);
+    const readResult = await fileSystem.read(scopedPath);
     if (readResult.isErr()) {
       return new Err(readResult.error.message);
     }
     if (!readResult.value) {
-      return new Err(`File not found: \`${fileId}\`.`);
+      return new Err(`File not found: \`${fileRef}\`.`);
     }
 
     const bufferResult = await streamToBuffer(readResult.value);
@@ -206,7 +258,7 @@ export async function getFileFromConversationAttachment(
       return new Err(bufferResult.error);
     }
 
-    const filename = fileId.split("/").pop() ?? fileId;
+    const filename = scopedPath.split("/").pop() ?? scopedPath;
     return new Ok({
       buffer: bufferResult.value,
       filename: sanitizeFilename(filename),
@@ -214,11 +266,13 @@ export async function getFileFromConversationAttachment(
     });
   }
 
+  const { runContext: agentLoopRunContext } = dustFileSystemRefResult.value;
+
   // Scoped paths resolve through mount path.
-  const parsed = parseScopedFilePath(fileId);
+  const parsed = parseScopedFilePath(fileRef);
   if (parsed) {
-    const conversation = toolContext.runContext.conversation;
-    const resolvedRes = await resolveFile(auth, conversation, fileId);
+    const conversation = agentLoopRunContext.conversation;
+    const resolvedRes = await resolveFile(auth, conversation, fileRef);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }
@@ -237,7 +291,7 @@ export async function getFileFromConversationAttachment(
   }
 
   // Legacy fileId path: scan the conversation to find the attachment.
-  const conversation = toolContext.runContext.conversation;
+  const conversation = agentLoopRunContext.conversation;
   let attachment: ConversationAttachmentType | null = null;
 
   for (const versions of conversation.content) {
@@ -248,7 +302,7 @@ export async function getFileFromConversationAttachment(
         const candidateAttachment = getAttachmentFromContentFragment(m);
         if (
           candidateAttachment &&
-          conversationAttachmentId(candidateAttachment) === fileId
+          conversationAttachmentId(candidateAttachment) === fileRef
         ) {
           attachment = candidateAttachment;
           break;
@@ -258,7 +312,7 @@ export async function getFileFromConversationAttachment(
       const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
 
       for (const f of generatedFiles) {
-        if (f.fileId === fileId) {
+        if (f.fileId === fileRef) {
           attachment = makeFileAttachment({
             fileId: f.fileId,
             source: "agent",
@@ -282,17 +336,17 @@ export async function getFileFromConversationAttachment(
 
   if (!attachment) {
     return new Err(
-      `Attachment with fileId ${fileId} not found in conversation`
+      `Attachment with fileId ${fileRef} not found in conversation`
     );
   }
 
   if (!isFileAttachmentType(attachment)) {
-    return new Err(`Attachment ${fileId} is not a file attachment`);
+    return new Err(`Attachment ${fileRef} is not a file attachment`);
   }
 
   const fileResource = await FileResource.fetchById(auth, attachment.fileId);
   if (!fileResource) {
-    return new Err(`File resource not found for fileId ${fileId}`);
+    return new Err(`File resource not found for fileId ${fileRef}`);
   }
 
   const readStream = fileResource.getReadStream({
@@ -307,7 +361,7 @@ export async function getFileFromConversationAttachment(
 
   return new Ok({
     buffer: bufferResult.value,
-    filename: sanitizeFilename(attachment.title || `attachment-${fileId}`),
+    filename: sanitizeFilename(attachment.title || `attachment-${fileRef}`),
     contentType: attachment.contentType || "application/octet-stream",
   });
 }

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -53,7 +53,7 @@ export const FILE_GENERATION_TOOLS_METADATA = [
   {
     name: "convert_file_format",
     description:
-      "Convert an existing conversation file into another format, for example turn a document into a PDF.",
+      "Convert an existing Dust file into another format, for example turn a document into a PDF.",
     schema: {
       file_name: z
         .string()
@@ -63,7 +63,7 @@ export const FILE_GENERATION_TOOLS_METADATA = [
       file_id_or_url: z
         .string()
         .describe(
-          "The ID or URL of the file to convert. You can either provide the ID of a file in the conversation (note: if the file ID is already in the desired format, no conversion is needed) or the URL to a file."
+          "The URL or Dust file to convert. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf'). If the file is already in the desired format, no conversion is needed."
         ),
       source_format: z
         .string()

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -3,7 +3,7 @@ import { Readable } from "node:stream";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { resolveToolFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   getContentTypeFromOutputFormat,
   isBinaryFormat,
@@ -63,14 +63,14 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     const convertapi = new ConvertAPI(convertAPIKey);
     let url = file_id_or_url;
 
-    // When the input is not a URL it references a conversation file: either a
-    // legacy `fil_` id or a canonical scoped path (e.g. `conversation-{id}/x.csv`)
-    // as returned by generate_file for text outputs. Resolve it to a signed URL
-    // that ConvertAPI can fetch.
+    // When the input is not a URL, resolve it from the current tool run to a
+    // signed URL that ConvertAPI can fetch.
     if (!validateUrl(file_id_or_url).valid) {
-      const refResult = await resolveConversationFileRef(auth, file_id_or_url, {
-        runContext,
-      });
+      const refResult = await resolveToolFileRef(
+        auth,
+        file_id_or_url,
+        runContext
+      );
       if (refResult.isErr()) {
         return new Err(
           new MCPError(`File not found: ${file_id_or_url}`, {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -82,7 +82,7 @@ export const GMAIL_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+          "Optional. File to attach to the email. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. `/files/pod-<id>/report.pdf` or `pod-<id>/report.pdf`)."
         ),
     },
     stake: "medium",
@@ -272,7 +272,7 @@ export const GMAIL_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+          "Optional. File to attach to the email. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. `/files/pod-<id>/report.pdf` or `pod-<id>/report.pdf`)."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -10,7 +10,7 @@ import {
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import {
-  getFileFromConversationAttachment,
+  getFileFromToolFileRef,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type {
@@ -269,10 +269,10 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
-  const fileResult = await getFileFromConversationAttachment(
+  const fileResult = await getFileFromToolFileRef(
     auth,
     attachmentFilePath,
-    { runContext }
+    runContext
   );
 
   if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -648,12 +648,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = [
   {
     name: "upload_file",
     description:
-      "Upload a file from the Dust conversation to Google Drive. Optionally specify a folder to upload into.",
+      "Upload a file from the current Dust execution to Google Drive. Optionally specify a folder to upload into.",
     schema: {
       fileId: z
         .string()
         .describe(
-          "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+          "The file to upload. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf')."
         ),
       parentId: z
         .string()
@@ -665,7 +665,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional custom filename for the uploaded file. If not provided, uses the original filename from the conversation attachment."
+          "Optional custom filename for the uploaded file. If not provided, uses the original filename."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import {
-  getFileFromConversationAttachment,
+  getFileFromToolFileRef,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
@@ -1780,9 +1780,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
 
     try {
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromToolFileRef(auth, fileId, runContext);
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -4,11 +4,12 @@ import type {
   ToolGeneratedFilePathType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { resolveToolFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type {
   AgentLoopRunContext,
   SandboxFunctionRunContext,
   ToolContext,
+  ToolRunContext,
 } from "@app/lib/actions/types";
 import type { ReferenceImageFile } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
@@ -393,22 +394,18 @@ async function processSingleImageFile(
     maxImageSize,
     supportedContentTypes,
     providerId,
-    toolContext,
+    runContext,
   }: {
     imageFileId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
-    toolContext: ToolContext | undefined;
+    runContext: ToolRunContext;
   }
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const refResult = await resolveConversationFileRef(
-    auth,
-    imageFileId,
-    toolContext
-  );
+  const refResult = await resolveToolFileRef(auth, imageFileId, runContext);
   if (refResult.isErr()) {
     return new Err(
       new MCPError(`File not found: ${imageFileId}`, { tracked: false })
@@ -474,12 +471,13 @@ export async function processImageFileIds(
 ): Promise<Ok<ReferenceImageFile[]> | Err<MCPError>> {
   if (!toolContext?.runContext) {
     return new Err(
-      new MCPError("No conversation context available for file access", {
+      new MCPError("No tool run context available for file access", {
         tracked: false,
       })
     );
   }
 
+  const { runContext } = toolContext;
   const maxImageSize = MAX_FILE_SIZES.image;
 
   const results = await concurrentExecutor(
@@ -490,7 +488,7 @@ export async function processImageFileIds(
         maxImageSize,
         supportedContentTypes,
         providerId,
-        toolContext,
+        runContext,
       }),
     { concurrency: 8 }
   );

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -26,8 +26,9 @@ export const imageGenerationToolInputSchema = z.object({
     .max(14)
     .optional()
     .describe(
-      "Optional reference images for editing or compositing. Accepts scoped file paths " +
-        "(e.g. 'conversation/photo.png') or legacy file sIds. Use to edit photos " +
+      "Optional reference images for editing or compositing. In an agent conversation, " +
+        "provide scoped file paths or legacy file sIds. In a pod function, provide file paths " +
+        "in the pod sandbox (e.g. '/files/pod-<id>/photo.png' or 'pod-<id>/photo.png'). Use to edit photos " +
         "(background removal, color changes, adding elements), combine multiple images, " +
         "apply a style from one image to another, or generate variations of an existing image. " +
         "Supports PNG, JPEG, and WebP. Up to 14 images."

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -399,18 +399,18 @@ export const JIRA_TOOLS_METADATA = [
   {
     name: "upload_attachment",
     description:
-      "Attach a file to a Jira issue (upload). The file can come from the current Dust conversation or be provided as base64 data.",
+      "Attach a file to a Jira issue (upload). The file can come from the current Dust execution or be provided as base64 data.",
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachment: z.union([
         z.object({
           type: z
             .literal("conversation_file")
-            .describe("Use this for files already in the Dust conversation"),
+            .describe("Use this for files already in the Dust execution"),
           fileId: z
             .string()
             .describe(
-              "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+              "The file to upload. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf')."
             ),
         }),
         z.object({

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -2,7 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
-import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { getFileFromToolFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   createComment,
   createIssue,
@@ -873,16 +873,16 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
         };
 
         if (attachment.type === "conversation_file") {
-          const fileResult = await getFileFromConversationAttachment(
+          const fileResult = await getFileFromToolFileRef(
             auth,
             attachment.fileId,
-            { runContext }
+            runContext
           );
 
           if (fileResult.isErr()) {
             return new Err(
               new MCPError(
-                `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
+                `Failed to get file ${attachment.fileId}: ${fileResult.error}`
               )
             );
           }

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -238,12 +238,12 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = [
   {
     name: "upload_file",
     description:
-      "Upload a file from the Dust conversation to Microsoft OneDrive or SharePoint. Supports files up to 250MB using the simple upload API. Uses driveId if provided, otherwise falls back to siteId.",
+      "Upload a file from the current Dust execution to Microsoft OneDrive or SharePoint. Supports files up to 250MB using the simple upload API. Uses driveId if provided, otherwise falls back to siteId.",
     schema: {
       fileId: z
         .string()
         .describe(
-          "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+          "The file to upload. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf')."
         ),
       driveId: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -6,7 +6,7 @@ import {
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import {
-  getFileFromConversationAttachment,
+  getFileFromToolFileRef,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
@@ -573,10 +573,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
 
     try {
-      // Get the file from conversation attachment
-      const fileResult = await getFileFromConversationAttachment(auth, fileId, {
-        runContext,
-      });
+      const fileResult = await getFileFromToolFileRef(auth, fileId, runContext);
 
       if (fileResult.isErr()) {
         return new Err(new MCPError(fileResult.error));

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -265,7 +265,7 @@ export const OUTLOOK_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+          "Optional. File to attach to the email. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. `/files/pod-<id>/report.pdf` or `pod-<id>/report.pdf`)."
         ),
       sharedMailboxAddress: z
         .string()
@@ -377,7 +377,7 @@ export const OUTLOOK_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+          "Optional. File to attach to the email. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. `/files/pod-<id>/report.pdf` or `pod-<id>/report.pdf`)."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -10,7 +10,7 @@ import {
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import {
-  getFileFromConversationAttachment,
+  getFileFromToolFileRef,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { getAllowedLabelsForMCPServer } from "@app/lib/api/actions/servers/microsoft/utils";
@@ -35,10 +35,10 @@ async function fetchAttachment(
     return new Ok(null);
   }
 
-  const fileResult = await getFileFromConversationAttachment(
+  const fileResult = await getFileFromToolFileRef(
     auth,
     attachmentFilePath,
-    { runContext }
+    runContext
   );
 
   if (fileResult.isErr()) {

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,8 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { getFileFromToolFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   isAgentLoopRunContext,
   type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import {
   formatSlackMessageForLLM,
@@ -753,7 +754,7 @@ export async function executeListPublicChannels(
 
 export async function executePostMessage(
   auth: Authenticator,
-  toolContext: ToolContext,
+  runContext: ToolRunContext,
   {
     accessToken,
     to,
@@ -794,17 +795,14 @@ export async function executePostMessage(
 
   const originalMessage = message;
 
-  if (
-    showSentByFooter !== false &&
-    isAgentLoopRunContext(toolContext.runContext)
-  ) {
+  if (showSentByFooter !== false && isAgentLoopRunContext(runContext)) {
     const agentUrl = getConversationRoute(
       auth.getNonNullableWorkspace().sId,
       "new",
-      `agentDetails=${toolContext.runContext?.agentConfiguration.sId}`,
+      `agentDetails=${runContext.agentConfiguration.sId}`,
       config.getAppUrl()
     );
-    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${toolContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
+    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${runContext.agentConfiguration.name} Agent> on Dust_`;
   } else {
     message = slackifyMarkdown(originalMessage);
   }
@@ -815,11 +813,7 @@ export async function executePostMessage(
 
   // If a file is provided, upload it as attachment of the original message.
   if (fileId) {
-    const fileResult = await getFileFromConversationAttachment(
-      auth,
-      fileId,
-      toolContext
-    );
+    const fileResult = await getFileFromToolFileRef(auth, fileId, runContext);
     if (fileResult.isErr()) {
       return new Err(
         new MCPError(`File not found: ${fileId}`, { tracked: false })

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -38,7 +38,7 @@ export const SLACK_BOT_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional file to attach to the Slack message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+          "Optional file to attach to the Slack message. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf')."
         ),
       unfurlLinks: z
         .boolean()

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -33,19 +33,15 @@ export function createSlackBotTools(
         unfurlMedia,
         showSentByFooter,
       },
-      { authInfo }
+      { authInfo, runContext }
     ) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
       }
 
-      if (!toolContext?.runContext) {
-        return new Err(new MCPError("Issue with agent context"));
-      }
-
       try {
-        return await executePostMessage(auth, toolContext, {
+        return await executePostMessage(auth, runContext, {
           to,
           message,
           threadTs,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -119,7 +119,7 @@ export const SLACK_PERSONAL_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "Optional file to attach to the message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+          "Optional file to attach to the message. In an agent conversation, provide a scoped file path or legacy file sId. In a pod function, provide the file path in the pod sandbox (e.g. '/files/pod-<id>/report.pdf' or 'pod-<id>/report.pdf')."
         ),
       unfurlLinks: z
         .boolean()

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -579,21 +579,15 @@ export function createSlackPersonalTools(
         unfurlMedia,
         show_sent_by_footer,
       },
-      { authInfo }
+      { authInfo, runContext }
     ) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
       }
 
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
-      }
-
       try {
-        return await executePostMessage(auth, toolContext, {
+        return await executePostMessage(auth, runContext, {
           to,
           message,
           threadTs,


### PR DESCRIPTION
## Description

Pod functions can now pass files from their pod filesystem to MCP tools that consume files.

File references are resolved from the active tool run context. Agent loops keep the existing scoped-path and legacy file-ID behavior. Sandbox functions use a `DustFileSystem` restricted to the invoking pod and accept both `pod-<id>/...` and `/files/pod-<id>/...` paths.

This enables pod file inputs for file conversion, Gmail and Outlook attachments, Google Drive and Microsoft Drive uploads, Jira attachments, image references, and Slack bot and personal attachments. The tool descriptions now explain the context-specific path semantics.

## Tests

- Added coverage for agent-loop references and absolute and canonical pod file paths.

## Risk

- Medium, affects file input resolution across several MCP servers while preserving agent-loop behavior.

## Deploy Plan

- Deploy front.