### PR TITLE
[LLM] Fix 500 when rendering conversations with removed models

### DIFF
--- a/front/lib/llms/agent_message_content_parser.ts
+++ b/front/lib/llms/agent_message_content_parser.ts
@@ -319,12 +319,10 @@ export function getCoTDelimitersConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }): DelimitersConfiguration {
   const model = getSupportedModelConfig(agentConfiguration.model);
-  assert(
-    model,
-    "Model configuration not found in getCoTDelimitersConfiguration"
-  );
 
-  if (DEEPSEEK_MODELS.includes(model.modelId)) {
+  // model config can be absent for messages produced by a
+  // since-removed model; fall back to default delimiters instead of throwing.
+  if (model && DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;
   }
 


### PR DESCRIPTION
## Description

`getCoTDelimitersConfiguration` no longer throws when a message's model has been removed from `SUPPORTED_MODEL_CONFIGS`; it falls back to the default CoT delimiters, fixing 500s on `GET /api/w/:wId/assistant/conversations/:cId/messages` for historical conversations.

## Tests

Not yet tested.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`