### PR TITLE
[front] improve space and pod section wording

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -176,8 +176,7 @@ export function AgentBuilderSpacesBlock({
             Visibility control and available data
           </h2>
           <p className="text-sm text-muted-foreground">
-            Select a space or pod to make this agent private to its members and
-            add access to its data and tools.
+            Add a space or pod to restrict usage to its members and make all its data available to this agent.
           </p>
         </div>
         <Button

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -4,12 +4,13 @@ import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
+import { SpaceRestrictionMessage } from "@app/components/shared/SpaceRestrictionMessage";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
-import { Button, ContentMessage, Planet } from "@dust-tt/sparkle";
+import { Button, Planet } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
@@ -171,9 +172,11 @@ export function AgentBuilderSpacesBlock({
     <div className="space-y-3">
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="heading-lg text-foreground">Spaces and Pods</h2>
+          <h2 className="heading-lg text-foreground">
+            Visibility control and available data
+          </h2>
           <p className="text-sm text-muted-foreground">
-            Set what knowledge and capabilities the agent can access.
+            Select a space or pod to make this agent private to its members and add access to its data and tools.
           </p>
         </div>
         <Button
@@ -183,18 +186,11 @@ export function AgentBuilderSpacesBlock({
           onClick={handleOpenSheet}
         />
       </div>
-      {nonGlobalSpacesWithRestrictions.length > 0 && (
-        <div className="mb-4 w-full">
-          <ContentMessage variant="golden" size="lg">
-            Based on your selection of knowledge and capabilities, this agent
-            can only be used by users with access to:{" "}
-            <strong>
-              {nonGlobalSpacesWithRestrictions.map((v) => v.name).join(", ")}
-            </strong>
-            .
-          </ContentMessage>
-        </div>
-      )}
+      <SpaceRestrictionMessage
+        entityName="agent"
+        owner={owner}
+        spaces={nonGlobalSpacesWithRestrictions}
+      />
       <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
 
       <SpaceSelectionSheet

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -176,7 +176,8 @@ export function AgentBuilderSpacesBlock({
             Visibility control and available data
           </h2>
           <p className="text-sm text-muted-foreground">
-            Select a space or pod to make this agent private to its members and add access to its data and tools.
+            Select a space or pod to make this agent private to its members and
+            add access to its data and tools.
           </p>
         </div>
         <Button

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -176,7 +176,8 @@ export function AgentBuilderSpacesBlock({
             Visibility control and available data
           </h2>
           <p className="text-sm text-muted-foreground">
-            Add a space or pod to restrict usage to its members and make all its data available to this agent.
+            Add a space or pod to restrict usage to its members and make all its
+            data available to this agent.
           </p>
         </div>
         <Button

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -86,7 +86,8 @@ export function SpaceSelectionSheet({
         <SheetHeader>
           <SheetTitle>Visibility control and available data</SheetTitle>
           <SheetDescription>
-            Select a space or pod to make this skill private to members of the space or pod. 
+            Select a space or pod to make this skill private to members of the
+            space or pod.
           </SheetDescription>
           <SearchInput
             name="space"

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -84,10 +84,9 @@ export function SpaceSelectionSheet({
     >
       <SheetContent>
         <SheetHeader>
-          <SheetTitle>Add Spaces and Pods</SheetTitle>
+          <SheetTitle>Visibility control and available data</SheetTitle>
           <SheetDescription>
-            Choose the spaces and Pods you want the {entityName} to have access
-            to.
+            Select a space or pod to make this skill private to members of the space or pod. 
           </SheetDescription>
           <SearchInput
             name="space"

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -86,8 +86,7 @@ export function SpaceSelectionSheet({
         <SheetHeader>
           <SheetTitle>Visibility control and available data</SheetTitle>
           <SheetDescription>
-            Select a space or pod to make this skill private to members of the
-            space or pod.
+            Add a space or pod to restrict usage to its members and make all its data available to this agent.
           </SheetDescription>
           <SearchInput
             name="space"

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -86,7 +86,8 @@ export function SpaceSelectionSheet({
         <SheetHeader>
           <SheetTitle>Visibility control and available data</SheetTitle>
           <SheetDescription>
-            Add a space or pod to restrict usage to its members and make all its data available to this agent.
+            Add a space or pod to restrict usage to its members and make all its
+            data available to this {entityName}.
           </SheetDescription>
           <SearchInput
             name="space"

--- a/front/components/shared/SpaceRestrictionMessage.tsx
+++ b/front/components/shared/SpaceRestrictionMessage.tsx
@@ -20,6 +20,28 @@ export function SpaceRestrictionMessage({
     return null;
   }
 
+  const spaceLinks = (
+    <strong>
+      {spaces.map((space, index) => (
+        <Fragment key={space.sId}>
+          {index > 0 && <span className="mr-0.5">, </span>}
+          <Hoverable
+            variant="primary"
+            className="text-inherit underline hover:font-medium"
+            href={
+              isProjectType(space)
+                ? getPodRoute(owner.sId, space.sId)
+                : getSpaceRoute(owner.sId, space.sId)
+            }
+            target="_blank"
+          >
+            {space.name}
+          </Hoverable>
+        </Fragment>
+      ))}
+    </strong>
+  );
+
   return (
     <div className="mb-4 w-full">
       <ContentMessage
@@ -28,28 +50,37 @@ export function SpaceRestrictionMessage({
         title={`Who can use this ${entityName}?`}
         icon={Users01}
       >
-        Only users with access to all of the following can read and use this {entityName}
-        :{" "}
-        <strong>
-          {spaces.map((space, index) => (
-            <Fragment key={space.sId}>
-              {index > 0 && <span className="mr-0.5">, </span>}
-              <Hoverable
-                variant="primary"
-                className="text-inherit underline hover:font-medium"
-                href={
-                  isProjectType(space)
-                    ? getPodRoute(owner.sId, space.sId)
-                    : getSpaceRoute(owner.sId, space.sId)
-                }
-                target="_blank"
-              >
-                {space.name}
-              </Hoverable>
-            </Fragment>
-          ))}
-        </strong>
-        .
+        {spaces.length === 1 ? (
+          <>
+            Only users with access to {spaceLinks} can read and use this{" "}
+            {entityName}.
+          </>
+        ) : (
+          <>
+            Only users with access to all of the following can read and use this{" "}
+            {entityName}:{" "}
+            <strong>
+              {spaces.map((space, index) => (
+                <Fragment key={space.sId}>
+                  {index > 0 && <span className="mr-0.5">, </span>}
+                  <Hoverable
+                    variant="primary"
+                    className="text-inherit underline hover:font-medium"
+                    href={
+                      isProjectType(space)
+                        ? getPodRoute(owner.sId, space.sId)
+                        : getSpaceRoute(owner.sId, space.sId)
+                    }
+                    target="_blank"
+                  >
+                    {space.name}
+                  </Hoverable>
+                </Fragment>
+              ))}
+            </strong>
+            .
+          </>
+        )}
       </ContentMessage>
     </div>
   );

--- a/front/components/shared/SpaceRestrictionMessage.tsx
+++ b/front/components/shared/SpaceRestrictionMessage.tsx
@@ -28,7 +28,7 @@ export function SpaceRestrictionMessage({
         title={`Who can use this ${entityName}?`}
         icon={Users01}
       >
-        Only users with access to all of the following can use this {entityName}
+        Only users with access to all of the following can read and use this {entityName}
         :{" "}
         <strong>
           {spaces.map((space, index) => (

--- a/front/components/shared/SpaceRestrictionMessage.tsx
+++ b/front/components/shared/SpaceRestrictionMessage.tsx
@@ -1,0 +1,56 @@
+import { getPodRoute, getSpaceRoute } from "@app/lib/utils/router";
+import type { SpaceType } from "@app/types/space";
+import { isProjectType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
+import { ContentMessage, Hoverable, Users01 } from "@dust-tt/sparkle";
+import { Fragment } from "react";
+
+interface SpaceRestrictionMessageProps {
+  entityName: "agent" | "skill";
+  owner: LightWorkspaceType;
+  spaces: SpaceType[];
+}
+
+export function SpaceRestrictionMessage({
+  entityName,
+  owner,
+  spaces,
+}: SpaceRestrictionMessageProps) {
+  if (spaces.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-4 w-full">
+      <ContentMessage
+        variant="golden"
+        size="lg"
+        title={`Who can use this ${entityName}?`}
+        icon={Users01}
+      >
+        Only users with access to all of the following can use this {entityName}
+        :{" "}
+        <strong>
+          {spaces.map((space, index) => (
+            <Fragment key={space.sId}>
+              {index > 0 && <span className="mr-0.5">, {" "}</span>}
+              <Hoverable
+                variant="primary"
+                className="text-inherit underline hover:font-medium"
+                href={
+                  isProjectType(space)
+                    ? getPodRoute(owner.sId, space.sId)
+                    : getSpaceRoute(owner.sId, space.sId)
+                }
+                target="_blank"
+              >
+                {space.name}
+              </Hoverable>
+            </Fragment>
+          ))}
+        </strong>
+        .
+      </ContentMessage>
+    </div>
+  );
+}

--- a/front/components/shared/SpaceRestrictionMessage.tsx
+++ b/front/components/shared/SpaceRestrictionMessage.tsx
@@ -33,7 +33,7 @@ export function SpaceRestrictionMessage({
         <strong>
           {spaces.map((space, index) => (
             <Fragment key={space.sId}>
-              {index > 0 && <span className="mr-0.5">, {" "}</span>}
+              {index > 0 && <span className="mr-0.5">, </span>}
               <Hoverable
                 variant="primary"
                 className="text-inherit underline hover:font-medium"

--- a/front/components/shared/SpaceRestrictionMessage.tsx
+++ b/front/components/shared/SpaceRestrictionMessage.tsx
@@ -58,27 +58,7 @@ export function SpaceRestrictionMessage({
         ) : (
           <>
             Only users with access to all of the following can read and use this{" "}
-            {entityName}:{" "}
-            <strong>
-              {spaces.map((space, index) => (
-                <Fragment key={space.sId}>
-                  {index > 0 && <span className="mr-0.5">, </span>}
-                  <Hoverable
-                    variant="primary"
-                    className="text-inherit underline hover:font-medium"
-                    href={
-                      isProjectType(space)
-                        ? getPodRoute(owner.sId, space.sId)
-                        : getSpaceRoute(owner.sId, space.sId)
-                    }
-                    target="_blank"
-                  >
-                    {space.name}
-                  </Hoverable>
-                </Fragment>
-              ))}
-            </strong>
-            .
+            {entityName}: {spaceLinks}.
           </>
         )}
       </ContentMessage>

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -3,6 +3,7 @@ import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useBlockedSkillSpaceRemovalConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
+import { SpaceRestrictionMessage } from "@app/components/shared/SpaceRestrictionMessage";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type {
   AttachedKnowledgeFormData,
@@ -12,7 +13,7 @@ import type {
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
-import { Button, ContentMessage, Planet } from "@dust-tt/sparkle";
+import { Button, Planet } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 
@@ -234,12 +235,10 @@ export function SkillBuilderRequestedSpacesSection({
       <div className="flex items-start justify-between">
         <div>
           <h3 className="heading-lg font-semibold text-foreground">
-            Spaces and Pods
+            Visibility control and available data
           </h3>
           <p className="text-sm text-muted-foreground">
-            Choose which spaces and Pods this skill can access. The skill can
-            use their knowledge and capabilities, and only users with access to
-            all selected spaces and Pods can use it.
+            Select a space or pod to make this skill private to its members and add access to its data and tools.
           </p>
         </div>
         <Button
@@ -250,21 +249,11 @@ export function SkillBuilderRequestedSpacesSection({
           onClick={handleOpenSheet}
         />
       </div>
-      {nonGlobalSpacesWithRestrictions.length > 0 && (
-        <div className="mb-4 w-full">
-          <ContentMessage variant="golden" size="lg">
-            This skill can access knowledge and capabilities from these spaces
-            and Pods, and only users with access to all of them can use
-            it:&nbsp;
-            <strong>
-              {nonGlobalSpacesWithRestrictions
-                .map((space) => space.name)
-                .join(", ")}
-            </strong>
-            .
-          </ContentMessage>
-        </div>
-      )}
+      <SpaceRestrictionMessage
+        entityName="skill"
+        owner={owner}
+        spaces={nonGlobalSpacesWithRestrictions}
+      />
       <SpaceChips
         spaces={spacesToDisplay}
         onRemoveSpace={isReadOnly ? undefined : handleRemoveSpace}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -238,8 +238,7 @@ export function SkillBuilderRequestedSpacesSection({
             Visibility control and available data
           </h3>
           <p className="text-sm text-muted-foreground">
-            Select a space or pod to make this skill private to its members and
-            add access to its data and tools.
+            Add a space or pod to restrict usage to its members and make all its data available to this skill.
           </p>
         </div>
         <Button

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -238,7 +238,8 @@ export function SkillBuilderRequestedSpacesSection({
             Visibility control and available data
           </h3>
           <p className="text-sm text-muted-foreground">
-            Add a space or pod to restrict usage to its members and make all its data available to this skill.
+            Add a space or pod to restrict usage to its members and make its
+            data available to this skill.
           </p>
         </div>
         <Button

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -238,7 +238,8 @@ export function SkillBuilderRequestedSpacesSection({
             Visibility control and available data
           </h3>
           <p className="text-sm text-muted-foreground">
-            Select a space or pod to make this skill private to its members and add access to its data and tools.
+            Select a space or pod to make this skill private to its members and
+            add access to its data and tools.
           </p>
         </div>
         <Button


### PR DESCRIPTION
## Description
This PR is to update the wording of spaces and pods selection and improve the wording of the message when it has access to restricted space in both Agent builder and skill builder. Note that this will be shipped without the feature flag.

If there is only one:
<img width="2006" height="438" alt="CleanShot 2026-07-27 at 16 34 43@2x" src="https://github.com/user-attachments/assets/32d14c51-5e08-4618-bd14-2966fdda48b8" />

If there are more than two:
<img width="1994" height="404" alt="CleanShot 2026-07-27 at 16 34 26@2x" src="https://github.com/user-attachments/assets/2652ae36-d7ef-499c-b72e-f06a4038f5a7" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
