### PR TITLE
fix: managers requested permissions

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2447,6 +2447,10 @@ export class GroupResource extends BaseResource<GroupModel> {
           roles: [
             { role: "admin", permissions: ["read", "admin"] },
             {
+              role: "manager",
+              permissions: ["read"],
+            },
+            {
               role: "user",
               permissions: ["read"],
             },

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1580,6 +1580,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: this.workspaceId,
           roles: [
             { role: "admin", permissions: ["admin"] },
+            { role: "manager", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
             { role: "user", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
           ],
           groups: this.groups.reduce((acc, group) => {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9770

This PR fixes the permission configuration for managers on groups and spaces by ensuring the `manager` role is explicitly included in the requested permissions lists.

- In `group_resource.ts`: adds a `manager` role entry with `["read"]` permissions to the requested permissions array so that managers can read agents and skill editors groups. This caused the manage agents page to not load.
- In `space_resource.ts`: adds a `manager` role entry with `["read"]` permissions for open spaces (or `[]` for restricted ones), mirroring the logic already applied to the `user` role.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.