### PR TITLE
[front] enh: improve batch tag update error handling

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -2,8 +2,9 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { TagFactory } from "@app/tests/utils/TagFactory";
+import { Err } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 function batchUpdateTags(workspace: { sId: string }, body: unknown) {
   return honoApp.request(
@@ -17,6 +18,10 @@ function batchUpdateTags(workspace: { sId: string }, body: unknown) {
 }
 
 describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("adds and removes tags while ignoring duplicate additions", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       method: "POST",
@@ -54,5 +59,45 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
         tagToAdd.sId,
       ]);
     }
+  });
+
+  it("returns 400 when adding tags fails", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    vi.spyOn(TagResource, "addToAgents").mockResolvedValue(
+      new Err(new Error("Failed to add tags"))
+    );
+
+    const response = await batchUpdateTags(workspace, { agentIds: [] });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Failed to add tags",
+      },
+    });
+  });
+
+  it("returns 400 when removing tags fails", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    vi.spyOn(TagResource, "removeFromAgents").mockResolvedValue(
+      new Err(new Error("Failed to remove tags"))
+    );
+
+    const response = await batchUpdateTags(workspace, { agentIds: [] });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Failed to remove tags",
+      },
+    });
   });
 });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -50,8 +50,43 @@ app.post(
       (agent) => agent.canEdit || auth.isAdmin()
     );
 
-    await TagResource.addToAgents(auth, tagsToAdd, editableAgents);
-    await TagResource.removeFromAgents(auth, tagsToRemove, editableAgents);
+    const addTagsResult = await TagResource.addToAgents(
+      auth,
+      tagsToAdd,
+      editableAgents
+    );
+    if (addTagsResult.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: addTagsResult.error.message,
+          },
+        },
+        addTagsResult.error
+      );
+    }
+
+    const removeTagsResult = await TagResource.removeFromAgents(
+      auth,
+      tagsToRemove,
+      editableAgents
+    );
+    if (removeTagsResult.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: removeTagsResult.error.message,
+          },
+        },
+        removeTagsResult.error
+      );
+    }
 
     return ctx.json({ success: true });
   }

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -277,30 +277,37 @@ export class TagResource extends BaseResource<TagModel> {
     auth: Authenticator,
     tags: TagResource[],
     agentConfigurations: LightAgentConfigurationType[]
-  ) {
+  ): Promise<Result<undefined, Error>> {
     if (
       !auth.isAdmin() &&
       agentConfigurations.some(
         (agentConfiguration) => !agentConfiguration.canEdit
       )
     ) {
-      throw new Error("You are not allowed to add tags to this agent");
+      return new Err(
+        new Error("You are not allowed to add tags to this agent")
+      );
     }
 
     if (tags.length === 0 || agentConfigurations.length === 0) {
-      return;
+      return new Ok(undefined);
     }
 
-    await TagAgentModel.bulkCreate(
-      agentConfigurations.flatMap((agentConfiguration) =>
-        tags.map((tag) => ({
-          workspaceId: auth.getNonNullableWorkspace().id,
-          tagId: tag.id,
-          agentConfigurationId: agentConfiguration.id,
-        }))
-      ),
-      { ignoreDuplicates: true }
-    );
+    try {
+      await TagAgentModel.bulkCreate(
+        agentConfigurations.flatMap((agentConfiguration) =>
+          tags.map((tag) => ({
+            workspaceId: auth.getNonNullableWorkspace().id,
+            tagId: tag.id,
+            agentConfigurationId: agentConfiguration.id,
+          }))
+        ),
+        { ignoreDuplicates: true }
+      );
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
   }
 
   async removeFromAgent(
@@ -324,29 +331,36 @@ export class TagResource extends BaseResource<TagModel> {
     auth: Authenticator,
     tags: TagResource[],
     agentConfigurations: LightAgentConfigurationType[]
-  ) {
+  ): Promise<Result<undefined, Error>> {
     if (
       !auth.isAdmin() &&
       agentConfigurations.some(
         (agentConfiguration) => !agentConfiguration.canEdit
       )
     ) {
-      throw new Error("You are not allowed to remove tags from this agent");
+      return new Err(
+        new Error("You are not allowed to remove tags from this agent")
+      );
     }
 
     if (tags.length === 0 || agentConfigurations.length === 0) {
-      return;
+      return new Ok(undefined);
     }
 
-    await TagAgentModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        tagId: tags.map((tag) => tag.id),
-        agentConfigurationId: agentConfigurations.map(
-          (agentConfiguration) => agentConfiguration.id
-        ),
-      },
-    });
+    try {
+      await TagAgentModel.destroy({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          tagId: tags.map((tag) => tag.id),
+          agentConfigurationId: agentConfigurations.map(
+            (agentConfiguration) => agentConfiguration.id
+          ),
+        },
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
   }
 
   async updateTag({ name, kind }: { name: string; kind: TagKind }) {

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -293,21 +293,17 @@ export class TagResource extends BaseResource<TagModel> {
       return new Ok(undefined);
     }
 
-    try {
-      await TagAgentModel.bulkCreate(
-        agentConfigurations.flatMap((agentConfiguration) =>
-          tags.map((tag) => ({
-            workspaceId: auth.getNonNullableWorkspace().id,
-            tagId: tag.id,
-            agentConfigurationId: agentConfiguration.id,
-          }))
-        ),
-        { ignoreDuplicates: true }
-      );
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
+    await TagAgentModel.bulkCreate(
+      agentConfigurations.flatMap((agentConfiguration) =>
+        tags.map((tag) => ({
+          workspaceId: auth.getNonNullableWorkspace().id,
+          tagId: tag.id,
+          agentConfigurationId: agentConfiguration.id,
+        }))
+      ),
+      { ignoreDuplicates: true }
+    );
+    return new Ok(undefined);
   }
 
   async removeFromAgent(
@@ -347,20 +343,16 @@ export class TagResource extends BaseResource<TagModel> {
       return new Ok(undefined);
     }
 
-    try {
-      await TagAgentModel.destroy({
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          tagId: tags.map((tag) => tag.id),
-          agentConfigurationId: agentConfigurations.map(
-            (agentConfiguration) => agentConfiguration.id
-          ),
-        },
-      });
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
+    await TagAgentModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        tagId: tags.map((tag) => tag.id),
+        agentConfigurationId: agentConfigurations.map(
+          (agentConfiguration) => agentConfiguration.id
+        ),
+      },
+    });
+    return new Ok(undefined);
   }
 
   async updateTag({ name, kind }: { name: string; kind: TagKind }) {


### PR DESCRIPTION
## Description

Bulk agent tag updates currently surface write failures (those due to permissions for instance) as unhandled server errors.

Follow-up to #29537. Both batch `TagResource` operations now bubble up errors as `Result`s, and let the endpoint return a 4xx when adding or removing tags fails.

## Tests

- Added endpoint coverage for tag addition and removal failures.

## Risk

- Low.

## Deploy Plan

- Deploy front.
