### PR TITLE
[front] chore: remove conditional MCP tool factories

### DIFF
--- a/front/lib/api/actions/servers/include_data/index.ts
+++ b/front/lib/api/actions/servers/include_data/index.ts
@@ -1,7 +1,11 @@
+import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
-import { createIncludeDataTools } from "@app/lib/api/actions/servers/include_data/tools";
+import {
+  BASE_TOOLS,
+  TOOLS_WITH_TAGS,
+} from "@app/lib/api/actions/servers/include_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -11,7 +15,10 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("include_data");
 
-  const tools = createIncludeDataTools(auth, toolContext);
+  const tools =
+    toolContext && shouldAutoGenerateTags(toolContext)
+      ? TOOLS_WITH_TAGS
+      : BASE_TOOLS;
   for (const tool of tools) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: "include_data",

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -1,10 +1,6 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import {
-  isAgentLoopRunContext,
-  type ToolContext,
-} from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
@@ -12,59 +8,37 @@ import {
   INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/include_data/metadata";
 import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
-import type { Authenticator } from "@app/lib/auth";
 
-// Create tools with access to auth via closure
-export function createIncludeDataTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-) {
-  const areTagsDynamic = toolContext
-    ? shouldAutoGenerateTags(toolContext)
-    : false;
+const baseHandlers: ToolHandlers<typeof INCLUDE_DATA_BASE_TOOLS_METADATA> = {
+  retrieve_recent_documents: async (params, { auth, runContext }) => {
+    const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(runContext)
+      ? runContext.stepContext
+      : {
+          retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K,
+          citationsOffset: 0,
+        };
+    return runIncludeDataRetrieval(auth, {
+      ...params,
+      citationsOffset,
+      retrievalTopK,
+    });
+  },
+};
 
-  const { retrievalTopK, citationsOffset } = isAgentLoopRunContext(
-    toolContext?.runContext
-  )
-    ? toolContext.runContext.stepContext
-    : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
+const handlersWithTags: ToolHandlers<
+  typeof INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA
+> = {
+  retrieve_recent_documents: baseHandlers.retrieve_recent_documents,
+  find_tags: async ({ query, dataSources }, { auth }) => {
+    return executeFindTags(auth, query, dataSources);
+  },
+};
 
-  if (!areTagsDynamic) {
-    // Return base tools without tags
-    const handlers: ToolHandlers<typeof INCLUDE_DATA_BASE_TOOLS_METADATA> = {
-      retrieve_recent_documents: async (params, _extra) => {
-        if (!toolContext?.runContext) {
-          throw new Error(
-            "agentLoopRunContext is required where the tool is called."
-          );
-        }
-        return runIncludeDataRetrieval(auth, {
-          ...params,
-          citationsOffset,
-          retrievalTopK,
-        });
-      },
-    };
-    return buildTools(INCLUDE_DATA_BASE_TOOLS_METADATA, handlers);
-  }
-
-  // Return tools with tags support
-  const handlers: ToolHandlers<typeof INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA> = {
-    retrieve_recent_documents: async (params, _extra) => {
-      if (!toolContext?.runContext) {
-        throw new Error(
-          "agentLoopRunContext is required where the tool is called."
-        );
-      }
-      return runIncludeDataRetrieval(auth, {
-        ...params,
-        citationsOffset,
-        retrievalTopK,
-      });
-    },
-    find_tags: async ({ query, dataSources }, _extra) => {
-      return executeFindTags(auth, query, dataSources);
-    },
-  };
-  return buildTools(INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA, handlers);
-}
+export const BASE_TOOLS = buildTools(
+  INCLUDE_DATA_BASE_TOOLS_METADATA,
+  baseHandlers
+);
+export const TOOLS_WITH_TAGS = buildTools(
+  INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA,
+  handlersWithTags
+);

--- a/front/lib/api/actions/servers/interactive_content/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/index.ts
@@ -1,8 +1,14 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { ToolContext } from "@app/lib/actions/types";
-import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
+import {
+  isAgentLoopRunContext,
+  type ToolContext,
+} from "@app/lib/actions/types";
+import {
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  INTERACTIVE_CONTENT_SERVER_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/interactive_content/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,7 +18,26 @@ async function createServer(
 ): Promise<McpServer> {
   const server = makeInternalMCPServer(INTERACTIVE_CONTENT_SERVER_NAME);
 
-  const tools = await createInteractiveContentTools(auth, toolContext);
+  // The file-id edit tool is deprecated in favor of editing the Frame's mounted source by path
+  // with the files server, then publishing. Conversations without the file system (created
+  // before it defaulted on) have no path tools, so they keep it.
+  //
+  // The file-id retrieve tool stays everywhere, including file-system conversations: unlike
+  // edit, it reads the canonical original directly by FileResource id rather than through the
+  // mount, so it still works for a Frame whose mountFilePath hasn't been resolved (e.g. one
+  // predating the mount system that has not gone through the backfill). The path-based files
+  // tools have no fallback for that case (files.resolve and the mount read both require
+  // mountFilePath to be set), so removing retrieve would leave such a Frame unreadable.
+  const runContext = toolContext?.runContext;
+  const conversation = isAgentLoopRunContext(runContext)
+    ? runContext.conversation
+    : toolContext?.listToolsContext?.conversation;
+  const tools =
+    conversation?.metadata?.useFileSystem === true
+      ? TOOLS.filter(
+          (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+        )
+      : TOOLS;
   for (const tool of tools) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: INTERACTIVE_CONTENT_SERVER_NAME,

--- a/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.test.ts
@@ -1,12 +1,15 @@
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import type { ToolContext } from "@app/lib/actions/types";
+import createServer from "@app/lib/api/actions/servers/interactive_content";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import { createInteractiveContentTools } from "@app/lib/api/actions/servers/interactive_content/tools";
+import type { Authenticator } from "@app/lib/auth";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { describe, expect, it } from "vitest";
 
 function toolContextWithUseFileSystem(
@@ -20,15 +23,31 @@ function toolContextWithUseFileSystem(
   } as unknown as ToolContext;
 }
 
-describe("createInteractiveContentTools", () => {
+async function getToolNames(
+  auth: Authenticator,
+  toolContext?: ToolContext
+): Promise<string[]> {
+  const server = await createServer(auth, toolContext);
+  const client = new Client({
+    name: "interactive-content-test",
+    version: "1.0.0",
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryWithAuthTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const { tools } = await client.listTools();
+  await client.close();
+
+  return tools.map((tool) => tool.name);
+}
+
+describe("interactive content server", () => {
   it("drops the file-id edit tool but keeps retrieve when the conversation has the file system", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
-    const tools = await createInteractiveContentTools(
-      auth,
-      toolContextWithUseFileSystem(true)
-    );
-    const names = tools.map((tool) => tool.name);
+    const names = await getToolNames(auth, toolContextWithUseFileSystem(true));
 
     expect(names).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
@@ -39,11 +58,10 @@ describe("createInteractiveContentTools", () => {
   it("keeps the file-id edit and retrieve tools for legacy conversations", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
-    const tools = await createInteractiveContentTools(
+    const names = await getToolNames(
       auth,
       toolContextWithUseFileSystem(undefined)
     );
-    const names = tools.map((tool) => tool.name);
 
     expect(names).toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
@@ -52,8 +70,7 @@ describe("createInteractiveContentTools", () => {
   it("keeps the file-id edit and retrieve tools when no conversation is available", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
-    const tools = await createInteractiveContentTools(auth, undefined);
-    const names = tools.map((tool) => tool.name);
+    const names = await getToolNames(auth);
 
     expect(names).toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
     expect(names).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -1,19 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  isAgentLoopRunContext,
-  type ToolContext,
-} from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
-import {
-  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
-  INTERACTIVE_CONTENT_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { INTERACTIVE_CONTENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import {
@@ -30,449 +21,405 @@ import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export
 import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
-import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 
-export async function createInteractiveContentTools(
-  auth: Authenticator,
-  toolContext?: ToolContext
-): Promise<ToolDefinition[]> {
-  const handlers: ToolHandlers<typeof INTERACTIVE_CONTENT_TOOLS_METADATA> = {
-    create_interactive_content_file: async (
-      { file_name, mime_type, mode, source, description },
-      { sendNotification, _meta }
-    ) => {
-      // TODO: enable create and publish to be conversation agnostic for both templates (local) and
-      //       createClientExecutablefile direclty on pod DFS so that we can re-enable this server
-      //       when run without conversation context.
-      assert(
-        isAgentLoopRunContext(toolContext?.runContext),
-        "AgentLoopRunContext expected"
+const handlers: ToolHandlers<typeof INTERACTIVE_CONTENT_TOOLS_METADATA> = {
+  create_interactive_content_file: async (
+    { file_name, mime_type, mode, source, description },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    // TODO: enable create and publish to be conversation agnostic for both templates (local) and
+    //       createClientExecutablefile direclty on pod DFS so that we can re-enable this server
+    //       when run without conversation context.
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const { conversation, agentConfiguration } = runContext;
+
+    let fileContent: string;
+
+    if (mode === "template") {
+      const templateResult = await fetchTemplateContent(auth, runContext, {
+        templateRef: source,
+      });
+
+      if (templateResult.isErr()) {
+        return templateResult;
+      }
+
+      fileContent = templateResult.value;
+    } else {
+      fileContent = source;
+    }
+
+    const result = await createClientExecutableFile(auth, {
+      content: fileContent,
+      conversationId: conversation.sId,
+      fileName: file_name,
+      mimeType: mime_type,
+      createdByAgentConfigurationId: agentConfiguration?.sId,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.tracked,
+        })
       );
+    }
 
-      const { conversation, agentConfiguration } = toolContext.runContext;
+    const { fileResource, warnings } = result.value;
 
-      let fileContent: string;
+    let responseText = description
+      ? `File '${fileResource.sId}' created successfully. ${description}`
+      : `File '${fileResource.sId}' created successfully.`;
 
-      if (mode === "template") {
-        const templateResult = await fetchTemplateContent(
-          auth,
-          toolContext.runContext,
+    responseText += formatValidationWarningsForLLM(warnings);
+
+    if (_meta?.progressToken) {
+      const notification: MCPProgressNotificationType =
+        buildInteractiveContentFileNotification(
+          _meta.progressToken,
+          fileResource,
+          "Creating interactive file..."
+        );
+
+      // Send a notification to the MCP Client, to display the interactive file.
+      await sendNotification(notification);
+    }
+
+    return new Ok([
+      {
+        type: "resource",
+        resource: {
+          contentType: fileResource.contentType,
+          fileId: fileResource.sId,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+          snippet: fileResource.snippet,
+          text: responseText,
+          title: fileResource.fileName,
+          uri: fileResource.getPublicUrl(auth),
+        },
+      },
+    ]);
+  },
+
+  edit_interactive_content_file: async (
+    { file_id, old_string, new_string, expected_replacements },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    const { agentConfiguration } = isAgentLoopRunContext(runContext)
+      ? runContext
+      : {};
+
+    const result = await editClientExecutableFile(auth, {
+      fileId: file_id,
+      oldString: old_string,
+      newString: new_string,
+      expectedReplacements: expected_replacements,
+      editedByAgentConfigurationId: agentConfiguration?.sId,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.tracked,
+        })
+      );
+    }
+
+    const {
+      fileResource,
+      replacementCount,
+      warnings,
+      referencedFilesChangeNotice,
+    } = result.value;
+
+    const pluralS = replacementCount === 1 ? "" : "s";
+    let responseText =
+      `File '${fileResource.sId}' updated successfully. Made ` +
+      `${replacementCount} replacement${pluralS}`;
+
+    responseText += formatValidationWarningsForLLM(warnings);
+    if (referencedFilesChangeNotice) {
+      responseText += referencedFilesChangeNotice;
+    }
+
+    if (_meta?.progressToken) {
+      const notification: MCPProgressNotificationType =
+        buildInteractiveContentFileNotification(
+          _meta.progressToken,
+          fileResource,
+          "Updating Interactive Content file..."
+        );
+
+      // Send a notification to the MCP Client, to refresh the Interactive Content file.
+      await sendNotification(notification);
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: responseText,
+      },
+    ]);
+  },
+
+  revert_interactive_content_file: async (
+    { file_id },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    if (!isAgentLoopRunContext(runContext)) {
+      throw new Error(
+        "Could not access Agent Loop Context from revert Interactive Content file tool."
+      );
+    }
+
+    const { agentConfiguration } = runContext;
+
+    const result = await revertClientExecutableFileChanges(auth, {
+      fileId: file_id,
+      revertedByAgentConfigurationId: agentConfiguration?.sId,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.tracked,
+        })
+      );
+    }
+
+    const {
+      value: { fileResource },
+    } = result;
+
+    if (_meta?.progressToken) {
+      const notification: MCPProgressNotificationType =
+        buildInteractiveContentFileNotification(
+          _meta.progressToken,
+          fileResource,
+          "Reverting Interactive Content file..."
+        );
+
+      // Send a notification to the MCP Client, to refresh the Interactive Content file.
+      await sendNotification(notification);
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: `File '${fileResource.sId}' reverted successfully.`,
+      },
+    ]);
+  },
+
+  rename_interactive_content_file: async (
+    { file_id, new_file_name },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    const { agentConfiguration } = isAgentLoopRunContext(runContext)
+      ? runContext
+      : {};
+
+    const result = await renameClientExecutableFile(auth, {
+      fileId: file_id,
+      newFileName: new_file_name,
+      renamedByAgentConfigurationId: agentConfiguration?.sId,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.tracked,
+        })
+      );
+    }
+
+    const fileResource = result.value;
+
+    const responseText = `File '${fileResource.sId}' renamed successfully to '${fileResource.fileName}'.`;
+
+    if (_meta?.progressToken) {
+      const notification: MCPProgressNotificationType =
+        buildInteractiveContentFileNotification(
+          _meta.progressToken,
+          fileResource,
+          "Renaming interactive file..."
+        );
+
+      await sendNotification(notification);
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: responseText,
+      },
+    ]);
+  },
+
+  retrieve_interactive_content_file: async ({ file_id }, { auth }) => {
+    const result = await getClientExecutableFileContent(auth, file_id);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.tracked,
+        })
+      );
+    }
+
+    const { fileResource, content } = result.value;
+
+    return new Ok([
+      {
+        type: "text",
+        text:
+          `File '${fileResource.sId}' (${fileResource.fileName}) retrieved ` +
+          `successfully. Content:\n\n${content}`,
+      },
+    ]);
+  },
+
+  get_interactive_content_file_share_url: async ({ file_id }, { auth }) => {
+    const shareUrlRes = await getClientExecutableFileShareUrl(auth, file_id);
+    if (shareUrlRes.isErr()) {
+      return new Err(new MCPError(shareUrlRes.error.message));
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: `URL: ${shareUrlRes.value}`,
+      },
+    ]);
+  },
+
+  export_interactive_content_file: async (
+    { file_id, format, orientation },
+    { auth }
+  ) => {
+    switch (format) {
+      case "pdf": {
+        const result = await exportInteractiveContentFileAsPdf(auth, {
+          fileId: file_id,
+          orientation,
+        });
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(result.error.message, { tracked: false })
+          );
+        }
+        return new Ok([
           {
-            templateRef: source,
-          }
-        );
-
-        if (templateResult.isErr()) {
-          return templateResult;
-        }
-
-        fileContent = templateResult.value;
-      } else {
-        fileContent = source;
-      }
-
-      const result = await createClientExecutableFile(auth, {
-        content: fileContent,
-        conversationId: conversation.sId,
-        fileName: file_name,
-        mimeType: mime_type,
-        createdByAgentConfigurationId: agentConfiguration?.sId,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.tracked,
-          })
-        );
-      }
-
-      const { fileResource, warnings } = result.value;
-
-      let responseText = description
-        ? `File '${fileResource.sId}' created successfully. ${description}`
-        : `File '${fileResource.sId}' created successfully.`;
-
-      responseText += formatValidationWarningsForLLM(warnings);
-
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType =
-          buildInteractiveContentFileNotification(
-            _meta.progressToken,
-            fileResource,
-            "Creating interactive file..."
-          );
-
-        // Send a notification to the MCP Client, to display the interactive file.
-        await sendNotification(notification);
-      }
-
-      return new Ok([
-        {
-          type: "resource",
-          resource: {
-            contentType: fileResource.contentType,
-            fileId: fileResource.sId,
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-            snippet: fileResource.snippet,
-            text: responseText,
-            title: fileResource.fileName,
-            uri: fileResource.getPublicUrl(auth),
+            type: "resource",
+            resource: {
+              uri: result.value.fileName,
+              mimeType: "application/pdf",
+              blob: result.value.buffer.toString("base64"),
+            },
           },
-        },
-      ]);
-    },
-
-    edit_interactive_content_file: async (
-      { file_id, old_string, new_string, expected_replacements },
-      { sendNotification, _meta }
-    ) => {
-      const { agentConfiguration } = isAgentLoopRunContext(
-        toolContext?.runContext
-      )
-        ? toolContext?.runContext
-        : {};
-
-      const result = await editClientExecutableFile(auth, {
-        fileId: file_id,
-        oldString: old_string,
-        newString: new_string,
-        expectedReplacements: expected_replacements,
-        editedByAgentConfigurationId: agentConfiguration?.sId,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.tracked,
-          })
-        );
+        ]);
       }
-
-      const {
-        fileResource,
-        replacementCount,
-        warnings,
-        referencedFilesChangeNotice,
-      } = result.value;
-
-      const pluralS = replacementCount === 1 ? "" : "s";
-      let responseText =
-        `File '${fileResource.sId}' updated successfully. Made ` +
-        `${replacementCount} replacement${pluralS}`;
-
-      responseText += formatValidationWarningsForLLM(warnings);
-      if (referencedFilesChangeNotice) {
-        responseText += referencedFilesChangeNotice;
-      }
-
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType =
-          buildInteractiveContentFileNotification(
-            _meta.progressToken,
-            fileResource,
-            "Updating Interactive Content file..."
+      case "png": {
+        const result = await screenshotInteractiveContentFile(auth, {
+          fileId: file_id,
+        });
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(result.error.message, { tracked: false })
           );
-
-        // Send a notification to the MCP Client, to refresh the Interactive Content file.
-        await sendNotification(notification);
-      }
-
-      return new Ok([
-        {
-          type: "text",
-          text: responseText,
-        },
-      ]);
-    },
-
-    revert_interactive_content_file: async (
-      { file_id },
-      { sendNotification, _meta }
-    ) => {
-      if (!isAgentLoopRunContext(toolContext?.runContext)) {
-        throw new Error(
-          "Could not access Agent Loop Context from revert Interactive Content file tool."
-        );
-      }
-
-      const { agentConfiguration } = toolContext.runContext;
-
-      const result = await revertClientExecutableFileChanges(auth, {
-        fileId: file_id,
-        revertedByAgentConfigurationId: agentConfiguration?.sId,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.tracked,
-          })
-        );
-      }
-
-      const {
-        value: { fileResource },
-      } = result;
-
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType =
-          buildInteractiveContentFileNotification(
-            _meta.progressToken,
-            fileResource,
-            "Reverting Interactive Content file..."
-          );
-
-        // Send a notification to the MCP Client, to refresh the Interactive Content file.
-        await sendNotification(notification);
-      }
-
-      return new Ok([
-        {
-          type: "text",
-          text: `File '${fileResource.sId}' reverted successfully.`,
-        },
-      ]);
-    },
-
-    rename_interactive_content_file: async (
-      { file_id, new_file_name },
-      { sendNotification, _meta }
-    ) => {
-      const { agentConfiguration } = isAgentLoopRunContext(
-        toolContext?.runContext
-      )
-        ? toolContext?.runContext
-        : {};
-
-      const result = await renameClientExecutableFile(auth, {
-        fileId: file_id,
-        newFileName: new_file_name,
-        renamedByAgentConfigurationId: agentConfiguration?.sId,
-      });
-
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.tracked,
-          })
-        );
-      }
-
-      const fileResource = result.value;
-
-      const responseText = `File '${fileResource.sId}' renamed successfully to '${fileResource.fileName}'.`;
-
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType =
-          buildInteractiveContentFileNotification(
-            _meta.progressToken,
-            fileResource,
-            "Renaming interactive file..."
-          );
-
-        await sendNotification(notification);
-      }
-
-      return new Ok([
-        {
-          type: "text",
-          text: responseText,
-        },
-      ]);
-    },
-
-    retrieve_interactive_content_file: async ({ file_id }) => {
-      const result = await getClientExecutableFileContent(auth, file_id);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.tracked,
-          })
-        );
-      }
-
-      const { fileResource, content } = result.value;
-
-      return new Ok([
-        {
-          type: "text",
-          text:
-            `File '${fileResource.sId}' (${fileResource.fileName}) retrieved ` +
-            `successfully. Content:\n\n${content}`,
-        },
-      ]);
-    },
-
-    get_interactive_content_file_share_url: async ({ file_id }) => {
-      const shareUrlRes = await getClientExecutableFileShareUrl(auth, file_id);
-      if (shareUrlRes.isErr()) {
-        return new Err(new MCPError(shareUrlRes.error.message));
-      }
-
-      return new Ok([
-        {
-          type: "text",
-          text: `URL: ${shareUrlRes.value}`,
-        },
-      ]);
-    },
-
-    export_interactive_content_file: async ({
-      file_id,
-      format,
-      orientation,
-    }) => {
-      switch (format) {
-        case "pdf": {
-          const result = await exportInteractiveContentFileAsPdf(auth, {
-            fileId: file_id,
-            orientation,
-          });
-          if (result.isErr()) {
-            return new Err(
-              new MCPError(result.error.message, { tracked: false })
-            );
-          }
-          return new Ok([
-            {
-              type: "resource",
-              resource: {
-                uri: result.value.fileName,
-                mimeType: "application/pdf",
-                blob: result.value.buffer.toString("base64"),
-              },
-            },
-          ]);
         }
-        case "png": {
-          const result = await screenshotInteractiveContentFile(auth, {
-            fileId: file_id,
-          });
-          if (result.isErr()) {
-            return new Err(
-              new MCPError(result.error.message, { tracked: false })
-            );
-          }
-          return new Ok([
-            {
-              type: "image",
-              data: result.value.buffer.toString("base64"),
-              mimeType: "image/png",
-            },
-          ]);
-        }
-        default:
-          assertNever(format);
+        return new Ok([
+          {
+            type: "image",
+            data: result.value.buffer.toString("base64"),
+            mimeType: "image/png",
+          },
+        ]);
       }
-    },
+      default:
+        assertNever(format);
+    }
+  },
 
-    publish_interactive_content_file: async (
-      { file_id, path },
-      { sendNotification, _meta }
-    ) => {
-      const { agentConfiguration } = isAgentLoopRunContext(
-        toolContext?.runContext
-      )
-        ? toolContext?.runContext
-        : {};
+  publish_interactive_content_file: async (
+    { file_id, path },
+    { auth, runContext, sendNotification, _meta }
+  ) => {
+    const { agentConfiguration } = isAgentLoopRunContext(runContext)
+      ? runContext
+      : {};
 
-      const file = await FileResource.fetchById(auth, file_id);
-      if (!file) {
-        return new Err(
-          new MCPError(`Frame not found: ${file_id}`, { tracked: false })
+    const file = await FileResource.fetchById(auth, file_id);
+    if (!file) {
+      return new Err(
+        new MCPError(`Frame not found: ${file_id}`, { tracked: false })
+      );
+    }
+
+    if (!file.isInteractiveContent) {
+      return new Err(
+        new MCPError(
+          `File '${file_id}' is not a Frame (content type: ${file.contentType}).`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const splitResult = splitFrameEntryScopedPath(path);
+    if (splitResult.isErr()) {
+      return new Err(
+        new MCPError(splitResult.error.message, { tracked: false })
+      );
+    }
+    const { root, entryRelPath } = splitResult.value;
+
+    const fsResult = await DustFileSystem.fromScopedPath(auth, root);
+    if (fsResult.isErr()) {
+      return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    }
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: createMountFrameSourceReader(fsResult.value, root),
+      entryRelPath,
+      rootScopedPath: root,
+      publishedByAgentConfigurationId: agentConfiguration?.sId,
+    });
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(result.error.message, {
+          tracked: result.error.code === "internal",
+        })
+      );
+    }
+
+    let responseText = `Frame '${file.sId}' published successfully.`;
+    responseText += formatValidationWarningsForLLM(result.value.warnings);
+
+    if (_meta?.progressToken) {
+      const notification: MCPProgressNotificationType =
+        buildInteractiveContentFileNotification(
+          _meta.progressToken,
+          file,
+          "Publishing Frame..."
         );
-      }
 
-      if (!file.isInteractiveContent) {
-        return new Err(
-          new MCPError(
-            `File '${file_id}' is not a Frame (content type: ${file.contentType}).`,
-            { tracked: false }
-          )
-        );
-      }
+      // Notify the MCP client to refresh the now-republished Frame.
+      await sendNotification(notification);
+    }
 
-      const splitResult = splitFrameEntryScopedPath(path);
-      if (splitResult.isErr()) {
-        return new Err(
-          new MCPError(splitResult.error.message, { tracked: false })
-        );
-      }
-      const { root, entryRelPath } = splitResult.value;
+    return new Ok([
+      {
+        type: "text",
+        text: responseText,
+      },
+    ]);
+  },
+};
 
-      const fsResult = await DustFileSystem.fromScopedPath(auth, root);
-      if (fsResult.isErr()) {
-        return new Err(
-          new MCPError(fsResult.error.message, { tracked: false })
-        );
-      }
-
-      const result = await publishFrame(auth, {
-        file,
-        reader: createMountFrameSourceReader(fsResult.value, root),
-        entryRelPath,
-        rootScopedPath: root,
-        publishedByAgentConfigurationId: agentConfiguration?.sId,
-      });
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error.message, {
-            tracked: result.error.code === "internal",
-          })
-        );
-      }
-
-      let responseText = `Frame '${file.sId}' published successfully.`;
-      responseText += formatValidationWarningsForLLM(result.value.warnings);
-
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType =
-          buildInteractiveContentFileNotification(
-            _meta.progressToken,
-            file,
-            "Publishing Frame..."
-          );
-
-        // Notify the MCP client to refresh the now-republished Frame.
-        await sendNotification(notification);
-      }
-
-      return new Ok([
-        {
-          type: "text",
-          text: responseText,
-        },
-      ]);
-    },
-  };
-
-  const tools = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);
-
-  // The file-id edit tool is deprecated in favor of editing the Frame's mounted source by path
-  // with the files server, then publishing. Conversations without the file system (created
-  // before it defaulted on) have no path tools, so they keep it.
-  //
-  // The file-id retrieve tool stays everywhere, including file-system conversations: unlike
-  // edit, it reads the canonical original directly by FileResource id rather than through the
-  // mount, so it still works for a Frame whose mountFilePath hasn't been resolved (e.g. one
-  // predating the mount system that has not gone through the backfill). The path-based files
-  // tools have no fallback for that case (files.resolve and the mount read both require
-  // mountFilePath to be set), so removing retrieve would leave such a Frame unreadable.
-  const { runContext } = toolContext ?? {};
-  const conversation = isAgentLoopRunContext(runContext)
-    ? runContext.conversation
-    : toolContext?.listToolsContext?.conversation;
-  if (conversation?.metadata?.useFileSystem === true) {
-    return tools.filter(
-      (tool) => tool.name !== EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME
-    );
-  }
-
-  return tools;
-}
+export const TOOLS = buildTools(INTERACTIVE_CONTENT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/sandbox/index.ts
+++ b/front/lib/api/actions/servers/sandbox/index.ts
@@ -2,8 +2,14 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
-import { createSandboxTools } from "@app/lib/api/actions/servers/sandbox/tools";
+import {
+  ADD_EGRESS_DOMAIN_TOOL_NAME,
+  isSandboxAgentEgressRequestsAllowed,
+  TOOLS,
+} from "@app/lib/api/actions/servers/sandbox/tools";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 async function createServer(
@@ -12,7 +18,13 @@ async function createServer(
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("sandbox");
 
-  const tools = await createSandboxTools(auth, toolContext);
+  // The add_egress_domain tool requires Computer access and the
+  // per-workspace setting that admins toggle on top of it.
+  const flags = await getFeatureFlags(auth);
+  const tools =
+    isComputerFeatureEnabled(flags) && isSandboxAgentEgressRequestsAllowed(auth)
+      ? TOOLS
+      : TOOLS.filter((tool) => tool.name !== ADD_EGRESS_DOMAIN_TOOL_NAME);
   for (const tool of tools) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: SANDBOX_TOOL_NAME,

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -1,8 +1,11 @@
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
+import createServer from "@app/lib/api/actions/servers/sandbox";
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Err, Ok } from "@app/types/shared/result";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -121,17 +124,30 @@ vi.mock("@app/logger/logger", () => {
 import {
   addEgressDomainTool,
   buildDescribeToolsetOutput,
-  createSandboxTools,
   runSandboxBashTool,
 } from "./index";
 
-describe("createSandboxTools", () => {
+async function getToolNames(auth: Authenticator): Promise<string[]> {
+  const server = await createServer(auth);
+  const client = new Client({ name: "sandbox-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryWithAuthTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const { tools } = await client.listTools();
+  await client.close();
+
+  return tools.map((tool) => tool.name);
+}
+
+describe("sandbox server", () => {
   it("omits add_egress_domain by default", async () => {
     const { authenticator: auth } = await createResourceTest({});
 
-    const tools = await createSandboxTools(auth);
+    const toolNames = await getToolNames(auth);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(toolNames).not.toContain("add_egress_domain");
   });
 
   it("includes add_egress_domain when Computer and metadata are enabled", async () => {
@@ -144,9 +160,9 @@ describe("createSandboxTools", () => {
       workspace.sId
     );
 
-    const tools = await createSandboxTools(auth);
+    const toolNames = await getToolNames(auth);
 
-    expect(tools.map((tool) => tool.name)).toContain("add_egress_domain");
+    expect(toolNames).toContain("add_egress_domain");
   });
 
   it("omits add_egress_domain when Computer is disabled", async () => {
@@ -160,9 +176,9 @@ describe("createSandboxTools", () => {
     );
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
-    const tools = await createSandboxTools(auth);
+    const toolNames = await getToolNames(auth);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(toolNames).not.toContain("add_egress_domain");
   });
 
   it("omits add_egress_domain when metadata is off", async () => {
@@ -172,9 +188,9 @@ describe("createSandboxTools", () => {
       workspace.sId
     );
 
-    const tools = await createSandboxTools(auth);
+    const toolNames = await getToolNames(auth);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(toolNames).not.toContain("add_egress_domain");
   });
 });
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -1,13 +1,11 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { BlockedAwaitingInputOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  ToolDefinition,
   ToolHandlerExtra,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
-import type { ToolContext } from "@app/lib/actions/types";
 import {
   isAgentLoopRunContext,
   isSandboxResumeState,
@@ -60,7 +58,7 @@ import { z } from "zod";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
-const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
+export const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
 const REDACTION_MARKER_PREFIX = "«redacted:";
 const REDACTION_MARKER_SUFFIX = "»";
 const REDACTION_MIN_LENGTH = 16;
@@ -217,46 +215,31 @@ async function redactSandboxEnvVarsFromOutput(
   return new Ok(redactedOutput);
 }
 
-function isSandboxAgentEgressRequestsAllowed(auth: Authenticator): boolean {
+export function isSandboxAgentEgressRequestsAllowed(
+  auth: Authenticator
+): boolean {
   return (
     auth.getNonNullableWorkspace().metadata?.sandboxAllowAgentEgressRequests ===
     true
   );
 }
 
-export async function createSandboxTools(
-  auth: Authenticator,
-  _toolContext?: ToolContext
-): Promise<ToolDefinition[]> {
-  const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
-    bash: runSandboxBashTool,
-    describe_toolset: async ({ format }, { auth, runContext }) => {
-      const providerId = isAgentLoopRunContext(runContext)
-        ? runContext.modelInfo.endpoint.modelConfig.providerId
-        : null;
-      if (!providerId) {
-        return new Err(new MCPError("Missing model provider ID"));
-      }
+const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
+  bash: runSandboxBashTool,
+  describe_toolset: async ({ format }, { auth, runContext }) => {
+    const providerId = isAgentLoopRunContext(runContext)
+      ? runContext.modelInfo.endpoint.modelConfig.providerId
+      : null;
+    if (!providerId) {
+      return new Err(new MCPError("Missing model provider ID"));
+    }
 
-      return buildDescribeToolsetOutput(auth, providerId, format ?? "yaml");
-    },
-    [ADD_EGRESS_DOMAIN_TOOL_NAME]: addEgressDomainTool,
-  };
+    return buildDescribeToolsetOutput(auth, providerId, format ?? "yaml");
+  },
+  [ADD_EGRESS_DOMAIN_TOOL_NAME]: addEgressDomainTool,
+};
 
-  const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers);
-
-  // The add_egress_domain tool requires Computer access and the
-  // per-workspace setting that admins toggle on top of it.
-  const flags = await getFeatureFlags(auth);
-  if (
-    isComputerFeatureEnabled(flags) &&
-    isSandboxAgentEgressRequestsAllowed(auth)
-  ) {
-    return tools;
-  }
-
-  return tools.filter((tool) => tool.name !== ADD_EGRESS_DOMAIN_TOOL_NAME);
-}
+export const TOOLS = buildTools(SANDBOX_TOOLS_METADATA, handlers);
 
 export async function buildDescribeToolsetOutput(
   auth: Authenticator,
@@ -488,7 +471,7 @@ export async function addEgressDomainTool(
   { auth, runContext }: ToolHandlerExtra
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
   assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
-  // Defense-in-depth: createSandboxTools already filters this tool out when
+  // Defense-in-depth: createServer already filters this tool out when
   // the workspace setting is off, so this metadata-only check is enough to
   // reject any caller that bypasses tool-list filtering.
   if (!isSandboxAgentEgressRequestsAllowed(auth)) {

--- a/front/lib/api/actions/servers/slack_personal/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/index.ts
@@ -6,11 +6,11 @@ import logger from "@app/logger/logger";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { SLACK_TOOL_LOG_NAME } from "./metadata";
-import type { SlackAIStatus } from "./tools";
 import {
-  createSlackPersonalTools,
   getSlackAIEnablementStatus,
   getSlackConnectionForMCPServer,
+  type SlackAIStatus,
+  TOOLS,
 } from "./tools";
 
 const localLogger = logger.child({ module: "mcp_slack_personal" });
@@ -37,8 +37,29 @@ async function createServer(
     "Slack MCP server initialized"
   );
 
-  const { searchMessagesTool, semanticSearchMessagesTool, commonTools } =
-    createSlackPersonalTools(auth, mcpServerId, toolContext);
+  const allowFooterRemoval =
+    auth.workspace()?.metadata?.slackPersonalAllowFooterRemoval ?? false;
+  // When footer removal is not allowed, strip show_sent_by_footer from the schema so
+  // the LLM never sees the parameter — the handler already enforces true server-side.
+  const tools = allowFooterRemoval
+    ? TOOLS
+    : TOOLS.map((tool) => {
+        if (tool.name === "post_message" || tool.name === "schedule_message") {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { show_sent_by_footer: _stripped, ...schemaWithoutFooter } =
+            tool.schema;
+          return { ...tool, schema: schemaWithoutFooter };
+        }
+        return tool;
+      });
+
+  const searchMessagesTool = tools.find((t) => t.name === "search_messages")!;
+  const semanticSearchMessagesTool = tools.find(
+    (t) => t.name === "semantic_search_messages"
+  )!;
+  const commonTools = tools.filter(
+    (t) => t.name !== "search_messages" && t.name !== "semantic_search_messages"
+  );
 
   // Register search tool based on Slack AI status.
   // If we're not connected to Slack, we arbitrarily include the keyword search tool,

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -1,16 +1,12 @@
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type {
-  ToolDefinition,
-  ToolHandlers,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
   type AgentLoopRunContext,
   isAgentLoopRunContext,
-  type ToolContext,
 } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
@@ -364,247 +360,202 @@ function handleSlackAuthError(error: unknown) {
   return null;
 }
 
-interface SlackPersonalToolsResult {
-  searchMessagesTool: ToolDefinition;
-  semanticSearchMessagesTool: ToolDefinition;
-  commonTools: ToolDefinition[];
-}
+const handlers: ToolHandlers<typeof SLACK_PERSONAL_TOOLS_METADATA> = {
+  search_messages: async (
+    {
+      keywords,
+      usersFrom,
+      usersTo,
+      usersMentioned,
+      relativeTimeFrame,
+      channels,
+    },
+    { authInfo, runContext }
+  ) => {
+    if (keywords.length > 5) {
+      return new Err(
+        new MCPError(
+          "The search query is too broad. Please reduce the number of keywords to 5 or less."
+        )
+      );
+    }
 
-export function createSlackPersonalTools(
-  auth: Authenticator,
-  mcpServerId: string,
-  toolContext?: ToolContext
-): SlackPersonalToolsResult {
-  const allowFooterRemoval =
-    auth.workspace()?.metadata?.slackPersonalAllowFooterRemoval ?? false;
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-  const handlers: ToolHandlers<typeof SLACK_PERSONAL_TOOLS_METADATA> = {
-    search_messages: async (
-      {
+    const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+    try {
+      // Keyword search in slack only support AND queries which can easily return 0 hits.
+      // To avoid this, we'll simulate an OR query by searching for each keyword separately.
+      // Then we will aggregate the results.
+      const results: SlackSearchMatch[][] = await concurrentExecutor(
         keywords,
-        usersFrom,
-        usersTo,
-        usersMentioned,
-        relativeTimeFrame,
-        channels,
-      },
-      { authInfo }
-    ) => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
-      }
+        async (keyword) => {
+          const query = buildSlackSearchQuery(keyword, {
+            timeFrame,
+            channels,
+            usersFrom,
+            usersTo,
+            usersMentioned,
+          });
 
-      if (keywords.length > 5) {
-        return new Err(
-          new MCPError(
-            "The search query is too broad. Please reduce the number of keywords to 5 or less."
-          )
-        );
-      }
+          return slackSearch(query, accessToken);
+        },
+        { concurrency: 3 }
+      );
 
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
+      // Flatten the results.
+      const rawMatches = results.flat();
 
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
+      // Deduplicate matches by their permalink across keywords.
+      const deduplicatedMatches = uniqBy(rawMatches, "permalink");
 
-      try {
-        // Keyword search in slack only support AND queries which can easily return 0 hits.
-        // To avoid this, we'll simulate an OR query by searching for each keyword separately.
-        // Then we will aggregate the results.
-        const results: SlackSearchMatch[][] = await concurrentExecutor(
-          keywords,
-          async (keyword) => {
-            const query = buildSlackSearchQuery(keyword, {
-              timeFrame,
-              channels,
-              usersFrom,
-              usersTo,
-              usersMentioned,
-            });
+      // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
+      const matches = deduplicatedMatches.slice(
+        0,
+        SLACK_SEARCH_ACTION_NUM_RESULTS
+      );
 
-            return slackSearch(query, accessToken);
+      if (matches.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `No messages found.`,
           },
-          { concurrency: 3 }
-        );
-
-        // Flatten the results.
-        const rawMatches = results.flat();
-
-        // Deduplicate matches by their permalink across keywords.
-        const deduplicatedMatches = uniqBy(rawMatches, "permalink");
-
-        // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
-        const matches = deduplicatedMatches.slice(
-          0,
-          SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
-
-        if (matches.length === 0) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `No messages found.`,
-            },
-          ]);
-        }
-
-        const { citationsOffset } = isAgentLoopRunContext(
-          toolContext.runContext
-        )
-          ? toolContext.runContext.stepContext
-          : { citationsOffset: 0 };
-
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
-
-        const searchResults = buildSearchResults<SlackSearchMatch>(
-          matches,
-          refs,
-          {
-            permalink: (match) => match.permalink,
-            text: (match) => formatSlackMessageForDisplay(match),
-            id: (match) => match.message_ts ?? "",
-            content: (match) => match.content ?? "",
-          }
-        );
-
-        return new Ok(
-          searchResults.map((result) => ({
-            type: "resource" as const,
-            resource: result,
-          }))
-        );
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error searching messages: ${normalizeError(error)}`)
-        );
+        ]);
       }
-    },
 
-    semantic_search_messages: async (
-      {
-        query,
+      const { citationsOffset } = isAgentLoopRunContext(runContext)
+        ? runContext.stepContext
+        : { citationsOffset: 0 };
+
+      const refs = getRefs().slice(
+        citationsOffset,
+        citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+      );
+
+      const searchResults = buildSearchResults<SlackSearchMatch>(
+        matches,
+        refs,
+        {
+          permalink: (match) => match.permalink,
+          text: (match) => formatSlackMessageForDisplay(match),
+          id: (match) => match.message_ts ?? "",
+          content: (match) => match.content ?? "",
+        }
+      );
+
+      return new Ok(
+        searchResults.map((result) => ({
+          type: "resource" as const,
+          resource: result,
+        }))
+      );
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
+      }
+      return new Err(
+        new MCPError(`Error searching messages: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  semantic_search_messages: async (
+    { query, usersFrom, usersTo, usersMentioned, relativeTimeFrame, channels },
+    { authInfo, runContext }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+    try {
+      const searchQuery = buildSlackSearchQuery(query, {
+        timeFrame,
+        channels,
         usersFrom,
         usersTo,
         usersMentioned,
-        relativeTimeFrame,
-        channels,
-      },
-      { authInfo }
-    ) => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
+      });
+
+      const matches = await slackSearch(searchQuery, accessToken);
+
+      if (matches.length === 0) {
+        return new Ok([{ type: "text" as const, text: `No messages found.` }]);
       }
 
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
+      const { citationsOffset } = isAgentLoopRunContext(runContext)
+        ? runContext.stepContext
+        : { citationsOffset: 0 };
 
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
+      const refs = getRefs().slice(
+        citationsOffset,
+        citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+      );
 
-      try {
-        const searchQuery = buildSlackSearchQuery(query, {
-          timeFrame,
-          channels,
-          usersFrom,
-          usersTo,
-          usersMentioned,
-        });
-
-        const matches = await slackSearch(searchQuery, accessToken);
-
-        if (matches.length === 0) {
-          return new Ok([
-            { type: "text" as const, text: `No messages found.` },
-          ]);
+      const searchResults = buildSearchResults<SlackSearchMatch>(
+        matches,
+        refs,
+        {
+          permalink: (match) => match.permalink,
+          text: (match) => formatSlackMessageForDisplay(match),
+          id: (match) => match.message_ts ?? "",
+          content: (match) => match.content ?? "",
         }
+      );
 
-        const { citationsOffset } = isAgentLoopRunContext(
-          toolContext.runContext
-        )
-          ? toolContext.runContext.stepContext
-          : { citationsOffset: 0 };
-
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
-
-        const searchResults = buildSearchResults<SlackSearchMatch>(
-          matches,
-          refs,
-          {
-            permalink: (match) => match.permalink,
-            text: (match) => formatSlackMessageForDisplay(match),
-            id: (match) => match.message_ts ?? "",
-            content: (match) => match.content ?? "",
-          }
-        );
-
-        return new Ok(
-          searchResults.map((result) => ({
-            type: "resource" as const,
-            resource: result,
-          }))
-        );
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error searching messages: ${normalizeError(error)}`)
-        );
+      return new Ok(
+        searchResults.map((result) => ({
+          type: "resource" as const,
+          resource: result,
+        }))
+      );
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error searching messages: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  post_message: async (
+    {
+      to,
+      message,
+      threadTs,
+      fileId,
+      unfurlLinks,
+      unfurlMedia,
+      show_sent_by_footer,
     },
+    { auth, authInfo, runContext }
+  ) => {
+    let attachmentRunContext: AgentLoopRunContext | undefined;
+    if (fileId) {
+      assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+      attachmentRunContext = runContext;
+    }
 
-    post_message: async (
-      {
-        to,
-        message,
-        threadTs,
-        fileId,
-        unfurlLinks,
-        unfurlMedia,
-        show_sent_by_footer,
-      },
-      { authInfo }
-    ) => {
-      let attachmentRunContext: AgentLoopRunContext | undefined;
-      if (fileId) {
-        assert(
-          isAgentLoopRunContext(toolContext?.runContext),
-          "AgentLoopRunContext expected"
-        );
-        attachmentRunContext = toolContext.runContext;
-      }
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
-      }
-
-      try {
-        return await executePostMessage(auth, toolContext, {
+    try {
+      return await executePostMessage(
+        auth,
+        { runContext },
+        {
           to,
           message,
           threadTs,
@@ -616,43 +567,41 @@ export function createSlackPersonalTools(
           unfurlMedia,
           accessToken,
           showSentByFooter: show_sent_by_footer ?? true,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
         }
-        return new Err(
-          new MCPError(`Error posting message: ${normalizeError(error)}`)
-        );
+      );
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error posting message: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  schedule_message: async (
+    {
+      to,
+      message,
+      post_at,
+      threadTs,
+      unfurlLinks,
+      unfurlMedia,
+      show_sent_by_footer,
     },
+    { auth, authInfo, runContext }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-    schedule_message: async (
-      {
-        to,
-        message,
-        post_at,
-        threadTs,
-        unfurlLinks,
-        unfurlMedia,
-        show_sent_by_footer,
-      },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
-      }
-
-      try {
-        return await executeScheduleMessage(auth, toolContext, {
+    try {
+      return await executeScheduleMessage(
+        auth,
+        { runContext },
+        {
           to,
           message,
           post_at,
@@ -661,593 +610,554 @@ export function createSlackPersonalTools(
           unfurlMedia,
           accessToken,
           showSentByFooter: show_sent_by_footer ?? true,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
         }
-        return new Err(
-          new MCPError(`Error scheduling message: ${normalizeError(error)}`)
-        );
+      );
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
-    },
+      return new Err(
+        new MCPError(`Error scheduling message: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-    search_user: async ({ query, search_all }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
+  search_user: async ({ query, search_all }, { authInfo, runContext }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeSearchUser(query, search_all ?? false, {
+        accessToken,
+        mcpServerId: runContext.toolConfiguration.toolServerId,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error searching user: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      try {
-        return await executeSearchUser(query, search_all ?? false, {
-          accessToken,
-          mcpServerId,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error searching user: ${normalizeError(error)}`)
-        );
+  list_user_groups: async (_params, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeListUserGroups({ accessToken });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
-    },
+      return new Err(
+        new MCPError(`Error listing user groups: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-    list_user_groups: async (_params, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
+  search_channels: async ({ query, search_all }, { authInfo, runContext }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeSearchChannels(query, search_all, {
+        accessToken,
+        mcpServerId: runContext.toolConfiguration.toolServerId,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error searching channels: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      try {
-        return await executeListUserGroups({ accessToken });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error listing user groups: ${normalizeError(error)}`)
-        );
+  list_messages: async (
+    { channel, relativeTimeFrame },
+    { authInfo, runContext }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const slackClient = await getSlackClient(accessToken);
+    const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+    // Resolve channel name to channel ID (supports public, private channels, and DMs).
+    let channelId: string | null;
+    try {
+      channelId = await resolveChannelId({
+        channelNameOrId: channel,
+        accessToken,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
-    },
+      return new Err(
+        new MCPError(`Error resolving channel: ${normalizeError(error)}`)
+      );
+    }
 
-    search_channels: async ({ query, search_all }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
+    if (!channelId) {
+      return new Err(
+        new MCPError(
+          `Unable to find channel "${channel}". Make sure the channel exists and you have access to it.`
+        )
+      );
+    }
+
+    // Calculate timestamp for timeFrame filtering.
+    const oldest = timeFrame
+      ? (timeFrameFromNow(timeFrame) / 1000).toString()
+      : undefined;
+
+    // Use conversations.history to get messages, which works for public, private channels, and DMs.
+    let response;
+    try {
+      response = await slackClient.conversations.history({
+        channel: channelId,
+        oldest,
+        limit: SLACK_THREAD_LISTING_LIMIT,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error fetching messages: ${normalizeError(error)}`)
+      );
+    }
 
-      try {
-        return await executeSearchChannels(query, search_all, {
-          accessToken,
-          mcpServerId,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error searching channels: ${normalizeError(error)}`)
-        );
+    if (!response.ok) {
+      // Trigger authentication flow for missing_scope.
+      if (response.error === "missing_scope") {
+        return new Ok(makePersonalAuthenticationError("slack_tools").content);
       }
-    },
+      return new Err(new MCPError(response.error ?? "Failed to list threads"));
+    }
 
-    list_messages: async ({ channel, relativeTimeFrame }, { authInfo }) => {
-      if (!toolContext?.runContext) {
-        return new Err(
-          new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
+    const rawMessages = response.messages ?? [];
+
+    // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS messages.
+    const matches = rawMessages.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
+
+    if (matches.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No messages found.`,
+        },
+      ]);
+    }
+
+    // Get display name for the channel.
+    const displayName = await resolveChannelDisplayName({
+      channelId,
+      accessToken,
+    });
+
+    const { citationsOffset } = isAgentLoopRunContext(runContext)
+      ? runContext.stepContext
+      : { citationsOffset: 0 };
+
+    let refs = getRefs().slice(
+      citationsOffset,
+      citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+    );
+
+    // Resolve user display names for all thread authors.
+    const threadsWithAuthors = await Promise.all(
+      matches.map(async (match) => {
+        const authorName = match.user
+          ? await resolveUserDisplayName({
+              userId: match.user,
+              accessToken,
+            })
+          : null;
+        return {
+          ts: match.ts,
+          reply_count: match.reply_count,
+          authorName: authorName ?? "Unknown",
+          // Reconstruct readable text from blocks/attachments: app/bot messages
+          // (Datadog, Zendesk, ...) often have an empty `text` and put content in
+          // `blocks[]`, which would otherwise render as empty for the agent.
+          renderedText: renderFormattedMessage(formatSlackMessageForLLM(match)),
+        };
+      })
+    );
+    const searchResults = buildSearchResults<{
+      permalink?: string;
+      renderedText: string;
+      ts?: string;
+      authorName: string;
+      reply_count?: number;
+    }>(threadsWithAuthors, refs, {
+      permalink: (match) => match.permalink,
+      text: (match) => {
+        const hasReplies = match.reply_count && match.reply_count > 0;
+        const prefix = hasReplies
+          ? `[Thread: ${match.ts}]`
+          : `[Message: ${match.ts}]`;
+        return `${prefix} From ${match.authorName} in ${displayName}: ${match.renderedText}`;
+      },
+      id: (match) => match.ts ?? "",
+      content: (match) => match.renderedText,
+    });
+
+    return new Ok(
+      searchResults.map((result) => ({
+        type: "resource" as const,
+        resource: result,
+      }))
+    );
+  },
+
+  read_thread_messages: async (
+    { channel, threadTs, limit, cursor, oldest, latest },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    return executeReadThreadMessages({
+      channel,
+      threadTs,
+      limit,
+      cursor,
+      oldest,
+      latest,
+      accessToken,
+    });
+  },
+
+  get_channel_canvases: async ({ channel_id }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeGetChannelCanvases({
+        channel_id,
+        accessToken,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error getting channel canvases: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
+  read_canvas: async (
+    { canvas_id, section_types, contains_text },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeReadCanvas({
+        canvas_id,
+        section_types,
+        contains_text,
+        accessToken,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error reading canvas: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      const slackClient = await getSlackClient(accessToken);
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
+  write_canvas: async (
+    { canvas_id, operation, content, section_id, title, channel_id },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      // Resolve channel name to channel ID (supports public, private channels, and DMs).
-      let channelId: string | null;
-      try {
-        channelId = await resolveChannelId({
-          channelNameOrId: channel,
-          accessToken,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error resolving channel: ${normalizeError(error)}`)
-        );
+    try {
+      return await executeWriteCanvas({
+        canvas_id,
+        operation,
+        content,
+        section_id,
+        title,
+        channel_id,
+        accessToken,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error writing canvas: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      if (!channelId) {
-        return new Err(
-          new MCPError(
-            `Unable to find channel "${channel}". Make sure the channel exists and you have access to it.`
-          )
-        );
+  create_channel: async (
+    { name, is_private, leave_after_creation },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeCreateChannel({
+        name,
+        is_private,
+        leave_after_creation,
+        accessToken,
+      });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(`Error creating channel: ${normalizeError(error)}`)
+      );
+    }
+  },
 
-      // Calculate timestamp for timeFrame filtering.
-      const oldest = timeFrame
-        ? (timeFrameFromNow(timeFrame) / 1000).toString()
-        : undefined;
+  invite_to_channel: async ({ channel, users }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      // Use conversations.history to get messages, which works for public, private channels, and DMs.
-      let response;
-      try {
-        response = await slackClient.conversations.history({
-          channel: channelId,
-          oldest,
-          limit: SLACK_THREAD_LISTING_LIMIT,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error fetching messages: ${normalizeError(error)}`)
-        );
+    try {
+      return await executeInviteToChannel({ channel, users, accessToken });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
+      return new Err(
+        new MCPError(
+          `Error inviting users to channel: ${normalizeError(error)}`
+        )
+      );
+    }
+  },
 
-      if (!response.ok) {
-        // Trigger authentication flow for missing_scope.
-        if (response.error === "missing_scope") {
+  archive_channel: async ({ channel }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    try {
+      return await executeArchiveChannel({ channel, accessToken });
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
+      }
+      return new Err(
+        new MCPError(`Error archiving channel: ${normalizeError(error)}`)
+      );
+    }
+  },
+  set_user_status: async (
+    { status_text, status_emoji, status_expiration },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Ok(makePersonalAuthenticationError("slack_tools").content);
+    }
+
+    try {
+      const result = await executeSetUserStatus({
+        accessToken,
+        statusText: status_text,
+        statusEmoji: status_emoji,
+        statusExpiration: status_expiration,
+      });
+      if (result.isErr()) {
+        if (isSlackMissingScope(result.error)) {
           return new Ok(makePersonalAuthenticationError("slack_tools").content);
         }
         return new Err(
-          new MCPError(response.error ?? "Failed to list threads")
+          new MCPError(`Failed to set Slack status: ${result.error}`)
         );
       }
-
-      const rawMessages = response.messages ?? [];
-
-      // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS messages.
-      const matches = rawMessages.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
-
-      if (matches.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `No messages found.`,
-          },
-        ]);
+      const displayText =
+        status_text || status_emoji
+          ? `Status set to ${[status_emoji, status_text].filter(Boolean).join(" ")}`
+          : "Status cleared";
+      return new Ok([{ type: "text" as const, text: displayText }]);
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
       }
-
-      // Get display name for the channel.
-      const displayName = await resolveChannelDisplayName({
-        channelId,
-        accessToken,
-      });
-
-      const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
-        ? toolContext.runContext.stepContext
-        : { citationsOffset: 0 };
-
-      let refs = getRefs().slice(
-        citationsOffset,
-        citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+      return new Err(
+        new MCPError(`Error setting status: ${normalizeError(error)}`)
       );
+    }
+  },
 
-      // Resolve user display names for all thread authors.
-      const threadsWithAuthors = await Promise.all(
-        matches.map(async (match) => {
-          const authorName = match.user
-            ? await resolveUserDisplayName({
-                userId: match.user,
-                accessToken,
-              })
-            : null;
-          return {
-            ts: match.ts,
-            reply_count: match.reply_count,
-            authorName: authorName ?? "Unknown",
-            // Reconstruct readable text from blocks/attachments: app/bot messages
-            // (Datadog, Zendesk, ...) often have an empty `text` and put content in
-            // `blocks[]`, which would otherwise render as empty for the agent.
-            renderedText: renderFormattedMessage(
-              formatSlackMessageForLLM(match)
-            ),
-          };
-        })
-      );
-      const searchResults = buildSearchResults<{
-        permalink?: string;
-        renderedText: string;
-        ts?: string;
-        authorName: string;
-        reply_count?: number;
-      }>(threadsWithAuthors, refs, {
-        permalink: (match) => match.permalink,
-        text: (match) => {
-          const hasReplies = match.reply_count && match.reply_count > 0;
-          const prefix = hasReplies
-            ? `[Thread: ${match.ts}]`
-            : `[Message: ${match.ts}]`;
-          return `${prefix} From ${match.authorName} in ${displayName}: ${match.renderedText}`;
-        },
-        id: (match) => match.ts ?? "",
-        content: (match) => match.renderedText,
-      });
+  add_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
 
-      return new Ok(
-        searchResults.map((result) => ({
-          type: "resource" as const,
-          resource: result,
-        }))
-      );
-    },
+    const slackClient = await getSlackClient(accessToken);
 
-    read_thread_messages: async (
-      { channel, threadTs, limit, cursor, oldest, latest },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      return executeReadThreadMessages({
+    try {
+      const response = await slackClient.reactions.add({
         channel,
-        threadTs,
-        limit,
-        cursor,
-        oldest,
-        latest,
-        accessToken,
-      });
-    },
-
-    get_channel_canvases: async ({ channel_id }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeGetChannelCanvases({
-          channel_id,
-          accessToken,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(
-            `Error getting channel canvases: ${normalizeError(error)}`
-          )
-        );
-      }
-    },
-
-    read_canvas: async (
-      { canvas_id, section_types, contains_text },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeReadCanvas({
-          canvas_id,
-          section_types,
-          contains_text,
-          accessToken,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error reading canvas: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    write_canvas: async (
-      { canvas_id, operation, content, section_id, title, channel_id },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeWriteCanvas({
-          canvas_id,
-          operation,
-          content,
-          section_id,
-          title,
-          channel_id,
-          accessToken,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error writing canvas: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    create_channel: async (
-      { name, is_private, leave_after_creation },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeCreateChannel({
-          name,
-          is_private,
-          leave_after_creation,
-          accessToken,
-        });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error creating channel: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    invite_to_channel: async ({ channel, users }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeInviteToChannel({ channel, users, accessToken });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(
-            `Error inviting users to channel: ${normalizeError(error)}`
-          )
-        );
-      }
-    },
-
-    archive_channel: async ({ channel }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeArchiveChannel({ channel, accessToken });
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error archiving channel: ${normalizeError(error)}`)
-        );
-      }
-    },
-    set_user_status: async (
-      { status_text, status_emoji, status_expiration },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Ok(makePersonalAuthenticationError("slack_tools").content);
-      }
-
-      try {
-        const result = await executeSetUserStatus({
-          accessToken,
-          statusText: status_text,
-          statusEmoji: status_emoji,
-          statusExpiration: status_expiration,
-        });
-        if (result.isErr()) {
-          if (isSlackMissingScope(result.error)) {
-            return new Ok(
-              makePersonalAuthenticationError("slack_tools").content
-            );
-          }
-          return new Err(
-            new MCPError(`Failed to set Slack status: ${result.error}`)
-          );
-        }
-        const displayText =
-          status_text || status_emoji
-            ? `Status set to ${[status_emoji, status_text].filter(Boolean).join(" ")}`
-            : "Status cleared";
-        return new Ok([{ type: "text" as const, text: displayText }]);
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error setting status: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    add_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.reactions.add({
-          channel,
-          timestamp,
-          name,
-        });
-
-        if (!response.ok) {
-          return new Err(
-            new MCPError(`Error adding reaction: ${response.error}`)
-          );
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully added :${name}: reaction to message`,
-          },
-        ]);
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error adding reaction: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    remove_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.reactions.remove({
-          channel,
-          timestamp,
-          name,
-        });
-
-        if (!response.ok) {
-          return new Err(
-            new MCPError(`Error removing reaction: ${response.error}`)
-          );
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Successfully removed :${name}: reaction from message`,
-          },
-        ]);
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error removing reaction: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    get_reactions: async ({ channel, timestamp, full }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      const slackClient = await getSlackClient(accessToken);
-
-      try {
-        const response = await slackClient.reactions.get({
-          channel,
-          timestamp,
-          full,
-        });
-
-        if (!response.ok) {
-          return new Err(
-            new MCPError(`Error getting reactions: ${response.error}`)
-          );
-        }
-
-        const reactions = response.message?.reactions ?? [];
-        if (reactions.length === 0) {
-          return new Ok([
-            { type: "text" as const, text: "No reactions on this message." },
-          ]);
-        }
-
-        const lines = reactions.map((r) => {
-          const count = r.count ?? 0;
-          const users = r.users?.map((u) => `<@${u}>`).join(", ") ?? "";
-          return users
-            ? `:${r.name}: ×${count} — ${users}`
-            : `:${r.name}: ×${count}`;
-        });
-
-        return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
-      } catch (error) {
-        const authError = handleSlackAuthError(error);
-        if (authError) {
-          return authError;
-        }
-        return new Err(
-          new MCPError(`Error getting reactions: ${normalizeError(error)}`)
-        );
-      }
-    },
-  };
-
-  const rawTools = buildTools(SLACK_PERSONAL_TOOLS_METADATA, handlers);
-
-  // When footer removal is not allowed, strip show_sent_by_footer from the schema so
-  // the LLM never sees the parameter — the handler already enforces true server-side.
-  const tools = allowFooterRemoval
-    ? rawTools
-    : rawTools.map((tool) => {
-        if (tool.name === "post_message" || tool.name === "schedule_message") {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { show_sent_by_footer: _stripped, ...schemaWithoutFooter } =
-            tool.schema;
-          return { ...tool, schema: schemaWithoutFooter };
-        }
-        return tool;
+        timestamp,
+        name,
       });
 
-  const searchMessagesTool = tools.find((t) => t.name === "search_messages")!;
-  const semanticSearchMessagesTool = tools.find(
-    (t) => t.name === "semantic_search_messages"
-  )!;
-  const commonTools = tools.filter(
-    (t) => t.name !== "search_messages" && t.name !== "semantic_search_messages"
-  );
+      if (!response.ok) {
+        return new Err(
+          new MCPError(`Error adding reaction: ${response.error}`)
+        );
+      }
 
-  return {
-    searchMessagesTool,
-    semanticSearchMessagesTool,
-    commonTools,
-  };
-}
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully added :${name}: reaction to message`,
+        },
+      ]);
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
+      }
+      return new Err(
+        new MCPError(`Error adding reaction: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  remove_reaction: async ({ channel, timestamp, name }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const slackClient = await getSlackClient(accessToken);
+
+    try {
+      const response = await slackClient.reactions.remove({
+        channel,
+        timestamp,
+        name,
+      });
+
+      if (!response.ok) {
+        return new Err(
+          new MCPError(`Error removing reaction: ${response.error}`)
+        );
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Successfully removed :${name}: reaction from message`,
+        },
+      ]);
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
+      }
+      return new Err(
+        new MCPError(`Error removing reaction: ${normalizeError(error)}`)
+      );
+    }
+  },
+
+  get_reactions: async ({ channel, timestamp, full }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Access token not found"));
+    }
+
+    const slackClient = await getSlackClient(accessToken);
+
+    try {
+      const response = await slackClient.reactions.get({
+        channel,
+        timestamp,
+        full,
+      });
+
+      if (!response.ok) {
+        return new Err(
+          new MCPError(`Error getting reactions: ${response.error}`)
+        );
+      }
+
+      const reactions = response.message?.reactions ?? [];
+      if (reactions.length === 0) {
+        return new Ok([
+          { type: "text" as const, text: "No reactions on this message." },
+        ]);
+      }
+
+      const lines = reactions.map((r) => {
+        const count = r.count ?? 0;
+        const users = r.users?.map((u) => `<@${u}>`).join(", ") ?? "";
+        return users
+          ? `:${r.name}: ×${count} — ${users}`
+          : `:${r.name}: ×${count}`;
+      });
+
+      return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
+    } catch (error) {
+      const authError = handleSlackAuthError(error);
+      if (authError) {
+        return authError;
+      }
+      return new Err(
+        new MCPError(`Error getting reactions: ${normalizeError(error)}`)
+      );
+    }
+  },
+};
+
+export const TOOLS = buildTools(SLACK_PERSONAL_TOOLS_METADATA, handlers);


### PR DESCRIPTION
## Description

Some MCP servers mix static handler construction with agent- or workspace-dependent tool selection inside `createXxxTools` factories.

This PR exports stable handler-backed tool arrays directly and keeps conditional filtering in `createServer`. Tag support, legacy interactive tools, sandbox egress, and Slack search schema behavior remain unchanged.

## Tests

- Updated tool-list tests for interactive content and sandbox.

## Risk

- Medium. Affects advertised tool sets for four internal MCP servers.

## Deploy Plan

- Deploy front.