### PR TITLE
[front] gate protected agent tags on agent:publish

### DIFF
--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -1,9 +1,9 @@
 import { useBatchUpdateAgentTags } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { compareForFuzzySort, subFilter, tagsSorter } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -44,8 +44,11 @@ export const AgentEditBar = ({
     owner,
   });
 
+  const { hasPermission } = useWorkspacePermissions();
+  const canPublishAgents = hasPermission("publish", "agent");
+
   const filteredTags = tags
-    .filter((t) => isBuilder(owner) || t.kind !== "protected")
+    .filter((t) => canPublishAgents || t.kind !== "protected")
     .filter((a) => {
       return subFilter(tagSearch, a.name.toLowerCase());
     })

--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -1,9 +1,9 @@
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useUpdateAgentTags } from "@app/lib/swr/tags";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
-import { isBuilder } from "@app/types/user";
 import {
   Button,
   Check,
@@ -39,6 +39,8 @@ export const TableTagSelector = ({
   const updateAgentTags = useUpdateAgentTags({
     owner,
   });
+  const { hasPermission } = useWorkspacePermissions();
+  const canPublishAgents = hasPermission("publish", "agent");
   if (isGlobalAgentId(agentConfigurationId)) {
     return null;
   }
@@ -76,7 +78,7 @@ export const TableTagSelector = ({
             </div>
           ) : (
             tags
-              .filter((t) => isBuilder(owner) || t.kind !== "protected")
+              .filter((t) => canPublishAgents || t.kind !== "protected")
               .map((t) => {
                 const isChecked = agentTags.some((x) => x.sId === t.sId);
                 return (


### PR DESCRIPTION
## Description

Part of removing `auth.isBuilder()` (dust-tt/tasks#9746). `AgentEditBar` and `TableTagSelector` gated the visibility of **protected/restricted agent tags** on the `isBuilder(owner)` type guard. They now gate on the **`agent:publish`** workspace permission (`useWorkspacePermissions().hasPermission("publish", "agent")`), since protected tags are used for published/official agents.

### Changes

- `front/components/assistant/AgentEditBar.tsx`
- `front/components/assistant/manager/TableTagSelector.tsx`

Both drop the `isBuilder` import and filter protected tags with `canPublishAgents` instead. `useWorkspacePermissions()` reads synchronously from the auth context (same shape as the previous check), so no loading changes.

### Testing

No tests exist for these components; `tsgo` + biome clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)