### PR TITLE
feat: remove audit logs from workspace permission

### DIFF
--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -92,7 +92,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
     const auth = await memberAuthInGroup(group);
 
     expect(await auth.hasWorkspacePermission("admin", "billing")).toBe(true);
-    expect(await auth.hasWorkspacePermission("read", "audit_log")).toBe(true);
+    expect(await auth.hasWorkspacePermission("admin", "identity")).toBe(true);
   });
 
   it("rejects an invalid capability query, even for admins", async () => {
@@ -141,7 +141,6 @@ describe("Authenticator.getWorkspacePermissions", () => {
       frame: ["invite", "publish"],
       billing: ["admin"],
       identity: ["admin"],
-      audit_log: ["read"],
       dust_app: ["admin"],
     });
   });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -72,9 +72,6 @@ export const ROLE_REGISTRY: Record<
   identity: {
     admin: { verbs: ["admin"], levels: ["type"] },
   },
-  audit_log: {
-    read: { verbs: ["read"], levels: ["type"] },
-  },
   models_tier: {
     use: { verbs: ["use"], levels: ["instance"] },
   },
@@ -198,7 +195,6 @@ export function workspacePermissionsFromGrants(
     frame: new Set(),
     billing: new Set(),
     identity: new Set(),
-    audit_log: new Set(),
     models_tier: new Set(),
     dust_app: new Set(),
   };

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -285,7 +285,7 @@ describe("GroupPermissionResource", () => {
       await expect(
         GroupPermissionResource.grantTypeWide(auth, {
           group: groupA,
-          grantType: "read",
+          grantType: "create",
           resourceType: "billing",
         })
       ).rejects.toThrow(/not allowed/);

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -31,7 +31,6 @@ export const GRANT_TYPES = [
   "create",
   "publish",
   "invite",
-  "read",
   "use",
   "*",
 ] as const;
@@ -45,7 +44,6 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "frame",
   "billing",
   "identity",
-  "audit_log",
   "models_tier",
   "dust_app",
   "*",
@@ -129,7 +127,6 @@ export function emptyWorkspacePermissions(): WorkspacePermissions {
     frame: [],
     billing: [],
     identity: [],
-    audit_log: [],
     models_tier: [],
     dust_app: [],
   };


### PR DESCRIPTION
## Description

This PR removes the `audit_log` permission from the workspace permission registry. The permission to read audit logs will be bundled in an admin security permission.

## Tests

Manually.

## Risks

Low. The change removes a permission entry that was unused.
## Deploy Plan

Check that no audit_logs permissions are saved in the db before deploying.