### PR TITLE
[front] fix: clipped UsedByButton since Button redesign

### DIFF
--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -102,6 +102,11 @@ function UsedByButtonIcon({
   );
 }
 
+// The composite icon (robot + count + chevron) is wider than the icon-only
+// fixed width (w-6 on xs); size to content instead.
+const USED_BY_BUTTON_CLASSES =
+  "w-auto border-0 px-2 hover:bg-muted-background hover:text-foreground";
+
 interface UsedByButtonProps {
   usage: AgentsUsageType | SkillUsageType | null;
   onItemClick: (assistantSid: string) => void;
@@ -137,7 +142,7 @@ export function UsedByButton({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        className="border-0 hover:bg-muted-background hover:text-foreground"
+        className={USED_BY_BUTTON_CLASSES}
         aria-label="Used by 0 agents"
         disabled
       />
@@ -217,7 +222,7 @@ export function UsedByButton({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          className="border-0 hover:bg-muted-background hover:text-foreground"
+          className={USED_BY_BUTTON_CLASSES}
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();


### PR DESCRIPTION
## Description

Fixes [`dust-tt/tasks#9679`.](https://github.com/dust-tt/tasks/issues/9679)

Since the Button redesign (`#28768`), the "Used by" button was clipped to 24px on all its surfaces (Tools list, Skills table, space categories/resources lists, triggers list).

`UsedByButton` passes a composite node (robot icon + usage count + chevron) through the Button `icon` prop with no `label`, so the redesigned Button infers icon-only (`!label && !showCounter && !isSelect && !!icon`) and pins the width to `w-6 px-0` on `xs`, clipping the content. The pre-redesign Button never inferred icon-only (it was an explicit size), which is why this worked before.

Fix: override the icon-only width from the consumer (`w-auto px-2`, merged last through twMerge) so the button sizes to its content, keeping the redesigned xs metrics. Shared Button untouched: no native prop combination can express the dual icon+count content (agents and skills), and `isCounter` renders a pill, which would be a visual change.

## Tests

- `tsgo --noEmit` and biome clean.
- Visually check:
<img width="1136" height="210" alt="Screenshot 2026-07-26 at 11 48 25 AM" src="https://github.com/user-attachments/assets/c77685db-a2f7-4657-a06d-0c1c7eb1be4d" />
<img width="1169" height="709" alt="Screenshot 2026-07-26 at 11 57 04 AM" src="https://github.com/user-attachments/assets/4b9fe514-8929-417a-8536-cb1951438a3f" />

## Risk

Low: scoped to `UsedByButton`'s two Button instances; no shared component changes.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)