### PR TITLE
[front] fix: prevent Manage Agents table blink on selection

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -103,7 +103,7 @@ const getTableColumns = ({
                 info.table.getIsAllPageRowsSelected();
               const hasSelection = Object.values(
                 info.table.getState().rowSelection
-              ).some(Boolean);
+              ).some((isSelected) => isSelected);
 
               return (
                 <Checkbox

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -73,13 +73,11 @@ const getTableColumns = ({
   owner,
   tags,
   isBatchEdit,
-  hasSelection,
   mutateAgentConfigurations,
 }: {
   owner: WorkspaceType;
   tags: TagType[];
   isBatchEdit: boolean;
-  hasSelection: boolean;
   mutateAgentConfigurations: () => Promise<any>;
 }) => {
   /**
@@ -103,6 +101,9 @@ const getTableColumns = ({
             header: (info: HeaderContext<RowData, boolean>) => {
               const areAllPageRowsSelected =
                 info.table.getIsAllPageRowsSelected();
+              const hasSelection = Object.values(
+                info.table.getState().rowSelection
+              ).some(Boolean);
 
               return (
                 <Checkbox
@@ -404,6 +405,18 @@ export function AssistantsTable({
 }: AssistantsTableProps) {
   const { tags } = useTags({ owner });
   const sortedTags = useMemo(() => [...tags].sort(tagsSorter), [tags]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mutateAgentConfigurations has an unstable identity but always mutates the same SWR cache key.
+  const columns = useMemo(
+    () =>
+      getTableColumns({
+        owner,
+        tags: sortedTags,
+        isBatchEdit,
+        mutateAgentConfigurations,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutateAgentConfigurations has an unstable identity but always mutates the same SWR cache key.
+    [owner, sortedTags, isBatchEdit]
+  );
 
   const { isDark } = useTheme();
 
@@ -591,13 +604,7 @@ export function AssistantsTable({
           <DataTable
             className="relative"
             data={rows}
-            columns={getTableColumns({
-              owner,
-              tags: sortedTags,
-              isBatchEdit,
-              hasSelection: selection.length > 0,
-              mutateAgentConfigurations,
-            })}
+            columns={columns}
             pagination={pagination}
             setPagination={setPagination}
             getRowId={(row) => row.sId}

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -414,7 +414,6 @@ export function AssistantsTable({
         isBatchEdit,
         mutateAgentConfigurations,
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutateAgentConfigurations has an unstable identity but always mutates the same SWR cache key.
     [owner, sortedTags, isBatchEdit]
   );
 


### PR DESCRIPTION
## Description

Clicking a checkbox on the Manage Agents page can make the whole table visibly blink.

The table was rebuilding its column definitions whenever the selection changed. This memoizes those columns and reads the select-all checkbox state directly from TanStack table state, so selecting agents no longer recreates the table structure.

## Tests

- Tested locally.

## Risk

- Low, front0end only

## Deploy Plan

- Deploy front.
