### PR TITLE
Include reasoning tokens in billed output usage

### DIFF
--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -28,14 +28,14 @@ function formatDuration(durationMs: number) {
 function formatTokenUsage({
   inputTokens,
   uncachedInputTokens,
-  outputTokens,
+  totalOutputTokens,
 }: TokenUsage) {
   const inputStr =
     inputTokens.toLocaleString() +
     (uncachedInputTokens
       ? ` (uncached: ${uncachedInputTokens.toLocaleString()})`
       : "");
-  const outputStr = outputTokens.toLocaleString();
+  const outputStr = totalOutputTokens.toLocaleString();
   return `${inputStr} → ${outputStr}`;
 }
 

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -285,7 +285,7 @@ async function attachRunToAgentMessage(
     auth,
     {
       inputTokens: promptTokens,
-      outputTokens: 20,
+      totalOutputTokens: 20,
       totalTokens: promptTokens + 20,
     },
     model.modelId

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -331,7 +331,7 @@ export abstract class LLM<
             usageDetails: {
               // Report the uncached input tokens if provider supports it.
               input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
-              output: tokenUsage.outputTokens,
+              output: tokenUsage.totalOutputTokens,
               total: tokenUsage.totalTokens,
               cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,
               cache_creation_input_tokens: tokenUsage.cacheCreationTokens ?? 0,
@@ -663,7 +663,7 @@ export abstract class LLM<
         generation.update({
           usageDetails: {
             input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
-            output: tokenUsage.outputTokens,
+            output: tokenUsage.totalOutputTokens,
             total: tokenUsage.totalTokens,
             cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,
             cache_creation_input_tokens: tokenUsage.cacheCreationTokens ?? 0,

--- a/front/lib/api/llm/traces/buffer.test.ts
+++ b/front/lib/api/llm/traces/buffer.test.ts
@@ -65,7 +65,7 @@ class LLMEventFactory {
       type: "token_usage",
       content: {
         inputTokens: faker.number.int({ min: 10, max: 1000 }),
-        outputTokens: faker.number.int({ min: 10, max: 1000 }),
+        totalOutputTokens: faker.number.int({ min: 10, max: 1000 }),
         totalTokens: 0, // Will be calculated
       },
       metadata: {

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -279,7 +279,7 @@ describe("convertToOldEvent — token_usage", () => {
             shortCacheCreated: 5_000,
             cacheHit: 20_000,
             standardInput: 1_000,
-            standardOutput: 400,
+            totalOutput: 500,
             reasoning: 100,
           },
           metadata: endpointMetadata,
@@ -290,7 +290,7 @@ describe("convertToOldEvent — token_usage", () => {
       type: "token_usage",
       content: {
         inputTokens: 56_000,
-        outputTokens: 400,
+        totalOutputTokens: 500,
         reasoningTokens: 100,
         totalTokens: 56_500,
         cachedTokens: 20_000,
@@ -314,8 +314,7 @@ describe("convertToOldEvent — token_usage", () => {
             shortCacheCreated: 0,
             cacheHit: 20_000,
             standardInput: 1_000,
-            standardOutput: 400,
-            reasoning: 0,
+            totalOutput: 400,
           },
           metadata: endpointMetadata,
         },
@@ -325,8 +324,7 @@ describe("convertToOldEvent — token_usage", () => {
       type: "token_usage",
       content: {
         inputTokens: 56_000,
-        outputTokens: 400,
-        reasoningTokens: 0,
+        totalOutputTokens: 400,
         totalTokens: 56_400,
         cachedTokens: 20_000,
         cacheCreationTokens: 35_000,
@@ -334,6 +332,27 @@ describe("convertToOldEvent — token_usage", () => {
       },
       metadata: llmMetadata,
     });
+  });
+
+  it("rejects reasoning tokens that are not a subset of output tokens", () => {
+    expect(() =>
+      convertToOldEvent(
+        {
+          type: "token_usage",
+          content: {
+            cacheCreated: 0,
+            longCacheCreated: 0,
+            shortCacheCreated: 0,
+            cacheHit: 0,
+            standardInput: 0,
+            totalOutput: 100,
+            reasoning: 101,
+          },
+          metadata: endpointMetadata,
+        },
+        llmMetadata
+      )
+    ).toThrow("reasoning must be a non-negative subset of totalOutput");
   });
 });
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -524,7 +524,7 @@ export function convertToOldEvent(
     case "token_usage": {
       const {
         standardInput,
-        standardOutput,
+        totalOutput,
         cacheHit,
         cacheCreated,
         longCacheCreated,
@@ -538,13 +538,21 @@ export function convertToOldEvent(
         ? longCacheCreated + shortCacheCreated
         : cacheCreated;
       const inputTokens = standardInput + cacheHit + totalCacheCreated;
+      if (
+        reasoning !== undefined &&
+        (reasoning < 0 || reasoning > totalOutput)
+      ) {
+        throw new Error(
+          "reasoning must be a non-negative subset of totalOutput"
+        );
+      }
       return {
         type: "token_usage",
         content: {
           inputTokens,
-          outputTokens: standardOutput,
-          reasoningTokens: reasoning,
-          totalTokens: inputTokens + standardOutput + reasoning,
+          totalOutputTokens: totalOutput,
+          ...(reasoning !== undefined ? { reasoningTokens: reasoning } : {}),
+          totalTokens: inputTokens + totalOutput,
           cachedTokens: cacheHit,
           cacheCreationTokens: totalCacheCreated,
           ...(hasDurationBreakdown

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -109,8 +109,12 @@ export interface TokenUsage {
   longCacheCreationTokens?: number;
   shortCacheCreationTokens?: number;
   cachedTokens?: number;
+  // Total input tokens including cache hits and cache creation tokens.
   inputTokens: number;
-  outputTokens: number;
+  // Total output tokens billed by the provider, including reasoning tokens.
+  // Do not add reasoningTokens to this value. reasoningTokens is a subset.
+  totalOutputTokens: number;
+  // Reasoning and thinking portion of totalOutputTokens.
   reasoningTokens?: number;
   totalTokens: number;
   // Raw input tokens after the last cache breakpoint (not from cache).

--- a/front/lib/api/llm/usage_metrics.ts
+++ b/front/lib/api/llm/usage_metrics.ts
@@ -43,7 +43,11 @@ export function emitTokenUsageMetrics(usage: TokenUsage, tags: string[]): void {
       ]);
     }
   }
-  if (usage.outputTokens > 0) {
-    statsD.distribution("llm_usage.output_tokens", usage.outputTokens, tags);
+  if (usage.totalOutputTokens > 0) {
+    statsD.distribution(
+      "llm_usage.output_tokens",
+      usage.totalOutputTokens,
+      tags
+    );
   }
 }

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -133,8 +133,7 @@ function makeStubConverters(): OutputEventConverters {
         shortCacheCreated: 0,
         cacheHit: 0,
         standardInput: 0,
-        standardOutput: 0,
-        reasoning: 0,
+        totalOutput: 0,
       },
       metadata,
     })),
@@ -422,7 +421,7 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
         shortCacheCreated: 4,
         cacheHit: 20,
         standardInput: 100,
-        standardOutput: 35,
+        totalOutput: 50,
         reasoning: 15,
       },
       metadata,
@@ -447,14 +446,14 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
         shortCacheCreated: 0,
         cacheHit: 20,
         standardInput: 100,
-        standardOutput: 35,
+        totalOutput: 50,
         reasoning: 15,
       },
       metadata,
     });
   });
 
-  it("rolls reasoning into standardOutput when there is no breakdown", () => {
+  it("keeps inclusive output without inventing a reasoning breakdown", () => {
     const usage: BetaMessageDeltaUsage = {
       cache_creation_input_tokens: null,
       cache_read_input_tokens: null,
@@ -472,8 +471,7 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
         shortCacheCreated: 0,
         cacheHit: 0,
         standardInput: 0,
-        standardOutput: 40,
-        reasoning: 0,
+        totalOutput: 40,
       },
       metadata,
     });
@@ -1282,7 +1280,7 @@ describe("rawOutputToEvents", () => {
         shortCacheCreated: 7,
         cacheHit: 0,
         standardInput: 3,
-        standardOutput: 5,
+        totalOutput: 5,
         reasoning: 0,
       },
     });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -344,10 +344,10 @@ export function messageDeltaUsageToTokenUsageEvent(
 ): TokenUsageEvent {
   const cacheHit = usage.cache_read_input_tokens ?? 0;
   const uncachedInput = usage.input_tokens ?? 0;
-  // thinking_tokens is the reasoning portion of output_tokens; subtracting
-  // yields non-reasoning generation. Null (no breakdown) rolls reasoning into
-  // standardOutput.
-  const thinkingTokens = usage.output_tokens_details?.thinking_tokens ?? 0;
+  // Anthropic defines output_tokens as the inclusive, authoritative billed
+  // output total. thinking_tokens is an optional subset for observability.
+  // https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost
+  const thinkingTokens = usage.output_tokens_details?.thinking_tokens;
 
   // The per-TTL breakdown lives on the full `Usage` object (`cache_creation`),
   // not on `MessageDeltaUsage`. When it's present, split cache creation into the
@@ -373,8 +373,8 @@ export function messageDeltaUsageToTokenUsageEvent(
       shortCacheCreated,
       cacheHit,
       standardInput: uncachedInput,
-      standardOutput: usage.output_tokens - thinkingTokens,
-      reasoning: thinkingTokens,
+      totalOutput: usage.output_tokens,
+      ...(thinkingTokens !== undefined ? { reasoning: thinkingTokens } : {}),
     },
     metadata,
   };

--- a/front/lib/model_constructors/sdk/google_genai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/output/utils.test.ts
@@ -1,0 +1,36 @@
+import { usageToTokenUsageEvent } from "@app/lib/model_constructors/sdk/google_genai/converters/output/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { GenerateContentResponseUsageMetadata } from "@google/genai";
+import { describe, expect, it } from "vitest";
+
+const metadata: EndpointMetadata = {
+  lab: "google",
+  host: "google-ai-studio",
+  model: "gemini-3.5-flash",
+  region: "global",
+};
+
+describe("usageToTokenUsageEvent", () => {
+  it("normalizes separately reported thought tokens into inclusive output", () => {
+    const usage: GenerateContentResponseUsageMetadata = {
+      promptTokenCount: 25,
+      candidatesTokenCount: 36,
+      thoughtsTokenCount: 312,
+      totalTokenCount: 373,
+    };
+
+    expect(usageToTokenUsageEvent(metadata, usage)).toEqual({
+      type: "token_usage",
+      content: {
+        cacheCreated: 0,
+        longCacheCreated: 0,
+        shortCacheCreated: 0,
+        cacheHit: 0,
+        standardInput: 25,
+        totalOutput: 348,
+        reasoning: 312,
+      },
+      metadata,
+    });
+  });
+});

--- a/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
@@ -157,6 +157,8 @@ export function usageToTokenUsageEvent(
   // subtract the cached portion so it is not counted twice against pricing.
   const totalInput =
     (usage?.promptTokenCount ?? 0) + (usage?.toolUsePromptTokenCount ?? 0);
+  const candidateTokens = usage?.candidatesTokenCount ?? 0;
+  const reasoning = usage?.thoughtsTokenCount;
   return {
     type: "token_usage",
     content: {
@@ -167,8 +169,10 @@ export function usageToTokenUsageEvent(
       shortCacheCreated: 0,
       cacheHit,
       standardInput: Math.max(0, totalInput - cacheHit),
-      standardOutput: usage?.candidatesTokenCount ?? 0,
-      reasoning: usage?.thoughtsTokenCount ?? 0,
+      // Gemini reports candidate and thought tokens separately, while Dust's
+      // totalOutput contract is the inclusive billed output total.
+      totalOutput: candidateTokens + (reasoning ?? 0),
+      ...(reasoning !== undefined ? { reasoning } : {}),
     },
     metadata,
   };

--- a/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
@@ -54,8 +54,9 @@ function usageToTokenUsageEvent(
       shortCacheCreated: 0,
       cacheHit: 0,
       standardInput: usage?.promptTokens ?? 0,
-      standardOutput: usage?.completionTokens ?? 0,
-      reasoning: 0,
+      // Mistral exposes one aggregate completion count with no reasoning-token
+      // breakdown, so the inclusive total remains unattributed.
+      totalOutput: usage?.completionTokens ?? 0,
     },
     metadata,
   };

--- a/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
@@ -40,7 +40,7 @@ function usageToTokenUsageEvent(
 ): TokenUsageEvent {
   const cacheHit = usage?.prompt_tokens_details?.cached_tokens ?? 0;
   const cacheCreated = usage?.prompt_tokens_details?.cache_write_tokens ?? 0;
-  const reasoning = usage?.completion_tokens_details?.reasoning_tokens ?? 0;
+  const reasoning = usage?.completion_tokens_details?.reasoning_tokens;
   return {
     type: "token_usage",
     content: {
@@ -55,8 +55,11 @@ function usageToTokenUsageEvent(
         0,
         (usage?.prompt_tokens ?? 0) - cacheHit - cacheCreated
       ),
-      standardOutput: (usage?.completion_tokens ?? 0) - reasoning,
-      reasoning,
+      // The current Fireworks path reports completion_tokens as its aggregate
+      // output. Preserve any optional reasoning detail as a subset. Providers
+      // without the breakdown simply omit reasoning.
+      totalOutput: usage?.completion_tokens ?? 0,
+      ...(reasoning !== undefined ? { reasoning } : {}),
     },
     metadata,
   };

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
@@ -100,7 +100,7 @@ describe("usageToTokenUsageEvent", () => {
         shortCacheCreated: 0,
         cacheHit: 1200,
         standardInput: 86,
-        standardOutput: 250,
+        totalOutput: 300,
         reasoning: 50,
       },
       metadata,

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -240,7 +240,7 @@ export function usageToTokenUsageEvent(
 ): TokenUsageEvent {
   const cacheHit = usage.input_tokens_details?.cached_tokens ?? 0;
   const cacheCreated = usage.input_tokens_details?.cache_write_tokens ?? 0;
-  const reasoning = usage.output_tokens_details?.reasoning_tokens ?? 0;
+  const reasoning = usage.output_tokens_details?.reasoning_tokens;
   return {
     type: "token_usage",
     content: {
@@ -252,8 +252,10 @@ export function usageToTokenUsageEvent(
       // input_tokens includes cache reads and writes. Subtract both to get
       // standard input.
       standardInput: Math.max(0, usage.input_tokens - cacheHit - cacheCreated),
-      standardOutput: usage.output_tokens - reasoning,
-      reasoning,
+      // OpenAI reports reasoning_tokens as a breakdown of the inclusive
+      // output_tokens total, not as an additional token count.
+      totalOutput: usage.output_tokens,
+      ...(reasoning !== undefined ? { reasoning } : {}),
     },
     metadata,
   };

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -91,8 +91,12 @@ export type TokenUsageContent = {
   cacheCreated: number;
   cacheHit: number;
   standardInput: number;
-  standardOutput: number;
-  reasoning: number;
+  // Inclusive billed output total. Provider adapters must normalize their raw
+  // usage into this value, including reasoning and thinking tokens.
+  totalOutput: number;
+  // Optional reasoning and thinking subset of totalOutput. Never add it to
+  // totalOutput for persistence or billing.
+  reasoning?: number;
 };
 export interface TokenUsageEvent {
   type: "token_usage";

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -427,10 +427,12 @@ export class RunResource extends BaseResource<RunModel> {
       return;
     }
 
+    // totalOutputTokens is the canonical inclusive billed output total. Any
+    // reasoningTokens value is already a subset and must not be added here.
     const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
-      completionTokens: usage.outputTokens,
+      completionTokens: usage.totalOutputTokens,
       cachedTokens: usage.cachedTokens ?? null,
       cacheCreationTokens: usage.cacheCreationTokens ?? null,
       longCacheCreationTokens: usage.longCacheCreationTokens ?? null,
@@ -442,7 +444,7 @@ export class RunResource extends BaseResource<RunModel> {
       {
         cacheCreationTokens: usage.cacheCreationTokens,
         cachedTokens: usage.cachedTokens ?? null,
-        completionTokens: usage.outputTokens,
+        completionTokens: usage.totalOutputTokens,
         modelId: modelConfig.modelId,
         promptTokens: usage.inputTokens,
         providerId: modelConfig.providerId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Working on credit observability, I noticed that thinking/reasoning tokens were not accounted for. This PR captures them we we can effectively bill them. This defines `outputTokens` as the inclusive billed output total and `reasoningTokens` as an optional subset.
Each provider adapter now normalizes its own usage format before billing and persistence. The transition
validates that reasoning tokens cannot exceed output tokens, and `completionTokens` stores the inclusive total.

Provider references:
- [OpenAI](https://developers.openai.com/api/docs/guides/reasoning#how-reasoning-works)
- [Anthropic](https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost#pricing)
- [Google Gemini](https://ai.google.dev/gemini-api/docs/generate-content/tokens)
- [xAI](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/usage-and-pricing)
- [Mistral](https://docs.mistral.ai/studio-api/conversations/reasoning)
- [Fireworks](https://docs.fireworks.ai/api-reference/post-chatcompletions).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
