### PR TITLE
[front] replace builder-role checks in data/app/provider server endpoints

### DIFF
--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -70,21 +70,21 @@ app.get(
 
     const query = ctx.req.valid("query");
 
-    // Auth gating: read = anyone, write = builder, undefined (all) = admin.
+    // Auth gating: read = anyone, write = agent publishers, undefined (all) = admin.
     switch (query.filterPermission) {
       case "read":
         // `read` is used for data source selection when creating personal assistants.
         break;
       case "write":
-        // `write` is used for selection of default slack channel in the workspace agent builder.
-        // biome-ignore lint/plugin/noDirectRoleCheck: conditional role check based on filterPermission query param
-        if (!auth.isBuilder()) {
+        // `write` is used for selection of default slack channel in the workspace agent builder,
+        // so it is gated on the agent publishing permission.
+        if (!(await auth.hasWorkspacePermission("publish", "agent"))) {
           return apiError(ctx, {
             status_code: 403,
             api_error: {
               type: "data_source_auth_error",
               message:
-                "Only builders of the current workspace can view 'write' permissions of a data source.",
+                "You do not have permission to view 'write' permissions of a data source.",
             },
           });
         }

--- a/front-api/routes/w/[wId]/dust_app_secrets/index.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/index.ts
@@ -11,10 +11,7 @@ import type {
 } from "@app/types/api/dust_app_secrets";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import {
-  ensureIsAdmin,
-  ensureIsBuilder,
-} from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -30,34 +27,42 @@ const PostDustAppSecretBodySchema = z.object({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsBuilder(),
-  async (ctx): HandlerResult<GetDustAppSecretsResponseBody> => {
-    const auth = ctx.get("auth");
-    const owner = auth.getNonNullableWorkspace();
+app.get("/", async (ctx): HandlerResult<GetDustAppSecretsResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const remaining = await rateLimiter({
-      key: `workspace:${owner.id}:dust_app_secrets`,
-      maxPerTimeframe: 60,
-      timeframeSeconds: 60,
-      logger,
+  // Dust app secrets are part of Dust app administration.
+  if (!(await auth.hasWorkspacePermission("admin", "dust_app"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You do not have permission to manage Dust app secrets.",
+      },
     });
-
-    if (remaining < 0) {
-      return apiError(ctx, {
-        status_code: 429,
-        api_error: {
-          type: "rate_limit_error",
-          message: "You have reached the rate limit for this workspace.",
-        },
-      });
-    }
-
-    const secrets = await getDustAppSecrets(auth);
-    return ctx.json({ secrets });
   }
-);
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const remaining = await rateLimiter({
+    key: `workspace:${owner.id}:dust_app_secrets`,
+    maxPerTimeframe: 60,
+    timeframeSeconds: 60,
+    logger,
+  });
+
+  if (remaining < 0) {
+    return apiError(ctx, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: "You have reached the rate limit for this workspace.",
+      },
+    });
+  }
+
+  const secrets = await getDustAppSecrets(auth);
+  return ctx.json({ secrets });
+});
 
 app.post(
   "/",

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -258,6 +258,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
 
   if (
     isUploadUseCase &&
+    // TODO(governance) - auth.isBuilder to be replaced with auth.isManager
     !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
   ) {
     return apiError(ctx, {
@@ -267,6 +268,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
         message: "You cannot edit files in that space.",
       },
     });
+    // TODO(governance) - auth.isBuilder to be replaced with auth.isManager
   } else if (!auth.isBuilder() && file.useCase !== "conversation") {
     return apiError(ctx, {
       status_code: 403,
@@ -317,6 +319,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
 
   if (
     isUploadUseCase &&
+    // TODO(governance) - auth.isBuilder to be replaced with auth.isManager
     !((isFileAuthor && canWriteInSpace) || auth.isBuilder())
   ) {
     return apiError(ctx, {
@@ -328,6 +331,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   } else if (
     !space &&
+    // TODO(governance) - auth.isBuilder to be replaced with auth.isManager
     !auth.isBuilder() &&
     file.useCase !== "conversation" &&
     file.useCase !== "avatar"

--- a/front-api/routes/w/[wId]/providers/[pId]/check.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/check.ts
@@ -1,6 +1,6 @@
 import type { GetProvidersCheckResponseBody } from "@app/types/api/provider_credentials";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -23,7 +23,7 @@ const app = workspaceApp();
 app.post(
   "/",
   validate("param", ParamsSchema),
-  ensureIsBuilder(),
+  ensureIsAdmin(),
   validate("json", PostCheckBodySchema),
   async (ctx): HandlerResult<GetProvidersCheckResponseBody> => {
     const { pId } = ctx.req.valid("param");

--- a/front-api/routes/w/[wId]/providers/index.ts
+++ b/front-api/routes/w/[wId]/providers/index.ts
@@ -2,7 +2,7 @@ import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import type { GetProvidersResponseBody } from "@app/types/api/providers";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import check from "./[pId]/check";
 import provider from "./[pId]/index";
@@ -23,7 +23,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsBuilder(),
+  ensureIsAdmin(),
   async (ctx): HandlerResult<GetProvidersResponseBody> => {
     const auth = ctx.get("auth");
 

--- a/front/lib/api/assistant/publishing_restrictions.ts
+++ b/front/lib/api/assistant/publishing_restrictions.ts
@@ -1,5 +1,3 @@
-import type { Authenticator } from "@app/lib/auth";
-
 export const PUBLISHING_RESTRICTIONS = {
   builders_and_admins: {
     message: "Publishing agents is restricted to builders and admins.",
@@ -30,21 +28,4 @@ export function getPublishingRestrictionMessage(
 ): string | null {
   const level = getPublishingRestrictionLevel(featureFlags);
   return level ? PUBLISHING_RESTRICTIONS[level].message : null;
-}
-
-function canPublishForRole(
-  role: "admin" | "builder",
-  check: { isAdmin: boolean; isBuilder: boolean }
-): boolean {
-  return role === "admin" ? check.isAdmin : check.isBuilder;
-}
-
-export function canPublishForAuth(
-  auth: Authenticator,
-  level: PublishingRestriction
-): boolean {
-  return canPublishForRole(PUBLISHING_RESTRICTIONS[level].requiredRole, {
-    isAdmin: auth.isAdmin(),
-    isBuilder: auth.isBuilder(),
-  });
 }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -267,7 +267,7 @@ export async function hardDeleteDataSource(
   auth: Authenticator,
   dataSource: DataSourceResource
 ) {
-  assert(auth.isBuilder(), "Only builders can delete data sources.");
+  assert(auth.isAdmin(), "Only admins can delete data sources.");
 
   // Delete all files in the data source's bucket.
   //


### PR DESCRIPTION
## Description

Part of removing `auth.isBuilder()` (dust-tt/tasks#9746, bucket A — server-side authorization). Replaces builder-role gates on several server endpoints/functions with the appropriate permission checks. One focused commit per concern.

### Changes

1. **`data_sources/[dsId]/managed/permissions`** — the `write` filterPermission (default Slack-channel selection in the workspace agent builder) now checks `hasWorkspacePermission("publish", "agent")` instead of `isBuilder()`, consistent with the other Slack-channel / agent-config endpoints (`linked_slack_channels`, `channels_linked_with_agent`).

2. **`dust_app_secrets` (GET)** — now checks `hasWorkspacePermission("admin", "dust_app")` instead of `ensureIsBuilder()`; secrets are part of Dust app administration. POST stays admin-only.

3. **`providers` + `providers/[pId]/check`** — provider settings and credential checks are **admin-only**: `ensureIsBuilder()` → `ensureIsAdmin()`.

4. **`hardDeleteDataSource`** (`lib/api/data_sources.ts`) — `assert(auth.isBuilder())` → `assert(auth.isAdmin())`. This function is only reached from internal/backend flows (temporal scrub, data-retention, scrub-workspace, poke, scripts, migration, run_agent cleanup), all via `internalAdminForWorkspace`, so the assert never distinguished builder from non-builder; making it `isAdmin()` drops the builder dependency without changing effective behavior.

5. **`publishing_restrictions.ts`** — removed the now-unused `canPublishForAuth` / `canPublishForRole` helpers (dead code that referenced `auth.isBuilder()`).

6. **Internal file endpoints (`files/[fileId]/index.ts`)** — no behavior change: `auth.isBuilder()` is intentionally **kept** during the transition (manager supersedes builder), annotated with `TODO(governance)` to swap to `auth.isManager()` once the builder role is removed.

### Notes

- Removed a now-moot `noDirectRoleCheck` biome suppression in `managed/permissions`.
- No tests existed for these routes; `tsgo` + biome clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)