### PR TITLE
[Activation] Descriptive title for nudge convos

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -9,46 +9,25 @@ import {
   ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
   ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
-import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
   {
     create_recommendation: async ({ title, content }, { auth, runContext }) => {
-      const conversation = isAgentLoopRunContext(runContext)
-        ? runContext.conversation
+      const conversationId = isAgentLoopRunContext(runContext)
+        ? runContext.conversation.id
         : null;
 
       const rec = await ActivationRecommendationResource.makeNew(auth, {
         title,
         content,
-        conversationId: conversation?.id ?? null,
+        conversationId,
       });
-
-      // Give the activation nudge conversation a descriptive, user-facing title
-      // derived from the recommendation.
-      if (conversation) {
-        const titleRes = await updateConversationTitle(auth, {
-          conversationId: conversation.sId,
-          title: `Activation Recommendation: ${title}`,
-        });
-        if (titleRes.isErr()) {
-          logger.error(
-            {
-              conversationId: conversation.sId,
-              recommendationId: rec.sId,
-              error: titleRes.error,
-            },
-            "[activation] Failed to set conversation title from recommendation"
-          );
-        }
-      }
 
       return new Ok([
         {

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -9,25 +9,46 @@ import {
   ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
   ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/activation_recommendations/metadata";
+import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
   {
     create_recommendation: async ({ title, content }, { auth, runContext }) => {
-      const conversationId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.id
+      const conversation = isAgentLoopRunContext(runContext)
+        ? runContext.conversation
         : null;
 
       const rec = await ActivationRecommendationResource.makeNew(auth, {
         title,
         content,
-        conversationId,
+        conversationId: conversation?.id ?? null,
       });
+
+      // Give the activation nudge conversation a descriptive, user-facing title
+      // derived from the recommendation.
+      if (conversation) {
+        const titleRes = await updateConversationTitle(auth, {
+          conversationId: conversation.sId,
+          title: `Activation Recommendation: ${title}`,
+        });
+        if (titleRes.isErr()) {
+          logger.error(
+            {
+              conversationId: conversation.sId,
+              recommendationId: rec.sId,
+              error: titleRes.error,
+            },
+            "[activation] Failed to set conversation title from recommendation"
+          );
+        }
+      }
 
       return new Ok([
         {

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -228,7 +228,7 @@ Pull the information from the required sources into context. Write it to a file 
 Before presenting the recommendation, ALWAYS call the tool \`create_recommendation\` to create the recommendation record in the database.
 
 Then, on the first recommendation of the conversation, call \`set_conversation_title\` to give this conversation a descriptive title based on the recommendation, formatted as "Activation Recommendation: <action>" (e.g. "Activation Recommendation: Simplify weekly reporting"). 
-This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject. Ensure that the title is maximum 6-8 words long.
+This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject. Ensure that the title is around 6 words long.
 
 ### Card Format
 

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -227,6 +227,9 @@ Pull the information from the required sources into context. Write it to a file 
 
 Before presenting the recommendation, ALWAYS call the tool \`create_recommendation\` to create the recommendation record in the database.
 
+Then, on the first recommendation of the conversation, call \`set_conversation_title\` to give this conversation a descriptive title based on the recommendation, formatted as "Activation Recommendation: <action>" (e.g. "Activation Recommendation: Simplify weekly reporting"). 
+This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject. Ensure that the title is maximum 6-8 words long.
+
 ### Card Format
 
 \`\`\`


### PR DESCRIPTION
## Description
Creates a more descriptive title for each activation nudge conversation, solving the problem of each conversation being titled "Triggered - Run Scheduled Activation Workflow".

Use the `create_recommendation` tool to set the conversation title to be "Activation Recommendation: [6-8 word title]", reusing the recommendation's existing action label (no extra LLM call that would be needed with the set_conversation_title tool). 
Falls back to "Triggered - ..." if the recommendation is never recorded.

## Tests
Tested locally.

## Risk
Low risk.

## Deploy Plan
Deploy front.
