### PR TITLE
Fix: isDevelopment always true in temporal workflows

### DIFF
--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -1,4 +1,4 @@
-import { isDevelopment } from "@app/types/shared/env";
+import { isCronScheduleConfig } from "@app/types/assistant/triggers";
 import { ActivityFailure, RetryState } from "@temporalio/common";
 import { proxyActivities, sleep } from "@temporalio/workflow";
 import type * as activities from "./activities";
@@ -7,11 +7,7 @@ import type * as activities from "./activities";
 const ON_THE_HOUR_JITTER_MS = 60 * 10 * 1000;
 
 const getJitterMs = () => {
-  if (isDevelopment()) {
-    return 0;
-  } else {
-    return Math.floor(Math.random() * ON_THE_HOUR_JITTER_MS);
-  }
+  return Math.floor(Math.random() * ON_THE_HOUR_JITTER_MS);
 };
 
 const { getTriggerActivity, runTriggeredAgentsActivity } = proxyActivities<
@@ -56,7 +52,7 @@ export async function agentTriggerWorkflow({
     // For triggers starting on the hour, we will add a little bit of jitter to the start time to avoid all conversations starting at the same time
     if (
       trigger.kind === "schedule" &&
-      trigger.configuration.type === "cron" &&
+      isCronScheduleConfig(trigger.configuration) &&
       trigger.configuration.cron.startsWith("0 ")
     ) {
       const jitterMs = getJitterMs();


### PR DESCRIPTION
## Description

`isDevelopment()` calls `process.env.NODE_ENV`, which is inaccessible inside Temporal workflow sandboxes — it always returns `true`. In `agentTriggerWorkflow`, this caused `getJitterMs()` to always return `0`, silently disabling cron jitter in production.

Removes the dev-environment guard from `getJitterMs()` so jitter applies unconditionally. Also replaces the raw `trigger.configuration.type === "cron"` string check with the `isCronScheduleConfig` type guard.

## Tests

Tested locally. The fix is straightforward: the broken `isDevelopment()` call is deleted rather than patched, so there's no conditional logic left to validate.

## Risk

Low. The only side-effect is that cron triggers in local dev now also get up to 10 min of jitter — acceptable. The production fix (restoring jitter) is the intended behaviour from PR #29538. Safe to rollback via redeploy.

## Deploy Plan

Deploy front (Temporal workers).
