### PR TITLE
[front] chore: remove static MCP tool factories

### DIFF
--- a/front/lib/api/actions/servers/confluence/index.ts
+++ b/front/lib/api/actions/servers/confluence/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { CONFLUENCE_TOOL_NAME } from "@app/lib/api/actions/servers/confluence/metadata";
-import { createConfluenceTools } from "@app/lib/api/actions/servers/confluence/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/confluence/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,8 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("confluence");
 
-  const tools = createConfluenceTools();
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: CONFLUENCE_TOOL_NAME,
     });

--- a/front/lib/api/actions/servers/confluence/tools/index.ts
+++ b/front/lib/api/actions/servers/confluence/tools/index.ts
@@ -1,6 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
-  ToolDefinition,
   ToolHandlerExtra,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -22,188 +21,186 @@ import {
 } from "@app/lib/api/actions/servers/confluence/rendering";
 import { Ok } from "@app/types/shared/result";
 
-export function createConfluenceTools(): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof CONFLUENCE_TOOLS_METADATA> = {
-    get_current_user: async (_params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await getCurrentUser(baseUrl, accessToken);
-          if (result.isErr()) {
-            throw new MCPError(`Error getting current user: ${result.error}`);
-          }
-          return result.value;
+const handlers: ToolHandlers<typeof CONFLUENCE_TOOLS_METADATA> = {
+  get_current_user: async (_params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await getCurrentUser(baseUrl, accessToken);
+        if (result.isErr()) {
+          throw new MCPError(`Error getting current user: ${result.error}`);
         }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
+        return result.value;
       }
+    );
 
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: "Current user information retrieved successfully",
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(authResult.result, null, 2),
+      },
+    ]);
+  },
+
+  get_spaces: async (_params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await listSpaces(baseUrl, accessToken);
+        if (result.isErr()) {
+          throw new MCPError(`Error listing spaces: ${result.error}`);
+        }
+        return result.value;
+      }
+    );
+
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
+
+    const formattedResults = renderConfluenceSpacesList(
+      authResult.result.results,
+      {
+        hasMore: Boolean(authResult.result._links?.next),
+      }
+    );
+    return new Ok([
+      {
+        type: "text" as const,
+        text: formattedResults,
+      },
+    ]);
+  },
+
+  get_pages: async (params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await listPages(baseUrl, accessToken, params);
+        if (result.isErr()) {
+          throw new MCPError(`Error listing pages: ${result.error}`);
+        }
+        return result.value;
+      }
+    );
+
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
+
+    const formattedResults = renderConfluencePageList(
+      authResult.result.results,
+      {
+        hasMore: Boolean(authResult.result._links?.next),
+      }
+    );
+    return new Ok([
+      {
+        type: "text" as const,
+        text: formattedResults,
+      },
+    ]);
+  },
+
+  get_page: async (params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await getPage(
+          baseUrl,
+          accessToken,
+          params.pageId,
+          params.includeBody
+        );
+        if (result.isErr()) {
+          throw new MCPError(`Error getting page: ${result.error}`);
+        }
+
+        return result.value;
+      }
+    );
+
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
+
+    if (authResult.result === null) {
       return new Ok([
         {
           type: "text" as const,
-          text: "Current user information retrieved successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(authResult.result, null, 2),
+          text: `Page with ID ${params.pageId} not found`,
         },
       ]);
-    },
+    }
 
-    get_spaces: async (_params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await listSpaces(baseUrl, accessToken);
-          if (result.isErr()) {
-            throw new MCPError(`Error listing spaces: ${result.error}`);
-          }
-          return result.value;
+    const formattedPage = renderConfluencePage(authResult.result, {
+      includeBody: params.includeBody ?? false,
+    });
+    return new Ok([
+      {
+        type: "text" as const,
+        text: formattedPage,
+      },
+    ]);
+  },
+
+  create_page: async (params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await createPage(baseUrl, accessToken, params);
+        if (result.isErr()) {
+          throw new MCPError(`Error creating page: ${result.error}`);
         }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
+        return result.value;
       }
+    );
 
-      const formattedResults = renderConfluenceSpacesList(
-        authResult.result.results,
-        {
-          hasMore: Boolean(authResult.result._links?.next),
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
+
+    return new Ok([
+      { type: "text" as const, text: "Page created successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify(authResult.result, null, 2),
+      },
+    ]);
+  },
+
+  update_page: async (params, { authInfo }: ToolHandlerExtra) => {
+    const authResult = await withAuth(
+      authInfo,
+      async (baseUrl, accessToken) => {
+        const result = await updatePage(baseUrl, accessToken, params);
+        if (result.isErr()) {
+          throw new MCPError(`Error updating page: ${result.error}`);
         }
-      );
-      return new Ok([
-        {
-          type: "text" as const,
-          text: formattedResults,
-        },
-      ]);
-    },
-
-    get_pages: async (params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await listPages(baseUrl, accessToken, params);
-          if (result.isErr()) {
-            throw new MCPError(`Error listing pages: ${result.error}`);
-          }
-          return result.value;
-        }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
+        return result.value;
       }
+    );
 
-      const formattedResults = renderConfluencePageList(
-        authResult.result.results,
-        {
-          hasMore: Boolean(authResult.result._links?.next),
-        }
-      );
-      return new Ok([
-        {
-          type: "text" as const,
-          text: formattedResults,
-        },
-      ]);
-    },
+    if (!authResult.success) {
+      return new Ok(authResult.error);
+    }
 
-    get_page: async (params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await getPage(
-            baseUrl,
-            accessToken,
-            params.pageId,
-            params.includeBody
-          );
-          if (result.isErr()) {
-            throw new MCPError(`Error getting page: ${result.error}`);
-          }
+    return new Ok([
+      { type: "text" as const, text: "Page updated successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify(authResult.result, null, 2),
+      },
+    ]);
+  },
+};
 
-          return result.value;
-        }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
-      }
-
-      if (authResult.result === null) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Page with ID ${params.pageId} not found`,
-          },
-        ]);
-      }
-
-      const formattedPage = renderConfluencePage(authResult.result, {
-        includeBody: params.includeBody ?? false,
-      });
-      return new Ok([
-        {
-          type: "text" as const,
-          text: formattedPage,
-        },
-      ]);
-    },
-
-    create_page: async (params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await createPage(baseUrl, accessToken, params);
-          if (result.isErr()) {
-            throw new MCPError(`Error creating page: ${result.error}`);
-          }
-          return result.value;
-        }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
-      }
-
-      return new Ok([
-        { type: "text" as const, text: "Page created successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(authResult.result, null, 2),
-        },
-      ]);
-    },
-
-    update_page: async (params, { authInfo }: ToolHandlerExtra) => {
-      const authResult = await withAuth(
-        authInfo,
-        async (baseUrl, accessToken) => {
-          const result = await updatePage(baseUrl, accessToken, params);
-          if (result.isErr()) {
-            throw new MCPError(`Error updating page: ${result.error}`);
-          }
-          return result.value;
-        }
-      );
-
-      if (!authResult.success) {
-        return new Ok(authResult.error);
-      }
-
-      return new Ok([
-        { type: "text" as const, text: "Page updated successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(authResult.result, null, 2),
-        },
-      ]);
-    },
-  };
-
-  return buildTools(CONFLUENCE_TOOLS_METADATA, handlers);
-}
+export const TOOLS = buildTools(CONFLUENCE_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/luma/index.ts
+++ b/front/lib/api/actions/servers/luma/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createLumaTools } from "@app/lib/api/actions/servers/luma/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/luma/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("luma");
 
-  const tools = createLumaTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "luma",
     });

--- a/front/lib/api/actions/servers/luma/tools/index.ts
+++ b/front/lib/api/actions/servers/luma/tools/index.ts
@@ -5,7 +5,6 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
 import type { LumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { getLumaClient } from "@app/lib/api/actions/servers/luma/client";
 import { LUMA_TOOLS_METADATA } from "@app/lib/api/actions/servers/luma/metadata";
@@ -17,7 +16,6 @@ import {
   renderGuestList,
   renderUser,
 } from "@app/lib/api/actions/servers/luma/rendering";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
 async function withClient(
@@ -31,266 +29,257 @@ async function withClient(
   return action(clientResult.value);
 }
 
-export function createLumaTools(
-  _auth: Authenticator,
-  _toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof LUMA_TOOLS_METADATA> = {
-    get_authenticated_user: async (_params, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.getSelf();
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to get account info: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          { type: "text" as const, text: renderUser(result.value) },
-        ]);
-      });
-    },
-
-    get_event: async ({ event_api_id }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.getEvent(event_api_id);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to get event: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          { type: "text" as const, text: renderEvent(result.value) },
-        ]);
-      });
-    },
-
-    list_events: async ({ after, before }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listEvents({ after, before });
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to list events: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderEventList(result.value.events, result.value.nextCursor),
-          },
-        ]);
-      });
-    },
-
-    create_event: async (params, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.createEvent(params);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to create event: ${result.error.message}`)
-          );
-        }
-        const event = result.value;
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `Created event "${event.name}".\n\n` +
-              `- ID: ${event.api_id}\n` +
-              (event.url ? `- URL: ${event.url}\n` : "") +
-              `- Start: ${event.start_at}`,
-          },
-        ]);
-      });
-    },
-
-    update_event: async (
-      { event_api_id, ...updateData },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        const result = await client.updateEvent(event_api_id, updateData);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to update event: ${result.error.message}`)
-          );
-        }
-        const event = result.value;
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `Updated event "${event.name}".\n\n` +
-              `- ID: ${event.api_id}\n` +
-              (event.url ? `- URL: ${event.url}\n` : "") +
-              `- Start: ${event.start_at}`,
-          },
-        ]);
-      });
-    },
-
-    list_guests: async (
-      { event_api_id, ...listParams },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listGuests(event_api_id, listParams);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to list guests: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderGuestList(result.value.guests, result.value.nextCursor),
-          },
-        ]);
-      });
-    },
-
-    get_guest: async (
-      { event_api_id, guest_api_id },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        const result = await client.getGuest(event_api_id, guest_api_id);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to get guest: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          { type: "text" as const, text: renderGuest(result.value) },
-        ]);
-      });
-    },
-
-    update_guest_status: async (
-      { event_api_id, guest_api_id_or_email, status, should_refund },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        const result = await client.updateGuestStatus(event_api_id, {
-          guest_api_id_or_email,
-          status,
-          should_refund,
-        });
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to update guest status: ${result.error.message}`
-            )
-          );
-        }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Updated guest "${guest_api_id_or_email}" to "${status}".`,
-          },
-        ]);
-      });
-    },
-
-    add_guests: async ({ event_api_id, guests }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.addGuests(event_api_id, guests);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to add guests: ${result.error.message}`)
-          );
-        }
-        const addedGuests = result.value;
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Added ${addedGuests.length} guests to the event.`,
-          },
-        ]);
-      });
-    },
-
-    send_invites: async ({ event_api_id, emails }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.sendInvites(event_api_id, { emails });
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to send invites: ${result.error.message}`)
-          );
-        }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Sent invitations to ${emails.length} emails.`,
-          },
-        ]);
-      });
-    },
-
-    search_guests: async ({ event_api_id, query }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listAllGuests(event_api_id);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to fetch guests: ${result.error.message}`)
-          );
-        }
-
-        const lowerQuery = query.toLowerCase();
-        const matches = result.value.filter(
-          (g) =>
-            g.name?.toLowerCase().includes(lowerQuery) ||
-            g.email?.toLowerCase().includes(lowerQuery)
+const handlers: ToolHandlers<typeof LUMA_TOOLS_METADATA> = {
+  get_authenticated_user: async (_params, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.getSelf();
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get account info: ${result.error.message}`)
         );
+      }
+      return new Ok([
+        { type: "text" as const, text: renderUser(result.value) },
+      ]);
+    });
+  },
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderGuestList(matches, null),
-          },
-        ]);
+  get_event: async ({ event_api_id }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.getEvent(event_api_id);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get event: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        { type: "text" as const, text: renderEvent(result.value) },
+      ]);
+    });
+  },
+
+  list_events: async ({ after, before }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listEvents({ after, before });
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to list events: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderEventList(result.value.events, result.value.nextCursor),
+        },
+      ]);
+    });
+  },
+
+  create_event: async (params, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.createEvent(params);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to create event: ${result.error.message}`)
+        );
+      }
+      const event = result.value;
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Created event "${event.name}".\n\n` +
+            `- ID: ${event.api_id}\n` +
+            (event.url ? `- URL: ${event.url}\n` : "") +
+            `- Start: ${event.start_at}`,
+        },
+      ]);
+    });
+  },
+
+  update_event: async (
+    { event_api_id, ...updateData },
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      const result = await client.updateEvent(event_api_id, updateData);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to update event: ${result.error.message}`)
+        );
+      }
+      const event = result.value;
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Updated event "${event.name}".\n\n` +
+            `- ID: ${event.api_id}\n` +
+            (event.url ? `- URL: ${event.url}\n` : "") +
+            `- Start: ${event.start_at}`,
+        },
+      ]);
+    });
+  },
+
+  list_guests: async (
+    { event_api_id, ...listParams },
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listGuests(event_api_id, listParams);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to list guests: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderGuestList(result.value.guests, result.value.nextCursor),
+        },
+      ]);
+    });
+  },
+
+  get_guest: async (
+    { event_api_id, guest_api_id },
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      const result = await client.getGuest(event_api_id, guest_api_id);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get guest: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        { type: "text" as const, text: renderGuest(result.value) },
+      ]);
+    });
+  },
+
+  update_guest_status: async (
+    { event_api_id, guest_api_id_or_email, status, should_refund },
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      const result = await client.updateGuestStatus(event_api_id, {
+        guest_api_id_or_email,
+        status,
+        should_refund,
       });
-    },
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to update guest status: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Updated guest "${guest_api_id_or_email}" to "${status}".`,
+        },
+      ]);
+    });
+  },
 
-    get_event_insights: async ({ event_api_id }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const eventResult = await client.getEvent(event_api_id);
-        if (eventResult.isErr()) {
-          return new Err(
-            new MCPError(`Failed to get event: ${eventResult.error.message}`)
-          );
-        }
+  add_guests: async ({ event_api_id, guests }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.addGuests(event_api_id, guests);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to add guests: ${result.error.message}`)
+        );
+      }
+      const addedGuests = result.value;
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Added ${addedGuests.length} guests to the event.`,
+        },
+      ]);
+    });
+  },
 
-        const guestsResult = await client.listAllGuests(event_api_id);
-        if (guestsResult.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to fetch guests: ${guestsResult.error.message}`
-            )
-          );
-        }
+  send_invites: async ({ event_api_id, emails }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.sendInvites(event_api_id, { emails });
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to send invites: ${result.error.message}`)
+        );
+      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Sent invitations to ${emails.length} emails.`,
+        },
+      ]);
+    });
+  },
 
-        const ticketsResult = await client.listTicketTypes(event_api_id);
-        if (ticketsResult.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to fetch ticket types: ${ticketsResult.error.message}`
-            )
-          );
-        }
+  search_guests: async ({ event_api_id, query }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listAllGuests(event_api_id);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to fetch guests: ${result.error.message}`)
+        );
+      }
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderEventInsights(
-              eventResult.value,
-              guestsResult.value,
-              ticketsResult.value
-            ),
-          },
-        ]);
-      });
-    },
-  };
+      const lowerQuery = query.toLowerCase();
+      const matches = result.value.filter(
+        (g) =>
+          g.name?.toLowerCase().includes(lowerQuery) ||
+          g.email?.toLowerCase().includes(lowerQuery)
+      );
 
-  return buildTools(LUMA_TOOLS_METADATA, handlers);
-}
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderGuestList(matches, null),
+        },
+      ]);
+    });
+  },
+
+  get_event_insights: async ({ event_api_id }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const eventResult = await client.getEvent(event_api_id);
+      if (eventResult.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get event: ${eventResult.error.message}`)
+        );
+      }
+
+      const guestsResult = await client.listAllGuests(event_api_id);
+      if (guestsResult.isErr()) {
+        return new Err(
+          new MCPError(`Failed to fetch guests: ${guestsResult.error.message}`)
+        );
+      }
+
+      const ticketsResult = await client.listTicketTypes(event_api_id);
+      if (ticketsResult.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to fetch ticket types: ${ticketsResult.error.message}`
+          )
+        );
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderEventInsights(
+            eventResult.value,
+            guestsResult.value,
+            ticketsResult.value
+          ),
+        },
+      ]);
+    });
+  },
+};
+
+export const TOOLS = buildTools(LUMA_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/openai_usage/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createOpenAIUsageTools } from "@app/lib/api/actions/servers/openai_usage/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/openai_usage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("openai_usage");
 
-  const tools = createOpenAIUsageTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "openai_usage",
     });

--- a/front/lib/api/actions/servers/openai_usage/tools/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/tools/index.ts
@@ -5,11 +5,9 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
 import type { OpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { getOpenAIUsageClient } from "@app/lib/api/actions/servers/openai_usage/client";
 import { OPENAI_USAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/openai_usage/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
 const LIMIT_RULES = {
@@ -29,92 +27,87 @@ async function withClient(
   return action(clientResult.value);
 }
 
-export function createOpenAIUsageTools(
-  _auth: Authenticator,
-  _toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof OPENAI_USAGE_TOOLS_METADATA> = {
-    get_completions_usage: async (params, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const rule = LIMIT_RULES[params.bucket_width];
-        const limit = params.limit ?? rule.default;
+const handlers: ToolHandlers<typeof OPENAI_USAGE_TOOLS_METADATA> = {
+  get_completions_usage: async (params, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const rule = LIMIT_RULES[params.bucket_width];
+      const limit = params.limit ?? rule.default;
 
-        if (limit > rule.max) {
-          return new Err(
-            new MCPError(
-              `Limit ${limit} exceeds maximum allowed for bucket_width=${params.bucket_width}. Maximum is ${rule.max}.`,
-              {
-                tracked: false,
-              }
-            )
-          );
-        }
-
-        const startTimeSeconds = Math.floor(
-          new Date(params.start_time).getTime() / 1000
+      if (limit > rule.max) {
+        return new Err(
+          new MCPError(
+            `Limit ${limit} exceeds maximum allowed for bucket_width=${params.bucket_width}. Maximum is ${rule.max}.`,
+            {
+              tracked: false,
+            }
+          )
         );
-        const endTimeSeconds = params.end_time
-          ? Math.floor(new Date(params.end_time).getTime() / 1000)
-          : undefined;
+      }
 
-        const result = await client.getCompletionsUsage({
-          start_time: startTimeSeconds,
-          ...(endTimeSeconds && { end_time: endTimeSeconds }),
-          bucket_width: params.bucket_width,
-          ...(params.api_key_ids && { api_key_ids: params.api_key_ids }),
-          ...(params.models && { models: params.models }),
-          ...(params.project_ids && { project_ids: params.project_ids }),
-          ...(params.user_ids && { user_ids: params.user_ids }),
-          ...(params.batch !== undefined && { batch: params.batch }),
-          ...(params.group_by && { group_by: params.group_by }),
-          limit,
-          ...(params.page && { page: params.page }),
-        });
+      const startTimeSeconds = Math.floor(
+        new Date(params.start_time).getTime() / 1000
+      );
+      const endTimeSeconds = params.end_time
+        ? Math.floor(new Date(params.end_time).getTime() / 1000)
+        : undefined;
 
-        if (result.isErr()) {
-          return result;
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: JSON.stringify(result.value, null, 2),
-          },
-        ]);
+      const result = await client.getCompletionsUsage({
+        start_time: startTimeSeconds,
+        ...(endTimeSeconds && { end_time: endTimeSeconds }),
+        bucket_width: params.bucket_width,
+        ...(params.api_key_ids && { api_key_ids: params.api_key_ids }),
+        ...(params.models && { models: params.models }),
+        ...(params.project_ids && { project_ids: params.project_ids }),
+        ...(params.user_ids && { user_ids: params.user_ids }),
+        ...(params.batch !== undefined && { batch: params.batch }),
+        ...(params.group_by && { group_by: params.group_by }),
+        limit,
+        ...(params.page && { page: params.page }),
       });
-    },
 
-    get_organization_costs: async (params, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const startTimeSeconds = Math.floor(
-          new Date(params.start_time).getTime() / 1000
-        );
-        const endTimeSeconds = params.end_time
-          ? Math.floor(new Date(params.end_time).getTime() / 1000)
-          : undefined;
+      if (result.isErr()) {
+        return result;
+      }
 
-        const result = await client.getOrganizationCosts({
-          start_time: startTimeSeconds,
-          ...(endTimeSeconds && { end_time: endTimeSeconds }),
-          ...(params.group_by && { group_by: params.group_by }),
-          limit: params.limit,
-          ...(params.page && { page: params.page }),
-          ...(params.project_ids && { project_ids: params.project_ids }),
-        });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(result.value, null, 2),
+        },
+      ]);
+    });
+  },
 
-        if (result.isErr()) {
-          return result;
-        }
+  get_organization_costs: async (params, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const startTimeSeconds = Math.floor(
+        new Date(params.start_time).getTime() / 1000
+      );
+      const endTimeSeconds = params.end_time
+        ? Math.floor(new Date(params.end_time).getTime() / 1000)
+        : undefined;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: JSON.stringify(result.value, null, 2),
-          },
-        ]);
+      const result = await client.getOrganizationCosts({
+        start_time: startTimeSeconds,
+        ...(endTimeSeconds && { end_time: endTimeSeconds }),
+        ...(params.group_by && { group_by: params.group_by }),
+        limit: params.limit,
+        ...(params.page && { page: params.page }),
+        ...(params.project_ids && { project_ids: params.project_ids }),
       });
-    },
-  };
 
-  return buildTools(OPENAI_USAGE_TOOLS_METADATA, handlers);
-}
+      if (result.isErr()) {
+        return result;
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(result.value, null, 2),
+        },
+      ]);
+    });
+  },
+};
+
+export const TOOLS = buildTools(OPENAI_USAGE_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/productboard/index.ts
+++ b/front/lib/api/actions/servers/productboard/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createProductboardTools } from "@app/lib/api/actions/servers/productboard/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/productboard/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("productboard");
 
-  const tools = createProductboardTools();
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "productboard",
     });

--- a/front/lib/api/actions/servers/productboard/tools/index.ts
+++ b/front/lib/api/actions/servers/productboard/tools/index.ts
@@ -1,6 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
-  ToolDefinition,
   ToolHandlerExtra,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -35,421 +34,417 @@ function getAccessToken(
   return new Ok(accessToken);
 }
 
-export function createProductboardTools(): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof PRODUCTBOARD_TOOLS_METADATA> = {
-    create_note: async ({ type, fields, relationships }, { authInfo }) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
+const handlers: ToolHandlers<typeof PRODUCTBOARD_TOOLS_METADATA> = {
+  create_note: async ({ type, fields, relationships }, { authInfo }) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
 
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
 
-      const result = await client.createNote({
-        type,
-        fields,
-        relationships,
-      });
+    const result = await client.createNote({
+      type,
+      fields,
+      relationships,
+    });
 
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to create note: ${normalizeError(result.error).message}`
-          )
-        );
-      }
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to create note: ${normalizeError(result.error).message}`
+        )
+      );
+    }
 
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Note created with id ${result.value.id}. API endpoint: ${result.value.links.self} (Note: This is an API endpoint for programmatic access, not a user-facing link to view the note)`,
-        },
-      ]);
-    },
-
-    update_note: async ({ note_id, fields, patch }, { authInfo }) => {
-      if (!fields && !patch) {
-        return new Err(
-          new MCPError(
-            "Either 'fields' or 'patch' must be provided to update the note."
-          )
-        );
-      }
-
-      if (fields && patch) {
-        return new Err(
-          new MCPError(
-            "Cannot use both 'fields' and 'patch' in the same update. Use either 'fields' for simple updates or 'patch' for granular operations."
-          )
-        );
-      }
-
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      const result = await client.updateNote(note_id, {
-        fields: fields && Object.keys(fields).length > 0 ? fields : undefined,
-        patch: patch && patch.length > 0 ? patch : undefined,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to update note: ${normalizeError(result.error).message}`
-          )
-        );
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Note updated with id ${result.value.id}`,
-        },
-      ]);
-    },
-
-    get_note: async ({ note_id, fields }, { authInfo }) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      const result = await client.getNote(note_id, fields);
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to get note: ${normalizeError(result.error).message}`
-          )
-        );
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: renderNote(result.value),
-        },
-      ]);
-    },
-
-    query_notes: async (
+    return new Ok([
       {
-        page_cursor,
-        archived,
-        processed,
-        owner_id,
-        owner_email,
-        creator_id,
-        creator_email,
-        source_record_id,
-        created_from,
-        created_to,
-        updated_from,
-        updated_to,
-        fields,
+        type: "text" as const,
+        text: `Note created with id ${result.value.id}. API endpoint: ${result.value.links.self} (Note: This is an API endpoint for programmatic access, not a user-facing link to view the note)`,
       },
-      { authInfo }
-    ) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
+    ]);
+  },
 
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
+  update_note: async ({ note_id, fields, patch }, { authInfo }) => {
+    if (!fields && !patch) {
+      return new Err(
+        new MCPError(
+          "Either 'fields' or 'patch' must be provided to update the note."
+        )
+      );
+    }
 
-      const result = await client.queryNotes({
-        pageCursor: page_cursor,
-        archived,
-        processed,
-        ownerId: owner_id,
-        ownerEmail: owner_email,
-        creatorId: creator_id,
-        creatorEmail: creator_email,
-        sourceRecordId: source_record_id,
-        createdFrom: created_from,
-        createdTo: created_to,
-        updatedFrom: updated_from,
-        updatedTo: updated_to,
-        fields,
-      });
+    if (fields && patch) {
+      return new Err(
+        new MCPError(
+          "Cannot use both 'fields' and 'patch' in the same update. Use either 'fields' for simple updates or 'patch' for granular operations."
+        )
+      );
+    }
 
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to query notes: ${normalizeError(result.error).message}`
-          )
-        );
-      }
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
 
-      const { notes, pageCursor, totalResults } = result.value;
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
 
-      return new Ok([
-        {
-          type: "text" as const,
-          text: renderNotesList(notes, { pageCursor, totalResults }),
-        },
-      ]);
-    },
+    const result = await client.updateNote(note_id, {
+      fields: fields && Object.keys(fields).length > 0 ? fields : undefined,
+      patch: patch && patch.length > 0 ? patch : undefined,
+    });
 
-    query_entities: async (
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to update note: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
       {
-        type,
-        name,
-        archived,
-        parent_id,
-        ids,
-        status_ids,
-        status_names,
-        owner_ids,
-        owner_emails,
-        fields,
-        page_cursor,
+        type: "text" as const,
+        text: `Note updated with id ${result.value.id}`,
       },
-      { authInfo }
-    ) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
+    ]);
+  },
 
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
+  get_note: async ({ note_id, fields }, { authInfo }) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
 
-      const result = await client.searchEntities({
-        type,
-        name,
-        archived,
-        parentId: parent_id,
-        ids,
-        statusIds: status_ids,
-        statusNames: status_names,
-        ownerIds: owner_ids,
-        ownerEmails: owner_emails,
-        fields,
-        pageCursor: page_cursor,
-      });
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
 
+    const result = await client.getNote(note_id, fields);
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to get note: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: renderNote(result.value),
+      },
+    ]);
+  },
+
+  query_notes: async (
+    {
+      page_cursor,
+      archived,
+      processed,
+      owner_id,
+      owner_email,
+      creator_id,
+      creator_email,
+      source_record_id,
+      created_from,
+      created_to,
+      updated_from,
+      updated_to,
+      fields,
+    },
+    { authInfo }
+  ) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.queryNotes({
+      pageCursor: page_cursor,
+      archived,
+      processed,
+      ownerId: owner_id,
+      ownerEmail: owner_email,
+      creatorId: creator_id,
+      creatorEmail: creator_email,
+      sourceRecordId: source_record_id,
+      createdFrom: created_from,
+      createdTo: created_to,
+      updatedFrom: updated_from,
+      updatedTo: updated_to,
+      fields,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to query notes: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    const { notes, pageCursor, totalResults } = result.value;
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: renderNotesList(notes, { pageCursor, totalResults }),
+      },
+    ]);
+  },
+
+  query_entities: async (
+    {
+      type,
+      name,
+      archived,
+      parent_id,
+      ids,
+      status_ids,
+      status_names,
+      owner_ids,
+      owner_emails,
+      fields,
+      page_cursor,
+    },
+    { authInfo }
+  ) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.searchEntities({
+      type,
+      name,
+      archived,
+      parentId: parent_id,
+      ids,
+      statusIds: status_ids,
+      statusNames: status_names,
+      ownerIds: owner_ids,
+      ownerEmails: owner_emails,
+      fields,
+      pageCursor: page_cursor,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to query entities: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: renderEntitiesList(result.value.entities, {
+          pageCursor: result.value.pageCursor,
+        }),
+      },
+    ]);
+  },
+
+  create_entity: async ({ type, fields, relationships }, { authInfo }) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.createEntity({
+      type,
+      fields,
+      relationships,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to create entity: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Entity created with id ${result.value.id}. API endpoint: ${result.value.links.self} (Note: This is an API endpoint for programmatic access, not a user-facing link to view the entity)`,
+      },
+    ]);
+  },
+
+  update_entity: async ({ entity_id, fields, patch }, { authInfo }) => {
+    if (!fields && !patch) {
+      return new Err(
+        new MCPError("At least one of 'fields' or 'patch' must be provided.")
+      );
+    }
+
+    if (fields && patch) {
+      return new Err(
+        new MCPError(
+          "Cannot use both 'fields' and 'patch' in the same request."
+        )
+      );
+    }
+
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.updateEntity(entity_id, {
+      fields: fields && Object.keys(fields).length > 0 ? fields : undefined,
+      patch: patch && patch.length > 0 ? patch : undefined,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to update entity: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Entity with id ${result.value.id} updated successfully.`,
+      },
+    ]);
+  },
+
+  get_relationships: async (
+    { entity_id, relationship_type, page_cursor },
+    { authInfo }
+  ) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.getEntityRelationships(entity_id, {
+      relationshipType: relationship_type,
+      pageCursor: page_cursor,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to get relationships: ${normalizeError(result.error).message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: renderRelationshipsList(result.value.relationships, {
+          pageCursor: result.value.pageCursor,
+          entityId: entity_id,
+        }),
+      },
+    ]);
+  },
+
+  get_configuration: async ({ entity_type }, { authInfo }) => {
+    const accessTokenResult = getAccessToken(authInfo);
+    if (accessTokenResult.isErr()) {
+      return accessTokenResult;
+    }
+
+    const clientResult = getProductboardClient(accessTokenResult.value);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    let config: ProductboardConfiguration;
+
+    if (entity_type === "textNote" || entity_type === "conversationNote") {
+      const result = await client.getNotesConfigurations();
       if (result.isErr()) {
         return new Err(
           new MCPError(
-            `Failed to query entities: ${normalizeError(result.error).message}`
+            `Failed to get note configuration: ${normalizeError(result.error).message}`
           )
         );
       }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: renderEntitiesList(result.value.entities, {
-            pageCursor: result.value.pageCursor,
-          }),
-        },
-      ]);
-    },
-
-    create_entity: async ({ type, fields, relationships }, { authInfo }) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
+      const noteConfig = result.value.find((c) => c.type === entity_type);
+      if (!noteConfig) {
+        return new Err(
+          new MCPError(`Configuration for note type '${entity_type}' not found`)
+        );
       }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      const result = await client.createEntity({
-        type,
-        fields,
-        relationships,
-      });
-
+      config = noteConfig;
+    } else {
+      const result = await client.getEntityConfiguration(entity_type);
       if (result.isErr()) {
         return new Err(
           new MCPError(
-            `Failed to create entity: ${normalizeError(result.error).message}`
+            `Failed to get entity configuration: ${normalizeError(result.error).message}`
           )
         );
       }
+      config = result.value;
+    }
 
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Entity created with id ${result.value.id}. API endpoint: ${result.value.links.self} (Note: This is an API endpoint for programmatic access, not a user-facing link to view the entity)`,
-        },
-      ]);
-    },
+    const isNoteType =
+      entity_type === "textNote" || entity_type === "conversationNote";
+    const text = isNoteType
+      ? renderNoteConfigurationsList([config])
+      : renderEntityConfigurationsList([config]);
 
-    update_entity: async ({ entity_id, fields, patch }, { authInfo }) => {
-      if (!fields && !patch) {
-        return new Err(
-          new MCPError("At least one of 'fields' or 'patch' must be provided.")
-        );
-      }
+    return new Ok([
+      {
+        type: "text" as const,
+        text,
+      },
+    ]);
+  },
+};
 
-      if (fields && patch) {
-        return new Err(
-          new MCPError(
-            "Cannot use both 'fields' and 'patch' in the same request."
-          )
-        );
-      }
-
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      const result = await client.updateEntity(entity_id, {
-        fields: fields && Object.keys(fields).length > 0 ? fields : undefined,
-        patch: patch && patch.length > 0 ? patch : undefined,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to update entity: ${normalizeError(result.error).message}`
-          )
-        );
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Entity with id ${result.value.id} updated successfully.`,
-        },
-      ]);
-    },
-
-    get_relationships: async (
-      { entity_id, relationship_type, page_cursor },
-      { authInfo }
-    ) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      const result = await client.getEntityRelationships(entity_id, {
-        relationshipType: relationship_type,
-        pageCursor: page_cursor,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to get relationships: ${normalizeError(result.error).message}`
-          )
-        );
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: renderRelationshipsList(result.value.relationships, {
-            pageCursor: result.value.pageCursor,
-            entityId: entity_id,
-          }),
-        },
-      ]);
-    },
-
-    get_configuration: async ({ entity_type }, { authInfo }) => {
-      const accessTokenResult = getAccessToken(authInfo);
-      if (accessTokenResult.isErr()) {
-        return accessTokenResult;
-      }
-
-      const clientResult = getProductboardClient(accessTokenResult.value);
-      if (clientResult.isErr()) {
-        return clientResult;
-      }
-      const client = clientResult.value;
-
-      let config: ProductboardConfiguration;
-
-      if (entity_type === "textNote" || entity_type === "conversationNote") {
-        const result = await client.getNotesConfigurations();
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to get note configuration: ${normalizeError(result.error).message}`
-            )
-          );
-        }
-        const noteConfig = result.value.find((c) => c.type === entity_type);
-        if (!noteConfig) {
-          return new Err(
-            new MCPError(
-              `Configuration for note type '${entity_type}' not found`
-            )
-          );
-        }
-        config = noteConfig;
-      } else {
-        const result = await client.getEntityConfiguration(entity_type);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to get entity configuration: ${normalizeError(result.error).message}`
-            )
-          );
-        }
-        config = result.value;
-      }
-
-      const isNoteType =
-        entity_type === "textNote" || entity_type === "conversationNote";
-      const text = isNoteType
-        ? renderNoteConfigurationsList([config])
-        : renderEntityConfigurationsList([config]);
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text,
-        },
-      ]);
-    },
-  };
-
-  return buildTools(PRODUCTBOARD_TOOLS_METADATA, handlers);
-}
+export const TOOLS = buildTools(PRODUCTBOARD_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/salesforce/index.ts
+++ b/front/lib/api/actions/servers/salesforce/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createSalesforceTools } from "@app/lib/api/actions/servers/salesforce/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/salesforce/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("salesforce");
 
-  const tools = createSalesforceTools(auth);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "salesforce",
     });

--- a/front/lib/api/actions/servers/salesforce/tools/index.ts
+++ b/front/lib/api/actions/servers/salesforce/tools/index.ts
@@ -1,8 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { jsonToMarkdown } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
@@ -19,7 +16,6 @@ import {
   withAuth,
 } from "@app/lib/api/actions/servers/salesforce/helpers";
 import { SALESFORCE_TOOLS_METADATA } from "@app/lib/api/actions/servers/salesforce/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 import type { DescribeSObjectResult } from "jsforce";
 
@@ -37,357 +33,348 @@ interface DescribeFieldResult {
   picklistValues?: Array<{ active: boolean; value: string }> | null;
 }
 
-export function createSalesforceTools(auth: Authenticator): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof SALESFORCE_TOOLS_METADATA> = {
-    execute_read_query: async ({ query }, extra) => {
-      return withAuth(extra, async (conn) => {
-        try {
-          const result = await conn.query(query);
+const handlers: ToolHandlers<typeof SALESFORCE_TOOLS_METADATA> = {
+  execute_read_query: async ({ query }, extra) => {
+    return withAuth(extra, async (conn) => {
+      try {
+        const result = await conn.query(query);
 
-          const formattedRecords = jsonToMarkdown(result.records);
+        const formattedRecords = jsonToMarkdown(result.records);
 
-          const summaryParts = [
-            `Query returned ${result.totalSize ?? result.records.length} record(s).`,
-          ];
+        const summaryParts = [
+          `Query returned ${result.totalSize ?? result.records.length} record(s).`,
+        ];
 
-          if (!result.done) {
-            summaryParts.push(
-              "More records are available. Refine the query or paginate to retrieve remaining records."
-            );
-          }
-
-          const summary = summaryParts.join(" ");
-
-          return new Ok([
-            { type: "text" as const, text: summary },
-            { type: "text" as const, text: formattedRecords },
-          ]);
-        } catch (error) {
-          return logAndReturnError({
-            error,
-            params: { query },
-            message: "Error executing Salesforce query",
-          });
+        if (!result.done) {
+          summaryParts.push(
+            "More records are available. Refine the query or paginate to retrieve remaining records."
+          );
         }
-      });
-    },
 
-    list_objects: async ({ filter }, extra) => {
-      return withAuth(extra, async (conn) => {
-        try {
-          const result = await conn.describeGlobal();
+        const summary = summaryParts.join(" ");
 
-          const objects = result.sobjects
-            .filter((object) => {
-              if (filter === "all") {
-                return true;
-              }
-              return object.custom === (filter === "custom");
-            })
-            .map((object) => `${object.name} (display_name="${object.label}")`)
-            .join("\n");
+        return new Ok([
+          { type: "text" as const, text: summary },
+          { type: "text" as const, text: formattedRecords },
+        ]);
+      } catch (error) {
+        return logAndReturnError({
+          error,
+          params: { query },
+          message: "Error executing Salesforce query",
+        });
+      }
+    });
+  },
 
-          return new Ok([
-            { type: "text", text: "Operation completed successfully" },
-            { type: "text", text: objects },
-          ]);
-        } catch (error) {
-          return logAndReturnError({
-            error,
-            params: { filter },
-            message: "Error listing Salesforce objects",
-          });
+  list_objects: async ({ filter }, extra) => {
+    return withAuth(extra, async (conn) => {
+      try {
+        const result = await conn.describeGlobal();
+
+        const objects = result.sobjects
+          .filter((object) => {
+            if (filter === "all") {
+              return true;
+            }
+            return object.custom === (filter === "custom");
+          })
+          .map((object) => `${object.name} (display_name="${object.label}")`)
+          .join("\n");
+
+        return new Ok([
+          { type: "text", text: "Operation completed successfully" },
+          { type: "text", text: objects },
+        ]);
+      } catch (error) {
+        return logAndReturnError({
+          error,
+          params: { filter },
+          message: "Error listing Salesforce objects",
+        });
+      }
+    });
+  },
+
+  describe_object: async ({ objectName }, extra) => {
+    return withAuth(extra, async (conn) => {
+      try {
+        const result: DescribeSObjectResult = await conn.describe(objectName);
+
+        let summary = `Object: ${result.name}\n`;
+        summary += `Label: ${result.label}\n`;
+        summary += `Plural Label: ${result.labelPlural}\n`;
+        if (result.keyPrefix) {
+          summary += `Key Prefix: ${result.keyPrefix}\n`;
         }
-      });
-    },
+        summary += `Queryable: ${result.queryable}\n`;
+        summary += `Createable: ${result.createable}\n`;
+        summary += `Updateable: ${result.updateable}\n`;
+        summary += `Deletable: ${result.deletable}\n`;
+        summary += `Feed Enabled: ${result.feedEnabled}\n\n`;
 
-    describe_object: async ({ objectName }, extra) => {
-      return withAuth(extra, async (conn) => {
-        try {
-          const result: DescribeSObjectResult = await conn.describe(objectName);
+        summary += "Fields:\n";
+        const standardFields = result.fields.filter((f) => !f.custom);
+        const customFields = result.fields.filter((f) => f.custom);
 
-          let summary = `Object: ${result.name}\n`;
-          summary += `Label: ${result.label}\n`;
-          summary += `Plural Label: ${result.labelPlural}\n`;
-          if (result.keyPrefix) {
-            summary += `Key Prefix: ${result.keyPrefix}\n`;
-          }
-          summary += `Queryable: ${result.queryable}\n`;
-          summary += `Createable: ${result.createable}\n`;
-          summary += `Updateable: ${result.updateable}\n`;
-          summary += `Deletable: ${result.deletable}\n`;
-          summary += `Feed Enabled: ${result.feedEnabled}\n\n`;
-
-          summary += "Fields:\n";
-          const standardFields = result.fields.filter((f) => !f.custom);
-          const customFields = result.fields.filter((f) => f.custom);
-
-          const formatField = (field: DescribeFieldResult) => {
-            let fieldStr = `- ${field.name} (Label: "${field.label}", Type: ${field.type}`;
-            if (
-              field.type === "reference" &&
-              field.referenceTo &&
-              field.referenceTo.length > 0
-            ) {
-              fieldStr += ` -> References: ${field.referenceTo.join(", ")}`;
-              if (field.relationshipName) {
-                fieldStr += ` (Use '${field.relationshipName}' for parent fields)`;
-              }
-            }
-            if (
-              field.type === "picklist" &&
-              field.picklistValues &&
-              field.picklistValues.length > 0
-            ) {
-              const activePicklistValues = field.picklistValues.filter(
-                (pv) => pv.active
-              );
-              const values = activePicklistValues
-                .map((pv) => pv.value)
-                .slice(0, 5);
-              if (values.length > 0) {
-                fieldStr += ` (Values: ${values.join(", ")}${activePicklistValues.length > 5 ? ", ..." : ""})`;
-              }
-            }
-            fieldStr += `, Nillable: ${field.nillable}, Createable: ${field.createable}, Updateable: ${field.updateable})`;
-            return fieldStr;
-          };
-
-          if (standardFields.length > 0) {
-            summary += "\nStandard Fields:\n";
-            standardFields.forEach((field) => {
-              summary += `${formatField(field)}\n`;
-            });
-          }
-
-          if (customFields.length > 0) {
-            summary += "\nCustom Fields (names end with '__c'):\n";
-            customFields.forEach((field) => {
-              summary += `${formatField(field)}\n`;
-            });
-          }
-
-          summary +=
-            "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
+        const formatField = (field: DescribeFieldResult) => {
+          let fieldStr = `- ${field.name} (Label: "${field.label}", Type: ${field.type}`;
           if (
-            result.childRelationships &&
-            result.childRelationships.length > 0
+            field.type === "reference" &&
+            field.referenceTo &&
+            field.referenceTo.length > 0
           ) {
-            result.childRelationships.forEach((rel) => {
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              summary += `- RelationshipName: ${rel.relationshipName || "(N/A - check API docs)"}`;
-              summary += `, ChildObject: ${rel.childSObject}`;
-              summary += `, Field on Child: ${rel.field}\n`;
-            });
-          } else {
-            summary += "No child relationships found.\n";
+            fieldStr += ` -> References: ${field.referenceTo.join(", ")}`;
+            if (field.relationshipName) {
+              fieldStr += ` (Use '${field.relationshipName}' for parent fields)`;
+            }
           }
+          if (
+            field.type === "picklist" &&
+            field.picklistValues &&
+            field.picklistValues.length > 0
+          ) {
+            const activePicklistValues = field.picklistValues.filter(
+              (pv) => pv.active
+            );
+            const values = activePicklistValues
+              .map((pv) => pv.value)
+              .slice(0, 5);
+            if (values.length > 0) {
+              fieldStr += ` (Values: ${values.join(", ")}${activePicklistValues.length > 5 ? ", ..." : ""})`;
+            }
+          }
+          fieldStr += `, Nillable: ${field.nillable}, Createable: ${field.createable}, Updateable: ${field.updateable})`;
+          return fieldStr;
+        };
 
-          summary +=
-            "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
-
-          return new Ok([
-            {
-              type: "text",
-              text: "Object described successfully. Summary provided.",
-            },
-            { type: "text", text: summary },
-          ]);
-        } catch (error) {
-          return logAndReturnError({
-            error,
-            params: { objectName },
-            message: "Error describing Salesforce object",
+        if (standardFields.length > 0) {
+          summary += "\nStandard Fields:\n";
+          standardFields.forEach((field) => {
+            summary += `${formatField(field)}\n`;
           });
         }
-      });
-    },
 
-    create_object: async ({ objectName, records, allOrNone }, extra) => {
-      return withAuth(extra, async (conn) => {
-        try {
-          const result = await conn.sobject(objectName).create(records, {
-            allOrNone,
-          });
-
-          const results = Array.isArray(result) ? result : [result];
-          const successCount = results.filter((r) => r.success).length;
-          const failureCount = results.length - successCount;
-
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `Create completed: ${successCount} successful, ${failureCount} failed`,
-            },
-            { type: "text" as const, text: JSON.stringify(result, null, 2) },
-          ]);
-        } catch (error) {
-          return logAndReturnError({
-            error,
-            params: { objectName, recordCount: records.length, allOrNone },
-            message: "Error creating Salesforce records",
+        if (customFields.length > 0) {
+          summary += "\nCustom Fields (names end with '__c'):\n";
+          customFields.forEach((field) => {
+            summary += `${formatField(field)}\n`;
           });
         }
-      });
-    },
 
-    update_object: async ({ objectName, records, allOrNone }, extra) => {
-      return withAuth(extra, async (conn) => {
-        try {
-          const result = await conn.sobject(objectName).update(records, {
-            allOrNone,
+        summary +=
+          "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
+        if (result.childRelationships && result.childRelationships.length > 0) {
+          result.childRelationships.forEach((rel) => {
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            summary += `- RelationshipName: ${rel.relationshipName || "(N/A - check API docs)"}`;
+            summary += `, ChildObject: ${rel.childSObject}`;
+            summary += `, Field on Child: ${rel.field}\n`;
           });
-
-          const results = Array.isArray(result) ? result : [result];
-          const successCount = results.filter((r) => r.success).length;
-          const failureCount = results.length - successCount;
-
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `Update completed: ${successCount} successful, ${failureCount} failed`,
-            },
-            { type: "text" as const, text: JSON.stringify(result, null, 2) },
-          ]);
-        } catch (error) {
-          return logAndReturnError({
-            error,
-            params: { objectName, recordCount: records.length, allOrNone },
-            message: "Error updating Salesforce records",
-          });
-        }
-      });
-    },
-
-    list_attachments: async ({ recordId }, extra) => {
-      return withAuth(extra, async (conn) => {
-        const attachmentsResult = await getAllSalesforceAttachments(
-          conn,
-          recordId
-        );
-
-        if (attachmentsResult.isErr()) {
-          return new Err(new MCPError(attachmentsResult.error));
+        } else {
+          summary += "No child relationships found.\n";
         }
 
-        const attachments = attachmentsResult.value;
-        const attachmentSummary = attachments.map((att) => ({
-          id: att.id,
-          filename: att.filename,
-          mimeType: att.mimeType,
-          size: att.size,
-          created: att.created,
-          author: att.author,
-        }));
+        summary +=
+          "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
 
         return new Ok([
           {
-            type: "text" as const,
-            text: `Found ${attachments.length} attachment(s) for record ${recordId}`,
+            type: "text",
+            text: "Object described successfully. Summary provided.",
           },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                attachments: attachmentSummary,
-              },
-              null,
-              2
-            ),
-          },
+          { type: "text", text: summary },
         ]);
-      });
-    },
+      } catch (error) {
+        return logAndReturnError({
+          error,
+          params: { objectName },
+          message: "Error describing Salesforce object",
+        });
+      }
+    });
+  },
 
-    read_attachment: async ({ recordId, attachmentId }, extra) => {
-      return withAuth(extra, async (conn) => {
-        const attachmentsResult = await getAllSalesforceAttachments(
-          conn,
-          recordId
-        );
-
-        if (attachmentsResult.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to get attachments: ${attachmentsResult.error}`
-            )
-          );
-        }
-
-        const attachments = attachmentsResult.value;
-        const targetAttachment = attachments.find(
-          (att) => att.id === attachmentId
-        );
-
-        if (!targetAttachment) {
-          return new Err(
-            new MCPError(
-              `Attachment with ID ${attachmentId} not found on record ${recordId}.`
-            )
-          );
-        }
-
-        const { mimeType, filename, size } = targetAttachment;
-        const safeFilename = filename || `attachment-${attachmentId}`;
-
-        // 50MB — matches the platform limit for data files (types/files.ts MAX_FILE_SIZES["data"]).
-        const MAX_ATTACHMENT_SIZE_BYTES = 50 * 1024 * 1024;
-        if (size !== undefined && size > MAX_ATTACHMENT_SIZE_BYTES) {
-          return new Err(
-            new MCPError(
-              `Attachment is too large to download (${(size / (1024 * 1024)).toFixed(1)}MB). Maximum supported size is 50MB.`
-            )
-          );
-        }
-
-        // Download once upfront; reuse buffer for both text extraction and binary blob.
-        // Avoids a double network call to Salesforce (mirrors Microsoft Drive pattern).
-        const downloadResult = await downloadSalesforceContent(
-          conn,
-          attachmentId
-        );
-        if (downloadResult.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to download attachment: ${downloadResult.error}`
-            )
-          );
-        }
-        const buffer = downloadResult.value;
-
-        const result = await processAttachment({
-          mimeType,
-          filename: safeFilename,
-          extractText: async () => extractTextFromBuffer(buffer, mimeType),
-          downloadContent: async () => new Ok(buffer),
+  create_object: async ({ objectName, records, allOrNone }, extra) => {
+    return withAuth(extra, async (conn) => {
+      try {
+        const result = await conn.sobject(objectName).create(records, {
+          allOrNone,
         });
 
-        if (result.isErr()) {
-          return new Err(result.error);
-        }
+        const results = Array.isArray(result) ? result : [result];
+        const successCount = results.filter((r) => r.success).length;
+        const failureCount = results.length - successCount;
 
-        // Always include a raw binary resource block so the user receives a
-        // downloadable file, even when text extraction succeeded (PDFs).
-        if (result.value.some((c) => c.type === "resource")) {
-          return new Ok(result.value);
-        }
-
-        const sanitized = sanitizeFilename(safeFilename);
         return new Ok([
-          ...result.value,
           {
-            type: "resource" as const,
-            resource: {
-              blob: buffer.toString("base64"),
-              _meta: { text: `Attachment: ${sanitized}` },
-              mimeType,
-              uri: sanitized,
-            },
+            type: "text" as const,
+            text: `Create completed: ${successCount} successful, ${failureCount} failed`,
           },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
         ]);
-      });
-    },
-  };
+      } catch (error) {
+        return logAndReturnError({
+          error,
+          params: { objectName, recordCount: records.length, allOrNone },
+          message: "Error creating Salesforce records",
+        });
+      }
+    });
+  },
 
-  return buildTools(SALESFORCE_TOOLS_METADATA, handlers);
-}
+  update_object: async ({ objectName, records, allOrNone }, extra) => {
+    return withAuth(extra, async (conn) => {
+      try {
+        const result = await conn.sobject(objectName).update(records, {
+          allOrNone,
+        });
+
+        const results = Array.isArray(result) ? result : [result];
+        const successCount = results.filter((r) => r.success).length;
+        const failureCount = results.length - successCount;
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Update completed: ${successCount} successful, ${failureCount} failed`,
+          },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
+      } catch (error) {
+        return logAndReturnError({
+          error,
+          params: { objectName, recordCount: records.length, allOrNone },
+          message: "Error updating Salesforce records",
+        });
+      }
+    });
+  },
+
+  list_attachments: async ({ recordId }, extra) => {
+    return withAuth(extra, async (conn) => {
+      const attachmentsResult = await getAllSalesforceAttachments(
+        conn,
+        recordId
+      );
+
+      if (attachmentsResult.isErr()) {
+        return new Err(new MCPError(attachmentsResult.error));
+      }
+
+      const attachments = attachmentsResult.value;
+      const attachmentSummary = attachments.map((att) => ({
+        id: att.id,
+        filename: att.filename,
+        mimeType: att.mimeType,
+        size: att.size,
+        created: att.created,
+        author: att.author,
+      }));
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Found ${attachments.length} attachment(s) for record ${recordId}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              attachments: attachmentSummary,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    });
+  },
+
+  read_attachment: async ({ recordId, attachmentId }, extra) => {
+    return withAuth(extra, async (conn) => {
+      const attachmentsResult = await getAllSalesforceAttachments(
+        conn,
+        recordId
+      );
+
+      if (attachmentsResult.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get attachments: ${attachmentsResult.error}`)
+        );
+      }
+
+      const attachments = attachmentsResult.value;
+      const targetAttachment = attachments.find(
+        (att) => att.id === attachmentId
+      );
+
+      if (!targetAttachment) {
+        return new Err(
+          new MCPError(
+            `Attachment with ID ${attachmentId} not found on record ${recordId}.`
+          )
+        );
+      }
+
+      const { mimeType, filename, size } = targetAttachment;
+      const safeFilename = filename || `attachment-${attachmentId}`;
+
+      // 50MB — matches the platform limit for data files (types/files.ts MAX_FILE_SIZES["data"]).
+      const MAX_ATTACHMENT_SIZE_BYTES = 50 * 1024 * 1024;
+      if (size !== undefined && size > MAX_ATTACHMENT_SIZE_BYTES) {
+        return new Err(
+          new MCPError(
+            `Attachment is too large to download (${(size / (1024 * 1024)).toFixed(1)}MB). Maximum supported size is 50MB.`
+          )
+        );
+      }
+
+      // Download once upfront; reuse buffer for both text extraction and binary blob.
+      // Avoids a double network call to Salesforce (mirrors Microsoft Drive pattern).
+      const downloadResult = await downloadSalesforceContent(
+        conn,
+        attachmentId
+      );
+      if (downloadResult.isErr()) {
+        return new Err(
+          new MCPError(`Failed to download attachment: ${downloadResult.error}`)
+        );
+      }
+      const buffer = downloadResult.value;
+
+      const result = await processAttachment({
+        mimeType,
+        filename: safeFilename,
+        extractText: async () => extractTextFromBuffer(buffer, mimeType),
+        downloadContent: async () => new Ok(buffer),
+      });
+
+      if (result.isErr()) {
+        return new Err(result.error);
+      }
+
+      // Always include a raw binary resource block so the user receives a
+      // downloadable file, even when text extraction succeeded (PDFs).
+      if (result.value.some((c) => c.type === "resource")) {
+        return new Ok(result.value);
+      }
+
+      const sanitized = sanitizeFilename(safeFilename);
+      return new Ok([
+        ...result.value,
+        {
+          type: "resource" as const,
+          resource: {
+            blob: buffer.toString("base64"),
+            _meta: { text: `Attachment: ${sanitized}` },
+            mimeType,
+            uri: sanitized,
+          },
+        },
+      ]);
+    });
+  },
+};
+
+export const TOOLS = buildTools(SALESFORCE_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/statuspage/index.ts
+++ b/front/lib/api/actions/servers/statuspage/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createStatuspageTools } from "@app/lib/api/actions/servers/statuspage/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/statuspage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("statuspage");
 
-  const tools = createStatuspageTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "statuspage",
     });

--- a/front/lib/api/actions/servers/statuspage/tools/index.ts
+++ b/front/lib/api/actions/servers/statuspage/tools/index.ts
@@ -5,7 +5,6 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
 import type { StatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { getStatuspageClient } from "@app/lib/api/actions/servers/statuspage/client";
 import { STATUSPAGE_TOOLS_METADATA } from "@app/lib/api/actions/servers/statuspage/metadata";
@@ -16,7 +15,6 @@ import {
   renderPagesList,
 } from "@app/lib/api/actions/servers/statuspage/rendering";
 import type { ComponentStatus } from "@app/lib/api/actions/servers/statuspage/types";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
 async function withClient(
@@ -30,195 +28,190 @@ async function withClient(
   return action(clientResult.value);
 }
 
-export function createStatuspageTools(
-  _auth: Authenticator,
-  _toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof STATUSPAGE_TOOLS_METADATA> = {
-    list_pages: async (_params, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listPages();
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to list pages: ${result.error.message}`)
-          );
-        }
+const handlers: ToolHandlers<typeof STATUSPAGE_TOOLS_METADATA> = {
+  list_pages: async (_params, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listPages();
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to list pages: ${result.error.message}`)
+        );
+      }
 
-        const pages = result.value;
-        const renderedText = renderPagesList(pages);
+      const pages = result.value;
+      const renderedText = renderPagesList(pages);
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderedText,
-          },
-        ]);
-      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderedText,
+        },
+      ]);
+    });
+  },
+
+  list_components: async ({ page_id }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listComponents(page_id);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to list components: ${result.error.message}`)
+        );
+      }
+
+      const components = result.value;
+      const renderedText = renderComponentsList(components);
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderedText,
+        },
+      ]);
+    });
+  },
+
+  list_incidents: async ({ page_id, filter }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.listIncidents(page_id, filter);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to list incidents: ${result.error.message}`)
+        );
+      }
+
+      const incidents = result.value;
+      const renderedText = renderIncidentsList(incidents);
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderedText,
+        },
+      ]);
+    });
+  },
+
+  get_incident: async ({ page_id, incident_id }, extra: ToolHandlerExtra) => {
+    return withClient(extra, async (client) => {
+      const result = await client.getIncident(page_id, incident_id);
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to get incident: ${result.error.message}`)
+        );
+      }
+
+      const incident = result.value;
+      const renderedText = renderIncidentDetails(incident);
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: renderedText,
+        },
+      ]);
+    });
+  },
+
+  create_incident: async (
+    {
+      page_id,
+      name,
+      status,
+      body,
+      component_ids,
+      component_status,
+      impact_override,
     },
-
-    list_components: async ({ page_id }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listComponents(page_id);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to list components: ${result.error.message}`)
-          );
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      // Build the component status map if both component_ids and component_status are provided
+      let components: Record<string, ComponentStatus> | undefined;
+      if (component_ids && component_ids.length > 0 && component_status) {
+        components = {};
+        for (const componentId of component_ids) {
+          components[componentId] = component_status;
         }
+      }
 
-        const components = result.value;
-        const renderedText = renderComponentsList(components);
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderedText,
-          },
-        ]);
+      const result = await client.createIncident(page_id, {
+        incident: {
+          name,
+          status,
+          body,
+          component_ids,
+          components,
+          impact_override,
+        },
       });
-    },
 
-    list_incidents: async ({ page_id, filter }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.listIncidents(page_id, filter);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to list incidents: ${result.error.message}`)
-          );
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to create incident: ${result.error.message}`)
+        );
+      }
+
+      const incident = result.value;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Successfully created incident "${incident.name}".\n\n` +
+            `- ID: ${incident.id}\n` +
+            `- Status: ${incident.status}\n` +
+            (incident.shortlink ? `- Link: ${incident.shortlink}\n` : "") +
+            "\nNotifications have been sent to subscribers.",
+        },
+      ]);
+    });
+  },
+
+  update_incident: async (
+    { page_id, incident_id, status, body, component_ids, component_status },
+    extra: ToolHandlerExtra
+  ) => {
+    return withClient(extra, async (client) => {
+      // Build the component status map if both component_ids and component_status are provided
+      let components: Record<string, ComponentStatus> | undefined;
+      if (component_ids && component_ids.length > 0 && component_status) {
+        components = {};
+        for (const componentId of component_ids) {
+          components[componentId] = component_status;
         }
+      }
 
-        const incidents = result.value;
-        const renderedText = renderIncidentsList(incidents);
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderedText,
-          },
-        ]);
+      const result = await client.updateIncident(page_id, incident_id, {
+        incident: {
+          status,
+          body,
+          component_ids,
+          components,
+        },
       });
-    },
 
-    get_incident: async ({ page_id, incident_id }, extra: ToolHandlerExtra) => {
-      return withClient(extra, async (client) => {
-        const result = await client.getIncident(page_id, incident_id);
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to get incident: ${result.error.message}`)
-          );
-        }
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to update incident: ${result.error.message}`)
+        );
+      }
 
-        const incident = result.value;
-        const renderedText = renderIncidentDetails(incident);
+      const incident = result.value;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: renderedText,
-          },
-        ]);
-      });
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Successfully updated incident "${incident.name}".\n\n` +
+            `- ID: ${incident.id}\n` +
+            `- Status: ${incident.status}\n` +
+            (incident.shortlink ? `- Link: ${incident.shortlink}\n` : "") +
+            "\nNotifications have been sent to subscribers.",
+        },
+      ]);
+    });
+  },
+};
 
-    create_incident: async (
-      {
-        page_id,
-        name,
-        status,
-        body,
-        component_ids,
-        component_status,
-        impact_override,
-      },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        // Build the component status map if both component_ids and component_status are provided
-        let components: Record<string, ComponentStatus> | undefined;
-        if (component_ids && component_ids.length > 0 && component_status) {
-          components = {};
-          for (const componentId of component_ids) {
-            components[componentId] = component_status;
-          }
-        }
-
-        const result = await client.createIncident(page_id, {
-          incident: {
-            name,
-            status,
-            body,
-            component_ids,
-            components,
-            impact_override,
-          },
-        });
-
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to create incident: ${result.error.message}`)
-          );
-        }
-
-        const incident = result.value;
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `Successfully created incident "${incident.name}".\n\n` +
-              `- ID: ${incident.id}\n` +
-              `- Status: ${incident.status}\n` +
-              (incident.shortlink ? `- Link: ${incident.shortlink}\n` : "") +
-              "\nNotifications have been sent to subscribers.",
-          },
-        ]);
-      });
-    },
-
-    update_incident: async (
-      { page_id, incident_id, status, body, component_ids, component_status },
-      extra: ToolHandlerExtra
-    ) => {
-      return withClient(extra, async (client) => {
-        // Build the component status map if both component_ids and component_status are provided
-        let components: Record<string, ComponentStatus> | undefined;
-        if (component_ids && component_ids.length > 0 && component_status) {
-          components = {};
-          for (const componentId of component_ids) {
-            components[componentId] = component_status;
-          }
-        }
-
-        const result = await client.updateIncident(page_id, incident_id, {
-          incident: {
-            status,
-            body,
-            component_ids,
-            components,
-          },
-        });
-
-        if (result.isErr()) {
-          return new Err(
-            new MCPError(`Failed to update incident: ${result.error.message}`)
-          );
-        }
-
-        const incident = result.value;
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `Successfully updated incident "${incident.name}".\n\n` +
-              `- ID: ${incident.id}\n` +
-              `- Status: ${incident.status}\n` +
-              (incident.shortlink ? `- Link: ${incident.shortlink}\n` : "") +
-              "\nNotifications have been sent to subscribers.",
-          },
-        ]);
-      });
-    },
-  };
-
-  return buildTools(STATUSPAGE_TOOLS_METADATA, handlers);
-}
+export const TOOLS = buildTools(STATUSPAGE_TOOLS_METADATA, handlers);


### PR DESCRIPTION
## Description

Several internal MCP servers wrap static handler maps in `createXxxTools` factories even though the factories do not use runtime context.

This PR removes those wrappers and exports their built `TOOLS` arrays directly. It is the first, purely static batch of the broader cleanup; servers that capture execution context or filter tools remain in separate PRs.

## Tests

- Covered by existing MCP server metadata tests.

## Risk

- Low. No handler or tool-selection behavior changes.

## Deploy Plan

- Deploy front.