### PR TITLE
[front] Fix billing period

### DIFF
--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -467,28 +467,45 @@ function billingPeriodFromContract(
   contract: CachedContract
 ): Result<BillingCycle, Error> {
   // Per-seat credits recur MONTHLY even on annually-billed seats (see
-  // `getNextSeatCreditRenewalDate`), on the grid anchored at the contract
-  // start — so the credit cycle is the current month of the contract
-  // anniversary day, regardless of any subscription's billing frequency.
-  // Boundaries keep the contract start's (hour-aligned) time-of-day, matching
-  // Metronome's period boundaries.
-  const hasCurrentPeriod = (contract.subscriptions ?? []).some(
-    (s) => s.billing_periods?.current !== undefined
-  );
-  if (!hasCurrentPeriod) {
+  // `getNextSeatCreditRenewalDate`), on the grid anchored at the contract's
+  // billing anchor date — so the credit cycle is the current month of that
+  // anchor day, regardless of any subscription's billing frequency.
+  //
+  // Read the anchor off `usage_statement_schedule.billing_anchor_date` — a
+  // required, contract-level field — rather than off
+  // `subscriptions[].billing_periods`: some contracts carry no subscriptions
+  // at all (e.g. programmatic-only contracts), so keying off subscription
+  // presence/ordering is fragile. Metronome resolves this field to a fixed
+  // date whose day-of-month recurs every period regardless of package (a
+  // contract-start-anchored package resolves it to the contract start's
+  // day-of-month; a "1st of month" package resolves it to day 1).
+  const anchorDateString =
+    contract.usage_statement_schedule?.billing_anchor_date;
+  if (!anchorDateString) {
     return new Err(
-      new Error("No current billing period found on Metronome contract")
+      new Error("No billing anchor date found on Metronome contract")
     );
   }
-  const contractStart = new Date(contract.starting_at);
-  return new Ok(
-    getBillingCycleFromDay(
-      contractStart.getUTCDate(),
-      new Date(),
-      true,
-      contractStart
-    )
+  const anchorDate = new Date(anchorDateString);
+  const cycle = getBillingCycleFromDay(
+    anchorDate.getUTCDate(),
+    new Date(),
+    true,
+    anchorDate
   );
+
+  // Clamp to the contract's actual start: during the partial first period
+  // (e.g. a "1st of month" package on a contract starting mid-month), the
+  // reconstructed monthly bucket extends earlier than the contract existed —
+  // there can't be usage to count before the contract started, so never
+  // report a cycleStart earlier than `contract.starting_at`.
+  const contractStart = new Date(contract.starting_at);
+  const cycleStart =
+    cycle.cycleStart.getTime() < contractStart.getTime()
+      ? contractStart
+      : cycle.cycleStart;
+
+  return new Ok({ cycleStart, cycleEnd: cycle.cycleEnd });
 }
 
 /**


### PR DESCRIPTION
## Description

`billingPeriodFromContract` (`front/lib/metronome/contracts.ts`) computes the workspace's current Metronome billing-period window (`cycleStart`/`cycleEnd`), used everywhere we need to know "how much has this workspace/user/key consumed during the current cycle" and "when do limits reset."

It previously derived the period's anchor day from `contract.starting_at`'s day-of-month. That's correct for legacy contract-start-anchored packages, but wrong for "1st of month" packages (`BILLING_CYCLE_CONFIG_FIRST_OF_MONTH`): those anchor to the calendar 1st regardless of when the contract actually started. A contract starting e.g. July 4th would have its computed period drift to July4→Aug4→Sep4→... instead of the real Metronome grid (July4→Aug1 stub period, then Aug1→Sep1, Sep1→Oct1, ...). This silently misaligns the displayed/enforced "current period" from Metronome's real credit-reset boundary starting the first time such a contract rolls past its initial partial period — e.g. Aug 1 for any "1st of month" contract created in July.

Fix, in two parts:

1. **Read the anchor from `contract.usage_statement_schedule.billing_anchor_date`** — a required, contract-level field that Metronome itself resolves per package (day-of-month of contract start for contract-start-anchored packages, day 1 for "1st of month" packages) — instead of `contract.starting_at` or `contract.subscriptions[].billing_periods`. Subscriptions can be entirely absent (e.g. programmatic-only contracts) and picking an arbitrary subscription to read periods from is fragile; this field is always present regardless of subscription shape.
2. **Clamp `cycleStart` to never precede `contract.starting_at`.** During a contract's first (partial) period on a "1st of month" package, reconstructing the monthly bucket from the anchor day alone extends `cycleStart` back to the 1st even though the contract only started mid-month — which would count usage from before the contract existed. Clamping fixes this (caught by manually inspecting poke's "Consumed" column on a contract that started mid-month).

This function backs every consumer of "the workspace's current billing period": members/credits usage display and reset date (`lib/api/credits/members_usage.ts`), bulk seat-change scheduling (`lib/api/credits/bulk_seat_change.ts`), programmatic spend (`lib/metronome/programmatic_awu_usage.ts`), per-user usage (`lib/metronome/per_user_usage.ts`), per-API-key usage (`lib/metronome/per_api_key_usage.ts`), and reinforcement/skill spend (`lib/reinforcement/billing.ts`).

## Tests

- `npx tsgo --noEmit` passes.
- Manually traced both anchor schemes (contract-start-anchored and "1st of month") by hand against concrete dates, including a contract starting mid-month, both before and after the period rolls over.
- No dedicated unit test added: `billingPeriodFromContract` is a private, non-exported helper, and per house convention unit tests on private lib helpers aren't required. Manual verification recommended on a workspace with a "1st of month" contract:
  - `/w/:wId/usage` → members table: check the **"Limits reset on ⟨date⟩"** header and per-user Consumed numbers.
  - `/poke/:wId` → Usage tab → members table: check per-user **Consumed**/**User cap** numbers and use the per-user **Reconcile** button.
  - `BulkChangeSeatModal` preview → **"Changes on next billing period (⟨date⟩)"**.

## Risk

- Workspaces on legacy contract-start-anchored packages: no behavior change (the anchor day already equalled the contract start's day-of-month; the clamp is a no-op since those periods never start before `contract.starting_at`).
- Workspaces on "1st of month" packages: this changes the computed billing-period window going forward, fixing the drift that would otherwise hit the first time such a contract rolls past its initial partial period. Pure bugfix, low risk, but touches a function feeding several usage/cap-display and scheduling paths — worth the manual spot-check above post-deploy.
- Rollback: revert this single-file commit; no data migration or schema involved.

## Deploy Plan

Standard deploy, no migration or feature flag. Worth deploying before Aug 1 to avoid the period-boundary drift affecting "1st of month" contracts that started in July.