### PR TITLE
files list: emit the [id: fil_xxx] suffix for every linked file

### DIFF
--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -9,6 +9,7 @@ import {
   makeExtra,
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -114,6 +115,8 @@ describe("listHandler", () => {
 
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       getAllFilesByPrefix: getAllFilesByPrefixMock,
+      // FileFactory copies ready conversation files to their mount path.
+      copyFile: vi.fn().mockResolvedValue(undefined),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
@@ -201,7 +204,7 @@ describe("listHandler", () => {
     expect(text.text).toContain(`conversation-${conversation.sId}/report.pdf`);
   });
 
-  it("shows [id: ...] suffix for interactive content types when fileId is set", async () => {
+  it("omits the [id: ...] suffix when no FileResource is linked", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
     const workspaceId = auth.getNonNullableWorkspace().sId;
 
@@ -231,12 +234,48 @@ describe("listHandler", () => {
     const text = result.value[0];
     assert(text.type === "text");
 
-    // fileId is null until the DB migration (the backend always returns null for now).
-    // Verify the interactive files are listed but without an ID suffix.
+    // No FileResource rows exist for these GCS objects, so no id can be surfaced.
     expect(text.text).toContain("chart.html");
     expect(text.text).toContain("slides.html");
     expect(text.text).toContain("report.pdf");
     expect(text.text).not.toContain("[id:");
+  });
+
+  it("shows the [id: ...] suffix for any file with a linked FileResource", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    // A ready conversation file claims its mount path, which is what the listing
+    // enrichment joins on.
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      fileSize: 8192,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [makeStorageFile(`${prefix}report.pdf`, "application/pdf", 8192)],
+      pageFetchCount: 1,
+    });
+
+    const result = await listHandler({}, makeExtra(auth, conversation));
+
+    assert(result.isOk());
+    const text = result.value[0];
+    assert(text.type === "text");
+    expect(text.text).toContain(
+      `conversation-${conversation.sId}/report.pdf (application/pdf, 8 KB) [id: ${file.sId}]`
+    );
   });
 
   it("lists another conversation when conversation_id is set", async () => {

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -19,10 +19,7 @@ import {
   type ConversationWithoutContentType,
   isPodConversation,
 } from "@app/types/assistant/conversation";
-import {
-  isInteractiveContentType,
-  stripMimeParameters,
-} from "@app/types/files";
+import { stripMimeParameters } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import partition from "lodash/partition";
@@ -231,13 +228,9 @@ export async function listHandler(
     const annotation = sourcePath
       ? ` (processed version of ${sourcePath})`
       : "";
-    // Frames are created and updated via the interactive_content MCP server, which
-    // identifies them by file ID rather than path. Exposing the ID here lets the agent
-    // reference the correct frame when calling those tools.
-    const fileIdSuffix =
-      isInteractiveContentType(mimeType) && file.fileId
-        ? ` [id: ${file.fileId}]`
-        : "";
+    // The file id is the stable handle for tools that read conversation files: paths must be
+    // reproduced byte-for-byte (typographic apostrophes, accents), which models get wrong.
+    const fileIdSuffix = file.fileId ? ` [id: ${file.fileId}]` : "";
     lines.push(
       `${file.path} (${mimeType}, ${kb} KB)${fileIdSuffix}${annotation}`
     );


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9648.

A user uploaded a `.pptx` named `P13490 - Etude d’opportunités de développement salons aéroport Marseille v3.pptx` (typographic apostrophe, U+2019) and asked the agent to send it to OneDrive. `microsoft_drive__upload_file` failed three times with `File not found`: every call retyped the canonical scoped path with an ASCII apostrophe (U+0027). The object was present at the deterministic mount path the whole time — and the agent had listed the correct name one step before each failing call.

**Root cause:** paths are byte-exact GCS lookup keys, and the file listing offers them as the *only* handle — a 79-character string with `’`, `é`×3 and `ô` the model must reproduce perfectly on every call. The stable handle already exists (`fil_YBECTK90Lve78MRJ14Tq` on the content fragment) and the conversation-file resolvers already accept it; `files__list` even fetched it for every file (`enrichListWithFileResourceIds`) and then discarded it at render time for everything but Frames.

**What this PR does:** drop the interactive-content gate in the listing so every file with a linked `FileResource` surfaces `[id: fil_xxx]`, giving the model a handle it can copy instead of a filename it must reproduce byte-perfect.

Same failure class as `28929` (microsoft_drive: target upload folders by id) — locale-dependent name strings as lookup keys, reported by French customers — and the same direction: prefer the stable id. Scoped paths keep working unchanged.

## Tests

- `files__list` emits `[id: fil_xxx]` for a plain `.pdf` with a linked `FileResource`; omits the suffix when no `FileResource` is linked.
- `npx tsgo --noEmit` + `npx biome check` clean.

## Risk

Worst case, the `[id: ...]` suffix on every listing line confuses an agent whose instructions parse listing output — the format is unchanged otherwise and the suffix already existed for Frames. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front`
