### PR TITLE
feat: remove warning from groups and governance page

### DIFF
--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -13,7 +13,6 @@ import {
   useWorkspaceVerifiedDomains,
 } from "@app/lib/swr/workspaces";
 import {
-  ContentMessage,
   Page,
   Spinner,
   Tabs,
@@ -94,10 +93,6 @@ export function MembersPage() {
               {membersContent}
             </TabsContent>
             <TabsContent value="groups" className="flex flex-col gap-4">
-              <ContentMessage size="md">
-                This page is WIP. Do not change unless you know what you are
-                doing.
-              </ContentMessage>
               <WorkspaceGroupsList owner={owner} />
             </TabsContent>
           </Tabs>

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -199,9 +199,6 @@ export const GovernancePage = () => {
 
   return (
     <GovernancePageLayout>
-      <ContentMessage>
-        This page is WIP. Do not change unless you know what you are doing.
-      </ContentMessage>
       {isAdmin && <WorkspaceNameEditor owner={owner} />}
       <LinkedSectionNotice
         description="Groups assigned here are managed in"


### PR DESCRIPTION
## Description

This PR removes the "WIP" warning banners from the Groups tab and the Governance page.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.