### PR TITLE
[front] enh: improve Pod function publish approval UI

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -278,7 +278,7 @@ export function ToolValidationCard({
     <ContentMessage
       title={title}
       variant="primary"
-      className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
+      className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-125"
       icon={icon}
     >
       {canCurrentUserRespond ? (
@@ -321,7 +321,7 @@ export function ToolValidationCard({
               </Label>
             )}
             {!toolOverride?.compactFooter && (
-              <div className="hidden sm:block sm:flex-grow" />
+              <div className="hidden sm:block sm:grow" />
             )}
             <div
               className={cn(
@@ -351,7 +351,7 @@ export function ToolValidationCard({
           </div>
         </>
       ) : (
-        <div className="font-sm whitespace-normal break-words text-foreground">
+        <div className="font-sm whitespace-normal wrap-break-word text-foreground">
           Waiting for{" "}
           <span className="font-semibold">{triggeringUser?.fullName}</span> to
           confirm.

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -31,6 +31,7 @@ import {
   Check,
   Checkbox,
   ContentMessage,
+  cn,
   Label,
   XClose,
 } from "@dust-tt/sparkle";
@@ -294,7 +295,13 @@ export function ToolValidationCard({
               {errorMessage}
             </div>
           )}
-          <div className="flex flex-col gap-3 sm:mt-3">
+          <div
+            className={cn(
+              "flex flex-col gap-3 sm:mt-3",
+              toolOverride?.compactFooter &&
+                "sm:flex-row sm:items-center sm:justify-between"
+            )}
+          >
             {(validationRequest.stake === "low" ||
               validationRequest.stake === "medium") && (
               <Label
@@ -316,7 +323,12 @@ export function ToolValidationCard({
             {!toolOverride?.compactFooter && (
               <div className="hidden sm:block sm:flex-grow" />
             )}
-            <div className="flex flex-row gap-3 self-end">
+            <div
+              className={cn(
+                "flex flex-row gap-3 self-end",
+                toolOverride?.compactFooter && "sm:self-auto"
+              )}
+            >
               <Button
                 label="Decline"
                 variant="outline"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -42,6 +42,7 @@ type ToolOverride = {
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   detailsExpanded?: boolean;
+  hideIcon?: boolean;
   inlineActions?: boolean;
 };
 
@@ -72,6 +73,7 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: () => "Publish this function?",
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
+      hideIcon: true,
       inlineActions: true,
     },
   },
@@ -278,8 +280,11 @@ export function ToolValidationCard({
     <ContentMessage
       title={title}
       variant="primary"
-      className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
-      icon={icon}
+      className={cn(
+        "flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]",
+        toolOverride?.inlineActions && "gap-4 p-5"
+      )}
+      icon={toolOverride?.hideIcon ? undefined : icon}
     >
       {canCurrentUserRespond ? (
         <>
@@ -299,7 +304,7 @@ export function ToolValidationCard({
             className={cn(
               "flex flex-col gap-3 sm:mt-3",
               toolOverride?.inlineActions &&
-                "border-t border-separator pt-3 sm:mt-0 sm:flex-row sm:items-center"
+                "mt-1 pt-2 sm:mt-2 sm:flex-row sm:items-center sm:justify-between"
             )}
           >
             {(validationRequest.stake === "low" ||

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -2,7 +2,6 @@ import { ToolValidationDetails } from "@app/components/assistant/conversation/To
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { validateToolInputs } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
@@ -39,6 +38,7 @@ import { useMemo, useState } from "react";
 
 type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
+  approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   detailsExpanded?: boolean;
 };
@@ -67,14 +67,8 @@ const MCP_TOOL_OVERRIDES: Partial<
   },
   [SANDBOX_FUNCTIONS_SERVER_NAME]: {
     publish: {
-      title: (inputs) => {
-        if (
-          !validateToolInputs(SANDBOX_FUNCTIONS_SERVER_NAME, "publish", inputs)
-        ) {
-          return "Allow agent to publish a Pod function?";
-        }
-        return `Allow agent to publish ${inputs.slug}?`;
-      },
+      title: () => "Publish this function?",
+      approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
     },
   },
@@ -329,7 +323,7 @@ export function ToolValidationCard({
                 onClick={() => void handleValidation("rejected")}
               />
               <Button
-                label="Allow"
+                label={toolOverride?.approveLabel ?? "Allow"}
                 variant="highlight"
                 size="xs"
                 icon={Check}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -42,7 +42,6 @@ type ToolOverride = {
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   detailsExpanded?: boolean;
-  hideIcon?: boolean;
   inlineActions?: boolean;
 };
 
@@ -73,7 +72,6 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: () => "Publish this function?",
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
-      hideIcon: true,
       inlineActions: true,
     },
   },
@@ -280,11 +278,8 @@ export function ToolValidationCard({
     <ContentMessage
       title={title}
       variant="primary"
-      className={cn(
-        "flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]",
-        toolOverride?.inlineActions && "gap-4 p-5"
-      )}
-      icon={toolOverride?.hideIcon ? undefined : icon}
+      className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
+      icon={icon}
     >
       {canCurrentUserRespond ? (
         <>
@@ -304,7 +299,7 @@ export function ToolValidationCard({
             className={cn(
               "flex flex-col gap-3 sm:mt-3",
               toolOverride?.inlineActions &&
-                "mt-1 pt-2 sm:mt-2 sm:flex-row sm:items-center sm:justify-between"
+                "mt-1 pt-1 sm:mt-2 sm:flex-row sm:items-center sm:justify-between"
             )}
           >
             {(validationRequest.stake === "low" ||

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -31,7 +31,6 @@ import {
   Check,
   Checkbox,
   ContentMessage,
-  cn,
   Label,
   XClose,
 } from "@dust-tt/sparkle";
@@ -41,8 +40,9 @@ type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
+  compactFooter?: boolean;
   detailsExpanded?: boolean;
-  inlineActions?: boolean;
+  hideIcon?: boolean;
 };
 
 /** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
@@ -72,7 +72,8 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: () => "Publish this function?",
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
-      inlineActions: true,
+      compactFooter: true,
+      hideIcon: true,
     },
   },
   [POD_TASKS_SERVER_NAME]: {
@@ -279,7 +280,7 @@ export function ToolValidationCard({
       title={title}
       variant="primary"
       className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
-      icon={icon}
+      icon={toolOverride?.hideIcon ? undefined : icon}
     >
       {canCurrentUserRespond ? (
         <>
@@ -295,13 +296,7 @@ export function ToolValidationCard({
               {errorMessage}
             </div>
           )}
-          <div
-            className={cn(
-              "flex flex-col gap-3 sm:mt-3",
-              toolOverride?.inlineActions &&
-                "mt-1 pt-1 sm:mt-2 sm:flex-row sm:items-center sm:justify-between"
-            )}
-          >
+          <div className="flex flex-col gap-3 sm:mt-3">
             {(validationRequest.stake === "low" ||
               validationRequest.stake === "medium") && (
               <Label
@@ -320,15 +315,10 @@ export function ToolValidationCard({
                 </span>
               </Label>
             )}
-            {!toolOverride?.inlineActions && (
+            {!toolOverride?.compactFooter && (
               <div className="hidden sm:block sm:flex-grow" />
             )}
-            <div
-              className={cn(
-                "flex flex-row gap-3 self-end",
-                toolOverride?.inlineActions && "sm:self-auto"
-              )}
-            >
+            <div className="flex flex-row gap-3 self-end">
               <Button
                 label="Decline"
                 variant="outline"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -31,6 +31,7 @@ import {
   Check,
   Checkbox,
   ContentMessage,
+  cn,
   Label,
   XClose,
 } from "@dust-tt/sparkle";
@@ -41,6 +42,7 @@ type ToolOverride = {
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   detailsExpanded?: boolean;
+  inlineActions?: boolean;
 };
 
 /** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
@@ -70,6 +72,7 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: () => "Publish this function?",
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
+      inlineActions: true,
     },
   },
   [POD_TASKS_SERVER_NAME]: {
@@ -292,7 +295,13 @@ export function ToolValidationCard({
               {errorMessage}
             </div>
           )}
-          <div className="flex flex-col gap-3 sm:mt-3">
+          <div
+            className={cn(
+              "flex flex-col gap-3 sm:mt-3",
+              toolOverride?.inlineActions &&
+                "border-t border-separator pt-3 sm:mt-0 sm:flex-row sm:items-center"
+            )}
+          >
             {(validationRequest.stake === "low" ||
               validationRequest.stake === "medium") && (
               <Label
@@ -311,8 +320,15 @@ export function ToolValidationCard({
                 </span>
               </Label>
             )}
-            <div className="hidden sm:block sm:flex-grow" />
-            <div className="flex flex-row gap-3 self-end">
+            {!toolOverride?.inlineActions && (
+              <div className="hidden sm:block sm:flex-grow" />
+            )}
+            <div
+              className={cn(
+                "flex flex-row gap-3 self-end",
+                toolOverride?.inlineActions && "sm:self-auto"
+              )}
+            >
               <Button
                 label="Decline"
                 variant="outline"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -31,7 +31,6 @@ import {
   Check,
   Checkbox,
   ContentMessage,
-  cn,
   Label,
   XClose,
 } from "@dust-tt/sparkle";
@@ -41,7 +40,6 @@ type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
-  compactFooter?: boolean;
   detailsExpanded?: boolean;
 };
 
@@ -72,7 +70,6 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: () => "Publish this function?",
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
-      compactFooter: true,
     },
   },
   [POD_TASKS_SERVER_NAME]: {
@@ -295,13 +292,7 @@ export function ToolValidationCard({
               {errorMessage}
             </div>
           )}
-          <div
-            className={cn(
-              "flex flex-col gap-3 sm:mt-3",
-              toolOverride?.compactFooter &&
-                "sm:flex-row sm:items-center sm:justify-between"
-            )}
-          >
+          <div className="flex flex-col gap-3 sm:mt-3">
             {(validationRequest.stake === "low" ||
               validationRequest.stake === "medium") && (
               <Label
@@ -320,15 +311,8 @@ export function ToolValidationCard({
                 </span>
               </Label>
             )}
-            {!toolOverride?.compactFooter && (
-              <div className="hidden sm:block sm:grow" />
-            )}
-            <div
-              className={cn(
-                "flex flex-row gap-3 self-end",
-                toolOverride?.compactFooter && "sm:self-auto"
-              )}
-            >
+            <div className="hidden sm:block sm:grow" />
+            <div className="flex flex-row gap-3 self-end">
               <Button
                 label="Decline"
                 variant="outline"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -2,6 +2,7 @@ import { ToolValidationDetails } from "@app/components/assistant/conversation/To
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { validateToolInputs } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   EDIT_INFORMATION_TOOL_NAME,
   POD_MANAGER_SERVER_NAME,
@@ -20,6 +21,7 @@ import {
   isPodTasksCreateTasksInput,
   isPodTasksUpdateTasksInput,
 } from "@app/lib/api/actions/servers/pod_tasks/types";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -61,6 +63,19 @@ const MCP_TOOL_OVERRIDES: Partial<
     add_egress_domain: {
       title: () => `Allow agent to add a domain to the Computer?`,
       detailsExpanded: true,
+    },
+  },
+  [SANDBOX_FUNCTIONS_SERVER_NAME]: {
+    publish: {
+      title: (inputs) => {
+        if (
+          !validateToolInputs(SANDBOX_FUNCTIONS_SERVER_NAME, "publish", inputs)
+        ) {
+          return "Allow agent to publish a Pod function?";
+        }
+        return `Allow agent to publish ${inputs.slug}?`;
+      },
+      alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
     },
   },
   [POD_TASKS_SERVER_NAME]: {

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -42,7 +42,6 @@ type ToolOverride = {
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
   compactFooter?: boolean;
   detailsExpanded?: boolean;
-  hideIcon?: boolean;
 };
 
 /** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
@@ -73,7 +72,6 @@ const MCP_TOOL_OVERRIDES: Partial<
       approveLabel: "Publish",
       alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
       compactFooter: true,
-      hideIcon: true,
     },
   },
   [POD_TASKS_SERVER_NAME]: {
@@ -280,7 +278,7 @@ export function ToolValidationCard({
       title={title}
       variant="primary"
       className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
-      icon={toolOverride?.hideIcon ? undefined : icon}
+      icon={icon}
     >
       {canCurrentUserRespond ? (
         <>

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -6,8 +6,12 @@ import { PodEditInformationValidationDetails } from "@app/components/assistant/c
 import { PodMembersUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails";
 import { PodTasksCreateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails";
 import { PodTasksUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails";
+import { SandboxFunctionPublishValidationDetails } from "@app/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { ASHBY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  ASHBY_SERVER_NAME,
+  validateToolInputs,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   CREATE_REFERRAL_TOOL_NAME,
   UPDATE_JOB_POSTING_TOOL_NAME,
@@ -34,6 +38,7 @@ import {
   isPodTasksCreateTasksInput,
   isPodTasksUpdateTasksInput,
 } from "@app/lib/api/actions/servers/pod_tasks/types";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import {
   SKILL_AUTHORING_SERVER_NAME,
   UPDATE_SKILL_TOOL_NAME,
@@ -218,6 +223,20 @@ export function ToolValidationDetails({
         user={user}
         conversationId={conversationId}
       />
+    );
+  }
+
+  if (
+    blockedAction.metadata.mcpServerName === SANDBOX_FUNCTIONS_SERVER_NAME &&
+    blockedAction.metadata.toolName === "publish" &&
+    validateToolInputs(
+      SANDBOX_FUNCTIONS_SERVER_NAME,
+      "publish",
+      blockedAction.inputs
+    )
+  ) {
+    return (
+      <SandboxFunctionPublishValidationDetails input={blockedAction.inputs} />
     );
   }
 

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -268,7 +268,9 @@ export function ToolValidationDetails({
                 <span className="text-xs font-medium text-muted-foreground">
                   {label}
                 </span>
-                <span className="whitespace-pre-wrap break-words">{value}</span>
+                <span className="whitespace-pre-wrap wrap-break-word">
+                  {value}
+                </span>
               </div>
             )
           )}

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,6 +1,5 @@
 interface SandboxFunctionPublishValidationDetailsProps {
   input: {
-    slug: string;
     description: string;
   };
 }
@@ -9,24 +8,8 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <div className="flex flex-col gap-3 pt-2">
-      <p className="text-sm text-muted-foreground">
-        The agent wants to publish this function to this Pod.
-      </p>
-
-      <div className="overflow-hidden rounded-xl border border-separator bg-background">
-        <div className="flex flex-col gap-1.5 px-3 py-3">
-          <div className="text-xs font-medium text-muted-foreground">
-            Function
-          </div>
-          <div className="wrap-break-word text-sm font-medium text-foreground">
-            {input.slug}
-          </div>
-          <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
-            {input.description}
-          </p>
-        </div>
-      </div>
-    </div>
+    <p className="whitespace-pre-wrap wrap-break-word pt-2 text-sm leading-5 text-muted-foreground">
+      {input.description}
+    </p>
   );
 }

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -9,11 +9,11 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <div className="flex flex-col gap-1 py-2 pl-7">
-      <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
+    <div className="flex flex-col gap-1.5 pb-1 pt-2">
+      <p className="heading-base wrap-break-word text-foreground">
         {input.slug}
       </p>
-      <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
+      <p className="max-w-md whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
         {input.description}
       </p>
     </div>

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,5 +1,6 @@
 interface SandboxFunctionPublishValidationDetailsProps {
   input: {
+    slug: string;
     description: string;
   };
 }
@@ -8,8 +9,13 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <p className="whitespace-pre-wrap wrap-break-word pt-2 text-sm leading-5 text-muted-foreground">
-      {input.description}
-    </p>
+    <div className="flex flex-col gap-1 pt-2">
+      <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
+        {input.slug}
+      </p>
+      <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
+        {input.description}
+      </p>
+    </div>
   );
 }

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -12,7 +12,7 @@ export function SandboxFunctionPublishValidationDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground">
-        Do you want to publish this function to this Pod?
+        The agent wants to publish this function to this Pod.
       </p>
 
       <dl className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,21 +1,43 @@
+import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
+import { Button, CodeBrowser } from "@dust-tt/sparkle";
+
 interface SandboxFunctionPublishValidationDetailsProps {
   input: {
     slug: string;
     description: string;
+    path: string;
   };
 }
 
 export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
+  const { openFilePreview } = useFilePreviewContext();
+  const sourceFileName = input.path.split("/").pop() || input.path;
+
   return (
-    <div className="flex flex-col gap-1.5 pb-1 pt-2">
-      <p className="heading-base wrap-break-word text-foreground">
-        {input.slug}
-      </p>
-      <p className="max-w-md whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
-        {input.description}
-      </p>
+    <div className="flex flex-col items-start gap-3 pb-1 pt-2">
+      <div className="flex flex-col gap-1.5">
+        <p className="heading-base wrap-break-word text-foreground">
+          {input.slug}
+        </p>
+        <p className="max-w-md whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
+          {input.description}
+        </p>
+      </div>
+      <Button
+        label="View source"
+        variant="outline"
+        size="xs"
+        icon={CodeBrowser}
+        onClick={() =>
+          openFilePreview({
+            filePath: input.path,
+            title: sourceFileName,
+            contentType: "application/typescript",
+          })
+        }
+      />
     </div>
   );
 }

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -16,7 +16,7 @@ export function SandboxFunctionPublishValidationDetails({
   const sourceFileName = input.path.split("/").pop() || input.path;
 
   return (
-    <div className="flex flex-col gap-3 py-2 pl-7 sm:flex-row sm:items-start sm:justify-between">
+    <div className="flex flex-col gap-3 py-2 pl-7 sm:flex-row">
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <p className="heading-base wrap-break-word text-foreground">
           {input.slug}

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,3 +1,5 @@
+import { Icon, Terminal } from "@dust-tt/sparkle";
+
 interface SandboxFunctionPublishValidationDetailsProps {
   input: {
     slug: string;
@@ -9,8 +11,11 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <div className="pt-2">
-      <div className="flex flex-col gap-1 rounded-xl bg-background px-3 py-2.5">
+    <div className="flex items-start gap-3 py-3">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background text-muted-foreground">
+        <Icon visual={Terminal} size="sm" />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
           {input.slug}
         </p>

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -16,7 +16,7 @@ export function SandboxFunctionPublishValidationDetails({
   const sourceFileName = input.path.split("/").pop() || input.path;
 
   return (
-    <div className="flex flex-col gap-3 pb-1 pl-7 pt-2 sm:flex-row sm:items-start sm:justify-between">
+    <div className="flex flex-col gap-3 py-2 pl-7 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <p className="heading-base wrap-break-word text-foreground">
           {input.slug}

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -16,8 +16,8 @@ export function SandboxFunctionPublishValidationDetails({
   const sourceFileName = input.path.split("/").pop() || input.path;
 
   return (
-    <div className="flex flex-col items-start gap-3 pb-1 pt-2">
-      <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-3 pb-1 pl-7 pt-2 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <p className="heading-base wrap-break-word text-foreground">
           {input.slug}
         </p>
@@ -30,6 +30,7 @@ export function SandboxFunctionPublishValidationDetails({
         variant="outline"
         size="xs"
         icon={CodeBrowser}
+        className="shrink-0 self-start"
         onClick={() =>
           openFilePreview({
             filePath: input.path,

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,0 +1,46 @@
+interface SandboxFunctionPublishValidationDetailsProps {
+  input: {
+    slug: string;
+    description: string;
+    path: string;
+  };
+}
+
+export function SandboxFunctionPublishValidationDetails({
+  input,
+}: SandboxFunctionPublishValidationDetailsProps) {
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground">
+        Review the function before publishing it to this Pod.
+      </p>
+
+      <dl className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">
+        <div className="flex flex-col gap-1 px-3 py-2.5">
+          <dt className="text-xs font-medium text-muted-foreground">
+            Function
+          </dt>
+          <dd className="break-words text-sm font-medium text-foreground">
+            {input.slug}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1 px-3 py-2.5">
+          <dt className="text-xs font-medium text-muted-foreground">
+            Description
+          </dt>
+          <dd className="whitespace-pre-wrap break-words text-sm text-foreground">
+            {input.description}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1 px-3 py-2.5">
+          <dt className="text-xs font-medium text-muted-foreground">
+            Source file
+          </dt>
+          <dd className="break-all font-mono text-xs text-foreground">
+            {input.path}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -20,7 +20,7 @@ export function SandboxFunctionPublishValidationDetails({
           <dt className="text-xs font-medium text-muted-foreground">
             Function
           </dt>
-          <dd className="break-words text-sm font-medium text-foreground">
+          <dd className="wrap-break-word text-sm font-medium text-foreground">
             {input.slug}
           </dd>
         </div>
@@ -28,7 +28,7 @@ export function SandboxFunctionPublishValidationDetails({
           <dt className="text-xs font-medium text-muted-foreground">
             Description
           </dt>
-          <dd className="whitespace-pre-wrap break-words text-sm text-foreground">
+          <dd className="whitespace-pre-wrap wrap-break-word text-sm text-foreground">
             {input.description}
           </dd>
         </div>

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -9,13 +9,15 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <div className="flex flex-col gap-1 pt-2">
-      <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
-        {input.slug}
-      </p>
-      <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
-        {input.description}
-      </p>
+    <div className="pt-2">
+      <div className="flex flex-col gap-1 rounded-xl bg-background px-3 py-2.5">
+        <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
+          {input.slug}
+        </p>
+        <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
+          {input.description}
+        </p>
+      </div>
     </div>
   );
 }

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -1,5 +1,3 @@
-import { Icon, Terminal } from "@dust-tt/sparkle";
-
 interface SandboxFunctionPublishValidationDetailsProps {
   input: {
     slug: string;
@@ -11,18 +9,13 @@ export function SandboxFunctionPublishValidationDetails({
   input,
 }: SandboxFunctionPublishValidationDetailsProps) {
   return (
-    <div className="flex items-start gap-3 py-3">
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background text-muted-foreground">
-        <Icon visual={Terminal} size="sm" />
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
-          {input.slug}
-        </p>
-        <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
-          {input.description}
-        </p>
-      </div>
+    <div className="flex flex-col gap-1 py-2 pl-7">
+      <p className="wrap-break-word text-sm font-medium leading-5 text-foreground">
+        {input.slug}
+      </p>
+      <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
+        {input.description}
+      </p>
     </div>
   );
 }

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -12,7 +12,7 @@ export function SandboxFunctionPublishValidationDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground">
-        Review the function before publishing it to this Pod.
+        Do you want to publish this function to this Pod?
       </p>
 
       <dl className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -2,7 +2,6 @@ interface SandboxFunctionPublishValidationDetailsProps {
   input: {
     slug: string;
     description: string;
-    path: string;
   };
 }
 
@@ -15,32 +14,19 @@ export function SandboxFunctionPublishValidationDetails({
         The agent wants to publish this function to this Pod.
       </p>
 
-      <dl className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">
-        <div className="flex flex-col gap-1 px-3 py-2.5">
-          <dt className="text-xs font-medium text-muted-foreground">
+      <div className="overflow-hidden rounded-xl border border-separator bg-background">
+        <div className="flex flex-col gap-1.5 px-3 py-3">
+          <div className="text-xs font-medium text-muted-foreground">
             Function
-          </dt>
-          <dd className="wrap-break-word text-sm font-medium text-foreground">
+          </div>
+          <div className="wrap-break-word text-sm font-medium text-foreground">
             {input.slug}
-          </dd>
-        </div>
-        <div className="flex flex-col gap-1 px-3 py-2.5">
-          <dt className="text-xs font-medium text-muted-foreground">
-            Description
-          </dt>
-          <dd className="whitespace-pre-wrap wrap-break-word text-sm text-foreground">
+          </div>
+          <p className="whitespace-pre-wrap wrap-break-word text-sm leading-5 text-muted-foreground">
             {input.description}
-          </dd>
+          </p>
         </div>
-        <div className="flex flex-col gap-1 px-3 py-2.5">
-          <dt className="text-xs font-medium text-muted-foreground">
-            Source file
-          </dt>
-          <dd className="break-all font-mono text-xs text-foreground">
-            {input.path}
-          </dd>
-        </div>
-      </dl>
+      </div>
     </div>
   );
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1345,6 +1345,31 @@ export type AutoInternalMCPServerNameType = AutoServerKeys<
   typeof INTERNAL_MCP_SERVERS
 >;
 
+export function validateToolInputs<
+  S extends InternalMCPServerNameType,
+  T extends InternalMCPToolNameType<S>,
+>(
+  serverName: S,
+  toolName: T,
+  inputs: Record<string, unknown>
+): inputs is z.infer<
+  z.ZodObject<
+    Extract<
+      (typeof INTERNAL_MCP_SERVERS)[S]["metadata"]["tools"][number],
+      { name: T }
+    >["schema"]
+  >
+> {
+  const toolMetadata = INTERNAL_MCP_SERVERS[serverName].metadata.tools.find(
+    (tool) => tool.name === toolName
+  );
+  if (!toolMetadata) {
+    return false;
+  }
+
+  return z.object(toolMetadata.schema).safeParse(inputs).success;
+}
+
 export function isAutoInternalMCPServerName(
   name: InternalMCPServerNameType
 ): name is AutoInternalMCPServerNameType {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1363,6 +1363,7 @@ export function validateToolInputs<
   const toolMetadata = INTERNAL_MCP_SERVERS[serverName].metadata.tools.find(
     (tool) => tool.name === toolName
   );
+  // The type enforces that this exists, but we return false out of retro-compatibility over tool/server name changes.
   if (!toolMetadata) {
     return false;
   }


### PR DESCRIPTION
## Description

Publishing a Pod function currently uses the generic tool validation details, which hides the relevant inputs behind a collapsed key/value view. This view is also very technical and can be intimidating + not very helpful to decide whether or not you should approve the action.

This adds a dedicated approval summary showing the function slug, description, and a button to preview the source file, along with the regular "Never ask again" button.

Before:
<img width="432" height="393" alt="image" src="https://github.com/user-attachments/assets/74591170-5831-414f-abc4-5add111e5996" />

After:
<img width="419" height="229" alt="image" src="https://github.com/user-attachments/assets/bd504a84-f4fb-4f41-892c-6c773500e81c" />

Also introduces a generic tool input validation function that will allow removing a lot of boilerplate code (every tool-specific typeguard that validates the input basically).

## Tests

- Tested manually.

## Risk

- Low.

## Deploy Plan

- Deploy front.
