### PR TITLE
[Pods] Reset file filters on folder navigation

### DIFF
--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -15,15 +15,17 @@ function makeFile({
   contentType,
   fileName,
   lastModifiedMs,
+  path = fileName,
 }: {
   contentType: string;
   fileName: string;
   lastModifiedMs: number;
+  path?: string;
 }): FileSystemFileEntry {
   return {
     isDirectory: false,
     fileName,
-    path: `conversation-c1/${fileName}`,
+    path: `conversation-c1/${path}`,
     contentType,
     fileId: `file-${fileName}`,
     sizeBytes: 100,
@@ -126,5 +128,36 @@ describe("FileExplorer file opening", () => {
     expect(
       await screen.findByRole("dialog", { name: "second.txt" })
     ).toBeInTheDocument();
+  });
+});
+
+describe("FileExplorer navigation", () => {
+  it("resets the type filter when opening a folder", () => {
+    const nestedFile = makeFile({
+      contentType: "text/plain",
+      fileName: "nested.txt",
+      lastModifiedMs: 1,
+      path: "folder/nested.txt",
+    });
+    const rootFile = makeFile({
+      contentType: "text/plain",
+      fileName: "root.txt",
+      lastModifiedMs: 1,
+    });
+
+    render(
+      <FileExplorer
+        defaultViewMode="list"
+        files={[nestedFile, rootFile]}
+        getFileUrl={(path) => `/files/${path}`}
+        isLoading={false}
+        onFileDownload={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Folders" }));
+    fireEvent.click(screen.getByText("folder"));
+
+    expect(screen.getByText("nested.txt")).toBeInTheDocument();
   });
 });

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -207,15 +207,18 @@ export function FileExplorer({
   const handleBreadcrumbNavigate = (index: number) => {
     if (index < 0) {
       setCurrentFolderPath("");
+      setActiveFilter("all");
       return;
     }
 
     const segments = getFolderBreadcrumbSegments(currentFolderPath);
     setCurrentFolderPath(segments[index]?.path ?? "");
+    setActiveFilter("all");
   };
 
   const handleFolderNavigate = (node: FileSystemTreeNode) => {
     setCurrentFolderPath(node.path);
+    setActiveFilter("all");
   };
 
   const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9813

The file type filter stayed active when users changed folders. When the selected type was absent in the destination folder, every item was hidden and the generic empty state appeared. Reset the filter to All when navigating into a folder or through the breadcrumb.

## Risks

Blast radius: Folder navigation in the shared file explorer used by Pods and conversation files.
Risk: low

## Test

- [x] Added a regression test that selects Folders, opens a folder containing a text file, and verifies the file is shown.

## Deploy Plan

- deploy front