### PR TITLE
[front] fix: 4xx personal OAuth setup when the workspace connection is missing or dangling

### DIFF
--- a/front-api/routes/w/[wId]/oauth/[provider]/setup.test.ts
+++ b/front-api/routes/w/[wId]/oauth/[provider]/setup.test.ts
@@ -1,0 +1,92 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { Err } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConnectionMetadata: vi.fn(),
+}));
+
+vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/types/oauth/oauth_api")>();
+
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function OAuthAPIMock() {
+      return {
+        getConnectionMetadata: mocks.getConnectionMetadata,
+      };
+    }),
+  };
+});
+
+function getSetup(workspace: { sId: string }, mcpServerId: string) {
+  const extraConfig = encodeURIComponent(
+    JSON.stringify({ mcp_server_id: mcpServerId })
+  );
+  return honoApp.request(
+    `/api/w/${workspace.sId}/oauth/hubspot/setup?useCase=personal_actions&extraConfig=${extraConfig}`
+  );
+}
+
+describe("OAuth setup handler", () => {
+  beforeEach(() => {
+    mocks.getConnectionMetadata.mockReset();
+  });
+
+  it("returns a 404 when the workspace connection for the MCP server is missing", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    // A server without any workspace-level connection.
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await getSetup(workspace, remoteServer.sId);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message:
+          "This tool has no workspace-level connection. Ask a workspace admin to connect the " +
+          "tool before setting up your personal connection.",
+      },
+    });
+    expect(mocks.getConnectionMetadata).not.toHaveBeenCalled();
+  });
+
+  it("returns a 404 when the workspace connection references a connection the OAuth service no longer has", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // The front row exists but its connectionId dangles in the OAuth service
+    // (e.g. after a workspace relocation).
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    await MCPServerConnectionFactory.remote(auth, remoteServer, "workspace");
+
+    mocks.getConnectionMetadata.mockResolvedValue(
+      new Err({
+        code: "connection_not_found",
+        message: "Requested connection was not found",
+      })
+    );
+
+    const response = await getSetup(workspace, remoteServer.sId);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message:
+          "This tool's workspace connection no longer exists. Ask a workspace admin to " +
+          "reconnect the tool before setting up your personal connection.",
+      },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/oauth/[provider]/setup.ts
+++ b/front-api/routes/w/[wId]/oauth/[provider]/setup.ts
@@ -7,6 +7,7 @@ import {
   OAUTH_PROVIDERS,
   OAUTH_USE_CASES,
 } from "@app/types/oauth/lib";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -70,13 +71,30 @@ app.get(
     );
 
     if (!urlRes.isOk()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: urlRes.error.message,
-        },
-      });
+      switch (urlRes.error.code) {
+        case "mcp_server_connection_not_found":
+          // The message is user-facing, crafted in `verifyWorkspaceOAuthConnectionForMCPServer`.
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "mcp_server_connection_not_found",
+              message: urlRes.error.message,
+            },
+          });
+        case "connection_creation_failed":
+        case "connection_not_implemented":
+        case "connection_finalization_failed":
+        case "credential_retrieval_failed":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: urlRes.error.message,
+            },
+          });
+        default:
+          return assertNever(urlRes.error.code);
+      }
     }
 
     return ctx.json({ redirectUrl: urlRes.value });

--- a/front/components/pages/oauth/OAuthSetupRedirectPage.test.tsx
+++ b/front/components/pages/oauth/OAuthSetupRedirectPage.test.tsx
@@ -1,0 +1,75 @@
+import { OAuthSetupRedirectPage } from "@app/components/pages/oauth/OAuthSetupRedirectPage";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useOAuthSetup: vi.fn(),
+}));
+
+vi.mock("@app/lib/platform", () => ({
+  useAppRouter: () => ({ replace: vi.fn() }),
+  usePathParam: (name: string) =>
+    name === "wId" ? "w_123" : name === "provider" ? "hubspot" : null,
+  useSearchParam: (name: string) =>
+    name === "useCase" ? "personal_actions" : null,
+}));
+
+vi.mock("@app/lib/swr/oauth", () => ({
+  useOAuthSetup: mocks.useOAuthSetup,
+}));
+
+vi.mock("@dust-tt/sparkle", () => ({
+  Spinner: () => <div role="status" />,
+}));
+
+function mockSetupError(error: unknown) {
+  mocks.useOAuthSetup.mockReturnValue({
+    redirectUrl: undefined,
+    isOAuthSetupLoading: false,
+    isOAuthSetupError: error,
+  });
+}
+
+const GENERIC_MESSAGE = "Failed to initialize OAuth connection.";
+
+describe("OAuthSetupRedirectPage error display", () => {
+  beforeEach(() => {
+    mocks.useOAuthSetup.mockReset();
+  });
+
+  it("displays the actionable message for mcp_server_connection_not_found", () => {
+    const message =
+      "This tool's workspace connection no longer exists. Ask a workspace admin to " +
+      "reconnect the tool before setting up your personal connection.";
+    mockSetupError({
+      error: { type: "mcp_server_connection_not_found", message },
+    });
+
+    render(<OAuthSetupRedirectPage />);
+
+    expect(screen.getByText(message)).toBeTruthy();
+  });
+
+  it("displays the generic message for internal_server_error", () => {
+    mockSetupError({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to get connection metadata: ECONNREFUSED 10.0.0.1",
+      },
+    });
+
+    render(<OAuthSetupRedirectPage />);
+
+    expect(screen.getByText(GENERIC_MESSAGE)).toBeTruthy();
+    expect(screen.queryByText(/ECONNREFUSED/)).toBeNull();
+  });
+
+  it("displays the generic message for non-API errors", () => {
+    mockSetupError(new Error("fetch failed"));
+
+    render(<OAuthSetupRedirectPage />);
+
+    expect(screen.getByText(GENERIC_MESSAGE)).toBeTruthy();
+    expect(screen.queryByText(/fetch failed/)).toBeNull();
+  });
+});

--- a/front/components/pages/oauth/OAuthSetupRedirectPage.tsx
+++ b/front/components/pages/oauth/OAuthSetupRedirectPage.tsx
@@ -1,5 +1,6 @@
 import { useAppRouter, usePathParam, useSearchParam } from "@app/lib/platform";
 import { useOAuthSetup } from "@app/lib/swr/oauth";
+import { isAPIErrorResponse } from "@app/types/error";
 import type {
   OAuthCredentials,
   OAuthProvider,
@@ -71,7 +72,13 @@ export function OAuthSetupRedirectPage() {
             ? "Invalid OAuth provider."
             : !useCase
               ? "Invalid OAuth use case."
-              : "Failed to initialize OAuth connection."}
+              : // Only `mcp_server_connection_not_found` messages are written for end users;
+                // other API errors can carry raw upstream details.
+                isAPIErrorResponse(isOAuthSetupError) &&
+                  isOAuthSetupError.error.type ===
+                    "mcp_server_connection_not_found"
+                ? isOAuthSetupError.error.message
+                : "Failed to initialize OAuth connection."}
         </p>
       </div>
     );

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
+import { verifyWorkspaceOAuthConnectionForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -58,7 +59,8 @@ export type OAuthError = {
     | "connection_creation_failed"
     | "connection_not_implemented"
     | "connection_finalization_failed"
-    | "credential_retrieval_failed";
+    | "credential_retrieval_failed"
+    | "mcp_server_connection_not_found";
   message: string;
   oAuthAPIError?: OAuthAPIError;
 };
@@ -129,6 +131,38 @@ export async function createConnectionAndGetSetupUrl(
   let relatedCredential: RelatedCredential | undefined = undefined;
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const userId = auth.getNonNullableUser().sId;
+
+  // Personal connections with an `mcp_server_id` inherit their config from the workspace-level
+  // admin connection. Verify it upfront: the front row can reference a connection that no longer
+  // exists in the OAuth service (e.g. after a workspace relocation), and every provider treats
+  // that as fatal deeper in the flow with a less actionable error. The provider re-fetches the
+  // same metadata right after; the redundant read is acceptable for this rare, human-initiated
+  // flow.
+  if (useCase === "personal_actions" && isString(extraConfig.mcp_server_id)) {
+    const workspaceConnectionRes =
+      await verifyWorkspaceOAuthConnectionForMCPServer(
+        auth,
+        extraConfig.mcp_server_id
+      );
+    if (workspaceConnectionRes.isErr()) {
+      // `info`, not `warn`: this is a user-recoverable condition, not a failure.
+      logger.info(
+        {
+          workspaceId,
+          userId,
+          provider,
+          useCase,
+          mcpServerId: extraConfig.mcp_server_id,
+          kind: workspaceConnectionRes.error.kind,
+        },
+        "OAuth: Workspace connection missing or invalid for personal connection setup"
+      );
+      return new Err({
+        code: "mcp_server_connection_not_found",
+        message: workspaceConnectionRes.error.message,
+      });
+    }
+  }
 
   if (providerStrategy.getRelatedCredential) {
     const credentialResult = await providerStrategy.getRelatedCredential!(

--- a/front/lib/api/oauth/mcp_server_connection_auth.test.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.test.ts
@@ -1,0 +1,129 @@
+import { verifyWorkspaceOAuthConnectionForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConnectionMetadata: vi.fn(),
+}));
+
+vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/types/oauth/oauth_api")>();
+
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function OAuthAPIMock() {
+      return {
+        getConnectionMetadata: mocks.getConnectionMetadata,
+      };
+    }),
+  };
+});
+
+async function setupWithWorkspaceConnection() {
+  const { workspace, authenticator } = await createResourceTest({
+    role: "admin",
+  });
+  const remoteServer = await RemoteMCPServerFactory.create(workspace);
+  await MCPServerConnectionFactory.remote(
+    authenticator,
+    remoteServer,
+    "workspace"
+  );
+  return { authenticator, remoteServer };
+}
+
+describe("verifyWorkspaceOAuthConnectionForMCPServer", () => {
+  beforeEach(() => {
+    mocks.getConnectionMetadata.mockReset();
+  });
+
+  it("returns Ok when the connection exists in the OAuth service", async () => {
+    const { authenticator, remoteServer } =
+      await setupWithWorkspaceConnection();
+
+    mocks.getConnectionMetadata.mockResolvedValue(
+      new Ok({ connection: { connection_id: "con_workspace" } })
+    );
+
+    const result = await verifyWorkspaceOAuthConnectionForMCPServer(
+      authenticator,
+      remoteServer.sId
+    );
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("returns Err when the OAuth service no longer has the connection", async () => {
+    const { authenticator, remoteServer } =
+      await setupWithWorkspaceConnection();
+
+    mocks.getConnectionMetadata.mockResolvedValue(
+      new Err({
+        code: "connection_not_found",
+        message: "Requested connection was not found",
+      })
+    );
+
+    const result = await verifyWorkspaceOAuthConnectionForMCPServer(
+      authenticator,
+      remoteServer.sId
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe("connection_not_found");
+      expect(result.error.message).toBe(
+        "This tool's workspace connection no longer exists. Ask a workspace admin to " +
+          "reconnect the tool before setting up your personal connection."
+      );
+    }
+  });
+
+  it("passes on transient OAuth service failures so callers surface them as internal errors", async () => {
+    const { authenticator, remoteServer } =
+      await setupWithWorkspaceConnection();
+
+    for (const code of [
+      "unexpected_network_error",
+      "internal_server_error",
+      "unexpected_response_format",
+    ]) {
+      mocks.getConnectionMetadata.mockResolvedValue(
+        new Err({ code, message: "OAuth service unavailable" })
+      );
+
+      const result = await verifyWorkspaceOAuthConnectionForMCPServer(
+        authenticator,
+        remoteServer.sId
+      );
+
+      expect(result.isOk()).toBe(true);
+    }
+  });
+
+  it("returns Err without calling the OAuth service when there is no workspace connection row", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    const result = await verifyWorkspaceOAuthConnectionForMCPServer(
+      authenticator,
+      remoteServer.sId
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.kind).toBe("connection_not_found");
+      expect(result.error.message).toBe(
+        "This tool has no workspace-level connection. Ask a workspace admin to connect the " +
+          "tool before setting up your personal connection."
+      );
+    }
+    expect(mocks.getConnectionMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -1,5 +1,8 @@
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
@@ -60,4 +63,63 @@ export async function getWorkspaceOAuthConnectionIdForMCPServer(
   }
 
   return new Ok(connectionId);
+}
+
+// Verify that the workspace-level OAuth connection for this MCP server exists and still
+// references a live connection in the OAuth service. The front row can reference a connection
+// the OAuth service no longer has (front tables are copied verbatim during workspace relocation
+// while OAuth service data is regional, among other orphaning scenarios) — the OAuth service
+// then returns `connection_not_found`. Only the two states demonstrated by broken references
+// are converted to a user-facing error: a missing row and a dangling connectionId. Everything
+// else — transient OAuth service failures, but also unexpected states like a credential-backed
+// connection on a personal OAuth attempt — deliberately passes the check: callers proceed and
+// surface those as internal errors to investigate rather than as admin configuration advice.
+// Error messages are user-facing: callers return them to the client as-is.
+export async function verifyWorkspaceOAuthConnectionForMCPServer(
+  auth: Authenticator,
+  mcpServerId: string
+): Promise<Result<undefined, WorkspaceMCPServerAuthRefError>> {
+  const connectionIdRes = await getWorkspaceOAuthConnectionIdForMCPServer(
+    auth,
+    mcpServerId
+  );
+  if (connectionIdRes.isErr()) {
+    if (connectionIdRes.error.kind !== "connection_not_found") {
+      return new Ok(undefined);
+    }
+    // The original diagnostic is replaced by a user-facing message below — log it here.
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        mcpServerId,
+        kind: connectionIdRes.error.kind,
+        error: connectionIdRes.error.message,
+      },
+      "OAuth: workspace connection lookup failed during preflight"
+    );
+    return new Err({
+      kind: "connection_not_found",
+      message:
+        "This tool has no workspace-level connection. Ask a workspace admin to connect the " +
+        "tool before setting up your personal connection.",
+    } satisfies WorkspaceMCPServerAuthRefError);
+  }
+
+  const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+  const metadataRes = await oauthApi.getConnectionMetadata({
+    connectionId: connectionIdRes.value,
+  });
+  if (
+    metadataRes.isErr() &&
+    metadataRes.error.code === "connection_not_found"
+  ) {
+    return new Err({
+      kind: "connection_not_found",
+      message:
+        "This tool's workspace connection no longer exists. Ask a workspace admin to " +
+        "reconnect the tool before setting up your personal connection.",
+    } satisfies WorkspaceMCPServerAuthRefError);
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -87,7 +87,6 @@ export async function verifyWorkspaceOAuthConnectionForMCPServer(
     if (connectionIdRes.error.kind !== "connection_not_found") {
       return new Ok(undefined);
     }
-    // The original diagnostic is replaced by a user-facing message below — log it here.
     logger.info(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,

--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -17,6 +17,8 @@ import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
 
 export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
+  requiresWorkspaceConnectionForPersonalAuth = true;
+
   setupUri({
     connection,
     useCase,


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9621. Setting up a personal OAuth connection crashes with an unhandled 500 (DD monitor 22026960) and a blank popup when the tool's workspace-level admin connection is missing — or exists but its `connectionId` no longer resolves in the OAuth service (one confirmed path: workspace relocation copies front rows verbatim while OAuth-service data is regional). Providers treat this as fatal deep in `getUpdatedExtraConfig` with a bare throw.

**Fix:**

- **Preflight** in `createConnectionAndGetSetupUrl`: for `personal_actions` with an `mcp_server_id`, verify the workspace connection (front-DB lookup + OAuth-service probe) before any provider code runs. The two broken-reference states from the ticket — missing row, dangling id — become a typed `mcp_server_connection_not_found` → 404 with an actionable "ask a workspace admin" message. Everything else (transient OAuth-service failures, unexpected states like a credential-backed connection on a personal OAuth attempt) deliberately passes the check and keeps failing loudly (pinned by tests). Covers every provider using this pattern with no per-provider changes.
- **Popup** displays the message for this error type only; all other errors keep the generic copy (internal messages can carry raw upstream details).
- **Jira** gets `requiresWorkspaceConnectionForPersonalAuth = true` like its 12 siblings, so the popup isn't opened at all when the workspace connection row is missing.

This detects and explains broken references; it does not repair them — the admin still reconnects the tool.

## Risk

Worst case, a preflight false positive blocks a setup that would have succeeded — it fails only on deterministic states; anything ambiguous passes through to today's behavior. Safe to rollback.

## Tests

- Route: missing row → 404, dangling `connectionId` → 404.
- Helper unit tests: valid / missing / dangling connection, and transient OAuth-service failures passing through.
- Component: popup shows the actionable message for `mcp_server_connection_not_found`, generic copy otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
