### PR TITLE
[front] use manager instead of builder for spaces/files authorization

### DIFF
--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -162,13 +162,13 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     return accessError;
   }
 
-  if (!auth.isBuilder() && file.useCase !== "conversation") {
+  if (!auth.isManager() && file.useCase !== "conversation") {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can delete files.",
+          "Only users that are `managers` for the current workspace can delete files.",
       },
     });
   }
@@ -219,13 +219,13 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     return accessError;
   }
 
-  if (!auth.isBuilder() && file.useCase !== "conversation") {
+  if (!auth.isManager() && file.useCase !== "conversation") {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "Only users that are `managers` for the current workspace can modify files.",
       },
     });
   }

--- a/front-api/routes/v1/w/[wId]/files/fileId.test.ts
+++ b/front-api/routes/v1/w/[wId]/files/fileId.test.ts
@@ -183,8 +183,8 @@ describe("POST /api/v1/w/[wId]/files/[fileId]", () => {
     });
   });
 
-  it("should return 403 without builder permissions on non-conversation files", async () => {
-    // Use a read-only (user-role) key which doesn't have builder permissions
+  it("should return 403 without manager permissions on non-conversation files", async () => {
+    // Use a read-only (user-role) key which doesn't have manager permissions
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
     });
@@ -193,9 +193,9 @@ describe("POST /api/v1/w/[wId]/files/[fileId]", () => {
       useCaseMetadata: { spaceId: "test-space-id" },
     });
 
-    // System keys always have builder permissions in real auth, so use a
+    // System keys always have manager permissions in real auth, so use a
     // non-system key for this test. Non-system keys first fail the use-case
-    // check though, so this scenario (non-builder + non-conversation + system
+    // check though, so this scenario (non-manager + non-conversation + system
     // key) cannot actually happen with real auth. Verify the system key can
     // modify instead.
     const response = await request(workspace, key, "test_file_id", {
@@ -204,7 +204,7 @@ describe("POST /api/v1/w/[wId]/files/[fileId]", () => {
     expect(response.status).toBe(200);
   });
 
-  it("should allow non-builder to modify conversation files", async () => {
+  it("should allow non-manager to modify conversation files", async () => {
     const { workspace, key } = await createPublicApiMockRequest();
     setupMockFile(workspace, { useCase: "conversation" });
 
@@ -272,8 +272,8 @@ describe("DELETE /api/v1/w/[wId]/files/[fileId]", () => {
     });
   });
 
-  it("should allow system key to delete non-conversation files (system keys have builder permissions)", async () => {
-    // System keys always have builder permissions in real auth, so they can
+  it("should allow system key to delete non-conversation files (system keys have manager permissions)", async () => {
+    // System keys always have manager permissions in real auth, so they can
     // delete any file type.
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
@@ -290,7 +290,7 @@ describe("DELETE /api/v1/w/[wId]/files/[fileId]", () => {
     expect(mockDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("should allow non-builder to delete conversation files", async () => {
+  it("should allow non-manager to delete conversation files", async () => {
     const { workspace, key } = await createPublicApiMockRequest();
     setupMockFile(workspace, { useCase: "conversation" });
 

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -70,21 +70,20 @@ app.get(
 
     const query = ctx.req.valid("query");
 
-    // Auth gating: read = anyone, write = builder, undefined (all) = admin.
+    // Auth gating: read = anyone, write = manager, undefined (all) = admin.
     switch (query.filterPermission) {
       case "read":
         // `read` is used for data source selection when creating personal assistants.
         break;
       case "write":
         // `write` is used for selection of default slack channel in the workspace agent builder.
-        // biome-ignore lint/plugin/noDirectRoleCheck: conditional role check based on filterPermission query param
-        if (!auth.isBuilder()) {
+        if (!auth.isManager()) {
           return apiError(ctx, {
             status_code: 403,
             api_error: {
               type: "data_source_auth_error",
               message:
-                "Only builders of the current workspace can view 'write' permissions of a data source.",
+                "Only managers of the current workspace can view 'write' permissions of a data source.",
             },
           });
         }

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -223,11 +223,11 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     vi.clearAllMocks();
   });
 
-  it("should allow builder to delete any file", async () => {
+  it("should allow manager to delete any file", async () => {
     const { auth, user, workspace, globalSpace } =
       await createPrivateApiMockRequest({
         method: "DELETE",
-        role: "builder",
+        role: "manager",
       });
 
     const file = await FileFactory.create(auth, user, {
@@ -273,7 +273,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(204);
   });
 
-  it("should deny non-author without builder role from deleting upload files", async () => {
+  it("should deny non-author without manager role from deleting upload files", async () => {
     const { auth, workspace, globalSpace } = await createPrivateApiMockRequest({
       method: "DELETE",
       role: "user",
@@ -303,7 +303,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
     });
   });
 
-  it("should deny non-builder from deleting non-conversation files", async () => {
+  it("should deny non-manager from deleting non-conversation files", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "DELETE",
       role: "user",
@@ -326,7 +326,7 @@ describe("DELETE /api/w/:wId/files/:fileId", () => {
       error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "Only users that are `managers` for the current workspace can modify files.",
       },
     });
   });
@@ -337,10 +337,10 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     vi.clearAllMocks();
   });
 
-  it("should allow builder to upload any file", async () => {
+  it("should allow manager to upload any file", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "POST",
-      role: "builder",
+      role: "manager",
     });
 
     const conversation = await ConversationFactory.create(auth, {
@@ -392,7 +392,7 @@ describe("POST /api/w/:wId/files/:fileId", () => {
     expect(response.status).toBe(200);
   });
 
-  it("should deny non-author without builder role from uploading to space", async () => {
+  it("should deny non-author without manager role from uploading to space", async () => {
     const { auth, workspace, globalSpace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -258,7 +258,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
 
   if (
     isUploadUseCase &&
-    !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
+    !((isFileAuthor && canWriteInSpace) || auth.isManager())
   ) {
     return apiError(ctx, {
       status_code: 403,
@@ -267,13 +267,13 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
         message: "You cannot edit files in that space.",
       },
     });
-  } else if (!auth.isBuilder() && file.useCase !== "conversation") {
+  } else if (!auth.isManager() && file.useCase !== "conversation") {
     return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "Only users that are `managers` for the current workspace can modify files.",
       },
     });
   }
@@ -317,7 +317,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
 
   if (
     isUploadUseCase &&
-    !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
+    !((isFileAuthor && canWriteInSpace) || auth.isManager())
   ) {
     return apiError(ctx, {
       status_code: 403,
@@ -328,7 +328,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   } else if (
     !space &&
-    !auth.isBuilder() &&
+    !auth.isManager() &&
     file.useCase !== "conversation" &&
     file.useCase !== "avatar"
   ) {
@@ -337,7 +337,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "Only users that are `managers` for the current workspace can modify files.",
       },
     });
   }

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
@@ -43,7 +43,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
   it("should return 400 when fileName is missing", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "manager",
     });
 
     const file = await FileFactory.create(auth, user, {
@@ -63,7 +63,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
   it("should return 400 when fileName is empty", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "manager",
     });
 
     const file = await FileFactory.create(auth, user, {
@@ -82,10 +82,10 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
     expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 
-  it("should allow builder to rename any file", async () => {
+  it("should allow manager to rename any file", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "manager",
     });
 
     const file = await FileFactory.create(auth, user, {
@@ -104,7 +104,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
     expect((await response.json()).file.fileName).toBe("new-name.pdf");
   });
 
-  it("should deny non-builder from renaming non-project files", async () => {
+  it("should deny non-manager from renaming non-project files", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
       role: "user",
@@ -127,7 +127,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
       error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `builders` for the current workspace can modify files.",
+          "Only users that are `managers` for the current workspace can modify files.",
       },
     });
   });
@@ -196,7 +196,7 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
   it("should trim whitespace from fileName", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
-      role: "builder",
+      role: "manager",
     });
 
     const file = await FileFactory.create(auth, user, {

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -53,14 +53,13 @@ app.patch(
           },
         });
       }
-      // biome-ignore lint/plugin/noDirectRoleCheck: conditional — only checked when file is not project_context
-    } else if (!auth.isBuilder()) {
+    } else if (!auth.isManager()) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
           message:
-            "Only users that are `builders` for the current workspace can modify files.",
+            "Only users that are `managers` for the current workspace can modify files.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -93,13 +93,13 @@ app.post(
         });
       }
     } else {
-      if (space.isGlobal() && !auth.isBuilder()) {
+      if (space.isGlobal() && !auth.isManager()) {
         return apiError(ctx, {
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `builders` for the current workspace can update a data source.",
+              "Only the users that are `managers` for the current workspace can update a data source.",
           },
         });
       }

--- a/front/lib/api/data_sources.test.ts
+++ b/front/lib/api/data_sources.test.ts
@@ -60,14 +60,14 @@ vi.mock("@app/poke/temporal/client", () => ({
 }));
 
 describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
-  let builderAuth: Authenticator;
+  let managerAuth: Authenticator;
   let userAuth: Authenticator;
   let folderDataSource: DataSourceResource;
 
   beforeEach(async () => {
-    // Setup builder user
-    const builderSetup = await createResourceTest({ role: "builder" });
-    builderAuth = builderSetup.authenticator;
+    // Setup manager user
+    const managerSetup = await createResourceTest({ role: "manager" });
+    managerAuth = managerSetup.authenticator;
 
     // Setup regular user
     const userSetup = await createResourceTest({
@@ -75,11 +75,11 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
     });
     userAuth = userSetup.authenticator;
 
-    // Create a folder data source owned by the builder in their workspace
+    // Create a folder data source owned by the manager in their workspace
     const dataSourceView = await DataSourceViewFactory.folder(
-      builderSetup.workspace,
-      builderSetup.globalSpace,
-      builderSetup.user
+      managerSetup.workspace,
+      managerSetup.globalSpace,
+      managerSetup.user
     );
     folderDataSource = dataSourceView.dataSource;
 
@@ -114,7 +114,7 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
       if (result.isErr()) {
         expect(result.error.code).toBe("unauthorized_deletion");
         expect(result.error.message).toContain(
-          "Only builders can delete data sources"
+          "Only managers can delete data sources"
         );
       }
       expect(launchScrubDataSourceWorkflow).not.toHaveBeenCalled();
@@ -142,15 +142,15 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
   });
 
   describe("successful deletions", () => {
-    it("should allow builder to delete folder data source", async () => {
+    it("should allow manager to delete folder data source", async () => {
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
       expect(result.isOk()).toBe(true);
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
-        builderAuth.workspace(),
+        managerAuth.workspace(),
         folderDataSource
       );
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledTimes(1);
@@ -173,16 +173,16 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
       ] as any);
 
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
       expect(result.isOk()).toBe(true);
-      expect(view1.delete).toHaveBeenCalledWith(builderAuth, {
+      expect(view1.delete).toHaveBeenCalledWith(managerAuth, {
         transaction: undefined,
         hardDelete: false,
       });
-      expect(view2.delete).toHaveBeenCalledWith(builderAuth, {
+      expect(view2.delete).toHaveBeenCalledWith(managerAuth, {
         transaction: undefined,
         hardDelete: false,
       });
@@ -191,7 +191,7 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
 
     it("should launch scrub workflow with correct workspace and data source", async () => {
       const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        builderAuth,
+        managerAuth,
         { dataSource: folderDataSource }
       );
 
@@ -200,7 +200,7 @@ describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
         expect(result.value.sId).toBe(folderDataSource.sId);
       }
       expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
-        builderAuth.workspace(),
+        managerAuth.workspace(),
         folderDataSource
       );
     });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -225,7 +225,7 @@ export async function softDeleteDataSourceAndLaunchScrubWorkflow(
   if (!isAuthorized) {
     return new Err({
       code: "unauthorized_deletion",
-      message: "Only builders can delete data sources.",
+      message: "Only managers can delete data sources.",
     });
   }
 
@@ -267,7 +267,7 @@ export async function hardDeleteDataSource(
   auth: Authenticator,
   dataSource: DataSourceResource
 ) {
-  assert(auth.isBuilder(), "Only builders can delete data sources.");
+  assert(auth.isManager(), "Only managers can delete data sources.");
 
   // Delete all files in the data source's bucket.
   //

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1528,7 +1528,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
-            { role: "builder", permissions: ["read", "write"] },
+            { role: "manager", permissions: ["read", "write"] },
           ],
           groups: this.groups.map((group) => ({
             id: group.groupId,
@@ -1554,7 +1554,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
-            { role: "builder", permissions: ["read", "write"] },
+            { role: "manager", permissions: ["read", "write"] },
             { role: "user", permissions: ["read"] },
           ],
           groups: this.groups.reduce((acc, group) => {


### PR DESCRIPTION
## Description

Part of removing `auth.isBuilder()` (dust-tt/tasks#9746, bucket A — server-side authorization). For **spaces and files** operations, require the **manager** role instead of the deprecated **builder** role.

### Changes

**Core:** `space_resource.requestedPermissions()` — global/conversations spaces and open regular spaces now grant `read`+`write` to `manager` instead of `builder`. Role matching is exact (`this.role() === r.role`, no hierarchy), so:
- admins keep access via their own `admin` entry,
- builder-role users lose global/open-space write (builder is being removed),
- managers gain it.

**Call sites** (`auth.isBuilder()` → `auth.isManager()`, messages updated):
- `front-api` files routes: `v1/.../files/[fileId]`, `w/.../files/[fileId]/index`, `.../rename`
- `front-api` `w/.../spaces/[spaceId]/data_sources`
- `front-api` `w/.../data_sources/[dsId]/managed/permissions`
- `front/lib/api/data_sources.ts` (soft + hard delete)

Out of scope (handled elsewhere): the dust-app checks (`dust_app:admin` PRs), the `ensureIsBuilder` middleware (broad, used by providers/skills/agents), agent publishing, and the auth-context `isBuilder` field (separate removal PR).

### Tests

Updated the directly-related tests (file routes + `data_sources`) to use the `manager` role and the new messages.

⚠️ **Broader test impact:** the `space_resource` change affects **every** `space.canWrite/canRead/canAdministrate` for builder-role users on global/open/conversations spaces. Many other tests set `role: "builder"` and may rely on that write access (skills, conversations, agents). I couldn't run the full DB test suite locally (workspace env issue), so I'm relying on CI to surface those; I'll fix the fallout in follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)