### PR TITLE
Add: small jitter in cron wake ups and triggers.

### DIFF
--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -173,6 +173,41 @@ async function createConversationForAgentConfiguration({
   return new Ok(newConversation.toJSON());
 }
 
+export async function getTriggerActivity({
+  userId,
+  workspaceId,
+  triggerId,
+}: {
+  userId: string;
+  workspaceId: string;
+  triggerId: string;
+}) {
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    userId,
+    workspaceId
+  );
+  if (!auth.workspace() || !auth.user()) {
+    throw new TriggerNonRetryableError(
+      "Invalid authentication. Missing workspaceId or userId."
+    );
+  }
+
+  if (!auth.isUser()) {
+    throw new TriggerNonRetryableError(
+      "Invalid authentication. Missing user permissions."
+    );
+  }
+
+  const triggerResource = await TriggerResource.fetchById(auth, triggerId);
+  if (!triggerResource) {
+    throw new TriggerNonRetryableError(
+      `Trigger with ID ${triggerId} not found.`
+    );
+  }
+
+  return triggerResource.toJSON();
+}
+
 export async function runTriggeredAgentsActivity({
   userId,
   workspaceId,
@@ -212,7 +247,7 @@ export async function runTriggeredAgentsActivity({
 
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: trigger.agentConfigurationId,
-    variant: "full",
+    variant: "extra_light",
   });
 
   if (!agentConfiguration) {
@@ -374,6 +409,30 @@ function buildWakeUpMessageContent(wakeUp: WakeUpType): string {
   content += `Wake-up reason: ${wakeUp.reason}`;
 
   return content;
+}
+
+export async function getWakeUpActivity({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}) {
+  const wakeUpAndAuthRes = await WakeUpResource.fetchWakeUpAndAuthenticatorById(
+    {
+      workspaceId,
+      wakeUpId,
+    }
+  );
+  if (wakeUpAndAuthRes.isErr()) {
+    logger.error(
+      { wakeUpId, workspaceId, error: normalizeError(wakeUpAndAuthRes.error) },
+      "Skipping wake-up: workspace or wake-up not found."
+    );
+    return;
+  }
+
+  return wakeUpAndAuthRes.value.wakeUp.toJSON();
 }
 
 export async function runWakeUpActivity({

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -1,26 +1,38 @@
+import { isDevelopment } from "@app/types/shared/env";
 import { ActivityFailure, RetryState } from "@temporalio/common";
-import { proxyActivities } from "@temporalio/workflow";
-
+import { proxyActivities, sleep } from "@temporalio/workflow";
 import type * as activities from "./activities";
 
-const { runTriggeredAgentsActivity } = proxyActivities<typeof activities>({
+// We spread the start time of triggers and wake-ups starting on the hour over 10 minutes to avoid all conversations starting at the same time.
+const ON_THE_HOUR_JITTER_MS = 60 * 10 * 1000;
+
+const getJitterMs = () => {
+  if (isDevelopment()) {
+    return 0;
+  } else {
+    return Math.floor(Math.random() * ON_THE_HOUR_JITTER_MS);
+  }
+};
+
+const { getTriggerActivity, runTriggeredAgentsActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "5 minutes",
   retry: {
     nonRetryableErrorTypes: ["TriggerNonRetryableError"],
   },
 });
 
-const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "5 minutes",
-  retry: {
-    initialInterval: "30 seconds",
-    backoffCoefficient: 2,
-    maximumAttempts: 3,
-    maximumInterval: "5 minutes",
-  },
-});
+const { getWakeUpActivity, expireWakeUpActivity, runWakeUpActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "5 minutes",
+    retry: {
+      initialInterval: "30 seconds",
+      backoffCoefficient: 2,
+      maximumAttempts: 3,
+      maximumInterval: "5 minutes",
+    },
+  });
 
 export async function agentTriggerWorkflow({
   userId,
@@ -33,6 +45,27 @@ export async function agentTriggerWorkflow({
   triggerId: string;
   webhookRequestId?: number;
 }) {
+  // Avoid fetching the trigger if we know it's a webhook trigger.
+  if (!webhookRequestId) {
+    const trigger = await getTriggerActivity({
+      userId,
+      workspaceId,
+      triggerId,
+    });
+
+    // For triggers starting on the hour, we will add a little bit of jitter to the start time to avoid all conversations starting at the same time
+    if (
+      trigger.kind === "schedule" &&
+      trigger.configuration.type === "cron" &&
+      trigger.configuration.cron.startsWith("0 ")
+    ) {
+      const jitterMs = getJitterMs();
+      if (jitterMs > 0) {
+        await sleep(jitterMs);
+      }
+    }
+  }
+
   await runTriggeredAgentsActivity({
     userId,
     workspaceId,
@@ -64,6 +97,23 @@ export async function wakeUpWorkflow({
   wakeUpId: string;
 }): Promise<void> {
   try {
+    const wakeUp = await getWakeUpActivity({ workspaceId, wakeUpId });
+    if (!wakeUp) {
+      return;
+    }
+
+    // For wake-ups starting on the hour, we will add a little bit of jitter to the start time to avoid all conversations starting at the same time
+    if (
+      wakeUp.status === "scheduled" &&
+      wakeUp.scheduleConfig.type === "cron" &&
+      wakeUp.scheduleConfig.cron.startsWith("0 ")
+    ) {
+      const jitterMs = getJitterMs();
+      if (jitterMs > 0) {
+        await sleep(jitterMs);
+      }
+    }
+
     await runWakeUpActivity({ workspaceId, wakeUpId });
   } catch (error) {
     if (isRunWakeUpActivityFailure(error)) {


### PR DESCRIPTION
## Description

Adds up to 10 minutes of random jitter to `agentTriggerWorkflow` and `wakeUpWorkflow` when cron expressions fire on the hour (`0 `), preventing thundering-herd spikes when many triggers/wake-ups are scheduled at the same time. Jitter is skipped entirely in development and for webhook-triggered runs.

Introduces `getTriggerActivity` and `getWakeUpActivity` as lightweight pre-run fetch steps so the workflow can inspect the trigger/wake-up config before deciding whether to sleep. Also switches `getAgentConfiguration` to `extra_light` variant in `runTriggeredAgentsActivity` — the full config was never needed there.

## Tests

Tested locally. Verified jitter is 0 in development (`isDevelopment()` guard) and that webhook-triggered workflows skip the fetch and sleep entirely.

## Risk

Low. Jitter only delays on-the-hour cron executions by up to 10 minutes — acceptable given these are background scheduled runs. No DB changes. Rollback is a straight revert.

## Deploy Plan

Deploy front (Temporal workers pick up the new workflow/activity definitions).
