### PR TITLE
[front] fix(skills): guarantee unique name when archiving same-named skills

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1422,25 +1422,30 @@ describe("SkillResource", () => {
 
     it("archives multiple skills sharing the same name without a unique constraint violation", async () => {
       // The (workspaceId, name, status) unique constraint means only one
-      // archived skill can keep a given name. Archiving a third same-named
-      // skill must not collide with a previously renamed archived skill.
-      const firstSkill = await SkillFactory.create(testContext.authenticator, {
-        name: "Duplicate Name Skill",
-      });
-      await firstSkill.archive(testContext.authenticator);
+      // archived skill can keep a given name. Archiving a same-named skill
+      // renames the previously archived one with a minute-granularity
+      // timestamp; a third archive on the same day (but a different minute)
+      // must not collide with the earlier rename target. We fake the clock so
+      // each archive lands on a distinct minute of the same day.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const archiveSameNameSkillAt = async (isoTime: string) => {
+          vi.setSystemTime(new Date(isoTime));
+          const skill = await SkillFactory.create(testContext.authenticator, {
+            name: "Duplicate Name Skill",
+          });
+          return skill.archive(testContext.authenticator);
+        };
 
-      const secondSkill = await SkillFactory.create(testContext.authenticator, {
-        name: "Duplicate Name Skill",
-      });
-      await secondSkill.archive(testContext.authenticator);
-
-      const thirdSkill = await SkillFactory.create(testContext.authenticator, {
-        name: "Duplicate Name Skill",
-      });
-      const { affectedCount } = await thirdSkill.archive(
-        testContext.authenticator
-      );
-      expect(affectedCount).toBe(1);
+        await archiveSameNameSkillAt("2026-07-26T12:00:00Z");
+        await archiveSameNameSkillAt("2026-07-26T12:01:00Z");
+        const { affectedCount } = await archiveSameNameSkillAt(
+          "2026-07-26T12:02:00Z"
+        );
+        expect(affectedCount).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("removes the skill's space requirements from agents when archiving and adds them back when restoring", async () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1420,6 +1420,29 @@ describe("SkillResource", () => {
       );
     });
 
+    it("archives multiple skills sharing the same name without a unique constraint violation", async () => {
+      // The (workspaceId, name, status) unique constraint means only one
+      // archived skill can keep a given name. Archiving a third same-named
+      // skill must not collide with a previously renamed archived skill.
+      const firstSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Duplicate Name Skill",
+      });
+      await firstSkill.archive(testContext.authenticator);
+
+      const secondSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Duplicate Name Skill",
+      });
+      await secondSkill.archive(testContext.authenticator);
+
+      const thirdSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Duplicate Name Skill",
+      });
+      const { affectedCount } = await thirdSkill.archive(
+        testContext.authenticator
+      );
+      expect(affectedCount).toBe(1);
+    });
+
     it("removes the skill's space requirements from agents when archiving and adds them back when restoring", async () => {
       const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1423,10 +1423,10 @@ describe("SkillResource", () => {
     it("archives multiple skills sharing the same name without a unique constraint violation", async () => {
       // The (workspaceId, name, status) unique constraint means only one
       // archived skill can keep a given name. Archiving a same-named skill
-      // renames the previously archived one with a minute-granularity
-      // timestamp; a third archive on the same day (but a different minute)
-      // must not collide with the earlier rename target. We fake the clock so
-      // each archive lands on a distinct minute of the same day.
+      // renames the previously archived one with a timestamped suffix; a third
+      // archive on the same day must not collide with the earlier rename
+      // target. We fake the clock so each archive lands on a distinct time of
+      // the same day.
       vi.useFakeTimers({ toFake: ["Date"] });
       try {
         const archiveSameNameSkillAt = async (isoTime: string) => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -64,7 +64,6 @@ import {
   serializeSkillTag,
   serializeUnavailableSkillTag,
 } from "@app/lib/skills/format";
-import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
@@ -2711,12 +2710,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       if (existingArchivedSkill) {
-        const timestamp = formatTimestampToFriendlyDate(
-          existingArchivedSkill.updatedAt.getTime(),
-          "compactWithDay"
-        );
+        // Suffix with the skill's sId to guarantee a unique name: multiple
+        // skills sharing the same name can be archived (e.g. same day), and a
+        // date-based suffix is not unique enough to satisfy the
+        // (workspaceId, name, status) unique constraint.
+        const existingArchivedSkillId = SkillResource.modelIdToSId({
+          id: existingArchivedSkill.id,
+          workspaceId: existingArchivedSkill.workspaceId,
+        });
         await existingArchivedSkill.update(
-          { name: `${existingArchivedSkill.name} (archived on ${timestamp})` },
+          {
+            name: `${existingArchivedSkill.name} (archived ${existingArchivedSkillId})`,
+          },
           { transaction }
         );
       }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2711,12 +2711,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       if (existingArchivedSkill) {
-        // Use minute granularity so that archiving the same-named skill more
-        // than once on the same day does not produce a colliding rename target
-        // that would violate the (workspaceId, name, status) unique constraint.
         const timestamp = formatTimestampToFriendlyDate(
           existingArchivedSkill.updatedAt.getTime(),
-          "compactWithMinute"
+          "long"
         );
         await existingArchivedSkill.update(
           { name: `${existingArchivedSkill.name} (archived on ${timestamp})` },

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -64,6 +64,7 @@ import {
   serializeSkillTag,
   serializeUnavailableSkillTag,
 } from "@app/lib/skills/format";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
@@ -2710,18 +2711,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       if (existingArchivedSkill) {
-        // Suffix with the skill's sId to guarantee a unique name: multiple
-        // skills sharing the same name can be archived (e.g. same day), and a
-        // date-based suffix is not unique enough to satisfy the
-        // (workspaceId, name, status) unique constraint.
-        const existingArchivedSkillId = SkillResource.modelIdToSId({
-          id: existingArchivedSkill.id,
-          workspaceId: existingArchivedSkill.workspaceId,
-        });
+        // Use minute granularity so that archiving the same-named skill more
+        // than once on the same day does not produce a colliding rename target
+        // that would violate the (workspaceId, name, status) unique constraint.
+        const timestamp = formatTimestampToFriendlyDate(
+          existingArchivedSkill.updatedAt.getTime(),
+          "compactWithMinute"
+        );
         await existingArchivedSkill.update(
-          {
-            name: `${existingArchivedSkill.name} (archived ${existingArchivedSkillId})`,
-          },
+          { name: `${existingArchivedSkill.name} (archived on ${timestamp})` },
           { transaction }
         );
       }

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -87,18 +87,12 @@ export function getWeekBoundaries(date: Date): {
  * long: September 23, 2025 at 3:37:32 PM
  * short: September 23, 2025
  * compactWithDay: Sep 23, 2025
- * compactWithMinute: Sep 23, 2025, 3:37 PM
  * compact: Sep, 2025
  *
  */
 export function formatTimestampToFriendlyDate(
   timestamp: number,
-  version:
-    | "long"
-    | "short"
-    | "compact"
-    | "compactWithDay"
-    | "compactWithMinute" = "long"
+  version: "long" | "short" | "compact" | "compactWithDay" = "long"
 ): string {
   const date = new Date(timestamp);
 
@@ -132,14 +126,6 @@ export function formatTimestampToFriendlyDate(
         year: "numeric",
         month: "short",
         day: "numeric",
-      });
-    case "compactWithMinute":
-      return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "numeric",
       });
   }
 }

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -87,12 +87,18 @@ export function getWeekBoundaries(date: Date): {
  * long: September 23, 2025 at 3:37:32 PM
  * short: September 23, 2025
  * compactWithDay: Sep 23, 2025
+ * compactWithMinute: Sep 23, 2025, 3:37 PM
  * compact: Sep, 2025
  *
  */
 export function formatTimestampToFriendlyDate(
   timestamp: number,
-  version: "long" | "short" | "compact" | "compactWithDay" = "long"
+  version:
+    | "long"
+    | "short"
+    | "compact"
+    | "compactWithDay"
+    | "compactWithMinute" = "long"
 ): string {
   const date = new Date(timestamp);
 
@@ -126,6 +132,14 @@ export function formatTimestampToFriendlyDate(
         year: "numeric",
         month: "short",
         day: "numeric",
+      });
+    case "compactWithMinute":
+      return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
       });
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #20976.

That PR added rename-on-conflict when archiving a skill, to work around the `(workspaceId, name, status)` unique constraint. But the rename target used a **day-granularity** timestamp (`formatTimestampToFriendlyDate(..., "compactWithDay")` → `"archived on Jul 26, 2026"`), which is not unique enough: when the same skill name is archived more than once on the same day, the rename itself collides with a previously renamed archived skill and throws `SequelizeUniqueConstraintError`.

This actually happened with a customer and triggered a monitor: https://dust4ai.slack.com/archives/C05F84CFP0E/p1785094982587329. There were also saw a couple other instances in last 15 days. So not common, but does happen.

This PR keeps the original human-readable date approach but uses the existing `"long"` format, which includes the time down to the **second** (`"archived on July 26, 2026 at 9:41:07 AM"`).  It's a bit uglier, but it's not something users will see frequently.

Note: previously renamed archived skills keep their existing date-based names; this only affects new archives, so no migration is needed.

## Tests

- Added a regression test in `skill_resource.test.ts` that archives three skills sharing the same name, faking the clock so each lands on a distinct time of the same day.
- Verified the test **fails** with the previous day-granularity format and **passes** with the second-granularity format.
- All archive/restore tests pass.

## Risk

- Low.

## Deploy Plan

- Deploy front.