### PR TITLE
[front] fix: pass run context in file utility tests

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,4 +1,4 @@
-import type { ToolContext } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -46,10 +46,11 @@ vi.mock("@app/lib/api/file_system", async (importOriginal) => {
   };
 });
 
-function makeToolContext(conversation: ConversationType): ToolContext {
+function makeRunContext(conversation: ConversationType): AgentLoopRunContext {
   return {
-    runContext: { contextType: "agent_loop", conversation },
-  } as unknown as ToolContext;
+    contextType: "agent_loop",
+    conversation,
+  } as unknown as AgentLoopRunContext;
 }
 
 function makeReadableStream(content: string): Readable {
@@ -97,7 +98,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         canonicalPath,
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isOk()).toBe(true);
@@ -130,7 +131,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/missing.pdf`,
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isErr()).toBe(true);
@@ -158,7 +159,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         `conversation-${conversation.sId}/file.txt`,
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isErr()).toBe(true);
@@ -215,7 +216,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         file.sId,
-        makeToolContext(conversationRes.value)
+        makeRunContext(conversationRes.value)
       );
 
       expect(result.isOk()).toBe(true);
@@ -252,7 +253,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "fil_notfound",
-        makeToolContext(conversationRes.value)
+        makeRunContext(conversationRes.value)
       );
 
       expect(result.isErr()).toBe(true);
@@ -287,7 +288,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/notes.txt",
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isOk()).toBe(true);
@@ -317,7 +318,7 @@ describe("getFileFromConversationAttachment", () => {
       const result = await getFileFromConversationAttachment(
         auth,
         "conversation/missing.pdf",
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isErr()).toBe(true);
@@ -366,7 +367,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         canonicalPath,
-        undefined // canonical paths do not need toolContext
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isOk()).toBe(true);
@@ -399,7 +400,7 @@ describe("resolveConversationFileRef", () => {
       const result = await resolveConversationFileRef(
         auth,
         `conversation-${conversation.sId}/missing.png`,
-        makeExtra(auth, conversation)
+        makeExtra(auth, conversation).runContext
       );
 
       expect(result.isErr()).toBe(true);
@@ -433,7 +434,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeExtra(auth, conversation)
+      makeExtra(auth, conversation).runContext
     );
 
     expect(result.isOk()).toBe(true);
@@ -476,7 +477,7 @@ describe("resolveConversationFileRef", () => {
     const result = await resolveConversationFileRef(
       auth,
       file.sId,
-      makeExtra(auth, conversationB)
+      makeExtra(auth, conversationB).runContext
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -1,6 +1,6 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import type { ToolRunContext } from "@app/lib/actions/types";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { Authenticator } from "@app/lib/auth";
@@ -23,7 +23,7 @@ import { SpaceFactory } from "./SpaceFactory";
 export function makeExtra(
   auth: Authenticator,
   conversation: ConversationResource
-): ToolHandlerExtra {
+): ToolHandlerExtra & { runContext: AgentLoopRunContext } {
   const runContext = {
     contextType: "agent_loop",
     conversation: {
@@ -31,8 +31,10 @@ export function makeExtra(
       visibility: conversation.visibility,
       owner: auth.getNonNullableWorkspace(),
     },
-  } as unknown as ToolRunContext;
-  return { auth, runContext } as unknown as ToolHandlerExtra;
+  } as unknown as AgentLoopRunContext;
+  return { auth, runContext } as unknown as ToolHandlerExtra & {
+    runContext: AgentLoopRunContext;
+  };
 }
 
 export async function setupPlainConversation(


### PR DESCRIPTION
## Description

typecheck fails on main after #29440 because the file utility tests still pass the full `ToolHandlerExtra` to helpers that now accept `AgentLoopRunContext`.

This narrows the `makeExtra` test factory return type to preserve its agent-loop context and passes `runContext` directly in the affected tests. Runtime behavior is unchanged.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- No deploy.
