### PR TITLE
Add user-scoped filesystem to DustFileSystem

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -18,6 +18,7 @@ const WORKSPACE_ID = "ws123";
 const BUCKET = "test-bucket";
 const CONV_ID = "conv456";
 const POD_ID = "pod789";
+const USER_ID = "user789";
 
 function makeBackend() {
   return new GCSFileSystemBackend(WORKSPACE_ID, BUCKET);
@@ -85,6 +86,31 @@ describe("GCSFileSystemBackend.list", () => {
         prefix: `w/${WORKSPACE_ID}/pods/${POD_ID}/files/`,
       })
     );
+  });
+
+  it("queries the correct GCS prefix for a user mount", async () => {
+    const backend = makeBackend();
+    await backend.list(`user-${USER_ID}/`);
+
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${WORKSPACE_ID}/users/${USER_ID}/files/`,
+      })
+    );
+  });
+
+  it("returns canonical scoped paths for a user mount", async () => {
+    const prefix = `w/${WORKSPACE_ID}/users/${USER_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}memory.md` })],
+      pageFetchCount: 1,
+    });
+
+    const result = await makeBackend().list(`user-${USER_ID}/`);
+    assert(result.isOk());
+
+    expect(result.value[0].path).toBe(`user-${USER_ID}/memory.md`);
+    expect(result.value[0].fileName).toBe("memory.md");
   });
 
   it("excludes .processed. siblings by default", async () => {
@@ -418,6 +444,24 @@ describe("GCSFileSystemBackend.write", () => {
       `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`
     );
     expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/csv" });
+  });
+
+  it("writes to the correct GCS path for a user", async () => {
+    const content = Buffer.from("# memory");
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+
+    await makeBackend().write(
+      `user-${USER_ID}/memory.md`,
+      content,
+      "text/markdown"
+    );
+
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/users/${USER_ID}/files/memory.md`
+    );
+    expect(saveMock).toHaveBeenCalledWith(content, {
+      contentType: "text/markdown",
+    });
   });
 
   it("converts string content to a Buffer", async () => {

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -9,6 +9,7 @@ import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
+  SCOPED_PREFIX_USER,
 } from "@app/lib/api/file_system/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -34,7 +35,7 @@ import type { FileSystemBackend } from "./file_system_backend";
 // ---------------------------------------------------------------------------
 
 type ParsedScopedPath = {
-  kind: "conversation" | "pod";
+  kind: "conversation" | "pod" | "user";
   id: string;
   /** Path component after `<kind>-<id>/`, empty string for a root listing. */
   rel: string;
@@ -61,6 +62,11 @@ function parseScopedPath(scopedPath: string): ParsedScopedPath | null {
   if (prefix.startsWith(SCOPED_PREFIX_POD)) {
     const id = prefix.slice(SCOPED_PREFIX_POD.length);
     return id ? { kind: "pod", id, rel } : null;
+  }
+
+  if (prefix.startsWith(SCOPED_PREFIX_USER)) {
+    const id = prefix.slice(SCOPED_PREFIX_USER.length);
+    return id ? { kind: "user", id, rel } : null;
   }
 
   return null;
@@ -99,6 +105,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       case "pod":
         return `w/${this.workspaceId}/pods/${p.id}/files/${p.rel}`;
 
+      case "user":
+        return `w/${this.workspaceId}/users/${p.id}/files/${p.rel}`;
+
       default:
         assertNever(p.kind);
     }
@@ -121,6 +130,11 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       return `${SCOPED_PREFIX_POD}${pod[1]}/${pod[2]}`;
     }
 
+    const user = rest.match(/^users\/([^/]+)\/files\/(.*)$/);
+    if (user) {
+      return `${SCOPED_PREFIX_USER}${user[1]}/${user[2]}`;
+    }
+
     return null;
   }
 
@@ -132,6 +146,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
       case "pod":
         return `w/${this.workspaceId}/pods/${mount.id}/files`;
+
+      case "user":
+        return `w/${this.workspaceId}/users/${mount.id}/files`;
 
       default:
         assertNever(mount.kind);
@@ -611,15 +628,20 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): SandboxMountAdapter {
     const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
     const targets: GCSMountTarget[] = [
-      ...mounts.map(
-        (mount): GCSMountTarget => ({
-          gcsPrefix: this.mountRootGCSPrefix(mount),
-          sandboxMountPoint: mount.sandboxMountPoint,
-          legacySandboxMountPoint: mount.legacySandboxMountPoint,
-          readOnly: false,
-          mountProfile: "workload",
-        })
-      ),
+      ...mounts
+        .filter(
+          (mount): mount is FileSystemMount & { sandboxMountPoint: string } =>
+            mount.sandboxMountPoint !== null
+        )
+        .map(
+          (mount): GCSMountTarget => ({
+            gcsPrefix: this.mountRootGCSPrefix(mount),
+            sandboxMountPoint: mount.sandboxMountPoint,
+            legacySandboxMountPoint: mount.legacySandboxMountPoint,
+            readOnly: false,
+            mountProfile: "workload",
+          })
+        ),
       ...sandboxOnlyMounts.map(
         (mount): GCSMountTarget => ({
           gcsPrefix: this.sandboxOnlyMountGCSPrefix(mount),

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -207,6 +207,60 @@ describe("DustFileSystem.forPod", () => {
 });
 
 // ---------------------------------------------------------------------------
+// forUser
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forUser", () => {
+  it("returns Ok with a read-write user mount for the authenticated user", async () => {
+    const { authenticator: auth, user } = await createResourceTest({});
+
+    const result = await DustFileSystem.forUser(auth);
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].kind).toBe("user");
+    expect(mounts[0].id).toBe(user.sId);
+    expect(mounts[0].scopedPrefix).toBe(`user-${user.sId}`);
+    expect(mounts[0].sandboxMountPoint).toBeNull();
+    expect(mounts[0].legacyPrefix).toBeNull();
+    expect(mounts[0].legacySandboxMountPoint).toBeNull();
+    expect(mounts[0].permissions.canRead).toBe(true);
+    expect(mounts[0].permissions.canWrite).toBe(true);
+  });
+
+  it("returns Err(unauthorized) when there is no authenticated user", async () => {
+    const { workspace } = await createResourceTest({});
+    const noUserAuth = await Authenticator.internalBuilderForWorkspace(
+      workspace.sId
+    );
+    expect(noUserAuth.user()).toBeNull();
+
+    const result = await DustFileSystem.forUser(noUserAuth);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+
+  it("toSandboxPath rejects the user scope (never sandbox-mounted)", async () => {
+    const { authenticator: auth, user } = await createResourceTest({});
+    const result = await DustFileSystem.forUser(auth);
+    assert(result.isOk());
+
+    const sandboxPath = result.value.toSandboxPath(
+      `user-${user.sId}/memory.md`
+    );
+
+    expect(sandboxPath.isErr()).toBe(true);
+    if (sandboxPath.isErr()) {
+      expect(sandboxPath.error.code).toBe("invalid_path");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // fromScopedPath
 // ---------------------------------------------------------------------------
 
@@ -280,6 +334,46 @@ describe("DustFileSystem.fromScopedPath", () => {
       mounts.some((m) => m.kind === "conversation" && m.id === conversation.sId)
     ).toBe(true);
   });
+
+  it("returns Ok with a user-scoped fs for the authenticated user's user- prefix", async () => {
+    const { authenticator: auth, user } = await createResourceTest({});
+
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      `user-${user.sId}/memory.md`
+    );
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts.some((m) => m.kind === "user" && m.id === user.sId)).toBe(
+      true
+    );
+  });
+
+  it("returns Err(unauthorized) for another user's user- prefix", async () => {
+    const { authenticator: auth, user } = await createResourceTest({});
+
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      `user-${user.sId}-other/memory.md`
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+
+  it("returns Err(invalid_path) for a user- prefix with an empty id", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const result = await DustFileSystem.fromScopedPath(auth, "user-/memory.md");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -320,6 +414,25 @@ describe("DustFileSystem.forAgentLoop", () => {
     expect(forAgentLoop.value.getMounts()).toEqual(
       forConversation.value.getMounts()
     );
+  });
+
+  it("throws when scopedPaths references a user-scoped path", async () => {
+    const { authenticator: auth, user } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    await expect(
+      DustFileSystem.forAgentLoop(auth, {
+        conversation,
+        scopedPaths: [`user-${user.sId}/memory.md`],
+      })
+    ).rejects.toThrow(/User-scoped paths are not supported/);
   });
 
   it("adds a second conversation mount when scopedPaths references another accessible conversation", async () => {

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -1,13 +1,15 @@
 /**
  * DustFileSystem is the single entry point for all file system operations in the Dust platform.
  *
- * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf` or
- * `pod-{pId}/data.csv`. Every public method accepts and returns scoped paths.
- * Legacy paths (`conversation/...`, `project/...`) are accepted for backward compat.
+ * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`,
+ * `pod-{pId}/data.csv`, or `user-{uId}/memory.md`. Every public method accepts and returns
+ * scoped paths. Legacy paths (`conversation/...`, `project/...`) are accepted for backward compat.
  *
  * Factories:
  *   DustFileSystem.forConversation(auth, conversation)   single conversation mount (+pod if project space)
  *   DustFileSystem.forConversations(auth, conversations) multiple conversation mounts (+pod if project space)
+ *   DustFileSystem.forPod(auth, space)                   single pod mount
+ *   DustFileSystem.forUser(auth)                         the authenticated user's own memory scope
  *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
  *   DustFileSystem.forAgentLoop(auth, { conversation, scopedPaths })
  *       defaults to the agent loop conversation (+ its pod when applicable), plus any
@@ -27,6 +29,7 @@ import {
   LEGACY_PREFIX_PROJECT,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
+  SCOPED_PREFIX_USER,
 } from "@app/lib/api/file_system/types";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
@@ -45,6 +48,7 @@ import { isPodConversation } from "@app/types/assistant/conversation";
 import { isSupportedImageContentType } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
 import * as path from "path";
 import type { Readable } from "stream";
 
@@ -69,7 +73,8 @@ export function sanitizeFileSystemName(name: string): string {
 
 type ParsedScopedPrefix =
   | { kind: "conversation"; id: string }
-  | { kind: "pod"; id: string };
+  | { kind: "pod"; id: string }
+  | { kind: "user"; id: string };
 
 export function parseScopedPrefix(
   scopedPath: string
@@ -88,6 +93,12 @@ export function parseScopedPrefix(
     const id = prefix.slice(SCOPED_PREFIX_POD.length);
 
     return id ? { kind: "pod", id } : null;
+  }
+
+  if (prefix.startsWith(SCOPED_PREFIX_USER)) {
+    const id = prefix.slice(SCOPED_PREFIX_USER.length);
+
+    return id ? { kind: "user", id } : null;
   }
 
   return null;
@@ -130,12 +141,29 @@ function createPodMount(
   };
 }
 
+function createUserMount(userId: string): FileSystemMount {
+  return {
+    kind: "user",
+    id: userId,
+    scopedPrefix: `${SCOPED_PREFIX_USER}${userId}`,
+    sandboxMountPoint: null,
+    legacyPrefix: null,
+    legacySandboxMountPoint: null,
+    permissions: {
+      canRead: true,
+      canWrite: true,
+    },
+  };
+}
+
 function collectScopedPrefixesFromPaths(scopedPaths: string[]): {
   conversationIds: Set<string>;
   podIds: Set<string>;
+  userIds: Set<string>;
 } {
   const conversationIds = new Set<string>();
   const podIds = new Set<string>();
+  const userIds = new Set<string>();
 
   for (const scopedPath of scopedPaths) {
     const parsed = parseScopedPrefix(scopedPath);
@@ -151,12 +179,16 @@ function collectScopedPrefixesFromPaths(scopedPaths: string[]): {
         podIds.add(parsed.id);
         break;
 
+      case "user":
+        userIds.add(parsed.id);
+        break;
+
       default:
         assertNever(parsed);
     }
   }
 
-  return { conversationIds, podIds };
+  return { conversationIds, podIds, userIds };
 }
 
 function hasMount(mounts: FileSystemMount[], scopedPrefix: string): boolean {
@@ -293,12 +325,46 @@ export class DustFileSystem {
   }
 
   /**
+   * Build a DustFileSystem scoped to the authenticated user's own memory space.
+   *
+   * The scope is always `auth.user()` and cannot be overridden, so an agent can never
+   * read or write another user's files. Returns `Err("unauthorized")` when there is no
+   * authenticated user.
+   */
+  static async forUser(
+    auth: Authenticator
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const user = auth.user();
+    if (!user) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          "No authenticated user for the user file system."
+        )
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const backend = new GCSFileSystemBackend(
+      owner.sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+
+    return new Ok(
+      new DustFileSystem(auth, [createUserMount(user.sId)], backend)
+    );
+  }
+
+  /**
    * Build a DustFileSystem for an agent loop.
    *
    * Always includes the agent loop conversation mount and, when applicable, its Pod mount
    * (same as {@link forConversation}). Additionally mounts any conversation or Pod referenced
    * in `scopedPaths` that the caller can access, so cross-scope operations (e.g. copy between
    * two conversations) can resolve both endpoints in a single filesystem instance.
+   *
+   * User-scoped paths are not supported here and trigger an assert, user filesystem is only
+   * reachable through forUser.
    */
   static async forAgentLoop(
     auth: Authenticator,
@@ -310,8 +376,13 @@ export class DustFileSystem {
       scopedPaths?: string[];
     }
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
-    const { conversationIds, podIds } =
+    const { conversationIds, podIds, userIds } =
       collectScopedPrefixesFromPaths(scopedPaths);
+
+    assert(
+      userIds.size === 0,
+      `User-scoped paths are not supported in the agent loop, access user files through DustFileSystem.forUser`
+    );
 
     const additionalConversationIds = [...conversationIds].filter(
       (conversationId) => conversationId !== conversation.sId
@@ -443,6 +514,19 @@ export class DustFileSystem {
         }
 
         return DustFileSystem.forPod(auth, space);
+      }
+
+      case "user": {
+        const user = auth.user();
+        if (!user || user.sId !== parsed.id) {
+          return new Err(
+            new DustFileSystemError(
+              "unauthorized",
+              "You do not have access to this user's file system."
+            )
+          );
+        }
+        return DustFileSystem.forUser(auth);
       }
 
       default:
@@ -981,6 +1065,14 @@ export class DustFileSystem {
     }
 
     const { mount, path: normalized } = resolved.value;
+    if (mount.sandboxMountPoint === null) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Scope is not available in the sandbox: ${scopedPath}`
+        )
+      );
+    }
     if (normalized === mount.scopedPrefix) {
       return new Err(
         new DustFileSystemError(

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -1,18 +1,20 @@
 /**
  * Shared types for the DustFileSystem abstraction.
  *
- * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`
- * or `pod-{pId}/data.csv`. Every public interface accepts and returns scoped paths.
+ * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`,
+ * `pod-{pId}/data.csv`, or `user-{uId}/memory.md`. Every public interface accepts and
+ * returns scoped paths.
  *
- * FileSystemMount: one logical namespace (conversation or pod) with its scoped prefix,
- * sandbox mount point, backward-compat aliases, and per-mount permissions.
+ * FileSystemMount: one logical namespace (conversation, pod, or user) with its scoped
+ * prefix, sandbox mount point, backward-compat aliases, and per-mount permissions.
  */
 
-export type FileSystemMountKind = "conversation" | "pod";
+export type FileSystemMountKind = "conversation" | "pod" | "user";
 
 /** Canonical scoped-path prefixes (include the trailing dash). */
 export const SCOPED_PREFIX_CONVERSATION = "conversation-" as const;
 export const SCOPED_PREFIX_POD = "pod-" as const;
+export const SCOPED_PREFIX_USER = "user-" as const;
 
 /** Legacy agent-visible path prefixes (no trailing dash/slash). */
 export const LEGACY_PREFIX_CONVERSATION = "conversation" as const;
@@ -27,8 +29,11 @@ export type FileSystemMount = {
   /** Prefix of every scoped path in this mount, e.g. `conversation-{cId}` or `pod-{pId}`. */
   scopedPrefix: string;
 
-  /** Absolute sandbox path, e.g. `/files/conversation-{cId}`. */
-  sandboxMountPoint: string;
+  /**
+   * Absolute sandbox path, e.g. `/files/conversation-{cId}`. Null for scopes that are
+   * never mounted into a sandbox (e.g. the user scope).
+   */
+  sandboxMountPoint: string | null;
 
   /**
    * Legacy scoped prefix (`"conversation"` or `"project"`) accepted for backward compat.


### PR DESCRIPTION
## Description

Add a new filesystem scope, `user-<userId>`to `DustFileSystem` 
GCS backed with one scope per (workspace, user) and accessible only by the authenticated user
Groundwork for User memory project, the scope will later hold a per user `memory.md` file.

## Tests

Added tests for the `forUser`factory and `fromScopedPath` routing 

## Risk

Low

## Deploy Plan

Deploy front
