### PR TITLE
Admin governance: bulk edit UI for manage skills table

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -242,31 +242,28 @@ export function ManageSkillsPage() {
     [rowSelection]
   );
 
-  const closeBatchEdition = useCallback(() => {
+  const closeBatchEdition = () => {
     setIsBatchEditing(false);
     setRowSelection({});
-  }, []);
+  };
 
-  const handleBatchAvailability = useCallback(
-    async (availability: SkillAvailability) => {
-      if (selectedSkillIds.length === 0 || isBatchUpdating) {
-        return;
+  const handleBatchAvailability = async (availability: SkillAvailability) => {
+    if (selectedSkillIds.length === 0 || isBatchUpdating) {
+      return;
+    }
+    setIsBatchUpdating(true);
+    try {
+      const success = await doUpdateAvailability(
+        selectedSkillIds,
+        availability
+      );
+      if (success) {
+        setRowSelection({});
       }
-      setIsBatchUpdating(true);
-      try {
-        const success = await doUpdateAvailability(
-          selectedSkillIds,
-          availability
-        );
-        if (success) {
-          setRowSelection({});
-        }
-      } finally {
-        setIsBatchUpdating(false);
-      }
-    },
-    [selectedSkillIds, isBatchUpdating, doUpdateAvailability]
-  );
+    } finally {
+      setIsBatchUpdating(false);
+    }
+  };
 
   const isBatchEditionAvailable =
     hasSkillPublicationGovernance &&

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -21,6 +21,7 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { isDustProvidedSkill, SKILL_ICON } from "@app/lib/skill";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   useSkillsWithRelations,
   useUpdateSkillsAvailability,
@@ -97,6 +98,7 @@ function sortSkillsByName(
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasPermission } = useWorkspacePermissions();
   const { hasFeature } = useFeatureFlags();
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
@@ -267,7 +269,9 @@ export function ManageSkillsPage() {
   );
 
   const isBatchEditionAvailable =
-    hasSkillPublicationGovernance && activeTab !== "archived";
+    hasSkillPublicationGovernance &&
+    hasPermission("publish", "skill") &&
+    activeTab !== "archived";
 
   const knownSkillsById = useMemo(
     () =>
@@ -424,12 +428,7 @@ export function ManageSkillsPage() {
                         ? "Auto-discoverable"
                         : tab.label
                     }
-                    onClick={() => {
-                      setSelectedTab(tab.id);
-                      // Selected rows belong to the current tab: drop the
-                      // selection when it changes.
-                      setRowSelection({});
-                    }}
+                    onClick={() => setSelectedTab(tab.id)}
                     tooltip={tab.description}
                     isCounter={tab.id !== "archived"}
                     counterValue={`${skillsByTab[tab.id].length}`}

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -2,6 +2,11 @@ import { AgentSidebarMenu } from "@app/components/assistant/conversation/Sidebar
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
+import type { BatchAvailabilityAction } from "@app/components/skills/SkillsBatchEdit";
+import {
+  BatchAvailabilityDialog,
+  SkillsBatchEditBar,
+} from "@app/components/skills/SkillsBatchEdit";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
 import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSection";
 import {
@@ -16,10 +21,16 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { isDustProvidedSkill, SKILL_ICON } from "@app/lib/skill";
-import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
+import {
+  useSkillsWithRelations,
+  useUpdateSkillsAvailability,
+} from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
-import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillAvailability,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
+} from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
   Button,
@@ -28,6 +39,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   FolderOpen,
+  ListSelect,
   Page,
   Plus,
   SearchInput,
@@ -36,6 +48,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const SKILL_MANAGER_TABS = [
@@ -85,9 +98,6 @@ export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
   const { hasFeature } = useFeatureFlags();
-  const hasSkillPublicationGovernance = hasFeature(
-    "admin_governance_skill_publication"
-  );
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -95,6 +105,15 @@ export function ManageSkillsPage() {
   const [selectedTab, setSelectedTab] = useHashParam("selectedTab", "active");
   const [skillSearch, setSkillSearch] = useState("");
   const [skillIdParam, setSkillIdParam] = useHashParam("skillId");
+  const [isBatchEditing, setIsBatchEditing] = useState(false);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [pendingBatchAction, setPendingBatchAction] =
+    useState<BatchAvailabilityAction | null>(null);
+
+  const hasSkillPublicationGovernance = hasFeature(
+    "admin_governance_skill_publication"
+  );
+  const doUpdateAvailability = useUpdateSkillsAvailability({ owner });
 
   const isSearchActive = !isEmptyString(skillSearch);
 
@@ -211,6 +230,45 @@ export function ManageSkillsPage() {
     [setSkillIdParam]
   );
 
+  const [isBatchUpdating, setIsBatchUpdating] = useState(false);
+
+  const selectedSkillIds = useMemo(
+    () =>
+      Object.entries(rowSelection)
+        .filter(([, selected]) => selected)
+        .map(([sId]) => sId),
+    [rowSelection]
+  );
+
+  const closeBatchEdition = useCallback(() => {
+    setIsBatchEditing(false);
+    setRowSelection({});
+  }, []);
+
+  const handleBatchAvailability = useCallback(
+    async (availability: SkillAvailability) => {
+      if (selectedSkillIds.length === 0 || isBatchUpdating) {
+        return;
+      }
+      setIsBatchUpdating(true);
+      try {
+        const success = await doUpdateAvailability(
+          selectedSkillIds,
+          availability
+        );
+        if (success) {
+          setRowSelection({});
+        }
+      } finally {
+        setIsBatchUpdating(false);
+      }
+    },
+    [selectedSkillIds, isBatchUpdating, doUpdateAvailability]
+  );
+
+  const isBatchEditionAvailable =
+    hasSkillPublicationGovernance && activeTab !== "archived";
+
   const knownSkillsById = useMemo(
     () =>
       new Map(
@@ -290,6 +348,18 @@ export function ManageSkillsPage() {
           owner={owner}
         />
       )}
+      {pendingBatchAction && (
+        <BatchAvailabilityDialog
+          action={pendingBatchAction}
+          selectedCount={selectedSkillIds.length}
+          isUpdating={isBatchUpdating}
+          onConfirm={async () => {
+            await handleBatchAvailability(pendingBatchAction.availability);
+            setPendingBatchAction(null);
+          }}
+          onCancel={() => setPendingBatchAction(null)}
+        />
+      )}
       <div className="flex w-full flex-col gap-8 pb-4">
         <Page.Header
           title="Manage Skills"
@@ -308,6 +378,14 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
+            {isBatchEditionAvailable && !isBatchEditing && (
+              <Button
+                variant="outline"
+                label="Batch edit"
+                icon={ListSelect}
+                onClick={() => setIsBatchEditing(true)}
+              />
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button label="Create skill" icon={Plus} isSelect />
@@ -326,6 +404,14 @@ export function ManageSkillsPage() {
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          {isBatchEditionAvailable && isBatchEditing && (
+            <SkillsBatchEditBar
+              selectedCount={selectedSkillIds.length}
+              isUpdating={isBatchUpdating}
+              onClose={closeBatchEdition}
+              onSelectAction={setPendingBatchAction}
+            />
+          )}
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>
               <TabsList>
@@ -338,7 +424,12 @@ export function ManageSkillsPage() {
                         ? "Auto-discoverable"
                         : tab.label
                     }
-                    onClick={() => setSelectedTab(tab.id)}
+                    onClick={() => {
+                      setSelectedTab(tab.id);
+                      // Selected rows belong to the current tab: drop the
+                      // selection when it changes.
+                      setRowSelection({});
+                    }}
                     tooltip={tab.description}
                     isCounter={tab.id !== "archived"}
                     counterValue={`${skillsByTab[tab.id].length}`}
@@ -367,6 +458,9 @@ export function ManageSkillsPage() {
                   onAgentClick={setAgentId}
                   onUsedBySkillClick={handleUsedBySkillSelect}
                   showAvailability={hasSkillPublicationGovernance}
+                  {...(isBatchEditionAvailable && isBatchEditing
+                    ? { rowSelection, setRowSelection }
+                    : {})}
                 />
               </>
             )}

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -1,0 +1,164 @@
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Eye,
+  EyeOff,
+  SearchMd,
+  XClose,
+} from "@dust-tt/sparkle";
+
+export type BatchAvailabilityAction = {
+  label: string;
+  icon: React.ComponentType;
+  availability: SkillAvailability;
+  getDialogTitle: (count: number) => string;
+  dialogDescription: string;
+  confirmLabel: string;
+  confirmVariant: "primary" | "warning";
+};
+
+const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
+  {
+    label: "Editor only",
+    icon: EyeOff,
+    availability: "editors",
+    getDialogTitle: (count) =>
+      `Make ${count} skill${pluralize(count)} editor only`,
+    dialogDescription:
+      "Editor only skills will no longer appear in the builder. They will keep working inside agents that already use them.",
+    confirmLabel: "Make editor only",
+    confirmVariant: "warning",
+  },
+  {
+    label: "Workspace members",
+    icon: Eye,
+    availability: "workspace_users",
+    getDialogTitle: (count) =>
+      `Make ${count} skill${pluralize(count)} available to workspace members`,
+    dialogDescription:
+      "Skills available to workspace members are visible to everyone. They can add them to agents, other skills and use them directly.",
+    confirmLabel: "Make available",
+    confirmVariant: "primary",
+  },
+  {
+    label: "Auto-discoverable",
+    icon: SearchMd,
+    availability: "users_and_agents",
+    getDialogTitle: (count) =>
+      `Make ${count} skill${pluralize(count)} auto-discoverable`,
+    dialogDescription:
+      "Auto-discoverable skills are available to workspace members and can be automatically activated by agents with Discover Skills tools enabled.",
+    confirmLabel: "Make auto-discoverable",
+    confirmVariant: "primary",
+  },
+];
+
+interface SkillsBatchEditBarProps {
+  selectedCount: number;
+  isUpdating: boolean;
+  onClose: () => void;
+  onSelectAction: (action: BatchAvailabilityAction) => void;
+}
+
+export function SkillsBatchEditBar({
+  selectedCount,
+  isUpdating,
+  onClose,
+  onSelectAction,
+}: SkillsBatchEditBarProps) {
+  return (
+    <div className="flex flex-row items-center justify-between gap-2 rounded-xl bg-muted-background px-2 py-2 dark:bg-muted-background-night">
+      <Button
+        variant="outline"
+        size="sm"
+        icon={XClose}
+        label="Close edition"
+        onClick={onClose}
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            label="Set access"
+            isSelect
+            isLoading={isUpdating}
+            disabled={selectedCount === 0 || isUpdating}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {BATCH_AVAILABILITY_ACTIONS.map((action) => (
+            <DropdownMenuItem
+              key={action.availability}
+              label={action.label}
+              icon={action.icon}
+              onClick={() => onSelectAction(action)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+interface BatchAvailabilityDialogProps {
+  action: BatchAvailabilityAction;
+  selectedCount: number;
+  isUpdating: boolean;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+export function BatchAvailabilityDialog({
+  action,
+  selectedCount,
+  isUpdating,
+  onConfirm,
+  onCancel,
+}: BatchAvailabilityDialogProps) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !isUpdating) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>{action.getDialogTitle(selectedCount)}</DialogTitle>
+          <DialogDescription>{action.dialogDescription}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            disabled: isUpdating,
+          }}
+          rightButtonProps={{
+            label: action.confirmLabel,
+            variant: action.confirmVariant,
+            disabled: isUpdating,
+            isLoading: isUpdating,
+            onClick: async (e: React.MouseEvent) => {
+              e.preventDefault();
+              await onConfirm();
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -3,8 +3,8 @@ import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Button,
   Dialog,
+  DialogContainer,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -31,7 +31,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} editor only`,
     dialogDescription:
-      "Editor only skills will no longer appear in the builder. They will keep working inside agents that already use them.",
+      "Non-editors won't see these skills as options in the builder. Agents and skills that already use them won't lose access.",
     confirmLabel: "Make editor only",
     confirmVariant: "warning",
   },
@@ -41,7 +41,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} available to workspace members`,
     dialogDescription:
-      "Skills available to workspace members are visible to everyone. They can add them to agents, other skills and use them directly.",
+      "Every workspace member can add them to agents, other skills and use them directly.",
     confirmLabel: "Make available",
     confirmVariant: "primary",
   },
@@ -131,8 +131,8 @@ export function BatchAvailabilityDialog({
       <DialogContent size="md" isAlertDialog>
         <DialogHeader hideButton>
           <DialogTitle>{action.getDialogTitle(selectedCount)}</DialogTitle>
-          <DialogDescription>{action.dialogDescription}</DialogDescription>
         </DialogHeader>
+        <DialogContainer>{action.dialogDescription}</DialogContainer>
         <DialogFooter
           leftButtonProps={{
             label: "Cancel",

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -12,15 +12,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Eye,
-  EyeOff,
-  SearchMd,
   XClose,
 } from "@dust-tt/sparkle";
 
 export type BatchAvailabilityAction = {
   label: string;
-  icon: React.ComponentType;
   availability: SkillAvailability;
   getDialogTitle: (count: number) => string;
   dialogDescription: string;
@@ -31,7 +27,6 @@ export type BatchAvailabilityAction = {
 const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
   {
     label: "Editor only",
-    icon: EyeOff,
     availability: "editors",
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} editor only`,
@@ -42,7 +37,6 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
   },
   {
     label: "Workspace members",
-    icon: Eye,
     availability: "workspace_users",
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} available to workspace members`,
@@ -53,7 +47,6 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
   },
   {
     label: "Auto-discoverable",
-    icon: SearchMd,
     availability: "users_and_agents",
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} auto-discoverable`,
@@ -102,7 +95,6 @@ export function SkillsBatchEditBar({
             <DropdownMenuItem
               key={action.availability}
               label={action.label}
-              icon={action.icon}
               onClick={() => onSelectAction(action)}
             />
           ))}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -2,7 +2,7 @@ import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
@@ -13,11 +13,24 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
-import { Chip, DataTable, Edit04, Eye, Trash01 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import {
+  Chip,
+  createSelectionColumn,
+  DataTable,
+  Edit04,
+  Eye,
+  Trash01,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  ColumnDef,
+  Row,
+  RowSelectionState,
+} from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
 type RowData = {
+  sId: string;
   name: string;
   icon: string | null;
   editedBy: number | null;
@@ -163,13 +176,16 @@ const getTableColumns = ({
   onAgentClick,
   onUsedBySkillClick,
   showAvailability,
+  enableRowSelection,
 }: {
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   showAvailability: boolean;
+  enableRowSelection: boolean;
 }) => {
   /**
    * Columns order:
+   * - Selection (batch edition only)
    * - Name (always)
    * - Access (skill publication governance only, hidden on mobile)
    * - Used by (hidden on mobile)
@@ -179,6 +195,7 @@ const getTableColumns = ({
    */
 
   return [
+    ...(enableRowSelection ? [createSelectionColumn<RowData>()] : []),
     nameColumn,
     ...(showAvailability ? [availabilityColumn] : []),
     usedByColumn(onAgentClick, onUsedBySkillClick),
@@ -197,6 +214,8 @@ type SkillsTableProps = {
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   showAvailability?: boolean;
+  rowSelection?: RowSelectionState;
+  setRowSelection?: (selection: RowSelectionState) => void;
 };
 
 export function SkillsTable({
@@ -206,16 +225,34 @@ export function SkillsTable({
   onAgentClick,
   onUsedBySkillClick,
   showAvailability = false,
+  rowSelection,
+  setRowSelection,
 }: SkillsTableProps) {
   const router = useAppRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] =
     useState<SkillWithoutInstructionsAndToolsWithRelationsType | null>(null);
 
+  const isSelectionEnabled = rowSelection !== undefined;
+
+  // Stable columns identity: rebuilding them on every selection change makes the
+  // table re-render all rows.
+  const columns = useMemo(
+    () =>
+      getTableColumns({
+        onAgentClick,
+        onUsedBySkillClick,
+        showAvailability,
+        enableRowSelection: isSelectionEnabled,
+      }),
+    [onAgentClick, onUsedBySkillClick, showAvailability, isSelectionEnabled]
+  );
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const rows: RowData[] = useMemo(
     () =>
       skills.map((skill) => ({
+        sId: skill.sId,
         name: skill.name,
         icon: skill.icon,
         editedBy: skill.editedBy,
@@ -226,6 +263,11 @@ export function SkillsTable({
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {
+          // During batch edition the DataTable itself toggles the row selection on
+          // click; don't open the details panel on top of it.
+          if (isSelectionEnabled) {
+            return;
+          }
           onSkillClick(skill);
         },
         menuItems:
@@ -267,7 +309,7 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, onUsedBySkillClick, owner.sId]
+    [skills, onSkillClick, onUsedBySkillClick, owner.sId, isSelectionEnabled]
   );
 
   if (rows.length === 0) {
@@ -289,13 +331,20 @@ export function SkillsTable({
       <DataTable
         className="relative"
         data={rows}
-        columns={getTableColumns({
-          onAgentClick,
-          onUsedBySkillClick,
-          showAvailability,
-        })}
+        columns={columns}
         pagination={pagination}
         setPagination={setPagination}
+        {...(rowSelection !== undefined && setRowSelection
+          ? {
+              rowSelection,
+              setRowSelection,
+              // Dust-provided (code-defined) skills have a fixed availability and
+              // cannot be batch-edited.
+              enableRowSelection: (row: Row<RowData>) =>
+                !isDustProvidedSkill(row.original),
+              getRowId: (row: RowData) => row.sId,
+            }
+          : {})}
       />
     </>
   );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -190,6 +190,53 @@ export function useSkillsWithRelations({
   };
 }
 
+export function useUpdateSkillsAvailability({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const sendNotification = useSendNotification();
+
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+
+  const doUpdateAvailability = async (
+    skillIds: string[],
+    availability: SkillAvailability
+  ): Promise<boolean> => {
+    try {
+      await fetcher(`/api/w/${owner.sId}/skills/availability`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skillIds, availability }),
+      });
+
+      void mutateActiveSkills();
+
+      sendNotification({
+        type: "success",
+        title: "Skills updated",
+        description: `Successfully updated ${skillIds.length} skill${pluralize(skillIds.length)}.`,
+      });
+      return true;
+    } catch (err) {
+      sendNotification({
+        type: "error",
+        title: "Error updating skills",
+        description: `Error: ${isAPIErrorResponse(err) ? err.error.message : "An unexpected error occurred."}`,
+      });
+      return false;
+    }
+  };
+
+  return doUpdateAvailability;
+}
+
 export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
   const { fetcher } = useFetcher();
   const getSimilarSkills = useCallback(


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9738

Add a bulk edit mode to the manage skills page
Only visible when feature flag is on
Only option for now is to bulk edit the availability (bulk archive will come next)

## Tests

tested locally

<img width="2778" height="1394" alt="image" src="https://github.com/user-attachments/assets/494d3b82-df92-4609-9da5-ab3cc26a0232" />


<img width="1384" height="774" alt="Screenshot 2026-07-27 at 15 19 32" src="https://github.com/user-attachments/assets/bd5ca71c-e818-445c-a6c6-606afa974557" />

<img width="311" height="301" alt="Screenshot 2026-07-27 at 15 19 37" src="https://github.com/user-attachments/assets/a43f8a38-4d6e-4fbf-b82f-e5ffb067ce33" />
<img width="578" height="249" alt="Screenshot 2026-07-27 at 15 19 42" src="https://github.com/user-attachments/assets/441a7aed-d7d2-41d7-9315-c06970b213f5" />
<img width="549" height="234" alt="Screenshot 2026-07-27 at 15 19 48" src="https://github.com/user-attachments/assets/c12cbda3-0f3a-4d78-a541-e9f6ae630c04" />

<img width="555" height="267" alt="Screenshot 2026-07-27 at 15 19 55" src="https://github.com/user-attachments/assets/abeb95c7-379e-42c8-a875-3ea01dfacb78" />

## Risk

low: purely UI + behind feature flag

## Deploy Plan

deploy front
