### PR TITLE
[Agent Loop] Retry empty model responses

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -254,7 +254,9 @@ export async function getOutputFromLLMStream(
     prompt,
     llm,
     updateResourceAndPublishEvent,
-  }: GetOutputRequestParams & { llm: LLM }
+  }: GetOutputRequestParams & {
+    llm: Pick<LLM, "getResponseFormat" | "getTraceId" | "stream">;
+  }
 ): Promise<GetOutputResponse> {
   const start = Date.now();
   let timeToFirstEvent: number | undefined = undefined;
@@ -595,6 +597,17 @@ export async function getOutputFromLLMStream(
         "Structured output JSON parsing failed: response from LLM may be invalid."
       );
     }
+  }
+
+  if (contents.length === 0 && actions.length === 0) {
+    return new Err({
+      type: "shouldRetryMessage",
+      content: {
+        type: "unknown_error",
+        message: "The model returned an empty response.",
+        isRetryable: true,
+      },
+    });
   }
 
   return new Ok({

--- a/front/temporal/agent_loop/lib/get_output_from_llm_empty.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm_empty.test.ts
@@ -4,11 +4,11 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { Ok } from "@app/types/shared/result";
 import { assert, describe, expect, it, vi } from "vitest";
 
@@ -35,13 +35,11 @@ describe("getOutputFromLLMStream", () => {
     assert(userMessage?.type === "user_message");
     assert(agentMessage?.type === "agent_message");
     const { model: agentModel, ...agentConfiguration } = agent;
-    const modelConfig = getSupportedModelConfig(agentModel);
-    assert(modelConfig);
-    const model = { ...agentModel, ...modelConfig };
+    const endpoint = getTestStreamEndpoint(agentModel.modelId);
     const contentParser = new AgentMessageContentParser(
       agentConfiguration,
       agentMessage.sId,
-      getDelimitersConfiguration({ model })
+      getDelimitersConfiguration({ endpoint, ...agentModel })
     );
     const metadata = {
       clientId: "google_ai_studio",
@@ -78,7 +76,7 @@ describe("getOutputFromLLMStream", () => {
       step: 1,
       agentConfiguration,
       agentMessage,
-      model,
+      model: endpoint.modelConfig,
       activityTimeoutDeadlineMs: Date.now() + 10_000,
       publishAgentError: vi.fn(async () => {}),
       prompt: [],

--- a/front/temporal/agent_loop/lib/get_output_from_llm_empty.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm_empty.test.ts
@@ -1,0 +1,100 @@
+import type { LLM } from "@app/lib/api/llm/llm";
+import { createLLMTraceId } from "@app/lib/api/llm/traces/buffer";
+import {
+  AgentMessageContentParser,
+  getDelimitersConfiguration,
+} from "@app/lib/llms/agent_message_content_parser";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { assert, describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  CancelledFailure: class CancelledFailure extends Error {},
+  heartbeat: vi.fn(),
+  sleep: vi.fn(),
+}));
+
+describe("getOutputFromLLMStream", () => {
+  it("retries a successful stream with no content or actions", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      model: {
+        providerId: "google_ai_studio",
+        modelId: "gemini-3.5-flash",
+      },
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const [[userMessage], [agentMessage]] = conversation.content;
+    assert(userMessage?.type === "user_message");
+    assert(agentMessage?.type === "agent_message");
+    const { model: agentModel, ...agentConfiguration } = agent;
+    const modelConfig = getSupportedModelConfig(agentModel);
+    assert(modelConfig);
+    const model = { ...agentModel, ...modelConfig };
+    const contentParser = new AgentMessageContentParser(
+      agentConfiguration,
+      agentMessage.sId,
+      getDelimitersConfiguration({ model })
+    );
+    const metadata = {
+      clientId: "google_ai_studio",
+      inferenceProvider: "agent-platform",
+      inferenceRegion: "global",
+      modelId: "gemini-3.5-flash",
+    } as const;
+    const llm = {
+      async *stream() {
+        yield {
+          type: "success",
+          aggregated: [],
+          metadata,
+        } as const;
+      },
+      getResponseFormat: () => null,
+      getTraceId: () => createLLMTraceId("test"),
+    } satisfies Pick<LLM, "getResponseFormat" | "getTraceId" | "stream">;
+    const flushParserTokens = vi.fn(async () => {});
+
+    const result = await getOutputFromLLMStream(auth, {
+      modelConversationRes: new Ok({
+        modelConversation: { messages: [] },
+        tokensUsed: 0,
+      }),
+      conversation,
+      toolSearchEnabled: false,
+      disableToolUse: false,
+      cacheDiagnosticsEnabled: false,
+      userMessage,
+      specifications: [],
+      flushParserTokens,
+      contentParser,
+      step: 1,
+      agentConfiguration,
+      agentMessage,
+      model,
+      activityTimeoutDeadlineMs: Date.now() + 10_000,
+      publishAgentError: vi.fn(async () => {}),
+      prompt: [],
+      llm,
+      updateResourceAndPublishEvent: vi.fn(async () => {}),
+    });
+
+    assert(result.isErr());
+    expect(result.error).toEqual({
+      type: "shouldRetryMessage",
+      content: {
+        type: "unknown_error",
+        message: "The model returned an empty response.",
+        isRetryable: true,
+      },
+    });
+    expect(flushParserTokens).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9783

The model provider can end a stream successfully while returning neither content nor a tool call. Since https://github.com/dust-tt/dust/pull/24842 removed the empty-response retry guard, the agent loop accepted that unusable response and finalized the message as succeeded.

Restore the guard so a literally empty response is retried through the existing model retry path. If all retries fail, the run now surfaces an error instead of silently succeeding.

## Risks

Blast radius: Agent model steps that return zero content items and zero tool calls.
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] `NODE_ENV=test npm test -- temporal/agent_loop/lib/get_output_from_llm.test.ts temporal/agent_loop/lib/get_output_from_llm_empty.test.ts`