### PR TITLE
[Connectors/Microsoft] Protect refreshed nodes from garbage collection

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2090,7 +2090,7 @@ export async function microsoftGarbageCollectionActivity({
   // during the garbage collection and the caching below prevents this from
   // being detected
   const nodesToCheck = nodes
-    .filter((n) => n.lastSeenTs ?? 0 < startGarbageCollectionTs)
+    .filter((n) => (n.lastSeenTs?.getTime() ?? 0) < startGarbageCollectionTs)
     .filter(
       (n) =>
         n.nodeType === "drive" ||

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2225,6 +2225,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_not_found",
               });
@@ -2236,6 +2237,7 @@ export async function microsoftGarbageCollectionActivity({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_removed_from_selection",
               });
@@ -2253,6 +2255,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_not_found",
               });
@@ -2265,6 +2268,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_marked_deleted",
               });
@@ -2285,6 +2289,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_outside_sync_scope",
               });
@@ -2312,6 +2317,7 @@ export async function microsoftGarbageCollectionActivity({
                 connectorId,
                 internalId: node.internalId,
                 dataSourceConfig,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
               });
             }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2208,6 +2208,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_not_found",
               });
@@ -2216,6 +2217,7 @@ export async function microsoftGarbageCollectionActivity({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_removed_from_selection",
               });
@@ -2230,6 +2232,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_not_found",
               });
@@ -2239,6 +2242,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_marked_deleted",
               });
@@ -2256,6 +2260,7 @@ export async function microsoftGarbageCollectionActivity({
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_outside_sync_scope",
               });
@@ -2280,6 +2285,7 @@ export async function microsoftGarbageCollectionActivity({
                 connectorId,
                 internalId: node.internalId,
                 dataSourceConfig,
+                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
               });
             }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -623,10 +623,8 @@ export async function markNodeAsSeen(connectorId: ModelId, internalId: string) {
     return;
   }
 
-  // if node was updated more recently than this sync, we don't need to mark it
-  if (node.lastSeenTs && node.lastSeenTs < new Date()) {
-    await node.update({ lastSeenTs: new Date() });
-  }
+  // Newly discovered folders have no lastSeenTs until their first traversal completes.
+  await node.update({ lastSeenTs: new Date() });
 }
 
 // A 404 returned while listing the children of a drive/folder is ambiguous: the
@@ -2056,7 +2054,13 @@ export async function microsoftGarbageCollectionActivity({
   idCursor: ModelId;
   startGarbageCollectionTs: number;
 }) {
-  const rootNodeIds = await getRootNodesToSync(connectorId);
+  const rootResources =
+    await MicrosoftRootResource.listRootsByConnectorId(connectorId);
+  const rootIds = new Set(rootResources.map((root) => root.internalId));
+  const rootNodeIds = await getRootNodesToSyncFromResources(
+    connectorId,
+    rootResources
+  );
 
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -2084,6 +2088,16 @@ export async function microsoftGarbageCollectionActivity({
   }
 
   const nextIdCursor = lastNode.id + 1;
+
+  const shouldAbortGc = async () => {
+    const currentRoots =
+      await MicrosoftRootResource.listRootsByConnectorId(connectorId);
+    const rootsChanged =
+      currentRoots.length !== rootIds.size ||
+      currentRoots.some((root) => !rootIds.has(root.internalId));
+
+    return rootsChanged || (await isMicrosoftFullSyncRunning(connectorId));
+  };
 
   // only consider nodes that were not seen after the start of the garbage
   // collection. This avoids edge cases such as if a node is moved back to sync
@@ -2203,21 +2217,25 @@ export async function microsoftGarbageCollectionActivity({
         switch (node.nodeType) {
           case "drive":
             if (!driveOrItem) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_not_found",
               });
             } else if (!rootNodeIds.includes(node.internalId)) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_drive_removed_from_selection",
               });
@@ -2227,22 +2245,26 @@ export async function microsoftGarbageCollectionActivity({
             const folder = driveOrItem as DriveItem | null;
 
             if (!folder) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_not_found",
               });
             } else if (folder.deleted) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_marked_deleted",
               });
@@ -2255,12 +2277,14 @@ export async function microsoftGarbageCollectionActivity({
                 startGarbageCollectionTs,
               })
             ) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
                 internalId: node.internalId,
                 deleteRootNode: true,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
                 reason: "gc_outside_sync_scope",
               });
@@ -2281,11 +2305,13 @@ export async function microsoftGarbageCollectionActivity({
                 startGarbageCollectionTs,
               }))
             ) {
+              if (await shouldAbortGc()) {
+                return nextIdCursor;
+              }
               await deleteFile({
                 connectorId,
                 internalId: node.internalId,
                 dataSourceConfig,
-                lastSeenCutoffMs: startGarbageCollectionTs,
                 logger,
               });
             }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -598,7 +598,11 @@ async function isParentAlreadyInNodes({
   return false;
 }
 
-export async function markNodeAsSeen(connectorId: ModelId, internalId: string) {
+export async function markNodeAsSeen(
+  connectorId: ModelId,
+  internalId: string,
+  startSyncTs?: number
+) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
@@ -623,7 +627,15 @@ export async function markNodeAsSeen(connectorId: ModelId, internalId: string) {
     return;
   }
 
-  // Newly discovered folders have no lastSeenTs until their first traversal completes.
+  // In-flight activities scheduled before startSyncTs was added omit it.
+  if (
+    startSyncTs !== undefined &&
+    node.lastSeenTs &&
+    node.lastSeenTs.getTime() > startSyncTs
+  ) {
+    return;
+  }
+
   await node.update({ lastSeenTs: new Date() });
 }
 

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2054,13 +2054,7 @@ export async function microsoftGarbageCollectionActivity({
   idCursor: ModelId;
   startGarbageCollectionTs: number;
 }) {
-  const rootResources =
-    await MicrosoftRootResource.listRootsByConnectorId(connectorId);
-  const rootIds = new Set(rootResources.map((root) => root.internalId));
-  const rootNodeIds = await getRootNodesToSyncFromResources(
-    connectorId,
-    rootResources
-  );
+  const rootNodeIds = await getRootNodesToSync(connectorId);
 
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -2088,16 +2082,6 @@ export async function microsoftGarbageCollectionActivity({
   }
 
   const nextIdCursor = lastNode.id + 1;
-
-  const shouldAbortGc = async () => {
-    const currentRoots =
-      await MicrosoftRootResource.listRootsByConnectorId(connectorId);
-    const rootsChanged =
-      currentRoots.length !== rootIds.size ||
-      currentRoots.some((root) => !rootIds.has(root.internalId));
-
-    return rootsChanged || (await isMicrosoftFullSyncRunning(connectorId));
-  };
 
   // only consider nodes that were not seen after the start of the garbage
   // collection. This avoids edge cases such as if a node is moved back to sync
@@ -2217,9 +2201,6 @@ export async function microsoftGarbageCollectionActivity({
         switch (node.nodeType) {
           case "drive":
             if (!driveOrItem) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
@@ -2230,9 +2211,6 @@ export async function microsoftGarbageCollectionActivity({
                 reason: "gc_drive_not_found",
               });
             } else if (!rootNodeIds.includes(node.internalId)) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
@@ -2247,9 +2225,6 @@ export async function microsoftGarbageCollectionActivity({
             const folder = driveOrItem as DriveItem | null;
 
             if (!folder) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
@@ -2260,9 +2235,6 @@ export async function microsoftGarbageCollectionActivity({
                 reason: "gc_not_found",
               });
             } else if (folder.deleted) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
@@ -2281,9 +2253,6 @@ export async function microsoftGarbageCollectionActivity({
                 startGarbageCollectionTs,
               })
             ) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFolder({
                 connectorId,
                 dataSourceConfig,
@@ -2310,9 +2279,6 @@ export async function microsoftGarbageCollectionActivity({
                 startGarbageCollectionTs,
               }))
             ) {
-              if (await shouldAbortGc()) {
-                return nextIdCursor;
-              }
               await deleteFile({
                 connectorId,
                 internalId: node.internalId,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -627,7 +627,7 @@ export async function markNodeAsSeen(
     return;
   }
 
-  // In-flight activities scheduled before startSyncTs was added omit it.
+  // No need to mark nodes updated more recently than this sync.
   if (
     startSyncTs !== undefined &&
     node.lastSeenTs &&

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -722,7 +722,6 @@ export async function deleteFolder({
   dataSourceConfig,
   internalId,
   deleteRootNode,
-  lastSeenCutoffMs,
   logger,
   reason,
 }: {
@@ -730,7 +729,6 @@ export async function deleteFolder({
   dataSourceConfig: DataSourceConfig;
   internalId: string;
   deleteRootNode?: boolean;
-  lastSeenCutoffMs?: number;
   logger: Logger;
   reason: MicrosoftFolderDeletionReason;
 }) {
@@ -740,14 +738,6 @@ export async function deleteFolder({
   );
 
   if (!folder) {
-    return false;
-  }
-
-  if (
-    lastSeenCutoffMs !== undefined &&
-    folder.lastSeenTs &&
-    folder.lastSeenTs.getTime() >= lastSeenCutoffMs
-  ) {
     return false;
   }
 
@@ -766,10 +756,6 @@ export async function deleteFolder({
   );
 
   if (root) {
-    if (reason === "gc_outside_sync_scope") {
-      return false;
-    }
-
     // Roots represent the user selection for synchronization As such, they
     // should be deleted first, explicitly by users, before deleting the
     // underlying folder
@@ -791,13 +777,11 @@ export async function deleteFile({
   connectorId,
   dataSourceConfig,
   internalId,
-  lastSeenCutoffMs,
   logger,
 }: {
   connectorId: number;
   dataSourceConfig: DataSourceConfig;
   internalId: string;
-  lastSeenCutoffMs?: number;
   logger: Logger;
 }) {
   const file = await MicrosoftNodeResource.fetchByInternalId(
@@ -806,14 +790,6 @@ export async function deleteFile({
   );
 
   if (!file) {
-    return false;
-  }
-
-  if (
-    lastSeenCutoffMs !== undefined &&
-    file.lastSeenTs &&
-    file.lastSeenTs.getTime() >= lastSeenCutoffMs
-  ) {
     return false;
   }
 

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -722,6 +722,7 @@ export async function deleteFolder({
   dataSourceConfig,
   internalId,
   deleteRootNode,
+  lastSeenCutoffMs,
   logger,
   reason,
 }: {
@@ -729,6 +730,7 @@ export async function deleteFolder({
   dataSourceConfig: DataSourceConfig;
   internalId: string;
   deleteRootNode?: boolean;
+  lastSeenCutoffMs?: number;
   logger: Logger;
   reason: MicrosoftFolderDeletionReason;
 }) {
@@ -738,6 +740,13 @@ export async function deleteFolder({
   );
 
   if (!folder) {
+    return false;
+  }
+
+  if (
+    lastSeenCutoffMs !== undefined &&
+    (folder.lastSeenTs?.getTime() ?? 0) >= lastSeenCutoffMs
+  ) {
     return false;
   }
 
@@ -777,11 +786,13 @@ export async function deleteFile({
   connectorId,
   dataSourceConfig,
   internalId,
+  lastSeenCutoffMs,
   logger,
 }: {
   connectorId: number;
   dataSourceConfig: DataSourceConfig;
   internalId: string;
+  lastSeenCutoffMs?: number;
   logger: Logger;
 }) {
   const file = await MicrosoftNodeResource.fetchByInternalId(
@@ -790,6 +801,13 @@ export async function deleteFile({
   );
 
   if (!file) {
+    return false;
+  }
+
+  if (
+    lastSeenCutoffMs !== undefined &&
+    (file.lastSeenTs?.getTime() ?? 0) >= lastSeenCutoffMs
+  ) {
     return false;
   }
 

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -722,6 +722,7 @@ export async function deleteFolder({
   dataSourceConfig,
   internalId,
   deleteRootNode,
+  lastSeenCutoffMs,
   logger,
   reason,
 }: {
@@ -729,6 +730,7 @@ export async function deleteFolder({
   dataSourceConfig: DataSourceConfig;
   internalId: string;
   deleteRootNode?: boolean;
+  lastSeenCutoffMs?: number;
   logger: Logger;
   reason: MicrosoftFolderDeletionReason;
 }) {
@@ -738,6 +740,14 @@ export async function deleteFolder({
   );
 
   if (!folder) {
+    return false;
+  }
+
+  if (
+    lastSeenCutoffMs !== undefined &&
+    folder.lastSeenTs &&
+    folder.lastSeenTs.getTime() >= lastSeenCutoffMs
+  ) {
     return false;
   }
 
@@ -756,6 +766,10 @@ export async function deleteFolder({
   );
 
   if (root) {
+    if (reason === "gc_outside_sync_scope") {
+      return false;
+    }
+
     // Roots represent the user selection for synchronization As such, they
     // should be deleted first, explicitly by users, before deleting the
     // underlying folder
@@ -777,11 +791,13 @@ export async function deleteFile({
   connectorId,
   dataSourceConfig,
   internalId,
+  lastSeenCutoffMs,
   logger,
 }: {
   connectorId: number;
   dataSourceConfig: DataSourceConfig;
   internalId: string;
+  lastSeenCutoffMs?: number;
   logger: Logger;
 }) {
   const file = await MicrosoftNodeResource.fetchByInternalId(
@@ -790,6 +806,14 @@ export async function deleteFile({
   );
 
   if (!file) {
+    return false;
+  }
+
+  if (
+    lastSeenCutoffMs !== undefined &&
+    file.lastSeenTs &&
+    file.lastSeenTs.getTime() >= lastSeenCutoffMs
+  ) {
     return false;
   }
 

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -151,7 +151,7 @@ export async function fullSyncWorkflow({
       );
     } while (nextPageLink);
 
-    await markNodeAsSeen(connectorId, nodeId);
+    await markNodeAsSeen(connectorId, nodeId, startSyncTs);
 
     if (workflowInfo().historyLength > 4000) {
       await continueAsNew<typeof fullSyncWorkflow>({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9794

Microsoft garbage collection intended to ignore nodes seen after the GC run started, but its filter was parsed as `lastSeenTs ?? (0 < startGarbageCollectionTs)`. As a result, nodes restored by the later full sync stayed GC-eligible. Newly discovered folders could additionally keep a null `lastSeenTs` after traversal.

The fix compares timestamps explicitly in milliseconds, marks successfully traversed folders as seen while preserving timestamps written by newer concurrent syncs, and checks the freshly fetched node timestamp again immediately before a GC deletion. This keeps a node restored after the GC page was loaded from being deleted from the stale page snapshot.

The new activity argument is optional so activity tasks scheduled before deployment remain compatible.

## Risks

Blast radius: Microsoft connector full-sync timestamps and garbage collection deletion guards.
Risk: low

## Deploy Plan

- deploy connectors