### PR TITLE
[docs] Point front docs and skills at front-api after the Next.js migration

### DIFF
--- a/.claude/skills/dust-audit-log-event/SKILL.md
+++ b/.claude/skills/dust-audit-log-event/SKILL.md
@@ -76,7 +76,7 @@ void emitAuditLogEvent({
     buildWorkspaceTarget(auth.getNonNullableWorkspace()),
     { type: "resource", id: resource.sId, name: resource.name },
   ],
-  context: getAuditLogContext(auth, req),
+  context: getAuditLogContext(auth),
   metadata: {
     field_name: String(value),
   },
@@ -144,7 +144,7 @@ Check all of the following:
   events
 - `targets` start with the workspace target when a workspace exists
 - metadata values are wrapped with `String(...)` when needed
-- request-backed events use `getAuditLogContext(auth, req)` when `req` is available
+- request-backed events use `getAuditLogContext(auth)` (the client IP comes from the `Authenticator`, set by the auth middleware)
 - the emit call uses `void`
 - the targets in the emit call exactly match (in type and count) the targets in the schema JSON file
 - if modifying an existing event's targets, the schema JSON file has been updated to match

--- a/.claude/skills/dust-breaking-changes/SKILL.md
+++ b/.claude/skills/dust-breaking-changes/SKILL.md
@@ -31,7 +31,7 @@ Before making ANY change to API code, follow this process:
 
 API code includes:
 
-- Route handlers in `front/pages/api/**`
+- Route handlers in `front-api/routes/**`
 - Request/response type definitions used by these routes
 - Validation schemas (Zod, etc.) used in API handlers
 - Middleware that affects API behavior
@@ -137,7 +137,7 @@ type APIResponse = {
 
 This rule applies automatically whenever you are:
 
-- Modifying files in `front/pages/api/**` or `front/app/api/**`
+- Modifying files in `front-api/routes/**`
 - Changing type definitions that are exported and used in API responses
 - Updating validation schemas used by API endpoints
 - Refactoring code that affects API contracts

--- a/.claude/skills/dust-elasticsearch/references/querying.md
+++ b/.claude/skills/dust-elasticsearch/references/querying.md
@@ -221,64 +221,60 @@ const query = {
 
 ## Step 3: Create API Endpoint
 
-Create `pages/api/w/[wId]/your_feature/stats.ts`:
+Create `front-api/routes/w/[wId]/your_feature/stats.ts`, then mount it from
+`front-api/routes/w/[wId]/your_feature/index.ts`. Endpoint rules (one file per URL, mounting,
+validation, errors) are in `front-api/CODING_RULES.md`:
 
 ```typescript
-import type { NextApiRequest, NextApiResponse } from "next";
-import { withSessionAuthentication } from "@/server/auth/wrappers";
-import { Authenticator } from "@/server/auth";
-import { apiError } from "@/lib/api_errors";
-import { queryYourData } from "@/lib/api/your_feature/queries/your_query";
+import { queryYourData } from "@app/lib/api/your_feature/queries/your_query";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-): Promise<void> {
-  const auth = await Authenticator.fromSuperUserSession(req, res);
+const DEFAULT_WINDOW_DAYS = 7;
 
-  if (!auth.workspace()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "Workspace not found",
-      },
+const GetStatsQuerySchema = z.object({
+  days: z.coerce.number().int().positive().default(DEFAULT_WINDOW_DAYS),
+  entityId: z.string().optional(),
+});
+
+// Mounted at /api/w/:wId/your_feature/stats.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("query", GetStatsQuerySchema),
+  async (ctx): HandlerResult<YourQueryResult> => {
+    const auth = ctx.get("auth");
+    const { days, entityId } = ctx.req.valid("query");
+
+    const result = await queryYourData({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      days,
+      entityId,
     });
-  }
 
-  switch (req.method) {
-    case "GET":
-      const days = req.query.days ? parseInt(req.query.days as string) : 7;
-      const entityId = req.query.entityId as string | undefined;
-
-      const result = await queryYourData({
-        workspaceId: auth.workspace().sId,
-        days,
-        entityId,
-      });
-
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: result.error.message,
-          },
-        });
-      }
-
-      return res.status(200).json(result.value);
-
-    default:
-      return apiError(req, res, {
-        status_code: 405,
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
         api_error: {
-          type: "method_not_allowed",
-          message: "Method not allowed",
+          type: "internal_server_error",
+          message: result.error.message,
         },
       });
-  }
-}
+    }
 
-export default withSessionAuthentication(handler);
+    return ctx.json(result.value);
+  }
+);
+
+export default app;
 ```
+
+`workspaceApp()` is the typed Hono factory for routes under `/w/:wId`. `workspaceAuth` is applied
+once at `front-api/routes/w/[wId]/index.ts`, so `ctx.get("auth")` is already a resolved
+`Authenticator` — no manual workspace check in the handler. Hono handles method dispatch, so there
+is no 405 branch to write.

--- a/.claude/skills/dust-swagger/SKILL.md
+++ b/.claude/skills/dust-swagger/SKILL.md
@@ -11,7 +11,7 @@ description: MANDATORY guideline - Always keep Swagger documentation in sync whe
 
 Automatically applies whenever you are:
 
-- Modifying files in `front/pages/api/**` or `front/app/api/**`
+- Modifying files in `front-api/routes/**`
 - Adding, removing, or renaming fields in request/response bodies (at any nesting level)
 - Changing field types or optionality in API schemas
 - Adding or removing endpoints
@@ -20,8 +20,8 @@ Automatically applies whenever you are:
 
 When modifying API schemas, check and update the following:
 
-- `pages/api/swagger_private_schemas.ts` — shared schemas for the private API
-- `pages/api/v1/w/[wId]/swagger_schemas.ts` — shared schemas for the public API
+- `front-api/routes/swagger_private_schemas.ts` — shared schemas for the private API
+- `front-api/routes/v1/w/[wId]/swagger_schemas.ts` — shared schemas for the public API
 - The `@swagger` annotation in the endpoint file itself
 
 ## Annotations

--- a/.claude/skills/dust-test/SKILL.md
+++ b/.claude/skills/dust-test/SKILL.md
@@ -20,7 +20,7 @@ When writing tests for a file:
 4. **Use factories**: Leverage test factories to set up data efficiently
 5. **Focus on behavior**: Test what the code does, not how it does it
 
-## For Front (TypeScript/Next.js)
+## For Front and Front-api (TypeScript)
 
 ### Setup
 

--- a/front-spa/TROUBLESHOOTING.md
+++ b/front-spa/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@
 Vite's dependency optimizer cache has gone stale (after a restart, dependency change, or git operation). The browser still has cached JS chunks referencing old dependency hashes, and Vite returns 504 for those.
 
 **Fix:**
-1. Restart the SPA Vite dev server (not the Next.js `front` service):
+1. Restart the SPA Vite dev server (not the `front-api` service):
    - With dust-hive: `dust-hive restart <env-name> front-spa-app`
    - Without dust-hive: kill and re-run the Vite dev server process for front-spa
 2. Hard refresh the browser: **Cmd+Shift+R**

--- a/front/AGENTS.md
+++ b/front/AGENTS.md
@@ -1,35 +1,42 @@
-Dust is a platform to build and operate agents for work. `front` is our main service and web application.
+Dust is a platform to build and operate agents for work. `front` holds the business logic, the
+React components and the background workers behind it. It is a library workspace, not a running
+server: HTTP handlers live in `front-api` (Hono) and the browser app in `front-spa`. `front-api`
+imports `front` through the `@app/*` path alias, `front-spa` through the `@dust-tt/front/*`
+workspace exports. The dependency is one-way — `front` never imports from `front-api` or
+`front-spa`.
 
 # Tech Stack
 
-- **Framework**: Next.js 14 (Pages Router with SSR)
 - **Language**: TypeScript (strict mode)
 - **UI**: React 18 with Sparkle Design System (shadcn/ui + Tailwind + Radix)
-- **Styling**: Tailwind CSS 3.x
+- **Styling**: Tailwind CSS 4.x
 - **Database**: PostgreSQL via Sequelize ORM (with Resources abstraction)
 - **State Management**: SWR for data fetching
+- **Background jobs**: Temporal workers (`start_worker.ts`, `temporal/`)
 
 # Codebase structure
 
 ```
 front/
-├── components/ # React components
+├── components/ # React components (rendered by front-spa)
 ├── hooks/ # SWR hooks
 ├── lib/ # Core business logic
 │ ├── api/ # API layer (interfaces between routes and resources)
 │ ├── resources
 │ └── swr/ # SWR hooks for data fetching (migrating to hooks/)
-├── pages/ # Next.js pages and API routes
-│ ├── api/ # API endpoints
-│ ├── api/v1/ # Public API endpoints
-│ └── [other]/ # Page components
+├── logger/ # Logger and request logging helpers
+├── poke/ # Poke (internal admin) hooks and workflows
 ├── types/ # TypeScript type definitions
 ├── tests/ # Test utilities and factories
 ├── temporal/ # Temporal workflows for background jobs
 ├── migrations/ # Database migrations
 ├── admin/ # Local helpers and scripts
+├── styles/ # Global styles
 └── public/ # Static assets
 ```
+
+API handlers are **not** here — they live in `front-api/routes/`, one file per URL. See
+`front-api/CODING_RULES.md` before adding or changing an endpoint.
 
 # Development setup
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -130,14 +130,14 @@ class ConversationModel extends Model { }
 
 ### [BACK12] No breaking changes in API endpoints
 
-**Public API (`pages/api/v1/`):** Breaking changes are never allowed. External consumers depend on
-a stable contract. Schemas must be append-only: never remove fields. When adding a new field, it
-must be optional and accept `undefined` as a value even if the latest client code always sends a
-value.
+**Public API (`front-api/routes/v1/`):** Breaking changes are never allowed. External consumers
+depend on a stable contract. Schemas must be append-only: never remove fields. When adding a new
+field, it must be optional and accept `undefined` as a value even if the latest client code always
+sends a value.
 
-**Private API (`pages/api/`):** Breaking changes are acceptable only after enough time has passed
-to be confident that no old clients are still deployed. Until then, follow the same backward
-compatibility rules as the public API. When introducing a breaking change, first deploy the
+**Private API (the rest of `front-api/routes/`):** Breaking changes are acceptable only after enough
+time has passed to be confident that no old clients are still deployed. Until then, follow the same
+backward compatibility rules as the public API. When introducing a breaking change, first deploy the
 updated client code, wait for all old clients to cycle out, then clean up the old contract.
 
 Example:
@@ -231,8 +231,8 @@ to adding, removing, or modifying fields at any level of nesting.
 
 In particular, check and update the following files when modifying API schemas:
 
-- `pages/api/swagger_private_schemas.ts` for private API shared schemas
-- `pages/api/v1/w/[wId]/swagger_schemas.ts` for public API shared schemas
+- `front-api/routes/swagger_private_schemas.ts` for private API shared schemas
+- `front-api/routes/v1/w/[wId]/swagger_schemas.ts` for public API shared schemas
 - The `@swagger` annotation in the endpoint file itself
 
 Every endpoint must have either `@swagger` (with proper documentation) or `@ignoreswagger`
@@ -268,7 +268,7 @@ The Type interface is not to be used in the backend.
 
 ### [BACK16] Keep API handlers thin — business logic belongs in `lib/api/*`
 
-API handlers (under `pages/api/`) should be limited to:
+API handlers (under `front-api/routes/`) should be limited to:
 
 - Authentication and authorization checks
 - HTTP method dispatch
@@ -420,9 +420,9 @@ the logic back into the handlers and accept the duplication.
 - WorkOS SDK expects all metadata values as strings. Convert numbers and booleans with `String(value)`
 - Schema files use `"string"` as the value type (e.g., `"role": "string"`)
 
-### [AUDIT6] Always include `getAuditLogContext(auth, req)` as the `context` parameter when a `NextApiRequest` is available
+### [AUDIT6] Always pass `getAuditLogContext(auth)` as the `context` parameter
 
-- This captures the client IP from `x-forwarded-for` headers
+- The client IP comes from the `Authenticator`: the auth middlewares (`workspace_auth`, `public_api_auth`, `sandbox_auth`) resolve it from the Hono context via `auth.setClientIp(...)`, preferring forwarded headers over the socket address
 - In Temporal activities or non-HTTP contexts, omit `context` (defaults to `auth.clientIp() ?? "internal"`) or pass `{ location: "internal" }` for direct emit
 
 ### [AUDIT7] Targets always include the workspace as the first target


### PR DESCRIPTION
## Description

Follow-up to #29560. That PR fixed `front-api/CODING_RULES.md`; this one fixes
the docs on the other side of the same migration.

`front/AGENTS.md` and several rules and skills still describe `front` as a
Next.js Pages Router app whose handlers live in `front/pages/api/**`. That
directory does not exist — handlers are in `front-api/routes/**` (991 files),
and `front` is a library + Temporal-workers workspace. These files are loaded
as project instructions and skill triggers, so the stale paths actively send
agents somewhere that isn't there.

**`front/AGENTS.md`**
- Describes `front` as the library/workers workspace, with `front-api` (Hono)
  and `front-spa` as its consumers and the dependency direction spelled out.
- Drops the `Framework: Next.js 14 (Pages Router with SSR)` line and the
  `pages/` subtree; adds `logger/`, `poke/`, `styles/` and the Temporal
  workers entry point.
- Tailwind `3.x` → `4.x` (front is on `^4.3.0`).

**`front/CODING_RULES.md`**
- BACK12 — public/private API scoped to `front-api/routes/v1/` and the rest of
  `front-api/routes/`.
- BACK14 — shared swagger schemas are at `front-api/routes/swagger_private_schemas.ts`
  and `front-api/routes/v1/w/[wId]/swagger_schemas.ts`.
- BACK16 — thin handlers live under `front-api/routes/`.
- AUDIT6 — required passing a `NextApiRequest` that cannot exist now. All 99
  call sites pass `getAuditLogContext(auth)`; the client IP reaches the
  `Authenticator` via `auth.setClientIp(...)` in `workspace_auth` /
  `public_api_auth` / `sandbox_auth`. Rule and rationale rewritten to match.

**Skills**
- `dust-swagger`, `dust-breaking-changes` — trigger globs and schema paths.
- `dust-audit-log-event` — drops the `getAuditLogContext(auth, req)` form.
- `dust-elasticsearch` — the endpoint example was a Next handler using import
  paths (`@/server/auth/wrappers`, `@/lib/api_errors`) that never existed here.
  Rewritten as a Hono route following current conventions: `workspaceApp()`,
  `validate("query", ...)`, `apiError(ctx, ...)`, `HandlerResult<T>`, modelled
  on `front-api/routes/w/[wId]/assistant/agent_configurations/name_available.ts`.
- `dust-test` — the section covers `front` and `front-api`; neither is Next.

**`front-spa/TROUBLESHOOTING.md`** — the sibling dev service is `front-api`.

## Tests

None — markdown only, no code touched. Every path, symbol and behavior asserted
in these docs was checked against the current tree (swagger schema locations,
`getAuditLogContext` call sites and signature, `workspaceApp` semantics, front's
directory list and Tailwind version).

## Risk

None. No runtime or build impact.

## Deploy Plan

Nothing to do — merge.

## Not in this PR

- `.grit/patterns/enforceClientTypesInPublicApi.grit` already allow-lists
  `front-api/routes/v1/`, but keeps a now-dead `.*pages/api/v1/.*` regex, and
  its `.md` test fixture still exercises that dead path rather than the live
  one. Harmless, but the test isn't covering what it looks like it covers.
- The `dust-hive` skill still lists a Next.js `front` service and tells you to
  run `npm run lint` / `npm run build` in `front` (neither script exists). It
  is gitignored (`.gitignore:19`) and ships with the hive tool, so it can't be
  fixed here.