### PR TITLE
[front] fix: resume files cat inside oversized lines via byte_offset

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -6,6 +6,7 @@ import {
   INTERACTIVE_CONTENT_SERVER_NAME,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { BYTE_OFFSET_SCHEMA } from "@app/lib/api/files/text_file_pagination";
 import { FILE_PREVIEW_DIRECTIVE_EXAMPLE } from "@app/lib/markdown/file_preview";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import { z } from "zod";
@@ -190,9 +191,12 @@ const FILES_TOOLS_COMMON_METADATA = [
     name: FILES_CAT_ACTION_NAME,
     description:
       "Read the content of a file. " +
-      "For text files, returns lines with their line numbers." +
+      "For text files, returns lines with their line numbers. " +
       "Use `offset` to start at a specific line and `limit` to control how many lines to return. " +
-      "When the output is truncated, a footer indicates the next offset to use. " +
+      "When the output stops at a line boundary, the footer indicates the next `offset` to use. " +
+      "When the output is truncated inside a single oversized line, the footer indicates a `byte_offset` instead: " +
+      "pass it back (without `offset`) to continue reading from that exact position inside the line; " +
+      "using `offset` there would skip the rest of the line. " +
       "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
       "For binary documents (PDF, DOCX, PPTX, etc.), call " +
       `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EXTRACT_TEXT_ACTION_NAME)}\` first to extract their text content.`,
@@ -207,7 +211,9 @@ const FILES_TOOLS_COMMON_METADATA = [
         .int()
         .min(1)
         .optional()
-        .describe("Line number to start reading from (1-indexed, default 1)"),
+        .describe(
+          "Line number to start reading from (1-indexed, default 1). Do not combine with `byte_offset`."
+        ),
       limit: z
         .number()
         .int()
@@ -217,6 +223,7 @@ const FILES_TOOLS_COMMON_METADATA = [
         .describe(
           `Maximum number of lines to return (default ${CAT_LINES_DEFAULT}, max ${CAT_LINES_MAX})`
         ),
+      byte_offset: BYTE_OFFSET_SCHEMA,
     },
     stake: "never_ask" as const,
     eager: true,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -191,12 +191,10 @@ const FILES_TOOLS_COMMON_METADATA = [
     name: FILES_CAT_ACTION_NAME,
     description:
       "Read the content of a file. " +
-      "For text files, returns lines with their line numbers. " +
+      "For text files, reads line by line, returning each line with its line number. " +
       "Use `offset` to start at a specific line and `limit` to control how many lines to return. " +
-      "When the output stops at a line boundary, the footer indicates the next `offset` to use. " +
-      "When the output is truncated inside a single oversized line, the footer indicates a `byte_offset` instead: " +
-      "pass it back (without `offset`) to continue reading from that exact position inside the line; " +
-      "using `offset` there would skip the rest of the line. " +
+      "When more content remains, the footer provides the `byte_offset` to pass back (without `offset`) " +
+      "to continue from the exact position where the response stopped, even inside an oversized line. " +
       "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
       "For binary documents (PDF, DOCX, PPTX, etc.), call " +
       `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EXTRACT_TEXT_ACTION_NAME)}\` first to extract their text content.`,
@@ -212,7 +210,8 @@ const FILES_TOOLS_COMMON_METADATA = [
         .min(1)
         .optional()
         .describe(
-          "Line number to start reading from (1-indexed, default 1). Do not combine with `byte_offset`."
+          "Line number to start reading from (1-indexed, default 1). Use for direct jumps to a line; " +
+            "continuation footers provide `byte_offset` instead. Do not combine with `byte_offset`."
         ),
       limit: z
         .number()

--- a/front/lib/api/actions/servers/files/tools/cat.test.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.test.ts
@@ -1,0 +1,333 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
+}));
+vi.mock("@app/lib/api/config", () => ({
+  default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
+}));
+
+function mockStoredFile(content: string, contentType: string) {
+  fileStorageMock.setFileMetadata(() => ({
+    contentType,
+    size: String(Buffer.byteLength(content, "utf8")),
+  }));
+  fileStorageMock.setFileContent(() => content);
+}
+
+function textOf(result: Awaited<ReturnType<typeof catHandler>>): string {
+  assert(result.isOk(), "expected an Ok result");
+  const block = result.value[0];
+  assert(block.type === "text", "expected a text block");
+  return block.text;
+}
+
+// Splits the response into the display content and the bracketed footer.
+function splitBody(text: string): { body: string; footer: string | null } {
+  const idx = text.lastIndexOf("\n\n[");
+  if (idx === -1) {
+    return { body: text, footer: null };
+  }
+  return { body: text.slice(0, idx), footer: text.slice(idx + 2) };
+}
+
+function extractByteOffset(text: string): number {
+  const match = text.match(/byte_offset=(\d+)/);
+  assert(match, "expected a byte_offset continuation in the footer");
+  return Number(match[1]);
+}
+
+// Reconstructs the original file lines from a sequence of response bodies, by stripping the
+// `N: ` / `N (cont.): ` display prefixes and joining continuation segments.
+function reconstruct(bodies: string[]): string {
+  const lines: string[] = [];
+  for (const body of bodies) {
+    for (const displayLine of body.split("\n")) {
+      const contMatch = displayLine.match(/^\d+ \(cont\.\): (.*)$/);
+      if (contMatch) {
+        assert(lines.length > 0, "continuation without a preceding line");
+        lines[lines.length - 1] += contMatch[1];
+        continue;
+      }
+      const match = displayLine.match(/^\d+: (.*)$/);
+      assert(match, `unparseable display line: ${displayLine.slice(0, 80)}`);
+      lines.push(match[1]);
+    }
+  }
+  return lines.join("\n");
+}
+
+// Reads a whole file through catHandler, following byte_offset continuations and offsets
+// until exhaustion, and returns the reconstructed content.
+async function readAll(
+  path: string,
+  extra: ToolHandlerExtra,
+  { maxCalls = 20 }: { maxCalls?: number } = {}
+): Promise<string> {
+  const bodies: string[] = [];
+  let args: { path: string; offset?: number; byte_offset?: number } = { path };
+
+  for (let call = 0; call < maxCalls; call++) {
+    const text = textOf(await catHandler(args, extra));
+    const { body, footer } = splitBody(text);
+    bodies.push(body);
+    expect(body).not.toContain("�");
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+      FILE_OFFLOAD_TEXT_SIZE_BYTES
+    );
+
+    if (footer?.includes("byte_offset=")) {
+      args = { path, byte_offset: extractByteOffset(footer) };
+      continue;
+    }
+    const offsetMatch = footer?.match(/offset=(\d+) to read more/);
+    if (offsetMatch) {
+      args = { path, offset: Number(offsetMatch[1]) };
+      continue;
+    }
+    return reconstruct(bodies);
+  }
+
+  throw new Error(`file not exhausted after ${maxCalls} calls`);
+}
+
+describe("catHandler", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
+  it("reads a small file with line numbers", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("alpha\nbeta\n", "text/plain");
+
+    const text = textOf(
+      await catHandler(
+        { path: `conversation-${conversation.sId}/notes.txt` },
+        makeExtra(auth, conversation)
+      )
+    );
+
+    expect(text).toBe("1: alpha\n2: beta");
+  });
+
+  it("paginates by lines with offset and suggests the next offset", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const content =
+      Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+    mockStoredFile(content, "text/plain");
+    const path = `conversation-${conversation.sId}/notes.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(await catHandler({ path, limit: 4 }, extra));
+    expect(first).toContain("1: line 1");
+    expect(first).toContain("4: line 4");
+    expect(first).not.toContain("5: line 5");
+    expect(first).toContain("Use offset=5 to read more");
+
+    const second = textOf(
+      await catHandler({ path, offset: 5, limit: 4 }, extra)
+    );
+    expect(second).toContain("5: line 5");
+    expect(second).toContain("Use offset=9 to read more");
+
+    const third = textOf(await catHandler({ path, offset: 9 }, extra));
+    expect(third).toBe("9: line 9\n10: line 10");
+  });
+
+  it("returns 'no lines' for an offset past the end of the file", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("only line\n", "text/plain");
+
+    const text = textOf(
+      await catHandler(
+        { path: `conversation-${conversation.sId}/notes.txt`, offset: 5 },
+        makeExtra(auth, conversation)
+      )
+    );
+
+    expect(text).toContain("No lines found at offset 5");
+  });
+
+  it("resumes an oversized ASCII line with byte_offset", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const line = "A".repeat(30_000);
+    mockStoredFile(line + "\n", "text/plain");
+    const path = `conversation-${conversation.sId}/big.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(await catHandler({ path }, extra));
+    expect(Buffer.byteLength(first, "utf8")).toBeLessThanOrEqual(
+      FILE_OFFLOAD_TEXT_SIZE_BYTES
+    );
+    expect(first).toContain("Truncated inside line 1");
+    expect(first).toContain(`File is ${30_001} bytes`);
+    expect(first).toContain("Do not use offset=2");
+    const byteOffset = extractByteOffset(first);
+
+    const second = textOf(
+      await catHandler({ path, byte_offset: byteOffset }, extra)
+    );
+    expect(second).toContain("1 (cont.): ");
+    expect(second).toContain("[Reached end of file.]");
+
+    expect(reconstruct([splitBody(first).body, splitBody(second).body])).toBe(
+      line
+    );
+  });
+
+  it("does not split a multibyte UTF-8 character at the truncation boundary", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    // 20,000 ASCII bytes then 4-byte emojis: the ~18KB cut lands inside the ASCII run on the
+    // first page and inside the emoji run on a later page.
+    const line = "x".repeat(20_000) + "🌍".repeat(3_000);
+    mockStoredFile(line + "\n", "text/plain");
+    const path = `conversation-${conversation.sId}/emoji.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const reconstructed = await readAll(path, extra);
+    expect(reconstructed).toBe(line);
+  });
+
+  it("continues into ordinary lines after finishing an oversized line", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const bigLine = "B".repeat(25_000);
+    const content = `${bigLine}\nsecond line\nthird line\n`;
+    mockStoredFile(content, "text/plain");
+    const path = `conversation-${conversation.sId}/mixed.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(await catHandler({ path }, extra));
+    const byteOffset = extractByteOffset(first);
+
+    const second = textOf(
+      await catHandler({ path, byte_offset: byteOffset }, extra)
+    );
+    expect(second).toContain("1 (cont.): ");
+    expect(second).toContain("2: second line");
+    expect(second).toContain("3: third line");
+
+    expect(reconstruct([splitBody(first).body, splitBody(second).body])).toBe(
+      `${bigLine}\nsecond line\nthird line`
+    );
+  });
+
+  it("reconstructs a line requiring several continuation reads", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    // Non-repeating content so any misplaced resume position corrupts the reconstruction.
+    let line = "";
+    while (line.length < 60_000) {
+      line += `<segment idx="${line.length}"/>`;
+    }
+    mockStoredFile(line + "\n", "text/plain");
+    const path = `conversation-${conversation.sId}/huge.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const reconstructed = await readAll(path, extra);
+    expect(reconstructed).toBe(line);
+  });
+
+  it("retrieves a marker beyond byte 20480 of an oversized HTML block (#9676)", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const marker = "UNIQUE_MARKER_BEYOND_20K_f3a9c2";
+    // One HTML instruction block serialized as a single line larger than 20KB, with the
+    // marker after the 20,480th byte.
+    const line = `<section class="instructions">${"lorem ipsum ".repeat(2_000)}${marker}</section>`;
+    assert(
+      line.indexOf(marker) > FILE_OFFLOAD_TEXT_SIZE_BYTES,
+      "marker must sit beyond the first 20KB"
+    );
+    mockStoredFile(line + "\n", "text/html");
+    const path = `conversation-${conversation.sId}/agent_config.html`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(await catHandler({ path }, extra));
+    expect(first).not.toContain(marker);
+    const byteOffset = extractByteOffset(first);
+
+    const second = textOf(
+      await catHandler({ path, byte_offset: byteOffset }, extra)
+    );
+    expect(second).toContain(marker);
+
+    expect(reconstruct([splitBody(first).body, splitBody(second).body])).toBe(
+      line
+    );
+  });
+
+  it("keeps the truncated response under the offload threshold for a maximal path", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("A".repeat(30_000) + "\n", "text/plain");
+    // GCS caps object names at 1024 bytes; a near-maximal path maximizes the footer size.
+    const path = `conversation-${conversation.sId}/${"x".repeat(980)}.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(await catHandler({ path }, extra));
+    expect(Buffer.byteLength(first, "utf8")).toBeLessThanOrEqual(
+      FILE_OFFLOAD_TEXT_SIZE_BYTES
+    );
+    expect(extractByteOffset(first)).toBeGreaterThan(0);
+  });
+
+  it("rejects a byte_offset at or beyond the current file size", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("A".repeat(30_000) + "\n", "text/plain");
+    const path = `conversation-${conversation.sId}/big.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const byteOffset = extractByteOffset(
+      textOf(await catHandler({ path }, extra))
+    );
+
+    // The file shrank since the footer was issued.
+    mockStoredFile("short\n", "text/plain");
+    const result = await catHandler({ path, byte_offset: byteOffset }, extra);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("beyond the end");
+      expect(result.error.message).toContain("may have changed");
+    }
+  });
+
+  it("errors when the stream runs short of the byte_offset despite a matching stat size", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    // stat reports the original size but the content shrank between stat and read.
+    fileStorageMock.setFileMetadata(() => ({
+      contentType: "text/plain",
+      size: String(30_001),
+    }));
+    fileStorageMock.setFileContent(() => "short\n");
+    const path = `conversation-${conversation.sId}/big.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const result = await catHandler({ path, byte_offset: 18_000 }, extra);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("changed");
+    }
+  });
+
+  it("rejects a call combining offset and byte_offset", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const result = await catHandler(
+      {
+        path: `conversation-${conversation.sId}/big.txt`,
+        offset: 2,
+        byte_offset: 100,
+      },
+      makeExtra(auth, conversation)
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not both");
+    }
+  });
+});

--- a/front/lib/api/actions/servers/files/tools/cat.test.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.test.ts
@@ -66,7 +66,7 @@ function reconstruct(bodies: string[]): string {
   return lines.join("\n");
 }
 
-// Reads a whole file through catHandler, following byte_offset continuations and offsets
+// Reads a whole file through catHandler, following the byte_offset continuation footers
 // until exhaustion, and returns the reconstructed content.
 async function readAll(
   path: string,
@@ -74,7 +74,7 @@ async function readAll(
   { maxCalls = 20 }: { maxCalls?: number } = {}
 ): Promise<string> {
   const bodies: string[] = [];
-  let args: { path: string; offset?: number; byte_offset?: number } = { path };
+  let args: { path: string; byte_offset?: number } = { path };
 
   for (let call = 0; call < maxCalls; call++) {
     const text = textOf(await catHandler(args, extra));
@@ -87,11 +87,6 @@ async function readAll(
 
     if (footer?.includes("byte_offset=")) {
       args = { path, byte_offset: extractByteOffset(footer) };
-      continue;
-    }
-    const offsetMatch = footer?.match(/offset=(\d+) to read more/);
-    if (offsetMatch) {
-      args = { path, offset: Number(offsetMatch[1]) };
       continue;
     }
     return reconstruct(bodies);
@@ -119,7 +114,7 @@ describe("catHandler", () => {
     expect(text).toBe("1: alpha\n2: beta");
   });
 
-  it("paginates by lines with offset and suggests the next offset", async () => {
+  it("continues line pages via byte_offset and supports direct offset jumps", async () => {
     const { auth, conversation } = await setupProjectConversation();
     const content =
       Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
@@ -131,16 +126,50 @@ describe("catHandler", () => {
     expect(first).toContain("1: line 1");
     expect(first).toContain("4: line 4");
     expect(first).not.toContain("5: line 5");
-    expect(first).toContain("Use offset=5 to read more");
+    expect(first).toContain("Use byte_offset=");
 
     const second = textOf(
-      await catHandler({ path, offset: 5, limit: 4 }, extra)
+      await catHandler(
+        { path, byte_offset: extractByteOffset(first), limit: 4 },
+        extra
+      )
     );
     expect(second).toContain("5: line 5");
-    expect(second).toContain("Use offset=9 to read more");
+    expect(second).toContain("8: line 8");
+    expect(second).toContain("Use byte_offset=");
 
+    // Direct line jumps via offset still work; only the continuation footer changed.
     const third = textOf(await catHandler({ path, offset: 9 }, extra));
     expect(third).toBe("9: line 9\n10: line 10");
+  });
+
+  it("continues from a byte cursor after a direct offset jump", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("alpha\nbeta\ngamma\n", "text/plain");
+    const path = `conversation-${conversation.sId}/notes.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const first = textOf(
+      await catHandler({ path, offset: 2, limit: 1 }, extra)
+    );
+    expect(first).toContain("2: beta");
+    // "alpha\nbeta\n" is 11 bytes: the cursor sits on the first byte of "gamma".
+    expect(extractByteOffset(first)).toBe(11);
+
+    const second = textOf(await catHandler({ path, byte_offset: 11 }, extra));
+    expect(second).toBe("3: gamma");
+  });
+
+  it("reconstructs an ordinary multi-line file following only byte cursors", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const content =
+      Array.from({ length: 250 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+    mockStoredFile(content, "text/plain");
+    const path = `conversation-${conversation.sId}/long.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const reconstructed = await readAll(path, extra);
+    expect(reconstructed).toBe(content.slice(0, -1));
   });
 
   it("returns 'no lines' for an offset past the end of the file", async () => {
@@ -170,7 +199,7 @@ describe("catHandler", () => {
     );
     expect(first).toContain("Truncated inside line 1");
     expect(first).toContain(`File is ${30_001} bytes`);
-    expect(first).toContain("Do not use offset=2");
+    expect(first).toContain("to continue reading line 1");
     const byteOffset = extractByteOffset(first);
 
     const second = textOf(

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -1,4 +1,3 @@
-import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
@@ -11,11 +10,18 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import {
+  byteOffsetBeyondEndMessage,
+  fileChangedMessage,
+  OFFSET_EXCLUSIVITY_ERROR_MESSAGE,
+  readTextFilePage,
+  renderTextFilePage,
+  TEXT_FILE_PAGE_CONTENT_BUDGET_BYTES,
+} from "@app/lib/api/files/text_file_pagination";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import * as readline from "readline";
 import type { Readable } from "stream";
 
 const CAT_IMAGE_MAX_BYTES = 2 * 1024 * 1024; // 2 MB vision limit.
@@ -55,51 +61,35 @@ function catImage(
 
 async function catText(
   stream: Readable,
-  path: string,
-  startLine: number,
-  maxLines: number,
-  fileSizeBytes: number
+  {
+    path,
+    fileSizeBytes,
+    maxLines,
+    startLine,
+    byteOffset,
+  }: {
+    path: string;
+    fileSizeBytes: number;
+    maxLines: number;
+    startLine: number;
+    byteOffset: number | null;
+  }
 ): Promise<ToolHandlerResult> {
-  const lines: string[] = [];
-  let lineNumber = 0;
-  let byteCount = 0;
-  let byteCapped = false;
-  let totalLines = 0;
-
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
+  let rendered;
   try {
-    for await (const line of rl) {
-      lineNumber++;
-
-      if (lineNumber < startLine) {
-        continue;
-      }
-
-      totalLines++;
-
-      const lineWithNumber = `${lineNumber}: ${line}`;
-      const lineBytes = Buffer.byteLength(lineWithNumber + "\n", "utf8");
-
-      if (byteCount + lineBytes > FILE_OFFLOAD_TEXT_SIZE_BYTES) {
-        if (lines.length === 0) {
-          // Truncate the oversized line to the byte limit so we don't send huge payloads.
-          const truncated = Buffer.from(lineWithNumber, "utf8")
-            .slice(0, FILE_OFFLOAD_TEXT_SIZE_BYTES)
-            .toString("utf8");
-          lines.push(truncated);
-        }
-        byteCapped = true;
-        break;
-      }
-
-      lines.push(lineWithNumber);
-      byteCount += lineBytes;
-
-      if (totalLines >= maxLines) {
-        break;
-      }
-    }
+    const page = await readTextFilePage(stream, {
+      fileSizeBytes,
+      maxLines,
+      budgetBytes: TEXT_FILE_PAGE_CONTENT_BUDGET_BYTES,
+      startLine,
+      byteOffset,
+    });
+    rendered = renderTextFilePage(page, {
+      path,
+      fileSizeBytes,
+      startLine,
+      byteOffset,
+    });
   } catch (err) {
     return new Err(
       new MCPError(
@@ -108,42 +98,28 @@ async function catText(
     );
   }
 
-  rl.close();
-
-  if (lines.length === 0) {
-    if (startLine > 1) {
-      return new Ok([
-        {
-          type: "text",
-          text: `No lines found at offset ${startLine} in \`${path}\`.`,
-        },
-      ]);
-    }
-    return new Ok([{ type: "text", text: `\`${path}\` is empty.` }]);
+  if (rendered.outcome === "file_changed") {
+    return new Err(new MCPError(fileChangedMessage(path), { tracked: false }));
   }
 
-  const endLine = startLine + lines.length - 1;
-  let text = lines.join("\n");
-
-  const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
-  const fileSizeKb = Math.ceil(fileSizeBytes / 1024);
-
-  if (byteCapped) {
-    text +=
-      `\n\n[Truncated at ${kb}KB. File is ${fileSizeKb}KB.` +
-      ` Showing lines ${startLine}-${endLine}.` +
-      ` Use offset=${endLine + 1} to read more.]`;
-  } else if (totalLines >= maxLines) {
-    text += `\n\n[Showing lines ${startLine}-${endLine}. Use offset=${endLine + 1} to read more.]`;
-  }
-
-  return new Ok([{ type: "text", text }]);
+  return new Ok([{ type: "text", text: rendered.text }]);
 }
 
 export async function catHandler(
-  { path, offset, limit }: { path: string; offset?: number; limit?: number },
+  {
+    path,
+    offset,
+    limit,
+    byte_offset: byteOffset,
+  }: { path: string; offset?: number; limit?: number; byte_offset?: number },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
+  if (byteOffset !== undefined && offset !== undefined) {
+    return new Err(
+      new MCPError(OFFSET_EXCLUSIVITY_ERROR_MESSAGE, { tracked: false })
+    );
+  }
+
   const conversationRes = requireAgentLoopConversation({ runContext });
   if (conversationRes.isErr()) {
     return conversationRes;
@@ -186,6 +162,14 @@ export async function catHandler(
     ]);
   }
 
+  if (byteOffset !== undefined && byteOffset >= sizeBytes) {
+    return new Err(
+      new MCPError(byteOffsetBeyondEndMessage(path, byteOffset, sizeBytes), {
+        tracked: false,
+      })
+    );
+  }
+
   const readResult = await dustFs.read(path);
   if (readResult.isErr()) {
     return new Err(new MCPError(readResult.error.message, { tracked: false }));
@@ -197,11 +181,11 @@ export async function catHandler(
     );
   }
 
-  return catText(
-    readResult.value, // Readable stream. readline will stop early when limit is reached
+  return catText(readResult.value, {
     path,
-    offset ?? 1,
-    limit ?? CAT_LINES_DEFAULT,
-    sizeBytes
-  );
+    fileSizeBytes: sizeBytes,
+    maxLines: limit ?? CAT_LINES_DEFAULT,
+    startLine: offset ?? 1,
+    byteOffset: byteOffset ?? null,
+  });
 }

--- a/front/lib/api/files/text_file_pagination.test.ts
+++ b/front/lib/api/files/text_file_pagination.test.ts
@@ -1,0 +1,236 @@
+import { readTextFilePage } from "@app/lib/api/files/text_file_pagination";
+import assert from "assert";
+import { Readable } from "stream";
+import { describe, expect, it } from "vitest";
+
+function streamOf(...chunks: string[]): Readable {
+  return Readable.from(chunks.map((c) => Buffer.from(c, "utf8")));
+}
+
+describe("readTextFilePage", () => {
+  it("handles newlines split across stream chunks", async () => {
+    const content = "abc\ndef\n";
+    const page = await readTextFilePage(streamOf("ab", "c\nde", "f\n"), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes: Buffer.byteLength(content, "utf8"),
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts).toEqual(["1: abc", "2: def"]);
+    expect(page.hasMore).toBe(false);
+    expect(page.endedMidLine).toBeNull();
+  });
+
+  it("emits a first line that exactly fills the budget without a continuation", async () => {
+    // "1: " (3 bytes) + 97 content bytes exactly fills a 100-byte budget. The join
+    // separator only exists between parts, so this line fits and no continuation must be
+    // produced (charging the separator unconditionally would yield byte_offset=EOF, which
+    // the handlers reject).
+    const line = "X".repeat(97);
+    const page = await readTextFilePage(streamOf(line), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes: 97,
+      maxLines: 100,
+      budgetBytes: 100,
+    });
+
+    expect(page.parts).toEqual([`1: ${line}`]);
+    expect(page.endedMidLine).toBeNull();
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("emits an exact-budget line with a trailing newline without an empty continuation", async () => {
+    const line = "X".repeat(97);
+    const page = await readTextFilePage(streamOf(line + "\n"), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes: 98,
+      maxLines: 100,
+      budgetBytes: 100,
+    });
+
+    expect(page.parts).toEqual([`1: ${line}`]);
+    expect(page.endedMidLine).toBeNull();
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("treats CRLF as a line boundary and strips the carriage return", async () => {
+    const content = "alpha\r\nbeta\r\n";
+    const page = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes: Buffer.byteLength(content, "utf8"),
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts).toEqual(["1: alpha", "2: beta"]);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("resumes at a byte_offset spanning chunk boundaries", async () => {
+    const line = "0123456789".repeat(10);
+    const content = line + "\n";
+    const fileSizeBytes = Buffer.byteLength(content, "utf8");
+
+    const first = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes,
+      maxLines: 100,
+      budgetBytes: 40,
+    });
+    assert(first.endedMidLine);
+
+    // Resume with the skipped prefix split across odd-sized chunks.
+    const second = await readTextFilePage(
+      streamOf(content.slice(0, 7), content.slice(7, 41), content.slice(41)),
+      {
+        startLine: 1,
+        byteOffset: first.endedMidLine.pos,
+        fileSizeBytes,
+        maxLines: 100,
+        budgetBytes: 1_000,
+      }
+    );
+    expect(second.parts).toEqual([
+      `1 (cont.): ${line.slice(first.endedMidLine.pos)}`,
+    ]);
+    expect(second.startedMidLine).toBe(true);
+    expect(second.hasMore).toBe(false);
+  });
+
+  it("counts newlines in the skipped prefix to keep line numbers accurate", async () => {
+    const content = "first\nsecond\nthird and more text\nfourth\n";
+    // Resume inside "third and more text" (line 3): bytes [0, 17) cover "first\nsecond\nthir".
+    const page = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: 17,
+      fileSizeBytes: Buffer.byteLength(content, "utf8"),
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts[0]).toBe("3 (cont.): d and more text");
+    expect(page.parts[1]).toBe("4: fourth");
+    expect(page.startedMidLine).toBe(true);
+  });
+
+  it("treats a byte_offset at a line start as a plain line, not a continuation", async () => {
+    const content = "abc\ndef\n";
+    // Byte 4 is the first byte of "def" (right after "abc\n").
+    const page = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: 4,
+      fileSizeBytes: Buffer.byteLength(content, "utf8"),
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts).toEqual(["2: def"]);
+    expect(page.startedMidLine).toBe(false);
+  });
+
+  it("snaps an inbound byte_offset backward off a multibyte character", async () => {
+    const line = "é".repeat(50); // 2 bytes per character.
+    const content = line + "\n";
+
+    // Byte 21 is the continuation byte of the 11th "é" (bytes [20, 22)); the resume must
+    // snap back to byte 20 and emit whole characters.
+    const page = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: 21,
+      fileSizeBytes: Buffer.byteLength(content, "utf8"),
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts).toEqual([`1 (cont.): ${"é".repeat(40)}`]);
+    expect(page.parts[0]).not.toContain("�");
+  });
+
+  it("snaps an inbound byte_offset even when the skip ends exactly at a chunk boundary", async () => {
+    const line = "é".repeat(50);
+    const content = line + "\n";
+
+    // The skip target (byte 21) is exactly the end of the first chunk, so the snap decision
+    // must carry over to the next chunk.
+    const page = await readTextFilePage(
+      streamOf(content.slice(0, 10), content.slice(10)),
+      {
+        startLine: 1,
+        byteOffset: 21,
+        fileSizeBytes: Buffer.byteLength(content, "utf8"),
+        maxLines: 100,
+        budgetBytes: 1_000,
+      }
+    );
+
+    expect(page.parts).toEqual([`1 (cont.): ${"é".repeat(40)}`]);
+    expect(page.parts[0]).not.toContain("�");
+  });
+
+  it("returns an empty page when the stream ends before the byte_offset", async () => {
+    const page = await readTextFilePage(streamOf("short"), {
+      startLine: 1,
+      byteOffset: 100,
+      fileSizeBytes: 5,
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+
+    expect(page.parts).toEqual([]);
+    expect(page.firstLine).toBeNull();
+  });
+
+  it("backs off to a UTF-8 boundary instead of splitting a character on output", async () => {
+    const line = "é".repeat(50); // 2 bytes per character.
+    const content = line + "\n";
+    const fileSizeBytes = Buffer.byteLength(content, "utf8");
+
+    // "1: " prefix is 3 bytes, so a 24-byte budget leaves 21 content bytes — landing inside
+    // the 11th "é" (bytes [20, 22)). The cut must back off to byte 20.
+    const page = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes,
+      maxLines: 100,
+      budgetBytes: 24,
+    });
+
+    assert(page.endedMidLine);
+    expect(page.parts[0]).toBe(`1: ${"é".repeat(10)}`);
+    expect(page.parts[0]).not.toContain("�");
+    expect(page.endedMidLine.pos).toBe(20);
+  });
+
+  it("resolves a page from an oversized line prefix without waiting for the newline", async () => {
+    // The rest of the line arrives late; the scanner must resolve the page from the
+    // buffered prefix alone instead of buffering the whole line up to its newline.
+    let restOfLineDelivered = false;
+    async function* chunks() {
+      yield Buffer.from("X".repeat(200), "utf8");
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      restOfLineDelivered = true;
+      yield Buffer.from("tail\n", "utf8");
+    }
+
+    const page = await readTextFilePage(Readable.from(chunks()), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes: 205,
+      maxLines: 100,
+      budgetBytes: 100,
+    });
+
+    assert(page.endedMidLine);
+    expect(page.parts[0]).toBe(`1: ${"X".repeat(97)}`);
+    expect(page.endedMidLine.pos).toBe(97);
+    expect(restOfLineDelivered).toBe(false);
+  });
+});

--- a/front/lib/api/files/text_file_pagination.test.ts
+++ b/front/lib/api/files/text_file_pagination.test.ts
@@ -21,6 +21,62 @@ describe("readTextFilePage", () => {
     expect(page.parts).toEqual(["1: abc", "2: def"]);
     expect(page.hasMore).toBe(false);
     expect(page.endedMidLine).toBeNull();
+    expect(page.nextByteOffset).toBeNull();
+  });
+
+  it("returns a byte cursor pointing after both CRLF bytes at a line-boundary stop", async () => {
+    const content = "alpha\r\nbeta\r\n";
+    const fileSizeBytes = Buffer.byteLength(content, "utf8");
+    const first = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes,
+      maxLines: 1,
+      budgetBytes: 1_000,
+    });
+
+    expect(first.parts).toEqual(["1: alpha"]);
+    // "alpha\r\n" is 7 bytes: the cursor must sit on the first byte of "beta".
+    expect(first.nextByteOffset).toBe(7);
+
+    const second = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: 7,
+      fileSizeBytes,
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+    expect(second.parts).toEqual(["2: beta"]);
+    expect(second.startedMidLine).toBe(false);
+  });
+
+  it("returns a byte cursor when the next line does not fit the remaining budget", async () => {
+    const content = "aaa\n" + "b".repeat(50) + "\n";
+    const fileSizeBytes = Buffer.byteLength(content, "utf8");
+    const first = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: null,
+      fileSizeBytes,
+      maxLines: 100,
+      budgetBytes: 20,
+    });
+
+    expect(first.parts).toEqual(["1: aaa"]);
+    expect(first.stopReason).toBe("budget");
+    expect(first.endedMidLine).toBeNull();
+    // The cursor sits on the first byte of the unemitted line 2.
+    expect(first.nextByteOffset).toBe(4);
+
+    const second = await readTextFilePage(streamOf(content), {
+      startLine: 1,
+      byteOffset: 4,
+      fileSizeBytes,
+      maxLines: 100,
+      budgetBytes: 1_000,
+    });
+    expect(second.parts).toEqual([`2: ${"b".repeat(50)}`]);
+    expect(second.startedMidLine).toBe(false);
+    expect(second.nextByteOffset).toBeNull();
   });
 
   it("emits a first line that exactly fills the budget without a continuation", async () => {
@@ -40,6 +96,7 @@ describe("readTextFilePage", () => {
     expect(page.parts).toEqual([`1: ${line}`]);
     expect(page.endedMidLine).toBeNull();
     expect(page.hasMore).toBe(false);
+    expect(page.nextByteOffset).toBeNull();
   });
 
   it("emits an exact-budget line with a trailing newline without an empty continuation", async () => {
@@ -55,6 +112,7 @@ describe("readTextFilePage", () => {
     expect(page.parts).toEqual([`1: ${line}`]);
     expect(page.endedMidLine).toBeNull();
     expect(page.hasMore).toBe(false);
+    expect(page.nextByteOffset).toBeNull();
   });
 
   it("treats CRLF as a line boundary and strips the carriage return", async () => {
@@ -84,6 +142,8 @@ describe("readTextFilePage", () => {
       budgetBytes: 40,
     });
     assert(first.endedMidLine);
+    // Mid-line and line-boundary stops share the same continuation cursor.
+    expect(first.nextByteOffset).toBe(first.endedMidLine.pos);
 
     // Resume with the skipped prefix split across odd-sized chunks.
     const second = await readTextFilePage(

--- a/front/lib/api/files/text_file_pagination.ts
+++ b/front/lib/api/files/text_file_pagination.ts
@@ -1,0 +1,428 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import type { Readable } from "stream";
+import { z } from "zod";
+
+/**
+ * Byte-accurate pagination for `cat`-style text file reads, shared by the agent-loop files
+ * server and the public Dust MCP files tools.
+ *
+ * Line-based reads paginate with `offset` (1-indexed line number). When a single line
+ * exceeds the whole byte budget of a page, the largest UTF-8-boundary-safe prefix is
+ * emitted and the footer hands back a `byte_offset` to resume from inside the line.
+ */
+
+// The `files` server is exempt from tool-output offloading (see
+// TEXT_OFFLOAD_EXEMPT_MCP_SERVERS), but the response is still budgeted so that content +
+// footer stay under FILE_OFFLOAD_TEXT_SIZE_BYTES: the read guarantee should not depend on
+// the exemption list.
+const TEXT_FILE_PAGE_FOOTER_RESERVED_BYTES = 2 * 1024;
+export const TEXT_FILE_PAGE_CONTENT_BUDGET_BYTES =
+  FILE_OFFLOAD_TEXT_SIZE_BYTES - TEXT_FILE_PAGE_FOOTER_RESERVED_BYTES;
+
+const NEWLINE_BYTE = 0x0a;
+const CARRIAGE_RETURN_BYTE = 0x0d;
+// A UTF-8 character is at most 4 bytes: one lead byte plus up to 3 continuation bytes.
+const UTF8_MAX_CONTINUATION_BYTES = 3;
+
+export const BYTE_OFFSET_SCHEMA = z
+  .number()
+  .int()
+  .min(1)
+  .optional()
+  .describe(
+    "Byte position to resume from, exactly as indicated by a previous response's truncation footer " +
+      "(`byte_offset=N`). Only for continuing a read that was truncated inside an oversized line. " +
+      "Never compute or invent this value. Do not combine with `offset`."
+  );
+
+export const OFFSET_EXCLUSIVITY_ERROR_MESSAGE =
+  "Provide either `offset` or `byte_offset`, not both. Use `byte_offset` only to continue a response that was truncated inside a line.";
+
+export function byteOffsetBeyondEndMessage(
+  path: string,
+  byteOffset: number,
+  sizeBytes: number
+): string {
+  return (
+    `byte_offset=${byteOffset} is at or beyond the end of \`${path}\` (${sizeBytes} bytes). ` +
+    `The file may have changed since this offset was issued; re-read it from the beginning (offset=1).`
+  );
+}
+
+export function fileChangedMessage(path: string): string {
+  return `\`${path}\` appears to have changed since this byte_offset was issued. Re-read the file from the beginning (offset=1).`;
+}
+
+function isUtf8ContinuationByte(byte: number): boolean {
+  return (byte & 0xc0) === 0x80;
+}
+
+/**
+ * Returns the largest cut <= maxBytes such that bytes[0, cut) does not end in the middle of a
+ * UTF-8 character.
+ */
+function utf8BoundaryFloor(bytes: Buffer, maxBytes: number): number {
+  if (maxBytes >= bytes.length) {
+    return bytes.length;
+  }
+
+  let cut = maxBytes;
+  for (
+    let i = 0;
+    i < UTF8_MAX_CONTINUATION_BYTES &&
+    cut > 0 &&
+    isUtf8ContinuationByte(bytes[cut]);
+    i++
+  ) {
+    cut--;
+  }
+  if (isUtf8ContinuationByte(bytes[cut])) {
+    // Still inside a continuation sequence: the data is not valid UTF-8, cut anywhere.
+    return maxBytes;
+  }
+
+  return cut;
+}
+
+function stripTrailingCr(bytes: Buffer): Buffer {
+  return bytes.length > 0 && bytes[bytes.length - 1] === CARRIAGE_RETURN_BYTE
+    ? bytes.subarray(0, bytes.length - 1)
+    : bytes;
+}
+
+function countNewlines(bytes: Buffer): number {
+  let count = 0;
+  let idx = bytes.indexOf(NEWLINE_BYTE);
+  while (idx !== -1) {
+    count++;
+    idx = bytes.indexOf(NEWLINE_BYTE, idx + 1);
+  }
+  return count;
+}
+
+export type TextFilePageParams = {
+  fileSizeBytes: number;
+  maxLines: number;
+  budgetBytes: number;
+  /** First line to emit for line-based pagination (1-indexed). Must be 1 when `byteOffset` is set. */
+  startLine: number;
+  /**
+   * Byte position to resume from (mid-line continuation), or null for line-based reads.
+   * Snapped backward to a UTF-8 character boundary when it lands inside a multibyte character.
+   */
+  byteOffset: number | null;
+};
+
+export type TextFilePage = {
+  /** Display lines/segments, already prefixed with their line number. */
+  parts: string[];
+  firstLine: number | null;
+  lastLine: number | null;
+  /** True when the page resumed inside a line (byteOffset mode, not at a line start). */
+  startedMidLine: boolean;
+  /** Set when the page ends inside a line; `pos` is the absolute byte offset to resume from. */
+  endedMidLine: { line: number; pos: number } | null;
+  /** True when file content remains beyond this page. */
+  hasMore: boolean;
+  stopReason: "budget" | "max_lines" | null;
+};
+
+/**
+ * Scans a text file stream and produces one page of numbered display lines.
+ *
+ * Line-based reads skip whole lines up to `startLine` (classic offset pagination).
+ * When `byteOffset` is set, exactly that many bytes are skipped (counting newlines to keep
+ * line numbers accurate) and emission resumes from inside the line at that position; an
+ * offset landing inside a multibyte character is snapped backward to the character start.
+ *
+ * When a single line exceeds the whole byte budget of an empty page, the largest
+ * UTF-8-boundary-safe prefix is emitted and `endedMidLine` carries the byte position to
+ * resume from.
+ *
+ * Line boundaries are `\n`; a `\r` directly before it is stripped from display (CRLF).
+ * Lone-`\r` (classic Mac) line endings are NOT treated as boundaries — such content reads
+ * as a single line with embedded carriage returns.
+ */
+export async function readTextFilePage(
+  stream: Readable,
+  params: TextFilePageParams
+): Promise<TextFilePage> {
+  let skipRemaining = params.byteOffset ?? 0;
+  let awaitingResume = params.byteOffset !== null;
+  // Last bytes seen while skipping, kept to snap a byteOffset that lands inside a multibyte
+  // character back to the character's lead byte, and to detect a resume at a line start.
+  const skipTail: number[] = [];
+  let lineNumber = 1;
+  let consumedBytes = 0;
+  let startedMidLine = false;
+  let isContinuationSegment = false;
+
+  let pending: Buffer[] = [];
+  let pendingBytes = 0;
+  const parts: string[] = [];
+  let budget = params.budgetBytes;
+  let emittedLineCount = 0;
+  let firstLine: number | null = null;
+  let lastLine: number | null = null;
+  let endedMidLine: { line: number; pos: number } | null = null;
+  let stopReason: "budget" | "max_lines" | null = null;
+
+  // Handles one complete line (bytes without the trailing "\n"). Returns false when the page
+  // is complete and scanning must stop.
+  const handleCompleteLine = (raw: Buffer, hasNewline: boolean): boolean => {
+    if (lineNumber < params.startLine) {
+      consumedBytes += raw.length + (hasNewline ? 1 : 0);
+      return true;
+    }
+
+    const displayRaw = stripTrailingCr(raw);
+    const prefix = isContinuationSegment
+      ? `${lineNumber} (cont.): `
+      : `${lineNumber}: `;
+    const prefixBytes = Buffer.byteLength(prefix, "utf8");
+    // Parts are joined with "\n", so the separator byte only exists for non-first parts.
+    const separatorBytes = parts.length > 0 ? 1 : 0;
+    const displayBytes = separatorBytes + prefixBytes + displayRaw.length;
+
+    if (displayBytes <= budget) {
+      parts.push(prefix + displayRaw.toString("utf8"));
+      budget -= displayBytes;
+      consumedBytes += raw.length + (hasNewline ? 1 : 0);
+      firstLine = firstLine ?? lineNumber;
+      lastLine = lineNumber;
+      emittedLineCount++;
+      isContinuationSegment = false;
+      if (emittedLineCount >= params.maxLines) {
+        stopReason = "max_lines";
+        return false;
+      }
+      return true;
+    }
+
+    if (parts.length > 0) {
+      // The line does not fit in the remaining budget: end the page at the previous line
+      // boundary and let the next call (offset-based) pick it up.
+      stopReason = "budget";
+      return false;
+    }
+
+    // Empty page with a line larger than the whole budget: emit the largest UTF-8-safe
+    // prefix and hand back the byte position to resume from.
+    const cut = utf8BoundaryFloor(displayRaw, budget - prefixBytes);
+    const head = displayRaw.subarray(0, cut);
+    parts.push(prefix + head.toString("utf8"));
+    consumedBytes += cut;
+    firstLine = firstLine ?? lineNumber;
+    lastLine = lineNumber;
+    endedMidLine = { line: lineNumber, pos: consumedBytes };
+    stopReason = "budget";
+    return false;
+  };
+
+  let stopped = false;
+
+  for await (const rawChunk of stream) {
+    let chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+
+    if (skipRemaining > 0) {
+      const skipped = chunk.subarray(0, Math.min(skipRemaining, chunk.length));
+      lineNumber += countNewlines(skipped);
+      consumedBytes += skipped.length;
+      for (const byte of skipped.subarray(
+        Math.max(0, skipped.length - UTF8_MAX_CONTINUATION_BYTES)
+      )) {
+        skipTail.push(byte);
+        if (skipTail.length > UTF8_MAX_CONTINUATION_BYTES) {
+          skipTail.shift();
+        }
+      }
+      skipRemaining -= skipped.length;
+      if (skipRemaining > 0) {
+        continue;
+      }
+      chunk = chunk.subarray(skipped.length);
+    }
+
+    if (awaitingResume) {
+      if (chunk.length === 0) {
+        continue;
+      }
+      // Snap backward when the requested byte offset lands inside a multibyte character:
+      // restore the character's already-skipped bytes so the output starts at its lead byte.
+      const restored: number[] = [];
+      let firstByte = chunk[0];
+      while (
+        isUtf8ContinuationByte(firstByte) &&
+        skipTail.length > 0 &&
+        restored.length < UTF8_MAX_CONTINUATION_BYTES
+      ) {
+        const previousByte = skipTail.pop();
+        if (previousByte === undefined) {
+          break;
+        }
+        restored.unshift(previousByte);
+        firstByte = previousByte;
+      }
+      if (restored.length > 0) {
+        if (isUtf8ContinuationByte(firstByte)) {
+          // Not valid UTF-8 around the requested position: keep the original cut.
+          skipTail.push(...restored);
+        } else {
+          chunk = Buffer.concat([Buffer.from(restored), chunk]);
+          consumedBytes -= restored.length;
+        }
+      }
+
+      // An empty tail after snapping only occurs for a byte_offset a few bytes into a
+      // leading multibyte character; treat the resume as a line start.
+      const byteBeforeResume =
+        skipTail.length > 0 ? skipTail[skipTail.length - 1] : null;
+      startedMidLine =
+        consumedBytes > 0 &&
+        byteBeforeResume !== null &&
+        byteBeforeResume !== NEWLINE_BYTE;
+      isContinuationSegment = startedMidLine;
+      awaitingResume = false;
+    }
+
+    let searchFrom = 0;
+    while (searchFrom <= chunk.length) {
+      const newlineIndex = chunk.indexOf(NEWLINE_BYTE, searchFrom);
+      if (newlineIndex === -1) {
+        const rest = chunk.subarray(searchFrom);
+        if (rest.length === 0) {
+          break;
+        }
+        if (lineNumber < params.startLine) {
+          // The line is being skipped: account for it as it streams instead of buffering it.
+          consumedBytes += rest.length;
+          break;
+        }
+        pending.push(rest);
+        pendingBytes += rest.length;
+        // A single line can be arbitrarily large. Once the buffered prefix alone exceeds
+        // the page budget the outcome is already decided (split, or stop at the previous
+        // line boundary), so resolve it now instead of buffering up to the newline.
+        if (pendingBytes > budget) {
+          const raw =
+            pending.length === 1 ? pending[0] : Buffer.concat(pending);
+          pending = [];
+          pendingBytes = 0;
+          handleCompleteLine(raw, false);
+          stopped = true;
+        }
+        break;
+      }
+
+      pending.push(chunk.subarray(searchFrom, newlineIndex));
+      const raw = pending.length === 1 ? pending[0] : Buffer.concat(pending);
+      pending = [];
+      pendingBytes = 0;
+      if (!handleCompleteLine(raw, true)) {
+        stopped = true;
+        break;
+      }
+      lineNumber++;
+      searchFrom = newlineIndex + 1;
+    }
+
+    if (stopped) {
+      break;
+    }
+  }
+
+  if (!stopped && pending.length > 0) {
+    const raw = pending.length === 1 ? pending[0] : Buffer.concat(pending);
+    pending = [];
+    handleCompleteLine(raw, false);
+  }
+
+  return {
+    parts,
+    firstLine,
+    lastLine,
+    startedMidLine,
+    endedMidLine,
+    hasMore: endedMidLine !== null || consumedBytes < params.fileSizeBytes,
+    stopReason,
+  };
+}
+
+export type TextFilePageRender =
+  | { outcome: "ok"; text: string }
+  /** byteOffset mode where the stream ran short of the offset: the file shrank between stat and read. */
+  | { outcome: "file_changed" };
+
+function describeShownRange(
+  firstLine: number,
+  lastLine: number,
+  startedMidLine: boolean
+): string {
+  if (startedMidLine) {
+    return lastLine > firstLine
+      ? `Showing the remainder of line ${firstLine}, then lines ${firstLine + 1}-${lastLine}.`
+      : `Showing the remainder of line ${firstLine}.`;
+  }
+  return `Showing lines ${firstLine}-${lastLine}.`;
+}
+
+/**
+ * Renders a scanned page as the model-facing text, including the pagination footer that
+ * tells the model how to continue (`offset` at line boundaries, `byte_offset` inside an
+ * oversized line).
+ */
+export function renderTextFilePage(
+  page: TextFilePage,
+  {
+    path,
+    fileSizeBytes,
+    startLine,
+    byteOffset,
+  }: {
+    path: string;
+    fileSizeBytes: number;
+    startLine: number;
+    byteOffset: number | null;
+  }
+): TextFilePageRender {
+  const { firstLine, lastLine } = page;
+  if (page.parts.length === 0 || firstLine === null || lastLine === null) {
+    if (byteOffset !== null) {
+      return { outcome: "file_changed" };
+    }
+    if (startLine > 1) {
+      return {
+        outcome: "ok",
+        text: `No lines found at offset ${startLine} in \`${path}\`.`,
+      };
+    }
+    return { outcome: "ok", text: `\`${path}\` is empty.` };
+  }
+
+  let text = page.parts.join("\n");
+
+  const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
+
+  if (page.endedMidLine) {
+    text +=
+      `\n\n[Truncated inside line ${page.endedMidLine.line} (${kb}KB output cap). ` +
+      `File is ${fileSizeBytes} bytes; shown up to byte ${page.endedMidLine.pos}. ` +
+      `To continue reading line ${page.endedMidLine.line}, call again with byte_offset=${page.endedMidLine.pos} and no offset. ` +
+      `Do not use offset=${page.endedMidLine.line + 1}: it would skip the remainder of line ${page.endedMidLine.line}.]`;
+  } else if (page.hasMore) {
+    const rangeLabel = describeShownRange(
+      firstLine,
+      lastLine,
+      page.startedMidLine
+    );
+    if (page.stopReason === "budget") {
+      text += `\n\n[Truncated at ${kb}KB. File is ${fileSizeBytes} bytes. ${rangeLabel} Use offset=${lastLine + 1} to read more.]`;
+    } else {
+      text += `\n\n[${rangeLabel} Use offset=${lastLine + 1} to read more.]`;
+    }
+  } else if (page.startedMidLine) {
+    text += `\n\n[Reached end of file.]`;
+  }
+
+  return { outcome: "ok", text };
+}

--- a/front/lib/api/files/text_file_pagination.ts
+++ b/front/lib/api/files/text_file_pagination.ts
@@ -3,12 +3,12 @@ import type { Readable } from "stream";
 import { z } from "zod";
 
 /**
- * Byte-accurate pagination for `cat`-style text file reads, shared by the agent-loop files
- * server and the public Dust MCP files tools.
+ * Byte-accurate pagination for `cat`-style text file reads.
  *
- * Line-based reads paginate with `offset` (1-indexed line number). When a single line
- * exceeds the whole byte budget of a page, the largest UTF-8-boundary-safe prefix is
- * emitted and the footer hands back a `byte_offset` to resume from inside the line.
+ * `offset` (1-indexed line number) starts a read at a specific line. Continuation is
+ * uniform: every truncated response's footer hands back the `byte_offset` of the next
+ * unread byte — the start of the next line when the page ended at a line boundary, or the
+ * position inside an oversized line when the page ended mid-line.
  */
 
 // The `files` server is exempt from tool-output offloading (see
@@ -30,13 +30,13 @@ export const BYTE_OFFSET_SCHEMA = z
   .min(1)
   .optional()
   .describe(
-    "Byte position to resume from, exactly as indicated by a previous response's truncation footer " +
-      "(`byte_offset=N`). Only for continuing a read that was truncated inside an oversized line. " +
-      "Never compute or invent this value. Do not combine with `offset`."
+    "Byte position from the immediately preceding response's continuation footer (`byte_offset=N`). " +
+      "Pass it back exactly to continue reading, whether the previous response ended at a line " +
+      "boundary or inside a line. Never compute or invent this value. Do not combine with `offset`."
   );
 
 export const OFFSET_EXCLUSIVITY_ERROR_MESSAGE =
-  "Provide either `offset` or `byte_offset`, not both. Use `byte_offset` only to continue a response that was truncated inside a line.";
+  "Provide either `offset` or `byte_offset`, not both. Use `byte_offset` to continue from a previous response's footer, and `offset` to start reading at a specific line.";
 
 export function byteOffsetBeyondEndMessage(
   path: string,
@@ -122,6 +122,11 @@ export type TextFilePage = {
   startedMidLine: boolean;
   /** Set when the page ends inside a line; `pos` is the absolute byte offset to resume from. */
   endedMidLine: { line: number; pos: number } | null;
+  /**
+   * Absolute byte position of the next unread byte — the continuation cursor for the
+   * footer, whether the page ended at a line boundary or inside a line. Null at end of file.
+   */
+  nextByteOffset: number | null;
   /** True when file content remains beyond this page. */
   hasMore: boolean;
   stopReason: "budget" | "max_lines" | null;
@@ -337,13 +342,16 @@ export async function readTextFilePage(
     handleCompleteLine(raw, false);
   }
 
+  const hasMore = endedMidLine !== null || consumedBytes < params.fileSizeBytes;
+
   return {
     parts,
     firstLine,
     lastLine,
     startedMidLine,
     endedMidLine,
-    hasMore: endedMidLine !== null || consumedBytes < params.fileSizeBytes,
+    nextByteOffset: hasMore ? consumedBytes : null,
+    hasMore,
     stopReason,
   };
 }
@@ -367,9 +375,9 @@ function describeShownRange(
 }
 
 /**
- * Renders a scanned page as the model-facing text, including the pagination footer that
- * tells the model how to continue (`offset` at line boundaries, `byte_offset` inside an
- * oversized line).
+ * Renders a scanned page as the model-facing text. Whenever more content remains, the
+ * footer returns the `byte_offset` to continue from; `offset` is only an input for direct
+ * line-based reads.
  */
 export function renderTextFilePage(
   page: TextFilePage,
@@ -403,22 +411,21 @@ export function renderTextFilePage(
 
   const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
 
-  if (page.endedMidLine) {
+  if (page.endedMidLine && page.nextByteOffset !== null) {
     text +=
       `\n\n[Truncated inside line ${page.endedMidLine.line} (${kb}KB output cap). ` +
-      `File is ${fileSizeBytes} bytes; shown up to byte ${page.endedMidLine.pos}. ` +
-      `To continue reading line ${page.endedMidLine.line}, call again with byte_offset=${page.endedMidLine.pos} and no offset. ` +
-      `Do not use offset=${page.endedMidLine.line + 1}: it would skip the remainder of line ${page.endedMidLine.line}.]`;
-  } else if (page.hasMore) {
+      `File is ${fileSizeBytes} bytes. ` +
+      `Use byte_offset=${page.nextByteOffset} to continue reading line ${page.endedMidLine.line}.]`;
+  } else if (page.nextByteOffset !== null) {
     const rangeLabel = describeShownRange(
       firstLine,
       lastLine,
       page.startedMidLine
     );
     if (page.stopReason === "budget") {
-      text += `\n\n[Truncated at ${kb}KB. File is ${fileSizeBytes} bytes. ${rangeLabel} Use offset=${lastLine + 1} to read more.]`;
+      text += `\n\n[Truncated at ${kb}KB. File is ${fileSizeBytes} bytes. ${rangeLabel} Use byte_offset=${page.nextByteOffset} to read more.]`;
     } else {
-      text += `\n\n[${rangeLabel} Use offset=${lastLine + 1} to read more.]`;
+      text += `\n\n[${rangeLabel} Use byte_offset=${page.nextByteOffset} to read more.]`;
     }
   } else if (page.startedMidLine) {
     text += `\n\n[Reached end of file.]`;


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9676.

`files cat` could not read past the first ~20KB of a single oversized line: the truncation footer suggested `offset=N+1`, which skips the truncated line, making its remaining bytes unreachable — in production, a 23KB single-block instruction file lost its last ~3KB. The byte slice at the cap could also split a multibyte UTF-8 character.

**What this PR does:**
1. Replaces the readline-based reader with a byte-accurate scanner (`readTextFilePage`, in `lib/api/files/text_file_pagination.ts`). Memory is bounded by the page budget plus one stream chunk; content is budgeted at 18KB with a 2KB footer reserve so responses stay under the 20KB offload threshold.
2. Makes `byte_offset` the single continuation cursor: every truncated response's footer returns the byte position of the next unread byte — the start of the next line at a line boundary, or the position inside an oversized line. `offset` remains as an input for direct line jumps (e.g. from `grep` results) but is no longer returned as a cursor. One continuation rule for the model instead of two.
3. Line numbers stay exact on byte resumes (newlines are counted in the skipped prefix), and cuts are UTF-8-safe both ways: outbound truncation and inbound offsets snap to character boundaries.
4. A `byte_offset` for a file that has changed returns a clear error telling the model to restart with `offset=1`.

## Tests

28 tests across scanner and handler: oversized ASCII/multibyte lines, exact reconstruction of ordinary and oversized files following only byte cursors, direct `offset` jumps with byte-cursor continuation, chunk-boundary resumes, CRLF cursors, exact-budget edge cases, staleness errors, and the #9676 payload (a marker beyond byte 20,480 in a >20KB single-line HTML block, retrieved via continuation).

## Risk

Worst case, a stale or invented `byte_offset` errors out or wastes a read; line-based reads behave as before (regression-tested). Safe to rollback — the continuation is stateless.

## Deploy Plan

- [ ] Deploy front. No migration, no ordering constraints.
- [ ] Verify against app.dust.tt (agent with >20KB single-block instructions must answer "Instruction 169" via continuation reads) before resolving dust-tt/tasks#9676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)