### PR TITLE
[front] chore: remove integration MCP tool factories

### DIFF
--- a/front/lib/api/actions/servers/github/index.ts
+++ b/front/lib/api/actions/servers/github/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/github/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("github");
 
-  const tools = createGithubTools(auth);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "github",
     });

--- a/front/lib/api/actions/servers/github/tools/index.test.ts
+++ b/front/lib/api/actions/servers/github/tools/index.test.ts
@@ -1,5 +1,5 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/github/tools";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -99,9 +99,7 @@ describe("GitHub pull request tools", () => {
     graphqlMock.mockResolvedValueOnce(response);
 
     const { authenticator } = await createResourceTest({ role: "admin" });
-    const tool = createGithubTools(authenticator).find(
-      ({ name }) => name === toolName
-    );
+    const tool = TOOLS.find(({ name }) => name === toolName);
     if (!tool) {
       throw new Error(`Tool not found: ${toolName}`);
     }

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -1,8 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { GITHUB_TOOLS_METADATA } from "@app/lib/api/actions/servers/github/metadata";
 import type { Authenticator } from "@app/lib/auth";
@@ -111,48 +108,47 @@ const createOctokit = async (
   });
 };
 
-export function createGithubTools(auth: Authenticator): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof GITHUB_TOOLS_METADATA> = {
-    create_issue: async (
-      { owner, repo, title, body, assignees, labels },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+const handlers: ToolHandlers<typeof GITHUB_TOOLS_METADATA> = {
+  create_issue: async (
+    { owner, repo, title, body, assignees, labels },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const { data: issue } = await octokit.request(
-          "POST /repos/{owner}/{repo}/issues",
-          {
-            owner,
-            repo,
-            title,
-            body,
-            assignees,
-            labels,
-          }
-        );
+    try {
+      const { data: issue } = await octokit.request(
+        "POST /repos/{owner}/{repo}/issues",
+        {
+          owner,
+          repo,
+          title,
+          body,
+          assignees,
+          labels,
+        }
+      );
 
-        return new Ok([
-          { type: "text" as const, text: `Issue created: #${issue.number}` },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error creating GitHub issue: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        { type: "text" as const, text: `Issue created: #${issue.number}` },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error creating GitHub issue: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    get_pull_request: async ({ owner, repo, pullNumber }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  get_pull_request: async ({ owner, repo, pullNumber }, { auth, authInfo }) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $pullNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               pullRequest(number: $pullNumber) {
@@ -203,317 +199,313 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const pull = (await octokit.graphql(query, {
-          owner,
-          repo,
-          pullNumber,
-        })) as {
-          repository: {
-            pullRequest: {
-              title: string;
-              body: string;
-              createdAt: string;
-              mergedAt: string | null;
-              commits: {
-                nodes: {
-                  commit: {
-                    oid: string;
-                    message: string;
-                    author: {
-                      user: {
-                        login: string;
-                      };
+      const pull = (await octokit.graphql(query, {
+        owner,
+        repo,
+        pullNumber,
+      })) as {
+        repository: {
+          pullRequest: {
+            title: string;
+            body: string;
+            createdAt: string;
+            mergedAt: string | null;
+            commits: {
+              nodes: {
+                commit: {
+                  oid: string;
+                  message: string;
+                  author: {
+                    user: {
+                      login: string;
                     };
                   };
-                }[];
-              };
-              comments: {
-                nodes: {
-                  author: {
-                    login: string;
-                  };
-                  body: string;
-                  createdAt: string;
-                }[];
-              };
-              reviews: {
-                nodes: {
-                  author: {
-                    login: string;
-                  };
-                  body: string;
-                  state: string;
-                  createdAt: string;
-                  comments: {
-                    nodes: {
-                      body: string;
-                      path: string;
-                      line: number;
-                    }[];
-                  };
-                }[];
-              };
+                };
+              }[];
+            };
+            comments: {
+              nodes: {
+                author: {
+                  login: string;
+                };
+                body: string;
+                createdAt: string;
+              }[];
+            };
+            reviews: {
+              nodes: {
+                author: {
+                  login: string;
+                };
+                body: string;
+                state: string;
+                createdAt: string;
+                comments: {
+                  nodes: {
+                    body: string;
+                    path: string;
+                    line: number;
+                  }[];
+                };
+              }[];
             };
           };
         };
+      };
 
-        const pullTitle = pull.repository.pullRequest.title;
-        const pullBody = pull.repository.pullRequest.body;
-        const pullCreatedAt = pull.repository.pullRequest.createdAt;
-        const pullMergedAt = pull.repository.pullRequest.mergedAt;
-        const pullCommits = pull.repository.pullRequest.commits.nodes.map(
-          (n) => {
+      const pullTitle = pull.repository.pullRequest.title;
+      const pullBody = pull.repository.pullRequest.body;
+      const pullCreatedAt = pull.repository.pullRequest.createdAt;
+      const pullMergedAt = pull.repository.pullRequest.mergedAt;
+      const pullCommits = pull.repository.pullRequest.commits.nodes.map((n) => {
+        return {
+          sha: n.commit.oid,
+          message: n.commit.message,
+          author: n.commit.author.user?.login || "unknown",
+        };
+      });
+      const pullComments = pull.repository.pullRequest.comments.nodes.map(
+        (n) => {
+          return {
+            createdAt: new Date(n.createdAt).getTime(),
+            author: n.author?.login || "unknown",
+            body: n.body,
+          };
+        }
+      );
+      const pullReviews = pull.repository.pullRequest.reviews.nodes.map((n) => {
+        return {
+          createdAt: new Date(n.createdAt).getTime(),
+          author: n.author?.login || "unknown",
+          body: n.body,
+          state: n.state,
+          comments: n.comments.nodes.map((c) => {
             return {
-              sha: n.commit.oid,
-              message: n.commit.message,
-              author: n.commit.author.user?.login || "unknown",
+              body: c.body,
+              path: c.path,
+              line: c.line,
             };
+          }),
+        };
+      });
+
+      const diffWithPositions = (diff: string) => {
+        const lines = diff.split("\n");
+
+        let currentFile = null;
+        let position = 0;
+        let globalMaxPosition = 0;
+
+        for (const line of lines) {
+          if (line.startsWith("diff --git")) {
+            currentFile = null;
+            position = 0;
+            continue;
           }
-        );
-        const pullComments = pull.repository.pullRequest.comments.nodes.map(
-          (n) => {
-            return {
-              createdAt: new Date(n.createdAt).getTime(),
-              author: n.author?.login || "unknown",
-              body: n.body,
-            };
+
+          if (line.startsWith("@@")) {
+            position = 0;
+            continue;
           }
-        );
-        const pullReviews = pull.repository.pullRequest.reviews.nodes.map(
-          (n) => {
-            return {
-              createdAt: new Date(n.createdAt).getTime(),
-              author: n.author?.login || "unknown",
-              body: n.body,
-              state: n.state,
-              comments: n.comments.nodes.map((c) => {
-                return {
-                  body: c.body,
-                  path: c.path,
-                  line: c.line,
-                };
-              }),
-            };
+
+          if (currentFile !== null) {
+            position++;
+            globalMaxPosition = Math.max(position, globalMaxPosition);
+          } else if (line.startsWith("+++")) {
+            currentFile = line.substring(4).trim();
           }
-        );
+        }
 
-        const diffWithPositions = (diff: string) => {
-          const lines = diff.split("\n");
+        const result = [];
+        currentFile = null;
+        position = 0;
+        const digits = globalMaxPosition.toString().length;
 
-          let currentFile = null;
-          let position = 0;
-          let globalMaxPosition = 0;
+        for (const line of lines) {
+          if (line.startsWith("diff --git")) {
+            currentFile = null;
+            position = 0;
+            result.push(line);
+            continue;
+          }
 
-          for (const line of lines) {
-            if (line.startsWith("diff --git")) {
-              currentFile = null;
-              position = 0;
-              continue;
-            }
-
+          if (currentFile !== null) {
+            const paddedPosition = position.toString().padStart(digits, " ");
             if (line.startsWith("@@")) {
-              position = 0;
-              continue;
+              result.push(line);
+            } else {
+              result.push(`[${paddedPosition}] ${line}`);
             }
-
-            if (currentFile !== null) {
-              position++;
-              globalMaxPosition = Math.max(position, globalMaxPosition);
-            } else if (line.startsWith("+++")) {
+            position++;
+          } else {
+            result.push(line);
+            if (line.startsWith("+++")) {
               currentFile = line.substring(4).trim();
             }
           }
+        }
 
-          const result = [];
-          currentFile = null;
-          position = 0;
-          const digits = globalMaxPosition.toString().length;
+        return result.join("\n");
+      };
 
-          for (const line of lines) {
-            if (line.startsWith("diff --git")) {
-              currentFile = null;
-              position = 0;
-              result.push(line);
-              continue;
-            }
-
-            if (currentFile !== null) {
-              const paddedPosition = position.toString().padStart(digits, " ");
-              if (line.startsWith("@@")) {
-                result.push(line);
-              } else {
-                result.push(`[${paddedPosition}] ${line}`);
-              }
-              position++;
-            } else {
-              result.push(line);
-              if (line.startsWith("+++")) {
-                currentFile = line.substring(4).trim();
-              }
-            }
-          }
-
-          return result.join("\n");
-        };
-
-        const diff = await octokit.request(
-          "GET /repos/{owner}/{repo}/pulls/{pull_number}",
-          {
-            owner,
-            repo,
-            pull_number: pullNumber,
-            headers: {
-              Accept: "application/vnd.github.v3.diff",
-            },
-          }
-        );
-        // @ts-expect-error - data is a string when mediatType.format is `diff` (wrongly typed as
-        // their defauilt response type)
-        const pullDiff = diffWithPositions(diff.data as string);
-
-        const createdAtLine = `CREATED_AT: ${new Date(pullCreatedAt).toISOString()}\n\n`;
-        const mergedAtLine =
-          pullMergedAt != null
-            ? `MERGED_AT: ${new Date(pullMergedAt).toISOString()}\n\n`
-            : `MERGED_AT: (not merged)\n\n`;
-
-        const content =
-          `TITLE: ${pullTitle}\n\n` +
-          createdAtLine +
-          mergedAtLine +
-          `BODY:\n` +
-          `${pullBody}\n\n` +
-          `COMMITS:\n` +
-          `${(pullCommits || [])
-            .map((c) => `${c.sha} ${c.author}: ${c.message}`)
-            .join("\n")}\n\n` +
-          `DIFF (lines are prepended by diff file positions):\n` +
-          `${pullDiff}\n\n` +
-          `COMMENTS:\n` +
-          `${(pullComments || [])
-            .map((c) => {
-              return `${c.author} [${new Date(c.createdAt).toISOString()}]:\n${c.body}`;
-            })
-            .join("\n")}\n\n` +
-          `REVIEWS:\n` +
-          `${(pullReviews || [])
-            .map(
-              (r) =>
-                `${r.author} [${new Date(r.createdAt).toISOString()}]:\n(${r.state})\n${r.body}\n${(
-                  r.comments || []
-                )
-                  .map((c) => ` - ${c.path}:${c.line}:\n${c.body}`)
-                  .join("\n")}`
-            )
-            .join("\n")}`;
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved pull request #${pullNumber}`,
+      const diff = await octokit.request(
+        "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+        {
+          owner,
+          repo,
+          pull_number: pullNumber,
+          headers: {
+            Accept: "application/vnd.github.v3.diff",
           },
-          { type: "text" as const, text: JSON.stringify(content, null, 2) },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error retrieving GitHub pull request: ${normalizeError(e).message}`
+        }
+      );
+      // @ts-expect-error - data is a string when mediatType.format is `diff` (wrongly typed as
+      // their defauilt response type)
+      const pullDiff = diffWithPositions(diff.data as string);
+
+      const createdAtLine = `CREATED_AT: ${new Date(pullCreatedAt).toISOString()}\n\n`;
+      const mergedAtLine =
+        pullMergedAt != null
+          ? `MERGED_AT: ${new Date(pullMergedAt).toISOString()}\n\n`
+          : `MERGED_AT: (not merged)\n\n`;
+
+      const content =
+        `TITLE: ${pullTitle}\n\n` +
+        createdAtLine +
+        mergedAtLine +
+        `BODY:\n` +
+        `${pullBody}\n\n` +
+        `COMMITS:\n` +
+        `${(pullCommits || [])
+          .map((c) => `${c.sha} ${c.author}: ${c.message}`)
+          .join("\n")}\n\n` +
+        `DIFF (lines are prepended by diff file positions):\n` +
+        `${pullDiff}\n\n` +
+        `COMMENTS:\n` +
+        `${(pullComments || [])
+          .map((c) => {
+            return `${c.author} [${new Date(c.createdAt).toISOString()}]:\n${c.body}`;
+          })
+          .join("\n")}\n\n` +
+        `REVIEWS:\n` +
+        `${(pullReviews || [])
+          .map(
+            (r) =>
+              `${r.author} [${new Date(r.createdAt).toISOString()}]:\n(${r.state})\n${r.body}\n${(
+                r.comments || []
+              )
+                .map((c) => ` - ${c.path}:${c.line}:\n${c.body}`)
+                .join("\n")}`
           )
-        );
-      }
+          .join("\n")}`;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved pull request #${pullNumber}`,
+        },
+        { type: "text" as const, text: JSON.stringify(content, null, 2) },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub pull request: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  update_issue: async (
+    {
+      owner,
+      repo,
+      issueNumber,
+      title,
+      body,
+      state,
+      stateReason,
+      assignees,
+      labels,
+      milestone,
     },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-    update_issue: async (
-      {
-        owner,
-        repo,
-        issueNumber,
-        title,
-        body,
-        state,
-        stateReason,
-        assignees,
-        labels,
-        milestone,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    try {
+      const { data: issue } = await octokit.request(
+        "PATCH /repos/{owner}/{repo}/issues/{issue_number}",
+        {
+          owner,
+          repo,
+          issue_number: issueNumber,
+          title,
+          body,
+          state,
+          state_reason: stateReason,
+          assignees,
+          labels,
+          milestone,
+        }
+      );
 
-      try {
-        const { data: issue } = await octokit.request(
-          "PATCH /repos/{owner}/{repo}/issues/{issue_number}",
-          {
-            owner,
-            repo,
-            issue_number: issueNumber,
-            title,
-            body,
-            state,
-            state_reason: stateReason,
-            assignees,
-            labels,
-            milestone,
-          }
-        );
+      return new Ok([
+        { type: "text" as const, text: `Issue #${issue.number} updated` },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error updating GitHub issue: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-        return new Ok([
-          { type: "text" as const, text: `Issue #${issue.number} updated` },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error updating GitHub issue: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+  create_pull_request_review: async (
+    { owner, repo, pullNumber, body, event, comments = [] },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-    create_pull_request_review: async (
-      { owner, repo, pullNumber, body, event, comments = [] },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    try {
+      const { data: review } = await octokit.request(
+        "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+        {
+          owner,
+          repo,
+          pull_number: pullNumber,
+          body,
+          event,
+          comments,
+        }
+      );
 
-      try {
-        const { data: review } = await octokit.request(
-          "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
-          {
-            owner,
-            repo,
-            pull_number: pullNumber,
-            body,
-            event,
-            comments,
-          }
-        );
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Review created with ID ${review.id}`,
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error reviewing GitHub pull request: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Review created with ID ${review.id}`,
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error reviewing GitHub pull request: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+  list_organization_projects: async ({ owner }, { auth, authInfo }) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-    list_organization_projects: async ({ owner }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const projectsQuery = `
+    try {
+      const projectsQuery = `
         query($owner: String!) {
           organization(login: $owner) {
             projectsV2(first: 100) {
@@ -540,87 +532,87 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           }
         }`;
 
-        const results = (await octokit.graphql(projectsQuery, {
-          owner,
-        })) as {
-          organization: {
-            projectsV2: {
-              nodes: {
-                id: string;
-                title: string;
-                shortDescription: string | null;
-                url: string;
-                closed: boolean;
-                fields: {
-                  nodes: {
+      const results = (await octokit.graphql(projectsQuery, {
+        owner,
+      })) as {
+        organization: {
+          projectsV2: {
+            nodes: {
+              id: string;
+              title: string;
+              shortDescription: string | null;
+              url: string;
+              closed: boolean;
+              fields: {
+                nodes: {
+                  id: string;
+                  name: string;
+                  options: {
                     id: string;
                     name: string;
-                    options: {
-                      id: string;
-                      name: string;
-                    }[];
                   }[];
-                };
-              }[];
-            };
+                }[];
+              };
+            }[];
           };
         };
+      };
 
-        const projects = results.organization.projectsV2.nodes
-          .filter((project: any) => !project.closed)
-          .map((project) => ({
-            ...project,
-            fields: {
-              nodes: project.fields.nodes.filter((n) => n.id),
-            },
-          }));
-
-        let content = "";
-        projects.forEach((project) => {
-          content +=
-            `project='${project.title}' node_id=${project.id} ` +
-            `description='${project.shortDescription}'\n`;
-          project.fields.nodes.forEach((field) => {
-            content += `  field='${field.name}' node_id=${field.id}\n`;
-            field.options.forEach((o) => {
-              content += `    option='${o.name}' node_id=${o.id}\n`;
-            });
-          });
-          content += "\n";
-        });
-
-        if (!content) {
-          return new Ok([
-            { type: "text" as const, text: "No open projects found" },
-          ]);
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${projects.length} open projects`,
+      const projects = results.organization.projectsV2.nodes
+        .filter((project: any) => !project.closed)
+        .map((project) => ({
+          ...project,
+          fields: {
+            nodes: project.fields.nodes.filter((n) => n.id),
           },
-          { type: "text" as const, text: JSON.stringify(content, null, 2) },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error retrieving GitHub repository projects: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+        }));
 
-    add_issue_to_project: async (
-      { owner, repo, issueNumber, projectId, field },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
+      let content = "";
+      projects.forEach((project) => {
+        content +=
+          `project='${project.title}' node_id=${project.id} ` +
+          `description='${project.shortDescription}'\n`;
+        project.fields.nodes.forEach((field) => {
+          content += `  field='${field.name}' node_id=${field.id}\n`;
+          field.options.forEach((o) => {
+            content += `    option='${o.name}' node_id=${o.id}\n`;
+          });
+        });
+        content += "\n";
       });
 
-      try {
-        const issueQuery = `
+      if (!content) {
+        return new Ok([
+          { type: "text" as const, text: "No open projects found" },
+        ]);
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${projects.length} open projects`,
+        },
+        { type: "text" as const, text: JSON.stringify(content, null, 2) },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub repository projects: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  add_issue_to_project: async (
+    { owner, repo, issueNumber, projectId, field },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
+
+    try {
+      const issueQuery = `
         query($owner: String!, $repo: String!, $issueNumber: Int!) {
           repository(owner: $owner, name: $repo) {
             issue(number: $issueNumber) {
@@ -629,19 +621,19 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
           }
         }`;
 
-        const issue = (await octokit.graphql(issueQuery, {
-          owner,
-          repo,
-          issueNumber,
-        })) as {
-          repository: {
-            issue: {
-              id: string;
-            };
+      const issue = (await octokit.graphql(issueQuery, {
+        owner,
+        repo,
+        issueNumber,
+      })) as {
+        repository: {
+          issue: {
+            id: string;
           };
         };
+      };
 
-        const addToProjectMutation = `
+      const addToProjectMutation = `
           mutation($projectId: ID!, $contentId: ID!) {
             addProjectV2ItemById(input: {
               projectId: $projectId
@@ -653,19 +645,19 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const item = (await octokit.graphql(addToProjectMutation, {
-          projectId,
-          contentId: issue.repository.issue.id,
-        })) as {
-          addProjectV2ItemById: {
-            item: {
-              id: string;
-            };
+      const item = (await octokit.graphql(addToProjectMutation, {
+        projectId,
+        contentId: issue.repository.issue.id,
+      })) as {
+        addProjectV2ItemById: {
+          item: {
+            id: string;
           };
         };
+      };
 
-        if (field) {
-          const updateFieldMutation = `
+      if (field) {
+        const updateFieldMutation = `
           mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String) {
             updateProjectV2ItemFieldValue(input: {
               projectId: $projectId,
@@ -681,73 +673,73 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-          await octokit.graphql(updateFieldMutation, {
-            projectId,
-            itemId: item.addProjectV2ItemById.item.id,
-            fieldId: field.fieldId,
-            optionId: field.optionId,
-          });
+        await octokit.graphql(updateFieldMutation, {
+          projectId,
+          itemId: item.addProjectV2ItemById.item.id,
+          fieldId: field.fieldId,
+          optionId: field.optionId,
+        });
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Issue #${issueNumber} added to project`,
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error adding GitHub issue to project: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  comment_on_issue: async (
+    { owner, repo, issueNumber, body },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
+
+    try {
+      const { data: comment } = await octokit.request(
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+        {
+          owner,
+          repo,
+          issue_number: issueNumber,
+          body,
         }
+      );
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Issue #${issueNumber} added to project`,
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error adding GitHub issue to project: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error commenting on GitHub issue: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    comment_on_issue: async (
-      { owner, repo, issueNumber, body },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  list_discussion_categories: async (
+    { owner, repo, perPage = 25, after, before },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const { data: comment } = await octokit.request(
-          "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-          {
-            owner,
-            repo,
-            issue_number: issueNumber,
-            body,
-          }
-        );
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error commenting on GitHub issue: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
-
-    list_discussion_categories: async (
-      { owner, repo, perPage = 25, after, before },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $first: Int!, $after: String, $before: String) {
             repository(owner: $owner, name: $repo) {
               discussionCategories(first: $first, after: $after, before: $before) {
@@ -770,92 +762,91 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const categoriesResult = (await octokit.graphql(query, {
-          owner,
-          repo,
-          first: perPage,
-          after,
-          before,
-        })) as {
-          repository: {
-            discussionCategories: {
-              totalCount: number;
-              pageInfo: {
-                hasNextPage: boolean;
-                endCursor: string | null;
-                startCursor: string | null;
-                hasPreviousPage: boolean;
-              };
-              nodes: {
-                id: string;
-                name: string;
-                slug: string;
-                description: string | null;
-                emoji: string;
-                isAnswerable: boolean;
-              }[];
+      const categoriesResult = (await octokit.graphql(query, {
+        owner,
+        repo,
+        first: perPage,
+        after,
+        before,
+      })) as {
+        repository: {
+          discussionCategories: {
+            totalCount: number;
+            pageInfo: {
+              hasNextPage: boolean;
+              endCursor: string | null;
+              startCursor: string | null;
+              hasPreviousPage: boolean;
             };
+            nodes: {
+              id: string;
+              name: string;
+              slug: string;
+              description: string | null;
+              emoji: string;
+              isAnswerable: boolean;
+            }[];
           };
         };
+      };
 
-        const categories =
-          categoriesResult.repository.discussionCategories.nodes;
+      const categories = categoriesResult.repository.discussionCategories.nodes;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${categories.length} GitHub discussion categories`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                totalCount:
-                  categoriesResult.repository.discussionCategories.totalCount,
-                categories,
-                pageInfo:
-                  categoriesResult.repository.discussionCategories.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error listing GitHub discussion categories: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${categories.length} GitHub discussion categories`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              totalCount:
+                categoriesResult.repository.discussionCategories.totalCount,
+              categories,
+              pageInfo:
+                categoriesResult.repository.discussionCategories.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error listing GitHub discussion categories: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    create_discussion: async (
-      { owner, repo, categoryId, title, body },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  create_discussion: async (
+    { owner, repo, categoryId, title, body },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const repositoryQuery = `
+    try {
+      const repositoryQuery = `
           query($owner: String!, $repo: String!) {
             repository(owner: $owner, name: $repo) {
               id
             }
           }`;
 
-        const repositoryResult = (await octokit.graphql(repositoryQuery, {
-          owner,
-          repo,
-        })) as {
-          repository: {
-            id: string;
-          };
+      const repositoryResult = (await octokit.graphql(repositoryQuery, {
+        owner,
+        repo,
+      })) as {
+        repository: {
+          id: string;
         };
+      };
 
-        const createDiscussionMutation = `
+      const createDiscussionMutation = `
           mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
             createDiscussion(input: {
               repositoryId: $repositoryId,
@@ -872,56 +863,56 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const discussionResult = (await octokit.graphql(
-          createDiscussionMutation,
-          {
-            repositoryId: repositoryResult.repository.id,
-            categoryId,
-            title,
-            body,
-          }
-        )) as {
-          createDiscussion: {
-            discussion: {
-              id: string;
-              number: number;
-              title: string;
-              url: string;
-            };
+      const discussionResult = (await octokit.graphql(
+        createDiscussionMutation,
+        {
+          repositoryId: repositoryResult.repository.id,
+          categoryId,
+          title,
+          body,
+        }
+      )) as {
+        createDiscussion: {
+          discussion: {
+            id: string;
+            number: number;
+            title: string;
+            url: string;
           };
         };
+      };
 
-        const discussion = discussionResult.createDiscussion.discussion;
+      const discussion = discussionResult.createDiscussion.discussion;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Discussion created: #${discussion.number}`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(discussion, null, 2),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error creating GitHub discussion: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Discussion created: #${discussion.number}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(discussion, null, 2),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error creating GitHub discussion: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    comment_on_discussion: async (
-      { owner, repo, discussionNumber, body, replyToId },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  comment_on_discussion: async (
+    { owner, repo, discussionNumber, body, replyToId },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const discussionQuery = `
+    try {
+      const discussionQuery = `
           query($owner: String!, $repo: String!, $discussionNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               discussion(number: $discussionNumber) {
@@ -930,28 +921,28 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const discussionResult = (await octokit.graphql(discussionQuery, {
-          owner,
-          repo,
-          discussionNumber,
-        })) as {
-          repository: {
-            discussion: {
-              id: string;
-            } | null;
-          };
+      const discussionResult = (await octokit.graphql(discussionQuery, {
+        owner,
+        repo,
+        discussionNumber,
+      })) as {
+        repository: {
+          discussion: {
+            id: string;
+          } | null;
         };
+      };
 
-        const discussion = discussionResult.repository.discussion;
-        if (!discussion) {
-          return new Err(
-            new MCPError(
-              `Discussion #${discussionNumber} not found in ${owner}/${repo}`
-            )
-          );
-        }
+      const discussion = discussionResult.repository.discussion;
+      if (!discussion) {
+        return new Err(
+          new MCPError(
+            `Discussion #${discussionNumber} not found in ${owner}/${repo}`
+          )
+        );
+      }
 
-        const addCommentMutation = `
+      const addCommentMutation = `
           mutation($discussionId: ID!, $body: String!, $replyToId: ID) {
             addDiscussionComment(input: {
               discussionId: $discussionId,
@@ -965,47 +956,50 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const commentResult = (await octokit.graphql(addCommentMutation, {
-          discussionId: discussion.id,
-          body,
-          replyToId,
-        })) as {
-          addDiscussionComment: {
-            comment: {
-              id: string;
-              url: string;
-            };
+      const commentResult = (await octokit.graphql(addCommentMutation, {
+        discussionId: discussion.id,
+        body,
+        replyToId,
+      })) as {
+        addDiscussionComment: {
+          comment: {
+            id: string;
+            url: string;
           };
         };
+      };
 
-        const comment = commentResult.addDiscussionComment.comment;
+      const comment = commentResult.addDiscussionComment.comment;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Comment added to discussion #${discussionNumber} with ID ${comment.id}`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(comment, null, 2),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error commenting on GitHub discussion: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Comment added to discussion #${discussionNumber} with ID ${comment.id}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(comment, null, 2),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error commenting on GitHub discussion: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    get_discussion: async ({ owner, repo, discussionNumber }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  get_discussion: async (
+    { owner, repo, discussionNumber },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $discussionNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               discussion(number: $discussionNumber) {
@@ -1036,93 +1030,93 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const discussionResult = (await octokit.graphql(query, {
-          owner,
-          repo,
-          discussionNumber,
-        })) as {
-          repository: {
-            discussion: {
-              id: string;
-              number: number;
-              title: string;
-              body: string;
-              bodyText: string;
-              url: string;
-              createdAt: string;
-              updatedAt: string;
-              isAnswered: boolean;
-              author: {
-                login: string;
-              } | null;
-              category: {
-                id: string;
-                name: string;
-                slug: string;
-                description: string | null;
-                emoji: string;
-                isAnswerable: boolean;
-              };
-              comments: {
-                totalCount: number;
-              };
+      const discussionResult = (await octokit.graphql(query, {
+        owner,
+        repo,
+        discussionNumber,
+      })) as {
+        repository: {
+          discussion: {
+            id: string;
+            number: number;
+            title: string;
+            body: string;
+            bodyText: string;
+            url: string;
+            createdAt: string;
+            updatedAt: string;
+            isAnswered: boolean;
+            author: {
+              login: string;
             } | null;
-          };
+            category: {
+              id: string;
+              name: string;
+              slug: string;
+              description: string | null;
+              emoji: string;
+              isAnswerable: boolean;
+            };
+            comments: {
+              totalCount: number;
+            };
+          } | null;
         };
+      };
 
-        const discussion = discussionResult.repository.discussion;
-        if (!discussion) {
-          return new Err(
-            new MCPError(
-              `Discussion #${discussionNumber} not found in ${owner}/${repo}`
-            )
-          );
-        }
-
-        const formattedDiscussion = {
-          id: discussion.id,
-          number: discussion.number,
-          title: discussion.title,
-          body: discussion.body,
-          bodyText: discussion.bodyText,
-          url: discussion.url,
-          createdAt: discussion.createdAt,
-          updatedAt: discussion.updatedAt,
-          isAnswered: discussion.isAnswered,
-          author: discussion.author?.login || "unknown",
-          category: discussion.category,
-          commentCount: discussion.comments.totalCount,
-        };
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved discussion #${discussionNumber}`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(formattedDiscussion, null, 2),
-          },
-        ]);
-      } catch (e) {
+      const discussion = discussionResult.repository.discussion;
+      if (!discussion) {
         return new Err(
           new MCPError(
-            `Error retrieving GitHub discussion: ${normalizeError(e).message}`
+            `Discussion #${discussionNumber} not found in ${owner}/${repo}`
           )
         );
       }
-    },
 
-    get_discussion_comments: async (
-      { owner, repo, discussionNumber, perPage = 50, after, before },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+      const formattedDiscussion = {
+        id: discussion.id,
+        number: discussion.number,
+        title: discussion.title,
+        body: discussion.body,
+        bodyText: discussion.bodyText,
+        url: discussion.url,
+        createdAt: discussion.createdAt,
+        updatedAt: discussion.updatedAt,
+        isAnswered: discussion.isAnswered,
+        author: discussion.author?.login || "unknown",
+        category: discussion.category,
+        commentCount: discussion.comments.totalCount,
+      };
 
-      try {
-        const query = `
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved discussion #${discussionNumber}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(formattedDiscussion, null, 2),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub discussion: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  get_discussion_comments: async (
+    { owner, repo, discussionNumber, perPage = 50, after, before },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
+
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $discussionNumber: Int!, $first: Int!, $after: String, $before: String) {
             repository(owner: $owner, name: $repo) {
               discussion(number: $discussionNumber) {
@@ -1164,130 +1158,130 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const discussionResult = (await octokit.graphql(query, {
-          owner,
-          repo,
-          discussionNumber,
-          first: perPage,
-          after,
-          before,
-        })) as {
-          repository: {
-            discussion: {
-              comments: {
-                totalCount: number;
-                pageInfo: {
-                  hasNextPage: boolean;
-                  endCursor: string | null;
-                  startCursor: string | null;
-                  hasPreviousPage: boolean;
-                };
-                nodes: {
-                  id: string;
-                  body: string;
-                  bodyText: string;
-                  isAnswer: boolean;
-                  createdAt: string;
-                  updatedAt: string;
-                  author: {
-                    login: string;
-                  } | null;
-                  replies: {
-                    totalCount: number;
-                    nodes: {
-                      id: string;
-                      body: string;
-                      bodyText: string;
-                      isAnswer: boolean;
-                      createdAt: string;
-                      updatedAt: string;
-                      author: {
-                        login: string;
-                      } | null;
-                    }[];
-                  };
-                }[];
+      const discussionResult = (await octokit.graphql(query, {
+        owner,
+        repo,
+        discussionNumber,
+        first: perPage,
+        after,
+        before,
+      })) as {
+        repository: {
+          discussion: {
+            comments: {
+              totalCount: number;
+              pageInfo: {
+                hasNextPage: boolean;
+                endCursor: string | null;
+                startCursor: string | null;
+                hasPreviousPage: boolean;
               };
-            } | null;
-          };
+              nodes: {
+                id: string;
+                body: string;
+                bodyText: string;
+                isAnswer: boolean;
+                createdAt: string;
+                updatedAt: string;
+                author: {
+                  login: string;
+                } | null;
+                replies: {
+                  totalCount: number;
+                  nodes: {
+                    id: string;
+                    body: string;
+                    bodyText: string;
+                    isAnswer: boolean;
+                    createdAt: string;
+                    updatedAt: string;
+                    author: {
+                      login: string;
+                    } | null;
+                  }[];
+                };
+              }[];
+            };
+          } | null;
         };
+      };
 
-        const discussion = discussionResult.repository.discussion;
-        if (!discussion) {
-          return new Err(
-            new MCPError(
-              `Discussion #${discussionNumber} not found in ${owner}/${repo}`
-            )
-          );
-        }
-
-        const comments = discussion.comments.nodes.map((comment) => ({
-          id: comment.id,
-          author: comment.author?.login || "unknown",
-          body: comment.body,
-          bodyText: comment.bodyText,
-          isAnswer: comment.isAnswer,
-          createdAt: comment.createdAt,
-          updatedAt: comment.updatedAt,
-          replyCount: comment.replies.totalCount,
-          replies: comment.replies.nodes.map((reply) => ({
-            id: reply.id,
-            author: reply.author?.login || "unknown",
-            body: reply.body,
-            bodyText: reply.bodyText,
-            isAnswer: reply.isAnswer,
-            createdAt: reply.createdAt,
-            updatedAt: reply.updatedAt,
-          })),
-        }));
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${comments.length} comments from discussion #${discussionNumber}`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                totalCount: discussion.comments.totalCount,
-                comments,
-                pageInfo: discussion.comments.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
+      const discussion = discussionResult.repository.discussion;
+      if (!discussion) {
         return new Err(
           new MCPError(
-            `Error retrieving GitHub discussion comments: ${normalizeError(e).message}`
+            `Discussion #${discussionNumber} not found in ${owner}/${repo}`
           )
         );
       }
+
+      const comments = discussion.comments.nodes.map((comment) => ({
+        id: comment.id,
+        author: comment.author?.login || "unknown",
+        body: comment.body,
+        bodyText: comment.bodyText,
+        isAnswer: comment.isAnswer,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+        replyCount: comment.replies.totalCount,
+        replies: comment.replies.nodes.map((reply) => ({
+          id: reply.id,
+          author: reply.author?.login || "unknown",
+          body: reply.body,
+          bodyText: reply.bodyText,
+          isAnswer: reply.isAnswer,
+          createdAt: reply.createdAt,
+          updatedAt: reply.updatedAt,
+        })),
+      }));
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${comments.length} comments from discussion #${discussionNumber}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              totalCount: discussion.comments.totalCount,
+              comments,
+              pageInfo: discussion.comments.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub discussion comments: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  list_discussions: async (
+    {
+      owner,
+      repo,
+      categoryId,
+      answered,
+      sort = "UPDATED_AT",
+      direction = "DESC",
+      perPage = 50,
+      after,
+      before,
     },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-    list_discussions: async (
-      {
-        owner,
-        repo,
-        categoryId,
-        answered,
-        sort = "UPDATED_AT",
-        direction = "DESC",
-        perPage = 50,
-        after,
-        before,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $first: Int!, $orderBy: DiscussionOrder, $categoryId: ID, $answered: Boolean, $after: String, $before: String) {
             repository(owner: $owner, name: $repo) {
               discussions(first: $first, orderBy: $orderBy, categoryId: $categoryId, answered: $answered, after: $after, before: $before) {
@@ -1326,106 +1320,106 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const discussionsResult = (await octokit.graphql(query, {
-          owner,
-          repo,
-          first: perPage,
-          orderBy: {
-            field: sort,
-            direction,
-          },
-          categoryId,
-          answered,
-          after,
-          before,
-        })) as {
-          repository: {
-            discussions: {
-              totalCount: number;
-              pageInfo: {
-                hasNextPage: boolean;
-                endCursor: string | null;
-                startCursor: string | null;
-                hasPreviousPage: boolean;
-              };
-              nodes: {
-                id: string;
-                number: number;
-                title: string;
-                bodyText: string;
-                url: string;
-                createdAt: string;
-                updatedAt: string;
-                isAnswered: boolean;
-                author: {
-                  login: string;
-                } | null;
-                category: {
-                  id: string;
-                  name: string;
-                  slug: string;
-                  description: string | null;
-                  emoji: string;
-                  isAnswerable: boolean;
-                };
-                comments: {
-                  totalCount: number;
-                };
-              }[];
+      const discussionsResult = (await octokit.graphql(query, {
+        owner,
+        repo,
+        first: perPage,
+        orderBy: {
+          field: sort,
+          direction,
+        },
+        categoryId,
+        answered,
+        after,
+        before,
+      })) as {
+        repository: {
+          discussions: {
+            totalCount: number;
+            pageInfo: {
+              hasNextPage: boolean;
+              endCursor: string | null;
+              startCursor: string | null;
+              hasPreviousPage: boolean;
             };
+            nodes: {
+              id: string;
+              number: number;
+              title: string;
+              bodyText: string;
+              url: string;
+              createdAt: string;
+              updatedAt: string;
+              isAnswered: boolean;
+              author: {
+                login: string;
+              } | null;
+              category: {
+                id: string;
+                name: string;
+                slug: string;
+                description: string | null;
+                emoji: string;
+                isAnswerable: boolean;
+              };
+              comments: {
+                totalCount: number;
+              };
+            }[];
           };
         };
+      };
 
-        const discussions = discussionsResult.repository.discussions.nodes.map(
-          (discussion) => ({
-            id: discussion.id,
-            number: discussion.number,
-            title: discussion.title,
-            bodyText: discussion.bodyText,
-            url: discussion.url,
-            createdAt: discussion.createdAt,
-            updatedAt: discussion.updatedAt,
-            isAnswered: discussion.isAnswered,
-            author: discussion.author?.login || "unknown",
-            category: discussion.category,
-            commentCount: discussion.comments.totalCount,
-          })
-        );
+      const discussions = discussionsResult.repository.discussions.nodes.map(
+        (discussion) => ({
+          id: discussion.id,
+          number: discussion.number,
+          title: discussion.title,
+          bodyText: discussion.bodyText,
+          url: discussion.url,
+          createdAt: discussion.createdAt,
+          updatedAt: discussion.updatedAt,
+          isAnswered: discussion.isAnswered,
+          author: discussion.author?.login || "unknown",
+          category: discussion.category,
+          commentCount: discussion.comments.totalCount,
+        })
+      );
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${discussions.length} discussions`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                totalCount: discussionsResult.repository.discussions.totalCount,
-                discussions,
-                pageInfo: discussionsResult.repository.discussions.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error listing GitHub discussions: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${discussions.length} discussions`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              totalCount: discussionsResult.repository.discussions.totalCount,
+              discussions,
+              pageInfo: discussionsResult.repository.discussions.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error listing GitHub discussions: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    get_issue: async ({ owner, repo, issueNumber }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  get_issue: async ({ owner, repo, issueNumber }, { auth, authInfo }) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $issueNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               issue(number: $issueNumber) {
@@ -1461,147 +1455,142 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const issue = (await octokit.graphql(query, {
-          owner,
-          repo,
-          issueNumber,
-        })) as {
-          repository: {
-            issue: {
-              title: string;
-              body: string;
-              state: string;
-              createdAt: string;
-              updatedAt: string;
-              author: {
+      const issue = (await octokit.graphql(query, {
+        owner,
+        repo,
+        issueNumber,
+      })) as {
+        repository: {
+          issue: {
+            title: string;
+            body: string;
+            state: string;
+            createdAt: string;
+            updatedAt: string;
+            author: {
+              login: string;
+            };
+            labels: {
+              nodes: {
+                name: string;
+                color: string;
+              }[];
+            };
+            assignees: {
+              nodes: {
                 login: string;
-              };
-              labels: {
-                nodes: {
-                  name: string;
-                  color: string;
-                }[];
-              };
-              assignees: {
-                nodes: {
+              }[];
+            };
+            comments: {
+              nodes: {
+                author: {
                   login: string;
-                }[];
-              };
-              comments: {
-                nodes: {
-                  author: {
-                    login: string;
-                  };
-                  body: string;
-                  createdAt: string;
-                }[];
-              };
+                };
+                body: string;
+                createdAt: string;
+              }[];
             };
           };
         };
-
-        const issueData = issue.repository.issue;
-        const formattedIssue = {
-          title: issueData.title,
-          body: issueData.body,
-          state: issueData.state,
-          createdAt: issueData.createdAt,
-          updatedAt: issueData.updatedAt,
-          author: issueData.author.login,
-          labels: issueData.labels.nodes.map((label) => ({
-            name: label.name,
-            color: label.color,
-          })),
-          assignees: issueData.assignees.nodes.map(
-            (assignee) => assignee.login
-          ),
-          comments: issueData.comments.nodes.map((comment) => ({
-            author: comment.author.login,
-            body: comment.body,
-            createdAt: comment.createdAt,
-          })),
-        };
-
-        return new Ok([
-          { type: "text" as const, text: `Retrieved issue #${issueNumber}` },
-          {
-            type: "text" as const,
-            text: JSON.stringify(formattedIssue, null, 2),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error retrieving GitHub issue: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
-
-    get_issue_custom_fields: async (
-      { owner, repo, issueNumber, projectId },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      // Helper function to format field values
-      const formatFieldValues = (
-        fieldValues: Array<{
-          field?: {
-            name: string;
-            id: string;
-          };
-          text?: string;
-          name?: string;
-          number?: number;
-          date?: string;
-          title?: string;
-          startDate?: string;
-          duration?: number;
-        }>
-      ) => {
-        return fieldValues.map((fieldValue) => {
-          if (!fieldValue.field) {
-            return null;
-          }
-          const fieldName = fieldValue.field.name;
-          let value: string | number | null = null;
-          let valueType = "unknown";
-
-          if ("text" in fieldValue && fieldValue.text !== undefined) {
-            value = fieldValue.text;
-            valueType = "text";
-          } else if ("name" in fieldValue && fieldValue.name !== undefined) {
-            value = fieldValue.name;
-            valueType = "singleSelect";
-          } else if (
-            "number" in fieldValue &&
-            fieldValue.number !== undefined
-          ) {
-            value = fieldValue.number;
-            valueType = "number";
-          } else if ("date" in fieldValue && fieldValue.date !== undefined) {
-            value = fieldValue.date;
-            valueType = "date";
-          } else if ("title" in fieldValue && fieldValue.title !== undefined) {
-            value = fieldValue.title;
-            valueType = "iteration";
-          }
-
-          return {
-            fieldId: fieldValue.field.id,
-            fieldName,
-            value,
-            valueType,
-          };
-        });
       };
 
-      try {
-        // First, get the issue ID and project items
-        const issueQuery = `
+      const issueData = issue.repository.issue;
+      const formattedIssue = {
+        title: issueData.title,
+        body: issueData.body,
+        state: issueData.state,
+        createdAt: issueData.createdAt,
+        updatedAt: issueData.updatedAt,
+        author: issueData.author.login,
+        labels: issueData.labels.nodes.map((label) => ({
+          name: label.name,
+          color: label.color,
+        })),
+        assignees: issueData.assignees.nodes.map((assignee) => assignee.login),
+        comments: issueData.comments.nodes.map((comment) => ({
+          author: comment.author.login,
+          body: comment.body,
+          createdAt: comment.createdAt,
+        })),
+      };
+
+      return new Ok([
+        { type: "text" as const, text: `Retrieved issue #${issueNumber}` },
+        {
+          type: "text" as const,
+          text: JSON.stringify(formattedIssue, null, 2),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub issue: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  get_issue_custom_fields: async (
+    { owner, repo, issueNumber, projectId },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
+
+    // Helper function to format field values
+    const formatFieldValues = (
+      fieldValues: Array<{
+        field?: {
+          name: string;
+          id: string;
+        };
+        text?: string;
+        name?: string;
+        number?: number;
+        date?: string;
+        title?: string;
+        startDate?: string;
+        duration?: number;
+      }>
+    ) => {
+      return fieldValues.map((fieldValue) => {
+        if (!fieldValue.field) {
+          return null;
+        }
+        const fieldName = fieldValue.field.name;
+        let value: string | number | null = null;
+        let valueType = "unknown";
+
+        if ("text" in fieldValue && fieldValue.text !== undefined) {
+          value = fieldValue.text;
+          valueType = "text";
+        } else if ("name" in fieldValue && fieldValue.name !== undefined) {
+          value = fieldValue.name;
+          valueType = "singleSelect";
+        } else if ("number" in fieldValue && fieldValue.number !== undefined) {
+          value = fieldValue.number;
+          valueType = "number";
+        } else if ("date" in fieldValue && fieldValue.date !== undefined) {
+          value = fieldValue.date;
+          valueType = "date";
+        } else if ("title" in fieldValue && fieldValue.title !== undefined) {
+          value = fieldValue.title;
+          valueType = "iteration";
+        }
+
+        return {
+          fieldId: fieldValue.field.id,
+          fieldName,
+          value,
+          valueType,
+        };
+      });
+    };
+
+    try {
+      // First, get the issue ID and project items
+      const issueQuery = `
           query($owner: String!, $repo: String!, $issueNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               issue(number: $issueNumber) {
@@ -1672,63 +1661,63 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const issueResult = (await octokit.graphql(issueQuery, {
-          owner,
-          repo,
-          issueNumber,
-        })) as {
-          repository: {
-            issue: {
-              id: string;
-              number: number;
-              title: string;
-              projectItems: {
-                nodes: Array<{
+      const issueResult = (await octokit.graphql(issueQuery, {
+        owner,
+        repo,
+        issueNumber,
+      })) as {
+        repository: {
+          issue: {
+            id: string;
+            number: number;
+            title: string;
+            projectItems: {
+              nodes: Array<{
+                id: string;
+                project: {
                   id: string;
-                  project: {
-                    id: string;
-                    title: string;
-                  };
-                  fieldValues: {
-                    nodes: Array<{
-                      field: {
-                        name: string;
-                        id: string;
-                      };
-                      text?: string;
-                      name?: string;
-                      number?: number;
-                      date?: string;
-                      title?: string;
-                      startDate?: string;
-                      duration?: number;
-                    }>;
-                  };
-                }>;
-              };
-            } | null;
-          };
+                  title: string;
+                };
+                fieldValues: {
+                  nodes: Array<{
+                    field: {
+                      name: string;
+                      id: string;
+                    };
+                    text?: string;
+                    name?: string;
+                    number?: number;
+                    date?: string;
+                    title?: string;
+                    startDate?: string;
+                    duration?: number;
+                  }>;
+                };
+              }>;
+            };
+          } | null;
         };
+      };
 
-        if (!issueResult.repository.issue) {
-          return new Err(
-            new MCPError(`Issue #${issueNumber} not found in ${owner}/${repo}`)
-          );
-        }
+      if (!issueResult.repository.issue) {
+        return new Err(
+          new MCPError(`Issue #${issueNumber} not found in ${owner}/${repo}`)
+        );
+      }
 
-        const issue = issueResult.repository.issue;
-        const projectItems = issue.projectItems.nodes;
+      const issue = issueResult.repository.issue;
+      const projectItems = issue.projectItems.nodes;
 
-        // If projectId is specified, filter to that project only
-        let filteredProjectItems = projectItems;
-        if (projectId) {
-          filteredProjectItems = projectItems.filter(
-            (item) => item.project.id === projectId
-          );
+      // If projectId is specified, filter to that project only
+      let filteredProjectItems = projectItems;
+      if (projectId) {
+        filteredProjectItems = projectItems.filter(
+          (item) => item.project.id === projectId
+        );
 
-          if (filteredProjectItems.length === 0) {
-            // Try to get project title for better error message
-            const projectQuery = `
+        if (filteredProjectItems.length === 0) {
+          // Try to get project title for better error message
+          const projectQuery = `
               query($projectId: ID!) {
                 node(id: $projectId) {
                   ... on ProjectV2 {
@@ -1737,98 +1726,95 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                 }
               }`;
 
-            try {
-              const projectResult = (await octokit.graphql(projectQuery, {
-                projectId,
-              })) as {
-                node: {
-                  title: string;
-                } | null;
-              };
+          try {
+            const projectResult = (await octokit.graphql(projectQuery, {
+              projectId,
+            })) as {
+              node: {
+                title: string;
+              } | null;
+            };
 
-              const projectTitle =
-                projectResult.node?.title ?? `Project ${projectId}`;
-              return new Ok([
-                {
-                  type: "text" as const,
-                  text: `Issue #${issueNumber} is not in project "${projectTitle}"`,
-                },
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({ customFields: [] }, null, 2),
-                },
-              ]);
-            } catch {
-              return new Err(
-                new MCPError(
-                  `Issue #${issueNumber} is not in the specified project, or project not found`
-                )
-              );
-            }
+            const projectTitle =
+              projectResult.node?.title ?? `Project ${projectId}`;
+            return new Ok([
+              {
+                type: "text" as const,
+                text: `Issue #${issueNumber} is not in project "${projectTitle}"`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify({ customFields: [] }, null, 2),
+              },
+            ]);
+          } catch {
+            return new Err(
+              new MCPError(
+                `Issue #${issueNumber} is not in the specified project, or project not found`
+              )
+            );
           }
         }
+      }
 
-        // Format results grouped by project
-        const projectsWithFields = filteredProjectItems.map((item) => {
-          return {
-            projectId: item.project.id,
-            projectTitle: item.project.title,
-            customFields: removeNulls(
-              formatFieldValues(item.fieldValues.nodes)
-            ),
-          };
-        });
+      // Format results grouped by project
+      const projectsWithFields = filteredProjectItems.map((item) => {
+        return {
+          projectId: item.project.id,
+          projectTitle: item.project.title,
+          customFields: removeNulls(formatFieldValues(item.fieldValues.nodes)),
+        };
+      });
 
-        if (
-          projectsWithFields.filter((p) => p.customFields.length > 0).length ===
-          0
-        ) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `Issue #${issueNumber} is not in any projects with custom fields`,
-            },
-            {
-              type: "text" as const,
-              text: JSON.stringify({ projects: [] }, null, 2),
-            },
-          ]);
-        }
-
-        const resultMessage =
-          projectId && projectsWithFields.length > 0
-            ? `Retrieved custom fields for issue #${issueNumber} in project "${projectsWithFields[0].projectTitle}"`
-            : `Retrieved custom fields for issue #${issueNumber} across ${projectsWithFields.length} project(s)`;
-
+      if (
+        projectsWithFields.filter((p) => p.customFields.length > 0).length === 0
+      ) {
         return new Ok([
           {
             type: "text" as const,
-            text: resultMessage,
+            text: `Issue #${issueNumber} is not in any projects with custom fields`,
           },
           {
             type: "text" as const,
-            text: JSON.stringify(
-              {
-                issueNumber,
-                projects: projectsWithFields,
-              },
-              null,
-              2
-            ),
+            text: JSON.stringify({ projects: [] }, null, 2),
           },
         ]);
-      } catch (e) {
-        const error = normalizeError(e);
-        // Handle case where projectItems field might not be available
-        if (
-          error.message.includes("projectItems") ||
-          error.message.includes("Cannot query field")
-        ) {
-          // Fallback: if projectItems is not available, try the project-specific query
-          if (projectId) {
-            try {
-              // Get issue ID first
-              const issueQuery = `
+      }
+
+      const resultMessage =
+        projectId && projectsWithFields.length > 0
+          ? `Retrieved custom fields for issue #${issueNumber} in project "${projectsWithFields[0].projectTitle}"`
+          : `Retrieved custom fields for issue #${issueNumber} across ${projectsWithFields.length} project(s)`;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultMessage,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              issueNumber,
+              projects: projectsWithFields,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      const error = normalizeError(e);
+      // Handle case where projectItems field might not be available
+      if (
+        error.message.includes("projectItems") ||
+        error.message.includes("Cannot query field")
+      ) {
+        // Fallback: if projectItems is not available, try the project-specific query
+        if (projectId) {
+          try {
+            // Get issue ID first
+            const issueQuery = `
                 query($owner: String!, $repo: String!, $issueNumber: Int!) {
                   repository(owner: $owner, name: $repo) {
                     issue(number: $issueNumber) {
@@ -1839,32 +1825,32 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                   }
                 }`;
 
-              const issueResult = (await octokit.graphql(issueQuery, {
-                owner,
-                repo,
-                issueNumber,
-              })) as {
-                repository: {
-                  issue: {
-                    id: string;
-                    number: number;
-                    title: string;
-                  } | null;
-                };
+            const issueResult = (await octokit.graphql(issueQuery, {
+              owner,
+              repo,
+              issueNumber,
+            })) as {
+              repository: {
+                issue: {
+                  id: string;
+                  number: number;
+                  title: string;
+                } | null;
               };
+            };
 
-              if (!issueResult.repository.issue) {
-                return new Err(
-                  new MCPError(
-                    `Issue #${issueNumber} not found in ${owner}/${repo}`
-                  )
-                );
-              }
+            if (!issueResult.repository.issue) {
+              return new Err(
+                new MCPError(
+                  `Issue #${issueNumber} not found in ${owner}/${repo}`
+                )
+              );
+            }
 
-              const issueId = issueResult.repository.issue.id;
+            const issueId = issueResult.repository.issue.id;
 
-              // Query the specific project
-              const projectQuery = `
+            // Query the specific project
+            const projectQuery = `
                 query($projectId: ID!) {
                   node(id: $projectId) {
                     ... on ProjectV2 {
@@ -1935,127 +1921,127 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                   }
                 }`;
 
-              const projectResult = (await octokit.graphql(projectQuery, {
-                projectId,
-              })) as {
-                node: {
-                  title: string;
-                  items: {
-                    nodes: Array<{
+            const projectResult = (await octokit.graphql(projectQuery, {
+              projectId,
+            })) as {
+              node: {
+                title: string;
+                items: {
+                  nodes: Array<{
+                    id: string;
+                    content: {
                       id: string;
-                      content: {
-                        id: string;
-                        number: number;
-                      } | null;
-                      fieldValues: {
-                        nodes: Array<{
-                          field: {
-                            name: string;
-                            id: string;
-                          };
-                          text?: string;
-                          name?: string;
-                          number?: number;
-                          date?: string;
-                          title?: string;
-                          startDate?: string;
-                          duration?: number;
-                        }>;
-                      };
-                    }>;
-                  };
-                } | null;
-              };
+                      number: number;
+                    } | null;
+                    fieldValues: {
+                      nodes: Array<{
+                        field: {
+                          name: string;
+                          id: string;
+                        };
+                        text?: string;
+                        name?: string;
+                        number?: number;
+                        date?: string;
+                        title?: string;
+                        startDate?: string;
+                        duration?: number;
+                      }>;
+                    };
+                  }>;
+                };
+              } | null;
+            };
 
-              if (!projectResult.node) {
-                return new Err(
-                  new MCPError(`Project with ID ${projectId} not found`)
-                );
-              }
-
-              const projectItem = projectResult.node.items.nodes.find(
-                (item) => item.content?.id === issueId
+            if (!projectResult.node) {
+              return new Err(
+                new MCPError(`Project with ID ${projectId} not found`)
               );
+            }
 
-              if (!projectItem) {
-                return new Ok([
-                  {
-                    type: "text" as const,
-                    text: `Issue #${issueNumber} is not in project "${projectResult.node.title}"`,
-                  },
-                  {
-                    type: "text" as const,
-                    text: JSON.stringify({ customFields: [] }, null, 2),
-                  },
-                ]);
-              }
+            const projectItem = projectResult.node.items.nodes.find(
+              (item) => item.content?.id === issueId
+            );
 
-              const customFields = removeNulls(
-                formatFieldValues(projectItem.fieldValues.nodes)
-              );
-
+            if (!projectItem) {
               return new Ok([
                 {
                   type: "text" as const,
-                  text: `Retrieved custom fields for issue #${issueNumber} in project "${projectResult.node.title}"`,
+                  text: `Issue #${issueNumber} is not in project "${projectResult.node.title}"`,
                 },
                 {
                   type: "text" as const,
-                  text: JSON.stringify(
-                    {
-                      projectTitle: projectResult.node.title,
-                      issueNumber,
-                      customFields,
-                    },
-                    null,
-                    2
-                  ),
+                  text: JSON.stringify({ customFields: [] }, null, 2),
                 },
               ]);
-            } catch (fallbackError) {
-              return new Err(
-                new MCPError(
-                  `Error retrieving GitHub issue custom fields: ${normalizeError(fallbackError).message}. Note: Querying all projects requires the projectItems field which may not be available on all GitHub plans.`
-                )
-              );
             }
-          } else {
+
+            const customFields = removeNulls(
+              formatFieldValues(projectItem.fieldValues.nodes)
+            );
+
+            return new Ok([
+              {
+                type: "text" as const,
+                text: `Retrieved custom fields for issue #${issueNumber} in project "${projectResult.node.title}"`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    projectTitle: projectResult.node.title,
+                    issueNumber,
+                    customFields,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ]);
+          } catch (fallbackError) {
             return new Err(
               new MCPError(
-                `Error retrieving GitHub issue custom fields: ${error.message}. Note: Querying all projects requires the projectItems field which may not be available on all GitHub plans. Please specify a projectId.`
+                `Error retrieving GitHub issue custom fields: ${normalizeError(fallbackError).message}. Note: Querying all projects requires the projectItems field which may not be available on all GitHub plans.`
               )
             );
           }
+        } else {
+          return new Err(
+            new MCPError(
+              `Error retrieving GitHub issue custom fields: ${error.message}. Note: Querying all projects requires the projectItems field which may not be available on all GitHub plans. Please specify a projectId.`
+            )
+          );
         }
-
-        return new Err(
-          new MCPError(
-            `Error retrieving GitHub issue custom fields: ${error.message}`
-          )
-        );
       }
+
+      return new Err(
+        new MCPError(
+          `Error retrieving GitHub issue custom fields: ${error.message}`
+        )
+      );
+    }
+  },
+
+  list_issues: async (
+    {
+      owner,
+      repo,
+      state = "OPEN",
+      labels,
+      sort = "CREATED_AT",
+      direction = "DESC",
+      perPage = 50,
+      after,
+      before,
     },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-    list_issues: async (
-      {
-        owner,
-        repo,
-        state = "OPEN",
-        labels,
-        sort = "CREATED_AT",
-        direction = "DESC",
-        perPage = 50,
-        after,
-        before,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const query = `
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [IssueState!], $labels: [String!], $after: String, $before: String) {
             repository(owner: $owner, name: $repo) {
               issues(first: $first, orderBy: $orderBy, states: $states, labels: $labels, after: $after, before: $before) {
@@ -2093,106 +2079,106 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const issues = (await octokit.graphql(query, {
-          owner,
-          repo,
-          first: perPage,
-          after: after,
-          before: before,
-          orderBy: {
-            field: sort,
-            direction: direction,
-          },
-          states: state === "ALL" ? undefined : [state],
-          labels: labels,
-        })) as {
-          repository: {
-            issues: {
-              pageInfo: {
-                hasNextPage: boolean;
-                endCursor: string | null;
-                startCursor: string | null;
-                hasPreviousPage: boolean;
-              };
-              nodes: {
-                number: number;
-                title: string;
-                state: string;
-                createdAt: string;
-                updatedAt: string;
-                author: {
-                  login: string;
-                };
-                labels: {
-                  nodes: {
-                    name: string;
-                    color: string;
-                  }[];
-                };
-                assignees: {
-                  nodes: {
-                    login: string;
-                  }[];
-                };
-                comments: {
-                  totalCount: number;
-                };
-              }[];
+      const issues = (await octokit.graphql(query, {
+        owner,
+        repo,
+        first: perPage,
+        after: after,
+        before: before,
+        orderBy: {
+          field: sort,
+          direction: direction,
+        },
+        states: state === "ALL" ? undefined : [state],
+        labels: labels,
+      })) as {
+        repository: {
+          issues: {
+            pageInfo: {
+              hasNextPage: boolean;
+              endCursor: string | null;
+              startCursor: string | null;
+              hasPreviousPage: boolean;
             };
+            nodes: {
+              number: number;
+              title: string;
+              state: string;
+              createdAt: string;
+              updatedAt: string;
+              author: {
+                login: string;
+              };
+              labels: {
+                nodes: {
+                  name: string;
+                  color: string;
+                }[];
+              };
+              assignees: {
+                nodes: {
+                  login: string;
+                }[];
+              };
+              comments: {
+                totalCount: number;
+              };
+            }[];
           };
         };
+      };
 
-        const formattedIssues = issues.repository.issues.nodes.map((issue) => ({
-          number: issue.number,
-          title: issue.title,
-          state: issue.state,
-          createdAt: issue.createdAt,
-          updatedAt: issue.updatedAt,
-          author: issue.author.login,
-          labels: issue.labels.nodes.map((label) => ({
-            name: label.name,
-            color: label.color,
-          })),
-          assignees: issue.assignees.nodes.map((a) => a.login),
-          commentCount: issue.comments.totalCount,
-        }));
+      const formattedIssues = issues.repository.issues.nodes.map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        createdAt: issue.createdAt,
+        updatedAt: issue.updatedAt,
+        author: issue.author.login,
+        labels: issue.labels.nodes.map((label) => ({
+          name: label.name,
+          color: label.color,
+        })),
+        assignees: issue.assignees.nodes.map((a) => a.login),
+        commentCount: issue.comments.totalCount,
+      }));
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${formattedIssues.length} issues`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                issues: formattedIssues,
-                pageInfo: issues.repository.issues.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error listing GitHub issues: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${formattedIssues.length} issues`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              issues: formattedIssues,
+              pageInfo: issues.repository.issues.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error listing GitHub issues: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
 
-    search_advanced: async (
-      { query, first = 30, after, before },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+  search_advanced: async (
+    { query, first = 30, after, before },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
 
-      try {
-        const searchQuery = `
+    try {
+      const searchQuery = `
           query($searchQuery: String!, $first: Int!, $after: String, $before: String, $includeReviewRequests: Boolean!) {
             search(query: $searchQuery, type: ISSUE_ADVANCED, first: $first, after: $after, before: $before) {
               issueCount
@@ -2294,210 +2280,210 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        const results = await graphqlWithReviewerFallback<{
-          search: {
-            issueCount: number;
-            pageInfo: {
-              hasNextPage: boolean;
-              endCursor: string | null;
-              startCursor: string | null;
-              hasPreviousPage: boolean;
-            };
-            nodes: Array<
-              | {
-                  __typename: "Issue";
-                  number: number;
-                  title: string;
-                  body: string;
-                  state: string;
-                  createdAt: string;
-                  updatedAt: string;
-                  closedAt: string | null;
-                  url: string;
-                  repository: {
-                    owner: {
-                      login: string;
-                    };
-                    name: string;
-                  };
-                  author: {
+      const results = await graphqlWithReviewerFallback<{
+        search: {
+          issueCount: number;
+          pageInfo: {
+            hasNextPage: boolean;
+            endCursor: string | null;
+            startCursor: string | null;
+            hasPreviousPage: boolean;
+          };
+          nodes: Array<
+            | {
+                __typename: "Issue";
+                number: number;
+                title: string;
+                body: string;
+                state: string;
+                createdAt: string;
+                updatedAt: string;
+                closedAt: string | null;
+                url: string;
+                repository: {
+                  owner: {
                     login: string;
                   };
-                  labels: {
-                    nodes: Array<{
-                      name: string;
-                      color: string;
-                    }>;
-                  };
-                  assignees: {
-                    nodes: Array<{
-                      login: string;
-                    }>;
-                  };
-                  comments: {
-                    totalCount: number;
-                  };
-                }
-              | {
-                  __typename: "PullRequest";
-                  number: number;
-                  title: string;
-                  body: string;
-                  state: string;
-                  createdAt: string;
-                  updatedAt: string;
-                  mergedAt: string | null;
-                  closedAt: string | null;
-                  url: string;
-                  repository: {
-                    owner: {
-                      login: string;
-                    };
+                  name: string;
+                };
+                author: {
+                  login: string;
+                };
+                labels: {
+                  nodes: Array<{
                     name: string;
-                  };
-                  author: {
+                    color: string;
+                  }>;
+                };
+                assignees: {
+                  nodes: Array<{
+                    login: string;
+                  }>;
+                };
+                comments: {
+                  totalCount: number;
+                };
+              }
+            | {
+                __typename: "PullRequest";
+                number: number;
+                title: string;
+                body: string;
+                state: string;
+                createdAt: string;
+                updatedAt: string;
+                mergedAt: string | null;
+                closedAt: string | null;
+                url: string;
+                repository: {
+                  owner: {
                     login: string;
                   };
-                  baseRefName: string;
-                  headRefName: string;
-                  additions: number;
-                  deletions: number;
-                  changedFiles: number;
-                  labels: {
-                    nodes: Array<{
-                      name: string;
-                      color: string;
-                    }>;
-                  };
-                  assignees: {
-                    nodes: Array<{
-                      login: string;
-                    }>;
-                  };
-                  reviewRequests?: {
-                    nodes: Array<{
-                      requestedReviewer: {
-                        login?: string;
-                        slug?: string;
-                      } | null;
-                    }>;
-                  } | null;
-                  comments: {
-                    totalCount: number;
-                  };
-                  reviews: {
-                    totalCount: number;
-                  };
-                }
-            >;
-          };
-        }>(octokit, searchQuery, {
-          searchQuery: query,
-          first,
-          after,
-          before,
-        });
-
-        const formattedResults = results.search.nodes.map((node) => {
-          const base = {
-            number: node.number,
-            title: node.title,
-            body: node.body,
-            state: node.state,
-            createdAt: node.createdAt,
-            updatedAt: node.updatedAt,
-            closedAt: node.closedAt,
-            url: node.url,
-            repository: `${node.repository.owner.login}/${node.repository.name}`,
-            author: node.author.login,
-            labels: node.labels.nodes.map((label) => ({
-              name: label.name,
-              color: label.color,
-            })),
-            assignees: node.assignees.nodes.map((a) => a.login),
-            commentCount: node.comments.totalCount,
-          };
-
-          if (node.__typename === "PullRequest") {
-            return {
-              ...base,
-              type: "pull_request" as const,
-              mergedAt: node.mergedAt,
-              baseRefName: node.baseRefName,
-              headRefName: node.headRefName,
-              additions: node.additions,
-              deletions: node.deletions,
-              changedFiles: node.changedFiles,
-              reviewRequests: node.reviewRequests
-                ? removeNulls(
-                    node.reviewRequests.nodes.map((request) =>
-                      getReviewerIdentifier(request.requestedReviewer)
-                    )
-                  )
-                : [],
-              reviewCount: node.reviews.totalCount,
-            };
-          } else {
-            return {
-              ...base,
-              type: "issue" as const,
-            };
-          }
-        });
-
-        const issues = formattedResults.filter((r) => r.type === "issue");
-        const pullRequests = formattedResults.filter(
-          (r) => r.type === "pull_request"
-        );
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Found ${results.search.issueCount} total results (${issues.length} issues, ${pullRequests.length} pull requests), retrieved ${formattedResults.length} results`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                totalCount: results.search.issueCount,
-                issues,
-                pullRequests,
-                results: formattedResults,
-                pageInfo: results.search.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error searching GitHub issues and pull requests: ${normalizeError(e).message}`
-          )
-        );
-      }
-    },
-
-    list_pull_requests: async (
-      {
-        owner,
-        repo,
-        state = "OPEN",
-        sort = "CREATED_AT",
-        direction = "DESC",
-        perPage = 30,
+                  name: string;
+                };
+                author: {
+                  login: string;
+                };
+                baseRefName: string;
+                headRefName: string;
+                additions: number;
+                deletions: number;
+                changedFiles: number;
+                labels: {
+                  nodes: Array<{
+                    name: string;
+                    color: string;
+                  }>;
+                };
+                assignees: {
+                  nodes: Array<{
+                    login: string;
+                  }>;
+                };
+                reviewRequests?: {
+                  nodes: Array<{
+                    requestedReviewer: {
+                      login?: string;
+                      slug?: string;
+                    } | null;
+                  }>;
+                } | null;
+                comments: {
+                  totalCount: number;
+                };
+                reviews: {
+                  totalCount: number;
+                };
+              }
+          >;
+        };
+      }>(octokit, searchQuery, {
+        searchQuery: query,
+        first,
         after,
         before,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
       });
 
-      try {
-        const query = `
+      const formattedResults = results.search.nodes.map((node) => {
+        const base = {
+          number: node.number,
+          title: node.title,
+          body: node.body,
+          state: node.state,
+          createdAt: node.createdAt,
+          updatedAt: node.updatedAt,
+          closedAt: node.closedAt,
+          url: node.url,
+          repository: `${node.repository.owner.login}/${node.repository.name}`,
+          author: node.author.login,
+          labels: node.labels.nodes.map((label) => ({
+            name: label.name,
+            color: label.color,
+          })),
+          assignees: node.assignees.nodes.map((a) => a.login),
+          commentCount: node.comments.totalCount,
+        };
+
+        if (node.__typename === "PullRequest") {
+          return {
+            ...base,
+            type: "pull_request" as const,
+            mergedAt: node.mergedAt,
+            baseRefName: node.baseRefName,
+            headRefName: node.headRefName,
+            additions: node.additions,
+            deletions: node.deletions,
+            changedFiles: node.changedFiles,
+            reviewRequests: node.reviewRequests
+              ? removeNulls(
+                  node.reviewRequests.nodes.map((request) =>
+                    getReviewerIdentifier(request.requestedReviewer)
+                  )
+                )
+              : [],
+            reviewCount: node.reviews.totalCount,
+          };
+        } else {
+          return {
+            ...base,
+            type: "issue" as const,
+          };
+        }
+      });
+
+      const issues = formattedResults.filter((r) => r.type === "issue");
+      const pullRequests = formattedResults.filter(
+        (r) => r.type === "pull_request"
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Found ${results.search.issueCount} total results (${issues.length} issues, ${pullRequests.length} pull requests), retrieved ${formattedResults.length} results`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              totalCount: results.search.issueCount,
+              issues,
+              pullRequests,
+              results: formattedResults,
+              pageInfo: results.search.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error searching GitHub issues and pull requests: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+
+  list_pull_requests: async (
+    {
+      owner,
+      repo,
+      state = "OPEN",
+      sort = "CREATED_AT",
+      direction = "DESC",
+      perPage = 30,
+      after,
+      before,
+    },
+    { auth, authInfo }
+  ) => {
+    const octokit = await createOctokit(auth, {
+      accessToken: authInfo?.token,
+    });
+
+    try {
+      const query = `
           query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [PullRequestState!], $after: String, $before: String, $includeReviewRequests: Boolean!) {
             repository(owner: $owner, name: $repo) {
               pullRequests(first: $first, orderBy: $orderBy, states: $states, after: $after, before: $before) {
@@ -2555,140 +2541,139 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             }
           }`;
 
-        let graphqlStates;
-        if (state === "ALL") {
-          graphqlStates = undefined;
-        } else if (state === "OPEN") {
-          graphqlStates = ["OPEN"];
-        } else if (state === "CLOSED") {
-          graphqlStates = ["CLOSED"];
-        } else if (state === "MERGED") {
-          graphqlStates = ["MERGED"];
-        }
-
-        const pullRequests = await graphqlWithReviewerFallback<{
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: boolean;
-                endCursor: string | null;
-                startCursor: string | null;
-                hasPreviousPage: boolean;
-              };
-              nodes: {
-                number: number;
-                title: string;
-                state: string;
-                createdAt: string;
-                updatedAt: string;
-                mergedAt: string | null;
-                closedAt: string | null;
-                author: {
-                  login: string;
-                };
-                baseRefName: string;
-                headRefName: string;
-                additions: number;
-                deletions: number;
-                changedFiles: number;
-                labels: {
-                  nodes: {
-                    name: string;
-                    color: string;
-                  }[];
-                };
-                assignees: {
-                  nodes: {
-                    login: string;
-                  }[];
-                };
-                reviewRequests?: {
-                  nodes: {
-                    requestedReviewer: {
-                      login?: string;
-                      slug?: string;
-                    } | null;
-                  }[];
-                } | null;
-                comments: {
-                  totalCount: number;
-                };
-                reviews: {
-                  totalCount: number;
-                };
-              }[];
-            };
-          };
-        }>(octokit, query, {
-          owner,
-          repo,
-          before,
-          after,
-          first: perPage,
-          orderBy: {
-            field: sort,
-            direction: direction,
-          },
-          states: graphqlStates,
-        });
-
-        const formattedPullRequests =
-          pullRequests.repository.pullRequests.nodes.map((pr) => ({
-            number: pr.number,
-            title: pr.title,
-            state: pr.state,
-            createdAt: pr.createdAt,
-            updatedAt: pr.updatedAt,
-            mergedAt: pr.mergedAt,
-            closedAt: pr.closedAt,
-            author: pr.author.login,
-            baseRefName: pr.baseRefName,
-            headRefName: pr.headRefName,
-            additions: pr.additions,
-            deletions: pr.deletions,
-            changedFiles: pr.changedFiles,
-            labels: pr.labels.nodes.map((label) => ({
-              name: label.name,
-              color: label.color,
-            })),
-            assignees: pr.assignees.nodes.map((assignee) => assignee.login),
-            reviewRequests: pr.reviewRequests
-              ? removeNulls(
-                  pr.reviewRequests.nodes.map((request) =>
-                    getReviewerIdentifier(request.requestedReviewer)
-                  )
-                )
-              : [],
-            commentCount: pr.comments.totalCount,
-            reviewCount: pr.reviews.totalCount,
-          }));
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved ${formattedPullRequests.length} pull requests`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                pullRequests: formattedPullRequests,
-                pageInfo: pullRequests.repository.pullRequests.pageInfo,
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (e) {
-        return new Err(
-          new MCPError(
-            `Error listing GitHub pull requests: ${normalizeError(e).message}`
-          )
-        );
+      let graphqlStates;
+      if (state === "ALL") {
+        graphqlStates = undefined;
+      } else if (state === "OPEN") {
+        graphqlStates = ["OPEN"];
+      } else if (state === "CLOSED") {
+        graphqlStates = ["CLOSED"];
+      } else if (state === "MERGED") {
+        graphqlStates = ["MERGED"];
       }
-    },
-  };
 
-  return buildTools(GITHUB_TOOLS_METADATA, handlers);
-}
+      const pullRequests = await graphqlWithReviewerFallback<{
+        repository: {
+          pullRequests: {
+            pageInfo: {
+              hasNextPage: boolean;
+              endCursor: string | null;
+              startCursor: string | null;
+              hasPreviousPage: boolean;
+            };
+            nodes: {
+              number: number;
+              title: string;
+              state: string;
+              createdAt: string;
+              updatedAt: string;
+              mergedAt: string | null;
+              closedAt: string | null;
+              author: {
+                login: string;
+              };
+              baseRefName: string;
+              headRefName: string;
+              additions: number;
+              deletions: number;
+              changedFiles: number;
+              labels: {
+                nodes: {
+                  name: string;
+                  color: string;
+                }[];
+              };
+              assignees: {
+                nodes: {
+                  login: string;
+                }[];
+              };
+              reviewRequests?: {
+                nodes: {
+                  requestedReviewer: {
+                    login?: string;
+                    slug?: string;
+                  } | null;
+                }[];
+              } | null;
+              comments: {
+                totalCount: number;
+              };
+              reviews: {
+                totalCount: number;
+              };
+            }[];
+          };
+        };
+      }>(octokit, query, {
+        owner,
+        repo,
+        before,
+        after,
+        first: perPage,
+        orderBy: {
+          field: sort,
+          direction: direction,
+        },
+        states: graphqlStates,
+      });
+
+      const formattedPullRequests =
+        pullRequests.repository.pullRequests.nodes.map((pr) => ({
+          number: pr.number,
+          title: pr.title,
+          state: pr.state,
+          createdAt: pr.createdAt,
+          updatedAt: pr.updatedAt,
+          mergedAt: pr.mergedAt,
+          closedAt: pr.closedAt,
+          author: pr.author.login,
+          baseRefName: pr.baseRefName,
+          headRefName: pr.headRefName,
+          additions: pr.additions,
+          deletions: pr.deletions,
+          changedFiles: pr.changedFiles,
+          labels: pr.labels.nodes.map((label) => ({
+            name: label.name,
+            color: label.color,
+          })),
+          assignees: pr.assignees.nodes.map((assignee) => assignee.login),
+          reviewRequests: pr.reviewRequests
+            ? removeNulls(
+                pr.reviewRequests.nodes.map((request) =>
+                  getReviewerIdentifier(request.requestedReviewer)
+                )
+              )
+            : [],
+          commentCount: pr.comments.totalCount,
+          reviewCount: pr.reviews.totalCount,
+        }));
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${formattedPullRequests.length} pull requests`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              pullRequests: formattedPullRequests,
+              pageInfo: pullRequests.repository.pullRequests.pageInfo,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (e) {
+      return new Err(
+        new MCPError(
+          `Error listing GitHub pull requests: ${normalizeError(e).message}`
+        )
+      );
+    }
+  },
+};
+
+export const TOOLS = buildTools(GITHUB_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/image_generation/index.ts
+++ b/front/lib/api/actions/servers/image_generation/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { IMAGE_GENERATION_SERVER_NAME } from "@app/lib/api/actions/servers/image_generation/metadata";
-import { createImageGenerationTools } from "@app/lib/api/actions/servers/image_generation/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/image_generation/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,8 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(IMAGE_GENERATION_SERVER_NAME);
 
-  const tools = createImageGenerationTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: IMAGE_GENERATION_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -1,13 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   type AgentLoopRunContext,
   isAgentLoopRunContext,
-  type ToolContext,
 } from "@app/lib/actions/types";
 import { getImageGenerationLLM } from "@app/lib/api/actions/servers/image_generation/getImageGenerationLLM";
 import {
@@ -23,7 +19,6 @@ import type {
   ReferenceImageFile,
 } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
@@ -31,169 +26,161 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { startObservation } from "@langfuse/tracing";
 import assert from "assert";
 
-export function createImageGenerationTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof IMAGE_GENERATION_TOOLS_METADATA> = {
-    generate_image: async (
-      { prompt, outputName, aspectRatio, referenceImages, quality },
-      { sendNotification, _meta }
-    ) => {
-      let referenceImagesRunContext: AgentLoopRunContext | undefined;
-      if (referenceImages?.length) {
-        assert(
-          isAgentLoopRunContext(toolContext?.runContext),
-          "AgentLoopRunContext expected"
-        );
-        referenceImagesRunContext = toolContext.runContext;
+const handlers: ToolHandlers<typeof IMAGE_GENERATION_TOOLS_METADATA> = {
+  generate_image: async (
+    { prompt, outputName, aspectRatio, referenceImages, quality },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    let referenceImagesRunContext: AgentLoopRunContext | undefined;
+    if (referenceImages?.length) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      referenceImagesRunContext = runContext;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    await sendImageProgressNotification(
+      sendNotification,
+      _meta?.progressToken,
+      "Generating image..."
+    );
+
+    const imageGenerationModel = await getImageGenerationLLM(auth);
+
+    if (!imageGenerationModel) {
+      const errorMessage =
+        "No image generation model available for this workspace.";
+      logger.error({ workspaceId: workspace.sId }, errorMessage);
+      return new Err(new MCPError(errorMessage, { tracked: false }));
+    }
+
+    const { providerId } = imageGenerationModel;
+
+    getStatsDClient().increment("tools.image_generation.generated", 1, [
+      `aspect_ratio:${aspectRatio}`,
+      `image_count:${referenceImages?.length ?? 0}`,
+      `quality:${quality}`,
+      `provider:${providerId}`,
+    ]);
+
+    const rateLimitResult = await checkImageGenerationRateLimit(
+      auth,
+      workspace,
+      providerId
+    );
+    if (rateLimitResult.isErr()) {
+      return rateLimitResult;
+    }
+
+    let referenceFiles: ReferenceImageFile[] = [];
+
+    if (referenceImages && referenceImagesRunContext) {
+      const processResult = await processImageFileIds(auth, {
+        imageFileIds: referenceImages,
+        runContext: referenceImagesRunContext,
+        supportedContentTypes: imageGenerationModel.supportedContentTypes,
+        providerId,
+      });
+      if (processResult.isErr()) {
+        return processResult;
       }
+      referenceFiles = processResult.value;
+    }
 
-      const workspace = auth.getNonNullableWorkspace();
+    const generationInput = {
+      prompt,
+      aspectRatio,
+      referenceFiles,
+      quality,
+    } satisfies ImageGenerationInput;
 
-      await sendImageProgressNotification(
-        sendNotification,
-        _meta?.progressToken,
-        "Generating image..."
-      );
-
-      const imageGenerationModel = await getImageGenerationLLM(auth);
-
-      if (!imageGenerationModel) {
-        const errorMessage =
-          "No image generation model available for this workspace.";
-        logger.error({ workspaceId: workspace.sId }, errorMessage);
-        return new Err(new MCPError(errorMessage, { tracked: false }));
-      }
-
-      const { providerId } = imageGenerationModel;
-
-      getStatsDClient().increment("tools.image_generation.generated", 1, [
-        `aspect_ratio:${aspectRatio}`,
-        `image_count:${referenceImages?.length ?? 0}`,
-        `quality:${quality}`,
-        `provider:${providerId}`,
-      ]);
-
-      const rateLimitResult = await checkImageGenerationRateLimit(
-        auth,
-        workspace,
-        providerId
-      );
-      if (rateLimitResult.isErr()) {
-        return rateLimitResult;
-      }
-
-      let referenceFiles: ReferenceImageFile[] = [];
-
-      if (referenceImages && referenceImagesRunContext) {
-        const processResult = await processImageFileIds(auth, {
+    const generation = startObservation(
+      "image-generation",
+      {
+        input: {
+          prompt,
+          aspectRatio,
+          outputName,
           imageFileIds: referenceImages,
-          runContext: referenceImagesRunContext,
-          supportedContentTypes: imageGenerationModel.supportedContentTypes,
-          providerId,
-        });
-        if (processResult.isErr()) {
-          return processResult;
-        }
-        referenceFiles = processResult.value;
-      }
+          quality,
+        },
+        model: imageGenerationModel.modelId,
+        modelParameters:
+          imageGenerationModel.getModelParameters(generationInput),
+      },
+      { asType: "generation" }
+    );
 
-      const generationInput = {
-        prompt,
-        aspectRatio,
-        referenceFiles,
-        quality,
-      } satisfies ImageGenerationInput;
+    generation.updateTrace({
+      tags: [
+        `workspaceId:${workspace.sId}`,
+        `operationType:image_generation`,
+        `tool:generate_image`,
+      ],
+      metadata: {
+        fileIds: referenceImages,
+      },
+      userId: workspace.sId,
+    });
 
-      const generation = startObservation(
-        "image-generation",
+    const generationResult =
+      await imageGenerationModel.generateImage(generationInput);
+
+    if (generationResult.isErr()) {
+      const genError = generationResult.error;
+      const tracked = genError.code !== "safety_blocked";
+
+      logger.error(
         {
-          input: {
-            prompt,
-            aspectRatio,
-            outputName,
-            imageFileIds: referenceImages,
-            quality,
-          },
-          model: imageGenerationModel.modelId,
-          modelParameters:
-            imageGenerationModel.getModelParameters(generationInput),
+          error: genError,
         },
-        { asType: "generation" }
+        "Error generating image."
       );
-
-      generation.updateTrace({
-        tags: [
-          `workspaceId:${workspace.sId}`,
-          `operationType:image_generation`,
-          `tool:generate_image`,
-        ],
-        metadata: {
-          fileIds: referenceImages,
-        },
-        userId: workspace.sId,
-      });
-
-      const generationResult =
-        await imageGenerationModel.generateImage(generationInput);
-
-      if (generationResult.isErr()) {
-        const genError = generationResult.error;
-        const tracked = genError.code !== "safety_blocked";
-
-        logger.error(
-          {
-            error: genError,
-          },
-          "Error generating image."
-        );
-        generation.update({
-          level: "ERROR",
-          statusMessage: "Error generating image",
-          metadata: {
-            error: normalizeError(genError),
-          },
-        });
-        generation.end();
-
-        return new Err(
-          new MCPError(genError.message, { tracked, cause: genError })
-        );
-      }
-
-      const { images, usageMetadata } = generationResult.value;
-
-      trackTokenUsage({
-        ...usageMetadata,
-        providerId: imageGenerationModel.providerId,
-      });
-
-      const { inputTokens, outputTokens, totalTokens, costDetails } =
-        computeImageGenerationCostDetails(
-          usageMetadata,
-          imageGenerationModel.modelId
-        );
-
       generation.update({
-        usageDetails: {
-          input: inputTokens,
-          output: outputTokens,
-          total: totalTokens,
+        level: "ERROR",
+        statusMessage: "Error generating image",
+        metadata: {
+          error: normalizeError(genError),
         },
-        costDetails,
       });
-
       generation.end();
 
-      return uploadAndFormatImageResponse(
-        auth,
-        toolContext,
-        images,
-        outputName
+      return new Err(
+        new MCPError(genError.message, { tracked, cause: genError })
       );
-    },
-  };
+    }
 
-  return buildTools(IMAGE_GENERATION_TOOLS_METADATA, handlers);
-}
+    const { images, usageMetadata } = generationResult.value;
+
+    trackTokenUsage({
+      ...usageMetadata,
+      providerId: imageGenerationModel.providerId,
+    });
+
+    const { inputTokens, outputTokens, totalTokens, costDetails } =
+      computeImageGenerationCostDetails(
+        usageMetadata,
+        imageGenerationModel.modelId
+      );
+
+    generation.update({
+      usageDetails: {
+        input: inputTokens,
+        output: outputTokens,
+        total: totalTokens,
+      },
+      costDetails,
+    });
+
+    generation.end();
+
+    return uploadAndFormatImageResponse(
+      auth,
+      { runContext },
+      images,
+      outputName
+    );
+  },
+};
+
+export const TOOLS = buildTools(IMAGE_GENERATION_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/notion/index.ts
+++ b/front/lib/api/actions/servers/notion/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { NOTION_TOOL_NAME } from "@app/lib/api/actions/servers/notion/metadata";
-import { createNotionTools } from "@app/lib/api/actions/servers/notion/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/notion/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,8 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("notion");
 
-  const tools = createNotionTools(toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: NOTION_TOOL_NAME,
     });

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -1,17 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  ToolDefinition,
   ToolHandlerExtra,
   ToolHandlerResult,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
-import {
-  isAgentLoopRunContext,
-  type ToolContext,
-} from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { NOTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/notion/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -69,356 +65,347 @@ async function withNotionClient<T>(
   }
 }
 
-export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof NOTION_TOOLS_METADATA> = {
-    search: async (
-      { query, type, relativeTimeFrame },
-      { authInfo }: ToolHandlerExtra
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Ok(makePersonalAuthenticationError("notion").content);
-      }
-      const notion = new Client({ auth: accessToken });
+const handlers: ToolHandlers<typeof NOTION_TOOLS_METADATA> = {
+  search: async (
+    { query, type, relativeTimeFrame },
+    { authInfo, runContext }: ToolHandlerExtra
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Ok(makePersonalAuthenticationError("notion").content);
+    }
+    const notion = new Client({ auth: accessToken });
 
-      const rawResults = await notion.search({
-        query,
-        filter: {
-          property: "object",
-          value: type === "database" ? "data_source" : type,
+    const rawResults = await notion.search({
+      query,
+      filter: {
+        property: "object",
+        value: type === "database" ? "data_source" : type,
+      },
+      page_size: NOTION_SEARCH_ACTION_NUM_RESULTS,
+    });
+
+    const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+    let results = rawResults.results;
+
+    // Notion search does not support time frame filtering, so we need to filter the results after the search.
+    if (timeFrame) {
+      const timestampInMs = timeFrameFromNow(timeFrame);
+      const date = new Date(timestampInMs);
+      results = rawResults.results.filter((result) => {
+        if (isFullPage(result) || isFullDataSource(result)) {
+          const lastEditedTime = parseISO(result.last_edited_time);
+          return lastEditedTime > date;
+        }
+        return true;
+      });
+    }
+
+    if (results.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "No results found.",
         },
-        page_size: NOTION_SEARCH_ACTION_NUM_RESULTS,
+      ]);
+    } else {
+      const { citationsOffset } = isAgentLoopRunContext(runContext)
+        ? runContext.stepContext
+        : { citationsOffset: 0 };
+
+      const refs = getRefs().slice(
+        citationsOffset,
+        citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
+      );
+
+      const resultResources = results.map((result) => {
+        if (isFullPage(result)) {
+          const title =
+            (
+              Object.values(result.properties).find(
+                (p) => p.type === "title"
+              ) as { title: RichTextItemResponse[] }
+            )?.title[0]?.plain_text ?? "Untitled Page";
+
+          const description = Object.entries(result.properties)
+            .filter(
+              ([, value]) =>
+                value.type === "rich_text" && value.rich_text.length > 0
+            )
+            .map(([name, value]): [string, RichTextItemResponse[]] => [
+              name,
+              value.type === "rich_text" ? value.rich_text : [],
+            ])
+            .map(([name, richText]): string => {
+              return `${name}: ${richText
+                .filter((t) => !!t?.plain_text)
+                .map((t) => t?.plain_text)
+                .join(" ")}`;
+            })
+            .join("\n");
+
+          return {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+            uri: result.url,
+            text: title,
+            id: result.id,
+            tags: [
+              `created: ${result.created_time}`,
+              `lastEdited: ${result.last_edited_time}`,
+            ],
+            ref: refs.shift() ?? "",
+            chunks: description ? [description] : [],
+            source: {
+              provider: "notion",
+            },
+          } satisfies SearchResultResourceType;
+        } else if (isFullDataSource(result)) {
+          const title = result.title[0]?.plain_text ?? "Untitled Database";
+          const description = result.description
+            ?.map((d) => d?.plain_text)
+            .join(" ");
+
+          return {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+            uri: result.url,
+            text: title,
+            id: result.id,
+            tags: [
+              `created: ${result.created_time}`,
+              `lastEdited: ${result.last_edited_time}`,
+            ],
+            ref: refs.shift() ?? "",
+            chunks: description ? [description] : [],
+            source: {
+              provider: "notion",
+            },
+          } satisfies SearchResultResourceType;
+        } else {
+          return JSON.stringify(result.object);
+        }
       });
 
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-      let results = rawResults.results;
-
-      // Notion search does not support time frame filtering, so we need to filter the results after the search.
-      if (timeFrame) {
-        const timestampInMs = timeFrameFromNow(timeFrame);
-        const date = new Date(timestampInMs);
-        results = rawResults.results.filter((result) => {
-          if (isFullPage(result) || isFullDataSource(result)) {
-            const lastEditedTime = parseISO(result.last_edited_time);
-            return lastEditedTime > date;
-          }
-          return true;
-        });
-      }
-
-      if (results.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "No results found.",
-          },
-        ]);
-      } else {
-        const { citationsOffset } = isAgentLoopRunContext(
-          toolContext?.runContext
+      return new Ok(
+        resultResources.map((result) =>
+          typeof result === "string"
+            ? {
+                type: "text" as const,
+                text: result,
+              }
+            : {
+                type: "resource" as const,
+                resource: result,
+              }
         )
-          ? toolContext.runContext.stepContext
-          : { citationsOffset: 0 };
+      );
+    }
+  },
 
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
-        );
+  retrieve_page: async ({ pageId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.pages.retrieve({ page_id: pageId }),
+      authInfo
+    );
+  },
 
-        const resultResources = results.map((result) => {
-          if (isFullPage(result)) {
-            const title =
-              (
-                Object.values(result.properties).find(
-                  (p) => p.type === "title"
-                ) as { title: RichTextItemResponse[] }
-              )?.title[0]?.plain_text ?? "Untitled Page";
+  retrieve_database_schema: async ({ databaseId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.dataSources.retrieve({ data_source_id: databaseId }),
+      authInfo
+    );
+  },
 
-            const description = Object.entries(result.properties)
-              .filter(
-                ([, value]) =>
-                  value.type === "rich_text" && value.rich_text.length > 0
-              )
-              .map(([name, value]): [string, RichTextItemResponse[]] => [
-                name,
-                value.type === "rich_text" ? value.rich_text : [],
-              ])
-              .map(([name, richText]): string => {
-                return `${name}: ${richText
-                  .filter((t) => !!t?.plain_text)
-                  .map((t) => t?.plain_text)
-                  .join(" ")}`;
-              })
-              .join("\n");
+  retrieve_database_content: async (
+    { databaseId, filter, sorts, start_cursor, page_size },
+    { authInfo }
+  ) => {
+    return withNotionClient(
+      (notion) =>
+        notion.dataSources.query({
+          data_source_id: databaseId,
+          filter: filter as QueryDataSourceParameters["filter"],
+          sorts,
+          start_cursor,
+          page_size,
+        }),
+      authInfo
+    );
+  },
 
-            return {
-              mimeType:
-                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-              uri: result.url,
-              text: title,
-              id: result.id,
-              tags: [
-                `created: ${result.created_time}`,
-                `lastEdited: ${result.last_edited_time}`,
-              ],
-              ref: refs.shift() ?? "",
-              chunks: description ? [description] : [],
-              source: {
-                provider: "notion",
-              },
-            } satisfies SearchResultResourceType;
-          } else if (isFullDataSource(result)) {
-            const title = result.title[0]?.plain_text ?? "Untitled Database";
-            const description = result.description
-              ?.map((d) => d?.plain_text)
-              .join(" ");
+  query_database: async (
+    { databaseId, filter, sorts, start_cursor, page_size },
+    { authInfo }
+  ) => {
+    return withNotionClient(
+      (notion) =>
+        notion.dataSources.query({
+          data_source_id: databaseId,
+          filter: filter as QueryDataSourceParameters["filter"],
+          sorts,
+          start_cursor,
+          page_size,
+        }),
+      authInfo
+    );
+  },
 
-            return {
-              mimeType:
-                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-              uri: result.url,
-              text: title,
-              id: result.id,
-              tags: [
-                `created: ${result.created_time}`,
-                `lastEdited: ${result.last_edited_time}`,
-              ],
-              ref: refs.shift() ?? "",
-              chunks: description ? [description] : [],
-              source: {
-                provider: "notion",
-              },
-            } satisfies SearchResultResourceType;
-          } else {
-            return JSON.stringify(result.object);
-          }
-        });
+  create_page: async ({ parent, properties, icon, cover }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.pages.create({ parent, properties, icon, cover }),
+      authInfo
+    );
+  },
 
-        return new Ok(
-          resultResources.map((result) =>
-            typeof result === "string"
-              ? {
-                  type: "text" as const,
-                  text: result,
-                }
-              : {
-                  type: "resource" as const,
-                  resource: result,
-                }
-          )
+  insert_row_into_database: async (
+    { databaseId, properties, icon, cover },
+    { authInfo }
+  ) => {
+    return withNotionClient(
+      (notion) =>
+        notion.pages.create({
+          parent: { database_id: databaseId, type: "database_id" },
+          properties,
+          icon,
+          cover,
+        }),
+      authInfo
+    );
+  },
+
+  create_database: async (
+    { parent, title, properties, icon, cover },
+    { authInfo }
+  ) => {
+    return withNotionClient(
+      (notion) =>
+        notion.databases.create({
+          parent,
+          title,
+          initial_data_source: { properties },
+          icon,
+          cover,
+        }),
+      authInfo
+    );
+  },
+
+  update_page: async ({ pageId, properties }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.pages.update({ page_id: pageId, properties }),
+      authInfo
+    );
+  },
+
+  retrieve_block: async ({ blockId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.blocks.retrieve({ block_id: blockId }),
+      authInfo
+    );
+  },
+
+  retrieve_block_children: async (
+    { blockId, start_cursor, page_size },
+    { authInfo }
+  ) => {
+    return withNotionClient(
+      (notion) =>
+        notion.blocks.children.list({
+          block_id: blockId,
+          start_cursor,
+          page_size,
+        }),
+      authInfo
+    );
+  },
+
+  add_page_content: async ({ after, blockId, children }, { authInfo }) => {
+    return withNotionClient(
+      (notion) =>
+        notion.blocks.children.append({
+          after,
+          block_id: blockId,
+          children,
+        }),
+      authInfo
+    );
+  },
+
+  create_comment: async (
+    { parent_page_id, discussion_id, comment },
+    { authInfo }
+  ) => {
+    return withNotionClient((notion) => {
+      if (!parent_page_id && !discussion_id) {
+        throw new Error(
+          "Either parent_page_id or discussion_id must be provided."
         );
       }
-    },
+      let params: CreateCommentParameters;
+      if (parent_page_id) {
+        params = {
+          parent: { page_id: parent_page_id },
+          rich_text: [{ type: "text", text: { content: comment } }],
+        };
+      } else {
+        params = {
+          discussion_id: discussion_id!,
+          rich_text: [{ type: "text", text: { content: comment } }],
+        };
+      }
+      return notion.comments.create(params);
+    }, authInfo);
+  },
 
-    retrieve_page: async ({ pageId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.pages.retrieve({ page_id: pageId }),
-        authInfo
-      );
-    },
+  delete_block: async ({ blockId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.blocks.update({ block_id: blockId, archived: true }),
+      authInfo
+    );
+  },
 
-    retrieve_database_schema: async ({ databaseId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.dataSources.retrieve({ data_source_id: databaseId }),
-        authInfo
-      );
-    },
+  delete_page: async ({ pageId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.pages.update({ page_id: pageId, in_trash: true }),
+      authInfo
+    );
+  },
 
-    retrieve_database_content: async (
-      { databaseId, filter, sorts, start_cursor, page_size },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.dataSources.query({
-            data_source_id: databaseId,
-            filter: filter as QueryDataSourceParameters["filter"],
-            sorts,
-            start_cursor,
-            page_size,
-          }),
-        authInfo
-      );
-    },
+  fetch_comments: async ({ blockId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.comments.list({ block_id: blockId }),
+      authInfo
+    );
+  },
 
-    query_database: async (
-      { databaseId, filter, sorts, start_cursor, page_size },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.dataSources.query({
-            data_source_id: databaseId,
-            filter: filter as QueryDataSourceParameters["filter"],
-            sorts,
-            start_cursor,
-            page_size,
-          }),
-        authInfo
-      );
-    },
+  update_row_database: async ({ pageId, properties }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.pages.update({ page_id: pageId, properties }),
+      authInfo
+    );
+  },
 
-    create_page: async ({ parent, properties, icon, cover }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.pages.create({ parent, properties, icon, cover }),
-        authInfo
-      );
-    },
+  update_schema_database: async ({ databaseId, properties }, { authInfo }) => {
+    return withNotionClient(
+      (notion) =>
+        notion.dataSources.update({
+          data_source_id: databaseId,
+          properties,
+        }),
+      authInfo
+    );
+  },
 
-    insert_row_into_database: async (
-      { databaseId, properties, icon, cover },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.pages.create({
-            parent: { database_id: databaseId, type: "database_id" },
-            properties,
-            icon,
-            cover,
-          }),
-        authInfo
-      );
-    },
+  list_users: async (_params, { authInfo }) => {
+    return withNotionClient((notion) => notion.users.list({}), authInfo);
+  },
 
-    create_database: async (
-      { parent, title, properties, icon, cover },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.databases.create({
-            parent,
-            title,
-            initial_data_source: { properties },
-            icon,
-            cover,
-          }),
-        authInfo
-      );
-    },
+  get_about_user: async ({ userId }, { authInfo }) => {
+    return withNotionClient(
+      (notion) => notion.users.retrieve({ user_id: userId }),
+      authInfo
+    );
+  },
+};
 
-    update_page: async ({ pageId, properties }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, properties }),
-        authInfo
-      );
-    },
-
-    retrieve_block: async ({ blockId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.blocks.retrieve({ block_id: blockId }),
-        authInfo
-      );
-    },
-
-    retrieve_block_children: async (
-      { blockId, start_cursor, page_size },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.blocks.children.list({
-            block_id: blockId,
-            start_cursor,
-            page_size,
-          }),
-        authInfo
-      );
-    },
-
-    add_page_content: async ({ after, blockId, children }, { authInfo }) => {
-      return withNotionClient(
-        (notion) =>
-          notion.blocks.children.append({
-            after,
-            block_id: blockId,
-            children,
-          }),
-        authInfo
-      );
-    },
-
-    create_comment: async (
-      { parent_page_id, discussion_id, comment },
-      { authInfo }
-    ) => {
-      return withNotionClient((notion) => {
-        if (!parent_page_id && !discussion_id) {
-          throw new Error(
-            "Either parent_page_id or discussion_id must be provided."
-          );
-        }
-        let params: CreateCommentParameters;
-        if (parent_page_id) {
-          params = {
-            parent: { page_id: parent_page_id },
-            rich_text: [{ type: "text", text: { content: comment } }],
-          };
-        } else {
-          params = {
-            discussion_id: discussion_id!,
-            rich_text: [{ type: "text", text: { content: comment } }],
-          };
-        }
-        return notion.comments.create(params);
-      }, authInfo);
-    },
-
-    delete_block: async ({ blockId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.blocks.update({ block_id: blockId, archived: true }),
-        authInfo
-      );
-    },
-
-    delete_page: async ({ pageId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, in_trash: true }),
-        authInfo
-      );
-    },
-
-    fetch_comments: async ({ blockId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.comments.list({ block_id: blockId }),
-        authInfo
-      );
-    },
-
-    update_row_database: async ({ pageId, properties }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, properties }),
-        authInfo
-      );
-    },
-
-    update_schema_database: async (
-      { databaseId, properties },
-      { authInfo }
-    ) => {
-      return withNotionClient(
-        (notion) =>
-          notion.dataSources.update({
-            data_source_id: databaseId,
-            properties,
-          }),
-        authInfo
-      );
-    },
-
-    list_users: async (_params, { authInfo }) => {
-      return withNotionClient((notion) => notion.users.list({}), authInfo);
-    },
-
-    get_about_user: async ({ userId }, { authInfo }) => {
-      return withNotionClient(
-        (notion) => notion.users.retrieve({ user_id: userId }),
-        authInfo
-      );
-    },
-  };
-
-  return buildTools(NOTION_TOOLS_METADATA, handlers);
-}
+export const TOOLS = buildTools(NOTION_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/salesloft/index.ts
+++ b/front/lib/api/actions/servers/salesloft/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createSalesloftTools } from "@app/lib/api/actions/servers/salesloft/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/salesloft/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,8 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("salesloft");
 
-  const tools = createSalesloftTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "salesloft",
     });

--- a/front/lib/api/actions/servers/salesloft/tools/index.ts
+++ b/front/lib/api/actions/servers/salesloft/tools/index.ts
@@ -1,85 +1,73 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
 import {
   formatActionAsString,
   getActionsWithDetails,
   getBearerToken,
 } from "@app/lib/api/actions/servers/salesloft/helpers";
 import { SALESLOFT_TOOLS_METADATA } from "@app/lib/api/actions/servers/salesloft/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
-export function createSalesloftTools(
-  auth: Authenticator,
-  _toolContext?: ToolContext
-): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof SALESLOFT_TOOLS_METADATA> = {
-    get_actions: async ({ include_due_actions_only }, extra) => {
-      const bearerToken = getBearerToken(extra);
-      if (!bearerToken) {
-        return new Err(
-          new MCPError(
-            "No bearer token found. Please configure a secret for this Salesloft integration"
-          )
-        );
-      }
+const handlers: ToolHandlers<typeof SALESLOFT_TOOLS_METADATA> = {
+  get_actions: async ({ include_due_actions_only }, extra) => {
+    const bearerToken = getBearerToken(extra);
+    if (!bearerToken) {
+      return new Err(
+        new MCPError(
+          "No bearer token found. Please configure a secret for this Salesloft integration"
+        )
+      );
+    }
 
-      const userEmail = auth.user()?.email;
-      if (!userEmail) {
-        return new Err(
-          new MCPError(
-            "Unable to determine user email. Please ensure you are authenticated."
-          )
-        );
-      }
+    const userEmail = extra.auth.user()?.email;
+    if (!userEmail) {
+      return new Err(
+        new MCPError(
+          "Unable to determine user email. Please ensure you are authenticated."
+        )
+      );
+    }
 
-      const result = await getActionsWithDetails(bearerToken, {
-        includeDueActionsOnly: include_due_actions_only,
-        userEmail: userEmail,
-      });
+    const result = await getActionsWithDetails(bearerToken, {
+      includeDueActionsOnly: include_due_actions_only,
+      userEmail: userEmail,
+    });
 
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message ?? "Operation failed")
-        );
-      }
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message ?? "Operation failed"));
+    }
 
-      const actionsWithDetails = result.value;
+    const actionsWithDetails = result.value;
 
-      const actionTypeText = include_due_actions_only ? "due or overdue" : "";
+    const actionTypeText = include_due_actions_only ? "due or overdue" : "";
 
-      if (actionsWithDetails.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: include_due_actions_only
-              ? "No due or overdue actions found."
-              : "No actions found.",
-          },
-        ]);
-      }
-
-      const formattedText = actionsWithDetails
-        .map((action, index) => {
-          return `--- Action ${index + 1} of ${actionsWithDetails.length} ---\n${formatActionAsString(
-            action
-          )}`;
-        })
-        .join("\n\n");
-
+    if (actionsWithDetails.length === 0) {
       return new Ok([
         {
           type: "text" as const,
-          text: `Found ${actionsWithDetails.length} ${actionTypeText} action(s):\n\n${formattedText}`,
+          text: include_due_actions_only
+            ? "No due or overdue actions found."
+            : "No actions found.",
         },
       ]);
-    },
-  };
+    }
 
-  return buildTools(SALESLOFT_TOOLS_METADATA, handlers);
-}
+    const formattedText = actionsWithDetails
+      .map((action, index) => {
+        return `--- Action ${index + 1} of ${actionsWithDetails.length} ---\n${formatActionAsString(
+          action
+        )}`;
+      })
+      .join("\n\n");
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${actionsWithDetails.length} ${actionTypeText} action(s):\n\n${formattedText}`,
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(SALESLOFT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/val_town/helpers.ts
+++ b/front/lib/api/actions/servers/val_town/helpers.ts
@@ -1,6 +1,5 @@
-import type { ToolContext } from "@app/lib/actions/types";
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt } from "@app/types/shared/utils/encryption";
 import ValTown from "@valtown/sdk";
@@ -18,11 +17,11 @@ export function isValTownError(error: unknown): error is ValTownError {
   );
 }
 
-export async function getValTownClient(
-  auth: Authenticator,
-  toolContext?: ToolContext
-): Promise<ValTown | null> {
-  const toolConfig = toolContext?.runContext?.toolConfiguration;
+export async function getValTownClient({
+  auth,
+  runContext,
+}: ToolHandlerExtra): Promise<ValTown | null> {
+  const toolConfig = runContext.toolConfiguration;
   if (
     !toolConfig ||
     !isLightServerSideMCPToolConfiguration(toolConfig) ||

--- a/front/lib/api/actions/servers/val_town/index.ts
+++ b/front/lib/api/actions/servers/val_town/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createValTownTools } from "@app/lib/api/actions/servers/val_town/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/val_town/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,9 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("val_town");
 
-  const tools = createValTownTools(auth, toolContext);
-
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "val_town",
     });

--- a/front/lib/api/actions/servers/val_town/tools/index.ts
+++ b/front/lib/api/actions/servers/val_town/tools/index.ts
@@ -1,13 +1,11 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { ToolContext } from "@app/lib/actions/types";
 import {
   getValTownClient,
   isValTownError,
 } from "@app/lib/api/actions/servers/val_town/helpers";
 import { VAL_TOWN_TOOLS_METADATA } from "@app/lib/api/actions/servers/val_town/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -16,65 +14,116 @@ import type { RequestInit } from "undici";
 const API_KEY_NOT_CONFIGURED_ERROR =
   "Val Town API key not configured. Please configure a secret containing your Val Town API key in the agent settings.";
 
-export function createValTownTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof VAL_TOWN_TOOLS_METADATA> = {
-    create_val: async ({ name, privacy, description, orgId }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
+const handlers: ToolHandlers<typeof VAL_TOWN_TOOLS_METADATA> = {
+  create_val: async ({ name, privacy, description, orgId }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      const val = await client.vals.create({
+        name,
+        privacy,
+        ...(description && { description }),
+        ...(orgId && { orgId }),
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Successfully created val "${name}" with ID: ${val.id}\n` +
+            (val.links?.self ? `Link to the val: ${val.links.self}\n` : ""),
+        },
+      ]);
+    } catch (error: unknown) {
+      if (isValTownError(error) && error.status === 409) {
         return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+          new MCPError(
+            `A val named "${name}" already exists in your account. Please either:\n` +
+              `1. Choose a different name for your new val\n` +
+              `2. Use the list_vals tool to see all your existing vals\n` +
+              `3. Delete the existing val from Val Town if you want to replace it`
+          )
         );
       }
 
-      try {
-        const val = await client.vals.create({
-          name,
-          privacy,
-          ...(description && { description }),
-          ...(orgId && { orgId }),
-        });
+      return new Err(
+        new MCPError(`Error creating val: ${normalizeError(error).message}`)
+      );
+    }
+  },
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              `Successfully created val "${name}" with ID: ${val.id}\n` +
-              (val.links?.self ? `Link to the val: ${val.links.self}\n` : ""),
-          },
-        ]);
-      } catch (error: unknown) {
-        if (isValTownError(error) && error.status === 409) {
-          return new Err(
-            new MCPError(
-              `A val named "${name}" already exists in your account. Please either:\n` +
-                `1. Choose a different name for your new val\n` +
-                `2. Use the list_vals tool to see all your existing vals\n` +
-                `3. Delete the existing val from Val Town if you want to replace it`
-            )
-          );
-        }
+  get_val: async ({ valId }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
 
-        return new Err(
-          new MCPError(`Error creating val: ${normalizeError(error).message}`)
-        );
+    try {
+      const val = await client.vals.retrieve(valId);
+
+      let resultText = `Val Details:\n`;
+      resultText += `Name: ${val.name}\n`;
+      resultText += `ID: ${val.id}\n`;
+      resultText += `Description: ${val.description ?? "No description"}\n`;
+      resultText += `Privacy: ${val.privacy}\n`;
+      resultText += `Author: ${val.author?.username ?? "Unknown"}\n`;
+      if (val.links?.self) {
+        resultText += `Self Link: ${val.links.self}\n`;
       }
-    },
-
-    get_val: async ({ valId }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
+      if (val.links?.html) {
+        resultText += `HTML Link: ${val.links.html}\n`;
       }
+      resultText += `Created: ${new Date(val.createdAt).toLocaleString()}\n`;
 
-      try {
-        const val = await client.vals.retrieve(valId);
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error getting val: ${normalizeError(err).message}`)
+      );
+    }
+  },
 
-        let resultText = `Val Details:\n`;
+  list_vals: async (
+    { limit, cursor, privacy, user_id, list_only_user_vals = true },
+    extra
+  ) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      const response = list_only_user_vals
+        ? await client.me.vals.list({
+            limit,
+            ...(cursor && { cursor }),
+          })
+        : await client.vals.list({
+            limit,
+            ...(cursor && { cursor }),
+            ...(privacy && { privacy }),
+            ...(user_id && { user_id }),
+          });
+
+      const vals = response.data || [];
+
+      let resultText = `Found ${vals.length} val(s):\n\n`;
+
+      for (const val of vals) {
         resultText += `Name: ${val.name}\n`;
         resultText += `ID: ${val.id}\n`;
         resultText += `Description: ${val.description ?? "No description"}\n`;
@@ -86,449 +135,386 @@ export function createValTownTools(
         if (val.links?.html) {
           resultText += `HTML Link: ${val.links.html}\n`;
         }
+        if (val.author?.username) {
+          resultText += `HTTP Endpoint: https://${val.author.username}-${val.name}.web.val.run\n`;
+        }
         resultText += `Created: ${new Date(val.createdAt).toLocaleString()}\n`;
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error getting val: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    list_vals: async ({
-      limit,
-      cursor,
-      privacy,
-      user_id,
-      list_only_user_vals = true,
-    }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
+        resultText += `---\n`;
       }
 
-      try {
-        const response = list_only_user_vals
-          ? await client.me.vals.list({
-              limit,
-              ...(cursor && { cursor }),
-            })
-          : await client.vals.list({
-              limit,
-              ...(cursor && { cursor }),
-              ...(privacy && { privacy }),
-              ...(user_id && { user_id }),
-            });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error listing vals: ${normalizeError(err).message}`)
+      );
+    }
+  },
 
-        const vals = response.data || [];
+  search_vals: async ({ query, limit = 20, cursor, privacy }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
 
-        let resultText = `Found ${vals.length} val(s):\n\n`;
+    try {
+      const response = await client.vals.list({
+        limit,
+        ...(cursor && { cursor }),
+        ...(privacy && { privacy }),
+      });
 
-        for (const val of vals) {
-          resultText += `Name: ${val.name}\n`;
-          resultText += `ID: ${val.id}\n`;
-          resultText += `Description: ${val.description ?? "No description"}\n`;
-          resultText += `Privacy: ${val.privacy}\n`;
-          resultText += `Author: ${val.author?.username ?? "Unknown"}\n`;
-          if (val.links?.self) {
-            resultText += `Self Link: ${val.links.self}\n`;
-          }
-          if (val.links?.html) {
-            resultText += `HTML Link: ${val.links.html}\n`;
-          }
-          if (val.author?.username) {
-            resultText += `HTTP Endpoint: https://${val.author.username}-${val.name}.web.val.run\n`;
-          }
-          resultText += `Created: ${new Date(val.createdAt).toLocaleString()}\n`;
-          resultText += `---\n`;
+      const allVals = response.data || [];
+
+      const searchResults = allVals.filter((val) => {
+        const searchText = `${val.name} ${val.description ?? ""}`.toLowerCase();
+        return searchText.includes(query.toLowerCase());
+      });
+
+      let resultText = `Found ${searchResults.length} val(s) matching "${query}":\n\n`;
+
+      for (const val of searchResults) {
+        resultText += `Name: ${val.name}\n`;
+        resultText += `ID: ${val.id}\n`;
+        if (val.description) {
+          resultText += `Description: ${val.description}\n`;
         }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error listing vals: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    search_vals: async ({ query, limit = 20, cursor, privacy }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        const response = await client.vals.list({
-          limit,
-          ...(cursor && { cursor }),
-          ...(privacy && { privacy }),
-        });
-
-        const allVals = response.data || [];
-
-        const searchResults = allVals.filter((val) => {
-          const searchText =
-            `${val.name} ${val.description ?? ""}`.toLowerCase();
-          return searchText.includes(query.toLowerCase());
-        });
-
-        let resultText = `Found ${searchResults.length} val(s) matching "${query}":\n\n`;
-
-        for (const val of searchResults) {
-          resultText += `Name: ${val.name}\n`;
-          resultText += `ID: ${val.id}\n`;
-          if (val.description) {
-            resultText += `Description: ${val.description}\n`;
-          }
-          if (val.links?.self) {
-            resultText += `API Link: ${val.links.self}\n`;
-          }
-          if (val.links?.html) {
-            resultText += `HTML Link: ${val.links.html}\n`;
-          }
-          if (val.author?.username) {
-            resultText += `HTTP Endpoint: https://${val.author.username}-${val.name}.web.val.run\n`;
-          }
-          resultText += `Created: ${new Date(val.createdAt).toLocaleString()}\n`;
-          resultText += `---\n`;
+        if (val.links?.self) {
+          resultText += `API Link: ${val.links.self}\n`;
         }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error searching vals: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    list_val_files: async ({ valId, path = "", limit, offset }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        const response = await client.vals.files.retrieve(valId, {
-          path,
-          recursive: true,
-          ...(limit && { limit }),
-          ...(offset && { offset }),
-        });
-
-        const files = Array.isArray(response) ? response : response.data || [];
-
-        let resultText = `Found ${files.length} file(s) in val ${valId} at path "${path || "root"}":\n\n`;
-
-        for (const file of files) {
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          resultText += `Path: ${file.path || "Unknown"}\n`;
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          resultText += `Type: ${file.type || "Unknown"}\n`;
-          if (file.links) {
-            if (file.links.self) {
-              resultText += `Self Link: ${file.links.self}\n`;
-            }
-            if (file.links.html) {
-              resultText += `HTML Link: ${file.links.html}\n`;
-            }
-            if (file.links.module) {
-              resultText += `Module Link: ${file.links.module}\n`;
-            }
-            if (file.links.endpoint) {
-              resultText += `Endpoint Link: ${file.links.endpoint}\n`;
-            }
-          }
-          if (file.createdAt) {
-            resultText += `Created: ${new Date(file.createdAt).toLocaleString()}\n`;
-          }
-          if (file.updatedAt) {
-            resultText += `Updated: ${new Date(file.updatedAt).toLocaleString()}\n`;
-          }
-          resultText += `---\n`;
+        if (val.links?.html) {
+          resultText += `HTML Link: ${val.links.html}\n`;
         }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(
-            `Error listing val files: ${normalizeError(err).message}`
-          )
-        );
-      }
-    },
-
-    get_file_content: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
+        if (val.author?.username) {
+          resultText += `HTTP Endpoint: https://${val.author.username}-${val.name}.web.val.run\n`;
+        }
+        resultText += `Created: ${new Date(val.createdAt).toLocaleString()}\n`;
+        resultText += `---\n`;
       }
 
-      try {
-        const response = await client.vals.files.getContent(valId, {
-          path: filePath,
-        });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error searching vals: ${normalizeError(err).message}`)
+      );
+    }
+  },
 
-        const content = await response.text();
-        let resultText = `File Content for ${filePath}:\n`;
-        resultText += `\nContent:\n${content}`;
+  list_val_files: async ({ valId, path = "", limit, offset }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(
-            `Error getting file content: ${normalizeError(err).message}`
-          )
-        );
-      }
-    },
+    try {
+      const response = await client.vals.files.retrieve(valId, {
+        path,
+        recursive: true,
+        ...(limit && { limit }),
+        ...(offset && { offset }),
+      });
 
-    delete_file: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
+      const files = Array.isArray(response) ? response : response.data || [];
 
-      try {
-        await client.vals.files.delete(valId, {
-          path: filePath,
-          recursive: false,
-        });
+      let resultText = `Found ${files.length} file(s) in val ${valId} at path "${path || "root"}":\n\n`;
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully deleted file "${filePath}" from val ${valId}`,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error deleting file: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    update_file_content: async ({ valId, filePath, content }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        await client.vals.files.update(valId, {
-          path: filePath,
-          content,
-        });
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully updated file "${filePath}" in val ${valId}\n`,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(
-            `Error updating file content: ${normalizeError(err).message}`
-          )
-        );
-      }
-    },
-
-    write_file: async ({
-      valId,
-      filePath,
-      content,
-      name,
-      type,
-      parent_path,
-    }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        await client.vals.files.update(valId, {
-          path: filePath,
-          ...(content !== undefined && { content }),
-          ...(name !== undefined && { name }),
-          ...(type !== undefined && { type }),
-          ...(parent_path !== undefined && { parent_path }),
-        });
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully updated file "${filePath}" in val ${valId}${
-              type ? ` (type: ${type})` : ""
-            }\n`,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error updating file: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    create_file: async ({ valId, filePath }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        await client.vals.files.create(valId, {
-          path: filePath,
-          content: "",
-          type: "file",
-        });
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully created empty file "${filePath}" in val ${valId}. Use write_file to add content and set the file type.\n`,
-          },
-        ]);
-      } catch (err) {
-        return new Err(
-          new MCPError(`Error creating file: ${normalizeError(err).message}`)
-        );
-      }
-    },
-
-    call_http_endpoint: async ({ valId, filePath, body, method = "POST" }) => {
-      const client = await getValTownClient(auth, toolContext);
-      if (!client) {
-        return new Err(
-          new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
-        );
-      }
-
-      try {
-        let parsedBody: unknown = null;
-        if (body) {
-          try {
-            parsedBody = JSON.parse(body);
-          } catch (parseError) {
-            return new Err(
-              new MCPError(`Invalid JSON in body: ${parseError}`, {
-                tracked: false,
-              })
-            );
+      for (const file of files) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        resultText += `Path: ${file.path || "Unknown"}\n`;
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        resultText += `Type: ${file.type || "Unknown"}\n`;
+        if (file.links) {
+          if (file.links.self) {
+            resultText += `Self Link: ${file.links.self}\n`;
+          }
+          if (file.links.html) {
+            resultText += `HTML Link: ${file.links.html}\n`;
+          }
+          if (file.links.module) {
+            resultText += `Module Link: ${file.links.module}\n`;
+          }
+          if (file.links.endpoint) {
+            resultText += `Endpoint Link: ${file.links.endpoint}\n`;
           }
         }
+        if (file.createdAt) {
+          resultText += `Created: ${new Date(file.createdAt).toLocaleString()}\n`;
+        }
+        if (file.updatedAt) {
+          resultText += `Updated: ${new Date(file.updatedAt).toLocaleString()}\n`;
+        }
+        resultText += `---\n`;
+      }
 
-        const fileResponse = await client.vals.files.retrieve(valId, {
-          path: filePath,
-          recursive: true,
-        });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error listing val files: ${normalizeError(err).message}`)
+      );
+    }
+  },
 
-        const targetFile = Array.isArray(fileResponse)
-          ? fileResponse[0]
-          : fileResponse.data?.[0] || fileResponse;
+  get_file_content: async ({ valId, filePath }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
 
-        if (!targetFile) {
+    try {
+      const response = await client.vals.files.getContent(valId, {
+        path: filePath,
+      });
+
+      const content = await response.text();
+      let resultText = `File Content for ${filePath}:\n`;
+      resultText += `\nContent:\n${content}`;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          `Error getting file content: ${normalizeError(err).message}`
+        )
+      );
+    }
+  },
+
+  delete_file: async ({ valId, filePath }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      await client.vals.files.delete(valId, {
+        path: filePath,
+        recursive: false,
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully deleted file "${filePath}" from val ${valId}`,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error deleting file: ${normalizeError(err).message}`)
+      );
+    }
+  },
+
+  update_file_content: async ({ valId, filePath, content }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      await client.vals.files.update(valId, {
+        path: filePath,
+        content,
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully updated file "${filePath}" in val ${valId}\n`,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          `Error updating file content: ${normalizeError(err).message}`
+        )
+      );
+    }
+  },
+
+  write_file: async (
+    { valId, filePath, content, name, type, parent_path },
+    extra
+  ) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      await client.vals.files.update(valId, {
+        path: filePath,
+        ...(content !== undefined && { content }),
+        ...(name !== undefined && { name }),
+        ...(type !== undefined && { type }),
+        ...(parent_path !== undefined && { parent_path }),
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully updated file "${filePath}" in val ${valId}${
+            type ? ` (type: ${type})` : ""
+          }\n`,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error updating file: ${normalizeError(err).message}`)
+      );
+    }
+  },
+
+  create_file: async ({ valId, filePath }, extra) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      await client.vals.files.create(valId, {
+        path: filePath,
+        content: "",
+        type: "file",
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully created empty file "${filePath}" in val ${valId}. Use write_file to add content and set the file type.\n`,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error creating file: ${normalizeError(err).message}`)
+      );
+    }
+  },
+
+  call_http_endpoint: async (
+    { valId, filePath, body, method = "POST" },
+    extra
+  ) => {
+    const client = await getValTownClient(extra);
+    if (!client) {
+      return new Err(
+        new MCPError(API_KEY_NOT_CONFIGURED_ERROR, { tracked: false })
+      );
+    }
+
+    try {
+      let parsedBody: unknown = null;
+      if (body) {
+        try {
+          parsedBody = JSON.parse(body);
+        } catch (parseError) {
           return new Err(
-            new MCPError(`File "${filePath}" not found in val ${valId}`, {
+            new MCPError(`Invalid JSON in body: ${parseError}`, {
               tracked: false,
             })
           );
         }
+      }
 
-        if (!targetFile.links?.endpoint) {
-          return new Err(
-            new MCPError(
-              `File "${filePath}" does not have an endpoint link. This file may not be an HTTP val.`,
-              { tracked: false }
-            )
-          );
-        }
+      const fileResponse = await client.vals.files.retrieve(valId, {
+        path: filePath,
+        recursive: true,
+      });
 
-        const requestOptions: RequestInit = {
-          method,
-        };
+      const targetFile = Array.isArray(fileResponse)
+        ? fileResponse[0]
+        : fileResponse.data?.[0] || fileResponse;
 
-        if (parsedBody && method !== "GET") {
-          requestOptions.headers = {
-            "Content-Type": "application/json",
-          };
-          requestOptions.body = JSON.stringify(parsedBody);
-        }
-
-        const response = await untrustedFetch(
-          targetFile.links.endpoint,
-          requestOptions
-        );
-
-        const contentType = response.headers.get("content-type");
-        let result: unknown;
-        let resultText = `HTTP ${response.status} ${response.statusText}\n`;
-        resultText += `Endpoint: ${targetFile.links.endpoint}\n\n`;
-
-        if (contentType?.includes("application/json")) {
-          result = await response.json();
-          resultText += JSON.stringify(result, null, 2);
-        } else {
-          const textResult = await response.text();
-          resultText += textResult;
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: resultText,
-          },
-        ]);
-      } catch (err) {
+      if (!targetFile) {
         return new Err(
-          new MCPError(`Error triggering val: ${normalizeError(err).message}`)
+          new MCPError(`File "${filePath}" not found in val ${valId}`, {
+            tracked: false,
+          })
         );
       }
-    },
-  };
 
-  return buildTools(VAL_TOWN_TOOLS_METADATA, handlers);
-}
+      if (!targetFile.links?.endpoint) {
+        return new Err(
+          new MCPError(
+            `File "${filePath}" does not have an endpoint link. This file may not be an HTTP val.`,
+            { tracked: false }
+          )
+        );
+      }
+
+      const requestOptions: RequestInit = {
+        method,
+      };
+
+      if (parsedBody && method !== "GET") {
+        requestOptions.headers = {
+          "Content-Type": "application/json",
+        };
+        requestOptions.body = JSON.stringify(parsedBody);
+      }
+
+      const response = await untrustedFetch(
+        targetFile.links.endpoint,
+        requestOptions
+      );
+
+      const contentType = response.headers.get("content-type");
+      let result: unknown;
+      let resultText = `HTTP ${response.status} ${response.statusText}\n`;
+      resultText += `Endpoint: ${targetFile.links.endpoint}\n\n`;
+
+      if (contentType?.includes("application/json")) {
+        result = await response.json();
+        resultText += JSON.stringify(result, null, 2);
+      } else {
+        const textResult = await response.text();
+        resultText += textResult;
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: resultText,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(`Error triggering val: ${normalizeError(err).message}`)
+      );
+    }
+  },
+};
+
+export const TOOLS = buildTools(VAL_TOWN_TOOLS_METADATA, handlers);


### PR DESCRIPTION
## Description

Some integration MCP servers build their tool maps through factories only to capture authentication or execution context.

This PR exports their `TOOLS` arrays directly and reads `auth`, `authInfo`, and `runContext` from the handler execution context. Tool schemas and advertised tool sets stay unchanged. Conditional tool selection remains in a separate PR.

## Tests

- Updated existing GitHub tool tests.

## Risk

- Low. Internal MCP handler context only.

## Deploy Plan

- Deploy front.