### PR TITLE
[dust-hive] perf: speed up environment spawn

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -278,17 +278,17 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   const filesResult = await setupEnvironmentFiles(metadata, ports, settings);
   if (!filesResult.ok) return filesResult;
 
-  // Phase 1.5: Create test database (if test postgres is running)
-  await tryCreateTestDatabase(name);
-
-  // Phase 2: Setup worktree
-  const worktreeResult = await setupWorktree(
-    metadata,
-    worktreePath,
-    workspaceBranch,
-    Boolean(options.reuseExistingBranch),
-    settings
-  );
+  // Phase 2: Setup worktree and test database in parallel
+  const [worktreeResult] = await Promise.all([
+    setupWorktree(
+      metadata,
+      worktreePath,
+      workspaceBranch,
+      Boolean(options.reuseExistingBranch),
+      settings
+    ),
+    tryCreateTestDatabase(name),
+  ]);
   if (!worktreeResult.ok) return worktreeResult;
 
   // Phase 3: Start build watchers (sparkle and SDK)

--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -69,9 +69,9 @@ async function symlinkCargoTarget(srcDir: string, destDir: string): Promise<void
   }
 }
 
-// Find all files matching filename in the repo (excluding node_modules and other large dirs)
+// Find all local agent config files in the repo (excluding node_modules and other large dirs)
 // Uses -prune to skip entire directory trees rather than filtering after traversal
-async function findAgentsFiles(srcDir: string, filename: string): Promise<string[]> {
+async function findAgentsFiles(srcDir: string): Promise<string[]> {
   const proc = Bun.spawn(
     [
       "find",
@@ -101,8 +101,13 @@ async function findAgentsFiles(srcDir: string, filename: string): Promise<string
       ")",
       "-prune",
       "-o",
+      "(",
       "-name",
-      filename,
+      "AGENTS.local.md",
+      "-o",
+      "-name",
+      "AGENTS.override.md",
+      ")",
       "-type",
       "f",
       "-print",
@@ -128,16 +133,13 @@ async function findAgentsFiles(srcDir: string, filename: string): Promise<string
 // Copy user config files (AGENTS.local.md, AGENTS.override.md files, .claude/) from main repo to worktree
 async function copyUserConfigFiles(srcDir: string, destDir: string): Promise<void> {
   // Find and copy all AGENTS.local.md and AGENTS.override.md files, preserving directory structure
-  const filenames = ["AGENTS.local.md", "AGENTS.override.md"];
-  for (const filename of filenames) {
-    const agentsFiles = await findAgentsFiles(srcDir, filename);
-    for (const srcPath of agentsFiles) {
-      // Get relative path from srcDir
-      const relativePath = srcPath.slice(srcDir.length + 1);
-      const destPath = `${destDir}/${relativePath}`;
-      await Bun.spawn(["cp", srcPath, destPath]).exited;
-      logger.success(`Copied ${relativePath}`);
-    }
+  const agentsFiles = await findAgentsFiles(srcDir);
+  for (const srcPath of agentsFiles) {
+    // Get relative path from srcDir
+    const relativePath = srcPath.slice(srcDir.length + 1);
+    const destPath = `${destDir}/${relativePath}`;
+    await Bun.spawn(["cp", srcPath, destPath]).exited;
+    logger.success(`Copied ${relativePath}`);
   }
 
   // Copy directories recursively, merging with existing content


### PR DESCRIPTION
## Description

Goal is to reduce the time between running `dhx` and having a new hive environment ready.

Measurements below cover the actual hive setup. Codex startup and interactive tmux attachment are excluded. The baseline critical path after CLI startup was:

| Phase | Time |
| --- | ---: |
| Git worktree checkout | 2.40s |
| Test database setup | 1.10s |
| Dependency and local config setup | 1.36s |
| Build watchers and tmux session | 0.48s |

The Git worktree checkout was the largest individual operation and the clearest removable cost was the 1.10s test database setup: it was independent from the checkout, but ran immediately before it. The two operations now run concurrently, and database setup completes before checkout finishes.

The spawn also walked the repository once for `AGENTS.local.md` and again for `AGENTS.override.md`. Both patterns are now handled by a single scan, reducing the isolated scan time from about 0.41s to 0.24s.

## Tests

- Benchmarked locally before and after.

## Risk

- Low, limited to internal tooling.

## Deploy Plan

- No deploy.
