### PR TITLE
[DX] stop the sparkle watcher from deleting dist when mprocs stops

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -21,6 +21,9 @@
       "ignore": ""
     }
   },
+  "nodemonConfig": {
+    "signal": "SIGQUIT"
+  },
   "main": "dist/cjs/index.js",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -59,7 +59,6 @@ procs:
   sparkle:
     cwd: "<CONFIG_DIR>/../sparkle"
     shell: |
-      trap 'npm run build; exit' TERM INT
       npm run watch
 
   sdks-js:


### PR DESCRIPTION
## Description

Stopping mprocs left `sparkle/dist` deleted, so `npx tsgo --noEmit` in `front` (and any other consumer) failed with `Cannot find module '@dust-tt/sparkle' or its corresponding type declarations` until sparkle was rebuilt by hand.

**Cause.** sparkle's `watch` is npm-watch, i.e. nodemon, and nodemon binds SIGHUP to `restart` whenever its `signal` option is `SIGUSR2` — its default (`lib/nodemon.js:161`, `lib/config/defaults.js:20`). Tearing down an mprocs proc closes its pty, which delivers exactly that SIGHUP, so nodemon kicked off a fresh `npm run build` — whose first step is `rm -rf dist` — and was killed about a second later. Deleting `dist` takes ~1s, rebuilding it ~7s, so `dist` stayed deleted.

**Fix.** Set nodemon's `signal` to a non-`SIGUSR2` value, which leaves SIGHUP unbound so nodemon terminates on shutdown instead of starting a build. `signal` only controls how nodemon kills the build on restart; nodemon's own SIGINT/SIGTERM quit handling (`run.js:552-553`) is untouched.

`SIGTERM` is not a valid choice here: `run.js:239` restarts whenever the child exits via `config.signal`, which reintroduces the wipe via the shutdown SIGTERM. `SIGQUIT` behaves like `SIGUSR2` (catchable, terminates by default) without being a signal the shutdown path delivers.

This also drops the `trap 'npm run build; exit' TERM INT` line added in #29464. mprocs runs each proc as `/bin/sh -c <script>`, and because the script is newline-separated with a simple last command, `/bin/sh` `exec()`s `npm run watch` over itself and the trap is discarded — so it never ran on macOS (verified: no wrapper shell process for the sparkle proc, and `/bin/sh -c $'trap ...\nsleep N'` leaves no shell behind, while the `;`-separated form does). Its intent — a current sparkle build after stopping — holds regardless, since the watcher rebuilds on every `src` change, so `dist` is already up to date when the watcher exits.

## Tests

Tested locally by starting the watcher under a pty and killing the pty owner, which is what mprocs exiting does. Each candidate was checked both for the normal watch path and for the shutdown path:

| `signal` | rebuild on `src` change | `dist` after teardown |
| --- | --- | --- |
| *(default `SIGUSR2`)* | works | **wiped** |
| `SIGTERM` | works | **wiped** |
| `SIGKILL` | works | intact |
| `SIGQUIT` (this PR) | works | intact |

After the change: `dist` survives the teardown, rebuild-on-change still works, and `npx tsgo --noEmit` in `front` exits 0.

## Risk

None. Local dev tooling only, no production impact.

## Deploy Plan

- Standard deploy, no migration needed.