### PR TITLE
fix: skip unrecognized resourceType in workspace permission expansion

### DIFF
--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -151,7 +151,7 @@ function typeLevelVerbsForGrant(
   grantType: ConcreteGrantType,
   resourceType: ConcreteResourceType
 ): GrantVerb[] {
-  const role = ROLE_REGISTRY[resourceType][grantType];
+  const role = ROLE_REGISTRY[resourceType]?.[grantType];
   if (!role || !role.levels.includes("type")) {
     return [];
   }
@@ -210,6 +210,10 @@ export function workspacePermissionsFromGrants(
         : [resourceType];
 
     for (const resource of resources) {
+      if (!ROLE_REGISTRY[resource]) {
+        continue;
+      }
+
       const verbs =
         grantType === "*"
           ? allTypeLevelVerbsForResource(resource)


### PR DESCRIPTION
## Description

Makes `workspacePermissionsFromGrants` fail closed when a grant row carries a `resourceType` the registry doesn't recognize, instead of throwing.

`auth-context` was 500ing with:

```
TypeError: Cannot read properties of undefined (reading 'admin')
    at typeLevelVerbsForGrant (group_permission_registry.ts:151)
    at workspacePermissionsFromGrants (group_permission_registry.ts:212)
    at Authenticator.getWorkspacePermissions (auth.ts:1167)
```

Root cause is a deploy-ordering issue: the `dust_app` permission backfill was started before the updated role registry (which adds `dust_app` to `ROLE_REGISTRY`) was deployed. So `group_permissions` rows with `resourceType: "dust_app"` (grantType `admin`) already existed in the DB while the running code's `ROLE_REGISTRY` had no `dust_app` key. `ROLE_REGISTRY["dust_app"]` is `undefined`, so indexing it with `"admin"` throws and takes down the whole endpoint.

The fix skips any resource the registry doesn't know in the grant-expansion loop:

```ts
if (!ROLE_REGISTRY[resource]) {
  continue;
}
```

An unknown resourceType now confers no permissions (fail-closed) rather than crashing auth resolution. Beyond this specific incident, it hardens the read path against any future case where grants exist for a resource type the running code hasn't caught up to. The write path (`assertValidGrant`) is unchanged and still rejects unknown types on insert.

## Tests
Manually.

## Risk

Low. Fail-closed guard: an unrecognized resourceType yields no permissions instead of a 500. No change to writes or to any known resource type. Rollback-safe (single-line revert).

## Deploy Plan

Standard deployment.