### PR TITLE
feat: use admin security workspace permission

### DIFF
--- a/front-api/routes/w/[wId]/audit-logs.ts
+++ b/front-api/routes/w/[wId]/audit-logs.ts
@@ -10,7 +10,6 @@ import { generateWorkOSAdminPortalUrl } from "@app/lib/api/workos/organization";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -28,10 +27,20 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsAdmin(),
   validate("json", PostAuditLogsRequestBodySchema),
   async (ctx): HandlerResult<AuditLogsPortalResponse> => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "You do not have permission to manage identity and provisioning settings.",
+        },
+      });
+    }
 
     if (!(await isAuditLogsEnabled(auth))) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/domains.ts
+++ b/front-api/routes/w/[wId]/domains.ts
@@ -12,7 +12,6 @@ import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import logger from "@app/logger/logger";
 import type { GetWorkspaceDomainsResponseBody } from "@app/types/api/workos/organization";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -21,57 +20,75 @@ const DeleteWorkspaceDomainRequestBodySchema = z.object({
   domain: z.string(),
 });
 
+const SECURITY_PERMISSION_ERROR_MESSAGE =
+  "You do not have permission to manage identity and provisioning settings.";
+
 // Mounted at /api/w/:wId/domains.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<GetWorkspaceDomainsResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetWorkspaceDomainsResponseBody> => {
+  const auth = ctx.get("auth");
 
-    // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
-    // created via admin tools), we create one before fetching domains. This ensures the
-    // endpoint works for all workspaces, regardless of how they were created.
-    const organizationRes = await getOrCreateWorkOSOrganization(
-      auth.getNonNullableWorkspace()
-    );
-
-    if (organizationRes.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to get WorkOS organization",
-        },
-      });
-    }
-
-    // If there is no organization, return an empty array.
-    if (!organizationRes.value) {
-      return ctx.json({ domains: [] });
-    }
-
-    const { link } = await generateWorkOSAdminPortalUrl({
-      organization: organizationRes.value.id,
-      workOSIntent: WorkOSPortalIntent.DomainVerification,
-      returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
-    });
-
-    return ctx.json({
-      addDomainLink: link,
-      domains: organizationRes.value.domains,
+  if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: SECURITY_PERMISSION_ERROR_MESSAGE,
+      },
     });
   }
-);
+
+  // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
+  // created via admin tools), we create one before fetching domains. This ensures the
+  // endpoint works for all workspaces, regardless of how they were created.
+  const organizationRes = await getOrCreateWorkOSOrganization(
+    auth.getNonNullableWorkspace()
+  );
+
+  if (organizationRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to get WorkOS organization",
+      },
+    });
+  }
+
+  // If there is no organization, return an empty array.
+  if (!organizationRes.value) {
+    return ctx.json({ domains: [] });
+  }
+
+  const { link } = await generateWorkOSAdminPortalUrl({
+    organization: organizationRes.value.id,
+    workOSIntent: WorkOSPortalIntent.DomainVerification,
+    returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
+  });
+
+  return ctx.json({
+    addDomainLink: link,
+    domains: organizationRes.value.domains,
+  });
+});
 
 app.delete(
   "/",
-  ensureIsAdmin(),
   validate("json", DeleteWorkspaceDomainRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: SECURITY_PERMISSION_ERROR_MESSAGE,
+        },
+      });
+    }
 
     const body = ctx.req.valid("json");
 

--- a/front-api/routes/w/[wId]/dsync.ts
+++ b/front-api/routes/w/[wId]/dsync.ts
@@ -14,7 +14,6 @@ import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
 
@@ -23,6 +22,18 @@ const app = workspaceApp();
 
 async function checkAccess(ctx: Context) {
   const auth = ctx.get("auth");
+
+  if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You do not have permission to manage identity and provisioning settings.",
+      },
+    });
+  }
+
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.workOSOrganizationId) {
     return apiError(ctx, {
@@ -72,44 +83,39 @@ async function checkAccess(ctx: Context) {
 }
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<WorkOSConnectionSyncStatus> => {
-    const result = await checkAccess(ctx);
-    if (result instanceof Response) {
-      return result;
-    }
-    const { auth, workspace, activeDirectory } = result;
-
-    let status: "not_configured" | "configured" | "configuring" =
-      "not_configured";
-    if (activeDirectory) {
-      status =
-        activeDirectory.state === "active" ? "configured" : "configuring";
-    }
-
-    const { link } = await generateWorkOSAdminPortalUrl({
-      organization: workspace.workOSOrganizationId!,
-      workOSIntent: WorkOSPortalIntent.DSync,
-      returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
-    });
-
-    return ctx.json({
-      status,
-      connection: activeDirectory
-        ? {
-            id: activeDirectory.id,
-            state: activeDirectory.state,
-            type: activeDirectory.type,
-          }
-        : null,
-      setupLink: link,
-    });
+app.get("/", async (ctx): HandlerResult<WorkOSConnectionSyncStatus> => {
+  const result = await checkAccess(ctx);
+  if (result instanceof Response) {
+    return result;
   }
-);
+  const { auth, workspace, activeDirectory } = result;
 
-app.delete("/", ensureIsAdmin(), async (ctx) => {
+  let status: "not_configured" | "configured" | "configuring" =
+    "not_configured";
+  if (activeDirectory) {
+    status = activeDirectory.state === "active" ? "configured" : "configuring";
+  }
+
+  const { link } = await generateWorkOSAdminPortalUrl({
+    organization: workspace.workOSOrganizationId!,
+    workOSIntent: WorkOSPortalIntent.DSync,
+    returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
+  });
+
+  return ctx.json({
+    status,
+    connection: activeDirectory
+      ? {
+          id: activeDirectory.id,
+          state: activeDirectory.state,
+          type: activeDirectory.type,
+        }
+      : null,
+    setupLink: link,
+  });
+});
+
+app.delete("/", async (ctx) => {
   const result = await checkAccess(ctx);
   if (result instanceof Response) {
     return result;

--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -60,7 +60,7 @@ describe("GET /api/w/:wId/governance-permissions", () => {
       "invite:frame": adminsOnly("invite", "frame"),
       "publish:frame": adminsOnly("publish", "frame"),
       "admin:billing": adminsOnly("admin", "billing"),
-      "admin:identity": adminsOnly("admin", "identity"),
+      "admin:security": adminsOnly("admin", "security"),
     });
   });
 

--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -2,6 +2,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
@@ -235,5 +236,83 @@ describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
     }
+  });
+});
+
+describe("POST /api/w/:wId (identity settings permission)", () => {
+  it("lets a member with the admin:security permission enforce SSO", async () => {
+    const { workspace, user } = await setup("user");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    const response = await post(workspace, { ssoEnforced: true });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.ssoEnforced).toBe(true);
+  });
+
+  it("returns 403 for a member without the admin:security permission", async () => {
+    const { workspace } = await setup("user");
+
+    const response = await post(workspace, { ssoEnforced: true });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "You do not have permission to manage identity and provisioning settings.",
+      },
+    });
+  });
+
+  it("still blocks non-security settings for a member with only the admin:security permission", async () => {
+    const { workspace, user } = await setup("user");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    const response = await post(workspace, {
+      reinforcementCapAwuCredits: 5_000,
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
+      },
+    });
+  });
+
+  it("does not let an admin:security holder escalate to an admin-only setting via a mixed body", async () => {
+    const { workspace, user } = await setup("user");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    // Craft a body mixing an identity setting (`ssoEnforced`) with an admin-only
+    // setting (`regionalModelsOnly`). The zod union strips the request down to a
+    // single member, so the admin-only field never reaches the handler and cannot
+    // be applied by a non-admin.
+    const response = await post(workspace, {
+      ssoEnforced: true,
+      regionalModelsOnly: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.ssoEnforced).toBe(true);
+    expect(updated?.regionalModelsOnly).toBe(false);
   });
 });

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -21,7 +21,10 @@ import { EmbeddingProviderSchema } from "@app/types/assistant/models/embedding";
 import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import {
+  ENSURE_IS_ADMIN_ERROR_MESSAGE,
+  ensureIsAdmin,
+} from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
@@ -344,13 +347,37 @@ app.get(
 
 app.post(
   "/",
-  ensureIsAdmin(),
   validate("json", PostWorkspaceRequestBodySchema),
   async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
     const body = ctx.req.valid("json");
+
+    // Domain auto-join and SSO enforcement live on the IT & Security page, so holders of
+    // the `admin:security` permission may change them. Every other workspace setting remains
+    // admin-only. `body` is the zod-parsed output: the union strips it down to a single member's
+    // keys, so this classification matches exactly the branch the handler below will execute.
+    const isIdentitySetting =
+      "domainAutoJoinEnabled" in body ||
+      "domainUpdates" in body ||
+      "ssoEnforced" in body;
+
+    const isAuthorized = isIdentitySetting
+      ? await auth.hasWorkspacePermission("admin", "security")
+      : auth.isAdmin();
+
+    if (!isAuthorized) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: isIdentitySetting
+            ? "You do not have permission to manage identity and provisioning settings."
+            : ENSURE_IS_ADMIN_ERROR_MESSAGE,
+        },
+      });
+    }
 
     const workspace = await WorkspaceResource.fetchByModelId(owner.id);
     if (!workspace) {

--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -13,7 +13,6 @@ import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
 
@@ -22,6 +21,18 @@ const app = workspaceApp();
 
 async function checkAccess(ctx: Context) {
   const auth = ctx.get("auth");
+
+  if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "You do not have permission to manage identity and provisioning settings.",
+      },
+    });
+  }
+
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.workOSOrganizationId) {
     return apiError(ctx, {
@@ -71,47 +82,42 @@ async function checkAccess(ctx: Context) {
 }
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsAdmin(),
-  async (ctx): HandlerResult<WorkOSConnectionSyncStatus> => {
-    const result = await checkAccess(ctx);
-    if (result instanceof Response) {
-      return result;
-    }
-    const { auth, workspace, activeConnection } = result;
-
-    // TODO(audit): sso.connection_created — SSO connections are created via WorkOS admin portal.
-    // Implement once WorkOS connection.activated webhook is subscribed.
-
-    let status: "not_configured" | "configured" | "configuring" =
-      "not_configured";
-    if (activeConnection) {
-      status =
-        activeConnection.state === "active" ? "configured" : "configuring";
-    }
-
-    const { link } = await generateWorkOSAdminPortalUrl({
-      organization: workspace.workOSOrganizationId!,
-      workOSIntent: WorkOSPortalIntent.SSO,
-      returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
-    });
-
-    return ctx.json({
-      connection: activeConnection
-        ? {
-            id: activeConnection.id,
-            state: activeConnection.state,
-            type: activeConnection.type,
-          }
-        : null,
-      setupLink: link,
-      status,
-    });
+app.get("/", async (ctx): HandlerResult<WorkOSConnectionSyncStatus> => {
+  const result = await checkAccess(ctx);
+  if (result instanceof Response) {
+    return result;
   }
-);
+  const { auth, workspace, activeConnection } = result;
 
-app.delete("/", ensureIsAdmin(), async (ctx) => {
+  // TODO(audit): sso.connection_created — SSO connections are created via WorkOS admin portal.
+  // Implement once WorkOS connection.activated webhook is subscribed.
+
+  let status: "not_configured" | "configured" | "configuring" =
+    "not_configured";
+  if (activeConnection) {
+    status = activeConnection.state === "active" ? "configured" : "configuring";
+  }
+
+  const { link } = await generateWorkOSAdminPortalUrl({
+    organization: workspace.workOSOrganizationId!,
+    workOSIntent: WorkOSPortalIntent.SSO,
+    returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
+  });
+
+  return ctx.json({
+    connection: activeConnection
+      ? {
+          id: activeConnection.id,
+          state: activeConnection.state,
+          type: activeConnection.type,
+        }
+      : null,
+    setupLink: link,
+    status,
+  });
+});
+
+app.delete("/", async (ctx) => {
   const result = await checkAccess(ctx);
   if (result instanceof Response) {
     return result;

--- a/front-api/routes/w/[wId]/verified-domains.test.ts
+++ b/front-api/routes/w/[wId]/verified-domains.test.ts
@@ -1,0 +1,47 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function verifiedDomainsUrl(wId: string) {
+  return `/api/w/${wId}/verified-domains`;
+}
+
+async function setup(role: MembershipRoleType = "admin") {
+  return createPrivateApiMockRequest({ method: "GET", role });
+}
+
+describe("GET /api/w/:wId/verified-domains", () => {
+  it("allows a manager", async () => {
+    const { workspace } = await setup("manager");
+
+    const response = await honoApp.request(verifiedDomainsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ verifiedDomains: [] });
+  });
+
+  it("allows a member with the admin:security permission", async () => {
+    const { workspace, user } = await setup("user");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    const response = await honoApp.request(verifiedDomainsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ verifiedDomains: [] });
+  });
+
+  it("returns 403 for a member without manager role or the admin:security permission", async () => {
+    const { workspace } = await setup("user");
+
+    const response = await honoApp.request(verifiedDomainsUrl(workspace.sId));
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+});

--- a/front-api/routes/w/[wId]/verified-domains.ts
+++ b/front-api/routes/w/[wId]/verified-domains.ts
@@ -1,7 +1,6 @@
 import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/lib/api/workspace";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -11,9 +10,23 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsManager(),
   async (ctx): HandlerResult<GetWorkspaceVerifiedDomainsResponseBody> => {
     const auth = ctx.get("auth");
+
+    // Managers see verified domains (Members page), as do holders of the `admin:security`
+    // permission (IT & Security page).
+    if (
+      !auth.isManager() &&
+      !(await auth.hasWorkspacePermission("admin", "security"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "You do not have permission to view verified domains.",
+        },
+      });
+    }
 
     const workspace = auth.getNonNullableWorkspace();
     const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -116,10 +116,6 @@ export const adminRoutes: RouteObject[] = [
     // Admin-only areas.
     element: <RequireRoleLayout requiredRole="admin" />,
     children: [
-      {
-        path: "identity-and-provisioning",
-        element: <WorkspaceIdentityProvisioningPage />,
-      },
       { path: "model-providers", element: <ModelProvidersPage /> },
       { path: "workspace", element: <WorkspaceSettingsPage /> },
       { path: "branding", element: <WorkspaceBrandingPage /> },
@@ -152,6 +148,15 @@ export const adminRoutes: RouteObject[] = [
     children: [
       { path: "subscription", element: <SubscriptionPage /> },
       { path: "billing", element: <BillingPage /> },
+    ],
+  },
+  {
+    element: <RequirePermissionLayout verb="admin" resourceType="security" />,
+    children: [
+      {
+        path: "identity-and-provisioning",
+        element: <WorkspaceIdentityProvisioningPage />,
+      },
     ],
   },
 ];

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -11,6 +11,10 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import type {
+  ConcreteResourceType,
+  GrantVerb,
+} from "@app/types/group_permissions";
 import type { SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isManager } from "@app/types/user";
@@ -28,6 +32,25 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useContext, useMemo } from "react";
+
+function getAdminSectionHref(
+  owner: WorkspaceType,
+  hasPermission: (
+    verb: GrantVerb,
+    resourceType: ConcreteResourceType
+  ) => boolean
+): string | null {
+  if (isManager(owner)) {
+    return `/w/${owner.sId}/members`;
+  }
+  if (hasPermission("admin", "billing")) {
+    return `/w/${owner.sId}/billing`;
+  }
+  if (hasPermission("admin", "security")) {
+    return `/w/${owner.sId}/identity-and-provisioning`;
+  }
+  return null;
+}
 
 interface NavigationSidebarProps {
   children: React.ReactNode;
@@ -64,13 +87,7 @@ export const NavigationSidebar = React.forwardRef<
   const { hasFeature } = useFeatureFlags();
   const { hasPermission } = useWorkspacePermissions();
 
-  // Resolves the Admin tab's landing page (or null to hide it) from the member's role/permissions.
-  // Managers land on People; members who only hold the billing permission land on Billing.
-  const adminSectionHref = isManager(owner)
-    ? `/w/${owner.sId}/members`
-    : hasPermission("admin", "billing")
-      ? `/w/${owner.sId}/billing`
-      : null;
+  const adminSectionHref = getAdminSectionHref(owner, hasPermission);
 
   const showAdminSection = adminSectionHref !== null;
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -266,10 +266,11 @@ export const subNavigationAdmin = ({
   const nav: SidebarNavigation[] = [];
 
   const canAdminBilling = hasPermission("admin", "billing");
+  const canAdminSecurity = hasPermission("admin", "security");
 
   // Admins and managers see the admin sidebar; builders and members do
   // not. Each item is then individually enabled/disabled based on permission.
-  if (!isManager(owner) && !canAdminBilling) {
+  if (!isManager(owner) && !canAdminBilling && !canAdminSecurity) {
     return nav;
   }
 
@@ -300,7 +301,7 @@ export const subNavigationAdmin = ({
         icon: Fingerprint04,
         href: `/w/${owner.sId}/identity-and-provisioning`,
         current: isCurrent("identity_and_provisioning"),
-        disabled: !hasAdminRole,
+        disabled: !canAdminSecurity,
       },
       ...(isAdminGovernanceEnabled
         ? [

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -60,7 +60,7 @@ const GOVERNANCE_SETTING_METADATA: Partial<
       "Control who can manage billing settings, invoices, and payment methods.",
     isGroupsOnly: true,
   },
-  "admin:identity": {
+  "admin:security": {
     label: "Security access",
     description:
       "Control who can manage user access, identities, and provisioning.",

--- a/front/components/workspace/UpgradePlanDialog.tsx
+++ b/front/components/workspace/UpgradePlanDialog.tsx
@@ -1,10 +1,12 @@
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
-  Button,
   Dialog,
+  DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
+  DialogTitle,
 } from "@dust-tt/sparkle";
 
 interface UpgradePlanDialogProps {
@@ -23,21 +25,42 @@ export function UpgradePlanDialog({
   description = "You cannot enable auto-join with the free plan. Upgrade your plan to invite other members.",
 }: UpgradePlanDialogProps) {
   const router = useAppRouter();
+  const { hasPermission } = useWorkspacePermissions();
+
+  const canManageBilling = hasPermission("admin", "billing");
 
   return (
-    <Dialog open={isOpen}>
-      <DialogContent>
-        <DialogHeader>{title}</DialogHeader>
-        {description}
-        <DialogFooter>
-          <Button variant="outline" label="Cancel" onClick={onClose} />
-          <Button
-            label="Check Dust plans"
-            onClick={() => {
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>{description}</DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Check Dust plans",
+            variant: "primary",
+            disabled: !canManageBilling,
+            tooltip: canManageBilling
+              ? undefined
+              : "You do not have permission to upgrade the plan.",
+            onClick: () => {
               void router.push(`/w/${workspaceId}/subscription`);
-            }}
-          />
-        </DialogFooter>
+            },
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -92,7 +92,7 @@ describe("Authenticator.hasWorkspacePermission", () => {
     const auth = await memberAuthInGroup(group);
 
     expect(await auth.hasWorkspacePermission("admin", "billing")).toBe(true);
-    expect(await auth.hasWorkspacePermission("admin", "identity")).toBe(true);
+    expect(await auth.hasWorkspacePermission("admin", "security")).toBe(true);
   });
 
   it("rejects an invalid capability query, even for admins", async () => {
@@ -140,7 +140,7 @@ describe("Authenticator.getWorkspacePermissions", () => {
       skill: ["create", "publish"],
       frame: ["invite", "publish"],
       billing: ["admin"],
-      identity: ["admin"],
+      security: ["admin"],
       dust_app: ["admin"],
     });
   });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -69,7 +69,7 @@ export const ROLE_REGISTRY: Record<
   billing: {
     admin: { verbs: ["admin"], levels: ["type"] },
   },
-  identity: {
+  security: {
     admin: { verbs: ["admin"], levels: ["type"] },
   },
   models_tier: {
@@ -194,7 +194,7 @@ export function workspacePermissionsFromGrants(
     skill: new Set(),
     frame: new Set(),
     billing: new Set(),
-    identity: new Set(),
+    security: new Set(),
     models_tier: new Set(),
     dust_app: new Set(),
   };

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -43,7 +43,7 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "skill",
   "frame",
   "billing",
-  "identity",
+  "security",
   "models_tier",
   "dust_app",
   "*",
@@ -126,7 +126,7 @@ export function emptyWorkspacePermissions(): WorkspacePermissions {
     skill: [],
     frame: [],
     billing: [],
-    identity: [],
+    security: [],
     models_tier: [],
     dust_app: [],
   };
@@ -162,6 +162,6 @@ export const GOVERNANCE_CAPABILITIES = {
   ],
   billingAndSecurity: [
     { grantType: "admin", resourceType: "billing" },
-    { grantType: "admin", resourceType: "identity" },
+    { grantType: "admin", resourceType: "security" },
   ],
 } satisfies Record<string, CapabilitySpec[]>;


### PR DESCRIPTION
## Description

This PR enables users with the admin security permission to see and interact with the IT & Security page.

## Tests

Manually + unit tests added/updated in `index.test.ts` and `governance-permissions.test.ts`.

## Risks

Low. The change relaxes the requirement from "must be admin" to "must have the `admin:security` permission" for security-specific routes. Admins retain access since they implicitly hold all permissions.

## Deploy Plan

Check that no rows in the database have "identity" as resourceType before deploying.