### PR TITLE
[front] render tables in slack tool message

### DIFF
--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -55,7 +55,7 @@ export function makeSentByFooterBlock(
     elements: [
       {
         type: "mrkdwn",
-        text: `Sent via <${agentUrl}|${agentName} Agent> on Dust`,
+        text: `_Sent via <${agentUrl}|${agentName} Agent> on Dust_`,
       },
     ],
   };

--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -1,0 +1,42 @@
+import { truncate } from "@app/types/shared/utils/string_utils";
+import type { KnownBlock } from "@slack/web-api";
+import slackifyMarkdown from "slackify-markdown";
+
+/*
+ * This length threshold prevents the "msg_too_long" error from Slack's
+ * chat.update method. Per past incidents, the max message length is 3000
+ * characters; we stay conservative to leave room for ellipses.
+ */
+const MAX_SLACK_MESSAGE_LENGTH = 2500;
+
+// Mirrors connectors/src/connectors/slack/chat/blocks.ts::makeMarkdownBlock.
+// The newer `markdown` block renders tables, headers, lists, but is
+// not supported alongside file uploads — those fall back to a legacy mrkdwn
+// section built from slackify-markdown.
+export function makeMarkdownBlock(
+  text?: string,
+  isUpload?: boolean
+): KnownBlock[] {
+  if (!text) {
+    return [];
+  }
+
+  if (!isUpload) {
+    return [
+      {
+        type: "markdown",
+        text: truncate(text, MAX_SLACK_MESSAGE_LENGTH),
+      },
+    ];
+  }
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: truncate(slackifyMarkdown(text), MAX_SLACK_MESSAGE_LENGTH),
+      },
+    },
+  ];
+}

--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -7,13 +7,13 @@ import slackifyMarkdown from "slackify-markdown";
  * chat.update method. Per past incidents, the max message length is 3000
  * characters; we stay conservative to leave room for ellipses.
  */
-const MAX_SLACK_MESSAGE_LENGTH = 2500;
+export const MAX_SLACK_MESSAGE_LENGTH = 2500;
 
 // Mirrors connectors/src/connectors/slack/chat/blocks.ts::makeMarkdownBlock.
 // The newer `markdown` block renders tables, headers, lists, but is
 // not supported alongside file uploads — those fall back to a legacy mrkdwn
 // section built from slackify-markdown.
-export function makeMarkdownBlock(
+export function makeMarkdownBlocks(
   text?: string,
   isUpload?: boolean
 ): KnownBlock[] {
@@ -42,10 +42,19 @@ export function makeMarkdownBlock(
   ];
 }
 
-// "Sent via <agent> on Dust" attribution as a standalone context block (mrkdwn,
-// so the link uses `<url|label>`). Kept separate from the message block — like
-// the connector's makeFooterBlock — so it is never absorbed into a markdown
-// table.
+// "Sent via <agent> on Dust" attribution as legacy Slack mrkdwn (link uses
+// `<url|label>`). Single source of truth for the footer text, shared by the
+// context block below and the file-upload `initial_comment` path.
+export function makeSentByFooterText(
+  agentName: string,
+  agentUrl: string
+): string {
+  return `_Sent via <${agentUrl}|${agentName} Agent> on Dust_`;
+}
+
+// The footer as a standalone context block — kept separate from the message
+// block (like the connector's makeFooterBlock) so it is never absorbed into a
+// markdown table.
 export function makeSentByFooterBlock(
   agentName: string,
   agentUrl: string
@@ -55,7 +64,7 @@ export function makeSentByFooterBlock(
     elements: [
       {
         type: "mrkdwn",
-        text: `_Sent via <${agentUrl}|${agentName} Agent> on Dust_`,
+        text: makeSentByFooterText(agentName, agentUrl),
       },
     ],
   };

--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -20,7 +20,8 @@ export function makeMarkdownBlock(
   if (!text) {
     return [];
   }
-
+   // New markdown block has better support for markdown formatting,
+  // but is not supported when uploading files.
   if (!isUpload) {
     return [
       {

--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -20,7 +20,7 @@ export function makeMarkdownBlock(
   if (!text) {
     return [];
   }
-   // New markdown block has better support for markdown formatting,
+  // New markdown block has better support for markdown formatting,
   // but is not supported when uploading files.
   if (!isUpload) {
     return [

--- a/front/lib/api/actions/servers/slack/block.ts
+++ b/front/lib/api/actions/servers/slack/block.ts
@@ -41,3 +41,22 @@ export function makeMarkdownBlock(
     },
   ];
 }
+
+// "Sent via <agent> on Dust" attribution as a standalone context block (mrkdwn,
+// so the link uses `<url|label>`). Kept separate from the message block — like
+// the connector's makeFooterBlock — so it is never absorbed into a markdown
+// table.
+export function makeSentByFooterBlock(
+  agentName: string,
+  agentUrl: string
+): KnownBlock {
+  return {
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `Sent via <${agentUrl}|${agentName} Agent> on Dust`,
+      },
+    ],
+  };
+}

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -4,6 +4,7 @@ import {
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
+import { makeMarkdownBlock } from "@app/lib/api/actions/servers/slack/block";
 import {
   formatSlackMessageForLLM,
   renderFormattedMessage,
@@ -794,6 +795,12 @@ export async function executePostMessage(
 
   const originalMessage = message;
 
+  // Regular messages are sent as a `markdown` block (GFM: tables, headers, ...),
+  // so the footer uses GFM link syntax. The file-upload path uses legacy Slack
+  // mrkdwn via `initial_comment`, so it keeps `<url|label>` link syntax.
+  let gfmMessage = originalMessage;
+  let mrkdwnMessage = slackifyMarkdown(originalMessage);
+
   if (
     showSentByFooter !== false &&
     isAgentLoopRunContext(toolContext.runContext)
@@ -804,9 +811,9 @@ export async function executePostMessage(
       `agentDetails=${toolContext.runContext?.agentConfiguration.sId}`,
       config.getAppUrl()
     );
-    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${toolContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
-  } else {
-    message = slackifyMarkdown(originalMessage);
+    const agentName = toolContext.runContext?.agentConfiguration.name;
+    gfmMessage = `${originalMessage}\n_Sent via [${agentName} Agent](${agentUrl}) on Dust_`;
+    mrkdwnMessage = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentName} Agent> on Dust_`;
   }
 
   if (!(await hasSlackScope(accessToken, "files:write"))) {
@@ -852,7 +859,7 @@ export async function executePostMessage(
       file: fileBuffer,
       filename,
       filetype,
-      initial_comment: message,
+      initial_comment: mrkdwnMessage,
     };
     const uploadResp = threadTs
       ? await slackClient.filesUploadV2({
@@ -874,10 +881,13 @@ export async function executePostMessage(
     ]);
   }
 
-  // No file provided: regular message.
+  // No file provided: regular message. Sent as a `markdown` block so full GFM
+  // (tables, headers, lists) renders; `text` is a plain fallback for places
+  // that cannot render blocks (e.g. push notifications).
   const response = await slackClient.chat.postMessage({
     channel: resolvedTo,
-    text: message,
+    blocks: makeMarkdownBlock(gfmMessage),
+    text: originalMessage,
     mrkdwn: true,
     thread_ts: threadTs,
     unfurl_links: unfurlLinks,
@@ -906,12 +916,13 @@ export async function executeUpdateMessage({
   message: string;
 }) {
   const slackClient = await getSlackClient(accessToken);
-  const slackFormattedMessage = slackifyMarkdown(message);
+  const originalMessage = message;
 
   const response = await slackClient.chat.update({
     channel,
     ts: timestamp,
-    text: slackFormattedMessage,
+    text: originalMessage,
+    blocks: makeMarkdownBlock(originalMessage),
   });
 
   if (!response.ok) {
@@ -952,6 +963,10 @@ export async function executeScheduleMessage(
   const slackClient = await getSlackClient(accessToken);
   const originalMessage = message;
 
+  // Regular messages are sent as a `markdown` block (GFM: tables, headers, ...),
+  // so the footer uses GFM link syntax.
+  let gfmMessage = originalMessage;
+
   if (
     showSentByFooter !== false &&
     isAgentLoopRunContext(toolContext.runContext)
@@ -962,9 +977,8 @@ export async function executeScheduleMessage(
       `agentDetails=${toolContext.runContext?.agentConfiguration.sId}`,
       config.getAppUrl()
     );
-    message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${toolContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
-  } else {
-    message = slackifyMarkdown(originalMessage);
+    const agentName = toolContext.runContext?.agentConfiguration.name;
+    gfmMessage = `${originalMessage}\n_Sent via [${agentName} Agent](${agentUrl}) on Dust_`;
   }
 
   // Convert post_at to Unix timestamp in seconds.
@@ -1009,7 +1023,8 @@ export async function executeScheduleMessage(
 
   const response = await slackClient.chat.scheduleMessage({
     channel: to,
-    text: message,
+    blocks: makeMarkdownBlock(gfmMessage),
+    text: gfmMessage,
     post_at: timestampSeconds.toString(),
     thread_ts: threadTs,
     unfurl_links: unfurlLinks,

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -4,7 +4,10 @@ import {
   isAgentLoopRunContext,
   type ToolContext,
 } from "@app/lib/actions/types";
-import { makeMarkdownBlock } from "@app/lib/api/actions/servers/slack/block";
+import {
+  makeMarkdownBlock,
+  makeSentByFooterBlock,
+} from "@app/lib/api/actions/servers/slack/block";
 import {
   formatSlackMessageForLLM,
   renderFormattedMessage,
@@ -18,7 +21,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { WebAPICallResult } from "@slack/web-api";
+import type { KnownBlock, WebAPICallResult } from "@slack/web-api";
 import { WebClient } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse";
 import type { Usergroup } from "@slack/web-api/dist/types/response/UsergroupsListResponse";
@@ -795,11 +798,12 @@ export async function executePostMessage(
 
   const originalMessage = message;
 
-  // Regular messages are sent as a `markdown` block (GFM: tables, headers, ...),
-  // so the footer uses GFM link syntax. The file-upload path uses legacy Slack
-  // mrkdwn via `initial_comment`, so it keeps `<url|label>` link syntax.
-  let gfmMessage = originalMessage;
+  // The regular path renders the message as a `markdown` block and appends the
+  // footer as a separate context block (so it is never absorbed into a markdown
+  // table). The file-upload path uses legacy Slack mrkdwn via `initial_comment`
+  // (a plain string, no blocks), so the footer is concatenated inline there.
   let mrkdwnMessage = slackifyMarkdown(originalMessage);
+  let footerBlock: KnownBlock | undefined;
 
   if (
     showSentByFooter !== false &&
@@ -812,8 +816,8 @@ export async function executePostMessage(
       config.getAppUrl()
     );
     const agentName = toolContext.runContext?.agentConfiguration.name;
-    gfmMessage = `${originalMessage}\n_Sent via [${agentName} Agent](${agentUrl}) on Dust_`;
     mrkdwnMessage = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentName} Agent> on Dust_`;
+    footerBlock = makeSentByFooterBlock(agentName, agentUrl);
   }
 
   if (!(await hasSlackScope(accessToken, "files:write"))) {
@@ -882,11 +886,15 @@ export async function executePostMessage(
   }
 
   // No file provided: regular message. Sent as a `markdown` block so full GFM
-  // (tables, headers, lists) renders; `text` is a plain fallback for places
-  // that cannot render blocks (e.g. push notifications).
+  // (tables, headers, lists) renders, with the footer as a separate context
+  // block; `text` is a plain fallback for places that cannot render blocks
+  // (e.g. push notifications).
   const response = await slackClient.chat.postMessage({
     channel: resolvedTo,
-    blocks: makeMarkdownBlock(gfmMessage),
+    blocks: [
+      ...makeMarkdownBlock(originalMessage),
+      ...(footerBlock ? [footerBlock] : []),
+    ],
     text: originalMessage,
     mrkdwn: true,
     thread_ts: threadTs,
@@ -963,9 +971,9 @@ export async function executeScheduleMessage(
   const slackClient = await getSlackClient(accessToken);
   const originalMessage = message;
 
-  // Regular messages are sent as a `markdown` block (GFM: tables, headers, ...),
-  // so the footer uses GFM link syntax.
-  let gfmMessage = originalMessage;
+  // The message is rendered as a `markdown` block; the footer is appended as a
+  // separate context block so it is never absorbed into a markdown table.
+  let footerBlock: KnownBlock | undefined;
 
   if (
     showSentByFooter !== false &&
@@ -978,7 +986,7 @@ export async function executeScheduleMessage(
       config.getAppUrl()
     );
     const agentName = toolContext.runContext?.agentConfiguration.name;
-    gfmMessage = `${originalMessage}\n_Sent via [${agentName} Agent](${agentUrl}) on Dust_`;
+    footerBlock = makeSentByFooterBlock(agentName, agentUrl);
   }
 
   // Convert post_at to Unix timestamp in seconds.
@@ -1023,8 +1031,11 @@ export async function executeScheduleMessage(
 
   const response = await slackClient.chat.scheduleMessage({
     channel: to,
-    blocks: makeMarkdownBlock(gfmMessage),
-    text: gfmMessage,
+    blocks: [
+      ...makeMarkdownBlock(originalMessage),
+      ...(footerBlock ? [footerBlock] : []),
+    ],
+    text: originalMessage,
     post_at: timestampSeconds.toString(),
     thread_ts: threadTs,
     unfurl_links: unfurlLinks,

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -5,8 +5,10 @@ import {
   type ToolContext,
 } from "@app/lib/actions/types";
 import {
-  makeMarkdownBlock,
+  MAX_SLACK_MESSAGE_LENGTH,
+  makeMarkdownBlocks,
   makeSentByFooterBlock,
+  makeSentByFooterText,
 } from "@app/lib/api/actions/servers/slack/block";
 import {
   formatSlackMessageForLLM,
@@ -21,6 +23,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import type { KnownBlock, WebAPICallResult } from "@slack/web-api";
 import { WebClient } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse";
@@ -796,14 +799,15 @@ export async function executePostMessage(
     return new Err(new MCPError("Failed to open group DM"));
   }
 
-  const originalMessage = message;
-
   // The regular path renders the message as a `markdown` block and appends the
   // footer as a separate context block (so it is never absorbed into a markdown
   // table). The file-upload path uses legacy Slack mrkdwn via `initial_comment`
-  // (a plain string, no blocks), so the footer is concatenated inline there.
-  let mrkdwnMessage = slackifyMarkdown(originalMessage);
+  // (a plain string, no blocks), so the footer is concatenated inline there — we
+  // reserve room for it in the truncation so message + footer stays within
+  // MAX_SLACK_MESSAGE_LENGTH.
   let footerBlock: KnownBlock | undefined;
+  let bodyMaxLength = MAX_SLACK_MESSAGE_LENGTH;
+  let mrkdwnMessage = truncate(slackifyMarkdown(message), bodyMaxLength);
 
   if (
     showSentByFooter !== false &&
@@ -816,7 +820,10 @@ export async function executePostMessage(
       config.getAppUrl()
     );
     const agentName = toolContext.runContext?.agentConfiguration.name;
-    mrkdwnMessage = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentName} Agent> on Dust_`;
+    const footerText = makeSentByFooterText(agentName, agentUrl);
+    // -1 for the newline joining the message and the footer in the string path.
+    bodyMaxLength = MAX_SLACK_MESSAGE_LENGTH - footerText.length - 1;
+    mrkdwnMessage = `${truncate(slackifyMarkdown(message), bodyMaxLength)}\n${footerText}`;
     footerBlock = makeSentByFooterBlock(agentName, agentUrl);
   }
 
@@ -892,10 +899,10 @@ export async function executePostMessage(
   const response = await slackClient.chat.postMessage({
     channel: resolvedTo,
     blocks: [
-      ...makeMarkdownBlock(originalMessage),
+      ...makeMarkdownBlocks(message, false),
       ...(footerBlock ? [footerBlock] : []),
     ],
-    text: originalMessage,
+    text: truncate(message, MAX_SLACK_MESSAGE_LENGTH),
     mrkdwn: true,
     thread_ts: threadTs,
     unfurl_links: unfurlLinks,
@@ -924,13 +931,11 @@ export async function executeUpdateMessage({
   message: string;
 }) {
   const slackClient = await getSlackClient(accessToken);
-  const originalMessage = message;
-
   const response = await slackClient.chat.update({
     channel,
     ts: timestamp,
-    text: originalMessage,
-    blocks: makeMarkdownBlock(originalMessage),
+    text: truncate(message, MAX_SLACK_MESSAGE_LENGTH),
+    blocks: makeMarkdownBlocks(message),
   });
 
   if (!response.ok) {
@@ -969,8 +974,6 @@ export async function executeScheduleMessage(
   }
 ) {
   const slackClient = await getSlackClient(accessToken);
-  const originalMessage = message;
-
   // The message is rendered as a `markdown` block; the footer is appended as a
   // separate context block so it is never absorbed into a markdown table.
   let footerBlock: KnownBlock | undefined;
@@ -1032,10 +1035,10 @@ export async function executeScheduleMessage(
   const response = await slackClient.chat.scheduleMessage({
     channel: to,
     blocks: [
-      ...makeMarkdownBlock(originalMessage),
+      ...makeMarkdownBlocks(message, false),
       ...(footerBlock ? [footerBlock] : []),
     ],
-    text: originalMessage,
+    text: truncate(message, MAX_SLACK_MESSAGE_LENGTH),
     post_at: timestampSeconds.toString(),
     thread_ts: threadTs,
     unfurl_links: unfurlLinks,

--- a/front/lib/api/actions/servers/slack/update_message.test.ts
+++ b/front/lib/api/actions/servers/slack/update_message.test.ts
@@ -24,7 +24,7 @@ describe("executeUpdateMessage", () => {
     vi.clearAllMocks();
   });
 
-  it("updates a Slack message with Slack-formatted Markdown", async () => {
+  it("updates a Slack message with a markdown block preserving raw Markdown", async () => {
     mockChatUpdate.mockResolvedValue({
       ok: true,
       channel: "C123",
@@ -44,8 +44,12 @@ describe("executeUpdateMessage", () => {
       channel: "C123",
       ts: "1710000000.000100",
     });
-    expect(updateArgs.text).toContain("*Edited*");
-    expect(updateArgs.text).not.toContain("**Edited**");
+    // The message goes into a `markdown` block with the raw GFM preserved (not
+    // slackified), so tables/rich Markdown render. `text` is the plain fallback.
+    expect(updateArgs.blocks).toEqual([
+      { type: "markdown", text: "**Edited** message" },
+    ]);
+    expect(updateArgs.text).toBe("**Edited** message");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value[0].text).toBe(


### PR DESCRIPTION
## Description

fixes: [#9612](https://github.com/dust-tt/tasks/issues/9612#issuecomment-5055230755)
`executePostMessage`, `executeUpdateMessage` and `executeScheduleMessage` now output text using blocks instead of legacy mrkdwn which enable a richer formatting. 

## Tests

deployed front-edge to tests. Results:
<img width="774" height="373" alt="image" src="https://github.com/user-attachments/assets/e3a10c6f-c8a8-45df-a088-dd1d44738ded" />

**Update**: Tested in prod:
<img width="1069" height="263" alt="image" src="https://github.com/user-attachments/assets/27a3ba86-5965-4b66-8086-fa6d4a5a3c77" />

## Risk

Low, safe to revert.

## Deploy Plan


