### PR TITLE
Prevent seat change when subscription has ended

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/seat_type.ts
+++ b/front-api/routes/poke/workspaces/[wId]/seat_type.ts
@@ -89,6 +89,15 @@ app.post(
               message: "Failed to sync seat change with Metronome.",
             },
           });
+        case "subscription_cancellation_scheduled":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "This workspace's subscription has a cancellation scheduled; seats cannot be changed until it's reactivated or has fully ended.",
+            },
+          });
         default:
           assertNever(updateRes.error.type);
       }

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -119,6 +119,15 @@ app.patch(
               message: "Failed to update seat in billing system.",
             },
           });
+        case "subscription_cancellation_scheduled":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "The subscription has a cancellation scheduled; seats cannot be changed until it's reactivated or has fully ended.",
+            },
+          });
         default:
           assertNever(result.error.type);
       }

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -91,7 +91,10 @@ import {
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import { isCreditPricedPlan } from "@app/types/plan";
+import {
+  isCreditPricedPlan,
+  isSubscriptionCancellationScheduled,
+} from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
   AlertCircle,
@@ -162,6 +165,12 @@ export function UsagePage() {
   // invite, seat changes, spend limits, settings) is disabled.
   const isReadOnly = !isCreditPriced && hasFeature("usage_page_read_only");
   const canViewUsage = isCreditPriced || isReadOnly;
+  // A cancelled subscription already has its end date scheduled with
+  // Metronome; scheduling a seat change on top of it can land past that end
+  // date and get rejected. Block seat changes until the subscription is
+  // reactivated or has fully ended.
+  const isSubscriptionCancelled =
+    isSubscriptionCancellationScheduled(subscription);
   const [searchTerm, setSearchTerm] = useState("");
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null
@@ -911,6 +920,7 @@ export function UsagePage() {
       isLoading={isMembersUsageLoading}
       isRefreshing={isMembersUsageRefreshing}
       readOnly={isReadOnly}
+      seatActionsDisabled={isSubscriptionCancelled}
       showSpendLimit={!isFreePlanWorkspace}
       showModelTiersColumn={modelsPickerEnabled}
       userModelTierSelectionByUserId={userModelTierSelectionByUserId}
@@ -949,7 +959,9 @@ export function UsagePage() {
       onClear={selection.clearSelection}
       onBatchEditSpendLimit={handleBatchEditSpendLimit}
       onBatchChangeSeat={
-        isSeatBased && !isFreePlanWorkspace ? handleBatchChangeSeat : undefined
+        isSeatBased && !isFreePlanWorkspace && !isSubscriptionCancelled
+          ? handleBatchChangeSeat
+          : undefined
       }
       disabled={isReadOnly}
     />

--- a/front/components/workspace/BulkChangeSeatModal.tsx
+++ b/front/components/workspace/BulkChangeSeatModal.tsx
@@ -15,10 +15,12 @@ import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { formatCurrencyAmountCents } from "@app/lib/metronome/amounts";
 import type { BulkSeatChangePreviewBody } from "@app/lib/swr/memberships";
 import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { isMembershipSeatType, isPaidSeatType } from "@app/types/memberships";
+import { isSubscriptionCancellationScheduled } from "@app/types/plan";
 import {
   ArrowRight,
   Avatar,
@@ -467,6 +469,13 @@ function BulkChangeSeatForm({
   onFetchPreview,
   onValidate,
 }: BulkChangeSeatFormProps) {
+  const { subscription } = useAuth();
+  // A cancelled subscription already has its end date scheduled with
+  // Metronome; scheduling a seat change on top of it can land past that end
+  // date and get rejected. Block seat changes until the subscription is
+  // reactivated or has fully ended.
+  const isSubscriptionCancelled =
+    isSubscriptionCancellationScheduled(subscription);
   const [selectedSeat, setSelectedSeat] = useState<PaidSeatType | null>(null);
   const [preview, setPreview] = useState<BulkSeatChangePreviewBody | null>(
     null
@@ -518,6 +527,12 @@ function BulkChangeSeatForm({
         step={step}
       />
       <DialogContainer>
+        {isSubscriptionCancelled && (
+          <p className="mb-3 text-xs text-warning-600">
+            Your subscription is scheduled to end and seats can&apos;t be
+            changed until it&apos;s reactivated.
+          </p>
+        )}
         {step === "pick" ? (
           <BulkChangeSeatModalPickSeatDialogContent
             seatPlans={seatPlans}
@@ -547,7 +562,9 @@ function BulkChangeSeatForm({
           <Button
             label="Review"
             variant="primary"
-            disabled={!selectedSeat || isLoadingPreview}
+            disabled={
+              !selectedSeat || isLoadingPreview || isSubscriptionCancelled
+            }
             isLoading={isLoadingPreview}
             onClick={handleNext}
           />
@@ -555,7 +572,7 @@ function BulkChangeSeatForm({
           <Button
             label="Validate"
             variant="primary"
-            disabled={isSaving}
+            disabled={isSaving || isSubscriptionCancelled}
             isLoading={isSaving}
             onClick={handleValidate}
           />

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -25,6 +25,7 @@ import {
   isPaidSeatType,
   type MembershipSeatType,
 } from "@app/types/memberships";
+import { isSubscriptionCancellationScheduled } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -85,6 +86,12 @@ export function ChangeSeatModal({
   const { subscription } = useAuth();
   const router = useAppRouter();
   const useCheckoutPath = isFreePlan(subscription.plan.code);
+  // A cancelled subscription already has its end date scheduled with
+  // Metronome; scheduling a seat change on top of it can land past that end
+  // date and get rejected. Block seat changes until the subscription is
+  // reactivated or has fully ended.
+  const isSubscriptionCancelled =
+    isSubscriptionCancellationScheduled(subscription);
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
   const lastMemberRef = useRef<MemberUsageType | null>(null);
@@ -337,10 +344,17 @@ export function ChangeSeatModal({
               );
             })}
 
-            {isDeferredChange && (
-              <p className="mt-1 text-xs text-info-600">
-                The change will take effect at the next credit refresh.
+            {isSubscriptionCancelled ? (
+              <p className="mt-1 text-xs text-warning-600">
+                Your subscription is scheduled to end and seats can&apos;t be
+                changed until it&apos;s reactivated.
               </p>
+            ) : (
+              isDeferredChange && (
+                <p className="mt-1 text-xs text-info-600">
+                  The change will take effect at the next credit refresh.
+                </p>
+              )
             )}
             {isCancellingScheduledChange && (
               <p className="mt-1 text-xs text-info-600">
@@ -366,6 +380,7 @@ export function ChangeSeatModal({
               ? !selectedSeat || !toCheckoutParams(selectedSeat)
               : isSaving ||
                 !selectedSeat ||
+                isSubscriptionCancelled ||
                 (selectedSeat === currentSeatType &&
                   !isCancellingScheduledChange),
             onClick: handleValidate,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -613,6 +613,9 @@ interface MembersUsageTableProps {
   isSeatBased: boolean;
   showSpendLimit: boolean;
   readOnly: boolean;
+  // Disables only the seat-assign/change/remove actions (e.g. while the
+  // subscription has a cancellation scheduled), independent of `readOnly`.
+  seatActionsDisabled?: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
@@ -648,6 +651,7 @@ export function MembersUsageTable({
   isSeatBased,
   showSpendLimit,
   readOnly,
+  seatActionsDisabled = false,
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
@@ -713,7 +717,7 @@ export function MembersUsageTable({
                   {
                     kind: "item" as const,
                     label: "Assign seat",
-                    disabled: readOnly,
+                    disabled: readOnly || seatActionsDisabled,
                     onClick: () => onChangeSeat(m),
                   },
                 ]
@@ -723,7 +727,7 @@ export function MembersUsageTable({
                   {
                     kind: "item" as const,
                     label: "Change seat type",
-                    disabled: readOnly,
+                    disabled: readOnly || seatActionsDisabled,
                     onClick: () => onChangeSeat(m),
                   },
                 ]
@@ -775,7 +779,7 @@ export function MembersUsageTable({
                     kind: "item" as const,
                     label: "Remove seat",
                     variant: "warning" as const,
-                    disabled: readOnly,
+                    disabled: readOnly || seatActionsDisabled,
                     onClick: () => onRemoveSeat(m),
                   },
                 ]
@@ -796,6 +800,7 @@ export function MembersUsageTable({
       workspaceAllowedModelTiers,
       groupNameToId,
       readOnly,
+      seatActionsDisabled,
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,

--- a/front/components/workspace/billing/SubscriptionContext.tsx
+++ b/front/components/workspace/billing/SubscriptionContext.tsx
@@ -12,7 +12,10 @@ import { useAppRouter } from "@app/lib/platform";
 import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SubscriptionType } from "@app/types/plan";
-import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import {
+  isSubscriptionCancellationScheduled,
+  isSubscriptionMetronomeBilled,
+} from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo, useState } from "react";
@@ -108,7 +111,7 @@ export function SubscriptionProvider({
     (isBusinessPlanPrefix(subscription.plan.code) ||
       isCreditPricedFreePlan(subscription.plan.code));
   const isCancellationScheduled =
-    subscription.endDate !== null || subscription.requestCancelAt !== null;
+    isSubscriptionCancellationScheduled(subscription);
   const subscriptionEndsAtMs =
     subscription.endDate ??
     (isCancellationScheduled ? (invoice?.currentPeriodEndMs ?? null) : null);

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -724,7 +724,8 @@ export async function updateMembershipSeatAndTrack({
         | "metronome_error"
         | "free_seat_not_allowed"
         | "paid_seat_not_allowed_on_free_plan"
-        | "seat_limit_reached";
+        | "seat_limit_reached"
+        | "subscription_cancellation_scheduled";
     }
   >
 > {
@@ -761,10 +762,21 @@ export async function updateMembershipSeatAndTrack({
     }
   }
 
-  if (isPaidSeatType(newSeatType) && newSeatType !== previousSeatType) {
+  if (newSeatType !== previousSeatType) {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-    if (subscription && isFreePlan(subscription.getPlan().code)) {
+    // A cancellation already schedules the Metronome contract's end date;
+    // scheduling a seat change on top of it can land past that end date and
+    // get rejected by Metronome. Reject here instead of letting a scheduled
+    // Metronome sync (or, for bulk changes, an async Temporal activity) fail
+    // silently later with no visible error to the user.
+    if (subscription.isCancellationScheduled) {
+      return new Err({ type: "subscription_cancellation_scheduled" });
+    }
+    if (
+      isPaidSeatType(newSeatType) &&
+      isFreePlan(subscription.getPlan().code)
+    ) {
       return new Err({ type: "paid_seat_not_allowed_on_free_plan" });
     }
   }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -170,6 +170,14 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return !!this.metronomeContractId && !this.stripeSubscriptionId;
   }
 
+  // True once a cancellation is scheduled (immediate `endDate` or a deferred
+  // `requestCancelAt`), whether or not that date has passed yet. Mirrors
+  // `isSubscriptionCancellationScheduled` in `types/plan.ts` (the front-end
+  // serialized-type equivalent).
+  get isCancellationScheduled(): boolean {
+    return this.endDate !== null || this.requestCancelAt !== null;
+  }
+
   /**
    * Terminal status to use when `swapMetronomeContract` ends this subscription
    * (the in-place swap path, with no pre-staged pending row). `activatePending`

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -133,6 +133,14 @@ export function isSubscriptionMetronomeBilled(
   );
 }
 
+// True once the subscription has a cancellation scheduled (immediate `endDate`
+// or a deferred `requestCancelAt`), whether or not that date has passed yet.
+export function isSubscriptionCancellationScheduled(
+  subscription: SubscriptionType
+): boolean {
+  return subscription.endDate !== null || subscription.requestCancelAt !== null;
+}
+
 /**
  * Returns true if the workspace is on a credit-priced plan.
  *


### PR DESCRIPTION
## Description

Fixes a Metronome `400` error ("Subscription seat remove starting at date must be before the subscription ends") that occurred when an admin changed a member's seat while the workspace's subscription already had a cancellation scheduled (contract end date set via Stripe cancel-at-period-end or the in-app "Cancel subscription" flow).

**Root cause:** once a subscription's cancellation is scheduled, its Metronome contract already has a scheduled end date (`ending_before`). A subsequent seat change computes a deferred `starting_at` for the seat add/remove call that can land at or after that contract end date, which Metronome rejects.

**Fix:** block seat-change actions in the UI whenever `subscription.endDate` or `subscription.requestCancelAt` is set (new shared helper `isSubscriptionCancellationScheduled` in `types/plan.ts`, extracted from existing inline logic in `SubscriptionContext.tsx`):

- `ChangeSeatModal` / `BulkChangeSeatModal`: disable Validate/Review and show an explanatory message.
- `MembersUsageTable`: new `seatActionsDisabled` prop disables Assign/Change/Remove seat row actions specifically, without touching unrelated actions (spend limit, model tier).
- `UsagePage`: computes the flag, wires it through, and hides the "Batch change seat" bulk action entirely when cancelled.

Verified this does not misfire during subscription switches/upgrades: that path (`activatePending`/`swapMetronomeContract`, driven by the `contract.start` webhook) ends the old subscription atomically via `markAsEnded` (status + `endDate = now` in the same transaction as the new one activating) rather than staging a future `endDate` on a still-`active` subscription, so an in-flight upgrade is never mistaken for a cancellation.

## Tests

Manually verified on the usage page: with a subscription that has a scheduled cancellation, per-member seat change, remove seat, and batch seat change are all disabled with an explanatory message; verified an in-flight subscription upgrade (no cancellation) does not trigger the guard.

## Risk

Low. Purely additive UI guard — no change to the seat-change backend logic. Worst case is over-blocking (a seat change that would have actually succeeded gets blocked) rather than letting an invalid Metronome call through.

## Deploy Plan

Standard frontend deploy, no migration or backend coordination required.
