### PR TITLE
refactor: move agent configuration context out of the YAML export module

### DIFF
--- a/front/lib/api/assistant/configuration/context.ts
+++ b/front/lib/api/assistant/configuration/context.ts
@@ -1,0 +1,120 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * An agent configuration whose full definition can be reproduced: a workspace agent (global
+ * agents are code-defined) whose current version is active (an archived one would be resurrected
+ * by writing it back as a new version).
+ */
+export type ActiveWorkspaceAgentConfiguration = AgentConfigurationType & {
+  scope: Exclude<AgentConfigurationType["scope"], "global">;
+  status: "active";
+};
+
+/**
+ * An agent configuration plus the associations that live outside of it and are needed to write it
+ * back in full: its editors and its skills.
+ */
+export type AgentConfigurationContext = {
+  agentConfiguration: ActiveWorkspaceAgentConfiguration;
+  editorUsers: UserResource[];
+  skills: SkillResource[];
+};
+
+function isActiveWorkspaceAgentConfiguration(
+  agentConfiguration: AgentConfigurationType
+): agentConfiguration is ActiveWorkspaceAgentConfiguration {
+  return (
+    agentConfiguration.status === "active" &&
+    agentConfiguration.scope !== "global"
+  );
+}
+
+export async function getActiveWorkspaceAgentConfiguration(
+  auth: Authenticator,
+  agentId: string
+): Promise<
+  Result<ActiveWorkspaceAgentConfiguration, APIErrorWithContentfulStatusCode>
+> {
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "full",
+  });
+
+  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration you requested was not found.",
+      },
+    });
+  }
+
+  if (!isActiveWorkspaceAgentConfiguration(agentConfiguration)) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Archived and global agents cannot be exported or updated.",
+      },
+    });
+  }
+
+  return new Ok(agentConfiguration);
+}
+
+export async function getAgentConfigurationContext(
+  auth: Authenticator,
+  agentId: string,
+  { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
+): Promise<
+  Result<AgentConfigurationContext, APIErrorWithContentfulStatusCode>
+> {
+  const agentResult = await getActiveWorkspaceAgentConfiguration(auth, agentId);
+  if (agentResult.isErr()) {
+    return agentResult;
+  }
+
+  const agentConfiguration = agentResult.value;
+
+  const skills = await SkillResource.listByAgentConfiguration(
+    auth,
+    agentConfiguration
+  );
+  const editorsResult = await GroupResource.findEditorGroupForAgent(
+    auth,
+    agentConfiguration
+  );
+
+  if (editorsResult.isErr()) {
+    if (requireEditorGroup) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Unable to resolve existing agent editors: ${editorsResult.error.message}`,
+        },
+      });
+    }
+
+    return new Ok({
+      agentConfiguration,
+      editorUsers: [],
+      skills,
+    });
+  }
+
+  return new Ok({
+    agentConfiguration,
+    editorUsers: await editorsResult.value.getActiveMembers(auth),
+    skills,
+  });
+}

--- a/front/lib/api/assistant/configuration/model_update.ts
+++ b/front/lib/api/assistant/configuration/model_update.ts
@@ -1,6 +1,6 @@
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfigurationContext } from "@app/lib/api/assistant/configuration/context";
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
-import { getAgentConfigurationYAMLContext } from "@app/lib/api/assistant/configuration/yaml_export";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -127,7 +127,7 @@ async function upgradeAgentConfigurationModel(
 ): Promise<Result<void, Error>> {
   // Resolves the current configuration along with its editors and skills, and rejects agents
   // that cannot be re-saved as-is (archived, global).
-  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId, {
+  const contextResult = await getAgentConfigurationContext(auth, agentId, {
     requireEditorGroup: true,
   });
   if (contextResult.isErr()) {

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -8,16 +8,12 @@ import {
 } from "@app/lib/agent_builder/server_side_props_helpers";
 import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
 import type { AgentYAMLConfig } from "@app/lib/agent_yaml_converter/schemas";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationContext } from "@app/lib/api/assistant/configuration/context";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
@@ -26,113 +22,11 @@ import type { UserType } from "@app/types/user";
 
 const AGENT_NAME_SANITATION_REGEX = /[^a-zA-Z0-9-_]/g;
 
-export type ExportableAgentConfiguration = AgentConfigurationType & {
-  scope: Exclude<AgentConfigurationType["scope"], "global">;
-  status: "active";
-};
-
-type AgentConfigurationYAMLContext = {
-  agentConfiguration: ExportableAgentConfiguration;
-  editorUsers: UserResource[];
-  skills: SkillResource[];
-};
-
-function isExportableAgentConfiguration(
-  agentConfiguration: AgentConfigurationType
-): agentConfiguration is ExportableAgentConfiguration {
-  return (
-    agentConfiguration.status === "active" &&
-    agentConfiguration.scope !== "global"
-  );
-}
-
-export async function getExportableAgentConfiguration(
-  auth: Authenticator,
-  agentId: string
-): Promise<
-  Result<ExportableAgentConfiguration, APIErrorWithContentfulStatusCode>
-> {
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId,
-    variant: "full",
-  });
-
-  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
-    return new Err({
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration you requested was not found.",
-      },
-    });
-  }
-
-  if (!isExportableAgentConfiguration(agentConfiguration)) {
-    return new Err({
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Cannot export archived or global agents.",
-      },
-    });
-  }
-
-  return new Ok(agentConfiguration);
-}
-
-export async function getAgentConfigurationYAMLContext(
-  auth: Authenticator,
-  agentId: string,
-  { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
-): Promise<
-  Result<AgentConfigurationYAMLContext, APIErrorWithContentfulStatusCode>
-> {
-  const agentResult = await getExportableAgentConfiguration(auth, agentId);
-  if (agentResult.isErr()) {
-    return agentResult;
-  }
-
-  const agentConfiguration = agentResult.value;
-
-  const skills = await SkillResource.listByAgentConfiguration(
-    auth,
-    agentConfiguration
-  );
-  const editorsResult = await GroupResource.findEditorGroupForAgent(
-    auth,
-    agentConfiguration
-  );
-
-  if (editorsResult.isErr()) {
-    if (requireEditorGroup) {
-      return new Err({
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Unable to resolve existing agent editors: ${editorsResult.error.message}`,
-        },
-      });
-    }
-
-    return new Ok({
-      agentConfiguration,
-      editorUsers: [],
-      skills,
-    });
-  }
-
-  return new Ok({
-    agentConfiguration,
-    editorUsers: await editorsResult.value.getActiveMembers(auth),
-    skills,
-  });
-}
-
 export async function getAgentConfigurationAsYAMLConfig(
   auth: Authenticator,
   agentId: string
 ): Promise<Result<AgentYAMLConfig, APIErrorWithContentfulStatusCode>> {
-  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId);
+  const contextResult = await getAgentConfigurationContext(auth, agentId);
   if (contextResult.isErr()) {
     return contextResult;
   }

--- a/front/lib/api/assistant/configuration/yaml_import.test.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.test.ts
@@ -1,8 +1,6 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import {
-  getAgentConfigurationAsYAMLConfig,
-  getExportableAgentConfiguration,
-} from "@app/lib/api/assistant/configuration/yaml_export";
+import { getActiveWorkspaceAgentConfiguration } from "@app/lib/api/assistant/configuration/context";
+import { getAgentConfigurationAsYAMLConfig } from "@app/lib/api/assistant/configuration/yaml_export";
 import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import type { Authenticator } from "@app/lib/auth";
 import type { GroupResource as GroupResourceType } from "@app/lib/resources/group_resource";
@@ -88,7 +86,10 @@ async function createPatchableAgent({
     agentConfigurationId: agent.id,
   });
 
-  const agentForPatch = await getExportableAgentConfiguration(auth, agent.sId);
+  const agentForPatch = await getActiveWorkspaceAgentConfiguration(
+    auth,
+    agent.sId
+  );
   expect(agentForPatch.isOk()).toBe(true);
   if (agentForPatch.isErr()) {
     throw new Error(agentForPatch.error.api_error.message);

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -6,8 +6,8 @@ import {
   agentYAMLConfigSchema,
   agentYAMLGenerationSettingsSchema,
 } from "@app/lib/agent_yaml_converter/schemas";
+import { getAgentConfigurationContext } from "@app/lib/api/assistant/configuration/context";
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
-import { getAgentConfigurationYAMLContext } from "@app/lib/api/assistant/configuration/yaml_export";
 import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -301,7 +301,7 @@ export async function patchAgentConfigurationFromJSON(
     return saveEnabledResult;
   }
 
-  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId, {
+  const contextResult = await getAgentConfigurationContext(auth, agentId, {
     requireEditorGroup: true,
   });
   if (contextResult.isErr()) {


### PR DESCRIPTION
## Description

`getAgentConfigurationYAMLContext` neither reads nor writes YAML: it loads an
agent's full configuration along with the associations needed to write it back
(its editors and its skills). It lived in `yaml_export.ts` because the YAML
export was its first consumer, which made the bulk model update look like it
went through a YAML representation.

Move it to configuration/context.ts as `getAgentConfigurationContext`, with
`getExportableAgentConfiguration` becoming `getActiveWorkspaceAgentConfiguration`
(active status, workspace scope — nothing export-specific).

No behavior change beyond the wording of the rejection message, now shared by both consumers.

## Tests

Existing tests

## Risk

Low. Safe to rollback.

## Deploy Plan

Front only
