### PR TITLE
Do not fetch full conversation for sandbox child action

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -15,7 +15,7 @@ import {
   SkillResource,
 } from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
@@ -309,7 +309,7 @@ export async function resolveSkillMCPServers(
     conversation,
   }: {
     agentConfiguration: AgentConfigurationType;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
   }
 ): Promise<ResolvedSkillMCPServers> {
   const { effectiveSpaceIds, enabledSkills, systemSkills } =

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -10,9 +10,9 @@ import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
@@ -23,7 +23,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -74,9 +74,12 @@ export async function createSandboxChildAction(
     return new Err(new Error("Agent configuration not found."));
   }
 
-  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
-  const conversationResult = await getConversation(auth, conversationId);
-  if (conversationResult.isErr()) {
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+
+  if (!conversationResource) {
     return new Err(new Error("Conversation not found."));
   }
 
@@ -88,17 +91,43 @@ export async function createSandboxChildAction(
     return new Err(new Error("Parent action not found."));
   }
 
-  const conversation = conversationResult.value;
+  const agentMessageRes = await conversationResource.getMessageById(
+    auth,
+    agentMessageId
+  );
 
-  const agentMessage = conversation.content
-    .flat()
-    .find(
-      (m): m is AgentMessageType =>
-        m.type === "agent_message" && m.sId === agentMessageId
-    );
-  if (!agentMessage) {
+  if (agentMessageRes.isErr()) {
     return new Err(new Error("Agent message not found."));
   }
+
+  const agentMessageRenderRes = await batchRenderMessages(
+    auth,
+    conversationResource,
+    [agentMessageRes.value],
+    "full"
+  );
+  if (agentMessageRenderRes.isErr()) {
+    return new Err(new Error("Failed to render agent message."));
+  }
+
+  const agentMessage = agentMessageRenderRes.value[0];
+
+  if (!isAgentMessageType(agentMessage)) {
+    return new Err(new Error("Agent message not found."));
+  }
+
+  // Using the fetchConversationWithoutContent method as we need the read and action required states
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    return new Err(new Error("Failed to fetch conversation."));
+  }
+
+  const conversation = conversationRes.value;
 
   // JIT servers cover tools added via the conversation input bar, skill
   // servers cover tools attached through skills. Resolve the server config


### PR DESCRIPTION
## Description

`createSandboxChildAction` was fetching the full conversation (`getConversation`) just to locate a single agent message and read conversation metadata — triggering the `noExpensiveConversationFetch` lint rule with a suppression comment. Replaced with:
- `ConversationResource.fetchById()` to get the resource
- `conversationResource.getMessageById()` + `batchRenderMessages([msg], "full")` to fetch and render just the target agent message
- `ConversationResource.fetchConversationWithoutContent()` for the `read`/`action` state needed downstream

Also narrows the `resolveSkillMCPServers` `conversation` parameter type from `ConversationType` to `ConversationWithoutContentType`, removing the dead dependency on full content.

## Tests

Tested manually by running sandbox child actions end-to-end. No new unit tests — the logic change is a refactor of the fetch path with equivalent behavior.

## Risk

Low. The change is scoped entirely to `createSandboxChildAction`. Message lookup is now targeted by ID rather than a linear scan over the full conversation tree — strictly equivalent in behavior, more efficient. Rollback is safe.

## Deploy Plan

Deploy front.
