### PR TITLE
feat: bulk set model from Managed Agents

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -1,4 +1,7 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  archiveAgentConfiguration,
+  getAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -81,6 +84,45 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", (
     expect(updated?.instructions).toBe(agent.instructions);
     expect(updated?.scope).toBe(agent.scope);
     expect(updated?.tags.map((t) => t.sId)).toEqual([tag.sId]);
+  });
+
+  it("updates what it can and reports the rest as skipped", async () => {
+    const { workspace, auth, agent } = await setupTest("admin");
+    const target = await findTargetModel(auth);
+
+    // An archived agent cannot be re-saved: a new version would make it active again.
+    const archivedAgent = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      {
+        name: "Archived Test Agent",
+        model: { ...INITIAL_MODEL },
+      }
+    );
+    await archiveAgentConfiguration(auth, archivedAgent.sId);
+
+    const res = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId, archivedAgent.sId],
+      modelId: target.modelId,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updatedAgentIds).toEqual([agent.sId]);
+    expect(body.skippedAgentIds).toEqual([archivedAgent.sId]);
+
+    const updated = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(updated?.model.modelId).toBe(target.modelId);
+
+    const skipped = await getAgentConfiguration(auth, {
+      agentId: archivedAgent.sId,
+      variant: "light",
+    });
+    expect(skipped?.model.modelId).toBe(INITIAL_MODEL.modelId);
+    expect(skipped?.status).toBe("archived");
+    expect(skipped?.version).toBe(archivedAgent.version);
   });
 
   it("rejects a model that is not available in the workspace", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -1,0 +1,122 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
+import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+const INITIAL_MODEL = {
+  providerId: "openai",
+  modelId: "gpt-5-mini",
+} as const;
+
+function postBatchUpdateModel(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/batch_update_model`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+// A selectable model that differs from the one the test agents start with.
+async function findTargetModel(auth: Authenticator) {
+  const { models } = await getModelsForAuth(auth);
+  const target = models.find(
+    (m) => m.isSelectable && m.modelId !== INITIAL_MODEL.modelId
+  );
+  assert(target, "Expected another selectable model to be available.");
+  return target;
+}
+
+async function setupTest(role: "admin" | "user") {
+  const { workspace, auth } = await createPrivateApiMockRequest({ role });
+
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+    model: { ...INITIAL_MODEL },
+  });
+
+  const tag = await TagResource.makeNew(auth, {
+    name: "Test Tag",
+    kind: "standard",
+  });
+  await tag.addToAgent(auth, agent);
+
+  return { workspace, auth, agent, tag };
+}
+
+describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", () => {
+  it("saves a new version of the selected agents with the new model", async () => {
+    const { workspace, auth, agent, tag } = await setupTest("admin");
+    const target = await findTargetModel(auth);
+
+    const res = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId],
+      modelId: target.modelId,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updatedAgentIds).toEqual([agent.sId]);
+    expect(body.skippedAgentIds).toEqual([]);
+
+    const updated = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(updated?.model.providerId).toBe(target.providerId);
+    expect(updated?.model.modelId).toBe(target.modelId);
+    // Reasoning effort defaults to the target model's own default.
+    expect(updated?.model.reasoningEffort).toBe(target.defaultReasoningEffort);
+
+    // A new version was created, and everything else was carried over.
+    expect(updated?.version).toBe(agent.version + 1);
+    expect(updated?.name).toBe(agent.name);
+    expect(updated?.description).toBe(agent.description);
+    expect(updated?.instructions).toBe(agent.instructions);
+    expect(updated?.scope).toBe(agent.scope);
+    expect(updated?.tags.map((t) => t.sId)).toEqual([tag.sId]);
+  });
+
+  it("rejects a model that is not available in the workspace", async () => {
+    const { workspace, auth, agent } = await setupTest("admin");
+
+    const res = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId],
+      modelId: "not-a-model",
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain("not available");
+
+    const updated = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(updated?.model.modelId).toBe(INITIAL_MODEL.modelId);
+  });
+
+  it("rejects non-admin members", async () => {
+    const { workspace, auth, agent } = await setupTest("user");
+    const target = await findTargetModel(auth);
+
+    const res = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId],
+      modelId: target.modelId,
+    });
+
+    expect(res.status).toBe(403);
+
+    const updated = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(updated?.model.modelId).toBe(INITIAL_MODEL.modelId);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.ts
@@ -1,0 +1,76 @@
+import { updateAgentConfigurationsModel } from "@app/lib/api/assistant/configuration/model_update";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import type { BatchUpdateAgentModelResponseBody } from "@app/types/api/assistant/configuration";
+import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const BatchUpdateAgentModelRequestBodySchema = z.object({
+  agentIds: z.array(z.string()),
+  modelId: z.string(),
+  // Both default to what picking that model in the agent builder would do: the model's own
+  // default reasoning effort, and the agent's existing response format.
+  reasoningEffort: z.enum(ORDERED_REASONING_EFFORTS).optional(),
+  responseFormat: z.string().optional(),
+});
+
+// Mounted at /api/w/:wId/assistant/agent_configurations/batch_update_model.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", BatchUpdateAgentModelRequestBodySchema),
+  async (ctx): HandlerResult<BatchUpdateAgentModelResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const isSaveAgentConfigurationsEnabled =
+      await KillSwitchResource.isKillSwitchEnabled("save_agent_configurations");
+    if (isSaveAgentConfigurationsEnabled) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "Saving agent configurations is temporarily disabled, try again later.",
+        },
+      });
+    }
+
+    const { agentIds, modelId, reasoningEffort, responseFormat } =
+      ctx.req.valid("json");
+
+    // Not atomic: each agent is saved as a new version on its own, and the ones that could not
+    // be updated are reported back as skipped.
+    const result = await updateAgentConfigurationsModel(auth, {
+      agentIds,
+      modelId,
+      reasoningEffort,
+      responseFormat,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    const { updatedAgentIds, skippedAgentIds } = result.value;
+
+    return ctx.json({
+      success: true as const,
+      updatedAgentIds,
+      skippedAgentIds,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -22,6 +22,7 @@ import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 
 import agent from "./[aId]";
+import batchUpdateModel from "./batch_update_model";
 import batchUpdateScope from "./batch_update_scope";
 import batchUpdateTags from "./batch_update_tags";
 import createPending from "./create-pending";
@@ -330,6 +331,7 @@ app.post(
 
 // Register static paths BEFORE `/:aId` so the param route does not swallow
 // these names as agent ids.
+app.route("/batch_update_model", batchUpdateModel);
 app.route("/batch_update_scope", batchUpdateScope);
 app.route("/batch_update_tags", batchUpdateTags);
 app.route("/create-pending", createPending);

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -149,7 +149,6 @@ export const AgentEditBar = ({
           owner={owner}
           agentConfigurations={selectedAgents}
           disabled={selectedAgents.length === 0 || isLoading}
-          mutateAgentConfigurations={mutateAgentConfigurations}
         />
         <UnpublishAssistantsDialog
           owner={owner}

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -20,6 +20,7 @@ import {
 import { useState } from "react";
 
 import { DeleteAssistantsDialog } from "./DeleteAssistantsDialog";
+import { SetModelAssistantsDialog } from "./SetModelAssistantsDialog";
 import { UnpublishAssistantsDialog } from "./UnpublishAssistantsDialog";
 
 type AgentEditBarProps = {
@@ -144,6 +145,12 @@ export const AgentEditBar = ({
             </DropdownMenuTagList>
           </DropdownMenuContent>
         </DropdownMenu>
+        <SetModelAssistantsDialog
+          owner={owner}
+          agentConfigurations={selectedAgents}
+          disabled={selectedAgents.length === 0 || isLoading}
+          mutateAgentConfigurations={mutateAgentConfigurations}
+        />
         <UnpublishAssistantsDialog
           owner={owner}
           agentConfigurations={selectedAgents}

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -11,7 +11,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   CpuChip01,
-  cn,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -147,18 +146,10 @@ export function SetModelAssistantsDialog({
                     customItem={
                       <Label
                         htmlFor={itemId}
-                        className={cn(
-                          "flex min-w-0 grow items-center gap-2",
-                          model.isSelectable
-                            ? "cursor-pointer"
-                            : "cursor-not-allowed opacity-70"
-                        )}
+                        className="flex min-w-0 grow cursor-pointer items-center gap-2"
                       >
                         <Icon
-                          visual={getModelMakerLogo(
-                            getModelMaker(model),
-                            isDark
-                          )}
+                          visual={getModelMakerLogo(getModelMaker(model), isDark)}
                           size="md"
                           className="flex-shrink-0"
                         />

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -149,7 +149,10 @@ export function SetModelAssistantsDialog({
                         className="flex min-w-0 grow cursor-pointer items-center gap-2"
                       >
                         <Icon
-                          visual={getModelMakerLogo(getModelMaker(model), isDark)}
+                          visual={getModelMakerLogo(
+                            getModelMaker(model),
+                            isDark
+                          )}
                           size="md"
                           className="flex-shrink-0"
                         />

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -1,6 +1,9 @@
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useBatchUpdateAgentModel } from "@app/lib/swr/assistants";
+import {
+  useAgentConfigurations,
+  useBatchUpdateAgentModel,
+} from "@app/lib/swr/assistants";
 import { useModels } from "@app/lib/swr/models";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
@@ -34,14 +37,12 @@ interface SetModelAssistantsDialogProps {
   agentConfigurations: LightAgentConfigurationType[];
   disabled: boolean;
   owner: LightWorkspaceType;
-  mutateAgentConfigurations: () => Promise<unknown>;
 }
 
 export function SetModelAssistantsDialog({
   agentConfigurations,
   disabled,
   owner,
-  mutateAgentConfigurations,
 }: SetModelAssistantsDialogProps) {
   const { isDark } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
@@ -52,6 +53,13 @@ export function SetModelAssistantsDialog({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const { models, isModelsLoading } = useModels({ owner, disabled: !isOpen });
+
+  const { mutateRegardlessOfQueryParams: mutateAgentConfigurations } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: "list", // Anything would work
+      disabled: true, // We only use the hook to mutate the cache
+    });
 
   const batchUpdateAgentModel = useBatchUpdateAgentModel({ owner });
 
@@ -196,7 +204,7 @@ export function SetModelAssistantsDialog({
                 agentConfigurations.map((a) => a.sId),
                 { modelId: selectedModel.modelId }
               );
-              await mutateAgentConfigurations();
+              void mutateAgentConfigurations();
               setIsSaving(false);
               if (success) {
                 setIsOpen(false);

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -1,0 +1,216 @@
+import { getModelMakerLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useBatchUpdateAgentModel } from "@app/lib/swr/assistants";
+import { useModels } from "@app/lib/swr/models";
+import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { getModelMaker } from "@app/types/assistant/models/providers";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  CpuChip01,
+  cn,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Icon,
+  Label,
+  RadioGroup,
+  RadioGroupCustomItem,
+  SearchInput,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useRef, useState } from "react";
+
+const NOT_SELECTABLE_MODEL_DESCRIPTION = "Not enabled for you.";
+
+interface SetModelAssistantsDialogProps {
+  agentConfigurations: LightAgentConfigurationType[];
+  disabled: boolean;
+  owner: LightWorkspaceType;
+  mutateAgentConfigurations: () => Promise<unknown>;
+}
+
+export function SetModelAssistantsDialog({
+  agentConfigurations,
+  disabled,
+  owner,
+  mutateAgentConfigurations,
+}: SetModelAssistantsDialogProps) {
+  const { isDark } = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
+  const [selectedModel, setSelectedModel] =
+    useState<EnabledModelConfigurationType | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const { models, isModelsLoading } = useModels({ owner, disabled: !isOpen });
+
+  const batchUpdateAgentModel = useBatchUpdateAgentModel({ owner });
+
+  const searchLower = modelSearch.toLowerCase();
+  const filteredModels = models
+    .filter((m) => subFilter(searchLower, m.displayName.toLowerCase()))
+    .sort((a, b) => {
+      if (modelSearch) {
+        return compareForFuzzySort(searchLower, a.displayName, b.displayName);
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setModelSearch("");
+          setSelectedModel(null);
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          size="xs"
+          variant="outline"
+          icon={CpuChip01}
+          label="Set model"
+          disabled={disabled}
+        />
+      </DialogTrigger>
+      <DialogContent
+        size="lg"
+        height="lg"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          searchInputRef.current?.focus();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            Set model on {agentConfigurations.length} agent
+            {pluralize(agentConfigurations.length)}
+          </DialogTitle>
+          <DialogDescription>
+            The selected model replaces the current model of every selected
+            agent. Reasoning effort is reset to the model's default, other
+            settings are left untouched.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer
+          fixedContent={
+            <SearchInput
+              ref={searchInputRef}
+              name="modelSearch"
+              placeholder="Search models"
+              value={modelSearch}
+              onChange={setModelSearch}
+              disabled={isModelsLoading}
+            />
+          }
+        >
+          {isModelsLoading ? (
+            <div className="flex justify-center py-8">
+              <Spinner />
+            </div>
+          ) : filteredModels.length === 0 ? (
+            <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+              No models found
+            </div>
+          ) : (
+            <RadioGroup
+              value={selectedModel?.modelId ?? ""}
+              onValueChange={(value) => {
+                const model = models.find((m) => m.modelId === value);
+                if (model) {
+                  setSelectedModel(model);
+                }
+              }}
+            >
+              {filteredModels.map((model) => {
+                const itemId = `set-model-${model.modelId}`;
+                return (
+                  <RadioGroupCustomItem
+                    key={model.modelId}
+                    id={itemId}
+                    value={model.modelId}
+                    disabled={!model.isSelectable}
+                    iconPosition="start"
+                    customItem={
+                      <Label
+                        htmlFor={itemId}
+                        className={cn(
+                          "flex min-w-0 grow items-center gap-2",
+                          model.isSelectable
+                            ? "cursor-pointer"
+                            : "cursor-not-allowed opacity-70"
+                        )}
+                      >
+                        <Icon
+                          visual={getModelMakerLogo(
+                            getModelMaker(model),
+                            isDark
+                          )}
+                          size="md"
+                          className="flex-shrink-0"
+                        />
+                        <div className="flex min-w-0 flex-col">
+                          <span className="copy-sm font-medium text-foreground">
+                            {model.displayName}
+                          </span>
+                          <span className="copy-xs text-muted-foreground">
+                            {model.isSelectable
+                              ? model.shortDescription
+                              : NOT_SELECTABLE_MODEL_DESCRIPTION}
+                          </span>
+                        </div>
+                      </Label>
+                    }
+                  />
+                );
+              })}
+            </RadioGroup>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            disabled: isSaving,
+          }}
+          rightButtonProps={{
+            label: "Set model",
+            variant: "primary",
+            disabled: !selectedModel,
+            isLoading: isSaving,
+            onClick: async (e: React.MouseEvent) => {
+              // Keep the dialog open until the update went through.
+              e.preventDefault();
+              if (!selectedModel) {
+                return;
+              }
+              setIsSaving(true);
+              const success = await batchUpdateAgentModel(
+                agentConfigurations.map((a) => a.sId),
+                { modelId: selectedModel.modelId }
+              );
+              await mutateAgentConfigurations();
+              setIsSaving(false);
+              if (success) {
+                setIsOpen(false);
+              }
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/lib/api/assistant/configuration/model_update.ts
+++ b/front/lib/api/assistant/configuration/model_update.ts
@@ -1,0 +1,176 @@
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
+import { getAgentConfigurationYAMLContext } from "@app/lib/api/assistant/configuration/yaml_export";
+import type { Authenticator } from "@app/lib/auth";
+import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
+import { validateResponseFormat } from "@app/types/assistant/models/utils";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+// Each agent goes through a full save (new version + its actions and skills recreated), so keep
+// the parallelism low: enough to keep a large selection responsive, not enough to flood the
+// connection pool.
+const UPDATE_MODEL_CONCURRENCY = 4;
+
+export type UpdateAgentConfigurationsModelResult = {
+  updatedAgentIds: string[];
+  skippedAgentIds: string[];
+};
+
+/**
+ * Sets the model of several agents at once. Like saving an agent from the builder with another
+ * model selected, each agent gets a new version of its configuration; everything else (name,
+ * instructions, tools, skills, tags, editors) is carried over untouched.
+ *
+ * Not atomic: agents that cannot be upgraded (archived, global, not editable by the caller) are
+ * skipped and reported back rather than failing the whole batch.
+ *
+ * `reasoningEffort` defaults to the model's own default and `responseFormat` is left untouched
+ * when not provided.
+ */
+export async function updateAgentConfigurationsModel(
+  auth: Authenticator,
+  {
+    agentIds,
+    modelId,
+    reasoningEffort,
+    responseFormat,
+  }: {
+    agentIds: string[];
+    modelId: string;
+    reasoningEffort?: ReasoningEffort;
+    responseFormat?: string;
+  }
+): Promise<Result<UpdateAgentConfigurationsModelResult, Error>> {
+  if (agentIds.length === 0) {
+    return new Ok({ updatedAgentIds: [], skippedAgentIds: [] });
+  }
+
+  // Only models the caller could pick in the agent builder can be set: this accounts for
+  // workspace availability (providers, feature flags, plan) and model tiers.
+  const { models } = await getModelsForAuth(auth);
+  const model = models.find((m) => m.modelId === modelId);
+  if (!model || !model.isSelectable) {
+    return new Err(
+      new Error(`Model "${modelId}" is not available in this workspace.`)
+    );
+  }
+
+  const effort = reasoningEffort ?? model.defaultReasoningEffort;
+  if (!model.supportedReasoningEfforts[effort]) {
+    return new Err(
+      new Error(
+        `Model "${modelId}" does not support the "${effort}" reasoning effort.`
+      )
+    );
+  }
+
+  if (responseFormat) {
+    const formatValidation = validateResponseFormat(responseFormat);
+    if (!formatValidation.isValid) {
+      return new Err(
+        new Error(`Invalid response format: ${formatValidation.errorMessage}`)
+      );
+    }
+  }
+
+  const results = await concurrentExecutor(
+    agentIds,
+    async (agentId) => {
+      const res = await upgradeAgentConfigurationModel(auth, {
+        agentId,
+        model,
+        reasoningEffort: effort,
+        responseFormat,
+      });
+
+      if (res.isErr()) {
+        logger.warn(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            agentConfigurationId: agentId,
+            modelId: model.modelId,
+            error: res.error,
+          },
+          "Skipped agent while setting the model on a batch of agents"
+        );
+      }
+
+      return { agentId, isUpdated: res.isOk() };
+    },
+    { concurrency: UPDATE_MODEL_CONCURRENCY }
+  );
+
+  return new Ok({
+    updatedAgentIds: results.filter((r) => r.isUpdated).map((r) => r.agentId),
+    skippedAgentIds: results.filter((r) => !r.isUpdated).map((r) => r.agentId),
+  });
+}
+
+async function upgradeAgentConfigurationModel(
+  auth: Authenticator,
+  {
+    agentId,
+    model,
+    reasoningEffort,
+    responseFormat,
+  }: {
+    agentId: string;
+    model: EnabledModelConfigurationType;
+    reasoningEffort: ReasoningEffort;
+    responseFormat?: string;
+  }
+): Promise<Result<void, Error>> {
+  // Resolves the current configuration along with its editors and skills, and rejects agents
+  // that cannot be re-saved as-is (archived, global).
+  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId, {
+    requireEditorGroup: true,
+  });
+  if (contextResult.isErr()) {
+    return new Err(new Error(contextResult.error.api_error.message));
+  }
+
+  const { agentConfiguration, editorUsers, skills } = contextResult.value;
+
+  if (!agentConfiguration.canEdit && !auth.isAdmin()) {
+    return new Err(new Error("Agent is not editable by the caller."));
+  }
+
+  const res = await createOrUpgradeAgentConfiguration({
+    auth,
+    agentConfigurationId: agentConfiguration.sId,
+    assistant: {
+      name: agentConfiguration.name,
+      description: agentConfiguration.description,
+      instructions: agentConfiguration.instructions,
+      instructionsHtml: agentConfiguration.instructionsHtml,
+      pictureUrl: agentConfiguration.pictureUrl,
+      status: agentConfiguration.status,
+      scope: agentConfiguration.scope,
+      model: {
+        ...agentConfiguration.model,
+        providerId: model.providerId,
+        modelId: model.modelId,
+        reasoningEffort,
+        ...(responseFormat !== undefined && { responseFormat }),
+      },
+      actions: agentConfiguration.actions.filter(
+        isServerSideMCPServerConfiguration
+      ),
+      templateId: agentConfiguration.templateId,
+      tags: agentConfiguration.tags,
+      editors: editorUsers.map((user) => ({ sId: user.sId })),
+      skills: skills.map((skill) => ({ sId: skill.sId })),
+      additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
+    },
+  });
+  if (res.isErr()) {
+    return res;
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -37,10 +37,8 @@ import {
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import type { GetAgentUsageResponseBody } from "@app/types/api/assistant/agent_usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
-import type {
-  BatchUpdateAgentModelResponseBody,
-  GetAgentConfigurationsResponseBody,
-} from "@app/types/api/assistant/configuration";
+import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
+import { BatchUpdateAgentModelResponseBodySchema } from "@app/types/api/assistant/configuration";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/types/api/assistant/mcp_configurations";
 import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import type { GetAgentSummaryResponseBody } from "@app/types/api/assistant/observability/summary";
@@ -877,8 +875,21 @@ export function useBatchUpdateAgentModel({
       }
 
       // Each agent is saved on its own, so some of them may have been skipped.
-      const { updatedAgentIds, skippedAgentIds } =
-        (await res.json()) as BatchUpdateAgentModelResponseBody;
+      const parsed = BatchUpdateAgentModelResponseBodySchema.safeParse(
+        await res.json()
+      );
+      if (!parsed.success) {
+        sendNotification({
+          type: "info",
+          title: "Model update outcome unknown",
+          description:
+            "The update was submitted but the server response could not be read. " +
+            "The list has been refreshed with the current state.",
+        });
+        return true;
+      }
+
+      const { updatedAgentIds, skippedAgentIds } = parsed.data;
 
       sendNotification({
         type: skippedAgentIds.length > 0 ? "info" : "success",

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -37,7 +37,10 @@ import {
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import type { GetAgentUsageResponseBody } from "@app/types/api/assistant/agent_usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
-import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
+import type {
+  BatchUpdateAgentModelResponseBody,
+  GetAgentConfigurationsResponseBody,
+} from "@app/types/api/assistant/configuration";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/types/api/assistant/mcp_configurations";
 import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import type { GetAgentSummaryResponseBody } from "@app/types/api/assistant/observability/summary";
@@ -48,7 +51,9 @@ import type {
   AgentsGetViewType,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
@@ -828,6 +833,68 @@ export function useBatchUpdateAgentTags({
   );
 
   return batchUpdateAgentTags;
+}
+
+export function useBatchUpdateAgentModel({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const batchUpdateAgentModel = useCallback(
+    async (
+      agentIds: string[],
+      body: {
+        modelId: string;
+        reasoningEffort?: ReasoningEffort;
+        responseFormat?: string;
+      }
+    ) => {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/batch_update_model`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            agentIds,
+            ...body,
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Error updating model",
+          description: `Error: ${errorData.message}`,
+        });
+        return false;
+      }
+
+      // Each agent is saved on its own, so some of them may have been skipped.
+      const { updatedAgentIds, skippedAgentIds } =
+        (await res.json()) as BatchUpdateAgentModelResponseBody;
+
+      sendNotification({
+        type: skippedAgentIds.length > 0 ? "info" : "success",
+        title: "Model updated",
+        description:
+          skippedAgentIds.length > 0
+            ? `Model updated on ${updatedAgentIds.length} agent${pluralize(updatedAgentIds.length)}, ` +
+              `${skippedAgentIds.length} could not be updated.`
+            : `Model updated on ${updatedAgentIds.length} agent${pluralize(updatedAgentIds.length)}.`,
+      });
+      return true;
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return batchUpdateAgentModel;
 }
 
 export function useBatchUpdateAgentScope({

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -857,8 +857,8 @@ export function useBatchUpdateAgentModel({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            agentIds,
             ...body,
+            agentIds,
           }),
         }
       );

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -875,9 +875,8 @@ export function useBatchUpdateAgentModel({
       }
 
       // Each agent is saved on its own, so some of them may have been skipped.
-      const parsed = BatchUpdateAgentModelResponseBodySchema.safeParse(
-        await res.json()
-      );
+      const json = await res.json();
+      const parsed = BatchUpdateAgentModelResponseBodySchema.safeParse(json);
       if (!parsed.success) {
         sendNotification({
           type: "info",

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -879,11 +879,9 @@ export function useBatchUpdateAgentModel({
       const parsed = BatchUpdateAgentModelResponseBodySchema.safeParse(json);
       if (!parsed.success) {
         sendNotification({
-          type: "info",
-          title: "Model update outcome unknown",
-          description:
-            "The update was submitted but the server response could not be read. " +
-            "The list has been refreshed with the current state.",
+          type: "error",
+          title: "Error updating model",
+          description: "An unknown error occurred.",
         });
         return true;
       }

--- a/front/types/api/assistant/configuration/index.ts
+++ b/front/types/api/assistant/configuration/index.ts
@@ -16,3 +16,14 @@ export const PostAgentConfigurationResponseBodySchema = z.object({
 export type PostAgentConfigurationResponseBody = z.infer<
   typeof PostAgentConfigurationResponseBodySchema
 >;
+
+// Bulk model update is not atomic: each agent is saved as a new version on its own, so the
+// response tells which ones went through.
+export const BatchUpdateAgentModelResponseBodySchema = z.object({
+  success: z.literal(true),
+  updatedAgentIds: z.array(z.string()),
+  skippedAgentIds: z.array(z.string()),
+});
+export type BatchUpdateAgentModelResponseBody = z.infer<
+  typeof BatchUpdateAgentModelResponseBodySchema
+>;

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -123,6 +123,7 @@ const RadioGroupCustomItem = React.forwardRef<
       <div
         className={cn(
           "flex w-full flex-col",
+          props.disabled && "opacity-70 [&_label]:cursor-not-allowed",
           className,
           `items-${iconPosition}`
         )}


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/9790

Allow bulk setting model on the Managed Agents list.

- reuses the existing bulk edit UI
- updating models creates a new agent configuration so history of change is captured
- new route `/api/w/:wId/assistant/agent_configurations/batch_update_model` added (we already had `batch_update_scope` and `batch_update_tags`)
- for simplicity's sake, the route is not atomic, each agent is updated through the already existing `createOrUpgradeAgentConfiguration` function


## Tests

- added test for the API
- manually tested:

https://github.com/user-attachments/assets/0a881aa5-e1ce-43e8-b961-2ffc783f9082

