### PR TITLE
feat: move SSO and domain auto join settings to dedicated endpoints

### DIFF
--- a/front-api/routes/w/[wId]/domains.test.ts
+++ b/front-api/routes/w/[wId]/domains.test.ts
@@ -1,0 +1,131 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/workos/organization_primitives", async () => {
+  const actual = await vi.importActual(
+    "@app/lib/api/workos/organization_primitives"
+  );
+  return {
+    ...actual,
+    listWorkOSOrganizationsWithDomain: vi.fn().mockResolvedValue([]),
+  };
+});
+
+async function setup(role: MembershipRoleType = "admin") {
+  return createPrivateApiMockRequest({ method: "POST", role });
+}
+
+function post(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/domains`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedDomain(workspaceSId: string, domain: string) {
+  const resource = await WorkspaceResource.fetchById(workspaceSId);
+  const res = await resource?.upsertWorkspaceDomain({ domain });
+  expect(res?.isOk()).toBe(true);
+}
+
+async function verifiedDomains(workspaceSId: string) {
+  const resource = await WorkspaceResource.fetchById(workspaceSId);
+  return resource?.getVerifiedDomains() ?? [];
+}
+
+describe("POST /api/w/:wId/domains (auto-join)", () => {
+  it("updates auto-join for a single named domain", async () => {
+    const { workspace } = await setup();
+    await seedDomain(workspace.sId, "acme.com");
+
+    const response = await post(workspace, {
+      domain: "acme.com",
+      domainAutoJoinEnabled: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).workspace.sId).toBe(workspace.sId);
+
+    const domains = await verifiedDomains(workspace.sId);
+    expect(domains).toEqual([
+      { domain: "acme.com", domainAutoJoinEnabled: true },
+    ]);
+  });
+
+  it("updates auto-join across all domains when no domain is provided", async () => {
+    const { workspace } = await setup();
+    await seedDomain(workspace.sId, "acme.com");
+    await seedDomain(workspace.sId, "acme.io");
+
+    const response = await post(workspace, { domainAutoJoinEnabled: true });
+
+    expect(response.status).toBe(200);
+
+    const domains = await verifiedDomains(workspace.sId);
+    expect(domains).toHaveLength(2);
+    expect(domains.every((d) => d.domainAutoJoinEnabled)).toBe(true);
+  });
+
+  it("applies per-domain updates in batch mode", async () => {
+    const { workspace } = await setup();
+    await seedDomain(workspace.sId, "acme.com");
+    await seedDomain(workspace.sId, "acme.io");
+
+    const response = await post(workspace, {
+      domainUpdates: [
+        { domain: "acme.com", domainAutoJoinEnabled: true },
+        { domain: "acme.io", domainAutoJoinEnabled: false },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+
+    const domains = await verifiedDomains(workspace.sId);
+    expect(
+      domains.find((d) => d.domain === "acme.com")?.domainAutoJoinEnabled
+    ).toBe(true);
+    expect(
+      domains.find((d) => d.domain === "acme.io")?.domainAutoJoinEnabled
+    ).toBe(false);
+  });
+
+  it("lets a member with the admin:security permission update auto-join", async () => {
+    const { workspace, user } = await setup("user");
+    await seedDomain(workspace.sId, "acme.com");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    const response = await post(workspace, {
+      domain: "acme.com",
+      domainAutoJoinEnabled: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const domains = await verifiedDomains(workspace.sId);
+    expect(domains[0]?.domainAutoJoinEnabled).toBe(true);
+  });
+
+  it("returns 403 for a member without the admin:security permission", async () => {
+    const { workspace } = await setup("user");
+
+    const response = await post(workspace, { domainAutoJoinEnabled: true });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "You do not have permission to manage identity and provisioning settings.",
+      },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/domains.ts
+++ b/front-api/routes/w/[wId]/domains.ts
@@ -8,6 +8,8 @@ import {
   getOrCreateWorkOSOrganization,
 } from "@app/lib/api/workos/organization";
 import { removeWorkOSOrganizationDomain } from "@app/lib/api/workos/organization_primitives";
+import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import logger from "@app/logger/logger";
 import type { GetWorkspaceDomainsResponseBody } from "@app/types/api/workos/organization";
@@ -19,6 +21,25 @@ import { z } from "zod";
 const DeleteWorkspaceDomainRequestBodySchema = z.object({
   domain: z.string(),
 });
+
+const DomainAutoJoinBatchBodySchema = z.object({
+  domainUpdates: z.array(
+    z.object({
+      domain: z.string(),
+      domainAutoJoinEnabled: z.boolean(),
+    })
+  ),
+});
+
+const DomainAutoJoinSingleBodySchema = z.object({
+  domain: z.string().optional(),
+  domainAutoJoinEnabled: z.boolean(),
+});
+
+const PostDomainAutoJoinBodySchema = z.union([
+  DomainAutoJoinBatchBodySchema,
+  DomainAutoJoinSingleBodySchema,
+]);
 
 const SECURITY_PERMISSION_ERROR_MESSAGE =
   "You do not have permission to manage identity and provisioning settings.";
@@ -127,6 +148,98 @@ app.delete(
     });
 
     return ctx.body(null, 204);
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", PostDomainAutoJoinBodySchema),
+  async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: SECURITY_PERMISSION_ERROR_MESSAGE,
+        },
+      });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const body = ctx.req.valid("json");
+
+    const workspace = await WorkspaceResource.fetchByModelId(owner.id);
+    if (!workspace) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace you're trying to modify was not found.",
+        },
+      });
+    }
+
+    if ("domainUpdates" in body) {
+      for (const update of body.domainUpdates) {
+        const updateResult = await workspace.updateDomainAutoJoinEnabled({
+          domainAutoJoinEnabled: update.domainAutoJoinEnabled,
+          domain: update.domain,
+        });
+        if (updateResult.isErr()) {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateResult.error.message,
+            },
+          });
+        }
+
+        void emitAuditLogEvent({
+          auth,
+          action: "workspace.domain_auto_join_updated",
+          targets: [buildAuditLogTarget("workspace", owner)],
+          context: getAuditLogContext(auth),
+          metadata: {
+            domain: update.domain,
+            enabled: String(update.domainAutoJoinEnabled),
+          },
+        });
+      }
+
+      return ctx.json({ workspace: owner });
+    }
+
+    const { domain, domainAutoJoinEnabled } = body;
+    const updateResult = await workspace.updateDomainAutoJoinEnabled({
+      domainAutoJoinEnabled,
+      domain,
+    });
+    if (updateResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: updateResult.error.message,
+        },
+      });
+    }
+
+    void emitAuditLogEvent({
+      auth,
+      action: "workspace.domain_auto_join_updated",
+      targets: [buildAuditLogTarget("workspace", owner)],
+      context: getAuditLogContext(auth),
+      metadata: {
+        domain: domain ?? "*",
+        enabled: String(domainAutoJoinEnabled),
+      },
+    });
+
+    return ctx.json({ workspace: owner });
   }
 );
 

--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -2,7 +2,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
@@ -236,83 +235,5 @@ describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).error.type).toBe("workspace_auth_error");
     }
-  });
-});
-
-describe("POST /api/w/:wId (identity settings permission)", () => {
-  it("lets a member with the admin:security permission enforce SSO", async () => {
-    const { workspace, user } = await setup("user");
-
-    await grantWorkspacePermission(workspace, user, {
-      grantType: "admin",
-      resourceType: "security",
-    });
-
-    const response = await post(workspace, { ssoEnforced: true });
-
-    expect(response.status).toBe(200);
-
-    const updated = await WorkspaceResource.fetchById(workspace.sId);
-    expect(updated?.ssoEnforced).toBe(true);
-  });
-
-  it("returns 403 for a member without the admin:security permission", async () => {
-    const { workspace } = await setup("user");
-
-    const response = await post(workspace, { ssoEnforced: true });
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message:
-          "You do not have permission to manage identity and provisioning settings.",
-      },
-    });
-  });
-
-  it("still blocks non-security settings for a member with only the admin:security permission", async () => {
-    const { workspace, user } = await setup("user");
-
-    await grantWorkspacePermission(workspace, user, {
-      grantType: "admin",
-      resourceType: "security",
-    });
-
-    const response = await post(workspace, {
-      reinforcementCapAwuCredits: 5_000,
-    });
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
-      },
-    });
-  });
-
-  it("does not let an admin:security holder escalate to an admin-only setting via a mixed body", async () => {
-    const { workspace, user } = await setup("user");
-
-    await grantWorkspacePermission(workspace, user, {
-      grantType: "admin",
-      resourceType: "security",
-    });
-
-    // Craft a body mixing an identity setting (`ssoEnforced`) with an admin-only
-    // setting (`regionalModelsOnly`). The zod union strips the request down to a
-    // single member, so the admin-only field never reaches the handler and cannot
-    // be applied by a non-admin.
-    const response = await post(workspace, {
-      ssoEnforced: true,
-      regionalModelsOnly: true,
-    });
-
-    expect(response.status).toBe(200);
-
-    const updated = await WorkspaceResource.fetchById(workspace.sId);
-    expect(updated?.ssoEnforced).toBe(true);
-    expect(updated?.regionalModelsOnly).toBe(false);
   });
 });

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -21,10 +21,7 @@ import { EmbeddingProviderSchema } from "@app/types/assistant/models/embedding";
 import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import {
-  ENSURE_IS_ADMIN_ERROR_MESSAGE,
-  ensureIsAdmin,
-} from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
@@ -98,26 +95,8 @@ const WorkspaceNameUpdateBodySchema = z.object({
   name: z.string(),
 });
 
-const WorkspaceSsoEnforceUpdateBodySchema = z.object({
-  ssoEnforced: z.boolean(),
-});
-
 const WorkspaceRegionalModelsOnlyUpdateBodySchema = z.object({
   regionalModelsOnly: z.boolean(),
-});
-
-const WorkspaceAllowedDomainUpdateBodySchema = z.object({
-  domain: z.string().optional(),
-  domainAutoJoinEnabled: z.boolean(),
-});
-
-const WorkspaceBatchDomainUpdateBodySchema = z.object({
-  domainUpdates: z.array(
-    z.object({
-      domain: z.string(),
-      domainAutoJoinEnabled: z.boolean(),
-    })
-  ),
 });
 
 const WorkspaceProvidersUpdateBodySchema = z.object({
@@ -225,10 +204,7 @@ const WorkspaceDefaultAgentUpdateBodySchema = z.object({
 });
 
 const PostWorkspaceRequestBodySchema = z.union([
-  WorkspaceAllowedDomainUpdateBodySchema,
-  WorkspaceBatchDomainUpdateBodySchema,
   WorkspaceNameUpdateBodySchema,
-  WorkspaceSsoEnforceUpdateBodySchema,
   WorkspaceRegionalModelsOnlyUpdateBodySchema,
   WorkspaceProvidersUpdateBodySchema,
   WorkspaceWorkOSUpdateBodySchema,
@@ -347,37 +323,13 @@ app.get(
 
 app.post(
   "/",
+  ensureIsAdmin(),
   validate("json", PostWorkspaceRequestBodySchema),
   async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
     const body = ctx.req.valid("json");
-
-    // Domain auto-join and SSO enforcement live on the IT & Security page, so holders of
-    // the `admin:security` permission may change them. Every other workspace setting remains
-    // admin-only. `body` is the zod-parsed output: the union strips it down to a single member's
-    // keys, so this classification matches exactly the branch the handler below will execute.
-    const isIdentitySetting =
-      "domainAutoJoinEnabled" in body ||
-      "domainUpdates" in body ||
-      "ssoEnforced" in body;
-
-    const isAuthorized = isIdentitySetting
-      ? await auth.hasWorkspacePermission("admin", "security")
-      : auth.isAdmin();
-
-    if (!isAuthorized) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: isIdentitySetting
-            ? "You do not have permission to manage identity and provisioning settings."
-            : ENSURE_IS_ADMIN_ERROR_MESSAGE,
-        },
-      });
-    }
 
     const workspace = await WorkspaceResource.fetchByModelId(owner.id);
     if (!workspace) {
@@ -413,22 +365,6 @@ app.post(
         metadata: {
           previous_name: previousName,
           new_name: newName,
-        },
-      });
-    } else if ("ssoEnforced" in body) {
-      await workspace.updateWorkspaceSettings({
-        ssoEnforced: body.ssoEnforced,
-      });
-
-      owner.ssoEnforced = body.ssoEnforced;
-
-      void emitAuditLogEvent({
-        auth,
-        action: "workspace.sso_enforcement_updated",
-        targets: [buildAuditLogTarget("workspace", owner)],
-        context: getAuditLogContext(auth),
-        metadata: {
-          enabled: String(body.ssoEnforced),
         },
       });
     } else if ("regionalModelsOnly" in body) {
@@ -1006,59 +942,6 @@ app.post(
         context: getAuditLogContext(auth),
         metadata: {
           enabled: String(body.slackPersonalAllowFooterRemoval),
-        },
-      });
-    } else if ("domainUpdates" in body) {
-      for (const update of body.domainUpdates) {
-        const updateResult = await workspace.updateDomainAutoJoinEnabled({
-          domainAutoJoinEnabled: update.domainAutoJoinEnabled,
-          domain: update.domain,
-        });
-        if (updateResult.isErr()) {
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: updateResult.error.message,
-            },
-          });
-        }
-
-        void emitAuditLogEvent({
-          auth,
-          action: "workspace.domain_auto_join_updated",
-          targets: [buildAuditLogTarget("workspace", owner)],
-          context: getAuditLogContext(auth),
-          metadata: {
-            domain: update.domain,
-            enabled: String(update.domainAutoJoinEnabled),
-          },
-        });
-      }
-    } else {
-      const { domain, domainAutoJoinEnabled } = body;
-      const updateResult = await workspace.updateDomainAutoJoinEnabled({
-        domainAutoJoinEnabled,
-        domain,
-      });
-      if (updateResult.isErr()) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: updateResult.error.message,
-          },
-        });
-      }
-
-      void emitAuditLogEvent({
-        auth,
-        action: "workspace.domain_auto_join_updated",
-        targets: [buildAuditLogTarget("workspace", owner)],
-        context: getAuditLogContext(auth),
-        metadata: {
-          domain: domain ?? "*",
-          enabled: String(domainAutoJoinEnabled),
         },
       });
     }

--- a/front-api/routes/w/[wId]/sso.test.ts
+++ b/front-api/routes/w/[wId]/sso.test.ts
@@ -1,0 +1,66 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setup(role: MembershipRoleType = "admin") {
+  return createPrivateApiMockRequest({ method: "POST", role });
+}
+
+function enforceSso(workspace: { sId: string }, ssoEnforced: boolean) {
+  return honoApp.request(`/api/w/${workspace.sId}/sso`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ssoEnforced }),
+  });
+}
+
+describe("POST /api/w/:wId/sso", () => {
+  it("lets an admin enforce SSO", async () => {
+    const { workspace } = await setup();
+
+    const response = await enforceSso(workspace, true);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).workspace.ssoEnforced).toBe(true);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.ssoEnforced).toBe(true);
+  });
+
+  it("lets a member with the admin:security permission enforce SSO", async () => {
+    const { workspace, user } = await setup("user");
+
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "admin",
+      resourceType: "security",
+    });
+
+    const response = await enforceSso(workspace, true);
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.ssoEnforced).toBe(true);
+  });
+
+  it("returns 403 for a member without the admin:security permission", async () => {
+    const { workspace } = await setup("user");
+
+    const response = await enforceSso(workspace, true);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "You do not have permission to manage identity and provisioning settings.",
+      },
+    });
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.ssoEnforced).toBe(false);
+  });
+});

--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -8,13 +8,24 @@ import {
   generateWorkOSAdminPortalUrl,
   getWorkOSOrganizationSSOConnections,
 } from "@app/lib/api/workos/organization";
+import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
+import { z } from "zod";
+
+const SECURITY_PERMISSION_ERROR_MESSAGE =
+  "You do not have permission to manage identity and provisioning settings.";
+
+const PostSsoEnforcementBodySchema = z.object({
+  ssoEnforced: z.boolean(),
+});
 
 // Mounted at /api/w/:wId/sso.
 const app = workspaceApp();
@@ -27,8 +38,7 @@ async function checkAccess(ctx: Context) {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message:
-          "You do not have permission to manage identity and provisioning settings.",
+        message: SECURITY_PERMISSION_ERROR_MESSAGE,
       },
     });
   }
@@ -148,5 +158,57 @@ app.delete("/", async (ctx) => {
 
   return ctx.body(null, 204);
 });
+
+// SSO enforcement is a workspace-level flag gated behind `admin:security`. Unlike the handlers
+// above, it does not require a configured WorkOS org / active connection (a workspace can toggle
+// enforcement independently), so it only checks the permission rather than `checkAccess`.
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", PostSsoEnforcementBodySchema),
+  async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: SECURITY_PERMISSION_ERROR_MESSAGE,
+        },
+      });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const { ssoEnforced } = ctx.req.valid("json");
+
+    const workspace = await WorkspaceResource.fetchByModelId(owner.id);
+    if (!workspace) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace you're trying to modify was not found.",
+        },
+      });
+    }
+
+    await workspace.updateWorkspaceSettings({ ssoEnforced });
+
+    void emitAuditLogEvent({
+      auth,
+      action: "workspace.sso_enforcement_updated",
+      targets: [buildAuditLogTarget("workspace", owner)],
+      context: getAuditLogContext(auth),
+      metadata: {
+        enabled: String(ssoEnforced),
+      },
+    });
+
+    return ctx.json({
+      workspace: { ...owner, ssoEnforced: workspace.ssoEnforced },
+    });
+  }
+);
 
 export default app;

--- a/front/components/workspace/sso/AutoJoinToggle.tsx
+++ b/front/components/workspace/sso/AutoJoinToggle.tsx
@@ -54,7 +54,7 @@ function DomainAutoJoinModal({
   );
 
   async function handleUpdateWorkspace(): Promise<void> {
-    const res = await clientFetch(`/api/w/${owner.sId}`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/domains`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/components/workspace/sso/MultiDomainAutoJoinModal.tsx
+++ b/front/components/workspace/sso/MultiDomainAutoJoinModal.tsx
@@ -79,7 +79,7 @@ export function MultiDomainAutoJoinModal({
 
     setIsSubmitting(true);
     try {
-      const res = await clientFetch(`/api/w/${owner.sId}`, {
+      const res = await clientFetch(`/api/w/${owner.sId}/domains`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/components/workspace/sso/Toggle.tsx
+++ b/front/components/workspace/sso/Toggle.tsx
@@ -41,7 +41,7 @@ export function ToggleEnforceEnterpriseConnectionModal({
 
   const handleToggleSsoEnforced = React.useCallback(
     async (ssoEnforced: boolean) => {
-      const res = await clientFetch(`/api/w/${owner.sId}`, {
+      const res = await clientFetch(`/api/w/${owner.sId}/sso`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Description

This PR moves SSO enforcement and domain auto-join settings out of the generic workspace `POST /api/w/:wId` endpoint into dedicated, purpose-scoped endpoints. With this change the `POST /api/w/:wId` can go back to being an admin only endpoint. The new endpoints are restricted to users with admin security permission.

## Tests

Added tests.

## Risks

Low.

## Deploy Plan

Standard deployment.