### PR TITLE
[Monday] Use app-configured OAuth scopes

### DIFF
--- a/front/lib/api/oauth/providers/monday.test.ts
+++ b/front/lib/api/oauth/providers/monday.test.ts
@@ -1,0 +1,29 @@
+import { MondayOAuthProvider } from "@app/lib/api/oauth/providers/monday";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getAuthRedirectBaseUrl: () => "https://dust.tt",
+    getOAuthMondayClientId: () => "client-id",
+  },
+}));
+
+describe("MondayOAuthProvider.setupUri", () => {
+  it("uses the scopes configured in the Monday app", () => {
+    const provider = new MondayOAuthProvider();
+    const setupUri = provider.setupUri({
+      connection: {
+        connection_id: "connection-id",
+        created: Date.now(),
+        metadata: {},
+        provider: "monday",
+        status: "pending",
+      },
+      useCase: "personal_actions",
+    });
+
+    const url = new URL(setupUri);
+
+    expect(url.searchParams.has("scope")).toBe(false);
+  });
+});

--- a/front/lib/api/oauth/providers/monday.ts
+++ b/front/lib/api/oauth/providers/monday.ts
@@ -18,20 +18,9 @@ export class MondayOAuthProvider implements BaseOAuthStrategyProvider {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
   }) {
-    const scopes = [
-      "me:read",
-      "boards:read",
-      "boards:write",
-      "updates:read",
-      "updates:write",
-      "users:read",
-      "workspaces:read",
-    ];
-
     return (
       `https://auth.monday.com/oauth2/authorize` +
       `?client_id=${config.getOAuthMondayClientId()}` +
-      `&scope=${encodeURIComponent(scopes.join(" "))}` +
       `&state=${connection.connection_id}` +
       `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("monday"))}`
     );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9779

Dust sent a hard-coded `scope` parameter in Monday OAuth authorization requests. Monday requires an explicit scope list to exactly match the scopes configured for the applicable app version, while accounts can have different approved versions. This caused Monday to reject affected accounts with `invalid_scope` before returning to Dust.

Omit the optional `scope` parameter so Monday uses the scope list configured for the account/app version.

## Risks

Blast radius: Monday OAuth authorization for new connections.
Risk: low

## Deploy Plan
- deploy front

## Tests

- [x] Monday OAuth setup URL uses the app-configured scope list