### PR TITLE
[front] grant managers write on global and open spaces

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -93,6 +93,7 @@ app.post(
         });
       }
     } else {
+      // TODO(governance) - replace with isManager() once builder is removed (isBuilder allows builder+manager+admin)
       if (space.isGlobal() && !auth.isBuilder()) {
         return apiError(ctx, {
           status_code: 403,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1528,7 +1528,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
+            // TODO(governance): remove once manager is available for everyone
             { role: "builder", permissions: ["read", "write"] },
+            { role: "manager", permissions: ["read", "write"] },
           ],
           groups: this.groups.map((group) => ({
             id: group.groupId,
@@ -1554,7 +1556,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
+            // TODO(governance): remove once manager is available for everyone
             { role: "builder", permissions: ["read", "write"] },
+            { role: "manager", permissions: ["read", "write"] },
             { role: "user", permissions: ["read"] },
           ],
           groups: this.groups.reduce((acc, group) => {


### PR DESCRIPTION
## Description

Additive step toward removing the builder role (dust-tt/tasks#9746, bucket A).

`space_resource.requestedPermissions()` now grants `read`+`write` to the **`manager`** role — alongside the existing `builder` grant — on:
- global / conversations spaces
- open regular spaces

### Why it's safe (purely additive)

Role matching is exact (`this.role() === r.role`, no hierarchy), so this only **adds** the manager case. Builder-role users keep their access; managers (who currently do not match the `builder` entry) gain write. Nothing is removed.

### UI

No UI change needed. Space write gating flows through `space.canWrite(auth)` — the `/spaces/[spaceId]` endpoint returns `canWrite: space.canWrite(auth)`, surfaced as `useSpaceInfo().canWriteInSpace` and consumed across the space UI. Managers now get `canWrite === true`, enabling the write actions automatically.

### Follow-ups (separate PRs, per scope)

- Swap `auth.isBuilder()` → `auth.isManager()` at the files / data-source server checks.
- Eventually drop the `builder` grant once the role is fully removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)