### PR TITLE
[front] chore: remove runtime MCP tool factories

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
-import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/pod_manager/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -22,8 +22,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(POD_MANAGER_SERVER_NAME);
 
-  const tools = createProjectManagerTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: POD_MANAGER_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1,9 +1,6 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
@@ -63,7 +60,6 @@ import {
 import { listPodsForScope } from "@app/lib/api/projects/list";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
-import type { Authenticator } from "@app/lib/auth";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -111,1344 +107,1276 @@ function formatListedConversationWithoutMessages(
   };
 }
 
-export function createProjectManagerTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof POD_MANAGER_TOOLS_METADATA> = {
-    add_content_node: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getWritablePodContext(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
+const handlers: ToolHandlers<typeof POD_MANAGER_TOOLS_METADATA> = {
+  add_content_node: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getWritablePodContext(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
 
-        const { pod } = contextRes.value;
+      const { pod } = contextRes.value;
 
-        const dataSourceId = extractDataSourceIdFromNodeId(
-          params.dataSourceNodeId
+      const dataSourceId = extractDataSourceIdFromNodeId(
+        params.dataSourceNodeId
+      );
+      if (!dataSourceId) {
+        return new Err(
+          new MCPError("Invalid node ID, unable to extract data source ID", {
+            tracked: false,
+          })
         );
-        if (!dataSourceId) {
-          return new Err(
-            new MCPError("Invalid node ID, unable to extract data source ID", {
-              tracked: false,
-            })
-          );
-        }
+      }
 
-        const dataSource = await DataSourceResource.fetchByDustAPIDataSourceId(
+      const dataSource = await DataSourceResource.fetchByDustAPIDataSourceId(
+        auth,
+        dataSourceId
+      );
+
+      if (!dataSource) {
+        return new Err(
+          new MCPError(`Data source not found: ${dataSourceId}`, {
+            tracked: false,
+          })
+        );
+      }
+
+      // We assume the node is coming from company data, as it's the only allowed source for projects.
+      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+      const [dataSourceView] =
+        await DataSourceViewResource.listForDataSourcesInSpace(
           auth,
-          dataSourceId
+          [dataSource],
+          globalSpace
         );
 
-        if (!dataSource) {
-          return new Err(
-            new MCPError(`Data source not found: ${dataSourceId}`, {
+      if (!dataSourceView) {
+        return new Err(
+          new MCPError(
+            `Data source view not found for Company Data node: ${params.dataSourceNodeId}`,
+            {
               tracked: false,
-            })
-          );
-        }
+            }
+          )
+        );
+      }
 
-        // We assume the node is coming from company data, as it's the only allowed source for projects.
-        const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-        const [dataSourceView] =
-          await DataSourceViewResource.listForDataSourcesInSpace(
-            auth,
-            [dataSource],
-            globalSpace
-          );
+      const upsertRes = await addContentNodeToProject(auth, {
+        space: pod,
+        contentFragment: {
+          title: params.title,
+          url: params.url,
+          nodeId: params.nodeId,
+          nodeDataSourceViewId: dataSourceView.sId,
+        },
+      });
 
-        if (!dataSourceView) {
-          return new Err(
-            new MCPError(
-              `Data source view not found for Company Data node: ${params.dataSourceNodeId}`,
-              {
-                tracked: false,
-              }
-            )
-          );
-        }
+      if (upsertRes.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to add content node to Pod: ${upsertRes.error.message}`,
+            { tracked: false }
+          )
+        );
+      }
 
-        const upsertRes = await addContentNodeToProject(auth, {
-          space: pod,
-          contentFragment: {
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          contentNode: {
             title: params.title,
-            url: params.url,
             nodeId: params.nodeId,
             nodeDataSourceViewId: dataSourceView.sId,
+            url: params.url ?? null,
           },
-        });
+          message: `Content node "${params.title}" added to Pod context successfully.`,
+        })
+      );
+    }, "Failed to add content node");
+  },
 
-        if (upsertRes.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to add content node to Pod: ${upsertRes.error.message}`,
-              { tracked: false }
-            )
-          );
-        }
+  remove_content_node: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getWritablePodContext(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
 
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            contentNode: {
-              title: params.title,
-              nodeId: params.nodeId,
-              nodeDataSourceViewId: dataSourceView.sId,
-              url: params.url ?? null,
-            },
-            message: `Content node "${params.title}" added to Pod context successfully.`,
-          })
-        );
-      }, "Failed to add content node");
-    },
+      const { pod } = contextRes.value;
 
-    remove_content_node: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getWritablePodContext(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-
-        const removeRes = await removeContentNodesFromProject(auth, {
-          space: pod,
-          nodes: [
-            {
-              nodeId: params.nodeId,
-              nodeDataSourceViewId: params.nodeDataSourceViewId,
-            },
-          ],
-        });
-        if (removeRes.isErr()) {
-          return new Err(
-            new MCPError(removeRes.error.message, { tracked: false })
-          );
-        }
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
+      const removeRes = await removeContentNodesFromProject(auth, {
+        space: pod,
+        nodes: [
+          {
             nodeId: params.nodeId,
             nodeDataSourceViewId: params.nodeDataSourceViewId,
-            message:
-              "Content node reference removed from the Pod context if present (Company Data unchanged).",
-          })
+          },
+        ],
+      });
+      if (removeRes.isErr()) {
+        return new Err(
+          new MCPError(removeRes.error.message, { tracked: false })
         );
-      }, "Failed to remove linked content from Pod");
-    },
+      }
 
-    [EDIT_INFORMATION_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          nodeId: params.nodeId,
+          nodeDataSourceViewId: params.nodeDataSourceViewId,
+          message:
+            "Content node reference removed from the Pod context if present (Company Data unchanged).",
+        })
+      );
+    }, "Failed to remove linked content from Pod");
+  },
+
+  [EDIT_INFORMATION_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+
+      if (!pod.canAdministrate(auth)) {
+        return new Err(
+          new MCPError(
+            "You do not have permission to edit this Pod's information",
+            { tracked: false }
+          )
+        );
+      }
+
+      const { title, description, access } = params;
+      if (
+        title === undefined &&
+        description === undefined &&
+        access === undefined
+      ) {
+        return new Err(
+          new MCPError(
+            "At least one of title, description, or access must be provided",
+            { tracked: false }
+          )
+        );
+      }
+
+      const updates: ProjectMetadataBlob & {
+        title?: string;
+        access?: "restricted" | "open";
+      } = {};
+
+      if (title !== undefined) {
+        const updateNameRes = await pod.updateName(auth, title);
+        if (updateNameRes.isErr()) {
+          return new Err(
+            new MCPError(updateNameRes.error.message, { tracked: false })
+          );
         }
+        updates.title = title.trim();
+      }
 
-        const { pod } = contextRes.value;
+      if (description !== undefined) {
+        updates.description = description;
+      }
 
-        if (!pod.canAdministrate(auth)) {
+      if (access !== undefined) {
+        const owner = auth.getNonNullableWorkspace();
+        if (access === "open" && !areOpenPodsAllowed(owner)) {
           return new Err(
             new MCPError(
-              "You do not have permission to edit this Pod's information",
+              "Open Pods are disabled by your workspace admin. Set access to restricted instead.",
               { tracked: false }
             )
           );
         }
 
-        const { title, description, access } = params;
-        if (
-          title === undefined &&
-          description === undefined &&
-          access === undefined
-        ) {
-          return new Err(
-            new MCPError(
-              "At least one of title, description, or access must be provided",
-              { tracked: false }
-            )
-          );
-        }
-
-        const updates: ProjectMetadataBlob & {
-          title?: string;
-          access?: "restricted" | "open";
-        } = {};
-
-        if (title !== undefined) {
-          const updateNameRes = await pod.updateName(auth, title);
-          if (updateNameRes.isErr()) {
-            return new Err(
-              new MCPError(updateNameRes.error.message, { tracked: false })
-            );
-          }
-          updates.title = title.trim();
-        }
-
-        if (description !== undefined) {
-          updates.description = description;
-        }
-
-        if (access !== undefined) {
-          const owner = auth.getNonNullableWorkspace();
-          if (access === "open" && !areOpenPodsAllowed(owner)) {
-            return new Err(
-              new MCPError(
-                "Open Pods are disabled by your workspace admin. Set access to restricted instead.",
-                { tracked: false }
-              )
-            );
-          }
-
-          const newIsRestricted = access !== "open";
-          const currentlyRestricted = !pod.isOpen();
-          if (newIsRestricted !== currentlyRestricted) {
-            const { editorIds, memberIds } = await getPodMemberAndEditorSIds(
-              auth,
-              pod
-            );
-            const updatePermissionsRes = await pod.updatePermissions(auth, {
-              name: pod.name,
-              isRestricted: newIsRestricted,
-              managementMode: "manual",
-              memberIds,
-              editorIds,
-            });
-            if (updatePermissionsRes.isErr()) {
-              return new Err(
-                new MCPError(updatePermissionsRes.error.message, {
-                  tracked: false,
-                })
-              );
-            }
-            updates.access = access;
-          }
-        }
-
-        const { title: _title, access: _access, ...podUpdates } = updates;
-        let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-        if (!metadata) {
-          metadata = await ProjectMetadataResource.makeNew(
+        const newIsRestricted = access !== "open";
+        const currentlyRestricted = !pod.isOpen();
+        if (newIsRestricted !== currentlyRestricted) {
+          const { editorIds, memberIds } = await getPodMemberAndEditorSIds(
             auth,
-            pod,
-            podUpdates
+            pod
           );
-        } else {
-          await metadata.updateDescriptionAndPinnedFramePath(podUpdates);
+          const updatePermissionsRes = await pod.updatePermissions(auth, {
+            name: pod.name,
+            isRestricted: newIsRestricted,
+            managementMode: "manual",
+            memberIds,
+            editorIds,
+          });
+          if (updatePermissionsRes.isErr()) {
+            return new Err(
+              new MCPError(updatePermissionsRes.error.message, {
+                tracked: false,
+              })
+            );
+          }
+          updates.access = access;
         }
+      }
 
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            ...updates,
-            message: "Pod information updated successfully.",
-          })
+      const { title: _title, access: _access, ...podUpdates } = updates;
+      let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+      if (!metadata) {
+        metadata = await ProjectMetadataResource.makeNew(auth, pod, podUpdates);
+      } else {
+        await metadata.updateDescriptionAndPinnedFramePath(podUpdates);
+      }
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          ...updates,
+          message: "Pod information updated successfully.",
+        })
+      );
+    }, "Failed to edit Pod information");
+  },
+
+  [SET_PINNED_FRAME_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+
+      if (!pod.canAdministrate(auth)) {
+        return new Err(
+          new MCPError(
+            "You do not have permission to edit this Pod's information",
+            { tracked: false }
+          )
         );
-      }, "Failed to edit Pod information");
-    },
+      }
 
-    [SET_PINNED_FRAME_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
+      const validation = await validatePinnedFramePath(
+        auth,
+        pod,
+        params.pinnedFramePath
+      );
+      if (validation.isErr()) {
+        return new Err(
+          new MCPError(validation.error.message, { tracked: false })
+        );
+      }
+
+      // Use the normalized path.
+      const pinnedFramePath = validation.value;
+
+      let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+      if (!metadata) {
+        metadata = await ProjectMetadataResource.makeNew(auth, pod, {
+          pinnedFramePath,
         });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
+      } else {
+        await metadata.updatePinnedFramePath(pinnedFramePath);
+      }
 
-        const { pod } = contextRes.value;
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          pinnedFramePath,
+          message: pinnedFramePath
+            ? "Pinned frame updated successfully."
+            : "Pinned frame cleared successfully.",
+        })
+      );
+    }, "Failed to set Pod pinned frame");
+  },
 
-        if (!pod.canAdministrate(auth)) {
-          return new Err(
-            new MCPError(
-              "You do not have permission to edit this Pod's information",
-              { tracked: false }
-            )
-          );
-        }
+  [SET_DEFAULT_AGENT_TOOL_NAME]: async (
+    { agentName, dustPod },
+    { auth, runContext }
+  ) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
 
-        const validation = await validatePinnedFramePath(
+      const { pod } = contextRes.value;
+
+      if (!pod.canAdministrate(auth)) {
+        return new Err(
+          new MCPError(
+            "You do not have permission to edit this Pod's default agent",
+            { tracked: false }
+          )
+        );
+      }
+
+      // Resolve the agent by name. A null agentName clears the default so new
+      // conversations fall back to the workspace default (Dust).
+      let defaultAgentId: string | null = null;
+      let defaultAgentName: string | null = null;
+      if (agentName !== null) {
+        const resolvedAgentId = await resolveAgentConfigurationIdByName(
           auth,
-          pod,
-          params.pinnedFramePath
+          agentName
         );
-        if (validation.isErr()) {
+        if (!resolvedAgentId) {
           return new Err(
-            new MCPError(validation.error.message, { tracked: false })
-          );
-        }
-
-        // Use the normalized path.
-        const pinnedFramePath = validation.value;
-
-        let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-        if (!metadata) {
-          metadata = await ProjectMetadataResource.makeNew(auth, pod, {
-            pinnedFramePath,
-          });
-        } else {
-          await metadata.updatePinnedFramePath(pinnedFramePath);
-        }
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            pinnedFramePath,
-            message: pinnedFramePath
-              ? "Pinned frame updated successfully."
-              : "Pinned frame cleared successfully.",
-          })
-        );
-      }, "Failed to set Pod pinned frame");
-    },
-
-    [SET_DEFAULT_AGENT_TOOL_NAME]: async ({ agentName, dustPod }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-
-        if (!pod.canAdministrate(auth)) {
-          return new Err(
-            new MCPError(
-              "You do not have permission to edit this Pod's default agent",
-              { tracked: false }
-            )
-          );
-        }
-
-        // Resolve the agent by name. A null agentName clears the default so new
-        // conversations fall back to the workspace default (Dust).
-        let defaultAgentId: string | null = null;
-        let defaultAgentName: string | null = null;
-        if (agentName !== null) {
-          const resolvedAgentId = await resolveAgentConfigurationIdByName(
-            auth,
-            agentName
-          );
-          if (!resolvedAgentId) {
-            return new Err(
-              new MCPError(`No agent found matching "${agentName}".`, {
-                tracked: false,
-              })
-            );
-          }
-          const agent = await getAgentConfiguration(auth, {
-            agentId: resolvedAgentId,
-            variant: "extra_light",
-          });
-          if (!agent) {
-            return new Err(
-              new MCPError(`No agent found matching "${agentName}".`, {
-                tracked: false,
-              })
-            );
-          }
-          defaultAgentId = resolvedAgentId;
-          defaultAgentName = agent.name;
-        }
-
-        let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-        if (!metadata) {
-          metadata = await ProjectMetadataResource.makeNew(auth, pod, {
-            defaultAgentId,
-          });
-        } else {
-          await metadata.updateDefaultAgentId(defaultAgentId);
-        }
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            defaultAgentId,
-            message: defaultAgentId
-              ? `Pod default agent set to ${
-                  defaultAgentName ? `@${defaultAgentName}` : defaultAgentId
-                }.`
-              : "Pod default agent reset to the default (Dust).",
-          })
-        );
-      }, "Failed to set Pod default agent");
-    },
-
-    [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-
-        if (!pod.canAdministrate(auth)) {
-          return new Err(
-            new MCPError("You do not have permission to update Pod members", {
+            new MCPError(`No agent found matching "${agentName}".`, {
               tracked: false,
             })
           );
         }
-
-        const membersToAdd = params.membersToAdd ?? {};
-        const membersToRemove = params.membersToRemove ?? [];
-        const { editorIds: addEditorIds, memberIds: addMemberIds } =
-          partitionMembersToAdd(membersToAdd);
-
-        if (
-          addMemberIds.length === 0 &&
-          membersToRemove.length === 0 &&
-          addEditorIds.length === 0
-        ) {
-          return new Err(
-            new MCPError(
-              "At least one of membersToAdd or membersToRemove must be provided",
-              { tracked: false }
-            )
-          );
-        }
-
-        const roleByUserSId = await resolvePodUserRolesBySId(auth, pod);
-        const { editorIds: removeEditorIds, memberIds: removeMemberIds } =
-          partitionMembersToRemove(membersToRemove, roleByUserSId);
-
-        const addedMembers: string[] = [];
-        const removedMembers: string[] = [];
-        const addedEditors: string[] = [];
-        const removedEditors: string[] = [];
-
-        if (addEditorIds.length > 0) {
-          const uniqueAddEditorIds = [...new Set(addEditorIds)];
-          const addEditorsRes = await pod.addEditors(auth, {
-            userIds: uniqueAddEditorIds,
-          });
-          if (addEditorsRes.isErr()) {
-            return new Err(
-              new MCPError(
-                `Failed to add editors: ${addEditorsRes.error.message}`,
-                { tracked: false }
-              )
-            );
-          }
-          addedEditors.push(...addEditorsRes.value.map((user) => user.sId));
-        }
-
-        if (removeEditorIds.length > 0) {
-          const uniqueRemoveEditorIds = [...new Set(removeEditorIds)];
-          const removeEditorsRes = await pod.removeEditors(auth, {
-            userIds: uniqueRemoveEditorIds,
-          });
-          if (removeEditorsRes.isErr()) {
-            return new Err(
-              new MCPError(
-                `Failed to remove editors: ${removeEditorsRes.error.message}`,
-                { tracked: false }
-              )
-            );
-          }
-          removedEditors.push(
-            ...removeEditorsRes.value.map((user) => user.sId)
-          );
-        }
-
-        if (addMemberIds.length > 0) {
-          const uniqueAddIds = [...new Set(addMemberIds)];
-          const addMembersRes = await pod.addMembers(auth, {
-            userIds: uniqueAddIds,
-          });
-          if (addMembersRes.isErr()) {
-            return new Err(
-              new MCPError(
-                `Failed to add members: ${addMembersRes.error.message}`,
-                { tracked: false }
-              )
-            );
-          }
-          addedMembers.push(...addMembersRes.value.map((user) => user.sId));
-          notifyPodMembersAdded(auth, {
-            pod: pod.toJSON(),
-            addedUserIds: addedMembers,
-          });
-        }
-
-        if (removeMemberIds.length > 0) {
-          const uniqueRemoveIds = [...new Set(removeMemberIds)];
-          const removeMembersRes = await pod.removeMembers(auth, {
-            userIds: uniqueRemoveIds,
-          });
-          if (removeMembersRes.isErr()) {
-            return new Err(
-              new MCPError(
-                `Failed to remove members: ${removeMembersRes.error.message}`,
-                { tracked: false }
-              )
-            );
-          }
-          removedMembers.push(
-            ...removeMembersRes.value.map((user) => user.sId)
-          );
-        }
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            addedMembers,
-            removedMembers,
-            addedEditors,
-            removedEditors,
-            message: [
-              "Pod members updated successfully.",
-              addedEditors.length > 0
-                ? ` Added editors: ${addedEditors.join(", ")}.`
-                : "",
-              removedEditors.length > 0
-                ? ` Removed editors: ${removedEditors.join(", ")}.`
-                : "",
-              addedMembers.length > 0
-                ? ` Added members: ${addedMembers.join(", ")}.`
-                : "",
-              removedMembers.length > 0
-                ? ` Removed members: ${removedMembers.join(", ")}.`
-                : "",
-            ].join(""),
-          })
-        );
-      }, "Failed to update Pod members");
-    },
-
-    get_information: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
+        const agent = await getAgentConfiguration(auth, {
+          agentId: resolvedAgentId,
+          variant: "extra_light",
         });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod: pod } = contextRes.value;
-        const owner = auth.getNonNullableWorkspace();
-
-        // Fetch project metadata
-        const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
-
-        // Linked content nodes (Company Data references) have no other discovery surface, so we
-        // surface them here. Pod files do (they live under `pod-{podId}/<rel>` scoped paths and are
-        // discovered through the `files` MCP server), so we only report a count plus a hint.
-        const attachments = await listProjectContextAttachments(auth, pod);
-        const contentNodes = attachments
-          .filter(isContentNodeAttachmentType)
-          .map((node) => ({
-            name: node.title,
-            nodeId: node.nodeId,
-            dataSourceViewId: node.nodeDataSourceViewId,
-          }));
-
-        const fsResult = await DustFileSystem.forPod(auth, pod);
-        if (fsResult.isErr()) {
+        if (!agent) {
           return new Err(
-            new MCPError("Failed to initialise file system for this Pod.", {
-              tracked: true,
+            new MCPError(`No agent found matching "${agentName}".`, {
+              tracked: false,
             })
           );
         }
-        const podFilesResult = await fsResult.value.list(
-          `${SCOPED_PREFIX_POD}${pod.sId}`
-        );
-        if (podFilesResult.isErr()) {
-          return new Err(
-            new MCPError("Failed to list Pod files.", { tracked: true })
-          );
-        }
-        const projectFileCount = podFilesResult.value.filter(
-          (e) => !e.isDirectory
-        ).length;
+        defaultAgentId = resolvedAgentId;
+        defaultAgentName = agent.name;
+      }
 
-        let defaultAgent: { id: string; name: string | null } | null = null;
-        if (metadata?.defaultAgentId) {
-          const agent = await getAgentConfiguration(auth, {
-            agentId: metadata.defaultAgentId,
-            variant: "extra_light",
-          });
-          defaultAgent = {
-            id: metadata.defaultAgentId,
-            name: agent?.name ?? null,
-          };
-        }
-
-        // Construct project URL
-        const projectPath = getPodRoute(owner.sId, pod.sId);
-        const projectUrl = `${config.getAppUrl()}${projectPath}`;
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            pod: {
-              id: pod.sId,
-              name: pod.name,
-              url: projectUrl,
-              access: pod.isOpen() ? "open" : "restricted",
-              description: metadata?.description ?? null,
-              pinnedFramePath: metadata?.pinnedFramePath ?? null,
-              defaultAgent,
-              contentNodes,
-              files: {
-                count: projectFileCount,
-                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: { type: "pod" }\` to enumerate.`,
-              },
-            },
-            message: "Successfully retrieved Pod information",
-          })
-        );
-      }, "Failed to get Pod information");
-    },
-    [LIST_MEMBERS_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
+      let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+      if (!metadata) {
+        metadata = await ProjectMetadataResource.makeNew(auth, pod, {
+          defaultAgentId,
         });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
+      } else {
+        await metadata.updateDefaultAgentId(defaultAgentId);
+      }
 
-        const { pod } = contextRes.value;
-        const { limit = 20, pageCursor } = params;
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          defaultAgentId,
+          message: defaultAgentId
+            ? `Pod default agent set to ${
+                defaultAgentName ? `@${defaultAgentName}` : defaultAgentId
+              }.`
+            : "Pod default agent reset to the default (Dust).",
+        })
+      );
+    }, "Failed to set Pod default agent");
+  },
 
-        const decodedPageOffset = pageCursor
-          ? Number.parseInt(pageCursor, 10)
-          : 0;
-        const pageOffset =
-          Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
-            ? decodedPageOffset
-            : null;
+  [UPDATE_MEMBERS_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
 
-        if (pageOffset === null) {
-          return new Err(
-            new MCPError(
-              "Invalid pageCursor. Expected an offset cursor from a previous list_members response.",
-              { tracked: false }
-            )
-          );
-        }
+      const { pod } = contextRes.value;
 
-        const { groupsToProcess, allGroupMemberships } =
-          await pod.fetchManualGroupsMemberships(auth, {
-            shouldIncludeAllMembers: true,
-          });
-
-        const groupById = new Map(
-          groupsToProcess.map((group) => [group.id, group] as const)
-        );
-        const membershipByUserId = new Map<
-          number,
-          {
-            isEditor: boolean;
-            isActive: boolean;
-            joinedAtMs: number;
-          }
-        >();
-
-        for (const membership of allGroupMemberships) {
-          const group = groupById.get(membership.groupId);
-          if (!group) {
-            continue;
-          }
-
-          const previous = membershipByUserId.get(membership.userId);
-          membershipByUserId.set(membership.userId, {
-            isEditor:
-              Boolean(previous?.isEditor) || group.kind === "space_editors",
-            isActive:
-              Boolean(previous?.isActive) || membership.status === "active",
-            joinedAtMs: Math.min(
-              previous?.joinedAtMs ?? Number.POSITIVE_INFINITY,
-              membership.startAt.getTime()
-            ),
-          });
-        }
-
-        const users = await UserResource.fetchByModelIds([
-          ...membershipByUserId.keys(),
-        ]);
-        const userByModelId = new Map(
-          users.map((user) => [user.id, user] as const)
-        );
-
-        const members = [...membershipByUserId.entries()]
-          .map(([userModelId, membershipInfo]) => {
-            const user = userByModelId.get(userModelId);
-            if (!user) {
-              return null;
-            }
-
-            return {
-              id: user.sId,
-              name: user.fullName(),
-              email: user.email,
-              role: membershipInfo.isEditor ? "editor" : "member",
-              status: membershipInfo.isActive ? "active" : "suspended",
-              joinedAt: new Date(membershipInfo.joinedAtMs).toISOString(),
-            };
+      if (!pod.canAdministrate(auth)) {
+        return new Err(
+          new MCPError("You do not have permission to update Pod members", {
+            tracked: false,
           })
-          .filter(
-            (member): member is NonNullable<typeof member> => member !== null
+        );
+      }
+
+      const membersToAdd = params.membersToAdd ?? {};
+      const membersToRemove = params.membersToRemove ?? [];
+      const { editorIds: addEditorIds, memberIds: addMemberIds } =
+        partitionMembersToAdd(membersToAdd);
+
+      if (
+        addMemberIds.length === 0 &&
+        membersToRemove.length === 0 &&
+        addEditorIds.length === 0
+      ) {
+        return new Err(
+          new MCPError(
+            "At least one of membersToAdd or membersToRemove must be provided",
+            { tracked: false }
           )
-          .sort((a, b) => {
-            if (a.name !== b.name) {
-              return a.name.localeCompare(b.name, undefined, {
-                sensitivity: "base",
-              });
-            }
-            return a.id.localeCompare(b.id);
-          });
-
-        if (members.length === 0) {
-          return new Ok(
-            makeSuccessResponse({
-              success: true,
-              count: 0,
-              hasMore: false,
-              nextPageCursor: null,
-              members: [],
-              message: `No members found in Pod "${pod.name}".`,
-            })
-          );
-        }
-
-        const pageMembers = members.slice(pageOffset, pageOffset + limit);
-        const nextOffset = pageOffset + pageMembers.length;
-        const hasMore = nextOffset < members.length;
-        const nextPageCursor = hasMore ? String(nextOffset) : null;
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            count: pageMembers.length,
-            total: members.length,
-            hasMore,
-            nextPageCursor,
-            members: pageMembers,
-            message: `Found ${pageMembers.length} member(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch more members." : ""}.`,
-          })
         );
-      }, "Failed to list Pod members");
-    },
-    list_pods: async (params) => {
-      return withErrorHandling(async () => {
-        const owner = auth.getNonNullableWorkspace();
-        const workspaceSId = owner.sId;
-        const { access = "member", q, limit = 20, pageCursor } = params;
+      }
 
-        const decodedPageOffset = pageCursor
-          ? Number.parseInt(pageCursor, 10)
-          : 0;
-        const pageOffset =
-          Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
-            ? decodedPageOffset
-            : null;
+      const roleByUserSId = await resolvePodUserRolesBySId(auth, pod);
+      const { editorIds: removeEditorIds, memberIds: removeMemberIds } =
+        partitionMembersToRemove(membersToRemove, roleByUserSId);
 
-        if (pageOffset === null) {
+      const addedMembers: string[] = [];
+      const removedMembers: string[] = [];
+      const addedEditors: string[] = [];
+      const removedEditors: string[] = [];
+
+      if (addEditorIds.length > 0) {
+        const uniqueAddEditorIds = [...new Set(addEditorIds)];
+        const addEditorsRes = await pod.addEditors(auth, {
+          userIds: uniqueAddEditorIds,
+        });
+        if (addEditorsRes.isErr()) {
           return new Err(
             new MCPError(
-              "Invalid pageCursor. Expected an offset cursor from a previous list_pods response.",
+              `Failed to add editors: ${addEditorsRes.error.message}`,
               { tracked: false }
             )
           );
         }
+        addedEditors.push(...addEditorsRes.value.map((user) => user.sId));
+      }
 
-        const {
-          pods: pagePods,
-          total,
-          hasMore,
-        } = await listPodsForScope(auth, {
-          access,
-          q,
-          pagination: { limit, pageOffset },
+      if (removeEditorIds.length > 0) {
+        const uniqueRemoveEditorIds = [...new Set(removeEditorIds)];
+        const removeEditorsRes = await pod.removeEditors(auth, {
+          userIds: uniqueRemoveEditorIds,
         });
-
-        if (total === 0) {
-          let emptyMessage: string;
-          switch (access) {
-            case "open":
-              emptyMessage = q?.trim()
-                ? `No open Pods found matching "${q.trim()}".`
-                : "No non-archived open Pods found in this workspace.";
-              break;
-            case "member":
-              emptyMessage = q?.trim()
-                ? `No Pods found matching "${q.trim()}" where you are a member.`
-                : "No non-archived Pods found where you are a space member.";
-              break;
-            default:
-              assertNever(access);
-          }
-
-          return new Ok(
-            makeSuccessResponse({
-              success: true,
-              count: 0,
-              total: 0,
-              hasMore: false,
-              nextPageCursor: null,
-              pods: [],
-              message: emptyMessage,
-            })
+        if (removeEditorsRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to remove editors: ${removeEditorsRes.error.message}`,
+              { tracked: false }
+            )
           );
         }
+        removedEditors.push(...removeEditorsRes.value.map((user) => user.sId));
+      }
 
-        const nextPageCursor = hasMore
-          ? String(pageOffset + pagePods.length)
-          : null;
+      if (addMemberIds.length > 0) {
+        const uniqueAddIds = [...new Set(addMemberIds)];
+        const addMembersRes = await pod.addMembers(auth, {
+          userIds: uniqueAddIds,
+        });
+        if (addMembersRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to add members: ${addMembersRes.error.message}`,
+              { tracked: false }
+            )
+          );
+        }
+        addedMembers.push(...addMembersRes.value.map((user) => user.sId));
+        notifyPodMembersAdded(auth, {
+          pod: pod.toJSON(),
+          addedUserIds: addedMembers,
+        });
+      }
 
-        const pods = pagePods.map((pod) => ({
-          id: pod.sId,
-          name: pod.name,
-          dustPod: {
-            uri: makePodConfigurationURI(workspaceSId, pod.sId),
-            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
-          },
+      if (removeMemberIds.length > 0) {
+        const uniqueRemoveIds = [...new Set(removeMemberIds)];
+        const removeMembersRes = await pod.removeMembers(auth, {
+          userIds: uniqueRemoveIds,
+        });
+        if (removeMembersRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to remove members: ${removeMembersRes.error.message}`,
+              { tracked: false }
+            )
+          );
+        }
+        removedMembers.push(...removeMembersRes.value.map((user) => user.sId));
+      }
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          addedMembers,
+          removedMembers,
+          addedEditors,
+          removedEditors,
+          message: [
+            "Pod members updated successfully.",
+            addedEditors.length > 0
+              ? ` Added editors: ${addedEditors.join(", ")}.`
+              : "",
+            removedEditors.length > 0
+              ? ` Removed editors: ${removedEditors.join(", ")}.`
+              : "",
+            addedMembers.length > 0
+              ? ` Added members: ${addedMembers.join(", ")}.`
+              : "",
+            removedMembers.length > 0
+              ? ` Removed members: ${removedMembers.join(", ")}.`
+              : "",
+          ].join(""),
+        })
+      );
+    }, "Failed to update Pod members");
+  },
+
+  get_information: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod: pod } = contextRes.value;
+      const owner = auth.getNonNullableWorkspace();
+
+      // Fetch project metadata
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+
+      // Linked content nodes (Company Data references) have no other discovery surface, so we
+      // surface them here. Pod files do (they live under `pod-{podId}/<rel>` scoped paths and are
+      // discovered through the `files` MCP server), so we only report a count plus a hint.
+      const attachments = await listProjectContextAttachments(auth, pod);
+      const contentNodes = attachments
+        .filter(isContentNodeAttachmentType)
+        .map((node) => ({
+          name: node.title,
+          nodeId: node.nodeId,
+          dataSourceViewId: node.nodeDataSourceViewId,
         }));
 
-        let accessLabel: string;
+      const fsResult = await DustFileSystem.forPod(auth, pod);
+      if (fsResult.isErr()) {
+        return new Err(
+          new MCPError("Failed to initialise file system for this Pod.", {
+            tracked: true,
+          })
+        );
+      }
+      const podFilesResult = await fsResult.value.list(
+        `${SCOPED_PREFIX_POD}${pod.sId}`
+      );
+      if (podFilesResult.isErr()) {
+        return new Err(
+          new MCPError("Failed to list Pod files.", { tracked: true })
+        );
+      }
+      const projectFileCount = podFilesResult.value.filter(
+        (e) => !e.isDirectory
+      ).length;
+
+      let defaultAgent: { id: string; name: string | null } | null = null;
+      if (metadata?.defaultAgentId) {
+        const agent = await getAgentConfiguration(auth, {
+          agentId: metadata.defaultAgentId,
+          variant: "extra_light",
+        });
+        defaultAgent = {
+          id: metadata.defaultAgentId,
+          name: agent?.name ?? null,
+        };
+      }
+
+      // Construct project URL
+      const projectPath = getPodRoute(owner.sId, pod.sId);
+      const projectUrl = `${config.getAppUrl()}${projectPath}`;
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          pod: {
+            id: pod.sId,
+            name: pod.name,
+            url: projectUrl,
+            access: pod.isOpen() ? "open" : "restricted",
+            description: metadata?.description ?? null,
+            pinnedFramePath: metadata?.pinnedFramePath ?? null,
+            defaultAgent,
+            contentNodes,
+            files: {
+              count: projectFileCount,
+              hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: { type: "pod" }\` to enumerate.`,
+            },
+          },
+          message: "Successfully retrieved Pod information",
+        })
+      );
+    }, "Failed to get Pod information");
+  },
+  [LIST_MEMBERS_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const { limit = 20, pageCursor } = params;
+
+      const decodedPageOffset = pageCursor
+        ? Number.parseInt(pageCursor, 10)
+        : 0;
+      const pageOffset =
+        Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
+          ? decodedPageOffset
+          : null;
+
+      if (pageOffset === null) {
+        return new Err(
+          new MCPError(
+            "Invalid pageCursor. Expected an offset cursor from a previous list_members response.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const { groupsToProcess, allGroupMemberships } =
+        await pod.fetchManualGroupsMemberships(auth, {
+          shouldIncludeAllMembers: true,
+        });
+
+      const groupById = new Map(
+        groupsToProcess.map((group) => [group.id, group] as const)
+      );
+      const membershipByUserId = new Map<
+        number,
+        {
+          isEditor: boolean;
+          isActive: boolean;
+          joinedAtMs: number;
+        }
+      >();
+
+      for (const membership of allGroupMemberships) {
+        const group = groupById.get(membership.groupId);
+        if (!group) {
+          continue;
+        }
+
+        const previous = membershipByUserId.get(membership.userId);
+        membershipByUserId.set(membership.userId, {
+          isEditor:
+            Boolean(previous?.isEditor) || group.kind === "space_editors",
+          isActive:
+            Boolean(previous?.isActive) || membership.status === "active",
+          joinedAtMs: Math.min(
+            previous?.joinedAtMs ?? Number.POSITIVE_INFINITY,
+            membership.startAt.getTime()
+          ),
+        });
+      }
+
+      const users = await UserResource.fetchByModelIds([
+        ...membershipByUserId.keys(),
+      ]);
+      const userByModelId = new Map(
+        users.map((user) => [user.id, user] as const)
+      );
+
+      const members = [...membershipByUserId.entries()]
+        .map(([userModelId, membershipInfo]) => {
+          const user = userByModelId.get(userModelId);
+          if (!user) {
+            return null;
+          }
+
+          return {
+            id: user.sId,
+            name: user.fullName(),
+            email: user.email,
+            role: membershipInfo.isEditor ? "editor" : "member",
+            status: membershipInfo.isActive ? "active" : "suspended",
+            joinedAt: new Date(membershipInfo.joinedAtMs).toISOString(),
+          };
+        })
+        .filter(
+          (member): member is NonNullable<typeof member> => member !== null
+        )
+        .sort((a, b) => {
+          if (a.name !== b.name) {
+            return a.name.localeCompare(b.name, undefined, {
+              sensitivity: "base",
+            });
+          }
+          return a.id.localeCompare(b.id);
+        });
+
+      if (members.length === 0) {
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            count: 0,
+            hasMore: false,
+            nextPageCursor: null,
+            members: [],
+            message: `No members found in Pod "${pod.name}".`,
+          })
+        );
+      }
+
+      const pageMembers = members.slice(pageOffset, pageOffset + limit);
+      const nextOffset = pageOffset + pageMembers.length;
+      const hasMore = nextOffset < members.length;
+      const nextPageCursor = hasMore ? String(nextOffset) : null;
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          count: pageMembers.length,
+          total: members.length,
+          hasMore,
+          nextPageCursor,
+          members: pageMembers,
+          message: `Found ${pageMembers.length} member(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch more members." : ""}.`,
+        })
+      );
+    }, "Failed to list Pod members");
+  },
+  list_pods: async (params, { auth }) => {
+    return withErrorHandling(async () => {
+      const owner = auth.getNonNullableWorkspace();
+      const workspaceSId = owner.sId;
+      const { access = "member", q, limit = 20, pageCursor } = params;
+
+      const decodedPageOffset = pageCursor
+        ? Number.parseInt(pageCursor, 10)
+        : 0;
+      const pageOffset =
+        Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
+          ? decodedPageOffset
+          : null;
+
+      if (pageOffset === null) {
+        return new Err(
+          new MCPError(
+            "Invalid pageCursor. Expected an offset cursor from a previous list_pods response.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const {
+        pods: pagePods,
+        total,
+        hasMore,
+      } = await listPodsForScope(auth, {
+        access,
+        q,
+        pagination: { limit, pageOffset },
+      });
+
+      if (total === 0) {
+        let emptyMessage: string;
         switch (access) {
           case "open":
-            accessLabel = "open Pod(s)";
+            emptyMessage = q?.trim()
+              ? `No open Pods found matching "${q.trim()}".`
+              : "No non-archived open Pods found in this workspace.";
             break;
           case "member":
-            accessLabel = "Pod(s) you are a member of";
+            emptyMessage = q?.trim()
+              ? `No Pods found matching "${q.trim()}" where you are a member.`
+              : "No non-archived Pods found where you are a space member.";
             break;
           default:
             assertNever(access);
         }
-        const filterLabel = q?.trim() ? ` matching "${q.trim()}"` : "";
 
         return new Ok(
           makeSuccessResponse({
             success: true,
-            count: pods.length,
-            total,
-            hasMore,
-            nextPageCursor,
-            pods,
-            message:
-              `Found ${pods.length} of ${total} ${accessLabel}${filterLabel}.` +
-              (hasMore
-                ? " Pass nextPageCursor to fetch more Pods."
-                : " Use each entry's dustPod as the dustPod argument for other pod_manager tools."),
+            count: 0,
+            total: 0,
+            hasMore: false,
+            nextPageCursor: null,
+            pods: [],
+            message: emptyMessage,
           })
         );
-      }, "Failed to list Pods");
-    },
-    create_pod: async (params) => {
-      return withErrorHandling(async () => {
-        const owner = auth.getNonNullableWorkspace();
+      }
 
-        if (params.access === "open" && !areOpenPodsAllowed(owner)) {
-          return new Err(
-            new MCPError(
-              "Open Pods are disabled by your workspace admin. Create a restricted Pod instead.",
-              { tracked: false }
-            )
-          );
-        }
+      const nextPageCursor = hasMore
+        ? String(pageOffset + pagePods.length)
+        : null;
 
-        const createSpaceRes = await createSpaceAndGroup(auth, {
-          name: params.title,
-          isRestricted: params.access !== "open",
-          spaceKind: "project",
-          managementMode: "manual",
-          memberIds: [],
-        });
+      const pods = pagePods.map((pod) => ({
+        id: pod.sId,
+        name: pod.name,
+        dustPod: {
+          uri: makePodConfigurationURI(workspaceSId, pod.sId),
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+        },
+      }));
 
-        if (createSpaceRes.isErr()) {
-          const error = createSpaceRes.error;
-          switch (error.code) {
-            case "limit_reached":
-              return new Err(
-                new MCPError(
-                  "Pod creation limit reached for this workspace plan.",
-                  { tracked: false }
-                )
-              );
-            case "space_already_exists":
-              return new Err(
-                new MCPError("A Pod with this title already exists.", {
-                  tracked: false,
-                })
-              );
-            case "unauthorized":
-              return new Err(
-                new MCPError("You do not have permission to create a Pod.", {
-                  tracked: false,
-                })
-              );
-            case "internal_error":
-              return new Err(
-                new MCPError(error.message, {
-                  tracked: false,
-                })
-              );
-            default:
-              return new Err(
-                new MCPError(error.message, {
-                  tracked: false,
-                })
-              );
-          }
-        }
+      let accessLabel: string;
+      switch (access) {
+        case "open":
+          accessLabel = "open Pod(s)";
+          break;
+        case "member":
+          accessLabel = "Pod(s) you are a member of";
+          break;
+        default:
+          assertNever(access);
+      }
+      const filterLabel = q?.trim() ? ` matching "${q.trim()}"` : "";
 
-        // createSpaceAndGroup grants the creator editor access via a new group
-        // membership. Refresh auth so this tool can administrate the Pod immediately
-        // (e.g. addMembers, seedInitialTasks) and later tools see the membership.
-        await auth.refresh();
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          count: pods.length,
+          total,
+          hasMore,
+          nextPageCursor,
+          pods,
+          message:
+            `Found ${pods.length} of ${total} ${accessLabel}${filterLabel}.` +
+            (hasMore
+              ? " Pass nextPageCursor to fetch more Pods."
+              : " Use each entry's dustPod as the dustPod argument for other pod_manager tools."),
+        })
+      );
+    }, "Failed to list Pods");
+  },
+  create_pod: async (params, { auth }) => {
+    return withErrorHandling(async () => {
+      const owner = auth.getNonNullableWorkspace();
 
-        const pod = await SpaceResource.fetchById(
-          auth,
-          createSpaceRes.value.sId
-        );
-        if (!pod) {
-          return new Err(
-            new MCPError("Pod created but could not be retrieved.", {
-              tracked: false,
-            })
-          );
-        }
-
-        if (params.description) {
-          const metadata = await ProjectMetadataResource.fetchBySpace(
-            auth,
-            pod
-          );
-          if (metadata) {
-            await metadata.updateDescription(params.description);
-          } else {
-            await ProjectMetadataResource.makeNew(auth, pod, {
-              description: params.description,
-            });
-          }
-        }
-
-        const creatorId = auth.getNonNullableUser().sId;
-        const membersToAdd = Object.fromEntries(
-          Object.entries(params.membersToAdd ?? {}).filter(
-            ([userId]) => userId !== creatorId
+      if (params.access === "open" && !areOpenPodsAllowed(owner)) {
+        return new Err(
+          new MCPError(
+            "Open Pods are disabled by your workspace admin. Create a restricted Pod instead.",
+            { tracked: false }
           )
         );
-        const { editorIds: additionalEditorIds, memberIds } =
-          partitionMembersToAdd(membersToAdd);
+      }
 
-        if (additionalEditorIds.length > 0) {
-          const addEditorsRes = await pod.addEditors(auth, {
-            userIds: additionalEditorIds,
-          });
-          if (addEditorsRes.isErr()) {
+      const createSpaceRes = await createSpaceAndGroup(auth, {
+        name: params.title,
+        isRestricted: params.access !== "open",
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      if (createSpaceRes.isErr()) {
+        const error = createSpaceRes.error;
+        switch (error.code) {
+          case "limit_reached":
             return new Err(
               new MCPError(
-                `Pod created but failed to add some editors: ${addEditorsRes.error.message}`,
+                "Pod creation limit reached for this workspace plan.",
                 { tracked: false }
               )
             );
-          }
-        }
-
-        if (memberIds.length > 0) {
-          const addMembersRes = await pod.addMembers(auth, {
-            userIds: memberIds,
-          });
-          if (addMembersRes.isErr()) {
+          case "space_already_exists":
             return new Err(
-              new MCPError(
-                `Pod created but failed to add some members: ${addMembersRes.error.message}`,
-                { tracked: false }
-              )
-            );
-          }
-        }
-
-        if (params.seedInitialTasks) {
-          const seedResult = await seedInitialPodTasks(auth, pod);
-          if (
-            seedResult.isErr() &&
-            seedResult.error.code === "internal_error"
-          ) {
-            return new Err(
-              new MCPError("Pod created but failed to seed initial tasks.", {
+              new MCPError("A Pod with this title already exists.", {
                 tracked: false,
               })
             );
-          }
-        }
-
-        const projectUrl = `${config.getAppUrl()}${getPodRoute(
-          owner.sId,
-          pod.sId
-        )}`;
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            pod: {
-              id: pod.sId,
-              title: pod.name,
-              access: pod.isOpen() ? "open" : "restricted",
-              dustPod: {
-                uri: makePodConfigurationURI(owner.sId, pod.sId),
-                mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
-              },
-              url: projectUrl,
-            },
-            message: `Pod "${pod.name}" created successfully.`,
-          })
-        );
-      }, "Failed to create Pod");
-    },
-
-    retrieve_recent_documents: async (params) => {
-      return withErrorHandling(async () => {
-        if (!toolContext) {
-          return new Err(
-            new MCPError("No conversation context available", {
-              tracked: false,
-            })
-          );
-        }
-
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-        const dataSources = await buildProjectRetrieveDataSources(auth, {
-          space: pod,
-          onlyGroupConversationsAndConnectedData: false,
-        });
-
-        if (dataSources.length === 0) {
-          return new Err(
-            new MCPError(
-              "No Pod data source or Pod content nodes available to retrieve from.",
-              { tracked: false }
-            )
-          );
-        }
-
-        if (!toolContext?.runContext) {
-          throw new Error(
-            "agentLoopRunContext is required where the tool is called"
-          );
-        }
-
-        const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
-          toolContext.runContext
-        )
-          ? toolContext.runContext.stepContext
-          : {
-              retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K,
-              citationsOffset: 0,
-            };
-
-        return runIncludeDataRetrieval(auth, {
-          timeFrame: params.timeFrame,
-          dataSources,
-          nodeIds: params.nodeIds,
-          citationsOffset,
-          retrievalTopK,
-        });
-      }, "Failed to retrieve recent Pod documents");
-    },
-
-    [SEMANTIC_SEARCH_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        if (!toolContext?.runContext) {
-          return new Err(
-            new MCPError("No conversation context available", {
-              tracked: false,
-            })
-          );
-        }
-
-        const scope = params.searchScope ?? "all";
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-        const dataSources = await buildPodSearchDataSources(auth, pod, scope);
-
-        if (dataSources.length === 0) {
-          return new Err(
-            new MCPError(
-              scope === "conversations"
-                ? "No Pod data source available to search conversations, or the Pod connector is not linked (required to scope transcript documents)."
-                : "No Pod data sources available to search for this scope.",
-              { tracked: false }
-            )
-          );
-        }
-
-        return searchFunction(auth, {
-          query: params.query,
-          relativeTimeFrame: params.relativeTimeFrame ?? "all",
-          dataSources,
-          nodeIds: params.nodeIds,
-          toolContext,
-        });
-      }, "Failed to search Pod");
-    },
-
-    create_conversation: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getWritablePodContext(auth, {
-          toolContext,
-          dustPod: params.dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-        const user = auth.user();
-        const owner = auth.getNonNullableWorkspace();
-
-        // Get origin and timezone from the current conversation
-        let origin: UserMessageOrigin = "web";
-        let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-        if (isAgentLoopRunContext(toolContext?.runContext)) {
-          const userMessage = toolContext.runContext.conversation.content
-            .flat()
-            .findLast(isUserMessageType);
-          if (userMessage?.context) {
-            origin = userMessage.context.origin ?? origin;
-            timezone = userMessage.context.timezone ?? timezone;
-          }
-        }
-        if (isSandboxFunctionRunContext(toolContext?.runContext)) {
-          timezone =
-            toolContext.runContext.invocation.context?.timezone ?? timezone;
-        }
-
-        // Get agent configuration name & profile picture URL
-        const agentName = isAgentLoopRunContext(toolContext?.runContext)
-          ? toolContext.runContext.agentConfiguration.name
-          : "Agent";
-
-        const agentProfilePictureUrl = isAgentLoopRunContext(
-          toolContext?.runContext
-        )
-          ? toolContext.runContext.agentConfiguration.pictureUrl
-          : null;
-
-        let mentions: { configurationId: string }[] = [];
-        if (params.agentName) {
-          const matchedAgentId = await resolveAgentConfigurationIdByName(
-            auth,
-            params.agentName
-          );
-          if (!matchedAgentId) {
+          case "unauthorized":
             return new Err(
-              new MCPError(
-                `No agent found matching name: "${params.agentName}"`,
-                { tracked: false }
-              )
+              new MCPError("You do not have permission to create a Pod.", {
+                tracked: false,
+              })
             );
-          }
-          mentions = [{ configurationId: matchedAgentId }];
+          case "internal_error":
+            return new Err(
+              new MCPError(error.message, {
+                tracked: false,
+              })
+            );
+          default:
+            return new Err(
+              new MCPError(error.message, {
+                tracked: false,
+              })
+            );
         }
+      }
 
-        // Create conversation in the project space
-        const conversationResource = await createConversation(auth, {
-          title: params.title,
-          visibility: "unlisted",
-          spaceId: pod.id,
+      // createSpaceAndGroup grants the creator editor access via a new group
+      // membership. Refresh auth so this tool can administrate the Pod immediately
+      // (e.g. addMembers, seedInitialTasks) and later tools see the membership.
+      await auth.refresh();
+
+      const pod = await SpaceResource.fetchById(auth, createSpaceRes.value.sId);
+      if (!pod) {
+        return new Err(
+          new MCPError("Pod created but could not be retrieved.", {
+            tracked: false,
+          })
+        );
+      }
+
+      if (params.description) {
+        const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+        if (metadata) {
+          await metadata.updateDescription(params.description);
+        } else {
+          await ProjectMetadataResource.makeNew(auth, pod, {
+            description: params.description,
+          });
+        }
+      }
+
+      const creatorId = auth.getNonNullableUser().sId;
+      const membersToAdd = Object.fromEntries(
+        Object.entries(params.membersToAdd ?? {}).filter(
+          ([userId]) => userId !== creatorId
+        )
+      );
+      const { editorIds: additionalEditorIds, memberIds } =
+        partitionMembersToAdd(membersToAdd);
+
+      if (additionalEditorIds.length > 0) {
+        const addEditorsRes = await pod.addEditors(auth, {
+          userIds: additionalEditorIds,
         });
-
-        // Post user message
-        const messageRes = await postUserMessage(auth, {
-          conversationResource,
-          content: params.message,
-          mentions,
-          context: {
-            username: agentName,
-            fullName: user
-              ? `@${agentName} on behalf of ${user.fullName()}`
-              : `@${agentName}`,
-            email: null,
-            profilePictureUrl: agentProfilePictureUrl,
-            timezone,
-            origin,
-            clientSideMCPServerIds: [],
-            selectedMCPServerViewIds: [],
-            lastTriggerRunAt: null,
-          },
-          skipToolsValidation: false,
-          doNotAssociateUser: true,
-          skipDustAutoMention: true,
-        });
-
-        if (messageRes.isErr()) {
+        if (addEditorsRes.isErr()) {
           return new Err(
             new MCPError(
-              `Failed to post message: ${messageRes.error.api_error.message}`,
+              `Pod created but failed to add some editors: ${addEditorsRes.error.message}`,
               { tracked: false }
             )
           );
         }
+      }
 
-        const conversationUrl = getConversationRoute(
-          owner.sId,
-          conversationResource.sId,
-          undefined,
-          config.getAppUrl()
-        );
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            conversationId: conversationResource.sId,
-            conversationUrl,
-            userMessageId: messageRes.value.userMessage.sId,
-            message: `Conversation created successfully in Pod "${pod.name}"`,
-          })
-        );
-      }, "Failed to create conversation");
-    },
-
-    list_conversations: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod: params.dustPod,
+      if (memberIds.length > 0) {
+        const addMembersRes = await pod.addMembers(auth, {
+          userIds: memberIds,
         });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { pod } = contextRes.value;
-        const {
-          unreadOnly = false,
-          limit = 20,
-          pageCursor,
-          includeMessages = false,
-        } = params;
-
-        const updatedSinceMs =
-          params.updatedSince ??
-          Date.now() - LIST_CONVERSATIONS_DEFAULT_LOOKBACK_MS;
-
-        const listOptions = {
-          updatedSince: updatedSinceMs,
-          excludeTest: true,
-        };
-
-        if (!unreadOnly) {
-          const {
-            conversations: resourcePage,
-            hasMore,
-            lastValue,
-          } = await ConversationResource.listConversationsInSpacePaginated(
-            auth,
-            {
-              spaceId: pod.sId,
-              options: listOptions,
-              pagination: {
-                limit,
-                lastValue: pageCursor,
-              },
-            }
+        if (addMembersRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Pod created but failed to add some members: ${addMembersRes.error.message}`,
+              { tracked: false }
+            )
           );
+        }
+      }
 
-          if (resourcePage.length === 0) {
-            return new Ok([
-              {
-                type: "text" as const,
-                text: `No conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
-              },
-            ]);
-          }
-
-          const owner = auth.getNonNullableWorkspace();
-          let conversationsPayload: unknown[];
-
-          if (includeMessages) {
-            const conversationResults = await concurrentExecutor(
-              resourcePage,
-              // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
-              async (c) => getLightConversation(auth, c.sId, false),
-              { concurrency: 10 }
-            );
-            const conversationsForDisplay = conversationResults
-              .filter((r) => r.isOk())
-              .map((r) => r.value);
-            conversationsPayload = formatConversationsForDisplay(
-              conversationsForDisplay,
-              owner.sId
-            );
-          } else {
-            conversationsPayload = resourcePage.map((c) =>
-              formatListedConversationWithoutMessages(c, owner.sId)
-            );
-          }
-
-          const nextPageCursor = hasMore && lastValue ? lastValue : null;
-          return new Ok(
-            makeSuccessResponse({
-              success: true,
-              count: conversationsPayload.length,
-              unreadOnly: false,
-              includeMessages,
-              updatedSince: updatedSinceMs,
-              hasMore,
-              nextPageCursor,
-              conversations: conversationsPayload,
-              message: `Found ${conversationsPayload.length} conversation(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch older updates in this window." : ""}.`,
+      if (params.seedInitialTasks) {
+        const seedResult = await seedInitialPodTasks(auth, pod);
+        if (seedResult.isErr() && seedResult.error.code === "internal_error") {
+          return new Err(
+            new MCPError("Pod created but failed to seed initial tasks.", {
+              tracked: false,
             })
           );
         }
+      }
 
-        const spaceConversations =
-          await ConversationResource.listConversationsInSpace(auth, {
-            spaceId: pod.sId,
-            options: listOptions,
-          });
+      const projectUrl = `${config.getAppUrl()}${getPodRoute(
+        owner.sId,
+        pod.sId
+      )}`;
 
-        const unreadResources = spaceConversations.filter(
-          (c) => c.toJSON().unread
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          pod: {
+            id: pod.sId,
+            title: pod.name,
+            access: pod.isOpen() ? "open" : "restricted",
+            dustPod: {
+              uri: makePodConfigurationURI(owner.sId, pod.sId),
+              mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+            },
+            url: projectUrl,
+          },
+          message: `Pod "${pod.name}" created successfully.`,
+        })
+      );
+    }, "Failed to create Pod");
+  },
+
+  retrieve_recent_documents: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      if (!toolContext) {
+        return new Err(
+          new MCPError("No conversation context available", {
+            tracked: false,
+          })
         );
-        const pageResources = unreadResources.slice(0, limit);
+      }
 
-        if (pageResources.length === 0) {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const dataSources = await buildProjectRetrieveDataSources(auth, {
+        space: pod,
+        onlyGroupConversationsAndConnectedData: false,
+      });
+
+      if (dataSources.length === 0) {
+        return new Err(
+          new MCPError(
+            "No Pod data source or Pod content nodes available to retrieve from.",
+            { tracked: false }
+          )
+        );
+      }
+
+      if (!toolContext?.runContext) {
+        throw new Error(
+          "agentLoopRunContext is required where the tool is called"
+        );
+      }
+
+      const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
+        toolContext.runContext
+      )
+        ? toolContext.runContext.stepContext
+        : {
+            retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K,
+            citationsOffset: 0,
+          };
+
+      return runIncludeDataRetrieval(auth, {
+        timeFrame: params.timeFrame,
+        dataSources,
+        nodeIds: params.nodeIds,
+        citationsOffset,
+        retrievalTopK,
+      });
+    }, "Failed to retrieve recent Pod documents");
+  },
+
+  [SEMANTIC_SEARCH_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      if (!toolContext?.runContext) {
+        return new Err(
+          new MCPError("No conversation context available", {
+            tracked: false,
+          })
+        );
+      }
+
+      const scope = params.searchScope ?? "all";
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const dataSources = await buildPodSearchDataSources(auth, pod, scope);
+
+      if (dataSources.length === 0) {
+        return new Err(
+          new MCPError(
+            scope === "conversations"
+              ? "No Pod data source available to search conversations, or the Pod connector is not linked (required to scope transcript documents)."
+              : "No Pod data sources available to search for this scope.",
+            { tracked: false }
+          )
+        );
+      }
+
+      return searchFunction(auth, {
+        query: params.query,
+        relativeTimeFrame: params.relativeTimeFrame ?? "all",
+        dataSources,
+        nodeIds: params.nodeIds,
+        toolContext,
+      });
+    }, "Failed to search Pod");
+  },
+
+  create_conversation: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getWritablePodContext(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const user = auth.user();
+      const owner = auth.getNonNullableWorkspace();
+
+      // Get origin and timezone from the current conversation
+      let origin: UserMessageOrigin = "web";
+      let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      if (isAgentLoopRunContext(toolContext?.runContext)) {
+        const userMessage = toolContext.runContext.conversation.content
+          .flat()
+          .findLast(isUserMessageType);
+        if (userMessage?.context) {
+          origin = userMessage.context.origin ?? origin;
+          timezone = userMessage.context.timezone ?? timezone;
+        }
+      }
+      if (isSandboxFunctionRunContext(toolContext?.runContext)) {
+        timezone =
+          toolContext.runContext.invocation.context?.timezone ?? timezone;
+      }
+
+      // Get agent configuration name & profile picture URL
+      const agentName = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.agentConfiguration.name
+        : "Agent";
+
+      const agentProfilePictureUrl = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext.runContext.agentConfiguration.pictureUrl
+        : null;
+
+      let mentions: { configurationId: string }[] = [];
+      if (params.agentName) {
+        const matchedAgentId = await resolveAgentConfigurationIdByName(
+          auth,
+          params.agentName
+        );
+        if (!matchedAgentId) {
+          return new Err(
+            new MCPError(
+              `No agent found matching name: "${params.agentName}"`,
+              { tracked: false }
+            )
+          );
+        }
+        mentions = [{ configurationId: matchedAgentId }];
+      }
+
+      // Create conversation in the project space
+      const conversationResource = await createConversation(auth, {
+        title: params.title,
+        visibility: "unlisted",
+        spaceId: pod.id,
+      });
+
+      // Post user message
+      const messageRes = await postUserMessage(auth, {
+        conversationResource,
+        content: params.message,
+        mentions,
+        context: {
+          username: agentName,
+          fullName: user
+            ? `@${agentName} on behalf of ${user.fullName()}`
+            : `@${agentName}`,
+          email: null,
+          profilePictureUrl: agentProfilePictureUrl,
+          timezone,
+          origin,
+          clientSideMCPServerIds: [],
+          selectedMCPServerViewIds: [],
+          lastTriggerRunAt: null,
+        },
+        skipToolsValidation: false,
+        doNotAssociateUser: true,
+        skipDustAutoMention: true,
+      });
+
+      if (messageRes.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to post message: ${messageRes.error.api_error.message}`,
+            { tracked: false }
+          )
+        );
+      }
+
+      const conversationUrl = getConversationRoute(
+        owner.sId,
+        conversationResource.sId,
+        undefined,
+        config.getAppUrl()
+      );
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          conversationId: conversationResource.sId,
+          conversationUrl,
+          userMessageId: messageRes.value.userMessage.sId,
+          message: `Conversation created successfully in Pod "${pod.name}"`,
+        })
+      );
+    }, "Failed to create conversation");
+  },
+
+  list_conversations: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const {
+        unreadOnly = false,
+        limit = 20,
+        pageCursor,
+        includeMessages = false,
+      } = params;
+
+      const updatedSinceMs =
+        params.updatedSince ??
+        Date.now() - LIST_CONVERSATIONS_DEFAULT_LOOKBACK_MS;
+
+      const listOptions = {
+        updatedSince: updatedSinceMs,
+        excludeTest: true,
+      };
+
+      if (!unreadOnly) {
+        const {
+          conversations: resourcePage,
+          hasMore,
+          lastValue,
+        } = await ConversationResource.listConversationsInSpacePaginated(auth, {
+          spaceId: pod.sId,
+          options: listOptions,
+          pagination: {
+            limit,
+            lastValue: pageCursor,
+          },
+        });
+
+        if (resourcePage.length === 0) {
           return new Ok([
             {
               type: "text" as const,
-              text: `No unread conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+              text: `No conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
             },
           ]);
         }
@@ -1458,42 +1386,292 @@ export function createProjectManagerTools(
 
         if (includeMessages) {
           const conversationResults = await concurrentExecutor(
-            pageResources,
+            resourcePage,
             // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
             async (c) => getLightConversation(auth, c.sId, false),
             { concurrency: 10 }
           );
-          const withContent = conversationResults
+          const conversationsForDisplay = conversationResults
             .filter((r) => r.isOk())
             .map((r) => r.value);
           conversationsPayload = formatConversationsForDisplay(
-            withContent,
+            conversationsForDisplay,
             owner.sId
           );
         } else {
-          conversationsPayload = pageResources.map((c) =>
+          conversationsPayload = resourcePage.map((c) =>
             formatListedConversationWithoutMessages(c, owner.sId)
           );
         }
 
+        const nextPageCursor = hasMore && lastValue ? lastValue : null;
         return new Ok(
           makeSuccessResponse({
             success: true,
-            count: pageResources.length,
-            total: unreadResources.length,
-            unreadOnly: true,
+            count: conversationsPayload.length,
+            unreadOnly: false,
             includeMessages,
             updatedSince: updatedSinceMs,
+            hasMore,
+            nextPageCursor,
             conversations: conversationsPayload,
-            message: `Found ${pageResources.length} unread conversation(s) in Pod "${pod.name}"${unreadResources.length > limit ? ` (showing first ${limit} of ${unreadResources.length})` : ""}.`,
+            message: `Found ${conversationsPayload.length} conversation(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch older updates in this window." : ""}.`,
           })
         );
-      }, "Failed to list Pod conversations");
-    },
+      }
 
-    add_message_to_conversation: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getWritablePodContext(auth, {
+      const spaceConversations =
+        await ConversationResource.listConversationsInSpace(auth, {
+          spaceId: pod.sId,
+          options: listOptions,
+        });
+
+      const unreadResources = spaceConversations.filter(
+        (c) => c.toJSON().unread
+      );
+      const pageResources = unreadResources.slice(0, limit);
+
+      if (pageResources.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `No unread conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+          },
+        ]);
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+      let conversationsPayload: unknown[];
+
+      if (includeMessages) {
+        const conversationResults = await concurrentExecutor(
+          pageResources,
+          // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
+          async (c) => getLightConversation(auth, c.sId, false),
+          { concurrency: 10 }
+        );
+        const withContent = conversationResults
+          .filter((r) => r.isOk())
+          .map((r) => r.value);
+        conversationsPayload = formatConversationsForDisplay(
+          withContent,
+          owner.sId
+        );
+      } else {
+        conversationsPayload = pageResources.map((c) =>
+          formatListedConversationWithoutMessages(c, owner.sId)
+        );
+      }
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          count: pageResources.length,
+          total: unreadResources.length,
+          unreadOnly: true,
+          includeMessages,
+          updatedSince: updatedSinceMs,
+          conversations: conversationsPayload,
+          message: `Found ${pageResources.length} unread conversation(s) in Pod "${pod.name}"${unreadResources.length > limit ? ` (showing first ${limit} of ${unreadResources.length})` : ""}.`,
+        })
+      );
+    }, "Failed to list Pod conversations");
+  },
+
+  add_message_to_conversation: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getWritablePodContext(auth, {
+        toolContext,
+        dustPod: params.dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      const user = auth.user();
+      const owner = auth.getNonNullableWorkspace();
+
+      const conversationId =
+        params.conversationId ??
+        (isAgentLoopRunContext(toolContext?.runContext)
+          ? toolContext.runContext.conversation.sId
+          : null);
+
+      if (!conversationId) {
+        return new Err(
+          new MCPError(
+            "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversationId
+      );
+      if (!conversationResource) {
+        return new Err(
+          new MCPError(`Conversation not found: ${conversationId}`, {
+            tracked: false,
+          })
+        );
+      }
+
+      const conversation = conversationResource.toJSON();
+
+      if (conversation.spaceId !== pod.sId) {
+        return new Err(
+          new MCPError("Conversation is not in this Pod", {
+            tracked: false,
+          })
+        );
+      }
+
+      let origin: UserMessageOrigin = "web";
+      let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      if (isAgentLoopRunContext(toolContext?.runContext)) {
+        const userMessage = toolContext.runContext.conversation.content
+          .flat()
+          .findLast(isUserMessageType);
+        if (userMessage?.context) {
+          origin = userMessage.context.origin ?? origin;
+          timezone = userMessage.context.timezone ?? timezone;
+        }
+      }
+
+      const agentName = isAgentLoopRunContext(toolContext?.runContext)
+        ? toolContext.runContext.agentConfiguration.name
+        : "Agent";
+
+      const agentProfilePictureUrl = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext.runContext.agentConfiguration.pictureUrl
+        : null;
+
+      let mentions: { configurationId: string }[] = [];
+      if (params.agentName) {
+        const matchedAgentId = await resolveAgentConfigurationIdByName(
+          auth,
+          params.agentName
+        );
+        if (!matchedAgentId) {
+          return new Err(
+            new MCPError(
+              `No agent found matching name: "${params.agentName}"`,
+              { tracked: false }
+            )
+          );
+        }
+        mentions = [{ configurationId: matchedAgentId }];
+      }
+
+      const messageRes = await postUserMessage(auth, {
+        conversationResource,
+        content: params.message,
+        mentions,
+        context: {
+          username: agentName,
+          fullName: user
+            ? `@${agentName} on behalf of ${user.fullName()}`
+            : `@${agentName}`,
+          email: null,
+          profilePictureUrl: agentProfilePictureUrl,
+          timezone,
+          origin,
+          clientSideMCPServerIds: [],
+          selectedMCPServerViewIds: [],
+          lastTriggerRunAt: null,
+        },
+        skipToolsValidation: false,
+        doNotAssociateUser: true,
+        skipDustAutoMention: true,
+      });
+
+      if (messageRes.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to post message: ${messageRes.error.api_error.message}`,
+            { tracked: false }
+          )
+        );
+      }
+
+      const conversationUrl = getConversationRoute(
+        owner.sId,
+        conversation.sId,
+        undefined,
+        config.getAppUrl()
+      );
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          conversationId: conversation.sId,
+          conversationUrl,
+          userMessageId: messageRes.value.userMessage.sId,
+          message: `Message posted to conversation in Pod "${pod.name}".`,
+        })
+      );
+    }, "Failed to add message to conversation");
+  },
+
+  [MOVE_CONVERSATION_TOOL_NAME]: async (params, { auth, runContext }) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const owner = auth.getNonNullableWorkspace();
+
+      const conversationId =
+        params.conversationId ??
+        (isAgentLoopRunContext(toolContext?.runContext)
+          ? toolContext.runContext.conversation.sId
+          : null);
+
+      if (!conversationId) {
+        return new Err(
+          new MCPError(
+            "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversationId
+      );
+
+      if (!conversationResource) {
+        return new Err(
+          new MCPError(`Conversation not found: ${conversationId}`, {
+            tracked: false,
+          })
+        );
+      }
+
+      const conversation = conversationResource.toJSON();
+
+      const conversationUrl = getConversationRoute(
+        owner.sId,
+        conversation.sId,
+        undefined,
+        config.getAppUrl()
+      );
+
+      if (params.destination === "pod") {
+        if (!params.dustPod) {
+          return new Err(
+            new MCPError("dustPod is required when destination is 'pod'.", {
+              tracked: false,
+            })
+          );
+        }
+
+        const contextRes = await getPod(auth, {
           toolContext,
           dustPod: params.dustPod,
         });
@@ -1502,222 +1680,9 @@ export function createProjectManagerTools(
         }
 
         const { pod } = contextRes.value;
-        const user = auth.user();
-        const owner = auth.getNonNullableWorkspace();
-
-        const conversationId =
-          params.conversationId ??
-          (isAgentLoopRunContext(toolContext?.runContext)
-            ? toolContext.runContext.conversation.sId
-            : null);
-
-        if (!conversationId) {
-          return new Err(
-            new MCPError(
-              "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
-              { tracked: false }
-            )
-          );
-        }
-
-        const conversationResource = await ConversationResource.fetchById(
-          auth,
-          conversationId
-        );
-        if (!conversationResource) {
-          return new Err(
-            new MCPError(`Conversation not found: ${conversationId}`, {
-              tracked: false,
-            })
-          );
-        }
-
-        const conversation = conversationResource.toJSON();
-
-        if (conversation.spaceId !== pod.sId) {
-          return new Err(
-            new MCPError("Conversation is not in this Pod", {
-              tracked: false,
-            })
-          );
-        }
-
-        let origin: UserMessageOrigin = "web";
-        let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-        if (isAgentLoopRunContext(toolContext?.runContext)) {
-          const userMessage = toolContext.runContext.conversation.content
-            .flat()
-            .findLast(isUserMessageType);
-          if (userMessage?.context) {
-            origin = userMessage.context.origin ?? origin;
-            timezone = userMessage.context.timezone ?? timezone;
-          }
-        }
-
-        const agentName = isAgentLoopRunContext(toolContext?.runContext)
-          ? toolContext.runContext.agentConfiguration.name
-          : "Agent";
-
-        const agentProfilePictureUrl = isAgentLoopRunContext(
-          toolContext?.runContext
-        )
-          ? toolContext.runContext.agentConfiguration.pictureUrl
-          : null;
-
-        let mentions: { configurationId: string }[] = [];
-        if (params.agentName) {
-          const matchedAgentId = await resolveAgentConfigurationIdByName(
-            auth,
-            params.agentName
-          );
-          if (!matchedAgentId) {
-            return new Err(
-              new MCPError(
-                `No agent found matching name: "${params.agentName}"`,
-                { tracked: false }
-              )
-            );
-          }
-          mentions = [{ configurationId: matchedAgentId }];
-        }
-
-        const messageRes = await postUserMessage(auth, {
-          conversationResource,
-          content: params.message,
-          mentions,
-          context: {
-            username: agentName,
-            fullName: user
-              ? `@${agentName} on behalf of ${user.fullName()}`
-              : `@${agentName}`,
-            email: null,
-            profilePictureUrl: agentProfilePictureUrl,
-            timezone,
-            origin,
-            clientSideMCPServerIds: [],
-            selectedMCPServerViewIds: [],
-            lastTriggerRunAt: null,
-          },
-          skipToolsValidation: false,
-          doNotAssociateUser: true,
-          skipDustAutoMention: true,
-        });
-
-        if (messageRes.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to post message: ${messageRes.error.api_error.message}`,
-              { tracked: false }
-            )
-          );
-        }
-
-        const conversationUrl = getConversationRoute(
-          owner.sId,
-          conversation.sId,
-          undefined,
-          config.getAppUrl()
-        );
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            conversationId: conversation.sId,
-            conversationUrl,
-            userMessageId: messageRes.value.userMessage.sId,
-            message: `Message posted to conversation in Pod "${pod.name}".`,
-          })
-        );
-      }, "Failed to add message to conversation");
-    },
-
-    [MOVE_CONVERSATION_TOOL_NAME]: async (params) => {
-      return withErrorHandling(async () => {
-        const owner = auth.getNonNullableWorkspace();
-
-        const conversationId =
-          params.conversationId ??
-          (isAgentLoopRunContext(toolContext?.runContext)
-            ? toolContext.runContext.conversation.sId
-            : null);
-
-        if (!conversationId) {
-          return new Err(
-            new MCPError(
-              "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
-              { tracked: false }
-            )
-          );
-        }
-
-        const conversationResource = await ConversationResource.fetchById(
-          auth,
-          conversationId
-        );
-
-        if (!conversationResource) {
-          return new Err(
-            new MCPError(`Conversation not found: ${conversationId}`, {
-              tracked: false,
-            })
-          );
-        }
-
-        const conversation = conversationResource.toJSON();
-
-        const conversationUrl = getConversationRoute(
-          owner.sId,
-          conversation.sId,
-          undefined,
-          config.getAppUrl()
-        );
-
-        if (params.destination === "pod") {
-          if (!params.dustPod) {
-            return new Err(
-              new MCPError("dustPod is required when destination is 'pod'.", {
-                tracked: false,
-              })
-            );
-          }
-
-          const contextRes = await getPod(auth, {
-            toolContext,
-            dustPod: params.dustPod,
-          });
-          if (contextRes.isErr()) {
-            return contextRes;
-          }
-
-          const { pod } = contextRes.value;
-          const moveRes = await moveConversationToProject(auth, {
-            conversation,
-            spaceId: pod.sId,
-          });
-
-          if (moveRes.isErr()) {
-            return new Err(
-              new MCPError(moveRes.error.message, { tracked: false })
-            );
-          }
-
-          return new Ok(
-            makeSuccessResponse({
-              success: true,
-              destination: "pod",
-              conversationId: conversation.sId,
-              podId: pod.sId,
-              podName: pod.name,
-              conversationUrl,
-              message: `Conversation moved to Pod "${pod.name}".`,
-            })
-          );
-        }
-
-        const previousPodId = conversation.spaceId ?? null;
-        const moveRes = await moveConversationOutOfProject(auth, {
+        const moveRes = await moveConversationToProject(auth, {
           conversation,
+          spaceId: pod.sId,
         });
 
         if (moveRes.isErr()) {
@@ -1729,16 +1694,37 @@ export function createProjectManagerTools(
         return new Ok(
           makeSuccessResponse({
             success: true,
-            destination: "personal",
+            destination: "pod",
             conversationId: conversation.sId,
-            previousPodId,
+            podId: pod.sId,
+            podName: pod.name,
             conversationUrl,
-            message: "Conversation moved out of Pod successfully.",
+            message: `Conversation moved to Pod "${pod.name}".`,
           })
         );
-      }, "Failed to move conversation");
-    },
-  };
+      }
 
-  return buildTools(POD_MANAGER_TOOLS_METADATA, handlers);
-}
+      const previousPodId = conversation.spaceId ?? null;
+      const moveRes = await moveConversationOutOfProject(auth, {
+        conversation,
+      });
+
+      if (moveRes.isErr()) {
+        return new Err(new MCPError(moveRes.error.message, { tracked: false }));
+      }
+
+      return new Ok(
+        makeSuccessResponse({
+          success: true,
+          destination: "personal",
+          conversationId: conversation.sId,
+          previousPodId,
+          conversationUrl,
+          message: "Conversation moved out of Pod successfully.",
+        })
+      );
+    }, "Failed to move conversation");
+  },
+};
+
+export const TOOLS = buildTools(POD_MANAGER_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/pod_tasks/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { POD_TASKS_SERVER_NAME } from "@app/lib/api/actions/servers/pod_tasks/metadata";
-import { createProjectTasksTools } from "@app/lib/api/actions/servers/pod_tasks/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/pod_tasks/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,8 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(POD_TASKS_SERVER_NAME);
 
-  const tools = createProjectTasksTools(auth, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: POD_TASKS_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -1,8 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
@@ -202,333 +199,334 @@ function formatTaskListingLine(row: ProjectTaskResource): string {
   return lines.join("\n");
 }
 
-export function createProjectTasksTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-): ToolDefinition[] {
-  const owner = auth.getNonNullableWorkspace();
-  const handlers: ToolHandlers<typeof POD_TASKS_TOOLS_METADATA> = {
-    list_tasks: async ({
-      assigneeFilter = "mine",
-      statusFilter = "all",
-      daysAgo = 7,
-      dustPod,
-    }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod,
+const handlers: ToolHandlers<typeof POD_TASKS_TOOLS_METADATA> = {
+  list_tasks: async (
+    { assigneeFilter = "mine", statusFilter = "all", daysAgo = 7, dustPod },
+    { auth, runContext }
+  ) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+      const { pod } = contextRes.value;
+
+      let rows: ProjectTaskResource[] = [];
+
+      if (assigneeFilter === "mine") {
+        rows = await ProjectTaskResource.fetchLatestBySpace(auth, {
+          spaceId: pod.id,
         });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-        const { pod } = contextRes.value;
+      } else if (assigneeFilter === "all") {
+        rows = await ProjectTaskResource.fetchBySpace(auth, {
+          spaceId: pod.id,
+          timeScope: "all",
+        });
+      }
 
-        let rows: ProjectTaskResource[] = [];
+      const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
 
-        if (assigneeFilter === "mine") {
-          rows = await ProjectTaskResource.fetchLatestBySpace(auth, {
-            spaceId: pod.id,
-          });
-        } else if (assigneeFilter === "all") {
-          rows = await ProjectTaskResource.fetchBySpace(auth, {
-            spaceId: pod.id,
-            timeScope: "all",
-          });
-        }
+      if (statusFilter === "open") {
+        rows = rows.filter((t) => t.status !== "done");
+      } else if (statusFilter === "done") {
+        rows = rows.filter(
+          (t) => t.status === "done" && t.doneAt !== null && t.doneAt >= cutoff
+        );
+      } else {
+        // "all": keep open items as-is; limit done items by daysAgo.
+        rows = rows.filter(
+          (t) =>
+            t.status !== "done" || (t.doneAt !== null && t.doneAt >= cutoff)
+        );
+      }
 
-        const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
+      if (rows.length === 0) {
+        return new Ok([{ type: "text" as const, text: "No tasks found." }]);
+      }
 
-        if (statusFilter === "open") {
-          rows = rows.filter((t) => t.status !== "done");
-        } else if (statusFilter === "done") {
-          rows = rows.filter(
-            (t) =>
-              t.status === "done" && t.doneAt !== null && t.doneAt >= cutoff
-          );
-        } else {
-          // "all": keep open items as-is; limit done items by daysAgo.
-          rows = rows.filter(
-            (t) =>
-              t.status !== "done" || (t.doneAt !== null && t.doneAt >= cutoff)
-          );
-        }
-
-        if (rows.length === 0) {
-          return new Ok([{ type: "text" as const, text: "No tasks found." }]);
-        }
-
-        if (statusFilter === "done") {
-          rows.sort(
-            (a, b) => (b.doneAt?.getTime() ?? 0) - (a.doneAt?.getTime() ?? 0)
-          );
-          const lines: string[] = [
-            `Found ${rows.length} completed task(s) in the last ${daysAgo} day(s):\n`,
-          ];
-          for (const row of rows) {
-            lines.push(formatTaskListingLine(row));
-          }
-          return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
-        }
-        const assigneeLabel = assigneeFilter === "mine" ? "you" : "everyone";
-        const label =
-          statusFilter === "open"
-            ? `Found ${rows.length} open task(s) for ${assigneeLabel}:\n`
-            : `Found ${rows.length} task(s) for ${assigneeLabel}:\n`;
-
-        const lines: string[] = [label];
+      if (statusFilter === "done") {
+        rows.sort(
+          (a, b) => (b.doneAt?.getTime() ?? 0) - (a.doneAt?.getTime() ?? 0)
+        );
+        const lines: string[] = [
+          `Found ${rows.length} completed task(s) in the last ${daysAgo} day(s):\n`,
+        ];
         for (const row of rows) {
           lines.push(formatTaskListingLine(row));
         }
-
         return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
-      }, "Failed to list tasks");
-    },
+      }
+      const assigneeLabel = assigneeFilter === "mine" ? "you" : "everyone";
+      const label =
+        statusFilter === "open"
+          ? `Found ${rows.length} open task(s) for ${assigneeLabel}:\n`
+          : `Found ${rows.length} task(s) for ${assigneeLabel}:\n`;
 
-    [CREATE_TASKS_TOOL_NAME]: async ({ creatorType, tasks, dustPod }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
+      const lines: string[] = [label];
+      for (const row of rows) {
+        lines.push(formatTaskListingLine(row));
+      }
+
+      return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
+    }, "Failed to list tasks");
+  },
+
+  [CREATE_TASKS_TOOL_NAME]: async (
+    { creatorType, tasks, dustPod },
+    { auth, runContext }
+  ) => {
+    const owner = auth.getNonNullableWorkspace();
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+      const { pod } = contextRes.value;
+
+      const assignmentPool =
+        await pod.fetchDistinctActiveManualGroupMembers(auth);
+      const soleAssigneeModelId =
+        assignmentPool.length === 1 ? assignmentPool[0]!.id : null;
+
+      const currentUser = auth.getNonNullableUser();
+      const agentConfigurationId = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext.runContext.agentConfiguration.sId
+        : null;
+
+      if (creatorType === "agent" && !agentConfigurationId) {
+        return new Err(
+          new MCPError(
+            "Agent creator type specified, but no agent configuration ID found in the context.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const created: string[] = [];
+      const errors: string[] = [];
+      for (const item of tasks) {
+        let newUserId: ModelId | null = null;
+        if (typeof item.userId === "string") {
+          const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            item.userId,
+            owner.sId
+          );
+          if (!contextRes.value.pod.isMember(userAuth)) {
+            errors.push(
+              `Could not create task ${item.text} for user ${item.userId} because they are not a member of the Pod.`
+            );
+            continue;
+          }
+          newUserId = userAuth.getNonNullableUser().id;
+        } else if (
+          soleAssigneeModelId !== null &&
+          (item.userId === undefined || item.userId === null)
+        ) {
+          newUserId = soleAssigneeModelId;
         }
-        const { pod } = contextRes.value;
 
-        const assignmentPool =
-          await pod.fetchDistinctActiveManualGroupMembers(auth);
-        const soleAssigneeModelId =
-          assignmentPool.length === 1 ? assignmentPool[0]!.id : null;
+        const row = await ProjectTaskResource.makeNew(auth, {
+          spaceId: pod.id,
+          userId: newUserId,
+          createdByType: creatorType,
+          createdByAgentConfigurationId:
+            creatorType === "agent" ? agentConfigurationId : null,
+          createdByUserId: creatorType === "user" ? currentUser.id : null,
+          text: item.text,
+          status: item.doneRationale ? "done" : "todo",
+          doneAt: item.doneRationale ? new Date() : null,
+          actorRationale: item.doneRationale ?? null,
+          agentInstructions: null,
+        });
 
-        const currentUser = auth.getNonNullableUser();
-        const agentConfigurationId = isAgentLoopRunContext(
+        // Record the conversation where the task was created as a source so
+        // it surfaces in the kickoff prompt when the task is started.
+        const sourceConversation = isAgentLoopRunContext(
           toolContext?.runContext
         )
-          ? toolContext.runContext.agentConfiguration.sId
+          ? toolContext?.runContext?.conversation
           : null;
-
-        if (creatorType === "agent" && !agentConfigurationId) {
-          return new Err(
-            new MCPError(
-              "Agent creator type specified, but no agent configuration ID found in the context.",
-              { tracked: false }
-            )
-          );
+        if (sourceConversation) {
+          await row.upsertSource(auth, {
+            itemId: sourceConversation.sId,
+            source: {
+              sourceType: "project_conversation",
+              sourceId: sourceConversation.sId,
+              sourceTitle: sourceConversation.title ?? "Source conversation",
+              sourceUrl: `${config.getAppUrl()}${getConversationRoute(owner.sId, sourceConversation.sId)}`,
+            },
+          });
         }
 
-        const created: string[] = [];
-        const errors: string[] = [];
-        for (const item of tasks) {
-          let newUserId: ModelId | null = null;
-          if (typeof item.userId === "string") {
-            const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-              item.userId,
-              owner.sId
-            );
-            if (!contextRes.value.pod.isMember(userAuth)) {
-              errors.push(
-                `Could not create task ${item.text} for user ${item.userId} because they are not a member of the Pod.`
-              );
-              continue;
-            }
-            newUserId = userAuth.getNonNullableUser().id;
-          } else if (
-            soleAssigneeModelId !== null &&
-            (item.userId === undefined || item.userId === null)
-          ) {
-            newUserId = soleAssigneeModelId;
-          }
-
-          const row = await ProjectTaskResource.makeNew(auth, {
-            spaceId: pod.id,
-            userId: newUserId,
-            createdByType: creatorType,
-            createdByAgentConfigurationId:
-              creatorType === "agent" ? agentConfigurationId : null,
-            createdByUserId: creatorType === "user" ? currentUser.id : null,
-            text: item.text,
-            status: item.doneRationale ? "done" : "todo",
-            doneAt: item.doneRationale ? new Date() : null,
-            actorRationale: item.doneRationale ?? null,
-            agentInstructions: null,
-          });
-
-          // Record the conversation where the task was created as a source so
-          // it surfaces in the kickoff prompt when the task is started.
-          const sourceConversation = isAgentLoopRunContext(
-            toolContext?.runContext
-          )
-            ? toolContext?.runContext?.conversation
-            : null;
-          if (sourceConversation) {
+        if (item.sources) {
+          for (const sourceInput of item.sources) {
+            const source = inferProjectTaskSourceFromUrl({
+              url: sourceInput.url,
+              title: sourceInput.title,
+            });
             await row.upsertSource(auth, {
-              itemId: sourceConversation.sId,
-              source: {
-                sourceType: "project_conversation",
-                sourceId: sourceConversation.sId,
-                sourceTitle: sourceConversation.title ?? "Source conversation",
-                sourceUrl: `${config.getAppUrl()}${getConversationRoute(owner.sId, sourceConversation.sId)}`,
-              },
+              itemId: sourceInput.url,
+              source,
             });
           }
-
-          if (item.sources) {
-            for (const sourceInput of item.sources) {
-              const source = inferProjectTaskSourceFromUrl({
-                url: sourceInput.url,
-                title: sourceInput.title,
-              });
-              await row.upsertSource(auth, {
-                itemId: sourceInput.url,
-                source,
-              });
-            }
-          }
-
-          created.push(formatTaskListingLine(row));
         }
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: [
-              `Created ${created.length} task(s):\n${created.join("\n")}`,
-              ...errors.map((error) => `- ${error}`),
-            ].join("\n"),
-          },
-        ]);
-      }, "Failed to create tasks");
-    },
+        created.push(formatTaskListingLine(row));
+      }
 
-    [UPDATE_TASKS_TOOL_NAME]: async ({ tasks, dustPod }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-        const { pod } = contextRes.value;
+      return new Ok([
+        {
+          type: "text" as const,
+          text: [
+            `Created ${created.length} task(s):\n${created.join("\n")}`,
+            ...errors.map((error) => `- ${error}`),
+          ].join("\n"),
+        },
+      ]);
+    }, "Failed to create tasks");
+  },
 
-        const agentConfigurationId = isAgentLoopRunContext(
-          toolContext?.runContext
-        )
-          ? toolContext.runContext.agentConfiguration.sId
-          : null;
+  [UPDATE_TASKS_TOOL_NAME]: async (
+    { tasks, dustPod },
+    { auth, runContext }
+  ) => {
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+      const { pod } = contextRes.value;
 
-        const updated: string[] = [];
-        const errors: string[] = [];
+      const agentConfigurationId = isAgentLoopRunContext(
+        toolContext?.runContext
+      )
+        ? toolContext.runContext.agentConfiguration.sId
+        : null;
 
-        for (const item of tasks) {
-          const row = await ProjectTaskResource.fetchBySId(auth, item.taskId);
+      const updated: string[] = [];
+      const errors: string[] = [];
 
-          if (!row) {
-            errors.push(`Task not found: ${item.taskId}`);
-            continue;
-          }
+      for (const item of tasks) {
+        const row = await ProjectTaskResource.fetchBySId(auth, item.taskId);
 
-          const payloadRes = await buildTaskUpdatePayload(
-            auth,
-            pod,
-            row,
-            item,
-            agentConfigurationId
-          );
-          if (payloadRes.isErr()) {
-            errors.push(payloadRes.error.message);
-            continue;
-          }
-
-          const { taskUpdates } = payloadRes.value;
-
-          if (Object.keys(taskUpdates).length === 0) {
-            updated.push(formatTaskListingLine(row));
-            continue;
-          }
-
-          const updatedRow = await row.updateWithVersion(auth, taskUpdates);
-          updated.push(formatTaskListingLine(updatedRow));
+        if (!row) {
+          errors.push(`Task not found: ${item.taskId}`);
+          continue;
         }
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: [
-              `Updated ${updated.length} task(s):`,
-              ...updated.map((line) => line),
-              ...errors.map((error) => `- ${error}`),
-            ].join("\n"),
-          },
-        ]);
-      }, "Failed to update tasks");
-    },
-
-    [START_TASK_AGENT_TOOL_NAME]: async ({
-      taskId,
-      agentName,
-      customMessage,
-      dustPod,
-    }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          toolContext,
-          dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
+        const payloadRes = await buildTaskUpdatePayload(
+          auth,
+          pod,
+          row,
+          item,
+          agentConfigurationId
+        );
+        if (payloadRes.isErr()) {
+          errors.push(payloadRes.error.message);
+          continue;
         }
 
-        const { pod } = contextRes.value;
-        let agentConfigurationId: string | undefined;
-        if (agentName) {
-          const matchedAgentId = await resolveAgentConfigurationIdByName(
-            auth,
-            agentName
-          );
-          if (!matchedAgentId) {
-            return new Err(
-              new MCPError(`No agent found matching name: "${agentName}"`, {
-                tracked: false,
-              })
-            );
-          }
-          agentConfigurationId = matchedAgentId;
+        const { taskUpdates } = payloadRes.value;
+
+        if (Object.keys(taskUpdates).length === 0) {
+          updated.push(formatTaskListingLine(row));
+          continue;
         }
 
-        const startRes = await startAgentForProjectTask(auth, {
-          space: pod,
-          taskId,
-          agentConfigurationId,
-          customMessage,
-        });
+        const updatedRow = await row.updateWithVersion(auth, taskUpdates);
+        updated.push(formatTaskListingLine(updatedRow));
+      }
 
-        if (startRes.isErr()) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: [
+            `Updated ${updated.length} task(s):`,
+            ...updated.map((line) => line),
+            ...errors.map((error) => `- ${error}`),
+          ].join("\n"),
+        },
+      ]);
+    }, "Failed to update tasks");
+  },
+
+  [START_TASK_AGENT_TOOL_NAME]: async (
+    { taskId, agentName, customMessage, dustPod },
+    { auth, runContext }
+  ) => {
+    const owner = auth.getNonNullableWorkspace();
+    const toolContext: ToolContext = { runContext };
+    return withErrorHandling(async () => {
+      const contextRes = await getPod(auth, {
+        toolContext,
+        dustPod,
+      });
+      if (contextRes.isErr()) {
+        return contextRes;
+      }
+
+      const { pod } = contextRes.value;
+      let agentConfigurationId: string | undefined;
+      if (agentName) {
+        const matchedAgentId = await resolveAgentConfigurationIdByName(
+          auth,
+          agentName
+        );
+        if (!matchedAgentId) {
           return new Err(
-            new MCPError(startRes.error.message, {
+            new MCPError(`No agent found matching name: "${agentName}"`, {
               tracked: false,
             })
           );
         }
+        agentConfigurationId = matchedAgentId;
+      }
 
-        const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
-          owner.sId,
-          startRes.value.conversationId
-        )}`;
+      const startRes = await startAgentForProjectTask(auth, {
+        space: pod,
+        taskId,
+        agentConfigurationId,
+        customMessage,
+      });
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text:
-              startRes.value.action === "created"
-                ? `Started task work for ${taskId} by creating a new conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`
-                : `Started task work for ${taskId} by appending a new message to existing conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`,
-          },
-        ]);
-      }, "Failed to start task work");
-    },
-  };
+      if (startRes.isErr()) {
+        return new Err(
+          new MCPError(startRes.error.message, {
+            tracked: false,
+          })
+        );
+      }
 
-  return buildTools(POD_TASKS_TOOLS_METADATA, handlers);
-}
+      const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
+        owner.sId,
+        startRes.value.conversationId
+      )}`;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            startRes.value.action === "created"
+              ? `Started task work for ${taskId} by creating a new conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`
+              : `Started task work for ${taskId} by appending a new message to existing conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`,
+        },
+      ]);
+    }, "Failed to start task work");
+  },
+};
+
+export const TOOLS = buildTools(POD_TASKS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/schedules_management/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/index.ts
@@ -1,7 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createSchedulesManagementTools } from "@app/lib/api/actions/servers/schedules_management/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/schedules_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,9 +11,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("schedules_management");
 
-  const tools = createSchedulesManagementTools(auth, toolContext);
-
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "schedules_management",
     });

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -3,11 +3,10 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
-import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   resolveTriggerSpaceId,
@@ -45,12 +44,12 @@ function renderSchedule(
   return lines.join("\n");
 }
 
-function getUserTimezone(toolContext?: ToolContext): string | null {
-  if (!isAgentLoopRunContext(toolContext?.runContext)) {
+function getUserTimezone(runContext: ToolRunContext): string | null {
+  if (!isAgentLoopRunContext(runContext)) {
     return null;
   }
 
-  const content = toolContext?.runContext?.conversation?.content;
+  const content = runContext.conversation.content;
   if (!content) {
     return null;
   }
@@ -59,235 +58,224 @@ function getUserTimezone(toolContext?: ToolContext): string | null {
   return userMessage?.context.timezone ?? null;
 }
 
-export function createSchedulesManagementTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
-    create_schedule: async ({ name, schedule, prompt, timezone, podId }) => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
+const handlers: ToolHandlers<typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA> = {
+  create_schedule: async (
+    { name, schedule, prompt, timezone, podId },
+    { auth, runContext }
+  ) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const owner = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const { agentConfiguration } = runContext;
+
+    // When a podId is provided, attach the trigger to that Pod so the
+    // scheduled run lands in the Pod (where the pinned view lives).
+    const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
+    if (spaceIdRes.isErr()) {
+      return new Err(new MCPError(spaceIdRes.error));
+    }
+    const spaceId = spaceIdRes.value;
+
+    const resolvedTimezone = timezone ?? getUserTimezone(runContext);
+
+    if (!resolvedTimezone) {
+      logger.error("resolved timezone missing");
+      return new Err(new MCPError("Provide a timezone"));
+    }
+
+    const scheduleResult = await generateScheduleRule(auth, {
+      naturalDescription: schedule,
+      defaultTimezone: resolvedTimezone,
+    });
+
+    if (scheduleResult.isErr()) {
+      logger.error(
+        {
+          error: scheduleResult.error,
+          workspaceId: owner.id,
+          schedule,
+        },
+        "Error parsing schedule"
       );
-
-      const owner = auth.getNonNullableWorkspace();
-      const user = auth.getNonNullableUser();
-
-      const { agentConfiguration } = toolContext.runContext;
-
-      // When a podId is provided, attach the trigger to that Pod so the
-      // scheduled run lands in the Pod (where the pinned view lives).
-      const spaceIdRes = await resolveTriggerSpaceId(auth, podId);
-      if (spaceIdRes.isErr()) {
-        return new Err(new MCPError(spaceIdRes.error));
-      }
-      const spaceId = spaceIdRes.value;
-
-      const resolvedTimezone = timezone ?? getUserTimezone(toolContext);
-
-      if (!resolvedTimezone) {
-        logger.error("resolved timezone missing");
-        return new Err(new MCPError("Provide a timezone"));
-      }
-
-      const scheduleResult = await generateScheduleRule(auth, {
-        naturalDescription: schedule,
-        defaultTimezone: resolvedTimezone,
+      return new Err(
+        new MCPError(
+          `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am", "every other Monday at 9am").`
+        )
+      );
+    }
+    const scheduleConfig = scheduleResult.value;
+    let result;
+    try {
+      result = await TriggerResource.makeNew(auth, {
+        workspaceId: owner.id,
+        agentConfigurationId: agentConfiguration.sId,
+        name,
+        kind: "schedule",
+        status: "enabled",
+        configuration: scheduleConfig,
+        naturalLanguageDescription: schedule,
+        customPrompt: prompt,
+        editor: user.id,
+        webhookSourceViewId: null,
+        executionPerDayLimitOverride: null,
+        executionMode: "fair_use",
+        origin: "agent",
+        spaceId,
       });
 
-      if (scheduleResult.isErr()) {
-        logger.error(
-          {
-            error: scheduleResult.error,
-            workspaceId: owner.id,
-            schedule,
-          },
-          "Error parsing schedule"
-        );
-        return new Err(
-          new MCPError(
-            `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am", "every other Monday at 9am").`
-          )
-        );
-      }
-      const scheduleConfig = scheduleResult.value;
-      let result;
-      try {
-        result = await TriggerResource.makeNew(auth, {
-          workspaceId: owner.id,
-          agentConfigurationId: agentConfiguration.sId,
-          name,
-          kind: "schedule",
-          status: "enabled",
-          configuration: scheduleConfig,
-          naturalLanguageDescription: schedule,
-          customPrompt: prompt,
-          editor: user.id,
-          webhookSourceViewId: null,
-          executionPerDayLimitOverride: null,
-          executionMode: "fair_use",
-          origin: "agent",
-          spaceId,
-        });
-
-        if (result.isErr()) {
-          logger.error(result.error.message);
-          return new Err(
-            new MCPError(`Failed to enable schedule: ${result.error.message}`)
-          );
-        }
-      } catch (err) {
-        if (err instanceof UniqueConstraintError) {
-          return new Err(new MCPError("Schedule uniqueness constraint error"));
-        }
-        throw err;
-      }
-
-      getStatsDClient().increment("tools.schedules_management.created", 1, [
-        `workspace_id:${owner.sId}`,
-        `agent_id:${agentConfiguration.sId}`,
-      ]);
-
-      const trigger = result.value.toJSON();
-      if (!isScheduleTrigger(trigger)) {
-        return new Err(new MCPError("Unexpected trigger type"));
-      }
-
-      const configDesc = describeScheduleConfig(scheduleConfig);
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text:
-            `Created schedule "${name}"!\n\n` +
-            `Schedule: ${schedule}\n` +
-            `Configuration: ${configDesc} (${scheduleConfig.timezone})\n\n` +
-            `The agent will execute "${prompt}" according to this schedule.` +
-            (spaceId !== null ? " Its runs will land in the Pod." : "") +
-            `\n\n` +
-            renderSchedule(trigger),
-        },
-      ]);
-    },
-
-    list_schedules: async () => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
-      );
-
-      const owner = auth.getNonNullableWorkspace();
-      const userId = auth.getNonNullableUser().id;
-
-      const { agentConfiguration } = toolContext.runContext;
-
-      const schedulesResult =
-        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-          agentConfigurationId: agentConfiguration.sId,
-          editorIds: [userId],
-        });
-
-      if (schedulesResult.isErr()) {
-        return new Err(
-          new MCPError("Error while fetching schedules for this agent")
-        );
-      }
-
-      getStatsDClient().increment("tools.schedules_management.listed", 1, [
-        `workspace_id:${owner.sId}`,
-        `agent_id:${agentConfiguration.sId}`,
-      ]);
-
-      const schedules = schedulesResult.value
-        .map((s) => s.toJSON())
-        .filter(isScheduleTrigger);
-
-      if (schedules.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "No schedules configured for this agent.",
-          },
-        ]);
-      }
-
-      // Resolve Pod names for schedules attached to a Pod (single batch query).
-      const podIds = [
-        ...new Set(
-          schedules
-            .map((s) => s.spaceId)
-            .filter((id): id is string => id !== null)
-        ),
-      ];
-      const pods =
-        podIds.length > 0 ? await SpaceResource.fetchByIds(auth, podIds) : [];
-      const podNameById = new Map(pods.map((p) => [p.sId, p.name]));
-
-      const scheduleList = schedules
-        .map((schedule) =>
-          renderSchedule(
-            schedule,
-            schedule.spaceId ? podNameById.get(schedule.spaceId) : null
-          )
-        )
-        .join("\n\n");
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Schedules for this agent:\n\n${scheduleList}`,
-        },
-      ]);
-    },
-
-    disable_schedule: async ({ scheduleId }) => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
-      );
-
-      const owner = auth.getNonNullableWorkspace();
-      const userId = auth.getNonNullableUser().id;
-
-      const { agentConfiguration } = toolContext.runContext;
-
-      const triggersResult =
-        await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
-          agentConfigurationId: agentConfiguration.sId,
-          editorIds: [userId],
-        });
-      if (triggersResult.isErr()) {
-        return new Err(new MCPError("Error fetching schedules"));
-      }
-      const schedule = triggersResult.value.find(
-        (t) => t.kind === "schedule" && t.sId === scheduleId
-      );
-      if (!schedule) {
-        return new Err(new MCPError("Schedule not found"));
-      }
-
-      const scheduleName = schedule.name;
-      const result = await schedule.disable(auth);
-
       if (result.isErr()) {
+        logger.error(result.error.message);
         return new Err(
-          new MCPError(`Failed to disable schedule: ${result.error.message}`)
+          new MCPError(`Failed to enable schedule: ${result.error.message}`)
         );
       }
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return new Err(new MCPError("Schedule uniqueness constraint error"));
+      }
+      throw err;
+    }
 
-      getStatsDClient().increment("tools.schedules_management.disabled", 1, [
-        `workspace_id:${owner.sId}`,
-        `agent_id:${agentConfiguration.sId}`,
-      ]);
+    getStatsDClient().increment("tools.schedules_management.created", 1, [
+      `workspace_id:${owner.sId}`,
+      `agent_id:${agentConfiguration.sId}`,
+    ]);
 
+    const trigger = result.value.toJSON();
+    if (!isScheduleTrigger(trigger)) {
+      return new Err(new MCPError("Unexpected trigger type"));
+    }
+
+    const configDesc = describeScheduleConfig(scheduleConfig);
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Created schedule "${name}"!\n\n` +
+          `Schedule: ${schedule}\n` +
+          `Configuration: ${configDesc} (${scheduleConfig.timezone})\n\n` +
+          `The agent will execute "${prompt}" according to this schedule.` +
+          (spaceId !== null ? " Its runs will land in the Pod." : "") +
+          `\n\n` +
+          renderSchedule(trigger),
+      },
+    ]);
+  },
+
+  list_schedules: async (_params, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const owner = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+
+    const { agentConfiguration } = runContext;
+
+    const schedulesResult =
+      await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+        agentConfigurationId: agentConfiguration.sId,
+        editorIds: [userId],
+      });
+
+    if (schedulesResult.isErr()) {
+      return new Err(
+        new MCPError("Error while fetching schedules for this agent")
+      );
+    }
+
+    getStatsDClient().increment("tools.schedules_management.listed", 1, [
+      `workspace_id:${owner.sId}`,
+      `agent_id:${agentConfiguration.sId}`,
+    ]);
+
+    const schedules = schedulesResult.value
+      .map((s) => s.toJSON())
+      .filter(isScheduleTrigger);
+
+    if (schedules.length === 0) {
       return new Ok([
         {
           type: "text" as const,
-          text: `Disabled schedule "${scheduleName}".`,
+          text: "No schedules configured for this agent.",
         },
       ]);
-    },
-  };
+    }
 
-  return buildTools(SCHEDULES_MANAGEMENT_TOOLS_METADATA, handlers);
-}
+    // Resolve Pod names for schedules attached to a Pod (single batch query).
+    const podIds = [
+      ...new Set(
+        schedules
+          .map((s) => s.spaceId)
+          .filter((id): id is string => id !== null)
+      ),
+    ];
+    const pods =
+      podIds.length > 0 ? await SpaceResource.fetchByIds(auth, podIds) : [];
+    const podNameById = new Map(pods.map((p) => [p.sId, p.name]));
+
+    const scheduleList = schedules
+      .map((schedule) =>
+        renderSchedule(
+          schedule,
+          schedule.spaceId ? podNameById.get(schedule.spaceId) : null
+        )
+      )
+      .join("\n\n");
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Schedules for this agent:\n\n${scheduleList}`,
+      },
+    ]);
+  },
+
+  disable_schedule: async ({ scheduleId }, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const owner = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+
+    const { agentConfiguration } = runContext;
+
+    const triggersResult =
+      await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+        agentConfigurationId: agentConfiguration.sId,
+        editorIds: [userId],
+      });
+    if (triggersResult.isErr()) {
+      return new Err(new MCPError("Error fetching schedules"));
+    }
+    const schedule = triggersResult.value.find(
+      (t) => t.kind === "schedule" && t.sId === scheduleId
+    );
+    if (!schedule) {
+      return new Err(new MCPError("Schedule not found"));
+    }
+
+    const scheduleName = schedule.name;
+    const result = await schedule.disable(auth);
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to disable schedule: ${result.error.message}`)
+      );
+    }
+
+    getStatsDClient().increment("tools.schedules_management.disabled", 1, [
+      `workspace_id:${owner.sId}`,
+      `agent_id:${agentConfiguration.sId}`,
+    ]);
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Disabled schedule "${scheduleName}".`,
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(SCHEDULES_MANAGEMENT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/slack_bot/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/index.ts
@@ -1,19 +1,18 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createSlackBotTools } from "@app/lib/api/actions/servers/slack_bot/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/slack_bot/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
   auth: Authenticator,
-  mcpServerId: string,
+  _mcpServerId: string,
   toolContext?: ToolContext
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("slack_bot");
 
-  const tools = createSlackBotTools(auth, mcpServerId, toolContext);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "slack_bot",
     });

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -1,13 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   type AgentLoopRunContext,
   isAgentLoopRunContext,
-  type ToolContext,
 } from "@app/lib/actions/types";
 import {
   executeListPublicChannels,
@@ -17,49 +13,39 @@ import {
   getSlackClient,
 } from "@app/lib/api/actions/servers/slack/helpers";
 import { SLACK_BOT_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_bot/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 
-export function createSlackBotTools(
-  auth: Authenticator,
-  mcpServerId: string,
-  toolContext?: ToolContext
-): ToolDefinition[] {
-  const handlers: ToolHandlers<typeof SLACK_BOT_TOOLS_METADATA> = {
-    post_message: async (
-      {
-        to,
-        message,
-        threadTs,
-        fileId,
-        unfurlLinks,
-        unfurlMedia,
-        showSentByFooter,
-      },
-      { authInfo }
-    ) => {
-      let attachmentRunContext: AgentLoopRunContext | undefined;
-      if (fileId) {
-        assert(
-          isAgentLoopRunContext(toolContext?.runContext),
-          "AgentLoopRunContext expected"
-        );
-        attachmentRunContext = toolContext.runContext;
-      }
+const handlers: ToolHandlers<typeof SLACK_BOT_TOOLS_METADATA> = {
+  post_message: async (
+    {
+      to,
+      message,
+      threadTs,
+      fileId,
+      unfurlLinks,
+      unfurlMedia,
+      showSentByFooter,
+    },
+    { auth, authInfo, runContext }
+  ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (fileId) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
 
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      if (!toolContext?.runContext) {
-        return new Err(new MCPError("Issue with agent context"));
-      }
-
-      try {
-        return await executePostMessage(auth, toolContext, {
+    try {
+      return await executePostMessage(
+        auth,
+        { runContext },
+        {
           to,
           message,
           threadTs,
@@ -71,253 +57,249 @@ export function createSlackBotTools(
           unfurlMedia,
           accessToken,
           showSentByFooter: showSentByFooter ?? true,
-        });
-      } catch (error) {
-        return new Err(
-          new MCPError(`Error posting message: ${normalizeError(error)}`)
-        );
-      }
-    },
-    edit_message: async ({ channel, timestamp, message }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeUpdateMessage({
-          accessToken,
-          channel,
-          timestamp,
-          message,
-        });
-      } catch (error) {
-        return new Err(
-          new MCPError(`Error editing message: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    search_user: async ({ query, search_all }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeSearchUser(query, search_all ?? false, {
-          accessToken,
-          mcpServerId,
-        });
-      } catch (error) {
-        return new Err(
-          new MCPError(`Error searching user: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    list_public_channels: async ({ nameFilter }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeListPublicChannels(
-          nameFilter,
-          accessToken,
-          mcpServerId
-        );
-      } catch (error) {
-        return new Err(
-          new MCPError(`Error listing channels: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    read_channel_history: async (
-      { channel, limit = 20, cursor, oldest, latest },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.conversations.history({
-          channel: channel,
-          limit: Math.min(limit, 200),
-          cursor: cursor,
-          oldest: oldest,
-          latest: latest,
-        });
-
-        const hasMore = !!response.has_more;
-        const nextCursor = response.response_metadata?.next_cursor;
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                messages: response.messages,
-                has_more: hasMore,
-                next_cursor: nextCursor,
-                pagination_info: {
-                  current_page_size: response.messages?.length ?? 0,
-                  has_more_pages: hasMore,
-                  next_cursor_for_pagination: nextCursor,
-                },
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (error) {
-        return new Err(
-          new MCPError(
-            `Error reading channel history: ${normalizeError(error)}`
-          )
-        );
-      }
-    },
-
-    read_thread_messages: async (
-      { channel, threadTs, limit = 20, cursor, oldest, latest },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.conversations.replies({
-          channel: channel,
-          ts: threadTs,
-          limit: Math.min(limit, 200), // Slack API max is 200
-          cursor: cursor,
-          oldest: oldest,
-          latest: latest,
-        });
-
-        const hasMore = !!response.has_more;
-        const nextCursor = response.response_metadata?.next_cursor;
-
-        // First message is always the parent message
-        const parentMessage = response.messages?.[0];
-        const threadReplies = response.messages?.slice(1) ?? [];
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              {
-                parent_message: parentMessage,
-                thread_replies: threadReplies,
-                total_messages: response.messages?.length ?? 0,
-                has_more: hasMore,
-                next_cursor: nextCursor,
-                pagination_info: {
-                  current_page_size: response.messages?.length ?? 0,
-                  replies_in_this_page: threadReplies.length,
-                  has_more_pages: hasMore,
-                  next_cursor_for_pagination: nextCursor,
-                },
-              },
-              null,
-              2
-            ),
-          },
-        ]);
-      } catch (error) {
-        return new Err(
-          new MCPError(
-            `Error reading thread messages: ${normalizeError(error)}`
-          )
-        );
-      }
-    },
-
-    add_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.reactions.add({
-          channel,
-          timestamp,
-          name,
-        });
-
-        if (!response.ok) {
-          return new Err(
-            new MCPError(`Error adding reaction: ${response.error}`)
-          );
         }
+      );
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error posting message: ${normalizeError(error)}`)
+      );
+    }
+  },
+  edit_message: async ({ channel, timestamp, message }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully added ${name} reaction to message`,
-          },
-          { type: "text" as const, text: JSON.stringify(response, null, 2) },
-        ]);
-      } catch (error) {
+    try {
+      return await executeUpdateMessage({
+        accessToken,
+        channel,
+        timestamp,
+        message,
+      });
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error editing message: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  search_user: async ({ query, search_all }, { authInfo, runContext }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeSearchUser(query, search_all ?? false, {
+        accessToken,
+        mcpServerId: runContext.toolConfiguration.toolServerId,
+      });
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error searching user: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  list_public_channels: async ({ nameFilter }, { authInfo, runContext }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeListPublicChannels(
+        nameFilter,
+        accessToken,
+        runContext.toolConfiguration.toolServerId
+      );
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error listing channels: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  read_channel_history: async (
+    { channel, limit = 20, cursor, oldest, latest },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+    const slackClient = await getSlackClient(accessToken);
+
+    try {
+      const response = await slackClient.conversations.history({
+        channel: channel,
+        limit: Math.min(limit, 200),
+        cursor: cursor,
+        oldest: oldest,
+        latest: latest,
+      });
+
+      const hasMore = !!response.has_more;
+      const nextCursor = response.response_metadata?.next_cursor;
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              messages: response.messages,
+              has_more: hasMore,
+              next_cursor: nextCursor,
+              pagination_info: {
+                current_page_size: response.messages?.length ?? 0,
+                has_more_pages: hasMore,
+                next_cursor_for_pagination: nextCursor,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error reading channel history: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  read_thread_messages: async (
+    { channel, threadTs, limit = 20, cursor, oldest, latest },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const slackClient = await getSlackClient(accessToken);
+
+    try {
+      const response = await slackClient.conversations.replies({
+        channel: channel,
+        ts: threadTs,
+        limit: Math.min(limit, 200), // Slack API max is 200
+        cursor: cursor,
+        oldest: oldest,
+        latest: latest,
+      });
+
+      const hasMore = !!response.has_more;
+      const nextCursor = response.response_metadata?.next_cursor;
+
+      // First message is always the parent message
+      const parentMessage = response.messages?.[0];
+      const threadReplies = response.messages?.slice(1) ?? [];
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              parent_message: parentMessage,
+              thread_replies: threadReplies,
+              total_messages: response.messages?.length ?? 0,
+              has_more: hasMore,
+              next_cursor: nextCursor,
+              pagination_info: {
+                current_page_size: response.messages?.length ?? 0,
+                replies_in_this_page: threadReplies.length,
+                has_more_pages: hasMore,
+                next_cursor_for_pagination: nextCursor,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error reading thread messages: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  add_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const slackClient = await getSlackClient(accessToken);
+
+    try {
+      const response = await slackClient.reactions.add({
+        channel,
+        timestamp,
+        name,
+      });
+
+      if (!response.ok) {
         return new Err(
-          new MCPError(`Error adding reaction: ${normalizeError(error)}`)
+          new MCPError(`Error adding reaction: ${response.error}`)
         );
       }
-    },
 
-    remove_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully added ${name} reaction to message`,
+        },
+        { type: "text" as const, text: JSON.stringify(response, null, 2) },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error adding reaction: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      const slackClient = await getSlackClient(accessToken);
+  remove_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      try {
-        const response = await slackClient.reactions.remove({
-          channel,
-          timestamp,
-          name,
-        });
+    const slackClient = await getSlackClient(accessToken);
 
-        if (!response.ok) {
-          return new Err(
-            new MCPError(`Error removing reaction: ${response.error}`)
-          );
-        }
+    try {
+      const response = await slackClient.reactions.remove({
+        channel,
+        timestamp,
+        name,
+      });
 
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully removed ${name} reaction from message`,
-          },
-          { type: "text" as const, text: JSON.stringify(response, null, 2) },
-        ]);
-      } catch (error) {
+      if (!response.ok) {
         return new Err(
-          new MCPError(`Error removing reaction: ${normalizeError(error)}`)
+          new MCPError(`Error removing reaction: ${response.error}`)
         );
       }
-    },
-  };
 
-  return buildTools(SLACK_BOT_TOOLS_METADATA, handlers);
-}
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully removed ${name} reaction from message`,
+        },
+        { type: "text" as const, text: JSON.stringify(response, null, 2) },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(`Error removing reaction: ${normalizeError(error)}`)
+      );
+    }
+  },
+};
+
+export const TOOLS = buildTools(SLACK_BOT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/wakeups/index.ts
+++ b/front/lib/api/actions/servers/wakeups/index.ts
@@ -2,7 +2,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
-import { createWakeupsTools } from "@app/lib/api/actions/servers/wakeups/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/wakeups/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,9 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(WAKEUPS_SERVER_NAME);
 
-  const tools = createWakeupsTools(auth, toolContext);
-
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: WAKEUPS_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -3,10 +3,9 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   isAgentLoopRunContext,
-  type ToolContext,
+  type ToolRunContext,
 } from "@app/lib/actions/types";
 import { WAKEUPS_TOOLS_METADATA } from "@app/lib/api/actions/servers/wakeups/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { isUserMessageType } from "@app/types/assistant/conversation";
@@ -92,12 +91,12 @@ function parseWhen(when: string):
   return null;
 }
 
-function getUserTimezone(toolContext?: ToolContext): string | null {
-  if (!isAgentLoopRunContext(toolContext?.runContext)) {
+function getUserTimezone(runContext: ToolRunContext): string | null {
+  if (!isAgentLoopRunContext(runContext)) {
     return null;
   }
 
-  const content = toolContext?.runContext?.conversation?.content;
+  const content = runContext.conversation.content;
   if (!content) {
     return null;
   }
@@ -125,212 +124,190 @@ function renderWakeUp(wakeUp: WakeUpType): string {
   );
 }
 
-export function createWakeupsTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-) {
-  const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
-    schedule_wakeup: async ({ when, reason, timezone }) => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
+const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
+  schedule_wakeup: async ({ when, reason, timezone }, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const { conversation: runConversation, agentConfiguration } = runContext;
+
+    const parsed = parseWhen(when);
+    if (!parsed) {
+      return new Err(
+        new MCPError(
+          `Unable to parse \`when\`="${when}". Expected a relative duration ` +
+            '("in 2h"), an ISO 8601 timestamp ("2026-04-16T16:00:00Z"), or a 5-field cron ' +
+            'expression ("0 9 * * MON-FRI").'
+        )
       );
+    }
 
-      const { conversation: runConversation, agentConfiguration } =
-        toolContext.runContext;
-
-      const parsed = parseWhen(when);
-      if (!parsed) {
+    if (parsed.kind === "one_shot") {
+      const delayMs = parsed.fireAt.getTime() - Date.now();
+      if (delayMs <= 0) {
         return new Err(
           new MCPError(
-            `Unable to parse \`when\`="${when}". Expected a relative duration ` +
-              '("in 2h"), an ISO 8601 timestamp ("2026-04-16T16:00:00Z"), or a 5-field cron ' +
-              'expression ("0 9 * * MON-FRI").'
+            `Cannot schedule a wake-up in the past (${parsed.fireAt.toISOString()}).`
           )
         );
       }
-
-      if (parsed.kind === "one_shot") {
-        const delayMs = parsed.fireAt.getTime() - Date.now();
-        if (delayMs <= 0) {
-          return new Err(
-            new MCPError(
-              `Cannot schedule a wake-up in the past (${parsed.fireAt.toISOString()}).`
-            )
-          );
-        }
-        if (delayMs > MAX_ONE_SHOT_DELAY_MS) {
-          return new Err(
-            new MCPError(
-              `One-shot wake-ups cannot be scheduled more than ${MAX_ONE_SHOT_DELAY_MS / (24 * 60 * 60 * 1000)} days in the future.`
-            )
-          );
-        }
-      }
-
-      let cronTimezone: string | null = null;
-      if (parsed.kind === "cron") {
-        cronTimezone = timezone ?? getUserTimezone(toolContext);
-        if (!cronTimezone) {
-          return new Err(
-            new MCPError(
-              "Cron wake-ups require a `timezone` (IANA name, e.g. 'Europe/Paris'). " +
-                "None was provided and no timezone could be inferred from the conversation."
-            )
-          );
-        }
-      }
-
-      const conversation = await ConversationResource.fetchById(
-        auth,
-        runConversation.sId
-      );
-      if (!conversation) {
-        return new Err(
-          new MCPError("Current conversation could not be loaded.")
-        );
-      }
-
-      const conversationWakeUps = await WakeUpResource.listByConversation(
-        auth,
-        runConversation
-      );
-      const activeInConversation = conversationWakeUps.filter((w) =>
-        isActiveWakeUp(w.toJSON())
-      );
-      if (activeInConversation.length >= MAX_ACTIVE_WAKEUPS_PER_CONVERSATION) {
+      if (delayMs > MAX_ONE_SHOT_DELAY_MS) {
         return new Err(
           new MCPError(
-            `This conversation already has ${activeInConversation.length} active wake-up(s); ` +
-              `the limit is ${MAX_ACTIVE_WAKEUPS_PER_CONVERSATION}. Cancel the existing wake-up ` +
-              "before scheduling a new one."
+            `One-shot wake-ups cannot be scheduled more than ${MAX_ONE_SHOT_DELAY_MS / (24 * 60 * 60 * 1000)} days in the future.`
           )
         );
       }
+    }
 
-      const blob =
-        parsed.kind === "one_shot"
-          ? {
-              scheduleType: "one_shot" as const,
-              fireAt: parsed.fireAt,
-              cronExpression: null,
-              cronTimezone: null,
-              reason,
-            }
-          : {
-              scheduleType: "cron" as const,
-              fireAt: null,
-              cronExpression: parsed.cron,
-              // parsed.kind === "cron" means we resolved cronTimezone above.
-              cronTimezone: cronTimezone as string,
-              reason,
-            };
-
-      const result = await WakeUpResource.makeNew(
-        auth,
-        blob,
-        conversation.toJSON(),
-        agentConfiguration
-      );
-      if (result.isErr()) {
+    let cronTimezone: string | null = null;
+    if (parsed.kind === "cron") {
+      cronTimezone = timezone ?? getUserTimezone(runContext);
+      if (!cronTimezone) {
         return new Err(
-          new MCPError(`Failed to schedule wake-up: ${result.error.message}`)
+          new MCPError(
+            "Cron wake-ups require a `timezone` (IANA name, e.g. 'Europe/Paris'). " +
+              "None was provided and no timezone could be inferred from the conversation."
+          )
         );
       }
+    }
 
-      const wakeUp = result.value.toJSON();
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      runConversation.sId
+    );
+    if (!conversation) {
+      return new Err(new MCPError("Current conversation could not be loaded."));
+    }
+
+    const conversationWakeUps = await WakeUpResource.listByConversation(
+      auth,
+      runConversation
+    );
+    const activeInConversation = conversationWakeUps.filter((w) =>
+      isActiveWakeUp(w.toJSON())
+    );
+    if (activeInConversation.length >= MAX_ACTIVE_WAKEUPS_PER_CONVERSATION) {
+      return new Err(
+        new MCPError(
+          `This conversation already has ${activeInConversation.length} active wake-up(s); ` +
+            `the limit is ${MAX_ACTIVE_WAKEUPS_PER_CONVERSATION}. Cancel the existing wake-up ` +
+            "before scheduling a new one."
+        )
+      );
+    }
+
+    const blob =
+      parsed.kind === "one_shot"
+        ? {
+            scheduleType: "one_shot" as const,
+            fireAt: parsed.fireAt,
+            cronExpression: null,
+            cronTimezone: null,
+            reason,
+          }
+        : {
+            scheduleType: "cron" as const,
+            fireAt: null,
+            cronExpression: parsed.cron,
+            // parsed.kind === "cron" means we resolved cronTimezone above.
+            cronTimezone: cronTimezone as string,
+            reason,
+          };
+
+    const result = await WakeUpResource.makeNew(
+      auth,
+      blob,
+      conversation.toJSON(),
+      agentConfiguration
+    );
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to schedule wake-up: ${result.error.message}`)
+      );
+    }
+
+    const wakeUp = result.value.toJSON();
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Scheduled wake-up ${wakeUp.sId}.\n\n` +
+          `Schedule: ${renderScheduleConfig(wakeUp)}\n` +
+          `Reason: ${wakeUp.reason}`,
+      },
+    ]);
+  },
+
+  list_wakeups: async (_params, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const { conversation } = runContext;
+
+    const wakeUps = await WakeUpResource.listByConversation(auth, conversation);
+
+    if (wakeUps.length === 0) {
       return new Ok([
         {
           type: "text" as const,
-          text:
-            `Scheduled wake-up ${wakeUp.sId}.\n\n` +
-            `Schedule: ${renderScheduleConfig(wakeUp)}\n` +
-            `Reason: ${wakeUp.reason}`,
+          text: "No wake-ups in this conversation.",
         },
       ]);
-    },
+    }
 
-    list_wakeups: async () => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
+    const rendered = wakeUps.map((w) => renderWakeUp(w.toJSON())).join("\n\n");
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Wake-ups in this conversation:\n\n${rendered}`,
+      },
+    ]);
+  },
+
+  cancel_wakeup: async ({ wakeUpId }, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const { conversation } = runContext;
+
+    const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
+    if (!wakeUp) {
+      return new Err(new MCPError(`Wake-up ${wakeUpId} not found.`));
+    }
+
+    if (wakeUp.conversationId !== conversation.id) {
+      return new Err(
+        new MCPError(
+          `Wake-up ${wakeUpId} does not belong to the current conversation.`
+        )
       );
+    }
 
-      const { conversation } = toolContext.runContext;
-
-      const wakeUps = await WakeUpResource.listByConversation(
-        auth,
-        conversation
+    const previousStatus = wakeUp.status;
+    const cancelResult = await wakeUp.cancel(auth);
+    if (cancelResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to cancel wake-up ${wakeUpId}: ${cancelResult.error.message}`
+        )
       );
+    }
 
-      if (wakeUps.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "No wake-ups in this conversation.",
-          },
-        ]);
-      }
-
-      const rendered = wakeUps
-        .map((w) => renderWakeUp(w.toJSON()))
-        .join("\n\n");
+    if (previousStatus !== "scheduled") {
       return new Ok([
         {
           type: "text" as const,
-          text: `Wake-ups in this conversation:\n\n${rendered}`,
+          text: `Wake-up ${wakeUpId} was already ${previousStatus}; nothing to do.`,
         },
       ]);
-    },
+    }
 
-    cancel_wakeup: async ({ wakeUpId }) => {
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
-      );
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Cancelled wake-up ${wakeUpId}.`,
+      },
+    ]);
+  },
+};
 
-      const { conversation } = toolContext.runContext;
-
-      const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
-      if (!wakeUp) {
-        return new Err(new MCPError(`Wake-up ${wakeUpId} not found.`));
-      }
-
-      if (wakeUp.conversationId !== conversation.id) {
-        return new Err(
-          new MCPError(
-            `Wake-up ${wakeUpId} does not belong to the current conversation.`
-          )
-        );
-      }
-
-      const previousStatus = wakeUp.status;
-      const cancelResult = await wakeUp.cancel(auth);
-      if (cancelResult.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to cancel wake-up ${wakeUpId}: ${cancelResult.error.message}`
-          )
-        );
-      }
-
-      if (previousStatus !== "scheduled") {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Wake-up ${wakeUpId} was already ${previousStatus}; nothing to do.`,
-          },
-        ]);
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Cancelled wake-up ${wakeUpId}.`,
-        },
-      ]);
-    },
-  };
-
-  return buildTools(WAKEUPS_TOOLS_METADATA, handlers);
-}
+export const TOOLS = buildTools(WAKEUPS_TOOLS_METADATA, handlers);


### PR DESCRIPTION
## Description

Several internal MCP servers use factories to close over workspace or agent run context before building otherwise static tool maps.

This PR exports their `TOOLS` arrays directly and reads `auth`, `authInfo`, and `runContext` from the handler execution context. Tool schemas and advertised tool sets stay unchanged. Conditional tool selection remains in a separate PR.

## Tests

- Covered by existing tests.

## Risk

- Low. Internal MCP handler wiring only.

## Deploy Plan

- Deploy front.