### PR TITLE
Admin governance: show skill availability column in the manage skills page

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -10,7 +10,11 @@ import {
   useSetPageTitle,
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { isDustProvidedSkill, SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
@@ -80,6 +84,10 @@ function sortSkillsByName(
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const hasSkillPublicationGovernance = hasFeature(
+    "admin_governance_skill_publication"
+  );
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -154,9 +162,12 @@ export function ManageSkillsPage() {
       ),
       default: filteredList(
         sortedActiveSkills
-          .filter(
-            (s) =>
-              s.availability === "users_and_agents" || isDustProvidedSkill(s)
+          .filter((s) =>
+            // With skill publication governance the tab lists auto-discoverable
+            // skills: exactly the ones agents can activate on their own.
+            hasSkillPublicationGovernance
+              ? s.availability === "users_and_agents"
+              : s.availability === "users_and_agents" || isDustProvidedSkill(s)
           )
           .sort((a, b) => {
             // Display Dust-managed skills first.
@@ -171,7 +182,14 @@ export function ManageSkillsPage() {
       ),
       archived: filteredList(sortedArchivedSkills),
     };
-  }, [activeSkills, archivedSkills, skillSearch, user, isSearchActive]);
+  }, [
+    activeSkills,
+    archivedSkills,
+    skillSearch,
+    user,
+    isSearchActive,
+    hasSkillPublicationGovernance,
+  ]);
 
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 
@@ -315,7 +333,11 @@ export function ManageSkillsPage() {
                   <TabsTrigger
                     key={tab.id}
                     value={tab.id}
-                    label={tab.label}
+                    label={
+                      tab.id === "default" && hasSkillPublicationGovernance
+                        ? "Auto-discoverable"
+                        : tab.label
+                    }
                     onClick={() => setSelectedTab(tab.id)}
                     tooltip={tab.description}
                     isCounter={tab.id !== "archived"}
@@ -344,6 +366,7 @@ export function ManageSkillsPage() {
                   onSkillClick={handleSkillSelect}
                   onAgentClick={setAgentId}
                   onUsedBySkillClick={handleUsedBySkillSelect}
+                  showAvailability={hasSkillPublicationGovernance}
                 />
               </>
             )}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -7,12 +7,13 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
+  SkillAvailability,
   SkillUsageType,
   SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
-import { DataTable, Edit04, Eye, Trash01 } from "@dust-tt/sparkle";
+import { Chip, DataTable, Edit04, Eye, Trash01 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -21,12 +22,22 @@ type RowData = {
   icon: string | null;
   editedBy: number | null;
   description: string;
+  availability: SkillAvailability;
   editors: UserType[] | null;
   usage: SkillUsageType;
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
   menuItems: MenuItem[];
+};
+
+export const SKILL_AVAILABILITY_DISPLAY: Record<
+  SkillAvailability,
+  { label: string; color: "primary" | "success" | "highlight" }
+> = {
+  editors: { label: "Editor only", color: "primary" },
+  workspace_users: { label: "Workspace members", color: "success" },
+  users_and_agents: { label: "Auto-discoverable", color: "highlight" },
 };
 
 const nameColumn = {
@@ -55,6 +66,23 @@ const nameColumn = {
   },
   meta: {
     className: "w-40 @lg:w-full",
+  },
+};
+
+const availabilityColumn = {
+  header: "Access",
+  accessorKey: "availability",
+  cell: (info: CellContext<RowData, SkillAvailability>) => {
+    const display = SKILL_AVAILABILITY_DISPLAY[info.getValue()];
+    return (
+      <DataTable.CellContent>
+        <Chip size="xs" color={display.color} label={display.label} />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    // Wide enough for the longest chip label ("Workspace members").
+    className: "hidden @sm:w-44 @sm:table-cell",
   },
 };
 
@@ -131,21 +159,28 @@ const menuColumn = {
   },
 };
 
-const getTableColumns = (
-  onAgentClick: (agentId: string) => void,
-  onUsedBySkillClick: (skillId: string) => void
-) => {
+const getTableColumns = ({
+  onAgentClick,
+  onUsedBySkillClick,
+  showAvailability,
+}: {
+  onAgentClick: (agentId: string) => void;
+  onUsedBySkillClick: (skillId: string) => void;
+  showAvailability: boolean;
+}) => {
   /**
    * Columns order:
    * - Name (always)
-   * - Editors (hidden on mobile)
+   * - Access (skill publication governance only, hidden on mobile)
    * - Used by (hidden on mobile)
+   * - Editors (hidden on mobile)
    * - Last Edited (hidden on mobile)
    * - Actions (always)
    */
 
   return [
     nameColumn,
+    ...(showAvailability ? [availabilityColumn] : []),
     usedByColumn(onAgentClick, onUsedBySkillClick),
     editorsColumn,
     lastEditedColumn,
@@ -161,6 +196,7 @@ type SkillsTableProps = {
   ) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
+  showAvailability?: boolean;
 };
 
 export function SkillsTable({
@@ -169,6 +205,7 @@ export function SkillsTable({
   onSkillClick,
   onAgentClick,
   onUsedBySkillClick,
+  showAvailability = false,
 }: SkillsTableProps) {
   const router = useAppRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
@@ -183,6 +220,7 @@ export function SkillsTable({
         icon: skill.icon,
         editedBy: skill.editedBy,
         description: skill.userFacingDescription,
+        availability: skill.availability,
         editors: skill.relations.editors,
         usage: skill.relations.usage,
         updatedAt: skill.updatedAt,
@@ -251,7 +289,11 @@ export function SkillsTable({
       <DataTable
         className="relative"
         data={rows}
-        columns={getTableColumns(onAgentClick, onUsedBySkillClick)}
+        columns={getTableColumns({
+          onAgentClick,
+          onUsedBySkillClick,
+          showAvailability,
+        })}
         pagination={pagination}
         setPagination={setPagination}
       />


### PR DESCRIPTION
## Description


- the skills table shows an Access column with the availability of each skill (Published / Unpublished / Discoverable).
- default tab has been renamed "Auto-discoverable" + added a description for it
- all behind the `admin_governance_skill_publication` flag 

## Tests

tested locally

<img width="2762" height="1372" alt="image" src="https://github.com/user-attachments/assets/c73a68f3-4277-4647-a9b1-c749b3a30cb7" />


<img width="2750" height="1682" alt="image" src="https://github.com/user-attachments/assets/a46b19bd-3130-4944-b62f-b48937581acf" />


## Risk

low: behind feature flag + purely UI + easy to revert

## Deploy Plan

deploy front