### PR TITLE
feat: gate skills detect/import endpoints on workspace permissions

### DIFF
--- a/front-api/routes/w/[wId]/skills/detect/index.ts
+++ b/front-api/routes/w/[wId]/skills/detect/index.ts
@@ -13,7 +13,6 @@ import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -25,137 +24,141 @@ const app = workspaceApp();
 app.route("/upload", upload);
 
 /** @ignoreswagger */
-app.post(
-  "/",
-  ensureIsBuilder(),
-  async (ctx): HandlerResult<DetectSkillsResponseBody> => {
-    const auth = ctx.get("auth");
-    const owner = auth.getNonNullableWorkspace();
+app.post("/", async (ctx): HandlerResult<DetectSkillsResponseBody> => {
+  const auth = ctx.get("auth");
+  const owner = auth.getNonNullableWorkspace();
 
-    const body = await ctx.req.json().catch(() => null);
-    const repoUrl = body?.repoUrl;
-
-    if (!isString(repoUrl)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "repoUrl is required and must be a string.",
-        },
-      });
-    }
-
-    const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
-    const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
-    if (clientResult.isErr()) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: clientResult.error.message,
-        },
-      });
-    }
-
-    const result = await detectSkillsFromGitHubRepo(clientResult.value);
-
-    if (result.isErr()) {
-      const { error } = result;
-
-      switch (error.type) {
-        case "invalid_url":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: error.message,
-            },
-          });
-        case "not_found":
-          return apiError(ctx, {
-            status_code: 404,
-            api_error: {
-              type: "skill_github_repository_not_found",
-              message: error.message,
-            },
-          });
-        case "auth_error":
-          return apiError(ctx, {
-            status_code: 401,
-            api_error: {
-              type: "invalid_request_error",
-              message: error.message,
-            },
-          });
-        case "github_api_error":
-          logger.error(
-            { error, workspaceId: owner.sId },
-            "Error detecting skills from GitHub repo"
-          );
-          return apiError(ctx, {
-            status_code: 500,
-            api_error: {
-              type: "invalid_request_error",
-              message: error.message,
-            },
-          });
-        case "validation_error":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: error.message,
-            },
-          });
-        default:
-          assertNever(error);
-      }
-    }
-
-    const detectedSkills = result.value;
-
-    if (detectedSkills.length === 0) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
-        },
-      });
-    }
-
-    const existingSkills = await SkillResource.fetchByNames(
-      auth,
-      detectedSkills.map((s) => s.name)
-    );
-
-    const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
-
-    const skillSummaries: DetectedSkillSummary[] = detectedSkills.map(
-      (skill) => {
-        const existing = existingSkillsMap.get(skill.name);
-
-        if (!existing) {
-          return {
-            name: skill.name,
-            status: "ready",
-            existingSkillId: null,
-          };
-        }
-
-        return {
-          name: skill.name,
-          status: isSkillFromGitHubRepo(existing, { repoUrl })
-            ? "skill_already_exists"
-            : "name_conflict",
-          existingSkillId: existing.sId,
-        };
-      }
-    );
-
-    return ctx.json({ skills: skillSummaries });
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Detecting skills is restricted.",
+      },
+    });
   }
-);
+
+  const body = await ctx.req.json().catch(() => null);
+  const repoUrl = body?.repoUrl;
+
+  if (!isString(repoUrl)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "repoUrl is required and must be a string.",
+      },
+    });
+  }
+
+  const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
+  const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
+  if (clientResult.isErr()) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: clientResult.error.message,
+      },
+    });
+  }
+
+  const result = await detectSkillsFromGitHubRepo(clientResult.value);
+
+  if (result.isErr()) {
+    const { error } = result;
+
+    switch (error.type) {
+      case "invalid_url":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
+        });
+      case "not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "skill_github_repository_not_found",
+            message: error.message,
+          },
+        });
+      case "auth_error":
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
+        });
+      case "github_api_error":
+        logger.error(
+          { error, workspaceId: owner.sId },
+          "Error detecting skills from GitHub repo"
+        );
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
+        });
+      case "validation_error":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
+        });
+      default:
+        assertNever(error);
+    }
+  }
+
+  const detectedSkills = result.value;
+
+  if (detectedSkills.length === 0) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
+      },
+    });
+  }
+
+  const existingSkills = await SkillResource.fetchByNames(
+    auth,
+    detectedSkills.map((s) => s.name)
+  );
+
+  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
+
+  const skillSummaries: DetectedSkillSummary[] = detectedSkills.map((skill) => {
+    const existing = existingSkillsMap.get(skill.name);
+
+    if (!existing) {
+      return {
+        name: skill.name,
+        status: "ready",
+        existingSkillId: null,
+      };
+    }
+
+    return {
+      name: skill.name,
+      status: isSkillFromGitHubRepo(existing, { repoUrl })
+        ? "skill_already_exists"
+        : "name_conflict",
+      existingSkillId: existing.sId,
+    };
+  });
+
+  return ctx.json({ skills: skillSummaries });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/detect/upload.ts
+++ b/front-api/routes/w/[wId]/skills/detect/upload.ts
@@ -5,7 +5,6 @@ import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
@@ -18,8 +17,18 @@ import formidable from "formidable";
 const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 /** @ignoreswagger */
-app.post("/", ensureIsBuilder(), async (ctx) => {
+app.post("/", async (ctx) => {
   const auth = ctx.get("auth");
+
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Detecting skills is restricted.",
+      },
+    });
+  }
 
   const incoming = ctx.env?.incoming;
   if (!incoming) {

--- a/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
@@ -6,10 +6,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { GetGitHubConnectionResponseBody } from "@app/lib/skill_detection";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import {
-  ensureIsAdmin,
-  ensureIsBuilder,
-} from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { SuccessResponseBody } from "@front-api/routes/types";
@@ -18,20 +15,26 @@ import type { SuccessResponseBody } from "@front-api/routes/types";
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  ensureIsBuilder(),
-  async (ctx): HandlerResult<GetGitHubConnectionResponseBody> => {
-    const auth = ctx.get("auth");
-    const owner = auth.getNonNullableWorkspace();
+app.get("/", async (ctx): HandlerResult<GetGitHubConnectionResponseBody> => {
+  const auth = ctx.get("auth");
+  const owner = auth.getNonNullableWorkspace();
 
-    const workspace = await WorkspaceResource.fetchById(owner.sId);
-    const connection =
-      (await workspace?.getSkillImportGitHubConnectedByUser()) ?? null;
-
-    return ctx.json({ connection });
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Accessing the skill import GitHub connection is restricted.",
+      },
+    });
   }
-);
+
+  const workspace = await WorkspaceResource.fetchById(owner.sId);
+  const connection =
+    (await workspace?.getSkillImportGitHubConnectedByUser()) ?? null;
+
+  return ctx.json({ connection });
+});
 
 /** @ignoreswagger */
 app.post(


### PR DESCRIPTION
## Summary

Replaces the `ensureIsBuilder()` middleware in the skills detect/import endpoints (`front-api/routes/w/[wId]/skills`) with inline workspace-permission checks, matching the pattern already used in `skills/index.ts` and `skills/availability.ts`.

Endpoints changed (the ones that used `ensureIsBuilder()`):
- `detect/index.ts` — POST (detect skills from a GitHub repo)
- `detect/upload.ts` — POST (detect skills from uploaded files)
- `import/github-connection/index.ts` — GET (read the workspace's skill-import GitHub connection). POST/DELETE there already used `ensureIsAdmin()` and are untouched.

Each now checks:
```ts
if (!(await auth.hasWorkspacePermission("create", "skill"))) { /* 403 */ }
```

## Behavior

Preserved: with default governance seeding the builder group holds `create/skill` (admins bypass), plain `user` gets 403 — the existing "returns 403 for non-builder users" test still passes.

## Testing

- `npx tsgo --noEmit` clean
- github-connection test suite (8 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)