### PR TITLE
[LLM] Add OpenAI GPT-5.6 Luna batch endpoints (global + EU)

### DIFF
--- a/front/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
+++ b/front/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
@@ -1,0 +1,10 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
+import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+
+export class DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch extends OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch {
+  static readonly endpointFilter = {};
+  static readonly modelConfig = GPT_5_6_LUNA_MODEL_CONFIG;
+}
+
+defineDustBatchEndpoint(DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch);

--- a/front/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
+++ b/front/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
@@ -1,0 +1,10 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
+import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+
+export class DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch extends OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch {
+  static readonly endpointFilter = {};
+  static readonly modelConfig = GPT_5_6_LUNA_MODEL_CONFIG;
+}
+
+defineDustBatchEndpoint(DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch);

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -7,6 +7,8 @@ import { DustGoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch 
 import { DustMistralMistralMedium35EuropeMistralBatch } from "@app/lib/llms/batch/endpoints/mistral_mistral_medium_3_5_eu_mistral";
 import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses";
+import { DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
+import { DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -30,6 +32,10 @@ export const DUST_BATCH_ENDPOINTS = {
     DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch,
   [DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch.id]:
     DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch,
+  [DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch.id]:
+    DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch,
+  [DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch.id]:
+    DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch,
   [DustMistralMistralMedium35EuropeMistralBatch.id]:
     DustMistralMistralMedium35EuropeMistralBatch,
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
@@ -1,0 +1,25 @@
+import { OpenAIResponsesBatch } from "@app/lib/model_constructors/batch/clients/openai_responses";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { OPENAI_EU_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotSixLunaConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_six_luna";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch extends WithOpenAIGptFiveDotSixLunaConfig(
+  OpenAIResponsesBatch
+) {
+  // Batch pricing is half the standard OpenAI rate, itself charged a 10%
+  // regional uplift for models released on or after March 5, 2026.
+  // https://developers.openai.com/api/docs/models/gpt-5.6-luna
+  static readonly tokenPricing = {
+    standardInput: 0.55,
+    standardOutput: 3.3,
+  };
+
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_EU_BASE_URL;
+}
+
+OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
@@ -1,0 +1,24 @@
+import { OpenAIResponsesBatch } from "@app/lib/model_constructors/batch/clients/openai_responses";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { OPENAI_GLOBAL_BASE_URL } from "@app/lib/model_constructors/providers/openai/base_url";
+import { WithOpenAIGptFiveDotSixLunaConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_six_luna";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch extends WithOpenAIGptFiveDotSixLunaConfig(
+  OpenAIResponsesBatch
+) {
+  // Batch pricing is half the standard OpenAI rate.
+  // https://developers.openai.com/api/docs/models/gpt-5.6-luna
+  static readonly tokenPricing = {
+    standardInput: 0.5,
+    standardOutput: 3.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+
+  protected readonly baseUrl = OPENAI_GLOBAL_BASE_URL;
+}
+
+OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/index.ts
+++ b/front/lib/model_constructors/batch/index.ts
@@ -7,6 +7,8 @@ import { GoogleAiStudioGeminiThreeDotFiveFlashLiteGlobalGoogleAiStudioBatch } fr
 import { MistralMistralMedium35EuropeMistralBatch } from "@app/lib/model_constructors/batch/endpoints/mistral_mistral_medium_3_5_eu_mistral";
 import { OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_five_global_openai_responses";
+import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
+import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 
 export const BATCH_ENDPOINTS = {
   [AnthropicClaudeSonnetFourDotSixGlobalAnthropicBatch.id]:
@@ -23,6 +25,10 @@ export const BATCH_ENDPOINTS = {
     OpenAIGptFiveDotFiveGlobalOpenAIResponsesBatch,
   [OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch.id]:
     OpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch,
+  [OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch.id]:
+    OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch,
+  [OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch.id]:
+    OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch,
   [MistralMistralMedium35EuropeMistralBatch.id]:
     MistralMistralMedium35EuropeMistralBatch,
 } as const satisfies Record<string, BatchEndpointConstructor>;


### PR DESCRIPTION
## Description

Adds the OpenAI GPT-5.6 Luna batch endpoints for the global and EU regions, mirroring the existing Luna stream endpoints, with batch pricing at half the standard rate (0.5/3.0 global, 0.55/3.3 EU including the 10% regional uplift).

## Tests

Type-checked only — the endpoint classes are declarative config, validated by the registries' `satisfies` constraints.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`