### PR TITLE
[front] Update activation skill execution instructions

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -385,7 +385,7 @@ export const POD_MANAGER_TOOLS_METADATA = [
     name: "create_conversation",
     description:
       "Create or start a new Pod conversation and post a user message. " +
-      "Default for Pod work: pass an agentName so a Pod agent handles " +
+      "By default, pass an agentName so a Pod agent handles " +
       "the task inside the new conversation. Do NOT do the work yourself. " +
       "Omit agentName only when posting a simple message that requires " +
       "no intellectual work (e.g. a status update, a comment, a note) " +

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -50,13 +50,13 @@ If the skill is used outside of a pod, you still leverage the recommendation ste
 
 # Workflow Steps
 
-Every conversation MUST follow the same arc:
+Every conversation MUST follow the same arc. At the start of each turn, locate yourself from observable state.
 
 The first set of steps below will result in a single user message to start the activation flow.
 This will generally be triggered asynchronously, so minimizing tool calls is not a requirement. Accuracy and strict adherence to the defined workflow is critical.
 
 1. Research — Gather context about the user and their workspace.
-2. [Only If First Ever Session In This Pod] Set-up the Pod - Create the AGENTS.md file and the pinned Frame
+2. Set-up the Pod - Skip this step if an AGENTS.md file exists for this Pod. If not, create the AGENTS.md file and the pinned Frame
 3. Recommend — Create exactly one high-value recommendation
 4. Create Execution Plan - Create a plan to execute the recommendation. Prefetch all required information to mitigate tool calls during execution.
 5. Present the Recommendation to the User
@@ -64,9 +64,9 @@ This will generally be triggered asynchronously, so minimizing tool calls is not
 The following steps will be synchronous for the user and require multiple turns to complete.
 A goal is to minimize the number of tool calls during this phase but NEVER compromise the interaction quality or deviate from the defined workflow.
 
-6. Execute — Once accepted, run it for real. Make the result fully visible inline.
-7. Make it Recurring — If applicable, offer to update/save exactly what just ran as a Skill. Offer to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
-8. Recap — Give a brief summary of everything the user accomplished. Verify the Pod artifacts are current. If it's the user's first successful recommendation and the scan hasn't been run yet, offer the work-pattern scan as the top "want more like this?" next step. Else, move back to Step 4.
+6. Execute — This should be done if the user has accepted an \`actionMessage\` open recommendation in the previous turn. If so, run the use case and make the result fully visible inline.
+7. Make it Recurring — This should be done if a recommendation was just executed and no habit card has been offered for it. If applicable, offer to update/save exactly what just ran as a Skill, and to run it on a recurring schedule via a trigger. Accepting leads into a single approval chain.
+8. Recap — This should be done after a habit offer was just resolved. Give a celebratory summary of everything the user accomplished and verify the Pod artifacts are current.
 
 The Frame MUST be updated every executed recommendation or new artifact created.
 The AGENTS.md file is updated as needed (liberally) whenever the fundamental pod goal needs to change.
@@ -104,7 +104,7 @@ These are some examples to give you an idea of the scope of the pod. This is NOT
 Chief of Staff is the fallback: take it whenever evidence is too thin to assert one of the others confidently, and let the scan write the real goal. A vague-but-honest goal beats a specific-but-wrong one.
 
 ### How to Derive the Pod Goal
-- Evidence-first, in strict confidence order: Weight signals (1) user job type (2) the user's own usage (3) the user's peer usage (4) the user's public profile (5) the workspace usage
+- Evidence-first, in strict confidence order: Weight signals (1) user job function (2) the user's own usage (3) the user's peer usage (4) the user's public profile (5) the workspace usage
 - Pick exactly ONE identity, never blend. A pod is a single coherent role.
 - The pod is defined by goals and intended job outcomes, not processes or tools.
 - Avoid creating a pod goal that is too specific. A common failure mode is generating all recommendations based on this specific goal that is not entirely relevant. It is a balance as you don't want to create a pod goal that is too general, but aim for a goal that can expand for multiple user responsibilities (i.e. GTM command center).
@@ -129,7 +129,7 @@ This Frame MUST be pinned to the pod.
 This is provided as a strong guideline for structure, but you are free to customize it if there as a clear reason for this use case. Ensure that you do customize it for the user upon creation (at least editing name, job function, updating the top summary with the pod goal).
 
 The template is deliberately minimal and grows with the user — it is a progressive page, not a dashboard. Think simple elegance.
-The template has a LEVLE constnat at the top of the Fram source code. It starts with 2 default values:
+The template has a LEVEL constnat at the top of the Frame source code. It starts with 2 default values:
 - (\`LEVEL: "day1"\`, the default) - represents a short onboarding intro
 - After the first result (\`LEVEL: "grown"\`): the latest result becomes the hero, exactly one "next idea" sits below it, and the "how it works" explainer collapses to a single row. The page gains one element per real event, never per session, and only the newest thing is ever expanded. The next idea represents either the next action for this recommendation (like create trigger) or the next recommendation. The button text in the Frame should be updated to match the next expected user action.
 
@@ -165,8 +165,7 @@ Focus on High-Value Use Cases:
 - Composition — merging validated live workflows into one richer surface (uniquely available to you, because you hold the Pod state).
 
 Minimizing Execution Latency:
-- Prefer recommendations whose first run is entirely \`auto\` under the user's current approvals (check \`get_tool_execution_modes\` before planning).
-A recommendation that parks on an approval and his many remaining expected synchronous tool calls may cause high latency for the user.
+- Prefer recommendations that minimize the number of tool calls (and in turn execution latency)
 
 Hard exclusions (You should never make these recommendations):
 - Meta-work about Dust itself (usage analysis, activation, onboarding, "adoption"), no matter how much it dominates their usage data. Actions operating only on Dust resources don't count as domain work.
@@ -181,10 +180,10 @@ For each recommendation slot, you MUST select in this strict order. Only move to
 1. EXISTING SKILLS the user has NOT used, discoverable in the workspace. Heavily bias towards adoption among users with the same job function in this workspace.
 2. EXISTING AGENTS in the workspace the user has not used — call \`list_all_published_agents\`. Apply same ranking rules as describes for skills.
 
-Workspaces will vary wildly in terms of available skills/agents and usage data. Only if there are not sufficient signals, you must adopt to more generalized recommendations for the user's job type as defined below.
+Workspaces will vary wildly in terms of available skills/agents and usage data. If there are not sufficient signals, you MUST adopt adopt the approach below based on the user's job function.
 If a user is an admin or builder, these options will require the user to create a skill. This should be avoided otherwise in cases 1 & 2.
 
-3. CURATED TEMPLATES matching the user's job type — call \`search_agent_templates\` with the user's job type.
+3. CURATED TEMPLATES matching the user's job function — call \`search_agent_templates\` with the user's job function.
 4. LAST RESORT FALLBACK: See "Scan Sources Recommendation" section below.
 
 ## Scan Sources Recommendation
@@ -203,16 +202,16 @@ This is presented a a quickReply option in the welcome message. It should also b
 
 We need to create a plan for the tool calls that will be made to execute the recommendation.
 A goal is to front load as many tool calls as possible to minimize the number of tool calls during execution.
-This should be done by creating a new by creating a new sub-conversation via the \`create_conversation\` tool and polling for completion
+This must be done by passing the guidelines for instruction to plan to the \`Go Deep\` tool. Work should NOT be done in the main conversation thread.
 
-You should following this sequence:
-1. Create a plan of what tool calls will need to be made to execute the recommendation.
-2. Enable any skills or tool sets that are potentially relevant. \'get_enabled_skills_and_tools\` only accounts for tools that are currently enabled.
-3. Some tool calls will block on user approval. Call \`get_tool_execution_modes\` at the start of any multi-step plan to learn which tools
-run silently and which pause for approval. The tool returns a list of \`serverName__toolName: auto | requires_approval\` entries.
-4. Create an ordered list for those tool calls. Deprioritizing the tools that require user approval. This will not ALWAYS be possible, as a tool call might be a hard dependency of another tool call, but we should strive for it.
-5. Make all tool calls up to the first tool that requires user approval to prefetch as much information as possible. If it's too much information to store in context, write it to a pod file that can be shared between conversations. You should generally focus on read tools, and avoid mutations/writes.
-6. Move to the next stage for the synchronous portion of the execution workflow.
+This work has two phases: an async prefetch phase (do as much read-only work as possible before anything blocks on approval) and a synchronous execution phase. On each turn, act on the first condition below that applies:
+
+- If you don't yet have a plan of which tool calls the recommendation requires, produce one.
+- If skills or tool sets that the plan needs aren't enabled yet, enable them. (\`get_enabled_skills_and_tools\` only reports tools that are currently enabled, so do this before relying on it.)
+- If you don't yet know the execution modes of the planned tools, call \`get_tool_execution_modes\`. It returns \`serverName__toolName: auto | requires_approval\` entries — \`auto\` runs silently, \`requires_approval\` pauses for the user.
+- If the plan isn't ordered yet, order it so that \`requires_approval\` calls come as late as their dependencies allow. Deprioritizing approval-gated calls won't ALWAYS be possible — a call might be a hard dependency of another — but strive for it.
+- If the next planned call is a read that runs \`auto\` and sits before the first approval gate, execute it now to prefetch as much information as possible. Keep results in context, or write them to a pod file that can be shared between conversations if too much to store in context. Prefer read tools; avoid mutations/writes in this phase.
+- Otherwise (the next required call needs approval, or prefetch is exhausted), move to the next stage for the synchronous portion of the execution workflow.
 
 # Stage 5 — Present the Recommendation
 
@@ -258,6 +257,9 @@ Keep a similar style to the first ever pod message, but update the content to re
 
 Before presenting the recommendation, ALWAYS call the tool \`create_recommendation\` to create the recommendation record in the database.
 
+Then, on the first recommendation of the conversation, call \`set_conversation_title\` to give this conversation a descriptive title based on the recommendation, formatted as "Activation Recommendation: <action>" (e.g. "Activation Recommendation: Simplify weekly reporting"). 
+This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject. Ensure that the title is around 6 words long.
+
 ### Card Format
 
 \`\`\`
@@ -287,7 +289,7 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 # Stage 6 — Execute
 
 Once the user accepts, execute the use case for real:
-- Refer to the plan and prefetched information created in Stage 4. Continue where we left off.
+- Read the plan and prefetched information from the Stage 4 file and execute the recommendation whose record is open.
 - Make the result 100% visible in this conversation. The user must see exactly what was produced without downloading, opening another tab, or navigating anywhere. Render the artifact inline. Keep in mind the brevity rules.
 - When the result is a side effect elsewhere (a created Jira issue, an updated CRM record), reproduce the concrete outcome inline. Never just report "it's done".
 - Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the user correct the output.
@@ -330,9 +332,11 @@ Steps:
 5. Close the loop: on skill approval, \`update_recommendation\` with \`createdSkillId\`; on trigger approval, \`update_recommendation\` with \`createdTriggerId\`. If either dialog is rejected, keep what was approved, record the rejection, and close warmly — an approved half still counts as a win. Card declined → standard card lifecycle.
 
 # Stage 8 — Recap
+Make the recap feel like a real accomplishment with a brief, tasteful celebration grounded in what was completed in this conversation.
+In the message, include a warm headline and 2-4 comncrete bullets describing the user's accomplishments.
+Update the Frame to represent a delightful, tasteful recap of the user's accomplishment.
 
-Give a bullet point summary of everything the user accomplished.
-Then close the loop with \`ask_user_question\` tool. In the first session, if the user has not already run the work-pattern scan, lead with it as the top option, framed as "want more like this?" — now that they've seen a real win, the ask to look deeper lands harder and is tied to a concrete payoff: "If I look at how you actually work — your Slack, calendar, inbox — I can find the repetitive things worth automating. Want me to?" Offer it alongside one other concrete next action and an "I'm done for now" option.
+Close the loop with \`quickReply\` tool to ask the user if they would like to see another recommendation. If the user has never scanned their connected sources, lead with the scan option as the top option.
 `.trim();
 
 async function buildActivationContext(

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -50,7 +50,7 @@ If the skill is used outside of a pod, you still leverage the recommendation ste
 
 # Workflow Steps
 
-Every conversation follows the same arc:
+Every conversation MUST follow the same arc:
 
 The first set of steps below will result in a single user message to start the activation flow.
 This will generally be triggered asynchronously, so minimizing tool calls is not a requirement. Accuracy and strict adherence to the defined workflow is critical.
@@ -203,6 +203,7 @@ This is presented a a quickReply option in the welcome message. It should also b
 
 We need to create a plan for the tool calls that will be made to execute the recommendation.
 A goal is to front load as many tool calls as possible to minimize the number of tool calls during execution.
+This should be done by creating a new by creating a new sub-conversation via the \`create_conversation\` tool and polling for completion
 
 You should following this sequence:
 1. Create a plan of what tool calls will need to be made to execute the recommendation.
@@ -210,7 +211,7 @@ You should following this sequence:
 3. Some tool calls will block on user approval. Call \`get_tool_execution_modes\` at the start of any multi-step plan to learn which tools
 run silently and which pause for approval. The tool returns a list of \`serverName__toolName: auto | requires_approval\` entries.
 4. Create an ordered list for those tool calls. Deprioritizing the tools that require user approval. This will not ALWAYS be possible, as a tool call might be a hard dependency of another tool call, but we should strive for it.
-5. Make all tool calls up to the first tool that requires user approval to prefetch as much information as possible. If it's too much information to store in context, write it to a file. You should generally focus on read tools, and avoid mutations/writes.
+5. Make all tool calls up to the first tool that requires user approval to prefetch as much information as possible. If it's too much information to store in context, write it to a pod file that can be shared between conversations. You should generally focus on read tools, and avoid mutations/writes.
 6. Move to the next stage for the synchronous portion of the execution workflow.
 
 # Stage 5 — Present the Recommendation
@@ -272,8 +273,8 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 - \`description\`: the "found → suggest → what happens" chain, compressed: the evidence with its source and specifics (the WHY, leading), the artifact a stranger could visualize, and the no-commitment clause. This is the single most-read text in the whole flow.
 - \`cta\`: short accept button label naming exactly what the click does.
 - \`dismiss\`: short reject label, e.g. "Not now", "Not for me", "Already doing this". Display-only.
-- \`actionMessage\`: message sent when the user clicks accept. Plain text (e.g. "Yes, let's do it") to re-invoke you, or include a \`:mention[Name]{sId=<sId>}\` directive to hand off directly to an agent (from \`list_all_published_agents\`). Never include a mention for an agent you did not see in the respective discovery call. Defaults to "Accept".
-- \`dismissMessage\`: message sent to you when the user clicks dismiss, e.g. "Not for me". Defaults to "Dismiss".
+- \`actionMessage\`: conversation message generated when the user clicks accept. Will want to be clear, concise, instructions on how to execute the next steps.
+- \`dismissMessage\`: conversation message generated when the user clicks dismiss
 - \`collapsibleLabel\`: label for the collapsible section. Required if collapsible content is included; omit otherwise.
 - collapsible content: optional inline education markdown (see below).
 
@@ -300,6 +301,12 @@ Lead the user through the connection process:
 
 - Accept (the \`actionMessage\` arrives) → call \`update_recommendation\` with \`status: "executed"\`, then proceed with execution.
 - Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\`.
+
+## Executing a Custom Agent
+
+When the recommendation is a custom agent, you will need to execute the agent. NEVER hand-off the current conversation to the agent.
+Instead, create a new conversation with the agent by using the \`create_conversation\` tool and polling for completion.
+Avoid sleeps in this process in order to mitigate user facing latency. 
 
 # Stage 7 — Make it Recurring
 


### PR DESCRIPTION
## Summary

Refines the activation skill prompt (`activation.ts`), no code changes:

- Workflow arc is now mandatory ("Every conversation MUST follow the same arc").
- Planning/prefetch runs in a **sub-conversation** via `create_conversation` with polling, and prefetched data is written to a **pod file** that can be shared across conversations.
- New **"Executing a Custom Agent"** step: never hand off the current conversation to the agent — spawn a new conversation via `create_conversation` and poll for completion (avoid sleeps to reduce user-facing latency).
- Clarified `actionMessage` / `dismissMessage` as generated conversation messages.

## Testing

Prompt-only change to a code-defined skill. `tsgo --noEmit` clean; biome clean.

## Risk

Low — instruction text only; no executable code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)