### PR TITLE
[front] perf: batch agent tag updates

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -17,7 +17,7 @@ function batchUpdateTags(workspace: { sId: string }, body: unknown) {
 }
 
 describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", () => {
-  it("adds and removes tags for multiple agents", async () => {
+  it("adds and removes tags while ignoring duplicate additions", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -32,6 +32,7 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
     const tagToRemove = await TagFactory.create(workspace, {
       name: "to-remove",
     });
+    await tagToAdd.addToAgent(auth, firstAgent);
     await tagToRemove.addToAgent(auth, firstAgent);
     await tagToRemove.addToAgent(auth, secondAgent);
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -1,0 +1,57 @@
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { TagFactory } from "@app/tests/utils/TagFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function batchUpdateTags(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/batch_update_tags`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", () => {
+  it("adds and removes tags for multiple agents", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const firstAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "First agent",
+    });
+    const secondAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Second agent",
+    });
+    const tagToAdd = await TagFactory.create(workspace, { name: "to-add" });
+    const tagToRemove = await TagFactory.create(workspace, {
+      name: "to-remove",
+    });
+    await tagToRemove.addToAgent(auth, firstAgent);
+    await tagToRemove.addToAgent(auth, secondAgent);
+
+    const response = await batchUpdateTags(workspace, {
+      agentIds: [firstAgent.sId, secondAgent.sId],
+      addTagIds: [tagToAdd.sId],
+      removeTagIds: [tagToRemove.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const tagsByAgent = await TagResource.listForAgents(auth, [
+      firstAgent.id,
+      secondAgent.id,
+    ]);
+    for (const agent of [firstAgent, secondAgent]) {
+      expect(tagsByAgent[agent.id]?.map((tag) => tag.sId)).toEqual([
+        tagToAdd.sId,
+      ]);
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -1,6 +1,5 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { TagResource } from "@app/lib/resources/tags_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -43,28 +42,16 @@ app.post(
       });
     }
 
-    await concurrentExecutor(
+    const agents = await getAgentConfigurations(auth, {
       agentIds,
-      async (agentId) => {
-        const agent = await getAgentConfiguration(auth, {
-          agentId,
-          variant: "light",
-        });
-        if (!agent) {
-          return;
-        }
-        if (!agent.canEdit && !auth.isAdmin()) {
-          return;
-        }
-        for (const tag of tagsToAdd) {
-          await tag.addToAgent(auth, agent);
-        }
-        for (const tag of tagsToRemove) {
-          await tag.removeFromAgent(auth, agent);
-        }
-      },
-      { concurrency: 10 }
+      variant: "light",
+    });
+    const editableAgents = agents.filter(
+      (agent) => agent.canEdit || auth.isAdmin()
     );
+
+    await TagResource.addToAgents(auth, tagsToAdd, editableAgents);
+    await TagResource.removeFromAgents(auth, tagsToRemove, editableAgents);
 
     return ctx.json({ success: true });
   }

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -299,7 +299,8 @@ export class TagResource extends BaseResource<TagModel> {
           tagId: tag.id,
           agentConfigurationId: agentConfiguration.id,
         }))
-      )
+      ),
+      { ignoreDuplicates: true }
     );
   }
 

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -273,6 +273,36 @@ export class TagResource extends BaseResource<TagModel> {
     });
   }
 
+  static async addToAgents(
+    auth: Authenticator,
+    tags: TagResource[],
+    agentConfigurations: LightAgentConfigurationType[]
+  ) {
+    if (
+      !auth.isAdmin() &&
+      agentConfigurations.some(
+        (agentConfiguration) => !agentConfiguration.canEdit
+      )
+    ) {
+      throw new Error("You are not allowed to add tags to this agent");
+    }
+
+    if (tags.length === 0 || agentConfigurations.length === 0) {
+      return;
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    await TagAgentModel.bulkCreate(
+      agentConfigurations.flatMap((agentConfiguration) =>
+        tags.map((tag) => ({
+          workspaceId,
+          tagId: tag.id,
+          agentConfigurationId: agentConfiguration.id,
+        }))
+      )
+    );
+  }
+
   async removeFromAgent(
     auth: Authenticator,
     agentConfiguration: LightAgentConfigurationType
@@ -286,6 +316,35 @@ export class TagResource extends BaseResource<TagModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
         tagId: this.id,
         agentConfigurationId: agentConfiguration.id,
+      },
+    });
+  }
+
+  static async removeFromAgents(
+    auth: Authenticator,
+    tags: TagResource[],
+    agentConfigurations: LightAgentConfigurationType[]
+  ) {
+    if (
+      !auth.isAdmin() &&
+      agentConfigurations.some(
+        (agentConfiguration) => !agentConfiguration.canEdit
+      )
+    ) {
+      throw new Error("You are not allowed to remove tags from this agent");
+    }
+
+    if (tags.length === 0 || agentConfigurations.length === 0) {
+      return;
+    }
+
+    await TagAgentModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        tagId: tags.map((tag) => tag.id),
+        agentConfigurationId: agentConfigurations.map(
+          (agentConfiguration) => agentConfiguration.id
+        ),
       },
     });
   }

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -291,11 +291,10 @@ export class TagResource extends BaseResource<TagModel> {
       return;
     }
 
-    const workspaceId = auth.getNonNullableWorkspace().id;
     await TagAgentModel.bulkCreate(
       agentConfigurations.flatMap((agentConfiguration) =>
         tags.map((tag) => ({
-          workspaceId,
+          workspaceId: auth.getNonNullableWorkspace().id,
           tagId: tag.id,
           agentConfigurationId: agentConfiguration.id,
         }))


### PR DESCRIPTION
## Description

The batch tag endpoint currently fetches each agent configuration and writes each agent/tag pair separately, producing N+1 queries as the selection grows.

Not a huge problem at the moment nor one that was surfaced, but it is actually very slow and we're adding ways to select many agents at once and adding more modalities for batch actions, which creates a risk of this pattern being copied in a near future.

This PR batches the 2 operations (fetching the agents and updating the tags).

## Tests

- Added a test for the endpoint.
- Tested locally.

## Risk

- Low. Safe to revert.

## Deploy Plan

- Deploy front.
