### PR TITLE
[Content Tree] Ignore non-selectable nodes in Select All

### DIFF
--- a/front/components/ContentNodeTree.test.tsx
+++ b/front/components/ContentNodeTree.test.tsx
@@ -13,7 +13,7 @@ vi.stubGlobal(
 );
 
 describe("ContentNodeTree", () => {
-  it("does not select nodes that prevent selection with Select All", () => {
+  it("does not select prevented nodes but can unselect them", () => {
     const selectableNode = {
       childrenCount: 0,
       expandable: false,
@@ -55,6 +55,30 @@ describe("ContentNodeTree", () => {
       selectable: {
         isSelected: true,
         node: selectableNode,
+        parents: [],
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Unselect All" }));
+
+    const clearSelection = setSelectedNodes.mock.lastCall?.[0];
+    expect(
+      clearSelection?.({
+        prevented: {
+          isSelected: true,
+          node: preventedNode,
+          parents: [],
+        },
+      })
+    ).toEqual({
+      selectable: {
+        isSelected: false,
+        node: selectableNode,
+        parents: [],
+      },
+      prevented: {
+        isSelected: false,
+        node: preventedNode,
         parents: [],
       },
     });

--- a/front/components/ContentNodeTree.test.tsx
+++ b/front/components/ContentNodeTree.test.tsx
@@ -1,0 +1,62 @@
+import { ContentNodeTree } from "@app/components/ContentNodeTree";
+import type { ContentNode } from "@app/types/connectors/connectors_api";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+describe("ContentNodeTree", () => {
+  it("does not select nodes that prevent selection with Select All", () => {
+    const selectableNode = {
+      childrenCount: 0,
+      expandable: false,
+      internalId: "selectable",
+      lastUpdatedAt: null,
+      mimeType: "application/vnd.dust.folder",
+      parentInternalId: null,
+      permission: "none",
+      providerVisibility: null,
+      sourceUrl: null,
+      title: "Selectable",
+      type: "folder",
+    } satisfies ContentNode;
+    const preventedNode = {
+      ...selectableNode,
+      internalId: "prevented",
+      preventSelection: true,
+      title: "Prevented",
+    } satisfies ContentNode;
+    const setSelectedNodes = vi.fn();
+
+    render(
+      <ContentNodeTree
+        isTitleFilterEnabled
+        selectedNodes={{}}
+        setSelectedNodes={setSelectedNodes}
+        useResourcesHook={() => ({
+          resources: [selectableNode, preventedNode],
+          isResourcesLoading: false,
+          isResourcesError: false,
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select All" }));
+
+    const updateSelection = setSelectedNodes.mock.lastCall?.[0];
+    expect(updateSelection?.({})).toEqual({
+      selectable: {
+        isSelected: true,
+        node: selectableNode,
+        parents: [],
+      },
+    });
+  });
+});

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -380,13 +380,15 @@ function ContentNodeTreeChildren({
                 setSelectAllClicked(isSelected);
                 setSelectedNodes((prev) => {
                   const newState = { ...prev };
-                  filteredNodes.forEach((n) => {
-                    newState[n.internalId] = {
-                      isSelected,
-                      node: n,
-                      parents: isSelected ? parentIds : [],
-                    };
-                  });
+                  filteredNodes
+                    .filter((n) => n.preventSelection !== true)
+                    .forEach((n) => {
+                      newState[n.internalId] = {
+                        isSelected,
+                        node: n,
+                        parents: isSelected ? parentIds : [],
+                      };
+                    });
                   return newState;
                 });
               }}

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -380,15 +380,16 @@ function ContentNodeTreeChildren({
                 setSelectAllClicked(isSelected);
                 setSelectedNodes((prev) => {
                   const newState = { ...prev };
-                  filteredNodes
-                    .filter((n) => n.preventSelection !== true)
-                    .forEach((n) => {
-                      newState[n.internalId] = {
-                        isSelected,
-                        node: n,
-                        parents: isSelected ? parentIds : [],
-                      };
-                    });
+                  const nodesToUpdate = isSelected
+                    ? filteredNodes.filter((n) => n.preventSelection !== true)
+                    : filteredNodes;
+                  nodesToUpdate.forEach((n) => {
+                    newState[n.internalId] = {
+                      isSelected,
+                      node: n,
+                      parents: isSelected ? parentIds : [],
+                    };
+                  });
                   return newState;
                 });
               }}


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9778

`Select All` selected every displayed content node, including nodes explicitly marked as non-selectable. For Microsoft connections this could persist a site container, making the connector keep syncing all libraries under that site even after an individual library was deselected.

Bulk selection now skips non-selectable nodes.

## Risks

Blast radius: Bulk selection in connector content trees.
Risk: low

## Deploy Plan

- Deploy front

## Tests

- [x] `NODE_ENV=test npm test components/ContentNodeTree.test.tsx`