### PR TITLE
feat: manager role provisioned group

### DIFF
--- a/front-api/routes/w/[wId]/provisioning-status.ts
+++ b/front-api/routes/w/[wId]/provisioning-status.ts
@@ -3,6 +3,7 @@ import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
   GroupResource,
+  MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -19,6 +20,7 @@ app.get("/", async (ctx): HandlerResult<GetProvisioningStatusResponseBody> => {
 
   return ctx.json({
     hasAdminGroup: groups.some((g) => g.name === ADMIN_GROUP_NAME),
+    hasManagerGroup: groups.some((g) => g.name === MANAGER_GROUP_NAME),
     hasBuilderGroup: groups.some((g) => g.name === BUILDER_GROUP_NAME),
   });
 });

--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -1,5 +1,8 @@
 import { ConfirmContext } from "@app/components/Confirm";
-import { getRoleDescription } from "@app/components/members/Roles";
+import {
+  getRoleDescription,
+  getRoleProvisioningGroupsLabel,
+} from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -21,6 +24,27 @@ import {
 } from "@dust-tt/sparkle";
 import { useContext, useEffect, useState } from "react";
 
+function getInvitationRoleMessage({
+  isRoleManagedByProvisioning,
+  isAdminGovernanceEnabled,
+  role,
+}: {
+  isRoleManagedByProvisioning: boolean;
+  isAdminGovernanceEnabled: boolean;
+  role: ActiveRoleType;
+}): string {
+  if (isRoleManagedByProvisioning) {
+    return `This invitation's role is managed by your identity provider through group provisioning (${getRoleProvisioningGroupsLabel(
+      isAdminGovernanceEnabled
+    )}). Role changes must be made in your identity provider.`;
+  }
+
+  return `The role defines the rights of a member for the workspace. ${getRoleDescription(
+    role,
+    isAdminGovernanceEnabled
+  )}`;
+}
+
 export function EditInvitationModal({
   owner,
   invitation,
@@ -38,6 +62,8 @@ export function EditInvitationModal({
   const confirm = useContext(ConfirmContext);
   const { hasFeature } = useFeatureFlags();
 
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
+
   const { roleProvisioningStatus } = useProvisioningStatus({
     workspaceId: owner.sId,
   });
@@ -45,7 +71,18 @@ export function EditInvitationModal({
   // Check if this invitation's role would be managed by provisioning groups
   const isRoleManagedByProvisioning =
     (roleProvisioningStatus.hasAdminGroup && selectedRole === "admin") ||
+    (isAdminGovernanceEnabled &&
+      roleProvisioningStatus.hasManagerGroup &&
+      selectedRole === "manager") ||
     (roleProvisioningStatus.hasBuilderGroup && selectedRole === "builder");
+
+  const roleMessage = invitation
+    ? getInvitationRoleMessage({
+        isRoleManagedByProvisioning,
+        isAdminGovernanceEnabled,
+        role: invitation.initialRole,
+      })
+    : "";
 
   useEffect(() => {
     if (invitation) {
@@ -104,19 +141,7 @@ export function EditInvitationModal({
                     disabled={isRoleManagedByProvisioning}
                   />
                 </div>
-                <div className="text-muted-foreground">
-                  {isRoleManagedByProvisioning ? (
-                    "This invitation's role is managed by your identity provider through group provisioning (dust-admins and dust-builders groups). Role changes must be made in your identity provider."
-                  ) : (
-                    <>
-                      The role defines the rights of a member for the workspace.{" "}
-                      {getRoleDescription(
-                        invitation.initialRole,
-                        hasFeature("admin_governance")
-                      )}
-                    </>
-                  )}
-                </div>
+                <div className="text-muted-foreground">{roleMessage}</div>
               </div>
 
               <div className="flex items-center gap-2">

--- a/front/components/members/Roles.ts
+++ b/front/components/members/Roles.ts
@@ -67,3 +67,11 @@ export function getRoleDescription(
   }
   return ROLES_DATA[role].description;
 }
+
+export function getRoleProvisioningGroupsLabel(
+  isAdminGovernanceEnabled: boolean
+): string {
+  return isAdminGovernanceEnabled
+    ? "dust-admins, dust-managers and dust-builders groups"
+    : "dust-admins and dust-builders groups";
+}

--- a/front/components/members/Roles.ts
+++ b/front/components/members/Roles.ts
@@ -72,6 +72,6 @@ export function getRoleProvisioningGroupsLabel(
   isAdminGovernanceEnabled: boolean
 ): string {
   return isAdminGovernanceEnabled
-    ? "dust-admins, dust-managers and dust-builders groups"
+    ? "dust-admins and dust-managers groups"
     : "dust-admins and dust-builders groups";
 }

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -1,4 +1,7 @@
-import { getRoleDescription } from "@app/components/members/Roles";
+import {
+  getRoleDescription,
+  getRoleProvisioningGroupsLabel,
+} from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
@@ -33,6 +36,27 @@ import {
 import { useState } from "react";
 import type { KeyedMutator } from "swr";
 
+function getMemberRoleMessage({
+  hasActiveRoleProvisioningGroups,
+  isAdminGovernanceEnabled,
+  role,
+}: {
+  hasActiveRoleProvisioningGroups: boolean;
+  isAdminGovernanceEnabled: boolean;
+  role: ActiveRoleType;
+}): string {
+  if (hasActiveRoleProvisioningGroups) {
+    return `The roles are managed by your identity provider through group provisioning (${getRoleProvisioningGroupsLabel(
+      isAdminGovernanceEnabled
+    )}). Role changes must be made in your identity provider.`;
+  }
+
+  return `The role defines the rights of a member of the workspace. ${getRoleDescription(
+    role,
+    isAdminGovernanceEnabled
+  )}`;
+}
+
 export function ChangeMemberModal({
   onClose,
   member,
@@ -53,6 +77,8 @@ export function ChangeMemberModal({
   );
   const [isSaving, setIsSaving] = useState(false);
 
+  const isAdminGovernanceEnabled = hasFeature("admin_governance");
+
   const { roleProvisioningStatus } = useProvisioningStatus({
     workspaceId: workspace.sId,
   });
@@ -60,9 +86,21 @@ export function ChangeMemberModal({
   const hasActiveRoleProvisioningGroups = () => {
     return (
       roleProvisioningStatus.hasAdminGroup ||
+      // The manager provisioning group only governs roles from the UI when admin
+      // governance is enabled.
+      (isAdminGovernanceEnabled && roleProvisioningStatus.hasManagerGroup) ||
       roleProvisioningStatus.hasBuilderGroup
     );
   };
+
+  const roleMessage =
+    role && isActiveRoleType(role)
+      ? getMemberRoleMessage({
+          hasActiveRoleProvisioningGroups: hasActiveRoleProvisioningGroups(),
+          isAdminGovernanceEnabled,
+          role,
+        })
+      : "";
 
   // Revoking an admin requires to be an admin
   const canRevokeMember = role !== "admin" || isAdmin(workspace);
@@ -125,20 +163,7 @@ export function ChangeMemberModal({
                       disabled={hasActiveRoleProvisioningGroups()}
                     />
                   </div>
-                  <Page.P>
-                    {hasActiveRoleProvisioningGroups() ? (
-                      "The roles are managed by your identity provider through group provisioning (dust-admins and dust-builders groups). Role changes must be made in your identity provider."
-                    ) : (
-                      <>
-                        The role defines the rights of a member of the
-                        workspace.{" "}
-                        {getRoleDescription(
-                          role,
-                          hasFeature("admin_governance")
-                        )}
-                      </>
-                    )}
-                  </Page.P>
+                  <Page.P>{roleMessage}</Page.P>
                 </div>
 
                 {canRevokeMember && (

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -1,23 +1,50 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import { hasFeatureFlag } from "@app/lib/auth";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
   GroupResource,
+  MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { ActiveRoleType } from "@app/types/user";
+
+function determineExpectedRoleFromGroups(
+  userModelId: ModelId,
+  provisioningGroupMembers: {
+    adminUserIds: Set<ModelId>;
+    managerUserIds: Set<ModelId>;
+    builderUserIds: Set<ModelId>;
+  }
+): ActiveRoleType {
+  const { adminUserIds, managerUserIds, builderUserIds } =
+    provisioningGroupMembers;
+
+  if (adminUserIds.has(userModelId)) {
+    return "admin";
+  }
+  if (managerUserIds.has(userModelId)) {
+    return "manager";
+  }
+  if (builderUserIds.has(userModelId)) {
+    return "builder";
+  }
+  return "user";
+}
 
 export const applyGroupRoles = createPlugin({
   manifest: {
     id: "apply-roles-from-groups",
     name: "Apply group roles",
     description:
-      "Force resync roles using dust-admins and dust-builders groups",
+      "Force resync roles using dust-admins, dust-managers and dust-builders groups",
     resourceTypes: ["workspaces"],
     warning:
-      "This action will override the existing membership roles based on the dust-admins and dust-builders groups. " +
+      "This action will override the existing membership roles based on the dust-admins, dust-managers and dust-builders groups. " +
       "Make sure the user is aware of this and does not want to keep the roles assigned manually.",
     args: {},
     requiredRoles: ["engineering"],
@@ -46,6 +73,14 @@ export const applyGroupRoles = createPlugin({
       });
     }
 
+    const isManagerProvisioningEnabled = await hasFeatureFlag(
+      auth,
+      "admin_governance"
+    );
+    const [managerGroup] = isManagerProvisioningEnabled
+      ? provisioningGroups.filter((g) => g.name === MANAGER_GROUP_NAME)
+      : [];
+
     const [builderGroup] = provisioningGroups.filter(
       (g) => g.name === BUILDER_GROUP_NAME
     );
@@ -62,11 +97,16 @@ export const applyGroupRoles = createPlugin({
     const membershipsByProvisioningGroup =
       await GroupResource.getActiveMembershipsForGroups(
         auth,
-        removeNulls([adminGroup, builderGroup])
+        removeNulls([adminGroup, managerGroup, builderGroup])
       );
 
     const adminUserIds = new Set(
       membershipsByProvisioningGroup[adminGroup.id] ?? []
+    );
+    const managerUserIds = new Set(
+      managerGroup
+        ? (membershipsByProvisioningGroup[managerGroup.id] ?? [])
+        : []
     );
     const builderUserIds = new Set(
       builderGroup
@@ -85,11 +125,11 @@ export const applyGroupRoles = createPlugin({
       }
 
       const currentRole = membership.role;
-      const expectedRole = adminUserIds.has(user.id)
-        ? "admin"
-        : builderUserIds.has(user.id)
-          ? "builder"
-          : "user";
+      const expectedRole = determineExpectedRoleFromGroups(user.id, {
+        adminUserIds,
+        managerUserIds,
+        builderUserIds,
+      });
 
       if (currentRole !== expectedRole) {
         const updateResult = await MembershipResource.updateMembershipRole({

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -1,7 +1,17 @@
-import { getUserForWorkspace } from "@app/lib/api/user";
+import {
+  determineUserRoleFromGroups,
+  getUserForWorkspace,
+} from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
+import {
+  ADMIN_GROUP_NAME,
+  BUILDER_GROUP_NAME,
+  MANAGER_GROUP_NAME,
+} from "@app/lib/resources/group_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -286,5 +296,91 @@ describe("getUserForWorkspace", () => {
 
     const result = await getUserForWorkspace(auth, { userId: user1.sId });
     expect(result?.sId).toBe(user1.sId);
+  });
+});
+
+describe("determineUserRoleFromGroups", () => {
+  let workspace: WorkspaceType;
+  let user: UserResource;
+  let adminAuthenticator: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    adminAuthenticator = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+  });
+
+  // determineUserRoleFromGroups matches groups by name, not by kind, so a
+  // regular_auto group named after the reserved group exercises the same logic
+  // while allowing members to be added through the standard factory API.
+  async function addUserToRoleGroup(name: string) {
+    const group = await GroupFactory.regularAuto(workspace, name);
+    await GroupFactory.withMembers(adminAuthenticator, group, [user]);
+    return group;
+  }
+
+  it("returns 'user' when the user is in no role-granting group", async () => {
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("user");
+  });
+
+  it("returns 'admin' when the user is in the dust-admins group", async () => {
+    await addUserToRoleGroup(ADMIN_GROUP_NAME);
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("admin");
+  });
+
+  it("returns 'builder' when the user is in the dust-builders group", async () => {
+    await addUserToRoleGroup(BUILDER_GROUP_NAME);
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("builder");
+  });
+
+  it("grants 'manager' from the dust-managers group when admin governance is enabled", async () => {
+    await addUserToRoleGroup(MANAGER_GROUP_NAME);
+    await FeatureFlagFactory.basic(adminAuthenticator, "admin_governance");
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("manager");
+  });
+
+  it("prioritizes 'admin' over 'manager' and 'builder'", async () => {
+    await addUserToRoleGroup(ADMIN_GROUP_NAME);
+    await addUserToRoleGroup(MANAGER_GROUP_NAME);
+    await addUserToRoleGroup(BUILDER_GROUP_NAME);
+    await FeatureFlagFactory.basic(adminAuthenticator, "admin_governance");
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("admin");
+  });
+
+  it("prioritizes 'manager' over 'builder' when admin governance is enabled", async () => {
+    await addUserToRoleGroup(MANAGER_GROUP_NAME);
+    await addUserToRoleGroup(BUILDER_GROUP_NAME);
+    await FeatureFlagFactory.basic(adminAuthenticator, "admin_governance");
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("manager");
+  });
+
+  it("falls back to 'builder' when in both dust-managers and dust-builders groups but admin governance is disabled", async () => {
+    await addUserToRoleGroup(MANAGER_GROUP_NAME);
+    await addUserToRoleGroup(BUILDER_GROUP_NAME);
+
+    const role = await determineUserRoleFromGroups(workspace, user);
+
+    expect(role).toBe("builder");
   });
 });

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,9 +1,10 @@
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlagsForWorkspace } from "@app/lib/auth";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
   GroupResource,
+  MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -301,17 +302,29 @@ export async function determineUserRoleFromGroups(
     workspace,
   });
 
+  const featureFlags = await getFeatureFlagsForWorkspace(workspace);
+  const isManagerProvisioningEnabled =
+    featureFlags.includes("admin_governance");
+
+  let atLeastManager = false;
   let atLeastBuilder = false;
 
   for (const group of userGroups) {
     if (group.name === ADMIN_GROUP_NAME) {
       return "admin";
     }
+    if (group.name === MANAGER_GROUP_NAME) {
+      atLeastManager = true;
+    }
     if (group.name === BUILDER_GROUP_NAME) {
       atLeastBuilder = true;
     }
   }
-  // If we're here, the user is not in the admin group.
+  // If we're here, the user is not in the admin group. Role precedence is
+  // admin > manager > builder > user.
+  if (atLeastManager && isManagerProvisioningEnabled) {
+    return "manager";
+  }
   if (atLeastBuilder) {
     return "builder";
   }

--- a/front/lib/api/workos/organization_membership.ts
+++ b/front/lib/api/workos/organization_membership.ts
@@ -19,7 +19,7 @@ async function findWorkOSOrganizationsForUserIdUncached(userId: string) {
   const orgs = await concurrentExecutor(
     response.data
       .filter((membership) =>
-        ["admin", "builder", "user"].includes(membership.role.slug)
+        ["admin", "manager", "builder", "user"].includes(membership.role.slug)
       )
       .map((membership) => membership.organizationId),
     async (orgId) => getWorkOS().organizations.getOrganization(orgId),

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -803,6 +803,7 @@ export type GetWorkspaceVerifiedDomainsResponseBody = {
 
 export type GetProvisioningStatusResponseBody = {
   hasAdminGroup: boolean;
+  hasManagerGroup: boolean;
   hasBuilderGroup: boolean;
 };
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -57,6 +57,7 @@ import { col, fn, Op, QueryTypes, UniqueConstraintError } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
+export const MANAGER_GROUP_NAME = "dust-managers";
 // User-facing name of the manual builders group synced from the builder role (see
 // syncBuilderGroupMembership). Distinct from BUILDER_GROUP_NAME: workspaces provisioning
 // builders via SCIM keep their "dust-builders" IdP group alongside this one.
@@ -2568,8 +2569,9 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
-   * Checks if dust-builders and dust-admins groups exist and are actively provisioned
-   * in the workspace. This indicates that role management should be restricted in the UI.
+   * Checks if dust-admins, dust-managers and dust-builders groups exist and are actively
+   * provisioned in the workspace. This indicates that role management should be restricted
+   * in the UI.
    */
   static async listRoleProvisioningGroupsForWorkspace(
     auth: Authenticator
@@ -2585,7 +2587,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       where: {
         kind: "provisioned",
         name: {
-          [Op.in]: [ADMIN_GROUP_NAME, BUILDER_GROUP_NAME],
+          [Op.in]: [ADMIN_GROUP_NAME, MANAGER_GROUP_NAME, BUILDER_GROUP_NAME],
         },
       },
     });

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -243,6 +243,7 @@ export function useProvisioningStatus({
     if (!data) {
       return {
         hasAdminGroup: false,
+        hasManagerGroup: false,
         hasBuilderGroup: false,
       };
     }

--- a/front/scripts/simulate_workos_event.ts
+++ b/front/scripts/simulate_workos_event.ts
@@ -488,7 +488,7 @@ makeScript(
       logger.info(`  • Add user ${userEmail} to group "${groupName}"`);
       logger.info("  • Grant space access if group has associated space");
       logger.info(
-        "  • Update user role if special group (dust-admins/dust-builders)"
+        "  • Update user role if special group (dust-admins/dust-managers/dust-builders)"
       );
     } else if (eventType === "group.user_removed") {
       logger.info(`  • Remove user ${userEmail} from group "${groupName}"`);

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -35,6 +35,7 @@ import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
   GroupResource,
+  MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -214,7 +215,11 @@ async function handleRoleAssignmentForGroup(
     directoryId?: string;
   }
 ) {
-  if (group.name !== ADMIN_GROUP_NAME && group.name !== BUILDER_GROUP_NAME) {
+  if (
+    group.name !== ADMIN_GROUP_NAME &&
+    group.name !== MANAGER_GROUP_NAME &&
+    group.name !== BUILDER_GROUP_NAME
+  ) {
     // Not a special group, no role assignment needed.
     return;
   }


### PR DESCRIPTION
## Description

This PR extends the group-based role provisioning system to support the `dust-managers` provisioned group, gating it behind the `admin_governance` feature flag.

## Tests

## Risks

Low.

## Deploy Plan

Standard deployment.