### PR TITLE
Add: conditional index on agent step content for text content

### DIFF
--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -99,6 +99,14 @@ AgentStepContentModel.init(
           type: "function_call",
         },
       },
+      {
+        concurrently: true,
+        fields: ["workspaceId", "agentMessageId"],
+        name: "agent_step_contents_workspace_id_text_content_idx",
+        where: {
+          type: "text_content",
+        },
+      },
     ],
   }
 );

--- a/front/migrations/post-deploy/20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql
+++ b/front/migrations/post-deploy/20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_step_contents_workspace_id_text_content_idx ON public.agent_step_contents USING btree ("workspaceId", "agentMessageId") WHERE ((type)::text = 'text_content'::text);


### PR DESCRIPTION
## Description

Adds a conditional index `agent_step_contents_workspace_id_text_content_idx` on `agent_step_contents(workspaceId, agentMessageId) WHERE type = 'text_content'`. This backs the `textContentOnly` filtering path added to `AgentStepContentResource.fetchByAgentMessages` (PR #29505) — without it, filtering on `type` still requires scanning all rows for a given message. The Sequelize model is updated to declare the index as `concurrently: true` with a `where` clause.

## Tests

No functional code changes. Migration SQL validated locally. The `CREATE INDEX CONCURRENTLY` path is well-understood and has been used for other indexes in this table.

## Risk

Low. `CREATE INDEX CONCURRENTLY` acquires no exclusive lock; reads and writes continue normally during index build. `lock_timeout = 3s` prevents any blocking scenario from escalating. Rollback = `DROP INDEX CONCURRENTLY`.

## Deploy Plan

1. Deploy front (registers index definition in Sequelize model — no-op until migration runs).
2. Run post-deploy migration `20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql` — estimated duration depends on table size; statement_timeout set to 20 min.
