### PR TITLE
feat: ensureHasWorkspacePermission middleware for workspace-permission guards

### DIFF
--- a/front-api/middlewares/ensure_role.ts
+++ b/front-api/middlewares/ensure_role.ts
@@ -1,3 +1,8 @@
+import type { APIErrorType } from "@app/types/error";
+import type {
+  ConcreteResourceType,
+  GrantVerb,
+} from "@app/types/group_permissions";
 import type {
   PublicApiCtx,
   WorkspaceAwareCtx,
@@ -64,6 +69,36 @@ export const ensureIsBuilder = () =>
         api_error: {
           type: "workspace_auth_error",
           message: ENSURE_IS_BUILDER_ERROR_MESSAGE,
+        },
+      });
+    }
+
+    await next();
+  });
+
+/**
+ * Guards a route on a workspace-level governance capability (a type-wide grant),
+ * e.g. `ensureHasWorkspacePermission("admin", "billing", "...")`. Prefer this over
+ * the role middlewares (`ensureIsBuilder`, ...) for capability-based access.
+ *
+ * `errorType` defaults to `workspace_auth_error`; pass `app_auth_error` for the
+ * skills endpoints, which use that error type throughout.
+ */
+export const ensureHasWorkspacePermission = (
+  verb: GrantVerb,
+  resourceType: ConcreteResourceType,
+  message: string,
+  errorType: APIErrorType = "workspace_auth_error"
+) =>
+  createMiddleware<WorkspaceAwareCtx>(async (ctx, next) => {
+    const auth = ctx.get("auth");
+
+    if (!(await auth.hasWorkspacePermission(verb, resourceType))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: errorType,
+          message,
         },
       });
     }

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -5,6 +5,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -29,20 +30,15 @@ app.patch(
   "/",
   validate("param", ParamsSchema),
   validate("json", PatchLinkedSlackChannelsRequestBodySchema),
+  ensureHasWorkspacePermission(
+    "publish",
+    "agent",
+    "Only users who can publish agents can perform this action."
+  ),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
-
-    if (!(await auth.hasWorkspacePermission("publish", "agent"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "Only users who can publish agents can perform this action.",
-        },
-      });
-    }
 
     if (body.auto_respond_without_mention) {
       const featureFlags = await getFeatureFlags(auth);

--- a/front-api/routes/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
@@ -4,6 +4,7 @@ import logger from "@app/logger/logger";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -13,18 +14,13 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
+  ensureHasWorkspacePermission(
+    "publish",
+    "agent",
+    "Only users who can publish agents can perform this action."
+  ),
   async (ctx): HandlerResult<GetSlackChannelsLinkedWithAgentResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("publish", "agent"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "Only users who can publish agents can perform this action.",
-        },
-      });
-    }
 
     const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
       DataSourceResource.listByConnectorProvider(auth, "slack"),

--- a/front-api/routes/w/[wId]/audit-logs.ts
+++ b/front-api/routes/w/[wId]/audit-logs.ts
@@ -10,6 +10,7 @@ import { generateWorkOSAdminPortalUrl } from "@app/lib/api/workos/organization";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -28,19 +29,13 @@ const app = workspaceApp();
 app.post(
   "/",
   validate("json", PostAuditLogsRequestBodySchema),
+  ensureHasWorkspacePermission(
+    "admin",
+    "security",
+    "You do not have permission to manage identity and provisioning settings."
+  ),
   async (ctx): HandlerResult<AuditLogsPortalResponse> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You do not have permission to manage identity and provisioning settings.",
-        },
-      });
-    }
 
     if (!(await isAuditLogsEnabled(auth))) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/billing/info.ts
+++ b/front-api/routes/w/[wId]/billing/info.ts
@@ -1,38 +1,36 @@
 import { getWorkspaceBillingInfo } from "@app/lib/api/billing/info";
 import type { GetBillingInfoResponseBody } from "@app/types/api/billing/info";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/billing/info.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetBillingInfoResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetBillingInfoResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const result = await getWorkspaceBillingInfo(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to fetch Stripe billing information: ${result.error.message}`,
+        },
+      });
+    }
+
+    return ctx.json({ billingInfo: result.value });
   }
-
-  const result = await getWorkspaceBillingInfo(auth);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 502,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to fetch Stripe billing information: ${result.error.message}`,
-      },
-    });
-  }
-
-  return ctx.json({ billingInfo: result.value });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/billing/invoices.ts
+++ b/front-api/routes/w/[wId]/billing/invoices.ts
@@ -1,38 +1,36 @@
 import { listRecentBillingInvoices } from "@app/lib/api/billing/invoices";
 import type { GetBillingInvoicesResponseBody } from "@app/types/api/billing/invoices";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/billing/invoices.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetBillingInvoicesResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetBillingInvoicesResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const result = await listRecentBillingInvoices(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to fetch Stripe billing invoices: ${result.error.message}`,
+        },
+      });
+    }
+
+    return ctx.json({ billingInvoices: result.value });
   }
-
-  const result = await listRecentBillingInvoices(auth);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 502,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to fetch Stripe billing invoices: ${result.error.message}`,
-      },
-    });
-  }
-
-  return ctx.json({ billingInvoices: result.value });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/redemptions.ts
+++ b/front-api/routes/w/[wId]/coupon/redemptions.ts
@@ -3,6 +3,7 @@ import { getWorkspaceCoupons } from "@app/lib/api/coupons";
 import type { GetWorkspaceCouponsResponseBody } from "@app/types/api/coupons";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
@@ -34,25 +35,22 @@ function couponsErrorToApi(ctx: Context, err: WorkspaceCouponsError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetWorkspaceCouponsResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetWorkspaceCouponsResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const result = await getWorkspaceCoupons(auth);
+    if (result.isErr()) {
+      return couponsErrorToApi(ctx, result.error);
+    }
+    return ctx.json(result.value);
   }
-
-  const result = await getWorkspaceCoupons(auth);
-  if (result.isErr()) {
-    return couponsErrorToApi(ctx, result.error);
-  }
-  return ctx.json(result.value);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -1,6 +1,7 @@
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -18,67 +19,65 @@ const GetCouponValidateQuerySchema = z.object({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", validate("query", GetCouponValidateQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", GetCouponValidateQuerySchema),
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx) => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const { code, context = "subscription" } = ctx.req.valid("query");
+
+    const coupon = await CouponResource.findByCode(code);
+    if (!coupon) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "coupon_not_found",
+          message: "Coupon not found.",
+        },
+      });
+    }
+
+    const validationResult = coupon.validateRedemptionForContext(context);
+    if (validationResult.isErr()) {
+      const { code: errorCode } = validationResult.error;
+      const message =
+        errorCode === "wrong_coupon_type"
+          ? context === "credits"
+            ? "This coupon cannot be used for credit top-ups."
+            : "This coupon cannot be used for subscriptions."
+          : `Coupon is not redeemable: ${errorCode}.`;
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "coupon_not_redeemable",
+          message,
+        },
+      });
+    }
+
+    const existingRedemption =
+      await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+        auth,
+        { coupon }
+      );
+    if (existingRedemption) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "coupon_already_redeemed",
+          message: "This coupon has already been redeemed by this workspace.",
+        },
+      });
+    }
+
+    return ctx.json({ coupon: coupon.toJSON() });
   }
-
-  const { code, context = "subscription" } = ctx.req.valid("query");
-
-  const coupon = await CouponResource.findByCode(code);
-  if (!coupon) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "coupon_not_found",
-        message: "Coupon not found.",
-      },
-    });
-  }
-
-  const validationResult = coupon.validateRedemptionForContext(context);
-  if (validationResult.isErr()) {
-    const { code: errorCode } = validationResult.error;
-    const message =
-      errorCode === "wrong_coupon_type"
-        ? context === "credits"
-          ? "This coupon cannot be used for credit top-ups."
-          : "This coupon cannot be used for subscriptions."
-        : `Coupon is not redeemable: ${errorCode}.`;
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "coupon_not_redeemable",
-        message,
-      },
-    });
-  }
-
-  const existingRedemption =
-    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-      auth,
-      { coupon }
-    );
-  if (existingRedemption) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "coupon_already_redeemed",
-        message: "This coupon has already been redeemed by this workspace.",
-      },
-    });
-  }
-
-  return ctx.json({ coupon: coupon.toJSON() });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -1,28 +1,26 @@
 import { getMembersSeats } from "@app/lib/api/credits/members_seats";
 import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/credits/members-seats.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetMembersSeatsResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetMembersSeatsResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const body = await getMembersSeats({ auth });
+    return ctx.json(body);
   }
-
-  const body = await getMembersSeats({ auth });
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/domains.ts
+++ b/front-api/routes/w/[wId]/domains.ts
@@ -14,6 +14,7 @@ import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import logger from "@app/logger/logger";
 import type { GetWorkspaceDomainsResponseBody } from "@app/types/api/workos/organization";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -48,68 +49,61 @@ const SECURITY_PERMISSION_ERROR_MESSAGE =
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetWorkspaceDomainsResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "security",
+    SECURITY_PERMISSION_ERROR_MESSAGE
+  ),
+  async (ctx): HandlerResult<GetWorkspaceDomainsResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "security"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: SECURITY_PERMISSION_ERROR_MESSAGE,
-      },
+    // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
+    // created via admin tools), we create one before fetching domains. This ensures the
+    // endpoint works for all workspaces, regardless of how they were created.
+    const organizationRes = await getOrCreateWorkOSOrganization(
+      auth.getNonNullableWorkspace()
+    );
+
+    if (organizationRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to get WorkOS organization",
+        },
+      });
+    }
+
+    // If there is no organization, return an empty array.
+    if (!organizationRes.value) {
+      return ctx.json({ domains: [] });
+    }
+
+    const { link } = await generateWorkOSAdminPortalUrl({
+      organization: organizationRes.value.id,
+      workOSIntent: WorkOSPortalIntent.DomainVerification,
+      returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
+    });
+
+    return ctx.json({
+      addDomainLink: link,
+      domains: organizationRes.value.domains,
     });
   }
-
-  // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
-  // created via admin tools), we create one before fetching domains. This ensures the
-  // endpoint works for all workspaces, regardless of how they were created.
-  const organizationRes = await getOrCreateWorkOSOrganization(
-    auth.getNonNullableWorkspace()
-  );
-
-  if (organizationRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to get WorkOS organization",
-      },
-    });
-  }
-
-  // If there is no organization, return an empty array.
-  if (!organizationRes.value) {
-    return ctx.json({ domains: [] });
-  }
-
-  const { link } = await generateWorkOSAdminPortalUrl({
-    organization: organizationRes.value.id,
-    workOSIntent: WorkOSPortalIntent.DomainVerification,
-    returnUrl: `${ctx.req.header("origin")}/w/${auth.getNonNullableWorkspace().sId}/members`,
-  });
-
-  return ctx.json({
-    addDomainLink: link,
-    domains: organizationRes.value.domains,
-  });
-});
+);
 
 app.delete(
   "/",
   validate("json", DeleteWorkspaceDomainRequestBodySchema),
+  ensureHasWorkspacePermission(
+    "admin",
+    "security",
+    SECURITY_PERMISSION_ERROR_MESSAGE
+  ),
   async (ctx) => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: SECURITY_PERMISSION_ERROR_MESSAGE,
-        },
-      });
-    }
 
     const body = ctx.req.valid("json");
 
@@ -155,18 +149,13 @@ app.delete(
 app.post(
   "/",
   validate("json", PostDomainAutoJoinBodySchema),
+  ensureHasWorkspacePermission(
+    "admin",
+    "security",
+    SECURITY_PERMISSION_ERROR_MESSAGE
+  ),
   async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: SECURITY_PERMISSION_ERROR_MESSAGE,
-        },
-      });
-    }
 
     const owner = auth.getNonNullableWorkspace();
     const body = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/dust_app_secrets/index.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/index.ts
@@ -11,7 +11,10 @@ import type {
 } from "@app/types/api/dust_app_secrets";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import {
+  ensureHasWorkspacePermission,
+  ensureIsAdmin,
+} from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -27,42 +30,40 @@ const PostDustAppSecretBodySchema = z.object({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetDustAppSecretsResponseBody> => {
-  const auth = ctx.get("auth");
-
+app.get(
+  "/",
   // Dust app secrets are part of Dust app administration.
-  if (!(await auth.hasWorkspacePermission("admin", "dust_app"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "You do not have permission to manage Dust app secrets.",
-      },
+  ensureHasWorkspacePermission(
+    "admin",
+    "dust_app",
+    "You do not have permission to manage Dust app secrets."
+  ),
+  async (ctx): HandlerResult<GetDustAppSecretsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const owner = auth.getNonNullableWorkspace();
+
+    const remaining = await rateLimiter({
+      key: `workspace:${owner.id}:dust_app_secrets`,
+      maxPerTimeframe: 60,
+      timeframeSeconds: 60,
+      logger,
     });
+
+    if (remaining < 0) {
+      return apiError(ctx, {
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message: "You have reached the rate limit for this workspace.",
+        },
+      });
+    }
+
+    const secrets = await getDustAppSecrets(auth);
+    return ctx.json({ secrets });
   }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  const remaining = await rateLimiter({
-    key: `workspace:${owner.id}:dust_app_secrets`,
-    maxPerTimeframe: 60,
-    timeframeSeconds: 60,
-    logger,
-  });
-
-  if (remaining < 0) {
-    return apiError(ctx, {
-      status_code: 429,
-      api_error: {
-        type: "rate_limit_error",
-        message: "You have reached the rate limit for this workspace.",
-      },
-    });
-  }
-
-  const secrets = await getDustAppSecrets(auth);
-  return ctx.json({ secrets });
-});
+);
 
 app.post(
   "/",

--- a/front-api/routes/w/[wId]/members/free-seats.ts
+++ b/front-api/routes/w/[wId]/members/free-seats.ts
@@ -1,30 +1,28 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { GetFreeSeatCountsResponseBody } from "@app/types/api/members";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/members/free-seats.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetFreeSeatCountsResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetFreeSeatCountsResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
+    const freeSeatCounts = await MembershipResource.getFreeSeatCounts({
+      workspace: auth.getNonNullableWorkspace(),
     });
+    return ctx.json({ freeSeatCounts });
   }
-
-  const freeSeatCounts = await MembershipResource.getFreeSeatCounts({
-    workspace: auth.getNonNullableWorkspace(),
-  });
-  return ctx.json({ freeSeatCounts });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -6,6 +6,7 @@ import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecyc
 import type { GetMetronomeContractResponseBody } from "@app/types/api/credits/metronome_contract";
 import { PatchMetronomeContractRequestBody } from "@app/types/api/credits/metronome_contract";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
@@ -31,49 +32,40 @@ function lifecycleErrorToApi(ctx: Context, err: ContractLifecycleError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const result = await getMetronomeContractSummary(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to fetch Metronome contract: ${result.error.message}`,
+        },
+      });
+    }
+    return ctx.json({ contract: result.value });
   }
-
-  const result = await getMetronomeContractSummary(auth);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 502,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to fetch Metronome contract: ${result.error.message}`,
-      },
-    });
-  }
-  return ctx.json({ contract: result.value });
-});
+);
 
 app.patch(
   "/",
   validate("json", PatchMetronomeContractRequestBody),
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<PatchMetronomeContractResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const { action } = ctx.req.valid("json");
 

--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -16,6 +16,7 @@ import type { BillingPeriod } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
@@ -106,102 +107,96 @@ function mergeLineItems(
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetMetronomeInvoiceResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetMetronomeInvoiceResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
-  }
-
-  const subscription = auth.subscription();
-  const owner = auth.workspace();
-  if (!subscription || !owner) {
-    return ctx.json({ invoice: null });
-  }
-
-  const { metronomeContractId } = subscription;
-  const { metronomeCustomerId } = owner;
-  if (!metronomeContractId || !metronomeCustomerId) {
-    return ctx.json({ invoice: null });
-  }
-
-  const invoiceResult = await findCurrentInvoice(
-    metronomeCustomerId,
-    metronomeContractId
-  );
-  if (invoiceResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 502,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to fetch Metronome draft invoices: ${invoiceResult.error.message}`,
-      },
-    });
-  }
-
-  const invoice = invoiceResult.value;
-
-  if (!invoice || !invoice.start_timestamp || !invoice.end_timestamp) {
-    return ctx.json({ invoice: null });
-  }
-
-  const currency = creditTypeIdToCurrency(invoice.credit_type.id);
-  if (!currency) {
-    return ctx.json({ invoice: null });
-  }
-
-  const seatProductId = getProductWorkspaceSeatId();
-
-  let seatUnitPriceCents: number | null = null;
-
-  for (const item of invoice.line_items) {
-    const productId = item.product_id;
-    if (!productId || typeof item.unit_price !== "number") {
-      continue;
+    const subscription = auth.subscription();
+    const owner = auth.workspace();
+    if (!subscription || !owner) {
+      return ctx.json({ invoice: null });
     }
-    if (productId === seatProductId) {
-      seatUnitPriceCents = amountCents(item.unit_price, currency);
+
+    const { metronomeContractId } = subscription;
+    const { metronomeCustomerId } = owner;
+    if (!metronomeContractId || !metronomeCustomerId) {
+      return ctx.json({ invoice: null });
     }
+
+    const invoiceResult = await findCurrentInvoice(
+      metronomeCustomerId,
+      metronomeContractId
+    );
+    if (invoiceResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to fetch Metronome draft invoices: ${invoiceResult.error.message}`,
+        },
+      });
+    }
+
+    const invoice = invoiceResult.value;
+
+    if (!invoice || !invoice.start_timestamp || !invoice.end_timestamp) {
+      return ctx.json({ invoice: null });
+    }
+
+    const currency = creditTypeIdToCurrency(invoice.credit_type.id);
+    if (!currency) {
+      return ctx.json({ invoice: null });
+    }
+
+    const seatProductId = getProductWorkspaceSeatId();
+
+    let seatUnitPriceCents: number | null = null;
+
+    for (const item of invoice.line_items) {
+      const productId = item.product_id;
+      if (!productId || typeof item.unit_price !== "number") {
+        continue;
+      }
+      if (productId === seatProductId) {
+        seatUnitPriceCents = amountCents(item.unit_price, currency);
+      }
+    }
+
+    const currentPeriodStartMs = new Date(invoice.start_timestamp).getTime();
+    const currentPeriodEndMs = new Date(invoice.end_timestamp).getTime();
+
+    const summary: MetronomeInvoiceSummary = {
+      currency,
+      billingPeriod: inferBillingPeriod(
+        currentPeriodStartMs,
+        currentPeriodEndMs
+      ),
+      currentPeriodStartMs,
+      currentPeriodEndMs,
+      estimatedAmountCents: amountCents(invoice.total, currency),
+      seatUnitPriceCents,
+    };
+
+    return ctx.json({ invoice: summary });
   }
-
-  const currentPeriodStartMs = new Date(invoice.start_timestamp).getTime();
-  const currentPeriodEndMs = new Date(invoice.end_timestamp).getTime();
-
-  const summary: MetronomeInvoiceSummary = {
-    currency,
-    billingPeriod: inferBillingPeriod(currentPeriodStartMs, currentPeriodEndMs),
-    currentPeriodStartMs,
-    currentPeriodEndMs,
-    estimatedAmountCents: amountCents(invoice.total, currency),
-    seatUnitPriceCents,
-  };
-
-  return ctx.json({ invoice: summary });
-});
+);
 
 /** @ignoreswagger */
 app.get(
   "/lines",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<GetMetronomeInvoiceLinesResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const subscription = auth.subscription();
     const owner = auth.workspace();

--- a/front-api/routes/w/[wId]/metronome/migration.ts
+++ b/front-api/routes/w/[wId]/metronome/migration.ts
@@ -6,6 +6,7 @@ import {
   type WorkspaceMigrationStatus,
 } from "@app/lib/api/billing/migration_lifecycle";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
@@ -38,40 +39,31 @@ function lifecycleErrorToApi(ctx: Context, err: MigrationLifecycleError) {
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<WorkspaceMigrationStatus> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<WorkspaceMigrationStatus> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    return ctx.json(await getWorkspaceMigrationStatus(auth));
   }
-
-  return ctx.json(await getWorkspaceMigrationStatus(auth));
-});
+);
 
 /** @ignoreswagger */
 app.patch(
   "/",
   validate("json", PatchMigrationRequestBody),
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<PatchMigrationResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const { action } = ctx.req.valid("json");
 

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,32 +1,30 @@
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/lib/api/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/seats/count.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetWorkspaceSeatsCountResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetWorkspaceSeatsCountResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const owner = auth.getNonNullableWorkspace();
+
+    const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
+      owner.sId
+    );
+    return ctx.json({ seatsCount });
   }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
-    owner.sId
-  );
-  return ctx.json({ seatsCount });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/detect/index.ts
+++ b/front-api/routes/w/[wId]/skills/detect/index.ts
@@ -13,6 +13,7 @@ import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
@@ -24,141 +25,142 @@ const app = workspaceApp();
 app.route("/upload", upload);
 
 /** @ignoreswagger */
-app.post("/", async (ctx): HandlerResult<DetectSkillsResponseBody> => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
+app.post(
+  "/",
+  ensureHasWorkspacePermission(
+    "create",
+    "skill",
+    "Detecting skills is restricted.",
+    "app_auth_error"
+  ),
+  async (ctx): HandlerResult<DetectSkillsResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
 
-  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Detecting skills is restricted.",
-      },
-    });
-  }
+    const body = await ctx.req.json().catch(() => null);
+    const repoUrl = body?.repoUrl;
 
-  const body = await ctx.req.json().catch(() => null);
-  const repoUrl = body?.repoUrl;
-
-  if (!isString(repoUrl)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "repoUrl is required and must be a string.",
-      },
-    });
-  }
-
-  const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
-  const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
-  if (clientResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: clientResult.error.message,
-      },
-    });
-  }
-
-  const result = await detectSkillsFromGitHubRepo(clientResult.value);
-
-  if (result.isErr()) {
-    const { error } = result;
-
-    switch (error.type) {
-      case "invalid_url":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
-      case "not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "skill_github_repository_not_found",
-            message: error.message,
-          },
-        });
-      case "auth_error":
-        return apiError(ctx, {
-          status_code: 401,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
-      case "github_api_error":
-        logger.error(
-          { error, workspaceId: owner.sId },
-          "Error detecting skills from GitHub repo"
-        );
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
-      case "validation_error":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
-      default:
-        assertNever(error);
-    }
-  }
-
-  const detectedSkills = result.value;
-
-  if (detectedSkills.length === 0) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
-      },
-    });
-  }
-
-  const existingSkills = await SkillResource.fetchByNames(
-    auth,
-    detectedSkills.map((s) => s.name)
-  );
-
-  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
-
-  const skillSummaries: DetectedSkillSummary[] = detectedSkills.map((skill) => {
-    const existing = existingSkillsMap.get(skill.name);
-
-    if (!existing) {
-      return {
-        name: skill.name,
-        status: "ready",
-        existingSkillId: null,
-      };
+    if (!isString(repoUrl)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "repoUrl is required and must be a string.",
+        },
+      });
     }
 
-    return {
-      name: skill.name,
-      status: isSkillFromGitHubRepo(existing, { repoUrl })
-        ? "skill_already_exists"
-        : "name_conflict",
-      existingSkillId: existing.sId,
-    };
-  });
+    const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
+    const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
+    if (clientResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: clientResult.error.message,
+        },
+      });
+    }
 
-  return ctx.json({ skills: skillSummaries });
-});
+    const result = await detectSkillsFromGitHubRepo(clientResult.value);
+
+    if (result.isErr()) {
+      const { error } = result;
+
+      switch (error.type) {
+        case "invalid_url":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "skill_github_repository_not_found",
+              message: error.message,
+            },
+          });
+        case "auth_error":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "github_api_error":
+          logger.error(
+            { error, workspaceId: owner.sId },
+            "Error detecting skills from GitHub repo"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "validation_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        default:
+          assertNever(error);
+      }
+    }
+
+    const detectedSkills = result.value;
+
+    if (detectedSkills.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
+        },
+      });
+    }
+
+    const existingSkills = await SkillResource.fetchByNames(
+      auth,
+      detectedSkills.map((s) => s.name)
+    );
+
+    const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
+
+    const skillSummaries: DetectedSkillSummary[] = detectedSkills.map(
+      (skill) => {
+        const existing = existingSkillsMap.get(skill.name);
+
+        if (!existing) {
+          return {
+            name: skill.name,
+            status: "ready",
+            existingSkillId: null,
+          };
+        }
+
+        return {
+          name: skill.name,
+          status: isSkillFromGitHubRepo(existing, { repoUrl })
+            ? "skill_already_exists"
+            : "name_conflict",
+          existingSkillId: existing.sId,
+        };
+      }
+    );
+
+    return ctx.json({ skills: skillSummaries });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/detect/upload.ts
+++ b/front-api/routes/w/[wId]/skills/detect/upload.ts
@@ -5,6 +5,7 @@ import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
@@ -17,118 +18,119 @@ import formidable from "formidable";
 const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 /** @ignoreswagger */
-app.post("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.post(
+  "/",
+  ensureHasWorkspacePermission(
+    "create",
+    "skill",
+    "Detecting skills is restricted.",
+    "app_auth_error"
+  ),
+  async (ctx) => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Detecting skills is restricted.",
-      },
-    });
-  }
-
-  const incoming = ctx.env?.incoming;
-  if (!incoming) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Multipart upload is not supported in this runtime.",
-      },
-    });
-  }
-
-  const form = formidable({
-    multiples: true,
-    maxFileSize: MAX_ZIP_SIZE_BYTES,
-  });
-
-  let files: formidable.Files;
-  try {
-    [, files] = await form.parse(incoming);
-  } catch (err) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `File upload failed: ${normalizeError(err).message}`,
-      },
-    });
-  }
-
-  const uploadedFiles = files.files;
-
-  if (!uploadedFiles || uploadedFiles.length === 0) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "No files uploaded.",
-      },
-    });
-  }
-
-  const result = await detectSkillsFromUploadedFiles(uploadedFiles);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: result.error.message,
-      },
-    });
-  }
-
-  const detectedSkills = result.value;
-
-  if (detectedSkills.length === 0) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
-      },
-    });
-  }
-
-  const existingSkills = await SkillResource.fetchByNames(
-    auth,
-    detectedSkills.map((s) => s.name)
-  );
-
-  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
-
-  const skillSummaries: DetectedSkillSummary[] = detectedSkills.map((skill) => {
-    const existing = existingSkillsMap.get(skill.name);
-
-    if (!existing) {
-      return {
-        name: skill.name,
-        status: "ready",
-        existingSkillId: null,
-      };
+    const incoming = ctx.env?.incoming;
+    if (!incoming) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Multipart upload is not supported in this runtime.",
+        },
+      });
     }
 
-    if (existing.source === "local_file") {
-      return {
-        name: skill.name,
-        status: "skill_already_exists",
-        existingSkillId: existing.sId,
-      };
+    const form = formidable({
+      multiples: true,
+      maxFileSize: MAX_ZIP_SIZE_BYTES,
+    });
+
+    let files: formidable.Files;
+    try {
+      [, files] = await form.parse(incoming);
+    } catch (err) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `File upload failed: ${normalizeError(err).message}`,
+        },
+      });
     }
 
-    return {
-      name: skill.name,
-      status: "name_conflict",
-      existingSkillId: existing.sId,
-    };
-  });
+    const uploadedFiles = files.files;
 
-  return ctx.json({ skills: skillSummaries });
-});
+    if (!uploadedFiles || uploadedFiles.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "No files uploaded.",
+        },
+      });
+    }
+
+    const result = await detectSkillsFromUploadedFiles(uploadedFiles);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    const detectedSkills = result.value;
+
+    if (detectedSkills.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
+        },
+      });
+    }
+
+    const existingSkills = await SkillResource.fetchByNames(
+      auth,
+      detectedSkills.map((s) => s.name)
+    );
+
+    const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
+
+    const skillSummaries: DetectedSkillSummary[] = detectedSkills.map(
+      (skill) => {
+        const existing = existingSkillsMap.get(skill.name);
+
+        if (!existing) {
+          return {
+            name: skill.name,
+            status: "ready",
+            existingSkillId: null,
+          };
+        }
+
+        if (existing.source === "local_file") {
+          return {
+            name: skill.name,
+            status: "skill_already_exists",
+            existingSkillId: existing.sId,
+          };
+        }
+
+        return {
+          name: skill.name,
+          status: "name_conflict",
+          existingSkillId: existing.sId,
+        };
+      }
+    );
+
+    return ctx.json({ skills: skillSummaries });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/github-connection/index.ts
@@ -6,7 +6,10 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { GetGitHubConnectionResponseBody } from "@app/lib/skill_detection";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import {
+  ensureHasWorkspacePermission,
+  ensureIsAdmin,
+} from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { SuccessResponseBody } from "@front-api/routes/types";
@@ -15,26 +18,25 @@ import type { SuccessResponseBody } from "@front-api/routes/types";
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetGitHubConnectionResponseBody> => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "create",
+    "skill",
+    "Accessing the skill import GitHub connection is restricted.",
+    "app_auth_error"
+  ),
+  async (ctx): HandlerResult<GetGitHubConnectionResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
 
-  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Accessing the skill import GitHub connection is restricted.",
-      },
-    });
+    const workspace = await WorkspaceResource.fetchById(owner.sId);
+    const connection =
+      (await workspace?.getSkillImportGitHubConnectedByUser()) ?? null;
+
+    return ctx.json({ connection });
   }
-
-  const workspace = await WorkspaceResource.fetchById(owner.sId);
-  const connection =
-    (await workspace?.getSkillImportGitHubConnectedByUser()) ?? null;
-
-  return ctx.json({ connection });
-});
+);
 
 /** @ignoreswagger */
 app.post(

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -24,6 +24,7 @@ import {
   type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -275,18 +276,14 @@ app.get(
 app.post(
   "/",
   validate("json", PostSkillRequestBodySchema),
+  ensureHasWorkspacePermission(
+    "create",
+    "skill",
+    "Creating skills is restricted.",
+    "app_auth_error"
+  ),
   async (ctx): HandlerResult<PostSkillResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("create", "skill"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "app_auth_error",
-          message: "Creating skills is restricted.",
-        },
-      });
-    }
 
     const user = auth.getNonNullableUser();
 

--- a/front-api/routes/w/[wId]/sso.ts
+++ b/front-api/routes/w/[wId]/sso.ts
@@ -15,6 +15,7 @@ import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
@@ -166,18 +167,13 @@ app.delete("/", async (ctx) => {
 app.post(
   "/",
   validate("json", PostSsoEnforcementBodySchema),
+  ensureHasWorkspacePermission(
+    "admin",
+    "security",
+    SECURITY_PERMISSION_ERROR_MESSAGE
+  ),
   async (ctx): HandlerResult<GetWorkspaceResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "security"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: SECURITY_PERMISSION_ERROR_MESSAGE,
-        },
-      });
-    }
 
     const owner = auth.getNonNullableWorkspace();
     const { ssoEnforced } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -10,6 +10,7 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { wakeLock } from "@app/lib/wake_lock";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -17,65 +18,62 @@ import { validate } from "@front-api/middlewares/validator";
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetBusinessActivationResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    // Business activation is a credit-priced (Metronome) checkout flow: gate it
+    // on Metronome billing being enabled, consistently with the POST handler.
+    const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
+    if (!metronomeBillingEnabled) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    }
+
+    // The record can be looked up by contract id or by Stripe setup session id.
+    // The polling UI uses the session id so it can poll from the first step,
+    // before the contract id exists.
+    const contractId = ctx.req.query("contract_id");
+    const setupSessionId = ctx.req.query("setup_session_id");
+    const identifier = contractId
+      ? { contractId }
+      : setupSessionId
+        ? { setupSessionId }
+        : null;
+    if (!identifier) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Missing required query parameter: contract_id or setup_session_id.",
+        },
+      });
+    }
+
+    // The polling UI omits `receipt`; only the success screen requests the
+    // (slow) Stripe hosted invoice URL, so status polls stay fast.
+    const includeReceiptUrl = ctx.req.query("receipt") === "true";
+
+    const workspace = auth.getNonNullableWorkspace();
+    return ctx.json(
+      await getBusinessActivationStatus(workspace, identifier, {
+        includeReceiptUrl,
+      })
+    );
   }
-
-  // Business activation is a credit-priced (Metronome) checkout flow: gate it
-  // on Metronome billing being enabled, consistently with the POST handler.
-  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-  if (!metronomeBillingEnabled) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Metronome billing is not enabled for this workspace.",
-      },
-    });
-  }
-
-  // The record can be looked up by contract id or by Stripe setup session id.
-  // The polling UI uses the session id so it can poll from the first step,
-  // before the contract id exists.
-  const contractId = ctx.req.query("contract_id");
-  const setupSessionId = ctx.req.query("setup_session_id");
-  const identifier = contractId
-    ? { contractId }
-    : setupSessionId
-      ? { setupSessionId }
-      : null;
-  if (!identifier) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Missing required query parameter: contract_id or setup_session_id.",
-      },
-    });
-  }
-
-  // The polling UI omits `receipt`; only the success screen requests the
-  // (slow) Stripe hosted invoice URL, so status polls stay fast.
-  const includeReceiptUrl = ctx.req.query("receipt") === "true";
-
-  const workspace = auth.getNonNullableWorkspace();
-  return ctx.json(
-    await getBusinessActivationStatus(workspace, identifier, {
-      includeReceiptUrl,
-    })
-  );
-});
+);
 
 /** @ignoreswagger */
 app.post(

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -6,47 +6,45 @@ import type { GetPreparePaymentResponseBody } from "@app/types/api/checkout/prep
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/subscriptions/checkout/prepare-payment.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
+  async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "You need billing access to manage billing settings, invoices, and payment methods.",
-      },
-    });
+    const setup_session_id = ctx.req.query("setup_session_id");
+    if (!isString(setup_session_id)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing or invalid setup_session_id query parameter.",
+        },
+      });
+    }
+
+    // Prevent HTTP caching as session status can change on every call.
+    ctx.header("Cache-Control", "no-store");
+
+    const result = await getPreparePaymentData(auth, setup_session_id);
+    if (result.isErr()) {
+      return mapPreparePaymentError(ctx, result.error);
+    }
+
+    return ctx.json<GetPreparePaymentResponseBody>(result.value);
   }
-
-  const setup_session_id = ctx.req.query("setup_session_id");
-  if (!isString(setup_session_id)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid setup_session_id query parameter.",
-      },
-    });
-  }
-
-  // Prevent HTTP caching as session status can change on every call.
-  ctx.header("Cache-Control", "no-store");
-
-  const result = await getPreparePaymentData(auth, setup_session_id);
-  if (result.isErr()) {
-    return mapPreparePaymentError(ctx, result.error);
-  }
-
-  return ctx.json<GetPreparePaymentResponseBody>(result.value);
-});
+);
 
 function mapPreparePaymentError(
   ctx: Parameters<typeof apiError>[0],

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -17,7 +17,10 @@ import type {
 import { PatchSubscriptionRequestBody } from "@app/types/api/subscription";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import {
+  ensureHasWorkspacePermission,
+  ensureIsManager,
+} from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -66,19 +69,13 @@ app.get(
 app.post(
   "/",
   validate("json", PostSubscriptionRequestBody),
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<PostSubscriptionResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const body = ctx.req.valid("json");
 
@@ -119,19 +116,13 @@ app.post(
 app.patch(
   "/",
   validate("json", PatchSubscriptionRequestBody),
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<PatchSubscriptionResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const subscription = auth.subscription();
     if (!subscription) {

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,7 +1,8 @@
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import type { GetSubscriptionTrialInfoResponseBody } from "@app/types/api/subscription";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { ensureHasWorkspacePermission } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/subscriptions/trial-info.
 const app = workspaceApp();
@@ -9,19 +10,13 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get(
   "/",
+  ensureHasWorkspacePermission(
+    "admin",
+    "billing",
+    "You need billing access to manage billing settings, invoices, and payment methods."
+  ),
   async (ctx): HandlerResult<GetSubscriptionTrialInfoResponseBody> => {
     const auth = ctx.get("auth");
-
-    if (!(await auth.hasWorkspacePermission("admin", "billing"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "You need billing access to manage billing settings, invoices, and payment methods.",
-        },
-      });
-    }
 
     const subscription = auth.subscription();
     if (!subscription) {


### PR DESCRIPTION
Stacked on #29547.

## Summary

Adds a reusable Hono middleware `ensureHasWorkspacePermission(verb, resourceType, message, errorType?)` in `front-api/middlewares/ensure_role.ts` and uses it to replace the repeated inline `auth.hasWorkspacePermission(...)` 403 guards scattered across the workspace endpoints.

```ts
app.get(
  "/",
  ensureHasWorkspacePermission("admin", "billing", "You need billing access ..."),
  async (ctx) => { ... }
);
```

- `errorType` defaults to `"workspace_auth_error"` (consistent with the sibling `ensureIsAdmin` / `ensureIsManager` / `ensureIsBuilder` middlewares).
- The skills endpoints pass `"app_auth_error"` as the 4th arg to preserve the error type used throughout the skills module — no behavior change.

## What was converted

Standalone, top-of-handler guards in ~20 files (billing, subscriptions, metronome, security/domains/sso/audit-logs, dust_app_secrets, agent slack-channel endpoints, and the skills create/detect/import endpoints).

## What was intentionally left inline

The middleware only fits a guard that is the first thing a handler does. These stay inline because converting them would change logic:

- **Combined conditions**: `verified-domains.ts` and `subscriptions/pricing.ts` (`!isManager() && !hasWorkspacePermission(...)`), `spaces/[spaceId]/apps` (`!space.canWrite(auth) || ...`), `agent_configurations/[aId]/tags`, `files/[fileId]/share/{grants,index}` (part of an `||`), and the skill publish checks gated on `hasSkillPublicationGovernance`.
- **Nested checks**: `business-activation.ts` POST (inside a `wakeLock(...)` callback).
- **Preceded by a different check**: `skills/availability.ts` (a governance feature-flag check must run first; middleware would reorder it).
- **Shared helpers**: the `checkAccess` helpers in `sso.ts` / `dsync.ts` are already centralized (not repeated inline blocks).
- **`stripe/portal.ts`**: runs on `sessionApp()`, not `workspaceApp()` — it builds `auth` locally from the request body, so there is no `ctx.get("auth")` for the middleware to read.

## Testing

- `npx tsgo --noEmit` clean
- `biome check` (format:changed) clean
- All affected route test suites pass (106+ tests across domains, sso, skills, subscriptions, billing, coupon, seats, credits, members, business-activation, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)