### PR TITLE
[LLM] Add OpenAI GPT-5.5 EU batch endpoint

### DIFF
--- a/front/lib/llms/batch/endpoints/google_ai_studio_gemini_3_5_flash_lite_global_google_ai_studio.ts
+++ b/front/lib/llms/batch/endpoints/google_ai_studio_gemini_3_5_flash_lite_global_google_ai_studio.ts
@@ -1,8 +1,10 @@
 import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
 import { GoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_gemini_3_5_flash_lite_global_google_ai_studio";
+import { GEMINI_3_5_FLASH_LITE_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 
 export class DustGoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch extends GoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch {
   static readonly endpointFilter = {};
+  static readonly modelConfig = GEMINI_3_5_FLASH_LITE_MODEL_CONFIG;
 }
 
 defineDustBatchEndpoint(

--- a/front/lib/llms/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses.ts
+++ b/front/lib/llms/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses.ts
@@ -1,0 +1,10 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+
+export class DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch extends OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch {
+  static readonly endpointFilter = {};
+  static readonly modelConfig = GPT_5_5_MODEL_CONFIG;
+}
+
+defineDustBatchEndpoint(DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch);

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -5,6 +5,7 @@ import { DustGoogleAiStudioGeminiThreeDotOneProGlobalGoogleAiStudioBatch } from 
 import { DustGoogleAiStudioGeminiThreeDotFiveFlashGlobalGoogleAiStudioBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_gemini_3_5_flash_global_google_ai_studio";
 import { DustGoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_gemini_3_5_flash_lite_global_google_ai_studio";
 import { DustMistralMistralMedium35EuropeMistralBatch } from "@app/lib/llms/batch/endpoints/mistral_mistral_medium_3_5_eu_mistral";
+import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
@@ -27,6 +28,8 @@ export const DUST_BATCH_ENDPOINTS = {
     DustGoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch,
   [DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch.id]:
     DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch,
+  [DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch.id]:
+    DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch,
   [DustMistralMistralMedium35EuropeMistralBatch.id]:
     DustMistralMistralMedium35EuropeMistralBatch,
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash_lite.ts
@@ -5,23 +5,17 @@ export function WithDustGoogleAiStudioGeminiThreeDotFiveFlashLiteConfig<
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  // Spread the legacy model config onto the class statics (see
-  // `DustStreamEndpointConfiguration`). `Object.assign` returns
-  // `class & ModelConfigurationType`, so the fields are visible to the type
-  // checker without an unsafe cast.
-  abstract class DustGoogleAiStudioGemini35FlashLiteConfig extends Base {}
-  const WithConfig = Object.assign(
-    DustGoogleAiStudioGemini35FlashLiteConfig,
-    GEMINI_3_5_FLASH_LITE_MODEL_CONFIG
-  );
-
-  // Declared last so these own statics shadow (take precedence over) the spread
-  // config values.
-  abstract class DustGoogleAiStudioGemini35FlashLite extends WithConfig {
+  abstract class DustGoogleAiStudioGemini35FlashLite extends Base {
     static readonly displayName = "Gemini 3.5 Flash Lite";
     static readonly description =
       "Google's latest lightweight large context model (1m context).";
     static readonly byok = true;
+
+    // Nest the legacy model config under a single `modelConfig` static (see
+    // `DustStreamEndpointConfiguration`) so consumers can retrieve the full
+    // `ModelConfigurationType` off the endpoint without spreading its fields
+    // onto the class statics.
+    static readonly modelConfig = GEMINI_3_5_FLASH_LITE_MODEL_CONFIG;
   }
 
   return DustGoogleAiStudioGemini35FlashLite;

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_6_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_6_flash.ts
@@ -5,23 +5,17 @@ export function WithDustGoogleAiStudioGeminiThreeDotSixFlashConfig<
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  // Spread the legacy model config onto the class statics (see
-  // `DustStreamEndpointConfiguration`). `Object.assign` returns
-  // `class & ModelConfigurationType`, so the fields are visible to the type
-  // checker without an unsafe cast.
-  abstract class DustGoogleAiStudioGeminiThreeDotSixFlashConfig extends Base {}
-  const WithConfig = Object.assign(
-    DustGoogleAiStudioGeminiThreeDotSixFlashConfig,
-    GEMINI_3_6_FLASH_MODEL_CONFIG
-  );
-
-  // Declared last so these own statics shadow (take precedence over) the spread
-  // config values.
-  abstract class DustGoogleAiStudioGeminiThreeDotSixFlash extends WithConfig {
+  abstract class DustGoogleAiStudioGeminiThreeDotSixFlash extends Base {
     static readonly displayName = "Gemini 3.6 Flash";
     static readonly description =
       "Google's latest fast large context model (1m context).";
     static readonly byok = true;
+
+    // Nest the legacy model config under a single `modelConfig` static (see
+    // `DustStreamEndpointConfiguration`) so consumers can retrieve the full
+    // `ModelConfigurationType` off the endpoint without spreading its fields
+    // onto the class statics.
+    static readonly modelConfig = GEMINI_3_6_FLASH_MODEL_CONFIG;
   }
 
   return DustGoogleAiStudioGeminiThreeDotSixFlash;

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -55,14 +55,23 @@ export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConve
   static readonly lab = OPENAI_LAB;
   static readonly host = OPENAI_RESPONSES_HOST;
 
-  private readonly client: OpenAI;
+  protected abstract readonly baseUrl: string;
 
-  constructor({ OPENAI_API_KEY, OPENAI_BASE_URL }: Credentials) {
+  private readonly apiKey: string | undefined;
+  private _client: OpenAI | undefined;
+
+  constructor({ OPENAI_API_KEY }: Credentials) {
     super();
-    this.client = new OpenAI({
-      apiKey: OPENAI_API_KEY,
-      baseURL: OPENAI_BASE_URL,
+    this.apiKey = OPENAI_API_KEY;
+  }
+
+  // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.
+  private get client(): OpenAI {
+    this._client ??= new OpenAI({
+      apiKey: this.apiKey,
+      baseURL: this.baseUrl,
     });
+    return this._client;
   }
 
   rawBatchOutputToEvents(result: OpenAIResponse): NonDeltaResponseEvent[] {

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses.ts
@@ -1,0 +1,24 @@
+import { OpenAIResponsesBatch } from "@app/lib/model_constructors/batch/clients/openai_responses";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch extends WithOpenAIGptFiveDotFiveConfig(
+  OpenAIResponsesBatch
+) {
+  // Batch pricing is half the standard OpenAI rate, itself charged a 10%
+  // regional uplift for models released on or after March 5, 2026.
+  static readonly tokenPricing = {
+    standardInput: 2.75,
+    standardOutput: 16.5,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses.ts
@@ -1,5 +1,6 @@
 import { OpenAIResponsesBatch } from "@app/lib/model_constructors/batch/clients/openai_responses";
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
 import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 
@@ -15,6 +16,8 @@ export class OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch extends WithOpenAIGp
   static readonly region = GLOBAL;
 
   static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
 }
 
 OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/index.ts
+++ b/front/lib/model_constructors/batch/index.ts
@@ -5,6 +5,7 @@ import { GoogleAiStudioGeminiThreeDotOneProGlobalGoogleAiStudioBatch } from "@ap
 import { GoogleAiStudioGeminiThreeDotFiveFlashGlobalGoogleAiStudioBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_gemini_3_5_flash_global_google_ai_studio";
 import { GoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_gemini_3_5_flash_lite_global_google_ai_studio";
 import { MistralMistralMedium35EuropeMistralBatch } from "@app/lib/model_constructors/batch/endpoints/mistral_mistral_medium_3_5_eu_mistral";
+import { OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses";
 
 export const BATCH_ENDPOINTS = {
@@ -20,6 +21,8 @@ export const BATCH_ENDPOINTS = {
     GoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch,
   [OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch.id]:
     OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch,
+  [OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch.id]:
+    OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch,
   [MistralMistralMedium35EuropeMistralBatch.id]:
     MistralMistralMedium35EuropeMistralBatch,
 } as const satisfies Record<string, BatchEndpointConstructor>;

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -1,6 +1,5 @@
 export type Credentials = {
   OPENAI_API_KEY?: string;
-  OPENAI_BASE_URL?: string;
   ANTHROPIC_API_KEY?: string;
   GOOGLE_AI_STUDIO_API_KEY?: string;
   AGENT_PLATFORM_PROJECT_ID?: string;


### PR DESCRIPTION
## Description

Adds the OpenAI GPT-5.5 EU batch endpoint, resolving the OpenAI batch base URL per endpoint (as the stream client already does) instead of through a `OPENAI_BASE_URL` credential, and declares the `modelConfig` static that was missing on the new Gemini 3.5 Flash Lite / 3.6 Flash config mixins and batch endpoint.

## Tests

`npm run tsgo` passes; the EU batch endpoint has not been exercised against the live API yet.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
