### PR TITLE
Add: lint rule to make sure we know what we do when we are fetching a full conversation.

### DIFF
--- a/.grit/patterns/noExpensiveConversationFetch.grit
+++ b/.grit/patterns/noExpensiveConversationFetch.grit
@@ -1,0 +1,22 @@
+engine biome(1.0)
+language js
+
+// Discourages getConversation() and getLightConversation() which load the full
+// conversation content (messages, actions, etc.) and can be expensive.
+// Prefer ConversationResource.fetchById / fetchConversationWithoutContent when
+// message content is not needed. Suppress with:
+//   // biome-ignore lint/plugin/noExpensiveConversationFetch: <reason>
+pattern expensive_conversation_fetch() {
+    or {
+        `getConversation($args)`,
+        `getLightConversation($args)`,
+    }
+}
+
+expensive_conversation_fetch() as $match where {
+    register_diagnostic(
+        span = $match,
+        message = "getConversation/getLightConversation load the full conversation content and can be expensive. Prefer ConversationResource.fetchById or fetchConversationWithoutContent when message content is not needed. Suppress with biome-ignore only when a full (or light) conversation load is intentional.",
+        severity = "error"
+    )
+}

--- a/.grit/patterns/noExpensiveConversationFetch.md
+++ b/.grit/patterns/noExpensiveConversationFetch.md
@@ -1,0 +1,58 @@
+---
+tags: [lint, performance]
+level: error
+---
+
+# No expensive conversation fetch
+
+Flags calls to `getConversation()` and `getLightConversation()`, which load the
+full conversation content and can be expensive. Prefer
+`ConversationResource.fetchById` or `fetchConversationWithoutContent` when
+message content is not needed. Suppress intentionally with:
+
+```typescript
+// biome-ignore lint/plugin/noExpensiveConversationFetch: <reason>
+```
+
+```grit
+language js
+
+expensive_conversation_fetch() => `EXPENSIVE_CONVERSATION_FETCH_FORBIDDEN`
+```
+
+## Should flag getConversation
+
+```typescript
+const result = await getConversation(auth, conversationId);
+```
+
+```typescript
+const result = await EXPENSIVE_CONVERSATION_FETCH_FORBIDDEN;
+```
+
+## Should flag getLightConversation
+
+```typescript
+const result = await getLightConversation(auth, conversationId);
+```
+
+```typescript
+const result = await EXPENSIVE_CONVERSATION_FETCH_FORBIDDEN;
+```
+
+## Should not flag ConversationResource helpers
+
+```typescript
+const conversation = await ConversationResource.fetchById(auth, conversationId);
+const withoutContent =
+  await ConversationResource.fetchConversationWithoutContent(
+    auth,
+    conversationId
+  );
+```
+
+## Should not flag member calls (e.g. SDK client)
+
+```typescript
+const result = await api.getConversation({ conversationId });
+```

--- a/biome.json
+++ b/biome.json
@@ -99,6 +99,16 @@
       ]
     },
     {
+      "includes": [
+        "front/**/*.{js,jsx,ts,tsx}",
+        "front-api/**/*.{js,jsx,ts,tsx}",
+        "!front/lib/api/assistant/conversation/fetch.ts",
+        "!**/*.{test,spec}.{js,jsx,ts,tsx}",
+        "!front/tests/**"
+      ],
+      "plugins": ["./.grit/patterns/noExpensiveConversationFetch.grit"]
+    },
+    {
       "includes": ["front-api/**/*.ts", "!front-api/routes/types.ts"],
       "plugins": ["./.grit/patterns/noInlineSuccessResponseBody.grit"]
     },

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -52,6 +52,7 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(auth, cId, true);
     if (conversationRes.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -69,6 +69,7 @@ app.post(
     } = ctx.req.valid("json");
 
     const [conversationRes, agentConfiguration] = await Promise.all([
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       getConversation(auth, cId, true),
       getAgentConfiguration(auth, { agentId, variant: "full" }),
     ]);

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -78,6 +78,7 @@ app.post(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(auth, cId);
     if (conversationRes.isErr()) {
       return apiErrorForConversation(ctx, conversationRes.error);

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -161,6 +161,7 @@ app.get(
           }
         : undefined;
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(
       auth,
       cId,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -526,6 +526,7 @@ app.post(
       // created as well, so pulling the conversation again will allow to have an up to date view
       // of the conversation with agent messages included so that the user of the API can start
       // streaming events from these agent messages directly.
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       const updatedRes = await getConversation(auth, conversationResource.sId);
 
       if (updatedRes.isErr()) {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -130,6 +130,7 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   );
 
   // Fetch conversation-jitted servers.
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationResult = await getConversation(auth, cId);
   if (conversationResult.isErr()) {
     return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -22,6 +22,7 @@ app.get(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {
       return apiErrorForConversation(ctx, conversationRes.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -44,6 +44,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const owner = auth.getNonNullableWorkspace();
   const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return apiErrorForConversation(ctx, conversationRes.error);
@@ -90,6 +91,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const owner = auth.getNonNullableWorkspace();
   const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return apiErrorForConversation(ctx, conversationRes.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -474,6 +474,7 @@ app.post(
       // conversation again will allow to have an up to date view of the
       // conversation with agent messages included so that the user of the API
       // can start streaming events from these agent messages directly.
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       const updatedRes = await getConversation(auth, newConversation.sId);
 
       if (updatedRes.isOk()) {

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -486,6 +486,7 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       const verbose = args.verbose === "true";
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       const conversationRes = await getConversation(auth, args.cId as string);
 
       if (conversationRes.isErr()) {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -1530,6 +1530,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {
       return new Err(

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1308,6 +1308,7 @@ export function createProjectManagerTools(
           if (includeMessages) {
             const conversationResults = await concurrentExecutor(
               resourcePage,
+              // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
               async (c) => getLightConversation(auth, c.sId, false),
               { concurrency: 10 }
             );
@@ -1366,6 +1367,7 @@ export function createProjectManagerTools(
         if (includeMessages) {
           const conversationResults = await concurrentExecutor(
             pageResources,
+            // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
             async (c) => getLightConversation(auth, c.sId, false),
             { concurrency: 10 }
           );

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -725,6 +725,7 @@ export async function createConversationFork(
     );
   }
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const childConversation = await getConversation(
     auth,
     childConversationId.value.childConversationId
@@ -747,6 +748,7 @@ export async function createConversationFork(
     });
   }
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const parentConversationWithContent = await getConversation(
     auth,
     conversationId

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -227,6 +227,7 @@ export async function validateUserMention(
     approvalState: "approved" | "rejected";
   }
 ): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return new Err({
@@ -494,6 +495,7 @@ export async function dismissMention(
     id: string;
   }
 ): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return new Err({

--- a/front/lib/api/assistant/conversation/render_conversation_with_feedback.ts
+++ b/front/lib/api/assistant/conversation/render_conversation_with_feedback.ts
@@ -39,6 +39,7 @@ export async function renderConversationAsTextWithFeedback(
     Error
   >
 > {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return new Err(

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -97,6 +97,7 @@ export async function ensureConversationTitle(
     return conversation.title;
   }
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationLightRes = await getLightConversation(
     auth,
     conversation.sId

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -313,6 +313,7 @@ export async function sendBatchCallToLlm(
     const conversationResource = writeBatchResult.value;
 
     // Reconstruct the full conversation from DB.
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(
       auth,
       conversationResource.sId

--- a/front/lib/api/mcp_server/tools/conversations/get_messages.ts
+++ b/front/lib/api/mcp_server/tools/conversations/get_messages.ts
@@ -31,6 +31,7 @@ export function registerConversationsGetMessagesTool(server: McpServer) {
       inputSchema,
     },
     async (auth, { conversationId, lastValue }) => {
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       const conversationRes = await getLightConversation(
         auth,
         conversationId,

--- a/front/lib/api/poke/utils.ts
+++ b/front/lib/api/poke/utils.ts
@@ -47,6 +47,7 @@ export async function fetchPluginResource<T extends SupportedResourceType>(
       result = await AppResource.fetchById(auth, resourceId);
       break;
     case "conversations": {
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       const conversationRes = await getConversation(auth, resourceId);
       result = conversationRes.isOk() ? conversationRes.value : null;
       break;

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -74,6 +74,7 @@ export async function createSandboxChildAction(
     return new Err(new Error("Agent configuration not found."));
   }
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationResult = await getConversation(auth, conversationId);
   if (conversationResult.isErr()) {
     return new Err(new Error("Conversation not found."));

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -20,6 +20,7 @@ export async function getPokeConversation(
   includeDeleted?: boolean
 ): Promise<Result<PokeConversationType, ConversationError>> {
   const owner = auth.getNonNullableWorkspace();
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversation = await getConversation(
     auth,
     conversationId,

--- a/front/scripts/debug/profile_conversation_rendering.ts
+++ b/front/scripts/debug/profile_conversation_rendering.ts
@@ -50,6 +50,7 @@ makeScript(
 
     console.time("Fetching conversation");
 
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(
       auth,
       conversationId.toString()

--- a/front/scripts/dev/print_public_api_conversation.ts
+++ b/front/scripts/dev/print_public_api_conversation.ts
@@ -33,6 +33,7 @@ async function main() {
     dangerouslyRequestAllGroups: true,
   });
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getLightConversation(auth, cId, includeDeleted);
   if (conversationRes.isErr()) {
     throw new Error(conversationRes.error.message);

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -57,6 +57,7 @@ makeScript(
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
     const [conversationRes, agentConfiguration] = await Promise.all([
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
       getConversation(auth, conversationId, true),
       getAgentConfiguration(auth, { agentId, variant: "full" }),
     ]);

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -199,6 +199,7 @@ export async function failCompactionMessage(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const targetConversationRes = await getConversation(
     auth,
     conversationId,
@@ -293,6 +294,7 @@ export async function runCompaction(
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const targetConversationRes = await getConversation(
     auth,
     conversationId,
@@ -328,6 +330,7 @@ export async function runCompaction(
     sourceConversation &&
     sourceConversation.conversationId !== conversationId
   ) {
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const sourceConversationRes = await getConversation(
       auth,
       sourceConversation.conversationId,

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -601,6 +601,7 @@ export async function processTranscriptActivity(
     );
 
     // Get first from array with type='agent_message' in conversation.content;
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const lightConversationRes = await getLightConversation(
       auth,
       conversation.sId

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -253,6 +253,7 @@ async function runReinforcedSkillsStep({
     };
   }
 
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const conversationRes = await getConversation(
     auth,
     reinforcementConversationId

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -80,6 +80,7 @@ async function getConversationForAgentLoop(
   _workspaceId: string,
   _unicitySuffix: string
 ): Promise<ConversationType> {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
   const res = await getConversation(
     auth,
     conversationId,
@@ -215,6 +216,7 @@ export async function getAgentLoopDataWithAuth(
       throw error;
     }
   } else {
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
     const conversationRes = await getConversation(
       auth,
       conversationId,


### PR DESCRIPTION
## Description

Adds a Biome/GritQL lint rule (`noExpensiveConversationFetch`) that flags bare calls to `getConversation()` and `getLightConversation()` with `severity: error`. Both functions hydrate the full conversation content (messages, actions, etc.) and are expensive — callers that only need the conversation record should use `ConversationResource.fetchById` or `fetchConversationWithoutContent` instead. The rule is scoped to `front/**` and `front-api/**`, excluding `fetch.ts` (the canonical implementation) and test files. All existing call sites that legitimately need a full load are grandfathered with a `// biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load` suppression, making future accidental additions visible immediately in CI.

## Tests

Rule correctness validated via the GritQL test cases in `noExpensiveConversationFetch.md` (flags `getConversation()`/`getLightConversation()` standalone calls, ignores `ConversationResource.*` helpers and member-expression calls like `api.getConversation()`).

## Risk

Low. No runtime behaviour changes — lint config only. Existing call sites are suppressed and unaffected.

## Deploy Plan

No deploy needed.
