### PR TITLE
Optimize: do not fetch whole conversation for notifications.

### DIFF
--- a/front/lib/notifications/conversation_fetch.ts
+++ b/front/lib/notifications/conversation_fetch.ts
@@ -1,0 +1,311 @@
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MentionModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type {
+  ConversationWithoutContentType,
+  LightConversationType,
+  LightMessageType,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
+import {
+  ConversationError,
+  isVisibleMessage,
+} from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { Op } from "sequelize";
+
+const FIRST_VISIBLE_MESSAGE_RANK_LIMIT = 50;
+
+function keepLatestLightMessagePerRank(
+  messages: LightMessageType[]
+): LightMessageType[] {
+  const byRank = new Map<number, LightMessageType>();
+  for (const message of messages) {
+    const existing = byRank.get(message.rank);
+    if (!existing || message.version >= existing.version) {
+      byRank.set(message.rank, message);
+    }
+  }
+
+  return [...byRank.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, message]) => message);
+}
+
+async function renderLightMessages(
+  auth: Authenticator,
+  resource: ConversationResource,
+  messages: Awaited<ReturnType<ConversationResource["fetchMessagesByModelIds"]>>
+): Promise<Result<LightMessageType[], ConversationError>> {
+  if (messages.length === 0) {
+    return new Ok([]);
+  }
+
+  const renderRes = await batchRenderMessages(
+    auth,
+    resource,
+    messages,
+    "light"
+  );
+  if (renderRes.isErr()) {
+    return renderRes;
+  }
+
+  return new Ok(keepLatestLightMessagePerRank(renderRes.value));
+}
+
+export async function conversationWithoutContentForResource(
+  auth: Authenticator,
+  resource: ConversationResource
+): Promise<ConversationWithoutContentType> {
+  const { actionRequired, lastReadAt } =
+    await ConversationResource.getActionRequiredAndLastReadAtForUser(
+      auth,
+      resource.id
+    );
+
+  return {
+    ...resource.toJSON(),
+    actionRequired,
+    lastReadMs: lastReadAt?.getTime() ?? null,
+    unread: lastReadAt === null || resource.updatedAt > lastReadAt,
+  };
+}
+
+export async function fetchLightMessageBySId(
+  auth: Authenticator,
+  {
+    resource,
+    conversation,
+    messageId,
+  }: {
+    resource: ConversationResource;
+    conversation: ConversationWithoutContentType;
+    messageId: string;
+  }
+): Promise<Result<LightMessageType, ConversationError>> {
+  const messageRes = await ConversationResource.getMessageByIdInConversation(
+    auth,
+    conversation,
+    messageId
+  );
+  if (messageRes.isErr()) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  const message = messageRes.value;
+  // Match getLightConversation: only main-branch messages.
+  if (message.getBranchId()) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  const withIncludes = await resource.fetchMessagesByModelIds(auth, [
+    message.id,
+  ]);
+  const renderedRes = await renderLightMessages(auth, resource, withIncludes);
+  if (renderedRes.isErr()) {
+    return renderedRes;
+  }
+
+  const rendered = renderedRes.value[0];
+  if (!rendered) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  return new Ok(rendered);
+}
+
+export async function fetchFirstVisibleLightMessage(
+  auth: Authenticator,
+  resource: ConversationResource
+): Promise<Result<LightMessageType, ConversationError>> {
+  const messageIds = await resource.fetchEarliestLatestVersionMessageIds(auth, {
+    limit: FIRST_VISIBLE_MESSAGE_RANK_LIMIT,
+  });
+  const messages = await resource.fetchMessagesByModelIds(auth, messageIds);
+  const renderedRes = await renderLightMessages(auth, resource, messages);
+  if (renderedRes.isErr()) {
+    return renderedRes;
+  }
+
+  const firstVisible = renderedRes.value.find(isVisibleMessage);
+  if (!firstVisible) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  return new Ok(firstVisible);
+}
+
+export async function fetchUserMessageOriginBySId(
+  auth: Authenticator,
+  {
+    conversation,
+    messageId,
+  }: {
+    conversation: ConversationWithoutContentType;
+    messageId: string;
+  }
+): Promise<UserMessageOrigin | null> {
+  const messageRes = await ConversationResource.getMessageByIdInConversation(
+    auth,
+    conversation,
+    messageId
+  );
+  if (messageRes.isErr()) {
+    return null;
+  }
+
+  return messageRes.value.userMessage?.userContextOrigin ?? null;
+}
+
+export async function getUnreadNotificationFlags(
+  auth: Authenticator,
+  {
+    resource,
+    conversation,
+  }: {
+    resource: ConversationResource;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<{
+  hasUnreadMessages: boolean;
+  hasUnreadMentions: boolean;
+}> {
+  const lastReadAt =
+    conversation.lastReadMs !== null ? new Date(conversation.lastReadMs) : null;
+  const unreadMessageIds = await resource.fetchUnreadMessageIds(
+    auth,
+    lastReadAt
+  );
+
+  if (unreadMessageIds.length === 0) {
+    return { hasUnreadMessages: false, hasUnreadMentions: false };
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return { hasUnreadMessages: true, hasUnreadMentions: false };
+  }
+
+  const unreadMention = await MentionModel.findOne({
+    attributes: ["id"],
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      userId: user.id,
+      status: "approved",
+      messageId: { [Op.in]: unreadMessageIds },
+    },
+  });
+
+  return {
+    hasUnreadMessages: true,
+    hasUnreadMentions: unreadMention !== null,
+  };
+}
+
+export async function conversationUsesAgentsWithRetention(
+  auth: Authenticator,
+  resource: ConversationResource,
+  agentsRetention: Record<string, unknown>
+): Promise<boolean> {
+  const retentionAgentIds = new Set(Object.keys(agentsRetention));
+  if (retentionAgentIds.size === 0) {
+    return false;
+  }
+
+  const { agentConfigurationIds } =
+    await resource.fetchAgentConfigurationAndContentFragmentIds(auth);
+
+  return agentConfigurationIds.some((id) => retentionAgentIds.has(id));
+}
+
+export async function hasUnreadSucceededAgentReply(
+  auth: Authenticator,
+  conversationId: string
+): Promise<boolean> {
+  const resource = await ConversationResource.fetchById(auth, conversationId);
+  if (!resource) {
+    return false;
+  }
+
+  const conversation = await conversationWithoutContentForResource(
+    auth,
+    resource
+  );
+  const lastReadAt =
+    conversation.lastReadMs !== null ? new Date(conversation.lastReadMs) : null;
+  const unreadMessageIds = await resource.fetchUnreadMessageIds(
+    auth,
+    lastReadAt
+  );
+  if (unreadMessageIds.length === 0) {
+    return false;
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const message = await MessageModel.findOne({
+    attributes: ["id"],
+    where: {
+      workspaceId,
+      conversationId: conversation.id,
+      id: { [Op.in]: unreadMessageIds },
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+        attributes: [],
+        where: {
+          workspaceId,
+          conversationId: conversation.id,
+          status: "succeeded",
+        },
+      },
+    ],
+  });
+
+  return message !== null;
+}
+
+export async function fetchUnreadLightConversation(
+  auth: Authenticator,
+  conversationId: string
+): Promise<Result<LightConversationType, ConversationError>> {
+  const resource = await ConversationResource.fetchById(auth, conversationId);
+  if (!resource) {
+    return new Err(new ConversationError("conversation_not_found"));
+  }
+
+  const conversation = await conversationWithoutContentForResource(
+    auth,
+    resource
+  );
+  const lastReadAt =
+    conversation.lastReadMs !== null ? new Date(conversation.lastReadMs) : null;
+  const unreadMessageIds = await resource.fetchUnreadMessageIds(
+    auth,
+    lastReadAt
+  );
+  const messages = await resource.fetchMessagesByModelIds(
+    auth,
+    unreadMessageIds
+  );
+  const renderedRes = await renderLightMessages(auth, resource, messages);
+  if (renderedRes.isErr()) {
+    return renderedRes;
+  }
+
+  return new Ok({
+    ...conversation,
+    owner: auth.getNonNullableWorkspace(),
+    visibility: resource.visibility,
+    content: renderedRes.value,
+  });
+}

--- a/front/lib/notifications/helpers.test.ts
+++ b/front/lib/notifications/helpers.test.ts
@@ -1,0 +1,479 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  MentionModel,
+} from "@app/lib/models/agent/conversation";
+import { getConversationDetails } from "@app/lib/notifications/helpers";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function backdateMessageCreatedAt({
+  messageId,
+  workspaceId,
+  createdAt,
+}: {
+  messageId: number;
+  workspaceId: number;
+  createdAt: Date;
+}) {
+  // Sequelize validates FK exclusivity on update; raw SQL avoids that hook.
+  // biome-ignore lint/plugin/noRawSql: test helper backdating timestamps
+  await frontSequelize.query(
+    `UPDATE messages SET "createdAt" = :createdAt WHERE id = :id AND "workspaceId" = :workspaceId`,
+    {
+      replacements: {
+        createdAt: createdAt.toISOString(),
+        id: messageId,
+        workspaceId,
+      },
+    }
+  );
+}
+
+describe("getConversationDetails", () => {
+  let workspace: WorkspaceType;
+  let user: UserResource;
+  let mentionedUser: UserResource;
+  let auth: Authenticator;
+  let agent: LightAgentConfigurationType;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const result = await createResourceTest({ role: "user" });
+    workspace = result.workspace;
+    user = result.user;
+    auth = result.authenticator;
+
+    mentionedUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, mentionedUser, {
+      role: "user",
+    });
+
+    agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "DetailsAgent",
+      description: "Test agent",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    await ConversationModel.update(
+      { title: "Quarterly plan &amp; budget" },
+      { where: { id: conversation.id, workspaceId: workspace.id } }
+    );
+    conversation = { ...conversation, title: "Quarterly plan &amp; budget" };
+  });
+
+  it("returns details for a user message", async () => {
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Hello team",
+      origin: "web",
+    });
+
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.subject).toBe("Quarterly plan & budget");
+    expect(result.value.author).toBe(user.fullName());
+    expect(result.value.authorIsAgent).toBe(false);
+    expect(result.value.authorUserId).toBe(user.sId);
+    expect(result.value.newMessageContent).toBe("Hello team");
+    expect(result.value.workspaceName).toBe(workspace.name);
+    expect(result.value.hasUnreadMessages).toBe(true);
+    expect(result.value.isFromEmailAgentConversation).toBe(false);
+    expect(result.value.isFromSlackAgentConversation).toBe(false);
+    expect(result.value.isFromTrigger).toBe(false);
+  });
+
+  it("extracts approved mentions and unread mention flags for the subscriber", async () => {
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Hey @mentioned",
+    });
+
+    await MentionModel.create({
+      messageId: messageRow.id,
+      userId: mentionedUser.id,
+      workspaceId: workspace.id,
+      status: "approved",
+    });
+
+    // Use subscriberId (not auth) so hasUnreadMentions is evaluated for that user.
+    const forAuthor = await getConversationDetails({
+      subscriberId: user.sId,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+    expect(forAuthor.isOk()).toBe(true);
+    if (forAuthor.isOk()) {
+      expect(forAuthor.value.mentionedUserIds).toEqual([mentionedUser.sId]);
+      expect(forAuthor.value.hasUnreadMentions).toBe(false);
+    }
+
+    const forMentioned = await getConversationDetails({
+      subscriberId: mentionedUser.sId,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+    expect(forMentioned.isOk()).toBe(true);
+    if (forMentioned.isOk()) {
+      expect(forMentioned.value.mentionedUserIds).toEqual([mentionedUser.sId]);
+      expect(forMentioned.value.hasUnreadMentions).toBe(true);
+      expect(forMentioned.value.hasUnreadMessages).toBe(true);
+    }
+  });
+
+  it("flags email and slack origins on user messages and agent replies", async () => {
+    const { messageRow: emailUserMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "From email",
+        origin: "email",
+        rank: 0,
+      });
+
+    const emailDetails = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: emailUserMessage.sId,
+      },
+    });
+    expect(emailDetails.isOk()).toBe(true);
+    if (emailDetails.isOk()) {
+      expect(emailDetails.value.isFromEmailAgentConversation).toBe(true);
+      expect(emailDetails.value.isFromSlackAgentConversation).toBe(false);
+    }
+
+    const slackConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: slackUserMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation: slackConversation,
+        content: "From slack",
+        origin: "slack",
+        rank: 0,
+      });
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: slackConversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: slackUserMessage.id,
+    });
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentReply.agentMessageId!,
+      status: "succeeded",
+    });
+
+    const agentDetails = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: slackConversation.sId,
+        messageId: agentReply.sId,
+      },
+    });
+    expect(agentDetails.isOk()).toBe(true);
+    if (agentDetails.isOk()) {
+      expect(agentDetails.value.authorIsAgent).toBe(true);
+      expect(agentDetails.value.author).toBe("@DetailsAgent");
+      expect(agentDetails.value.isFromSlackAgentConversation).toBe(true);
+      expect(agentDetails.value.isFromEmailAgentConversation).toBe(false);
+    }
+  });
+
+  it("marks hasUnreadMessages when an agent completes after lastRead", async () => {
+    const { messageRow: userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Please answer",
+        rank: 0,
+      });
+
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessage.id,
+    });
+
+    const createdAt = new Date("2024-01-01T00:00:00.000Z");
+    const lastReadAt = new Date("2024-01-02T00:00:00.000Z");
+    const completedAt = new Date("2024-01-03T00:00:00.000Z");
+
+    await backdateMessageCreatedAt({
+      messageId: agentReply.id,
+      workspaceId: workspace.id,
+      createdAt,
+    });
+    await AgentMessageModel.update(
+      { status: "succeeded", completedAt },
+      {
+        where: {
+          id: agentReply.agentMessageId!,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt,
+    });
+
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: agentReply.sId,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.hasUnreadMessages).toBe(true);
+    }
+  });
+
+  it("reports no unread messages after the conversation was fully read", async () => {
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Already seen",
+    });
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt: new Date(Date.now() + 60_000),
+    });
+
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.hasUnreadMessages).toBe(false);
+      expect(result.value.hasUnreadMentions).toBe(false);
+    }
+  });
+
+  it("resolves first visible message and project name for new project conversations", async () => {
+    const space = await SpaceFactory.project(workspace, user.id);
+    // Refresh auth so space membership is visible to conversation creation.
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const projectConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      spaceId: space.id,
+    });
+    await ConversationModel.update(
+      { title: "Kickoff" },
+      { where: { id: projectConversation.id, workspaceId: workspace.id } }
+    );
+
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation: projectConversation,
+      content: "First visible message",
+      origin: "web",
+    });
+
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: projectConversation.sId,
+        isNewProjectConversation: true,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.isNewProjectConversation).toBe(true);
+      expect(result.value.projectName).toBe(space.name);
+      expect(result.value.newMessageContent).toBe("First visible message");
+      expect(result.value.subject).toBe("Kickoff");
+    }
+  });
+
+  it("returns conversation_not_found for a soft-deleted conversation", async () => {
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Gone soon",
+    });
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+    await conversationResource!.updateVisibilityToDeleted(auth);
+
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("conversation_not_found");
+    }
+  });
+
+  it("returns message_not_found for an unknown message id", async () => {
+    const result = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: "msg_does_not_exist",
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("message_not_found");
+    }
+  });
+
+  it("returns a placeholder when subscriberId is empty", async () => {
+    const result = await getConversationDetails({
+      subscriberId: "",
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: "msg_anything",
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.subject).toBe("Deleted conversation");
+      expect(result.value.hasUnreadMessages).toBe(false);
+    }
+  });
+
+  it("detects conversation and agent retention policies", async () => {
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Retention check",
+    });
+
+    await WorkspaceResource.updateConversationsRetention(workspace.id, 30);
+
+    const withConversationRetention = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      },
+    });
+    expect(withConversationRetention.isOk()).toBe(true);
+    if (withConversationRetention.isOk()) {
+      expect(
+        withConversationRetention.value.hasConversationRetentionPolicy
+      ).toBe(true);
+    }
+
+    await WorkspaceResource.updateConversationsRetention(workspace.id, -1);
+    await AgentDataRetentionModel.create({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      retentionDays: 14,
+    });
+
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: messageRow.id,
+    });
+
+    const withAgentRetention = await getConversationDetails({
+      auth,
+      payload: {
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        messageId: agentReply.sId,
+      },
+    });
+    expect(withAgentRetention.isOk()).toBe(true);
+    if (withAgentRetention.isOk()) {
+      expect(withAgentRetention.value.hasConversationRetentionPolicy).toBe(
+        false
+      );
+      expect(withAgentRetention.value.hasAgentRetentionPolicies).toBe(true);
+    }
+  });
+});

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -1,10 +1,16 @@
-import { isMessageUnread } from "@app/components/assistant/conversation/utils";
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { Authenticator } from "@app/lib/auth";
 import {
   getAgentsDataRetention,
   getConversationsDataRetention,
 } from "@app/lib/data_retention";
+import {
+  conversationUsesAgentsWithRetention,
+  conversationWithoutContentForResource,
+  fetchFirstVisibleLightMessage,
+  fetchLightMessageBySId,
+  fetchUserMessageOriginBySId,
+  getUnreadNotificationFlags,
+} from "@app/lib/notifications/conversation_fetch";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
@@ -14,10 +20,8 @@ import {
   isLightAgentMessageType,
   isPodConversation,
   isUserMessageType,
-  isVisibleMessage,
 } from "@app/types/assistant/conversation";
 import { isRichUserMention } from "@app/types/assistant/mentions";
-import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -103,12 +107,12 @@ export const getConversationDetails = async ({
     );
   }
 
-  const conversationRes = await getLightConversation(
+  const resource = await ConversationResource.fetchById(
     auth,
     payload.conversationId
   );
 
-  if (conversationRes.isErr()) {
+  if (!resource) {
     // Check if the conversation was deleted (expected during workflow delay).
     const deletedConversation = await ConversationResource.fetchById(
       auth,
@@ -122,7 +126,10 @@ export const getConversationDetails = async ({
     throw new Error(`Conversation not found: ${payload.conversationId}`);
   }
 
-  const conversation = conversationRes.value;
+  const conversation = await conversationWithoutContentForResource(
+    auth,
+    resource
+  );
 
   const workspaceName = auth.getNonNullableWorkspace().name;
   // Decode HTML entities in conversation title (e.g. from email subjects
@@ -132,14 +139,20 @@ export const getConversationDetails = async ({
   const isFromTrigger = !!conversation.triggerId;
 
   // Retrieve the message that triggered the notification.
-  // For new project conversations, use the first visible message
-  const message = !payload.isNewProjectConversation
-    ? conversation.content.find((msg) => msg.sId === payload.messageId)
-    : conversation.content.find(isVisibleMessage);
-  if (!message) {
-    // Message doesn't exist at all - could be true if it's in a branch.
-    return new Err(new ConversationError("message_not_found"));
+  // For new project conversations, use the first visible message.
+  const messageRes = !payload.isNewProjectConversation
+    ? await fetchLightMessageBySId(auth, {
+        resource,
+        conversation,
+        messageId: payload.messageId!,
+      })
+    : await fetchFirstVisibleLightMessage(auth, resource);
+
+  if (messageRes.isErr()) {
+    return messageRes;
   }
+
+  const message = messageRes.value;
   if (message.visibility === "deleted") {
     // Message was deleted during workflow delay - expected.
     return new Err(new ConversationError("message_not_found"));
@@ -153,30 +166,25 @@ export const getConversationDetails = async ({
     message.type === "agent_message" || message.type === "user_message"
       ? message.content
       : "";
-  const parentUserMessage = isLightAgentMessageType(message)
-    ? conversation.content
-        .flat()
-        .find((msg) => msg.sId === message.parentMessageId)
-    : undefined;
+
+  const parentOrigin = isLightAgentMessageType(message)
+    ? await fetchUserMessageOriginBySId(auth, {
+        conversation,
+        messageId: message.parentMessageId,
+      })
+    : null;
+
   const isFromEmailAgentConversation =
     (isUserMessageType(message) && message.context.origin === "email") ||
-    (parentUserMessage !== undefined &&
-      isUserMessageType(parentUserMessage) &&
-      parentUserMessage.context.origin === "email");
+    parentOrigin === "email";
 
   const isFromSlackAgentConversation =
     (isUserMessageType(message) && message.context.origin === "slack") ||
-    (parentUserMessage !== undefined &&
-      isUserMessageType(parentUserMessage) &&
-      parentUserMessage.context.origin === "slack");
+    parentOrigin === "slack";
 
   if (isCompactionMessageType(message)) {
     // Compaction messages don't trigger notifications.
     return new Err(new ConversationError("message_not_found"));
-  } else if (isContentFragmentType(message)) {
-    // Content fragments don't have author info.
-    author = "Someone else";
-    authorIsAgent = false;
   } else if (isUserMessageType(message)) {
     author =
       message.user?.fullName ?? message.context.fullName ?? "Someone else";
@@ -196,32 +204,18 @@ export const getConversationDetails = async ({
     assertNever(message);
   }
 
-  const unreadMessages = conversation.content.filter((msg) =>
-    isMessageUnread(msg, conversation.lastReadMs)
-  );
-
-  const hasUnreadMessages = unreadMessages.length > 0;
-
-  const hasUnreadMentions = unreadMessages.some((msg) => {
-    if (isContentFragmentType(msg) || isCompactionMessageType(msg)) {
-      return false;
-    }
-    return msg.richMentions.some(
-      (m) => isRichUserMention(m) && m.id === subscriberId
-    );
-  });
+  const { hasUnreadMessages, hasUnreadMentions } =
+    await getUnreadNotificationFlags(auth, { resource, conversation });
 
   const conversationsRetention = await getConversationsDataRetention(auth);
   const hasConversationRetentionPolicy = conversationsRetention !== null;
 
   const agentsRetention = await getAgentsDataRetention(auth);
-  const hasAgentRetentionPolicies = conversation.content.some((msg) => {
-    if (msg.type !== "agent_message") {
-      return false;
-    }
-
-    return msg.configuration.sId in agentsRetention;
-  });
+  const hasAgentRetentionPolicies = await conversationUsesAgentsWithRetention(
+    auth,
+    resource,
+    agentsRetention
+  );
 
   // Fetch project-specific details when this is a new project conversation notification.
   let projectName: string | undefined;

--- a/front/lib/notifications/workflows/activation-new-conversation.test.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.test.ts
@@ -1,0 +1,239 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { shouldSkipActivationNewConversation } from "@app/lib/notifications/workflows/activation-new-conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function backdateMessageCreatedAt({
+  messageId,
+  workspaceId,
+  createdAt,
+}: {
+  messageId: number;
+  workspaceId: number;
+  createdAt: Date;
+}) {
+  // biome-ignore lint/plugin/noRawSql: test helper backdating timestamps
+  await frontSequelize.query(
+    `UPDATE messages SET "createdAt" = :createdAt WHERE id = :id AND "workspaceId" = :workspaceId`,
+    {
+      replacements: {
+        createdAt: createdAt.toISOString(),
+        id: messageId,
+        workspaceId,
+      },
+    }
+  );
+}
+
+describe("shouldSkipActivationNewConversation", () => {
+  let workspace: WorkspaceType;
+  let user: UserResource;
+  let auth: Authenticator;
+  let agent: LightAgentConfigurationType;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const result = await createResourceTest({ role: "user" });
+    workspace = result.workspace;
+    user = result.user;
+    auth = result.authenticator;
+
+    agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "ActivationAgent",
+      description: "Test",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+  });
+
+  it("skips when subscriberId is missing", async () => {
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: null,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("skips when the conversation does not exist", async () => {
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: "conv_missing",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("skips when there is no succeeded agent reply", async () => {
+    const { messageRow: userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+        rank: 0,
+      });
+
+    await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessage.id,
+    });
+
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("does not skip when there is an unread succeeded agent reply", async () => {
+    const { messageRow: userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+        rank: 0,
+      });
+
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessage.id,
+    });
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentReply.agentMessageId!,
+      status: "succeeded",
+    });
+
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("skips when the succeeded agent reply was already read", async () => {
+    const { messageRow: userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+        rank: 0,
+      });
+
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessage.id,
+    });
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentReply.agentMessageId!,
+      status: "succeeded",
+    });
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt: new Date(Date.now() + 60_000),
+    });
+
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("does not skip when an agent completes after lastRead", async () => {
+    const { messageRow: userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+        rank: 0,
+      });
+
+    const agentReply = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agent.sId,
+      parentId: userMessage.id,
+    });
+
+    const createdAt = new Date("2024-01-01T00:00:00.000Z");
+    const lastReadAt = new Date("2024-01-02T00:00:00.000Z");
+    const completedAt = new Date("2024-01-03T00:00:00.000Z");
+
+    await backdateMessageCreatedAt({
+      messageId: agentReply.id,
+      workspaceId: workspace.id,
+      createdAt,
+    });
+    await AgentMessageModel.update(
+      { status: "succeeded", completedAt },
+      {
+        where: {
+          id: agentReply.agentMessageId!,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt,
+    });
+
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -1,5 +1,3 @@
-import { isMessageUnread } from "@app/components/assistant/conversation/utils";
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
@@ -8,12 +6,12 @@ import {
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
+import { hasUnreadSucceededAgentReply } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { getConversationDetails } from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isLightAgentMessageType } from "@app/types/assistant/conversation";
 import {
   ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
   NOTIFICATION_DELAY_OPTIONS,
@@ -53,7 +51,7 @@ const userNotificationDelaySchema = z.object({
   delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
 });
 
-const shouldSkipActivationNewConversation = async ({
+export const shouldSkipActivationNewConversation = async ({
   subscriberId,
   payload,
 }: {
@@ -69,21 +67,10 @@ const shouldSkipActivationNewConversation = async ({
     payload.workspaceId
   );
 
-  const conversationRes = await getLightConversation(
+  // Send only when the agent has actually finished replying and that reply is still unread for this user.
+  const hasUnreadAgentReply = await hasUnreadSucceededAgentReply(
     auth,
     payload.conversationId
-  );
-  if (conversationRes.isErr()) {
-    return true;
-  }
-  const conversation = conversationRes.value;
-
-  // Send only when the agent has actually finished replying and that reply is still unread for this user.
-  const hasUnreadAgentReply = conversation.content.some(
-    (msg) =>
-      isLightAgentMessageType(msg) &&
-      msg.status === "succeeded" &&
-      isMessageUnread(msg, conversation.lastReadMs)
   );
 
   return !hasUnreadAgentReply;

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -1,7 +1,5 @@
-import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   countConversationMessages,
   renderConversationAsText,
@@ -16,6 +14,7 @@ import {
   getUserNotificationDelay,
   type NotificationAllowedTags,
 } from "@app/lib/notifications";
+import { fetchUnreadLightConversation } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/conversations-unread";
 import {
   type ConversationDetailsPayload,
@@ -301,7 +300,7 @@ const generateUnreadMessagesSummary = async ({
     payload.workspaceId
   );
 
-  const conversationRes = await getLightConversation(
+  const conversationRes = await fetchUnreadLightConversation(
     auth,
     payload.conversationId
   );
@@ -314,11 +313,7 @@ const generateUnreadMessagesSummary = async ({
 
   const conversation = conversationRes.value;
 
-  const unreadMessages = conversation.content.filter((msg) =>
-    isMessageUnread(msg, conversation.lastReadMs)
-  );
-
-  if (unreadMessages.length === 0) {
+  if (conversation.content.length === 0) {
     return new Err(
       new DustError("no_unread_messages_found", "No unread messages")
     );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -4259,6 +4259,150 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     };
   }
 
+  /**
+   * Fetch message rows (with side-table includes) by model ids, ordered by rank/version ASC.
+   */
+  async fetchMessagesByModelIds(
+    auth: Authenticator,
+    messageIds: ModelId[]
+  ): Promise<MessageModel[]> {
+    if (messageIds.length === 0) {
+      return [];
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const sideTableWhere = {
+      workspaceId,
+      conversationId: this.id,
+    };
+
+    return MessageModel.findAll({
+      where: {
+        conversationId: this.id,
+        workspaceId,
+        id: { [Op.in]: messageIds },
+      },
+      order: [
+        ["rank", "ASC"],
+        ["version", "ASC"],
+      ],
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: false,
+          where: sideTableWhere,
+        },
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: false,
+          where: sideTableWhere,
+        },
+        {
+          model: ContentFragmentModel,
+          as: "contentFragment",
+          required: false,
+          where: sideTableWhere,
+        },
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
+          required: false,
+          where: sideTableWhere,
+        },
+      ],
+    });
+  }
+
+  /**
+   * Message ids that are unread for the given lastReadAt.
+   * Unread = created after lastRead, or agent message completed after lastRead.
+   * When lastReadAt is null, every main-branch message is unread.
+   */
+  async fetchUnreadMessageIds(
+    auth: Authenticator,
+    lastReadAt: Date | null
+  ): Promise<ModelId[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const baseWhere: WhereOptions<MessageModel> = {
+      workspaceId,
+      conversationId: this.id,
+      branchId: { [Op.is]: null },
+    };
+
+    if (lastReadAt === null) {
+      const messages = await MessageModel.findAll({
+        attributes: ["id"],
+        where: baseWhere,
+      });
+      return messages.map((message) => message.id);
+    }
+
+    const [createdAfter, completedAfter] = await Promise.all([
+      MessageModel.findAll({
+        attributes: ["id"],
+        where: {
+          ...baseWhere,
+          createdAt: { [Op.gt]: lastReadAt },
+        },
+      }),
+      MessageModel.findAll({
+        attributes: ["id"],
+        where: baseWhere,
+        include: [
+          {
+            model: AgentMessageModel,
+            as: "agentMessage",
+            required: true,
+            attributes: [],
+            where: {
+              workspaceId,
+              conversationId: this.id,
+              completedAt: { [Op.gt]: lastReadAt },
+            },
+          },
+        ],
+      }),
+    ]);
+
+    return [
+      ...new Set([
+        ...createdAfter.map((message) => message.id),
+        ...completedAfter.map((message) => message.id),
+      ]),
+    ];
+  }
+
+  /**
+   * Latest version message id per rank, earliest ranks first.
+   * Used to find the first visible message without loading the full conversation.
+   */
+  async fetchEarliestLatestVersionMessageIds(
+    auth: Authenticator,
+    { limit }: { limit: number }
+  ): Promise<ModelId[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const rankRows = await MessageModel.findAll({
+      attributes: [
+        [Sequelize.fn("MAX", Sequelize.col("version")), "maxVersion"],
+        [Sequelize.fn("MAX", Sequelize.col("id")), "id"],
+        [Sequelize.fn("MAX", Sequelize.col("rank")), "rank"],
+      ],
+      where: {
+        workspaceId,
+        conversationId: this.id,
+        branchId: { [Op.is]: null },
+        visibility: { [Op.ne]: "deleted" },
+      },
+      group: ["rank"],
+      order: [["rank", "ASC"]],
+      limit,
+    });
+
+    return rankRows.map((row) => row.id);
+  }
+
   static async updateRequirements(
     auth: Authenticator,
     sId: string,


### PR DESCRIPTION
## Description

The notification workflows (`activation-new-conversation`, `conversation-unread`, `getConversationDetails`) previously called `getLightConversation`, which loads the full serialized conversation content into memory. For long conversations this is wasteful since notifications only need a handful of targeted data points.

Replaced the full-load path with targeted DB queries extracted into `front/lib/notifications/conversation_fetch.ts`:
- `fetchUnreadMessageIds` — returns IDs of messages created or agent-completed after `lastReadAt`, via two parallel `MessageModel.findAll` queries instead of walking `conversation.content`
- `fetchMessagesByModelIds` — loads only the needed message rows with side-table includes (`UserMessageModel`, `AgentMessageModel`, etc.)
- `fetchEarliestLatestVersionMessageIds` — group-by-rank query to find the first visible message without fetching all ranks
- `getUnreadNotificationFlags` / `conversationUsesAgentsWithRetention` / `hasUnreadSucceededAgentReply` — targeted queries replacing inline `conversation.content` iteration in `helpers.ts` and `activation-new-conversation.ts`
- `fetchUnreadLightConversation` — builds a `LightConversationType` whose `content` is already pre-filtered to unread messages, so `conversation-unread.ts` no longer needs to filter after the fact

## Tests

Added Vitest integration tests:
- `helpers.test.ts` — 8 cases covering `getConversationDetails`: user/agent messages, mention flags, email/slack origins, read/unread states, retention policies, project conversations, deleted conversations, empty `subscriberId`
- `activation-new-conversation.test.ts` — 6 cases covering `shouldSkipActivationNewConversation`: missing subscriber, missing conversation, no agent reply, unread succeeded reply, already-read reply, agent completing after `lastReadAt`

## Risk

Low. The new queries reproduce the same filtering logic previously done in memory on `conversation.content`. Notification correctness depends on `fetchUnreadMessageIds` matching the old `isMessageUnread` semantics — covered by the new tests. No schema changes. Rollback is safe.

## Deploy Plan

Deploy front.
