### PR TITLE
Add pricing information in seat changes

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -6,6 +6,7 @@ import {
   formatPriceCents,
   getAvailableFrequencies,
   groupSeatTypesByFrequency,
+  includedSeatsOpen,
   SeatCard,
   sortSeatTypes,
 } from "@app/components/workspace/SeatCard";
@@ -75,10 +76,6 @@ const useGetEmailsListAndError = (
     };
   }, [inviteEmails]);
 };
-
-function includedSeatsOpen(info: SeatTypeInfo): number {
-  return Math.max(0, info.minSeats - info.assignedCount);
-}
 
 function isSeatAtCapacity(
   seatType: MembershipSeatType,

--- a/front/components/workspace/BulkChangeSeatModal.tsx
+++ b/front/components/workspace/BulkChangeSeatModal.tsx
@@ -2,6 +2,7 @@ import { BillingPeriodSwitch } from "@app/components/pages/onboarding/Subscripti
 import {
   formatPriceCents,
   getAvailableFrequencies,
+  getInvoiceImpactMessage,
   groupSeatTypesByFrequency,
   SEAT_TYPE_ICONS,
   SeatCard,
@@ -16,7 +17,6 @@ import type {
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { formatCurrencyAmountCents } from "@app/lib/metronome/amounts";
 import type { BulkSeatChangePreviewBody } from "@app/lib/swr/memberships";
 import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { isMembershipSeatType, isPaidSeatType } from "@app/types/memberships";
@@ -130,6 +130,10 @@ interface SeatMoveSectionProps {
   title: string;
   moves: BulkSeatChangePreviewBody["moves"];
   deltaMonthlyCents: number;
+  // Whether this section's moves take effect at the next credit refresh
+  // rather than right away — a deferred change is never a partial-period
+  // charge, so it skips proration entirely.
+  isDeferred: boolean;
   preview: BulkSeatChangePreviewBody;
   seatPlans: SeatPlanResponseBody;
 }
@@ -141,11 +145,22 @@ function SeatMoveSection({
   title,
   moves,
   deltaMonthlyCents,
+  isDeferred,
   preview,
   seatPlans,
 }: SeatMoveSectionProps) {
   const { targetSeatType, targetSeatName } = preview;
+  const targetSeatInfo = seatPlans[targetSeatType];
   const targetLabel = seatMoveLabel(targetSeatType, targetSeatName, seatPlans);
+  const moveCount = moves.reduce((sum, move) => sum + move.count, 0);
+  // Conservative: if any member in this section is coming off an annual
+  // seat, that seat's already-paid commitment isn't refunded, so treat the
+  // whole section as having no recurring old charge to net against rather
+  // than silently mixing annual (sunk) and non-annual (recurring) origins
+  // into one delta.
+  const hasAnnualOrigin = moves.some(
+    (move) => seatPlans[move.fromSeatType]?.billingFrequency === "annual"
+  );
   return (
     <div className="flex flex-col gap-2">
       <p className="text-sm font-semibold text-foreground">{title}</p>
@@ -183,24 +198,16 @@ function SeatMoveSection({
           </Fragment>
         ))}
       </div>
-      {deltaMonthlyCents !== 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This will {deltaMonthlyCents > 0 ? "add" : "remove"} an estimated{" "}
-          <span className="font-semibold text-foreground">
-            {formatCurrencyAmountCents({
-              amountCents: Math.abs(deltaMonthlyCents),
-              currency: preview.currency,
-            })}
-          </span>{" "}
-          {deltaMonthlyCents > 0 ? "to" : "from"} your monthly invoice.
-        </p>
-      ) : (
-        // Every move in the section is absorbed by committed (already paid)
-        // seats.
-        <p className="text-sm text-muted-foreground">
-          This will not change your invoice.
-        </p>
-      )}
+      <p className="text-sm text-muted-foreground">
+        {getInvoiceImpactMessage({
+          deltaCents: deltaMonthlyCents,
+          currency: preview.currency,
+          targetSeatInfo: targetSeatInfo ?? null,
+          moveCount,
+          isDeferred,
+          hasAnnualOrigin,
+        })}
+      </p>
     </div>
   );
 }
@@ -423,6 +430,7 @@ function BulkChangeSeatModalPreviewDialogContent({
           title="Immediate changes"
           moves={immediateMoves}
           deltaMonthlyCents={preview.immediateDeltaMonthlyCents}
+          isDeferred={false}
           preview={preview}
           seatPlans={seatPlans}
         />
@@ -436,6 +444,7 @@ function BulkChangeSeatModalPreviewDialogContent({
           }
           moves={deferredMoves}
           deltaMonthlyCents={preview.deferredDeltaMonthlyCents}
+          isDeferred={true}
           preview={preview}
           seatPlans={seatPlans}
         />

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -2,7 +2,9 @@ import { BillingPeriodSwitch } from "@app/components/pages/onboarding/Subscripti
 import {
   formatPriceCents,
   getAvailableFrequencies,
+  getInvoiceImpactMessage,
   groupSeatTypesByFrequency,
+  includedSeatsOpen,
   SeatCard,
   sortSeatTypes,
 } from "@app/components/workspace/SeatCard";
@@ -19,14 +21,20 @@ import type {
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { useUpdateMemberSeatType } from "@app/lib/swr/memberships";
+import type { BulkSeatChangePreviewBody } from "@app/lib/swr/memberships";
+import {
+  useBulkSeatChangePreview,
+  useUpdateMemberSeatType,
+} from "@app/lib/swr/memberships";
 import {
   isMembershipSeatType,
   isPaidSeatType,
   type MembershipSeatType,
+  toBaseSeatType,
 } from "@app/types/memberships";
 import { isSubscriptionCancellationScheduled } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -119,6 +127,12 @@ export function ChangeSeatModal({
   const { doUpdateSeatType } = useUpdateMemberSeatType({
     workspaceId: owner.sId,
   });
+  const { doFetchSeatChangePreview } = useBulkSeatChangePreview({
+    workspaceId: owner.sId,
+  });
+  const [invoicePreview, setInvoicePreview] =
+    useState<BulkSeatChangePreviewBody | null>(null);
+  const [isInvoicePreviewLoading, setIsInvoicePreviewLoading] = useState(false);
   const initializedMemberIdRef = useRef<string | null>(null);
 
   const seatTypesByFrequency = groupSeatTypesByFrequency(seatTypes, seatPlans);
@@ -178,6 +192,52 @@ export function ChangeSeatModal({
     isOpen,
   ]);
 
+  // Fetch the accurate invoice impact of the selected change from the same
+  // preview endpoint the bulk seat-change modal uses (proration, committed
+  // seat absorption and next-billing-period timing all live server-side —
+  // recomputing them from `seatPlans` alone risks staleness and drift from
+  // the real billing logic).
+  useEffect(() => {
+    if (
+      !isOpen ||
+      !displayedMemberId ||
+      !selectedSeat ||
+      useCheckoutPath ||
+      isSubscriptionCancelled ||
+      selectedSeat === currentSeatType ||
+      !isPaidSeatType(selectedSeat)
+    ) {
+      setInvoicePreview(null);
+      setIsInvoicePreviewLoading(false);
+      return;
+    }
+
+    let isStale = false;
+    setIsInvoicePreviewLoading(true);
+    void doFetchSeatChangePreview({
+      selection: { mode: "ids", userIds: [displayedMemberId] },
+      seatType: selectedSeat,
+    }).then((result) => {
+      if (isStale) {
+        return;
+      }
+      setInvoicePreview(result);
+      setIsInvoicePreviewLoading(false);
+    });
+
+    return () => {
+      isStale = true;
+    };
+  }, [
+    isOpen,
+    displayedMemberId,
+    selectedSeat,
+    useCheckoutPath,
+    isSubscriptionCancelled,
+    currentSeatType,
+    doFetchSeatChangePreview,
+  ]);
+
   function getBadge(
     seatType: MembershipSeatType,
     info: SeatTypeInfo
@@ -189,20 +249,32 @@ export function ChangeSeatModal({
         </span>
       );
     }
+    const price =
+      info.billingFrequency === "annual" ? (
+        <>
+          {formatPriceCents(info.priceCents / 12, info.currency, "monthly")} ·
+          billed annually
+        </>
+      ) : (
+        formatPriceCents(info.priceCents, info.currency, info.billingFrequency)
+      );
+    // Workspace seats draw from the shared credit pool rather than the
+    // plan's per-seat committed count, so the included-seats framing below
+    // doesn't apply to them.
+    if (toBaseSeatType(seatType) === "workspace") {
+      return (
+        <span className="text-xs text-foreground">
+          {price} · User can spend credits from the workspace pool.
+        </span>
+      );
+    }
+    const openCount = includedSeatsOpen(info);
     return (
       <span className="text-xs text-foreground">
-        {info.billingFrequency === "annual" ? (
-          <>
-            {formatPriceCents(info.priceCents / 12, info.currency, "monthly")} ·
-            billed annually
-          </>
-        ) : (
-          formatPriceCents(
-            info.priceCents,
-            info.currency,
-            info.billingFrequency
-          )
-        )}
+        {price} ·{" "}
+        {openCount > 0
+          ? `${openCount} included seat${pluralize(openCount)} open`
+          : "No included seats left — this will add a new billed seat"}
       </span>
     );
   }
@@ -283,6 +355,19 @@ export function ChangeSeatModal({
 
   const displayedFirstName =
     displayedMember?.name?.trim().split(/\s+/)[0] ?? null;
+
+  // A single member's move is classified as either immediate or deferred by
+  // the backend, never both — summing is equivalent to picking whichever one
+  // is non-zero.
+  const invoiceDeltaCents =
+    (invoicePreview?.immediateDeltaMonthlyCents ?? 0) +
+    (invoicePreview?.deferredDeltaMonthlyCents ?? 0);
+
+  const selectedSeatInfo = selectedSeat ? seatPlans[selectedSeat] : null;
+  // Trust the backend's own classification of this specific move (which
+  // bucket its delta landed in) over recomputing it client-side.
+  const isInvoiceDeltaDeferred =
+    (invoicePreview?.deferredDeltaMonthlyCents ?? 0) !== 0;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -365,6 +450,27 @@ export function ChangeSeatModal({
                 will be cancelled.
               </p>
             )}
+            {!isSubscriptionCancelled &&
+              selectedSeat &&
+              selectedSeat !== currentSeatType &&
+              (isInvoicePreviewLoading ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Estimating invoice impact…
+                </p>
+              ) : (
+                invoicePreview && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {getInvoiceImpactMessage({
+                      deltaCents: invoiceDeltaCents,
+                      currency: invoicePreview.currency,
+                      targetSeatInfo: selectedSeatInfo ?? null,
+                      moveCount: 1,
+                      isDeferred: isInvoiceDeltaDeferred,
+                      hasAnnualOrigin: currentFrequency === "annual",
+                    })}
+                  </p>
+                )
+              ))}
           </div>
         </DialogContainer>
         <DialogFooter

--- a/front/components/workspace/SeatCard.tsx
+++ b/front/components/workspace/SeatCard.tsx
@@ -7,10 +7,12 @@ import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
+import { formatCurrencyAmountCents } from "@app/lib/metronome/amounts";
 import { SEAT_PRODUCT_YEARLY_SUFFIX } from "@app/lib/metronome/constants";
 import type { SupportedCurrency } from "@app/types/currency";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   AlertCircle,
   Card,
@@ -94,6 +96,15 @@ export function getAvailableFrequencies(
   return SEAT_BILLING_FREQUENCIES.filter((f) => byFrequency[f].length > 0);
 }
 
+// Shared across price formatting and invoice-impact messaging so both stay
+// consistent when a new cadence is added.
+export const BILLING_FREQUENCY_SUFFIX: Record<SeatBillingFrequency, string> = {
+  weekly: "/wk",
+  monthly: "/mo",
+  quarterly: "/qtr",
+  annual: "/yr",
+};
+
 export function formatPriceCents(
   cents: number,
   currency: SupportedCurrency,
@@ -101,17 +112,19 @@ export function formatPriceCents(
 ): string {
   const symbol = CURRENCY_SYMBOLS[currency];
   const amount = (cents / 100).toFixed(2).replace(/\.00$/, "");
-  const suffixByFrequency: Record<SeatBillingFrequency, string> = {
-    weekly: "/wk",
-    monthly: "/mo",
-    quarterly: "/qtr",
-    annual: "/yr",
-  };
   // EUR is the only currency we render with a trailing symbol (e.g. "30€");
   // USD and GBP are prefix currencies ("$30", "£30").
   return currency === "eur"
-    ? `${amount}${symbol}${suffixByFrequency[billingFrequency]}`
-    : `${symbol}${amount}${suffixByFrequency[billingFrequency]}`;
+    ? `${amount}${symbol}${BILLING_FREQUENCY_SUFFIX[billingFrequency]}`
+    : `${symbol}${amount}${BILLING_FREQUENCY_SUFFIX[billingFrequency]}`;
+}
+
+// Seats already committed in the plan's billing floor (`minSeats`) that aren't
+// currently assigned to a member — i.e. free to consume without an extra
+// charge. Assigning past this count starts (or bumps the price of) a new
+// billed seat.
+export function includedSeatsOpen(info: SeatTypeInfo): number {
+  return Math.max(0, info.minSeats - info.assignedCount);
 }
 
 export function formatAwuCredits(info: SeatTypeInfo): string {
@@ -125,6 +138,217 @@ export function formatAwuCredits(info: SeatTypeInfo): string {
   return `${info.awuCredits.toLocaleString("en-US")} credits ${
     periodLabel[info.awuCreditsPeriod]
   }`;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Preview endpoints return a monthly-equivalent figure for every cadence
+// (e.g. annual price / 12), treating it as a steady-state run rate. Seats
+// don't actually bill that way at any cadence: every seat subscription is
+// created with `is_prorated: true` (`setup_common.ts`), so a change mid-term
+// is billed as a prorated true-up for the rest of the CURRENT billing
+// period, not the full period price. This inverts the monthly-equivalent
+// normalization back to the seat's actual per-period price.
+const PERIOD_PRICE_MULTIPLIER: Record<SeatBillingFrequency, number> = {
+  weekly: 12 / 52,
+  monthly: 1,
+  quarterly: 3,
+  annual: 12,
+};
+
+// Human label for "your current X" in invoice-impact copy.
+const BILLING_PERIOD_LABEL: Record<SeatBillingFrequency, string> = {
+  weekly: "weekly term",
+  monthly: "monthly billing period",
+  quarterly: "quarterly term",
+  annual: "annual term",
+};
+
+// Prorates a full-period amount for the days remaining in the current
+// billing period, as of right now.
+export function prorateAmountForCurrentPeriod({
+  amountCents,
+  currentBillingPeriod,
+}: {
+  amountCents: number;
+  currentBillingPeriod: { startsAt: string; endsAt: string };
+}): { amountCents: number; daysRemaining: number } | null {
+  const startMs = new Date(currentBillingPeriod.startsAt).getTime();
+  const endMs = new Date(currentBillingPeriod.endsAt).getTime();
+  const totalDays = (endMs - startMs) / MS_PER_DAY;
+  if (!(totalDays > 0)) {
+    return null;
+  }
+  const daysRemaining = Math.min(
+    totalDays,
+    Math.max(0, (endMs - Date.now()) / MS_PER_DAY)
+  );
+  return {
+    amountCents: Math.round(amountCents * (daysRemaining / totalDays)),
+    daysRemaining: Math.round(daysRemaining),
+  };
+}
+
+// Renders the "this will add/remove $X" line shown under a seat picker or a
+// seat-move summary, correctly scaled for the seat's billing cadence.
+export function getInvoiceImpactMessage({
+  deltaCents,
+  currency,
+  targetSeatInfo,
+  moveCount,
+  isDeferred,
+  hasAnnualOrigin,
+}: {
+  // Steady-state monthly-equivalent delta between the old and new seat,
+  // floor-aware (from the backend preview). Only meaningful for a deferred
+  // move away from a non-annual seat: at that point the old subscription
+  // simply stops and the new one starts fresh, so "your recurring bill
+  // changes by $X going forward" is a valid, non-prorated comparison.
+  deltaCents: number;
+  currency: SupportedCurrency;
+  // The target seat's own info (price, cadence, current billing period,
+  // committed floor). Null when the seat plan hasn't loaded yet.
+  targetSeatInfo: SeatTypeInfo | null;
+  // How many members are moving onto this seat type in this move — used
+  // only to check whether the workspace's already-committed (paid, unused)
+  // seats absorb the whole move.
+  moveCount: number;
+  // Whether this change takes effect at the next credit refresh rather than
+  // right away.
+  isDeferred: boolean;
+  // Whether (any of) the member(s) moving away are on an annual seat today.
+  // An annual seat is an already-paid, non-refundable commitment — there is
+  // no recurring old charge to net against once it's dropped, so a deferred
+  // move off of one is never framed as a delta/removal, only as the new
+  // seat's own charge starting fresh.
+  hasAnnualOrigin: boolean;
+}): React.ReactNode {
+  if (!targetSeatInfo) {
+    return null;
+  }
+  const { billingFrequency, priceCents, currentBillingPeriod } = targetSeatInfo;
+  const periodSuffix = BILLING_FREQUENCY_SUFFIX[billingFrequency];
+  const periodLabel = BILLING_PERIOD_LABEL[billingFrequency];
+
+  // A deferred move onto an annual seat commits to a fresh annual term,
+  // billed as a lump sum at the next credit refresh. This is never framed
+  // as removing money — the member pays that lump sum outright, on top of
+  // whatever they already paid for their current (shorter) period. Compare
+  // against one month-equivalent of the new price (what a normal month
+  // would have cost) so the number reflects the actual extra cash going out
+  // now, not a steady-state comparison against the old seat that could look
+  // tiny, or even net negative, while a large one-time charge is coming.
+  if (isDeferred && billingFrequency === "annual") {
+    const extraCents = Math.round((priceCents * 11) / 12);
+    return (
+      <>
+        This will add an estimated{" "}
+        <span className="font-semibold text-foreground">
+          {formatCurrencyAmountCents({ amountCents: extraCents, currency })}
+        </span>{" "}
+        to your next invoice — you&apos;ll be billed{" "}
+        <span className="font-semibold text-foreground">
+          {formatCurrencyAmountCents({ amountCents: priceCents, currency })}
+        </span>{" "}
+        upfront for the year starting next annual term.
+      </>
+    );
+  }
+
+  // A deferred change takes effect at the start of a fresh billing period —
+  // ordinarily the old subscription just stops and the new one starts
+  // clean, so the steady-state delta (already floor-aware from the
+  // backend) describes the change accurately, with nothing to prorate.
+  if (isDeferred) {
+    // ...unless the member is coming off an annual seat: that commitment
+    // was already paid in full and isn't refunded, so there's no recurring
+    // old charge to net against — only the new seat's own full price
+    // applies, unconditionally, starting the next period.
+    if (hasAnnualOrigin) {
+      if (priceCents === 0) {
+        return "This will not change your invoice.";
+      }
+      return (
+        <>
+          This will add an estimated{" "}
+          <span className="font-semibold text-foreground">
+            {formatCurrencyAmountCents({ amountCents: priceCents, currency })}
+            {periodSuffix}
+          </span>{" "}
+          to your invoice starting next {periodLabel}.
+        </>
+      );
+    }
+
+    if (deltaCents === 0) {
+      return "This will not change your invoice.";
+    }
+    const verb = deltaCents > 0 ? "add" : "remove";
+    const deltaPeriodCents =
+      Math.abs(deltaCents) * PERIOD_PRICE_MULTIPLIER[billingFrequency];
+    return (
+      <>
+        This will {verb} an estimated{" "}
+        <span className="font-semibold text-foreground">
+          {formatCurrencyAmountCents({
+            amountCents: deltaPeriodCents,
+            currency,
+          })}
+          {periodSuffix}
+        </span>{" "}
+        {deltaCents > 0 ? "to" : "from"} your invoice starting next{" "}
+        {periodLabel}.
+      </>
+    );
+  }
+
+  // Immediate change: a paid seat is never refunded/credited when removed,
+  // so there's no "old seat" side to net against — the only real invoice
+  // event is being charged for the new seat, prorated for the days left in
+  // ITS OWN current period, unless the workspace's already-committed
+  // (already-paid, unused) seats absorb the whole move.
+  const chargeableCount = Math.max(
+    0,
+    moveCount - includedSeatsOpen(targetSeatInfo)
+  );
+  if (chargeableCount === 0) {
+    return "This will not change your invoice.";
+  }
+  const fullPrice = (
+    <>
+      {formatCurrencyAmountCents({ amountCents: priceCents, currency })}
+      {periodSuffix}
+    </>
+  );
+  const proration = currentBillingPeriod
+    ? prorateAmountForCurrentPeriod({
+        amountCents: priceCents,
+        currentBillingPeriod,
+      })
+    : null;
+  if (proration) {
+    return (
+      <>
+        This will add an estimated{" "}
+        <span className="font-semibold text-foreground">
+          {formatCurrencyAmountCents({
+            amountCents: proration.amountCents,
+            currency,
+          })}
+        </span>
+        , prorated for the {proration.daysRemaining} day
+        {pluralize(proration.daysRemaining)} left in your current {periodLabel}{" "}
+        (full price: {fullPrice}).
+      </>
+    );
+  }
+  return (
+    <>
+      This will add up to{" "}
+      <span className="font-semibold text-foreground">{fullPrice}</span>,
+      prorated for the remainder of your current {periodLabel}.
+    </>
+  );
 }
 
 // The Metronome product names append SEAT_PRODUCT_YEARLY_SUFFIX to the

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -46,6 +46,10 @@ export interface SeatTypeInfo {
   maxSeats: number | null;
   // Number of workspace members currently assigned to this seat type.
   assignedCount: number;
+  // Current billing period of this seat type's Metronome subscription (ISO
+  // dates). Used to prorate annual seat changes for the remainder of the
+  // term; null when the subscription has no active period right now.
+  currentBillingPeriod: { startsAt: string; endsAt: string } | null;
 }
 
 // Dynamic seat-type → info map. The list of seat types is driven by the
@@ -146,6 +150,10 @@ export async function getSeatPlan(
     MembershipSeatType,
     SeatBillingFrequency
   >();
+  const currentBillingPeriodBySeatType = new Map<
+    MembershipSeatType,
+    { startsAt: string; endsAt: string } | null
+  >();
   const seatSubscriptions = getSeatSubscriptionsFromContract(
     contract,
     productSeatTypes
@@ -154,6 +162,16 @@ export async function getSeatPlan(
     billingFrequencyBySeatType.set(
       seatType,
       getSeatBillingFrequency(sub.subscription_rate.billing_frequency)
+    );
+    const currentPeriod = sub.billing_periods.current;
+    currentBillingPeriodBySeatType.set(
+      seatType,
+      currentPeriod
+        ? {
+            startsAt: currentPeriod.starting_at,
+            endsAt: currentPeriod.ending_before,
+          }
+        : null
     );
   }
 
@@ -227,6 +245,8 @@ export async function getSeatPlan(
       minSeats: limit?.minSeats ?? 0,
       maxSeats: limit?.maxSeats ?? null,
       assignedCount: seatCounts[seatType] ?? 0,
+      currentBillingPeriod:
+        currentBillingPeriodBySeatType.get(seatType) ?? null,
     };
   }
   return new Ok(response);


### PR DESCRIPTION
## Description

Makes it clear, at the point of a seat change, whether the change consumes an already-committed (paid) seat or will incur additional cost — both as a badge on each seat option and as an estimated invoice-impact line, in `ChangeSeatModal` and `BulkChangeSeatModal`.

- **Committed-seat badge:** mirrors the existing invite-flow messaging ("N included seat(s) open" / "No included seats left"), extracted into a shared `includedSeatsOpen` helper (`SeatCard.tsx`) so `InviteEmailButtonWithModal` and `ChangeSeatModal` share one implementation instead of duplicating it.
- **Invoice-impact line:** "This will add an estimated $X..." computed via the existing bulk seat-change preview endpoint (single-member selection for `ChangeSeatModal`) rather than reimplemented client-side, since committed-seat floors and billing-period timing already live server-side — avoids drift/staleness against the real billing logic.
- **Cadence-correct proration:** backend `SeatTypeInfo` (`seat_plan.ts`) now also exposes `currentBillingPeriod` (the seat subscription's Metronome billing period boundaries), used to prorate the estimate by the days remaining in the current period for every cadence (monthly/quarterly/annual/weekly) — not just a flat monthly-equivalent number.
- **Deferred changes:** changes taking effect at the next credit refresh show the plain full per-period price with no proration wording, since they always start at a fresh billing period boundary and are never partial.

included seats :
<img width="441" height="369" alt="Screenshot 2026-07-27 at 10 47 21" src="https://github.com/user-attachments/assets/f6db85d5-a1c4-4900-9f1a-22458f88c183" />

upgrade to non included :

<img width="434" height="358" alt="Screenshot 2026-07-27 at 11 50 31" src="https://github.com/user-attachments/assets/89f6d075-5971-47e5-b758-77978927d18e" />

downgrading max monthly -> pro monthly :

<img width="430" height="389" alt="Screenshot 2026-07-27 at 11 52 29" src="https://github.com/user-attachments/assets/7b5635a8-b7cb-4f30-9b10-8f830d7f3046" />

switching to yearly : 

<img width="423" height="433" alt="Screenshot 2026-07-27 at 11 50 09" src="https://github.com/user-attachments/assets/9f4dd258-2b76-40c5-89a5-27f315a1152d" />

pro yearly to max yearly :

<img width="428" height="385" alt="Screenshot 2026-07-27 at 11 55 57" src="https://github.com/user-attachments/assets/541b7a99-6ba5-4c6a-acc0-2aa6758a8ce7" />

## Tests

Manually verified across monthly and annual seats, immediate and deferred changes, additions and removals, in both the single-member and bulk seat-change modals.

## Risk

Low/medium. The invoice-impact number is an estimate (client-side proration against real billing-period dates), explicitly labeled "estimated" — Metronome has no proration-preview API, so this is not a guarantee of the exact amount that will be billed. No functional or billing behavior changes — this is purely informational UI.

## Deploy Plan

Standard frontend deploy. Stacked on #29521 — merge that one first.
