### PR TITLE
[poke] Restrict member seat dropdown to current contract seats

### DIFF
--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -26,11 +26,16 @@ export type MemberDisplayType = {
 };
 
 export function makeColumnsForMembers({
+  availableSeatTypes,
   onRevokeMember,
   onUpdateMemberRole,
   onUpdateMemberSeatType,
   readonly,
 }: {
+  // Seat types selectable in the dropdown. When undefined, all seat types are
+  // offered; when provided (e.g. restricted to the current contract's seats),
+  // only these are selectable.
+  availableSeatTypes?: readonly MembershipSeatType[];
   onRevokeMember: (m: MemberDisplayType) => Promise<void>;
   onUpdateMemberRole: (
     m: MemberDisplayType,
@@ -155,6 +160,14 @@ export function makeColumnsForMembers({
     cell: ({ row }) => {
       const member = row.original;
 
+      const seatTypes = availableSeatTypes ?? MEMBERSHIP_SEAT_TYPES;
+      // Keep the member's current seat selectable even if it is no longer
+      // offered by the contract, so the dropdown reflects the actual value.
+      const seatOptions =
+        member.seatType && !seatTypes.includes(member.seatType)
+          ? [...seatTypes, member.seatType]
+          : seatTypes;
+
       const scheduledChange =
         member.scheduledSeatType &&
         member.scheduledSeatType !== member.seatType ? (
@@ -190,7 +203,7 @@ export function makeColumnsForMembers({
             <option value="" disabled>
               -
             </option>
-            {MEMBERSHIP_SEAT_TYPES.map((st) => (
+            {seatOptions.map((st) => (
               <option key={st} value={st}>
                 {st}
               </option>

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -33,6 +33,9 @@ function prepareMembersForDisplay(
 }
 
 interface MembersDataTableProps {
+  // Seat types selectable in the seat dropdown. When undefined, all seat types
+  // are offered; typically restricted to the current contract's seats.
+  availableSeatTypes?: readonly MembershipSeatType[];
   groupName?: string;
   members: PokeWorkspaceMember[];
   owner: WorkspaceType;
@@ -40,6 +43,7 @@ interface MembersDataTableProps {
 }
 
 export function MembersDataTable({
+  availableSeatTypes,
   groupName,
   members,
   owner,
@@ -148,6 +152,7 @@ export function MembersDataTable({
         </div>
         <PokeDataTable
           columns={makeColumnsForMembers({
+            availableSeatTypes,
             onRevokeMember,
             onUpdateMemberRole,
             onUpdateMemberSeatType,

--- a/front/components/poke/pages/MembershipsPage.tsx
+++ b/front/components/poke/pages/MembershipsPage.tsx
@@ -3,6 +3,8 @@ import { MembersDataTable } from "@app/components/poke/members/table";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeMemberships } from "@app/poke/swr/memberships";
+import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
+import { MEMBERSHIP_SEAT_TYPES } from "@app/types/memberships";
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
 
 export function MembershipsPage() {
@@ -17,6 +19,19 @@ export function MembershipsPage() {
     owner,
     disabled: false,
   });
+
+  const { data: workspaceInfo } = usePokeWorkspaceInfo({
+    owner,
+    disabled: false,
+  });
+
+  // Restrict the seat dropdown to the seats entitled by the current contract
+  // (like SwitchContractDialog). Fall back to all seat types when the contract
+  // has no seat plan (e.g. not a Metronome contract).
+  const seatPlan = workspaceInfo?.seatPlan ?? null;
+  const availableSeatTypes = seatPlan
+    ? MEMBERSHIP_SEAT_TYPES.filter((st) => st === "none" || st in seatPlan)
+    : undefined;
 
   if (isLoading) {
     return (
@@ -46,7 +61,11 @@ export function MembershipsPage() {
       </h3>
       <div className="flex-grow p-6">
         <div className="flex justify-center">
-          <MembersDataTable members={members} owner={owner} />
+          <MembersDataTable
+            availableSeatTypes={availableSeatTypes}
+            members={members}
+            owner={owner}
+          />
         </div>
         <div className="flex justify-center">
           <InvitationsDataTable


### PR DESCRIPTION
## Description

Fixes [tasks#9789](https://github.com/dust-tt/tasks/issues/9789).

In Poke's members list, the dropdown to switch a member's seat offered **all** seat types. It now restricts to the seats entitled by the workspace's **current contract**, mirroring how `SwitchContractDialog` restricts to a package's seats.

## Approach

The current contract's entitled seats are already exposed via `usePokeWorkspaceInfo()` → `seatPlan` (a `Partial<Record<MembershipSeatType, SeatTypeInfo>>` built from `getSeatPlan` off the active Metronome contract). Its keys are exactly the billable seats on the contract, so those are threaded down into the seat dropdown. No backend/API change — the existing `workspace-info` endpoint is reused.

## Changes (front-end only)

- **`MembershipsPage.tsx`** — fetch `usePokeWorkspaceInfo`, derive `availableSeatTypes` = `"none"` + billable seats present in `seatPlan`. Falls back to `undefined` (all seats) when there is no seat plan (e.g. non-Metronome contracts).
- **`members/table.tsx`** — new optional `availableSeatTypes` prop, forwarded to the columns.
- **`members/columns.tsx`** — dropdown uses `availableSeatTypes` (defaulting to all seat types when absent), and keeps a member's current seat selectable even if the contract no longer offers it, so the `<select>` value stays accurate.

## Notes

- "none" (unassign) is always available regardless of contract.
- Other `MembersDataTable` callers (Space/Project/Group pages) are unchanged — they don't pass `availableSeatTypes`, so behavior there is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)