### PR TITLE
[front] Reconcile pool on credit.create for pool credits

### DIFF
--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -985,8 +985,6 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
       timestamp: new Date().toISOString(),
       credit_id: CREDIT_ID,
       credit_custom_fields: null,
-      // No contract_id → stampContractCreditType stamps "pool" without a
-      // contract fetch, keeping the test focused on the reconcile.
       contract_id: null,
       contract_custom_fields: null,
       parent_recurring_credit_id: null,
@@ -1021,7 +1019,7 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     ).mockResolvedValue(undefined);
   });
 
-  it("reconciles the pool when an AWU credit is created", async () => {
+  it("stamps and reconciles the pool when a pool AWU credit is created", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCredit).mockResolvedValue(
       new Ok(credit(getCreditTypeAwuId()))
@@ -1033,6 +1031,12 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     });
 
     expect(result.isOk()).toBe(true);
+    expect(setMetronomeContractCreditCustomFields).toHaveBeenCalledWith({
+      creditId: CREDIT_ID,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
+    });
     expect(syncPoolCreditStateFromBalance).toHaveBeenCalledWith({
       workspace,
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
@@ -1042,7 +1046,7 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("does not reconcile the pool for a non-AWU credit", async () => {
+  it("does not stamp or reconcile the pool for a non-AWU credit", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCredit).mockResolvedValue(
       new Ok(credit("non_awu_credit_type"))
@@ -1054,10 +1058,11 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     });
 
     expect(result.isOk()).toBe(true);
+    expect(setMetronomeContractCreditCustomFields).not.toHaveBeenCalled();
     expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
   });
 
-  it("reconciles per-user (not pool) state for a per-seat (INDIVIDUAL) credit", async () => {
+  it("reconciles per-user (not pool) state, without stamping, for a per-seat (INDIVIDUAL) credit", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCredit).mockResolvedValue(
       new Ok(credit(getCreditTypeAwuId(), { allocation: "INDIVIDUAL" }))
@@ -1069,6 +1074,7 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     });
 
     expect(result.isOk()).toBe(true);
+    expect(setMetronomeContractCreditCustomFields).not.toHaveBeenCalled();
     expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
     expect(
       launchReconcileWorkspaceUserCreditStatesWorkflow

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -1081,3 +1081,103 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     ).toHaveBeenCalledWith({ workspaceId: workspace.sId });
   });
 });
+
+describe("processMetronomeWebhook — credit.segment.start / credit.edit", () => {
+  function creditEvent(
+    type: "credit.segment.start" | "credit.edit"
+  ): MetronomeWebhookEvent {
+    return {
+      id: `evt_${type}_xxx`,
+      type,
+      timestamp: new Date().toISOString(),
+      credit_id: CREDIT_ID,
+      credit_custom_fields: null,
+      contract_id: null,
+      contract_custom_fields: null,
+      parent_recurring_credit_id: null,
+      customer_id: METRONOME_CUSTOMER_ID,
+      customer_custom_fields: null,
+      segment_id: "seg_xxx",
+    } as MetronomeWebhookEvent;
+  }
+
+  function credit(
+    creditTypeId: string,
+    { allocation }: { allocation?: "INDIVIDUAL" | "POOLED" } = {}
+  ): Credit {
+    return {
+      id: CREDIT_ID,
+      product: { id: "prod_free_credit", name: "Free Credits" },
+      type: "CREDIT",
+      access_schedule: {
+        schedule_items: [],
+        credit_type: { id: creditTypeId, name: "AWU" },
+      },
+      ...(allocation ? { subscription_config: { allocation } } : {}),
+    } as Credit;
+  }
+
+  beforeEach(() => {
+    vi.mocked(syncPoolCreditStateFromBalance).mockResolvedValue(undefined);
+    vi.mocked(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).mockResolvedValue(undefined);
+  });
+
+  it("reconciles the pool for a pool AWU credit segment", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit(getCreditTypeAwuId()))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditEvent("credit.segment.start"),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).toHaveBeenCalledWith({
+      workspace,
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    expect(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).not.toHaveBeenCalled();
+  });
+
+  it("reconciles per-user state for a per-seat credit on credit.edit (not only segment.start)", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit(getCreditTypeAwuId(), { allocation: "INDIVIDUAL" }))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditEvent("credit.edit"),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
+    expect(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).toHaveBeenCalledWith({ workspaceId: workspace.sId });
+  });
+
+  it("does nothing for a non-AWU credit segment", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit("non_awu_credit_type"))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditEvent("credit.segment.start"),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
+    expect(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -26,6 +26,7 @@ import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { launchReconcileWorkspaceUserCreditStatesWorkflow } from "@app/temporal/metronome_events_queue/client";
 import {
   launchScheduleWorkspaceScrubWorkflow,
   terminateScheduleWorkspaceScrubWorkflow,
@@ -54,6 +55,10 @@ vi.mock(import("@app/lib/metronome/client"), async (importOriginal) => {
 vi.mock("@app/temporal/scrub_workspace/client", () => ({
   launchScheduleWorkspaceScrubWorkflow: vi.fn(),
   terminateScheduleWorkspaceScrubWorkflow: vi.fn(),
+}));
+
+vi.mock("@app/temporal/metronome_events_queue/client", () => ({
+  launchReconcileWorkspaceUserCreditStatesWorkflow: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/subscription", () => ({
@@ -1011,6 +1016,9 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
       new Ok(undefined)
     );
     vi.mocked(syncPoolCreditStateFromBalance).mockResolvedValue(undefined);
+    vi.mocked(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).mockResolvedValue(undefined);
   });
 
   it("reconciles the pool when an AWU credit is created", async () => {
@@ -1029,6 +1037,9 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
       workspace,
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
+    expect(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).not.toHaveBeenCalled();
   });
 
   it("does not reconcile the pool for a non-AWU credit", async () => {
@@ -1046,7 +1057,7 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
     expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
   });
 
-  it("does not reconcile the pool for a per-seat (INDIVIDUAL) credit", async () => {
+  it("reconciles per-user (not pool) state for a per-seat (INDIVIDUAL) credit", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCredit).mockResolvedValue(
       new Ok(credit(getCreditTypeAwuId(), { allocation: "INDIVIDUAL" }))
@@ -1059,5 +1070,8 @@ describe("processMetronomeWebhook — credit.create pool reconcile", () => {
 
     expect(result.isOk()).toBe(true);
     expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
+    expect(
+      launchReconcileWorkspaceUserCreditStatesWorkflow
+    ).toHaveBeenCalledWith({ workspaceId: workspace.sId });
   });
 });

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -2,13 +2,16 @@ import {
   dispatchPaygCapReached,
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
+  syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import {
   getMetronomeCommit,
   getMetronomeContractById,
+  getMetronomeCredit,
   listMetronomeContracts,
   setMetronomeCommitCustomFields,
+  setMetronomeContractCreditCustomFields,
 } from "@app/lib/metronome/client";
 import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
@@ -30,7 +33,7 @@ import {
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
-import type { Commit, ContractV2 } from "@metronome/sdk/resources";
+import type { Commit, ContractV2, Credit } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { processMetronomeWebhook } from "./process_webhook";
@@ -42,7 +45,9 @@ vi.mock(import("@app/lib/metronome/client"), async (importOriginal) => {
     getMetronomeContractById: vi.fn(),
     listMetronomeContracts: vi.fn(),
     getMetronomeCommit: vi.fn(),
+    getMetronomeCredit: vi.fn(),
     setMetronomeCommitCustomFields: vi.fn(),
+    setMetronomeContractCreditCustomFields: vi.fn(),
   };
 });
 
@@ -64,6 +69,7 @@ vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
     dispatchPerUserCapReached: vi.fn(),
     dispatchPerUserCapResolved: vi.fn(),
     dispatchPaygCapReached: vi.fn(),
+    syncPoolCreditStateFromBalance: vi.fn(),
   };
 });
 
@@ -126,6 +132,7 @@ const NEW_CONTRACT_ID = "contract_new_yyy";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
 const USER_ID = "user_test_xxx";
 const COMMIT_ID = "commit_test_xxx";
+const CREDIT_ID = "credit_test_xxx";
 
 /** Build a contract event payload that matches the centralized webhook schema. */
 function contractEvent(
@@ -958,5 +965,99 @@ describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE st
 
     expect(result.isOk()).toBe(true);
     expect(setMetronomeCommitCustomFields).not.toHaveBeenCalled();
+  });
+});
+
+describe("processMetronomeWebhook — credit.create pool reconcile", () => {
+  // A recurring free AWU credit granted at contract-switch time lands via
+  // credit.create *after* contract.start already reconciled the pool (before
+  // the credit existed). credit.create must reconcile the pool so the
+  // workspace does not stay stuck in the pre-credit state.
+  function creditCreateEvent(): MetronomeWebhookEvent {
+    return {
+      id: "evt_credit_create_xxx",
+      type: "credit.create",
+      timestamp: new Date().toISOString(),
+      credit_id: CREDIT_ID,
+      credit_custom_fields: null,
+      // No contract_id → stampContractCreditType stamps "pool" without a
+      // contract fetch, keeping the test focused on the reconcile.
+      contract_id: null,
+      contract_custom_fields: null,
+      parent_recurring_credit_id: null,
+      customer_id: METRONOME_CUSTOMER_ID,
+      customer_custom_fields: null,
+    };
+  }
+
+  function credit(
+    creditTypeId: string,
+    { allocation }: { allocation?: "INDIVIDUAL" | "POOLED" } = {}
+  ): Credit {
+    return {
+      id: CREDIT_ID,
+      product: { id: "prod_free_credit", name: "Free Credits" },
+      type: "CREDIT",
+      access_schedule: {
+        schedule_items: [],
+        credit_type: { id: creditTypeId, name: "AWU" },
+      },
+      ...(allocation ? { subscription_config: { allocation } } : {}),
+    } as Credit;
+  }
+
+  beforeEach(() => {
+    vi.mocked(setMetronomeContractCreditCustomFields).mockResolvedValue(
+      new Ok(undefined)
+    );
+    vi.mocked(syncPoolCreditStateFromBalance).mockResolvedValue(undefined);
+  });
+
+  it("reconciles the pool when an AWU credit is created", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit(getCreditTypeAwuId()))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).toHaveBeenCalledWith({
+      workspace,
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+  });
+
+  it("does not reconcile the pool for a non-AWU credit", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit("non_awu_credit_type"))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
+  });
+
+  it("does not reconcile the pool for a per-seat (INDIVIDUAL) credit", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCredit).mockResolvedValue(
+      new Ok(credit(getCreditTypeAwuId(), { allocation: "INDIVIDUAL" }))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: creditCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -153,94 +153,49 @@ export class ProcessMetronomeWebhookError extends Error {
 }
 
 /**
- * Stamp `DUST_CONTRACT_CREDIT_TYPE` on a contract_credit. Idempotent — bails
- * out if the field is already set on the credit. Used by both `credit.create`
- * and `credit.segment.start` handlers so every newly visible credit gets
- * tagged regardless of which event Metronome fires first.
+ * Stamp `DUST_CONTRACT_CREDIT_TYPE` on an AWU contract_credit so pool balance
+ * alerts and queries count it. Idempotent — bails if already stamped. Only AWU
+ * credits are stamped; others belong to different pools and are left alone
+ * (mirrors `stampCommitCreditType`).
  *
+ *   - non-AWU credit type → not stamped (belongs to another pool)
+ *   - per-seat (INDIVIDUAL allocation) → not stamped (pool alerts don't track
+ *     per-seat balances)
  *   - excess product → "excess" (filtered out of default alerts)
- *   - per-seat (INDIVIDUAL allocation) → unstamped (workspace pool alerts
- *     don't track per-seat balances)
- *   - everything else (incl. customer-level credits) → "pool" (counted)
+ *   - everything else → "pool" (counted)
  */
 async function stampContractCreditType({
   workspaceId,
-  customerId,
-  contractId,
-  creditId,
-  creditCustomFields,
+  credit,
   eventType,
 }: {
   workspaceId: string;
-  customerId: string;
-  contractId: string | null | undefined;
-  creditId: string;
-  creditCustomFields?: Record<string, string> | null;
+  credit: Credit;
   eventType: string;
 }): Promise<Result<void, ProcessMetronomeWebhookError>> {
-  if (creditCustomFields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
+  if (credit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
     return new Ok(undefined);
   }
 
-  let value:
-    | typeof CONTRACT_CREDIT_TYPE_POOL
-    | typeof CONTRACT_CREDIT_TYPE_EXCESS = CONTRACT_CREDIT_TYPE_POOL;
-
-  if (contractId) {
-    const contractResult = await getMetronomeContractById({
-      metronomeCustomerId: customerId,
-      metronomeContractId: contractId,
-    });
-    if (contractResult.isErr()) {
-      logger.error(
-        {
-          workspaceId,
-          customerId,
-          contractId,
-          creditId,
-          error: contractResult.error,
-        },
-        `[Metronome Webhook] ${eventType}: failed to fetch contract for stamping`
-      );
-      return new Err(
-        new ProcessMetronomeWebhookError(
-          "processing_failed",
-          `Error fetching contract: ${contractResult.error.message}`
-        )
-      );
-    }
-
-    const credit = contractResult.value.credits?.find((c) => c.id === creditId);
-    if (!credit) {
-      logger.info(
-        { workspaceId, customerId, contractId, creditId },
-        `[Metronome Webhook] ${eventType}: credit not found on contract, skipping stamp`
-      );
-      return new Ok(undefined);
-    }
-
-    // Re-check after the fresh fetch — Metronome may have stamped it between
-    // event emission and our processing (e.g. if both credit.create and
-    // credit.segment.start fire).
-    if (credit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
-      return new Ok(undefined);
-    }
-
-    if (credit.subscription_config?.allocation === "INDIVIDUAL") {
-      return new Ok(undefined);
-    }
-
-    // Per-user free-seat credits are stamped "free_seat" at creation (see
-    // `addPerUserCreditToCustomer`), so they hit the already-stamped early
-    // return above and are never re-stamped "pool" here.
-
-    if (credit.product.id === getProductExcessCreditsId()) {
-      value = CONTRACT_CREDIT_TYPE_EXCESS;
-    }
+  if (credit.access_schedule?.credit_type?.id !== getCreditTypeAwuId()) {
+    return new Ok(undefined);
   }
 
+  if (credit.subscription_config?.allocation === "INDIVIDUAL") {
+    return new Ok(undefined);
+  }
+
+  // Per-user free-seat credits are stamped "free_seat" at creation (see
+  // `addPerUserCreditToCustomer`), so they hit the already-stamped early
+  // return above and are never re-stamped "pool" here.
+
+  const value =
+    credit.product.id === getProductExcessCreditsId()
+      ? CONTRACT_CREDIT_TYPE_EXCESS
+      : CONTRACT_CREDIT_TYPE_POOL;
+
   const setResult = await setMetronomeContractCreditCustomFields({
-    creditId,
+    creditId: credit.id,
     customFields: {
       [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: value,
     },
@@ -254,7 +209,7 @@ async function stampContractCreditType({
     );
   }
   logger.info(
-    { workspaceId, customerId, contractId, creditId, value, eventType },
+    { workspaceId, creditId: credit.id, value, eventType },
     `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE`
   );
   return new Ok(undefined);
@@ -321,9 +276,10 @@ function isSeatAwuCredit(credit: Credit): boolean {
   );
 }
 
-// Reconcile the workspace pool credit state from a commit/credit segment or
-// edit webhook event. Shared by `commit.segment.start`, `commit.edit`,
-// `credit.edit`, and `credit.segment.start`.
+// Reconcile the workspace pool credit state from a commit/credit segment,
+// create, or edit webhook event. Shared by `commit.*` and `credit.*` handlers.
+// Only AWU entities feed the pool; anything else (programmatic USD, EUR seat
+// credits, etc.) is out of scope for the pool state machine and skipped.
 async function reconcilePoolStateFromSegmentEvent({
   workspace,
   metronomeCustomerId,
@@ -335,12 +291,31 @@ async function reconcilePoolStateFromSegmentEvent({
 }): Promise<void> {
   const creditTypeId = commitOrCredit.access_schedule?.credit_type?.id;
 
-  if (creditTypeId === getCreditTypeAwuId()) {
-    await syncPoolCreditStateFromBalance({
-      workspace,
-      metronomeCustomerId,
-    });
+  if (creditTypeId !== getCreditTypeAwuId()) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        entityId: commitOrCredit.id,
+        creditTypeId,
+      },
+      "[Metronome Webhook] reconcilePoolStateFromSegmentEvent: non-AWU entity, skipping pool reconcile"
+    );
+    return;
   }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeCustomerId,
+      entityId: commitOrCredit.id,
+    },
+    "[Metronome Webhook] reconcilePoolStateFromSegmentEvent: reconciling pool from AWU entity"
+  );
+  await syncPoolCreditStateFromBalance({
+    workspace,
+    metronomeCustomerId,
+  });
 }
 
 type SpendThresholdEvent = Extract<
@@ -1347,40 +1322,7 @@ export async function processMetronomeWebhook({
         "[Metronome Webhook] credit.create: handler entered"
       );
 
-      // Stamp `DUST_CONTRACT_CREDIT_TYPE=pool` first: the pool balance is read
-      // with an `onlyPoolCredits` filter (see `getNetBalance`), so an unstamped
-      // credit is invisible to the reconcile below and the pool would stay
-      // stuck. Stamp, then reconcile against the now-visible credit.
-      const stampResult = await stampContractCreditType({
-        workspaceId: workspace.sId,
-        customerId: metronomeCustomerId,
-        contractId: event.contract_id ?? null,
-        creditId,
-        creditCustomFields: event.credit_custom_fields,
-        eventType: "credit.create",
-      });
-      if (stampResult.isErr()) {
-        return stampResult;
-      }
-
-      // Reconcile now that this credit exists and is stamped. A credit granted
-      // at contract-switch time (see `stepContractEdits`) is added to the
-      // already-active contract *after* `contract.start` fired, so that
-      // handler's reconcile ran before the credit existed. Metronome only
-      // fires `credit.create` — not `credit.segment.start` — for a segment
-      // that is already active when the credit is created, so the segment
-      // reconcile path would never re-run for it. Mirror both reconciles that
-      // `credit.segment.start` performs, split by allocation:
-      //
-      //   - Per-seat (INDIVIDUAL) AWU credit → reconcile per-user credit
-      //     states (a new seat allocation lands each user in the right
-      //     seat↔pool state). The workspace-scoped reconcile workflow collapses
-      //     concurrent launches, so onboarding many seats triggers one run.
-      //     No pool reconcile: seat credits never count toward the pool
-      //     balance (only "pool"-stamped credits do).
-      //   - Pool AWU credit (e.g. the recurring free credit) → reconcile the
-      //     workspace pool credit state, which would otherwise stay stuck
-      //     (e.g. `depleted`).
+      // Fetch the credit once: it drives both the stamp and the reconcile.
       const creditResult = await getMetronomeCredit({
         metronomeCustomerId,
         creditId,
@@ -1393,25 +1335,58 @@ export async function processMetronomeWebhook({
           )
         );
       }
-      if (creditResult.value) {
-        if (isSeatAwuCredit(creditResult.value)) {
-          await launchReconcileWorkspaceUserCreditStatesWorkflow({
-            workspaceId: workspace.sId,
-          });
-          logger.info(
-            { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-            "[Metronome Webhook] credit.create: seat credit created, user state reconcile triggered"
-          );
-        } else if (
-          creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
-        ) {
-          await reconcilePoolStateFromSegmentEvent({
-            workspace,
-            metronomeCustomerId,
-            commitOrCredit: creditResult.value,
-          });
-        }
+      const credit = creditResult.value;
+      if (!credit) {
+        logger.info(
+          { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+          "[Metronome Webhook] credit.create: credit not found, skipping"
+        );
+        break;
       }
+
+      // A credit granted at contract-switch time (see `stepContractEdits`) is
+      // added to the already-active contract *after* `contract.start` fired, so
+      // that handler's reconcile ran before the credit existed. Metronome only
+      // fires `credit.create` — not `credit.segment.start` — for a segment that
+      // is already active when the credit is created, so the segment reconcile
+      // path would never re-run for it. Mirror both reconciles that
+      // `credit.segment.start` performs, split by allocation.
+      if (isSeatAwuCredit(credit)) {
+        // Per-seat (INDIVIDUAL) AWU credit → reconcile per-user credit states
+        // (a new seat allocation lands each user in the right seat↔pool state).
+        // The workspace-scoped reconcile workflow collapses concurrent
+        // launches, so onboarding many seats triggers one run. Not stamped and
+        // no pool reconcile: seat credits never count toward the pool balance.
+        await launchReconcileWorkspaceUserCreditStatesWorkflow({
+          workspaceId: workspace.sId,
+        });
+        logger.info(
+          { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+          "[Metronome Webhook] credit.create: seat credit created, user state reconcile triggered"
+        );
+        break;
+      }
+
+      // Pool AWU credit (e.g. the recurring free credit) → stamp, then
+      // reconcile the workspace pool credit state (which would otherwise stay
+      // stuck, e.g. `depleted`). Stamp first: the pool balance is read with an
+      // `onlyPoolCredits` filter (see `getNetBalance`), so an unstamped credit
+      // is invisible to the reconcile. Non-AWU credits are left unstamped and
+      // skipped by the reconcile.
+      const stampResult = await stampContractCreditType({
+        workspaceId: workspace.sId,
+        credit,
+        eventType: "credit.create",
+      });
+      if (stampResult.isErr()) {
+        return stampResult;
+      }
+
+      await reconcilePoolStateFromSegmentEvent({
+        workspace,
+        metronomeCustomerId,
+        commitOrCredit: credit,
+      });
       break;
     }
 
@@ -1580,10 +1555,10 @@ export async function processMetronomeWebhook({
               "[Metronome Webhook] credit.segment.start: seat credit activated, reconcile triggered"
             );
           }
-        } else if (
-          creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
-        ) {
-          // Pool AWU credit: reconcile the workspace pool credit state.
+        } else {
+          // Pool credit: reconcile the workspace pool credit state. The helper
+          // gates on AWU (logging non-AWU skips), so non-AWU pool credits are
+          // a no-op.
           await reconcilePoolStateFromSegmentEvent({
             workspace,
             metronomeCustomerId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1336,25 +1336,69 @@ export async function processMetronomeWebhook({
     }
 
     case "credit.create": {
+      const { customer_id: metronomeCustomerId, credit_id: creditId } = event;
       logger.info(
         {
-          customerId: event.customer_id,
+          customerId: metronomeCustomerId,
           contractId: event.contract_id,
-          creditId: event.credit_id,
+          creditId,
           workspaceId: workspace.sId,
         },
         "[Metronome Webhook] credit.create: handler entered"
       );
+
+      // Stamp `DUST_CONTRACT_CREDIT_TYPE=pool` first: the pool balance is read
+      // with an `onlyPoolCredits` filter (see `getNetBalance`), so an unstamped
+      // credit is invisible to the reconcile below and the pool would stay
+      // stuck. Stamp, then reconcile against the now-visible credit.
       const stampResult = await stampContractCreditType({
         workspaceId: workspace.sId,
-        customerId: event.customer_id,
+        customerId: metronomeCustomerId,
         contractId: event.contract_id ?? null,
-        creditId: event.credit_id,
+        creditId,
         creditCustomFields: event.credit_custom_fields,
         eventType: "credit.create",
       });
       if (stampResult.isErr()) {
         return stampResult;
+      }
+
+      // Reconcile the workspace pool credit state against the live AWU
+      // balance now that this credit exists and is stamped. A recurring free
+      // AWU credit granted at contract-switch time (see `stepContractEdits`)
+      // is added to the already-active contract *after* `contract.start`
+      // fired, so that handler's reconcile ran before the credit existed and
+      // left the pool stuck (e.g. `depleted`). Metronome only fires
+      // `credit.create` — not `credit.segment.start` — for a segment that is
+      // already active when the credit is created, so the segment reconcile
+      // path would never re-run for it.
+      //
+      // Skip per-seat (INDIVIDUAL) credits: they never count toward the pool
+      // balance (only "pool"-stamped credits do), so reconciling for them
+      // would be a wasted no-op `getNetBalance` on every seat created at
+      // onboarding. Per-period renewals of seat credits are still covered by
+      // the `credit.segment.start` handler.
+      const creditResult = await getMetronomeCredit({
+        metronomeCustomerId,
+        creditId,
+      });
+      if (creditResult.isErr()) {
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching credit: ${creditResult.error.message}`
+          )
+        );
+      }
+      if (
+        creditResult.value &&
+        creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
+      ) {
+        await reconcilePoolStateFromSegmentEvent({
+          workspace,
+          metronomeCustomerId,
+          commitOrCredit: creditResult.value,
+        });
       }
       break;
     }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -292,15 +292,6 @@ async function reconcilePoolStateFromSegmentEvent({
   const creditTypeId = commitOrCredit.access_schedule?.credit_type?.id;
 
   if (creditTypeId !== getCreditTypeAwuId()) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId,
-        entityId: commitOrCredit.id,
-        creditTypeId,
-      },
-      "[Metronome Webhook] reconcilePoolStateFromSegmentEvent: non-AWU entity, skipping pool reconcile"
-    );
     return;
   }
 
@@ -1336,11 +1327,13 @@ export async function processMetronomeWebhook({
         );
       }
       const credit = creditResult.value;
-      if (!credit) {
-        logger.info(
-          { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-          "[Metronome Webhook] credit.create: credit not found, skipping"
-        );
+
+      // Non-AWU credits (programmatic USD, EUR seat credits, etc.) feed neither
+      // the pool nor per-user seat states — opt out.
+      if (
+        !credit ||
+        credit.access_schedule?.credit_type?.id !== getCreditTypeAwuId()
+      ) {
         break;
       }
 
@@ -1536,35 +1529,42 @@ export async function processMetronomeWebhook({
           )
         );
       }
-      if (creditResult.value) {
-        if (isSeatAwuCredit(creditResult.value)) {
-          // Per-seat (INDIVIDUAL) AWU credit: seat credits never count toward
-          // the pool balance, so a pool reconcile would be a wasted no-op.
-          // A new seat segment starting means a seat type was activated (e.g.
-          // a planned Pro→Max downgrade takes effect), so re-sync the seat
-          // count to reassign the per-user allocation and land each user's
-          // credit state in the right seat↔pool state. (credit.edit — an
-          // amount change — does not shift seat assignments, so it is left
-          // alone.)
-          if (event.type === "credit.segment.start") {
-            await launchReconcileWorkspaceUserCreditStatesWorkflow({
-              workspaceId: workspace.sId,
-            });
-            logger.info(
-              { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-              "[Metronome Webhook] credit.segment.start: seat credit activated, reconcile triggered"
-            );
-          }
-        } else {
-          // Pool credit: reconcile the workspace pool credit state. The helper
-          // gates on AWU (logging non-AWU skips), so non-AWU pool credits are
-          // a no-op.
-          await reconcilePoolStateFromSegmentEvent({
-            workspace,
+      const credit = creditResult.value;
+
+      // Non-AWU credits (programmatic USD, EUR seat credits, etc.) feed neither
+      // the pool nor per-user seat states — opt out.
+      if (
+        !credit ||
+        credit.access_schedule?.credit_type?.id !== getCreditTypeAwuId()
+      ) {
+        break;
+      }
+
+      if (isSeatAwuCredit(credit)) {
+        // Per-seat (INDIVIDUAL) AWU credit: a seat segment starting (a seat
+        // type activated, e.g. a planned Pro→Max downgrade) or an amount edit
+        // both shift per-user balances, so reconcile per-user credit states.
+        // The reconcile is workspace-scoped and idempotent. No pool reconcile:
+        // seat credits never count toward the pool balance.
+        await launchReconcileWorkspaceUserCreditStatesWorkflow({
+          workspaceId: workspace.sId,
+        });
+        logger.info(
+          {
             metronomeCustomerId,
-            commitOrCredit: creditResult.value,
-          });
-        }
+            creditId,
+            workspaceId: workspace.sId,
+            eventType: event.type,
+          },
+          "[Metronome Webhook] seat credit event: user state reconcile triggered"
+        );
+      } else {
+        // Pool AWU credit: reconcile the workspace pool credit state.
+        await reconcilePoolStateFromSegmentEvent({
+          workspace,
+          metronomeCustomerId,
+          commitOrCredit: credit,
+        });
       }
 
       // The free monthly/yearly credit grant is now driven by the Stripe

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1363,21 +1363,24 @@ export async function processMetronomeWebhook({
         return stampResult;
       }
 
-      // Reconcile the workspace pool credit state against the live AWU
-      // balance now that this credit exists and is stamped. A recurring free
-      // AWU credit granted at contract-switch time (see `stepContractEdits`)
-      // is added to the already-active contract *after* `contract.start`
-      // fired, so that handler's reconcile ran before the credit existed and
-      // left the pool stuck (e.g. `depleted`). Metronome only fires
-      // `credit.create` — not `credit.segment.start` — for a segment that is
-      // already active when the credit is created, so the segment reconcile
-      // path would never re-run for it.
+      // Reconcile now that this credit exists and is stamped. A credit granted
+      // at contract-switch time (see `stepContractEdits`) is added to the
+      // already-active contract *after* `contract.start` fired, so that
+      // handler's reconcile ran before the credit existed. Metronome only
+      // fires `credit.create` — not `credit.segment.start` — for a segment
+      // that is already active when the credit is created, so the segment
+      // reconcile path would never re-run for it. Mirror both reconciles that
+      // `credit.segment.start` performs, split by allocation:
       //
-      // Skip per-seat (INDIVIDUAL) credits: they never count toward the pool
-      // balance (only "pool"-stamped credits do), so reconciling for them
-      // would be a wasted no-op `getNetBalance` on every seat created at
-      // onboarding. Per-period renewals of seat credits are still covered by
-      // the `credit.segment.start` handler.
+      //   - Per-seat (INDIVIDUAL) AWU credit → reconcile per-user credit
+      //     states (a new seat allocation lands each user in the right
+      //     seat↔pool state). The workspace-scoped reconcile workflow collapses
+      //     concurrent launches, so onboarding many seats triggers one run.
+      //     No pool reconcile: seat credits never count toward the pool
+      //     balance (only "pool"-stamped credits do).
+      //   - Pool AWU credit (e.g. the recurring free credit) → reconcile the
+      //     workspace pool credit state, which would otherwise stay stuck
+      //     (e.g. `depleted`).
       const creditResult = await getMetronomeCredit({
         metronomeCustomerId,
         creditId,
@@ -1390,15 +1393,24 @@ export async function processMetronomeWebhook({
           )
         );
       }
-      if (
-        creditResult.value &&
-        creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
-      ) {
-        await reconcilePoolStateFromSegmentEvent({
-          workspace,
-          metronomeCustomerId,
-          commitOrCredit: creditResult.value,
-        });
+      if (creditResult.value) {
+        if (isSeatAwuCredit(creditResult.value)) {
+          await launchReconcileWorkspaceUserCreditStatesWorkflow({
+            workspaceId: workspace.sId,
+          });
+          logger.info(
+            { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+            "[Metronome Webhook] credit.create: seat credit created, user state reconcile triggered"
+          );
+        } else if (
+          creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
+        ) {
+          await reconcilePoolStateFromSegmentEvent({
+            workspace,
+            metronomeCustomerId,
+            commitOrCredit: creditResult.value,
+          });
+        }
       }
       break;
     }
@@ -1550,27 +1562,33 @@ export async function processMetronomeWebhook({
         );
       }
       if (creditResult.value) {
-        await reconcilePoolStateFromSegmentEvent({
-          workspace,
-          metronomeCustomerId,
-          commitOrCredit: creditResult.value,
-        });
-
-        // A new seat segment starting means a seat type was activated (e.g.
-        // a planned Pro→Max downgrade takes effect). Re-sync the seat count so
-        // the per-user allocation is reassigned and each user's credit state
-        // reflects the new seat type.
-        if (
-          event.type === "credit.segment.start" &&
-          isSeatAwuCredit(creditResult.value)
+        if (isSeatAwuCredit(creditResult.value)) {
+          // Per-seat (INDIVIDUAL) AWU credit: seat credits never count toward
+          // the pool balance, so a pool reconcile would be a wasted no-op.
+          // A new seat segment starting means a seat type was activated (e.g.
+          // a planned Pro→Max downgrade takes effect), so re-sync the seat
+          // count to reassign the per-user allocation and land each user's
+          // credit state in the right seat↔pool state. (credit.edit — an
+          // amount change — does not shift seat assignments, so it is left
+          // alone.)
+          if (event.type === "credit.segment.start") {
+            await launchReconcileWorkspaceUserCreditStatesWorkflow({
+              workspaceId: workspace.sId,
+            });
+            logger.info(
+              { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+              "[Metronome Webhook] credit.segment.start: seat credit activated, reconcile triggered"
+            );
+          }
+        } else if (
+          creditResult.value.subscription_config?.allocation !== "INDIVIDUAL"
         ) {
-          await launchReconcileWorkspaceUserCreditStatesWorkflow({
-            workspaceId: workspace.sId,
+          // Pool AWU credit: reconcile the workspace pool credit state.
+          await reconcilePoolStateFromSegmentEvent({
+            workspace,
+            metronomeCustomerId,
+            commitOrCredit: creditResult.value,
           });
-          logger.info(
-            { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-            "[Metronome Webhook] credit.segment.start: seat credit activated, reconcile triggered"
-          );
         }
       }
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1342,8 +1342,8 @@ export async function processMetronomeWebhook({
       // that handler's reconcile ran before the credit existed. Metronome only
       // fires `credit.create` — not `credit.segment.start` — for a segment that
       // is already active when the credit is created, so the segment reconcile
-      // path would never re-run for it. Mirror both reconciles that
-      // `credit.segment.start` performs, split by allocation.
+      // path would never re-run for it. Mirror the same split as
+      // `credit.segment.start`, plus the pool stamp on the pool branch.
       if (isSeatAwuCredit(credit)) {
         // Per-seat (INDIVIDUAL) AWU credit → reconcile per-user credit states
         // (a new seat allocation lands each user in the right seat↔pool state).
@@ -1357,29 +1357,27 @@ export async function processMetronomeWebhook({
           { metronomeCustomerId, creditId, workspaceId: workspace.sId },
           "[Metronome Webhook] credit.create: seat credit created, user state reconcile triggered"
         );
-        break;
-      }
+      } else {
+        // Pool AWU credit (e.g. the recurring free credit) → stamp, then
+        // reconcile the workspace pool credit state (which would otherwise stay
+        // stuck, e.g. `depleted`). Stamp first: the pool balance is read with an
+        // `onlyPoolCredits` filter (see `getNetBalance`), so an unstamped credit
+        // is invisible to the reconcile.
+        const stampResult = await stampContractCreditType({
+          workspaceId: workspace.sId,
+          credit,
+          eventType: "credit.create",
+        });
+        if (stampResult.isErr()) {
+          return stampResult;
+        }
 
-      // Pool AWU credit (e.g. the recurring free credit) → stamp, then
-      // reconcile the workspace pool credit state (which would otherwise stay
-      // stuck, e.g. `depleted`). Stamp first: the pool balance is read with an
-      // `onlyPoolCredits` filter (see `getNetBalance`), so an unstamped credit
-      // is invisible to the reconcile. Non-AWU credits are left unstamped and
-      // skipped by the reconcile.
-      const stampResult = await stampContractCreditType({
-        workspaceId: workspace.sId,
-        credit,
-        eventType: "credit.create",
-      });
-      if (stampResult.isErr()) {
-        return stampResult;
+        await reconcilePoolStateFromSegmentEvent({
+          workspace,
+          metronomeCustomerId,
+          commitOrCredit: credit,
+        });
       }
-
-      await reconcilePoolStateFromSegmentEvent({
-        workspace,
-        metronomeCustomerId,
-        commitOrCredit: credit,
-      });
       break;
     }
 


### PR DESCRIPTION
## Problem

When switching a contract with a **recurring free AWU credit** (the `recurringFreeCredit` option in Poke's Switch Contract dialog), the workspace pool credit state was left stuck (e.g. `depleted`) even though the contract had credits.

Root cause is an ordering issue in `switchContract`:

1. `provisionMetronomeContract` creates the contract → it becomes active → Metronome fires **`contract.start`** → the handler reconciles the pool (and per-user states) via `applyContractStartSubscriptionSwap`.
2. **Only after that**, `stepContractEdits` (and the seat sync) add the recurring credits.

So `contract.start` reconciled **before the credits existed**. The `credit.segment.start` handler already reconciles, but for a recurring credit added to an *already-active* contract Metronome fires only **`credit.create`** (the first segment is active at creation) — not a fresh `credit.segment.start`. And `credit.create` only stamped the credit; it never reconciled. Result: the state stayed at whatever `contract.start` computed before the credit landed.

This affects both the **pool** state (recurring free / pool credits) and the **per-user seat** state (per-seat `INDIVIDUAL` credits), by the same mechanism.

## Fix

Reconcile on `credit.create`, mirroring both reconciles `credit.segment.start` performs, split by allocation. The same split is now also applied in the existing `credit.segment.start` / `credit.edit` handler.

- **Pool AWU credit** (e.g. the recurring free credit) → reconcile the workspace pool credit state.
  - **Stamp first, then reconcile.** The pool balance is read with an `onlyPoolCredits` filter (`getNetBalance` filters on `custom_fields: { DUST_CONTRACT_CREDIT_TYPE: "pool" }`), so an unstamped credit is invisible to the reconcile. We stamp `DUST_CONTRACT_CREDIT_TYPE=pool`, then reconcile.
- **Per-seat (`INDIVIDUAL`) AWU credit** → reconcile per-user credit states (`launchReconcileWorkspaceUserCreditStatesWorkflow`), **not** the pool. Seat credits never count toward the pool balance, so a pool reconcile there was a wasted no-op `getNetBalance`. The reconcile workflow is workspace-scoped with `USE_EXISTING`, so onboarding many seats collapses into a single reconcile-all-users run.

### Why not set the custom field on the recurring-credit template instead?

Not possible with Metronome (`@metronome/sdk` v3.6.0): `add_recurring_credits[]` has no `custom_fields` field (unlike one-off `add_credits` / `add_commits`), there is no `recurring_credit` entity in `customFields.setValues`, and custom fields are not among the template fields documented to propagate to materialized instances. Per-instance stamping is the only option.

## Tests

Added a `credit.create` block to `process_webhook.test.ts`:
- reconciles the pool (and not per-user) for a pool AWU credit,
- reconciles per-user (and not pool) for a per-seat `INDIVIDUAL` credit,
- does nothing for a non-AWU credit.

All 28 tests in the file pass; `tsgo` and biome are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)