### PR TITLE
[front] Pod-scoped activation next steps + recommendation polish

### DIFF
--- a/front-api/routes/w/[wId]/action-recommendations/index.ts
+++ b/front-api/routes/w/[wId]/action-recommendations/index.ts
@@ -15,16 +15,24 @@ const UpdateRecommendationBodySchema = z.object({
   status: z.enum(["executed", "dismissed"]).optional(),
 });
 
+const ListRecommendationsQuerySchema = z.object({
+  podId: z.string().optional(),
+});
+
 // Mounted at /api/w/:wId/action-recommendations.
 const app = workspaceApp();
 
 /** @ignoreswagger */
 app.get(
   "/",
+  validate("query", ListRecommendationsQuerySchema),
   async (ctx): HandlerResult<GetActivationRecommendationsResponseBody> => {
     const auth = ctx.get("auth");
+    const { podId } = ctx.req.valid("query");
 
-    const recommendations = await listActivationRecommendationsForUser(auth);
+    const recommendations = await listActivationRecommendationsForUser(auth, {
+      podId,
+    });
 
     return ctx.json({ recommendations });
   }

--- a/front/components/assistant/conversation/ActivationNextSteps.tsx
+++ b/front/components/assistant/conversation/ActivationNextSteps.tsx
@@ -23,16 +23,20 @@ import { useContext, useState } from "react";
 
 interface ActivationNextStepsProps {
   owner: LightWorkspaceType;
+  podId?: string;
 }
 
-export function ActivationNextSteps({ owner }: ActivationNextStepsProps) {
+export function ActivationNextSteps({
+  owner,
+  podId,
+}: ActivationNextStepsProps) {
   const router = useAppRouter();
   const { setPendingInputText, setShouldFocusInput } =
     useContext(InputBarContext);
   const [isOpen, setIsOpen] = useState(false);
 
   const { recommendations, isRecommendationsLoading, mutateRecommendations } =
-    useActivationRecommendations({ workspaceId: owner.sId });
+    useActivationRecommendations({ workspaceId: owner.sId, podId });
   const { updateRecommendation } = useUpdateActivationRecommendation({
     workspaceId: owner.sId,
   });
@@ -91,7 +95,11 @@ export function ActivationNextSteps({ owner }: ActivationNextStepsProps) {
           <Icon visual={ChevronDown} size="xs" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="center" className="w-[420px] p-0">
+      <PopoverContent
+        align="center"
+        className="w-[440px] max-w-[90vw] p-0"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <div className="flex flex-col">
           {recommendations.map((rec) => (
             <div
@@ -106,7 +114,7 @@ export function ActivationNextSteps({ owner }: ActivationNextStepsProps) {
                 <span className="truncate text-sm font-semibold text-foreground">
                   {rec.title}
                 </span>
-                <span className="truncate text-xs text-muted-foreground">
+                <span className="line-clamp-2 text-xs text-muted-foreground">
                   {rec.content}
                 </span>
               </div>

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -1,3 +1,4 @@
+import { ActivationNextSteps } from "@app/components/assistant/conversation/ActivationNextSteps";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
@@ -196,7 +197,10 @@ export function PodConversationsTab({
         >
           <div className="flex w-full flex-col gap-3">
             <PodPinnedBanner owner={owner} podInfo={podInfo} />
-            <div className="flex items-center gap-2">
+            <div className="flex w-full justify-center">
+              <ActivationNextSteps owner={owner} podId={podInfo.sId} />
+            </div>
+            <div className="flex w-full items-center justify-center gap-2">
               <h2
                 className={cn(
                   "heading-2xl text-foreground",

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -14,19 +14,19 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     schema: {
       title: z
         .string()
-        .max(4096)
+        .max(60)
         .describe(
-          "Action label shown in the recommendations list (6-8 words). " +
+          "Short action label shown in the recommendations list (3-5 words, keep it tight). " +
             "Be specific enough that the user knows exactly what they would be doing. " +
-            "Example: 'Ask about recent Slack decisions'."
+            "Example: 'Ask about Slack decisions'."
         ),
       content: z
         .string()
-        .max(4096)
+        .max(100)
         .describe(
-          "Brief subtitle shown under the title in the recommendations list (8-10 words). " +
+          "Very brief subtitle shown under the title in the recommendations list (6-8 words max). " +
             "Explain the 'how' or 'why' in plain language. " +
-            "Example: 'Find past decisions in your Slack workspace in seconds'."
+            "Example: 'Find past decisions in Slack fast'."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 
 const NEXT_STEPS_WINDOW_DAYS = 30;
 const NEXT_STEPS_LIMIT = 5;
@@ -21,13 +22,24 @@ export interface UpdateActivationRecommendationResponseBody {
 }
 
 export async function listActivationRecommendationsForUser(
-  auth: Authenticator
+  auth: Authenticator,
+  { podId }: { podId?: string } = {}
 ): Promise<ActivationRecommendationForUserType[]> {
+  let spaceModelId: number | undefined;
+  if (podId !== undefined) {
+    const space = await SpaceResource.fetchById(auth, podId);
+    if (!space) {
+      return [];
+    }
+    spaceModelId = space.id;
+  }
+
   const recs = await ActivationRecommendationResource.listSuggestedByUser(
     auth,
     {
       limit: NEXT_STEPS_LIMIT,
       sinceDaysAgo: NEXT_STEPS_WINDOW_DAYS,
+      spaceModelId,
     }
   );
 

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -115,7 +115,11 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
 
   static async listSuggestedByUser(
     auth: Authenticator,
-    { limit = 5, sinceDaysAgo }: { limit?: number; sinceDaysAgo?: number } = {}
+    {
+      limit = 5,
+      sinceDaysAgo,
+      spaceModelId,
+    }: { limit?: number; sinceDaysAgo?: number; spaceModelId?: ModelId } = {}
   ): Promise<
     {
       resource: ActivationRecommendationResource;
@@ -141,7 +145,10 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
         {
           model: ConversationModel,
           attributes: ["sId"],
-          required: false,
+          required: spaceModelId !== undefined,
+          ...(spaceModelId !== undefined
+            ? { where: { spaceId: spaceModelId } }
+            : {}),
         },
       ],
       order: [["createdAt", "DESC"]],

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -20,9 +20,8 @@ import {
    and only the newest thing on the page is ever fully expanded.
 
    LEVEL is set by the agent from pod state each interaction:
-     "day1"  — pod intro + how-it-works timeline + "your first
-               idea is waiting in the chat". Nothing else exists,
-               so nothing else renders.
+     "day1"  — pod intro + how-it-works timeline. Nothing else
+               exists, so nothing else renders.
      "grown" — greeting + the latest result (expanded) + any
                collapsed Running/Earlier rows + exactly one Next
                idea + how-it-works decayed to a collapsed row.
@@ -186,12 +185,6 @@ function DayOneView() {
       </Reveal>
 
       <HowItWorksTimeline />
-
-      <Reveal i={HOW_IT_WORKS.length + 2}>
-        <p className="text-center text-sm text-muted-foreground">
-          Your first idea is waiting in the chat, right next to this page.
-        </p>
-      </Reveal>
     </div>
   );
 }
@@ -422,9 +415,6 @@ function BannerDay1() {
           );
         })}
       </div>
-      <p className="mt-auto text-xs text-muted-foreground">
-        Your first idea is waiting in the chat.
-      </p>
     </div>
   );
 }

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -12,17 +12,23 @@ import type { Fetcher } from "swr";
 
 export function useActivationRecommendations({
   workspaceId,
+  podId,
   disabled,
 }: {
   workspaceId: string;
+  podId?: string;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const recommendationsFetcher: Fetcher<GetActivationRecommendationsResponseBody> =
     fetcher;
 
+  const url = podId
+    ? `/api/w/${workspaceId}/action-recommendations?podId=${podId}`
+    : `/api/w/${workspaceId}/action-recommendations`;
+
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/action-recommendations`,
+    url,
     recommendationsFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Summary
- Adding "Your next steps" banner directly above pod conversation (scoped to conversations in the pod)
- Removing unnecessary frame template information accordingly

## Testing

<img width="832" height="266" alt="Screenshot 2026-07-24 at 4 57 30 PM" src="https://github.com/user-attachments/assets/f726758c-5b5d-4e3e-97ac-e066433cf1dc" />

## Risk

Low, still behind FF

## Deploy
1. Deploy front