### PR TITLE
[front] Expose spaces to governance-grant permission checks

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1551,6 +1551,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [{ role: "admin", permissions: ["admin", "write"] }],
           groups: this.groups.map((group) => ({
             id: group.groupId,
@@ -1565,6 +1567,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
             // TODO(governance): remove once manager is available for everyone
@@ -1593,6 +1597,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
             // TODO(governance): remove once manager is available for everyone
@@ -1617,6 +1623,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin"] },
             { role: "manager", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
@@ -1648,6 +1656,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return [
       {
         workspaceId: this.workspaceId,
+        resourceType: "space",
+        resourceId: this.id,
         roles: [{ role: "admin", permissions: ["admin"] }],
         groups: this.groups.reduce((acc, group) => {
           if (groupFilter(group)) {


### PR DESCRIPTION
## Description

Set `resourceType: "space"` + `resourceId` (the space's model id) on every branch of `SpaceResource.requestedPermissions()`, wiring spaces into the governance-grant path added in the parent PR #29379 (`Authenticator.hasResourcePermission`). A caller holding a matching `group_permissions` grant on the space now passes read/write/admin checks — alongside the existing role and group paths.

Dormant until such grants are actually written; the first consumer is the `space_editors` work (dust-tt/tasks#9753).

### Admins & the governance-grant path (solution space)

Enabling the governance path surfaced a design question: admins carry `PermissionSet.all()`, so a naive `has()` would grant admins **every** permission on **every** space that declares `resourceType` — including `read` on restricted/project spaces, where admins are intentionally *not* readers (they administrate without reading content). Options considered:

- **A — scope admin-all to type-wide capabilities in `PermissionSet.has()` (chosen; lives in #29379).** Admins hold every *workspace-level* capability (create/publish/…) but no implicit *instance* grants; per-space access stays role/group-defined. Single choke point; non-admin instance grants still work.
- **B — skip the governance path for admins in `hasResourcePermission`** (`!isAdmin() && …`). Functionally identical for spaces; states the admin concept at the call site rather than inside `has()`. Viable alternative.
- **C — only set `resourceType` on space kinds where admins have access** (skip restricted/project). Rejected: also disables the path for *non-admins* holding explicit grants on those spaces — the whole point of the feature.
- **D — materialize explicit admin grants** instead of the `isAdminAll` flag. Rejected: infeasible, and admins shouldn't hold instance read on restricted content anyway.

Net: admin per-space access is unchanged from today — read on global/open (via role), admin-only on restricted/project, admin+write on system; **no** implicit read on restricted/project spaces.

## Tests

Covered by `front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts` ("returns 403 if not authorized to write in the data source (admin)"), which asserts an admin cannot write a restricted space's data source — the exact admin/governance interaction above. No new non-admin behavior yet (path is dormant).

## Risk

Low. The path is dormant until space `group_permissions` grants are written; once they are, a caller with a matching grant on a space gains the corresponding read/write/admin (in addition to role/group access).

The one subtlety — admins carrying `PermissionSet.all()` gaining all permissions by default — is mitigated by **solution A** in the parent PR (#29379): admin-all is scoped to type-wide capabilities, so admins get **no** implicit instance permissions and per-space access stays role-defined (notably, admins keep no `read` on restricted/project spaces). This is enforced end-to-end by the data-source files test above.

Rollback: revert this one-file change; the parent framework is unaffected.

## Deploy Plan

Deploy front. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)