### PR TITLE
feat: check billing permission to manage billing

### DIFF
--- a/front-api/routes/stripe/portal.test.ts
+++ b/front-api/routes/stripe/portal.test.ts
@@ -1,0 +1,56 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const TEST_PORTAL_URL = "https://billing.stripe.com/test-portal";
+
+vi.mock("@app/lib/plans/stripe", () => ({
+  createCustomerPortalSession: vi.fn(),
+}));
+
+import { createCustomerPortalSession } from "@app/lib/plans/stripe";
+
+function post(body: unknown) {
+  return honoApp.request(`/api/stripe/portal`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/stripe/portal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createCustomerPortalSession).mockResolvedValue(TEST_PORTAL_URL);
+  });
+
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const response = await post({ workspaceId: workspace.sId });
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(createCustomerPortalSession)).not.toHaveBeenCalled();
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await post({ workspaceId: workspace.sId });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ portalUrl: TEST_PORTAL_URL });
+  });
+});

--- a/front-api/routes/stripe/portal.ts
+++ b/front-api/routes/stripe/portal.ts
@@ -41,14 +41,13 @@ app.post(
       });
     }
 
-    // biome-ignore lint/plugin/noDirectRoleCheck: custom auth flow — auth created inline, not via workspaceAuth middleware
-    if (!auth.isAdmin()) {
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
           message:
-            "Only users that are `admins` for the current workspace can see the subscription or modify it.",
+            "You need billing access to manage billing settings, invoices, and payment methods.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/billing/info.test.ts
+++ b/front-api/routes/w/[wId]/billing/info.test.ts
@@ -1,0 +1,40 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function infoUrl(wId: string) {
+  return `/api/w/${wId}/billing/info`;
+}
+
+describe("GET /api/w/:wId/billing/info", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(infoUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(infoUrl(workspace.sId));
+
+    // The default (non-credit-priced) plan short-circuits to a null billing
+    // info without hitting Stripe, so a granted member simply clears the gate.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ billingInfo: null });
+  });
+});

--- a/front-api/routes/w/[wId]/billing/info.ts
+++ b/front-api/routes/w/[wId]/billing/info.ts
@@ -1,32 +1,38 @@
 import { getWorkspaceBillingInfo } from "@app/lib/api/billing/info";
 import type { GetBillingInfoResponseBody } from "@app/types/api/billing/info";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/billing/info.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetBillingInfoResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetBillingInfoResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const result = await getWorkspaceBillingInfo(auth);
-    if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to fetch Stripe billing information: ${result.error.message}`,
-        },
-      });
-    }
-
-    return ctx.json({ billingInfo: result.value });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const result = await getWorkspaceBillingInfo(auth);
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Stripe billing information: ${result.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ billingInfo: result.value });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/billing/invoices.test.ts
+++ b/front-api/routes/w/[wId]/billing/invoices.test.ts
@@ -1,0 +1,40 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function invoicesUrl(wId: string) {
+  return `/api/w/${wId}/billing/invoices`;
+}
+
+describe("GET /api/w/:wId/billing/invoices", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(invoicesUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(invoicesUrl(workspace.sId));
+
+    // The default (non-credit-priced) plan short-circuits to an empty invoice
+    // list without hitting Stripe, so a granted member simply clears the gate.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ billingInvoices: [] });
+  });
+});

--- a/front-api/routes/w/[wId]/billing/invoices.ts
+++ b/front-api/routes/w/[wId]/billing/invoices.ts
@@ -1,32 +1,38 @@
 import { listRecentBillingInvoices } from "@app/lib/api/billing/invoices";
 import type { GetBillingInvoicesResponseBody } from "@app/types/api/billing/invoices";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/billing/invoices.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetBillingInvoicesResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetBillingInvoicesResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const result = await listRecentBillingInvoices(auth);
-    if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to fetch Stripe billing invoices: ${result.error.message}`,
-        },
-      });
-    }
-
-    return ctx.json({ billingInvoices: result.value });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const result = await listRecentBillingInvoices(auth);
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Stripe billing invoices: ${result.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ billingInvoices: result.value });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/redemptions.test.ts
+++ b/front-api/routes/w/[wId]/coupon/redemptions.test.ts
@@ -4,6 +4,7 @@ import type { MetronomeCredit } from "@app/lib/metronome/types";
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponFactory } from "@app/tests/utils/CouponFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -94,6 +95,23 @@ describe("GET /api/w/[wId]/coupon/redemptions", () => {
 
     expect(response.status).toBe(403);
     expect(metronomeClient.listMetronomeCustomerCredits).not.toHaveBeenCalled();
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(redemptionsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).coupons).toEqual([]);
   });
 
   it("returns an empty list without calling Metronome when nothing was redeemed", async () => {

--- a/front-api/routes/w/[wId]/coupon/redemptions.ts
+++ b/front-api/routes/w/[wId]/coupon/redemptions.ts
@@ -3,7 +3,6 @@ import { getWorkspaceCoupons } from "@app/lib/api/coupons";
 import type { GetWorkspaceCouponsResponseBody } from "@app/types/api/coupons";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
@@ -35,18 +34,25 @@ function couponsErrorToApi(ctx: Context, err: WorkspaceCouponsError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetWorkspaceCouponsResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetWorkspaceCouponsResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const result = await getWorkspaceCoupons(auth);
-    if (result.isErr()) {
-      return couponsErrorToApi(ctx, result.error);
-    }
-    return ctx.json(result.value);
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const result = await getWorkspaceCoupons(auth);
+  if (result.isErr()) {
+    return couponsErrorToApi(ctx, result.error);
+  }
+  return ctx.json(result.value);
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/validate.test.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.test.ts
@@ -1,6 +1,7 @@
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponFactory } from "@app/tests/utils/CouponFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -170,5 +171,35 @@ describe("GET /api/w/:wId/coupon/validate", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("coupon_already_redeemed");
+  });
+
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const coupon = await CouponFactory.create({ code: "MEMBERDENIED" });
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await validateCoupon(workspace, { code: coupon.code });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const coupon = await CouponFactory.create({ code: "MEMBERALLOWED" });
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await validateCoupon(workspace, { code: coupon.code });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).coupon.code).toBe("MEMBERALLOWED");
   });
 });

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -1,7 +1,6 @@
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -19,61 +18,67 @@ const GetCouponValidateQuerySchema = z.object({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  validate("query", GetCouponValidateQuerySchema),
-  async (ctx) => {
-    const auth = ctx.get("auth");
+app.get("/", validate("query", GetCouponValidateQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
 
-    const { code, context = "subscription" } = ctx.req.valid("query");
-
-    const coupon = await CouponResource.findByCode(code);
-    if (!coupon) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "coupon_not_found",
-          message: "Coupon not found.",
-        },
-      });
-    }
-
-    const validationResult = coupon.validateRedemptionForContext(context);
-    if (validationResult.isErr()) {
-      const { code: errorCode } = validationResult.error;
-      const message =
-        errorCode === "wrong_coupon_type"
-          ? context === "credits"
-            ? "This coupon cannot be used for credit top-ups."
-            : "This coupon cannot be used for subscriptions."
-          : `Coupon is not redeemable: ${errorCode}.`;
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "coupon_not_redeemable",
-          message,
-        },
-      });
-    }
-
-    const existingRedemption =
-      await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-        auth,
-        { coupon }
-      );
-    if (existingRedemption) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "coupon_already_redeemed",
-          message: "This coupon has already been redeemed by this workspace.",
-        },
-      });
-    }
-
-    return ctx.json({ coupon: coupon.toJSON() });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const { code, context = "subscription" } = ctx.req.valid("query");
+
+  const coupon = await CouponResource.findByCode(code);
+  if (!coupon) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Coupon not found.",
+      },
+    });
+  }
+
+  const validationResult = coupon.validateRedemptionForContext(context);
+  if (validationResult.isErr()) {
+    const { code: errorCode } = validationResult.error;
+    const message =
+      errorCode === "wrong_coupon_type"
+        ? context === "credits"
+          ? "This coupon cannot be used for credit top-ups."
+          : "This coupon cannot be used for subscriptions."
+        : `Coupon is not redeemable: ${errorCode}.`;
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_not_redeemable",
+        message,
+      },
+    });
+  }
+
+  const existingRedemption =
+    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+      auth,
+      { coupon }
+    );
+  if (existingRedemption) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_already_redeemed",
+        message: "This coupon has already been redeemed by this workspace.",
+      },
+    });
+  }
+
+  return ctx.json({ coupon: coupon.toJSON() });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/credits/members-seats.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.test.ts
@@ -1,0 +1,39 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function membersSeatsUrl(wId: string) {
+  return `/api/w/${wId}/credits/members-seats`;
+}
+
+describe("GET /api/w/:wId/credits/members-seats", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(membersSeatsUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(membersSeatsUrl(workspace.sId));
+
+    // A workspace with no Metronome contract skips the external seat lookup, so
+    // a granted member clears the gate and gets the DB-backed member seats.
+    expect(response.status).toBe(200);
+  });
+});

--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -1,22 +1,28 @@
 import { getMembersSeats } from "@app/lib/api/credits/members_seats";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/credits/members-seats.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetMembersSeatsResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetMembersSeatsResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const body = await getMembersSeats({ auth });
-    return ctx.json(body);
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const body = await getMembersSeats({ auth });
+  return ctx.json(body);
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/members/free-seats.test.ts
+++ b/front-api/routes/w/[wId]/members/free-seats.test.ts
@@ -1,0 +1,38 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function freeSeatsUrl(wId: string) {
+  return `/api/w/${wId}/members/free-seats`;
+}
+
+describe("GET /api/w/:wId/members/free-seats", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(freeSeatsUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(freeSeatsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveProperty("freeSeatCounts");
+  });
+});

--- a/front-api/routes/w/[wId]/members/free-seats.ts
+++ b/front-api/routes/w/[wId]/members/free-seats.ts
@@ -1,23 +1,30 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { GetFreeSeatCountsResponseBody } from "@app/types/api/members";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/members/free-seats.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetFreeSeatCountsResponseBody> => {
-    const auth = ctx.get("auth");
-    const freeSeatCounts = await MembershipResource.getFreeSeatCounts({
-      workspace: auth.getNonNullableWorkspace(),
+app.get("/", async (ctx): HandlerResult<GetFreeSeatCountsResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
     });
-    return ctx.json({ freeSeatCounts });
   }
-);
+
+  const freeSeatCounts = await MembershipResource.getFreeSeatCounts({
+    workspace: auth.getNonNullableWorkspace(),
+  });
+  return ctx.json({ freeSeatCounts });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/metronome/contract.test.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.test.ts
@@ -1,10 +1,8 @@
-import { Authenticator } from "@app/lib/auth";
-import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -70,29 +68,6 @@ async function setActiveSubscriptionBilling({
       throw updateResult.error;
     }
   }
-}
-
-// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
-// in a group that holds a type-wide grant, mirroring how governance grants billing access.
-async function grantBillingAdmin(
-  workspace: Awaited<
-    ReturnType<typeof createPrivateApiMockRequest>
-  >["workspace"],
-  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
-) {
-  const adminAuth = await Authenticator.internalAdminForWorkspace(
-    workspace.sId
-  );
-  const group = await GroupFactory.regularAuto(
-    workspace,
-    `billing-admin-${user.sId}`
-  );
-  await GroupFactory.withMembers(adminAuth, group, [user]);
-  await GroupPermissionResource.grantTypeWide(adminAuth, {
-    group,
-    grantType: "admin",
-    resourceType: "billing",
-  });
 }
 
 function makeCurrentDraftInvoice({ contractId }: { contractId: string }) {
@@ -308,7 +283,10 @@ describe("/api/w/[wId]/metronome/contract", () => {
         role: "user",
       });
 
-      await grantBillingAdmin(workspace, user);
+      await grantWorkspacePermission(workspace, user, {
+        grantType: "admin",
+        resourceType: "billing",
+      });
 
       const response = await honoApp.request(contractUrl(workspace.sId));
 

--- a/front-api/routes/w/[wId]/metronome/contract.test.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.test.ts
@@ -1,6 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -67,6 +70,29 @@ async function setActiveSubscriptionBilling({
       throw updateResult.error;
     }
   }
+}
+
+// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
+// in a group that holds a type-wide grant, mirroring how governance grants billing access.
+async function grantBillingAdmin(
+  workspace: Awaited<
+    ReturnType<typeof createPrivateApiMockRequest>
+  >["workspace"],
+  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    workspace,
+    `billing-admin-${user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType: "admin",
+    resourceType: "billing",
+  });
 }
 
 function makeCurrentDraftInvoice({ contractId }: { contractId: string }) {
@@ -261,6 +287,33 @@ describe("/api/w/[wId]/metronome/contract", () => {
 
       expect(vi.mocked(scheduleMetronomeContractEnd)).not.toHaveBeenCalled();
       expect(vi.mocked(reactivateMetronomeContract)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authorization", () => {
+    it("rejects a member without the billing admin permission", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      const response = await honoApp.request(contractUrl(workspace.sId));
+
+      expect(response.status).toBe(403);
+    });
+
+    it("allows a member with the billing admin permission", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      await grantBillingAdmin(workspace, user);
+
+      const response = await honoApp.request(contractUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ contract: null });
     });
   });
 });

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -6,7 +6,6 @@ import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecyc
 import type { GetMetronomeContractResponseBody } from "@app/types/api/credits/metronome_contract";
 import { PatchMetronomeContractRequestBody } from "@app/types/api/credits/metronome_contract";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
@@ -32,32 +31,50 @@ function lifecycleErrorToApi(ctx: Context, err: ContractLifecycleError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const result = await getMetronomeContractSummary(auth);
-    if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to fetch Metronome contract: ${result.error.message}`,
-        },
-      });
-    }
-    return ctx.json({ contract: result.value });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const result = await getMetronomeContractSummary(auth);
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Metronome contract: ${result.error.message}`,
+      },
+    });
+  }
+  return ctx.json({ contract: result.value });
+});
 
 app.patch(
   "/",
-  ensureIsAdmin(),
   validate("json", PatchMetronomeContractRequestBody),
   async (ctx): HandlerResult<PatchMetronomeContractResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
+
     const { action } = ctx.req.valid("json");
 
     const result = await applyContractLifecycleAction(auth, action);

--- a/front-api/routes/w/[wId]/metronome/invoice.test.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.test.ts
@@ -1,10 +1,13 @@
+import { Authenticator } from "@app/lib/auth";
 import {
   CREDIT_TYPE_EUR_ID,
   getCreditTypeAwuId,
 } from "@app/lib/metronome/constants";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -19,6 +22,29 @@ import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
 
 function invoiceLinesUrl(wId: string) {
   return `/api/w/${wId}/metronome/invoice/lines`;
+}
+
+// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
+// in a group that holds a type-wide grant, mirroring how governance grants billing access.
+async function grantBillingAdmin(
+  workspace: Awaited<
+    ReturnType<typeof createPrivateApiMockRequest>
+  >["workspace"],
+  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    workspace,
+    `billing-admin-${user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType: "admin",
+    resourceType: "billing",
+  });
 }
 
 async function setActiveSubscriptionBilling({
@@ -281,6 +307,33 @@ describe("/api/w/[wId]/metronome/invoice/lines", () => {
       totalCents: -1000,
       periodStartMs: new Date("2026-07-02T00:00:00.000Z").getTime(),
       periodEndMs: new Date(periodStart).getTime(),
+    });
+  });
+
+  describe("authorization", () => {
+    it("rejects a member without the billing admin permission", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      const response = await honoApp.request(invoiceLinesUrl(workspace.sId));
+
+      expect(response.status).toBe(403);
+    });
+
+    it("allows a member with the billing admin permission", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      await grantBillingAdmin(workspace, user);
+
+      const response = await honoApp.request(invoiceLinesUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ currency: null, lineItems: [] });
     });
   });
 });

--- a/front-api/routes/w/[wId]/metronome/invoice.test.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.test.ts
@@ -1,14 +1,12 @@
-import { Authenticator } from "@app/lib/auth";
 import {
   CREDIT_TYPE_EUR_ID,
   getCreditTypeAwuId,
 } from "@app/lib/metronome/constants";
-import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
@@ -22,29 +20,6 @@ import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
 
 function invoiceLinesUrl(wId: string) {
   return `/api/w/${wId}/metronome/invoice/lines`;
-}
-
-// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
-// in a group that holds a type-wide grant, mirroring how governance grants billing access.
-async function grantBillingAdmin(
-  workspace: Awaited<
-    ReturnType<typeof createPrivateApiMockRequest>
-  >["workspace"],
-  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
-) {
-  const adminAuth = await Authenticator.internalAdminForWorkspace(
-    workspace.sId
-  );
-  const group = await GroupFactory.regularAuto(
-    workspace,
-    `billing-admin-${user.sId}`
-  );
-  await GroupFactory.withMembers(adminAuth, group, [user]);
-  await GroupPermissionResource.grantTypeWide(adminAuth, {
-    group,
-    grantType: "admin",
-    resourceType: "billing",
-  });
 }
 
 async function setActiveSubscriptionBilling({
@@ -328,7 +303,10 @@ describe("/api/w/[wId]/metronome/invoice/lines", () => {
         role: "user",
       });
 
-      await grantBillingAdmin(workspace, user);
+      await grantWorkspacePermission(workspace, user, {
+        grantType: "admin",
+        resourceType: "billing",
+      });
 
       const response = await honoApp.request(invoiceLinesUrl(workspace.sId));
 

--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -16,7 +16,6 @@ import type { BillingPeriod } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
@@ -107,88 +106,102 @@ function mergeLineItems(
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetMetronomeInvoiceResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetMetronomeInvoiceResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const subscription = auth.subscription();
-    const owner = auth.workspace();
-    if (!subscription || !owner) {
-      return ctx.json({ invoice: null });
-    }
-
-    const { metronomeContractId } = subscription;
-    const { metronomeCustomerId } = owner;
-    if (!metronomeContractId || !metronomeCustomerId) {
-      return ctx.json({ invoice: null });
-    }
-
-    const invoiceResult = await findCurrentInvoice(
-      metronomeCustomerId,
-      metronomeContractId
-    );
-    if (invoiceResult.isErr()) {
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to fetch Metronome draft invoices: ${invoiceResult.error.message}`,
-        },
-      });
-    }
-
-    const invoice = invoiceResult.value;
-
-    if (!invoice || !invoice.start_timestamp || !invoice.end_timestamp) {
-      return ctx.json({ invoice: null });
-    }
-
-    const currency = creditTypeIdToCurrency(invoice.credit_type.id);
-    if (!currency) {
-      return ctx.json({ invoice: null });
-    }
-
-    const seatProductId = getProductWorkspaceSeatId();
-
-    let seatUnitPriceCents: number | null = null;
-
-    for (const item of invoice.line_items) {
-      const productId = item.product_id;
-      if (!productId || typeof item.unit_price !== "number") {
-        continue;
-      }
-      if (productId === seatProductId) {
-        seatUnitPriceCents = amountCents(item.unit_price, currency);
-      }
-    }
-
-    const currentPeriodStartMs = new Date(invoice.start_timestamp).getTime();
-    const currentPeriodEndMs = new Date(invoice.end_timestamp).getTime();
-
-    const summary: MetronomeInvoiceSummary = {
-      currency,
-      billingPeriod: inferBillingPeriod(
-        currentPeriodStartMs,
-        currentPeriodEndMs
-      ),
-      currentPeriodStartMs,
-      currentPeriodEndMs,
-      estimatedAmountCents: amountCents(invoice.total, currency),
-      seatUnitPriceCents,
-    };
-
-    return ctx.json({ invoice: summary });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const subscription = auth.subscription();
+  const owner = auth.workspace();
+  if (!subscription || !owner) {
+    return ctx.json({ invoice: null });
+  }
+
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeContractId || !metronomeCustomerId) {
+    return ctx.json({ invoice: null });
+  }
+
+  const invoiceResult = await findCurrentInvoice(
+    metronomeCustomerId,
+    metronomeContractId
+  );
+  if (invoiceResult.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Metronome draft invoices: ${invoiceResult.error.message}`,
+      },
+    });
+  }
+
+  const invoice = invoiceResult.value;
+
+  if (!invoice || !invoice.start_timestamp || !invoice.end_timestamp) {
+    return ctx.json({ invoice: null });
+  }
+
+  const currency = creditTypeIdToCurrency(invoice.credit_type.id);
+  if (!currency) {
+    return ctx.json({ invoice: null });
+  }
+
+  const seatProductId = getProductWorkspaceSeatId();
+
+  let seatUnitPriceCents: number | null = null;
+
+  for (const item of invoice.line_items) {
+    const productId = item.product_id;
+    if (!productId || typeof item.unit_price !== "number") {
+      continue;
+    }
+    if (productId === seatProductId) {
+      seatUnitPriceCents = amountCents(item.unit_price, currency);
+    }
+  }
+
+  const currentPeriodStartMs = new Date(invoice.start_timestamp).getTime();
+  const currentPeriodEndMs = new Date(invoice.end_timestamp).getTime();
+
+  const summary: MetronomeInvoiceSummary = {
+    currency,
+    billingPeriod: inferBillingPeriod(currentPeriodStartMs, currentPeriodEndMs),
+    currentPeriodStartMs,
+    currentPeriodEndMs,
+    estimatedAmountCents: amountCents(invoice.total, currency),
+    seatUnitPriceCents,
+  };
+
+  return ctx.json({ invoice: summary });
+});
 
 /** @ignoreswagger */
 app.get(
   "/lines",
-  ensureIsAdmin(),
   async (ctx): HandlerResult<GetMetronomeInvoiceLinesResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
 
     const subscription = auth.subscription();
     const owner = auth.workspace();

--- a/front-api/routes/w/[wId]/metronome/migration.test.ts
+++ b/front-api/routes/w/[wId]/metronome/migration.test.ts
@@ -1,0 +1,82 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function migrationUrl(wId: string) {
+  return `/api/w/${wId}/metronome/migration`;
+}
+
+function patch(wId: string, body: unknown) {
+  return honoApp.request(migrationUrl(wId), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/w/:wId/metronome/migration", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(migrationUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(migrationUrl(workspace.sId));
+
+    // The default subscription has no Stripe subscription, so the status is
+    // derived without any external call and a granted member clears the gate.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      pendingMigrationDate: null,
+      willBeRefundedOnEnd: false,
+    });
+  });
+});
+
+describe("PATCH /api/w/:wId/metronome/migration", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const response = await patch(workspace.sId, { action: "cancel" });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets a member with the billing admin permission through the auth gate", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await patch(workspace.sId, { action: "cancel" });
+
+    // The caller clears the billing-permission gate: the request now fails on
+    // the subscription state (not migrating) rather than on authorization.
+    expect(response.status).not.toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/metronome/migration.ts
+++ b/front-api/routes/w/[wId]/metronome/migration.ts
@@ -6,7 +6,6 @@ import {
   type WorkspaceMigrationStatus,
 } from "@app/lib/api/billing/migration_lifecycle";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
@@ -39,22 +38,41 @@ function lifecycleErrorToApi(ctx: Context, err: MigrationLifecycleError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<WorkspaceMigrationStatus> => {
-    const auth = ctx.get("auth");
-    return ctx.json(await getWorkspaceMigrationStatus(auth));
+app.get("/", async (ctx): HandlerResult<WorkspaceMigrationStatus> => {
+  const auth = ctx.get("auth");
+
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  return ctx.json(await getWorkspaceMigrationStatus(auth));
+});
 
 /** @ignoreswagger */
 app.patch(
   "/",
-  ensureIsAdmin(),
   validate("json", PatchMigrationRequestBody),
   async (ctx): HandlerResult<PatchMigrationResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
+
     const { action } = ctx.req.valid("json");
 
     const result =

--- a/front-api/routes/w/[wId]/seats/count.test.ts
+++ b/front-api/routes/w/[wId]/seats/count.test.ts
@@ -1,0 +1,38 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function seatsCountUrl(wId: string) {
+  return `/api/w/${wId}/seats/count`;
+}
+
+describe("GET /api/w/:wId/seats/count", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(seatsCountUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(seatsCountUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveProperty("seatsCount");
+  });
+});

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,26 +1,32 @@
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/lib/api/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/seats/count.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetWorkspaceSeatsCountResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetWorkspaceSeatsCountResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const owner = auth.getNonNullableWorkspace();
-
-    const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
-      owner.sId
-    );
-    return ctx.json({ seatsCount });
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
+    owner.sId
+  );
+  return ctx.json({ seatsCount });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
@@ -1,6 +1,7 @@
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { honoApp } from "@front-api/app";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -77,5 +78,24 @@ describe("GET /api/w/:wId/subscriptions/checkout/business-activation", () => {
     const response = await get(workspace, { setup_session_id: "cs_test" });
 
     expect(response.status).toBe(403);
+  });
+
+  it("lets a member with the billing admin permission through the auth gate", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    // No identifier: the caller clears the billing-permission gate and fails on
+    // identifier validation (400) rather than on authorization.
+    const response = await get(workspace);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 });

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -10,7 +10,6 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { wakeLock } from "@app/lib/wake_lock";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -18,58 +17,65 @@ import { validate } from "@front-api/middlewares/validator";
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
+  const auth = ctx.get("auth");
 
-    // Business activation is a credit-priced (Metronome) checkout flow: gate it
-    // on Metronome billing being enabled, consistently with the POST handler.
-    const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-    if (!metronomeBillingEnabled) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "Metronome billing is not enabled for this workspace.",
-        },
-      });
-    }
-
-    // The record can be looked up by contract id or by Stripe setup session id.
-    // The polling UI uses the session id so it can poll from the first step,
-    // before the contract id exists.
-    const contractId = ctx.req.query("contract_id");
-    const setupSessionId = ctx.req.query("setup_session_id");
-    const identifier = contractId
-      ? { contractId }
-      : setupSessionId
-        ? { setupSessionId }
-        : null;
-    if (!identifier) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "Missing required query parameter: contract_id or setup_session_id.",
-        },
-      });
-    }
-
-    // The polling UI omits `receipt`; only the success screen requests the
-    // (slow) Stripe hosted invoice URL, so status polls stay fast.
-    const includeReceiptUrl = ctx.req.query("receipt") === "true";
-
-    const workspace = auth.getNonNullableWorkspace();
-    return ctx.json(
-      await getBusinessActivationStatus(workspace, identifier, {
-        includeReceiptUrl,
-      })
-    );
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  // Business activation is a credit-priced (Metronome) checkout flow: gate it
+  // on Metronome billing being enabled, consistently with the POST handler.
+  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
+  if (!metronomeBillingEnabled) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Metronome billing is not enabled for this workspace.",
+      },
+    });
+  }
+
+  // The record can be looked up by contract id or by Stripe setup session id.
+  // The polling UI uses the session id so it can poll from the first step,
+  // before the contract id exists.
+  const contractId = ctx.req.query("contract_id");
+  const setupSessionId = ctx.req.query("setup_session_id");
+  const identifier = contractId
+    ? { contractId }
+    : setupSessionId
+      ? { setupSessionId }
+      : null;
+  if (!identifier) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Missing required query parameter: contract_id or setup_session_id.",
+      },
+    });
+  }
+
+  // The polling UI omits `receipt`; only the success screen requests the
+  // (slow) Stripe hosted invoice URL, so status polls stay fast.
+  const includeReceiptUrl = ctx.req.query("receipt") === "true";
+
+  const workspace = auth.getNonNullableWorkspace();
+  return ctx.json(
+    await getBusinessActivationStatus(workspace, identifier, {
+      includeReceiptUrl,
+    })
+  );
+});
 
 /** @ignoreswagger */
 app.post(
@@ -80,14 +86,13 @@ app.post(
       async () => {
         const auth = ctx.get("auth");
 
-        // biome-ignore lint/plugin/noDirectRoleCheck: inside wakeLock callback, middleware not applicable
-        if (!auth.isAdmin()) {
+        if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
           return apiError(ctx, {
             status_code: 403,
             api_error: {
               type: "workspace_auth_error",
               message:
-                "Only users that are `admins` for the current workspace can access this endpoint.",
+                "You need billing access to manage billing settings, invoices, and payment methods.",
             },
           });
         }

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.test.ts
@@ -1,0 +1,45 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function preparePaymentUrl(wId: string, query: Record<string, string> = {}) {
+  const qs = new URLSearchParams(query).toString();
+  return `/api/w/${wId}/subscriptions/checkout/prepare-payment${
+    qs ? `?${qs}` : ""
+  }`;
+}
+
+describe("GET /api/w/:wId/subscriptions/checkout/prepare-payment", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      preparePaymentUrl(workspace.sId, { setup_session_id: "cs_test" })
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets a member with the billing admin permission through the auth gate", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    // No setup_session_id: the caller clears the billing-permission gate and
+    // fails on the missing query parameter (400) rather than on authorization.
+    const response = await honoApp.request(preparePaymentUrl(workspace.sId));
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+});

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -6,40 +6,47 @@ import type { GetPreparePaymentResponseBody } from "@app/types/api/checkout/prep
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/subscriptions/checkout/prepare-payment.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
-    const setup_session_id = ctx.req.query("setup_session_id");
-    if (!isString(setup_session_id)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing or invalid setup_session_id query parameter.",
-        },
-      });
-    }
+app.get("/", async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
+  const auth = ctx.get("auth");
 
-    // Prevent HTTP caching as session status can change on every call.
-    ctx.header("Cache-Control", "no-store");
-
-    const auth = ctx.get("auth");
-    const result = await getPreparePaymentData(auth, setup_session_id);
-    if (result.isErr()) {
-      return mapPreparePaymentError(ctx, result.error);
-    }
-
-    return ctx.json<GetPreparePaymentResponseBody>(result.value);
+  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const setup_session_id = ctx.req.query("setup_session_id");
+  if (!isString(setup_session_id)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid setup_session_id query parameter.",
+      },
+    });
+  }
+
+  // Prevent HTTP caching as session status can change on every call.
+  ctx.header("Cache-Control", "no-store");
+
+  const result = await getPreparePaymentData(auth, setup_session_id);
+  if (result.isErr()) {
+    return mapPreparePaymentError(ctx, result.error);
+  }
+
+  return ctx.json<GetPreparePaymentResponseBody>(result.value);
+});
 
 function mapPreparePaymentError(
   ctx: Parameters<typeof apiError>[0],

--- a/front-api/routes/w/[wId]/subscriptions/index.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.test.ts
@@ -1,9 +1,7 @@
-import { Authenticator } from "@app/lib/auth";
-import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { honoApp } from "@front-api/app";
 import type { Stripe } from "stripe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,29 +41,6 @@ function patch(workspace: { sId: string }, body: unknown) {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-  });
-}
-
-// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
-// in a group that holds a type-wide grant, mirroring how governance grants billing access.
-async function grantBillingAdmin(
-  workspace: Awaited<
-    ReturnType<typeof createPrivateApiMockRequest>
-  >["workspace"],
-  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
-) {
-  const adminAuth = await Authenticator.internalAdminForWorkspace(
-    workspace.sId
-  );
-  const group = await GroupFactory.regularAuto(
-    workspace,
-    `billing-admin-${user.sId}`
-  );
-  await GroupFactory.withMembers(adminAuth, group, [user]);
-  await GroupPermissionResource.grantTypeWide(adminAuth, {
-    group,
-    grantType: "admin",
-    resourceType: "billing",
   });
 }
 
@@ -191,7 +166,10 @@ describe("POST /api/w/:wId/subscriptions", () => {
       role: "user",
     });
 
-    await grantBillingAdmin(workspace, user);
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
 
     const response = await post(workspace, { billingPeriod: "monthly" });
 
@@ -224,7 +202,10 @@ describe("PATCH /api/w/:wId/subscriptions", () => {
       role: "user",
     });
 
-    await grantBillingAdmin(workspace, user);
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
 
     const response = await patch(workspace, { action: "cancel_free_trial" });
 

--- a/front-api/routes/w/[wId]/subscriptions/index.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.test.ts
@@ -1,5 +1,8 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
 import type { Stripe } from "stripe";
@@ -32,6 +35,37 @@ function post(workspace: { sId: string }, body: unknown) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+  });
+}
+
+function patch(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/subscriptions`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Grants the workspace-level "admin" capability on "billing" to a non-admin user by placing them
+// in a group that holds a type-wide grant, mirroring how governance grants billing access.
+async function grantBillingAdmin(
+  workspace: Awaited<
+    ReturnType<typeof createPrivateApiMockRequest>
+  >["workspace"],
+  user: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["user"]
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    workspace,
+    `billing-admin-${user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType: "admin",
+    resourceType: "billing",
   });
 }
 
@@ -149,5 +183,53 @@ describe("POST /api/w/:wId/subscriptions", () => {
     const response = await post(workspace, { billingPeriod: "monthly" });
 
     expect(response.status).toBe(403);
+  });
+
+  it("lets a member with the billing admin permission through the auth gate", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    await grantBillingAdmin(workspace, user);
+
+    const response = await post(workspace, { billingPeriod: "monthly" });
+
+    // The caller clears the billing-permission gate: with metronome billing
+    // enabled the request now fails on the missing seat fields (400) rather
+    // than on authorization.
+    expect(response.status).not.toBe(403);
+  });
+});
+
+describe("PATCH /api/w/:wId/subscriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const response = await patch(workspace, { action: "cancel_free_trial" });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets a member with the billing admin permission through the auth gate", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    await grantBillingAdmin(workspace, user);
+
+    const response = await patch(workspace, { action: "cancel_free_trial" });
+
+    // The caller clears the billing-permission gate: the request now fails on the subscription
+    // state (not trialing) rather than on authorization.
+    expect(response.status).not.toBe(403);
   });
 });

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -17,10 +17,7 @@ import type {
 import { PatchSubscriptionRequestBody } from "@app/types/api/subscription";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import {
-  ensureIsAdmin,
-  ensureIsManager,
-} from "@front-api/middlewares/ensure_role";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -68,10 +65,21 @@ app.get(
 
 app.post(
   "/",
-  ensureIsAdmin(),
   validate("json", PostSubscriptionRequestBody),
   async (ctx): HandlerResult<PostSubscriptionResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
+
     const body = ctx.req.valid("json");
 
     try {
@@ -110,10 +118,20 @@ app.post(
 
 app.patch(
   "/",
-  ensureIsAdmin(),
   validate("json", PatchSubscriptionRequestBody),
   async (ctx): HandlerResult<PatchSubscriptionResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
 
     const subscription = auth.subscription();
     if (!subscription) {

--- a/front-api/routes/w/[wId]/subscriptions/pricing.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/pricing.test.ts
@@ -1,0 +1,49 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function pricingUrl(wId: string) {
+  return `/api/w/${wId}/subscriptions/pricing`;
+}
+
+describe("GET /api/w/:wId/subscriptions/pricing", () => {
+  it("returns 403 for a plain member (neither manager nor billing admin)", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(pricingUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(pricingUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveProperty("perSeatPricing");
+  });
+
+  it("allows a manager without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(pricingUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/front-api/routes/w/[wId]/subscriptions/pricing.ts
+++ b/front-api/routes/w/[wId]/subscriptions/pricing.ts
@@ -1,26 +1,37 @@
 import type { GetSubscriptionPricingResponseBody } from "@app/lib/resources/subscription_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/subscriptions/pricing.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsManager(),
-  async (ctx): HandlerResult<GetSubscriptionPricingResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetSubscriptionPricingResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const subscriptionResource = auth.subscriptionResource();
-    if (!subscriptionResource) {
-      return ctx.json({ perSeatPricing: null });
-    }
-
-    const perSeatPricing = await subscriptionResource.getPerSeatPricing();
-    return ctx.json({ perSeatPricing });
+  // Managers read pricing for the usage/members pages; billing-permission holders need it for the
+  // subscription page.
+  if (
+    !auth.isManager() &&
+    !(await auth.hasWorkspacePermission("admin", "billing"))
+  ) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You need billing access to manage billing settings, invoices, and payment methods.",
+      },
+    });
   }
-);
+
+  const subscriptionResource = auth.subscriptionResource();
+  if (!subscriptionResource) {
+    return ctx.json({ perSeatPricing: null });
+  }
+
+  const perSeatPricing = await subscriptionResource.getPerSeatPricing();
+  return ctx.json({ perSeatPricing });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.test.ts
@@ -1,0 +1,40 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function trialInfoUrl(wId: string) {
+  return `/api/w/${wId}/subscriptions/trial-info`;
+}
+
+describe("GET /api/w/:wId/subscriptions/trial-info", () => {
+  it("returns 403 for a member without the billing admin permission", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(trialInfoUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("allows a member with the billing admin permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "billing",
+    });
+
+    const response = await honoApp.request(trialInfoUrl(workspace.sId));
+
+    // The default (non-trialing) subscription returns null trial days without
+    // hitting Stripe, so a granted member simply clears the gate.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ trialDaysRemaining: null });
+  });
+});

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,8 +1,7 @@
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import type { GetSubscriptionTrialInfoResponseBody } from "@app/types/api/subscription";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
-import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/subscriptions/trial-info.
 const app = workspaceApp();
@@ -10,9 +9,19 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
   async (ctx): HandlerResult<GetSubscriptionTrialInfoResponseBody> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You need billing access to manage billing settings, invoices, and payment methods.",
+        },
+      });
+    }
 
     const subscription = auth.subscription();
     if (!subscription) {

--- a/front-spa/src/app/layouts/RequirePermissionLayout.tsx
+++ b/front-spa/src/app/layouts/RequirePermissionLayout.tsx
@@ -1,0 +1,32 @@
+import { AdminLayout } from "@dust-tt/front/components/layouts/AdminLayout";
+import Custom404 from "@dust-tt/front/components/pages/Custom404";
+import { useWorkspacePermissions } from "@dust-tt/front/lib/swr/permissions.js";
+import type {
+  ConcreteResourceType,
+  GrantVerb,
+} from "@dust-tt/front/types/group_permissions";
+import { Outlet } from "react-router-dom";
+
+interface RequirePermissionLayoutProps {
+  verb: GrantVerb;
+  resourceType: ConcreteResourceType;
+}
+
+export function RequirePermissionLayout({
+  verb,
+  resourceType,
+}: RequirePermissionLayoutProps) {
+  const { hasPermission } = useWorkspacePermissions();
+
+  const hasRequiredPermission = hasPermission(verb, resourceType);
+
+  if (!hasRequiredPermission) {
+    return <Custom404 />;
+  }
+
+  return (
+    <AdminLayout>
+      <Outlet />
+    </AdminLayout>
+  );
+}

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -1,3 +1,4 @@
+import { RequirePermissionLayout } from "@spa/app/layouts/RequirePermissionLayout";
 import { RequireRoleLayout } from "@spa/app/layouts/RequireRoleLayout";
 import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
@@ -122,8 +123,6 @@ export const adminRoutes: RouteObject[] = [
       { path: "model-providers", element: <ModelProvidersPage /> },
       { path: "workspace", element: <WorkspaceSettingsPage /> },
       { path: "branding", element: <WorkspaceBrandingPage /> },
-      { path: "subscription", element: <SubscriptionPage /> },
-      { path: "billing", element: <BillingPage /> },
       { path: "developers/api-keys", element: <APIKeysPage /> },
       {
         path: "developers/credits-usage",
@@ -145,6 +144,14 @@ export const adminRoutes: RouteObject[] = [
         path: "developers/self-improving-skills",
         element: <SelfImprovingSkillsPage />,
       },
+    ],
+  },
+  {
+    // Billing areas: accessible to admins and to members holding the billing admin permission.
+    element: <RequirePermissionLayout verb="admin" resourceType="billing" />,
+    children: [
+      { path: "subscription", element: <SubscriptionPage /> },
+      { path: "billing", element: <BillingPage /> },
     ],
   },
 ];

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -25,6 +25,7 @@ import {
   useMyUsage,
   useSeatPlan,
 } from "@app/lib/swr/credits";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   usePatchUser,
   usePendingInvitations,
@@ -216,7 +217,9 @@ interface UsageSectionProps {
 }
 
 function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
-  const { isAdmin, isManager, subscription } = useAuth();
+  const { isManager, subscription } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
+  const canAccessBilling = hasPermission("admin", "billing");
 
   const isCreditBased = isCreditPricedPlan(subscription.plan);
 
@@ -327,7 +330,7 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
         visible={visible}
       />
 
-      {isAdmin && (
+      {canAccessBilling && (
         <section className="flex items-center justify-between border-b border-border dark:border-border-dark pb-4">
           <div className="flex flex-col gap-0.5">
             <span className="text-sm font-semibold text-foreground">

--- a/front/components/layouts/AdminLayout.tsx
+++ b/front/components/layouts/AdminLayout.tsx
@@ -6,6 +6,7 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { cn } from "@dust-tt/sparkle";
 import type { ReactElement } from "react";
 import { useMemo } from "react";
@@ -19,6 +20,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   const { subscription } = useAuth();
 
   const { featureFlags } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions();
 
   const router = useAppRouter();
 
@@ -29,8 +31,9 @@ export function AdminLayout({ children }: AdminLayoutProps) {
         currentRoute: router.pathname,
         featureFlags,
         subscription,
+        hasPermission,
       }),
-    [owner, router.pathname, featureFlags, subscription]
+    [owner, router.pathname, featureFlags, subscription, hasPermission]
   );
 
   useSetSubNavigation(subNavigation);

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -10,9 +10,10 @@ import { UserMenu } from "@app/components/UserMenu";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
-import { isAdmin } from "@app/types/user";
+import { isAdmin, isManager } from "@app/types/user";
 import {
   CollapseButton,
   cn,
@@ -61,13 +62,30 @@ export const NavigationSidebar = React.forwardRef<
   }, [router.isReady, router.pathname]);
 
   const { hasFeature } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions();
+
+  // Resolves the Admin tab's landing page (or null to hide it) from the member's role/permissions.
+  // Managers land on People; members who only hold the billing permission land on Billing.
+  const adminSectionHref = isManager(owner)
+    ? `/w/${owner.sId}/members`
+    : hasPermission("admin", "billing")
+      ? `/w/${owner.sId}/billing`
+      : null;
+
+  const showAdminSection = adminSectionHref !== null;
 
   const { spaceMenuButtonRef } = useWelcomeTourGuide();
 
   // TODO(2024-06-19 flav): Fix issue with AppLayout changing between pagesg
   const navs = useMemo(
-    () => getTopNavigationTabs(owner, spaceMenuButtonRef),
-    [owner, spaceMenuButtonRef]
+    () =>
+      getTopNavigationTabs(
+        owner,
+        spaceMenuButtonRef,
+        showAdminSection,
+        adminSectionHref
+      ),
+    [owner, spaceMenuButtonRef, showAdminSection, adminSectionHref]
   );
 
   const currentTab = useMemo(

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,6 +1,10 @@
 import { computeIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
+import type {
+  ConcreteResourceType,
+  GrantVerb,
+} from "@app/types/group_permissions";
 import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
 import {
   isComputerFeatureEnabled,
@@ -178,7 +182,9 @@ export type SidebarNavigation = {
 
 export const getTopNavigationTabs = (
   owner: WorkspaceType,
-  spaceMenuButtonRef: React.RefObject<HTMLDivElement>
+  spaceMenuButtonRef: React.RefObject<HTMLDivElement>,
+  showAdminSection: boolean,
+  adminSectionHref: string | null
 ) => {
   const nav: TabAppLayoutNavigation[] = [];
 
@@ -208,12 +214,12 @@ export const getTopNavigationTabs = (
     ref: spaceMenuButtonRef,
   });
 
-  if (isManager(owner)) {
+  if (showAdminSection) {
     nav.push({
       id: "settings",
       label: "Admin",
       icon: Settings01,
-      href: `/w/${owner.sId}/members`,
+      href: adminSectionHref ?? `/w/${owner.sId}/members`,
       isCurrent: (currentRoute) =>
         matchesRoutePattern(currentRoute, [
           "/w/[wId]/members",
@@ -246,17 +252,24 @@ export const subNavigationAdmin = ({
   currentRoute,
   featureFlags,
   subscription,
+  hasPermission,
 }: {
   owner: WorkspaceType;
   currentRoute: string;
   featureFlags: WhitelistableFeature[];
   subscription: SubscriptionType;
+  hasPermission: (
+    verb: GrantVerb,
+    resourceType: ConcreteResourceType
+  ) => boolean;
 }): SidebarNavigation[] => {
   const nav: SidebarNavigation[] = [];
 
+  const canAdminBilling = hasPermission("admin", "billing");
+
   // Admins and managers see the admin sidebar; builders and members do
   // not. Each item is then individually enabled/disabled based on permission.
-  if (!isManager(owner)) {
+  if (!isManager(owner) && !canAdminBilling) {
     return nav;
   }
 
@@ -358,7 +371,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/billing`,
             current: isCurrent("billing"),
-            disabled: !hasAdminRole,
+            disabled: !canAdminBilling,
           }
         : {
             id: "subscription",
@@ -366,7 +379,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/subscription`,
             current: isCurrent("subscription"),
-            disabled: !hasAdminRole,
+            disabled: !canAdminBilling,
           },
     ],
   });

--- a/front/tests/utils/permissions.ts
+++ b/front/tests/utils/permissions.ts
@@ -1,0 +1,34 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import type {
+  GrantType,
+  GroupPermissionResourceType,
+} from "@app/types/group_permissions";
+import type { WorkspaceType } from "@app/types/user";
+
+// Grants a workspace-level (type-wide) capability to a non-admin user by placing them in a group
+// that holds the grant, mirroring how governance grants capabilities to groups.
+export async function grantWorkspacePermission(
+  workspace: WorkspaceType,
+  user: UserResource,
+  {
+    grantType,
+    resourceType,
+  }: { grantType: GrantType; resourceType: GroupPermissionResourceType }
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const group = await GroupFactory.regularAuto(
+    workspace,
+    `${grantType}-${resourceType}-${user.sId}`
+  );
+  await GroupFactory.withMembers(adminAuth, group, [user]);
+  await GroupPermissionResource.grantTypeWide(adminAuth, {
+    group,
+    grantType,
+    resourceType,
+  });
+}


### PR DESCRIPTION
## Description

This PR allows users with admin billing permission to see and interact with the billing page.

## Tests

Added unit tests checking that users with the admin billing permission can call the relevant endpoints.

## Risks

Low. The change is strictly additive in terms of who can access billing endpoints: workspace admins still have access (they implicitly hold all permissions), and non-admin users with the billing permission are now also granted access.

## Deploy Plan

Standard deployment.