### PR TITLE
Focus on text content for agent message in getLightConversation()

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -88,7 +88,8 @@ export const getLightConversation = async (
     branchId,
     "light",
     lastInteractionsToFetchToolOutputContentFor,
-    messagePagination
+    messagePagination,
+    true
   );
 
 // Batch size (in interactions) for extending the tool-output-content fetch window beyond the
@@ -142,7 +143,8 @@ async function _getConversation<V extends "light" | "full">(
   branchId: string | null = null,
   viewType: V = "full" as V,
   lastInteractionsToFetchToolOutputContentFor: number | null = null,
-  messagePagination?: { limit: number; lastRank: number | null }
+  messagePagination?: { limit: number; lastRank: number | null },
+  textContentOnly: boolean = false
 ): Promise<
   Result<
     (V extends "light"
@@ -308,7 +310,8 @@ async function _getConversation<V extends "light" | "full">(
     conversation,
     messages,
     viewType,
-    messagesWithToolOutputContent
+    messagesWithToolOutputContent,
+    textContentOnly
   );
 
   if (renderRes.isErr()) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -356,7 +356,8 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   messages: MessageModel[],
   viewType: V,
   messagesWithToolOutputContent: Set<ModelId> | null = null,
-  mentionsByMessageId: Map<ModelId, MentionModel[]>
+  mentionsByMessageId: Map<ModelId, MentionModel[]>,
+  textContentOnly: boolean = false
 ): Promise<
   Result<
     V extends "full" ? AgentMessageType[] : LightAgentMessageType[],
@@ -439,6 +440,7 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       AgentStepContentResource.fetchByAgentMessages(auth, {
         agentMessageIds,
         latestVersionsOnly: true,
+        textContentOnly,
       }),
     async () =>
       getMessagesReactions(auth, {
@@ -473,7 +475,7 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   let agentMCPActionsWithoutContent: AgentMCPActionResource[] = [];
 
   for (const action of allAgentMCPActions) {
-    // Light messages always exclude content for all actions.
+    // Light messages always exclude tool output content for all actions.
     // Otherwise, for full messages, we only include content for the actions that are in the optional outputItemContentOnlyForMessageIds.
     if (
       viewType === "light" ||
@@ -892,7 +894,8 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
   conversation: ConversationResource,
   messages: MessageModel[],
   viewType: V,
-  messagesWithToolOutputContent: Set<ModelId> | null = null
+  messagesWithToolOutputContent: Set<ModelId> | null = null,
+  textContentOnly: boolean = false
 ): Promise<
   Result<
     V extends "full"
@@ -936,7 +939,8 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     messages,
     viewType,
     messagesWithToolOutputContent,
-    mentionsByMessageId
+    mentionsByMessageId,
+    textContentOnly
   );
 
   if (agentMessagesRes.isErr()) {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -165,10 +165,12 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       agentMessageIds,
       transaction,
       latestVersionsOnly = false,
+      textContentOnly = false,
     }: {
       agentMessageIds: ModelId[];
       transaction?: Transaction;
       latestVersionsOnly?: boolean;
+      textContentOnly?: boolean;
     }
   ): Promise<AgentStepContentResource[]> {
     const owner = auth.getNonNullableWorkspace();
@@ -185,6 +187,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         this.model.findAll({
           where: {
             workspaceId: owner.id,
+            ...(textContentOnly ? { type: "text_content" } : {}),
             agentMessageId: {
               [Op.any]: Sequelize.literal("$agentMessageIds::bigint[]"),
             },


### PR DESCRIPTION
## Description

`getLightConversation()` now passes `textContentOnly=true` down through `_getConversation` → `batchRenderMessages` → `batchRenderAgentMessages` → `AgentStepContentResource.fetchByAgentMessages`. In `fetchByAgentMessages`, the new flag adds a `type: "text_content"` WHERE clause to the DB query, so non-text step content (tool outputs, images, etc.) is skipped entirely when rendering light agent messages.

Light conversation consumers — notification workflows, unread counts, pod conversation lists — only need the text portions of agent messages, not the full step content graph. This reduces DB load on those read paths.

## Tests

Tested manually by verifying light conversation endpoints still return correct agent message text content.

## Risk

Low. The `textContentOnly` flag is only set on the `getLightConversation()` path; all full-conversation fetches are unaffected. The DB filter narrows an existing query without changing the schema.

## Deploy Plan

Deploy front.
